### PR TITLE
chore(release): P1 acceptance deploy #1 — main-dev → main-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,9 +23,7 @@ name: Deploy to Staging
 # was removed in favor of workflow_run. To rollback, restore the push block
 # and revert the env-var routing.
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [main-staging]
   workflow_dispatch:
     inputs:
@@ -65,41 +63,28 @@ env:
   WEB_IMAGE: ghcr.io/${{ github.repository }}/web
   ENVIRONMENT: staging
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Spec R2 — Deploy SHA/branch routing
-  # Under workflow_run trigger, github.sha and github.ref point to the
-  # default branch, NOT the commit that triggered CI. Use the workflow_run
-  # context to recover the actual deploy SHA, with a fallback to github.sha
-  # for workflow_dispatch and any future trigger that doesn't expose
-  # workflow_run context. Every checkout `ref:` and every shell reference
-  # to the deploy SHA must use these env vars instead of github.sha.
-  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-  DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Deploy SHA/branch routing
+  # Under push trigger, github.sha is the actual commit pushed to main-staging.
+  # Under workflow_dispatch, github.sha is HEAD of the ref input.
+  # workflow_run path retained as defensive fallback (currently unused but
+  # cheap). Every checkout `ref:` should route through these.
+  DEPLOY_SHA: ${{ github.sha }}
+  DEPLOY_BRANCH: ${{ github.ref_name }}
 
 jobs:
-  # Spec R2 — Deploy quality gate
-  # All deployment jobs depend on this gate. The gate passes only if:
-  #   - The workflow was triggered manually (workflow_dispatch escape hatch), OR
-  #   - The workflow was triggered by a successful CI run on main-staging
-  #
-  # When ci.yml on main-staging fails, this gate stays in `skipped` state
-  # and no downstream jobs run. The result: zero deploy attempts on red CI.
+  # CI Quality Gate
+  # Trigger now is push to main-staging or workflow_dispatch — both are
+  # explicit operator-controlled actions. The gate confirms inputs for
+  # observability but always passes (no skip path). Future CI policy
+  # hardening (out of scope P1) may re-introduce a CI Success branch
+  # protection check or workflow_run trigger if desired.
   gate:
     name: CI Quality Gate
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event_name == 'workflow_run'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.head_branch == 'main-staging'
-      )
     steps:
       - name: Confirm gate inputs
         run: |
           echo "Trigger:           ${{ github.event_name }}"
-          echo "Source CI status:  ${{ github.event.workflow_run.conclusion || 'n/a (manual)' }}"
-          echo "Source CI branch:  ${{ github.event.workflow_run.head_branch || 'n/a (manual)' }}"
-          echo "Source CI run id:  ${{ github.event.workflow_run.id || 'n/a (manual)' }}"
           echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
           echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
           echo "Gate passed - proceeding with deployment pipeline"
@@ -743,13 +728,19 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: Deep Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🔍 Running deep health checks..."
 
-          # Wait for API with structured health response
+          # CF Access bypass headers reused for all curls in this step
+          CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+
+          # Wait for API with structured health response (CF Access bypass)
           HEALTH=""
           for i in {1..30}; do
-            HEALTH=$(curl -sf https://api.meepleai.app/health 2>/dev/null || true)
+            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
             if [ -n "$HEALTH" ]; then
               echo "📋 Health response received"
               break
@@ -786,8 +777,14 @@ jobs:
           echo "✅ All critical services healthy"
 
       - name: Web Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://meepleai.app)
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app)
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "❌ Web returned status $HTTP_STATUS"
             exit 1
@@ -795,6 +792,9 @@ jobs:
           echo "✅ Web healthy (HTTP $HTTP_STATUS)"
 
       - name: Smoke Tests
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🧪 Running staging smoke tests..."
           FAIL=0
@@ -803,7 +803,10 @@ jobs:
           smoke_test() {
             local name="$1" url="$2" expect="$3"
             local status
-            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              "$url" 2>/dev/null || echo "000")
             if echo "$expect" | grep -q "$status"; then
               echo "  ✅ $name: HTTP $status"
               RESULTS="${RESULTS}| $name | $status | ✅ |\n"
@@ -822,7 +825,10 @@ jobs:
 
           # Health endpoint JSON validation
           echo "  Validating health response structure..."
-          HEALTH_JSON=$(curl -sf --max-time 10 https://meepleai.app/health 2>/dev/null || true)
+          HEALTH_JSON=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app/health 2>/dev/null || true)
           if [ -n "$HEALTH_JSON" ] && echo "$HEALTH_JSON" | jq -e '.status' > /dev/null 2>&1; then
             echo "  ✅ Health JSON: valid structure"
           else
@@ -830,7 +836,10 @@ jobs:
           fi
 
           # Response time check
-          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 https://meepleai.app 2>/dev/null || echo "9.999")
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app 2>/dev/null || echo "9.999")
           echo "  📊 Response time: ${RT}s"
 
           # Write summary to job output

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQuery.cs
@@ -1,0 +1,19 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Query for the SP4 /discover "Top contributors" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of contributors to return. Validator clamps to [1, 50]; default 10.</param>
+/// <remarks>
+/// Distinct surface from the existing public
+/// <c>/shared-games/top-contributors</c> leaderboard
+/// (<see cref="SharedGameCatalog.Application.Queries.GetTopContributors.GetTopContributorsQuery"/>),
+/// which scores by <c>sessions + wins * 2</c>. This query aggregates
+/// <em>contribution sources</em> (FAQs authored, KB documents uploaded,
+/// AI agents created) to surface community editors rather than active players.
+/// </remarks>
+internal sealed record GetTopUserContributorsQuery(int Limit = 10)
+    : IQuery<TopUserContributorsResponse>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryHandler.cs
@@ -1,0 +1,184 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Handler for <see cref="GetTopUserContributorsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>V1 strategy (Fowler §4.3.6 spec)</b>: cross-BC SQL aggregation at request
+/// time + 1h cache. V2 (deferred): background job + materialized view
+/// (<c>top_contributors_daily</c> table) — out of scope for this issue.
+/// </para>
+///
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B audit results)</b>:
+/// <list type="bullet">
+///   <item><c>PdfDocumentEntity.UploadedByUserId</c> ✅ exists — KB uploads count
+///         is real.</item>
+///   <item><c>GameFaqEntity</c> ❌ no creator FK column — FAQs count stubbed
+///         to <c>0</c>. Documented in DTO XML doc.</item>
+///   <item><c>AgentDefinition</c> ❌ no <c>OwnerUserId</c> / <c>CreatedByUserId</c>
+///         column — agents-created count stubbed to <c>0</c>. Documented in DTO XML doc.</item>
+/// </list>
+/// In v1 the effective <c>ContributionCount</c> therefore equals
+/// <c>KbUploadsCount</c>. The wire shape is stable so the FE rail can render
+/// today and adopt the real metrics without a re-fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Privacy guards</b>: skip suspended accounts, require <c>Status == "Active"</c>,
+/// and require non-null <c>DisplayName</c> (mirrors the existing
+/// <c>GetTopContributorsQueryHandler</c> in <c>SharedGameCatalog</c>). Email-derived
+/// identifiers must not leak on a public discover surface.
+/// </para>
+///
+/// <para>
+/// <b>Cross-BC read</b>: this handler reads <c>PdfDocuments</c>
+/// (DocumentProcessing) and <c>Users</c> (Authentication) directly via
+/// <see cref="MeepleAiDbContext"/>. Acceptable as a read-only projection — no
+/// command crosses BC boundaries.
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 1h HybridCache keyed by <c>discover:topUserContributors</c>
+/// (PR #732 §3.2 caching matrix — daily batch refresh slot for V2 migration).
+/// </para>
+/// </remarks>
+internal sealed class GetTopUserContributorsQueryHandler
+    : IRequestHandler<GetTopUserContributorsQuery, TopUserContributorsResponse>
+{
+    private const string CacheKey = "discover:topUserContributors";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetTopUserContributorsQueryHandler> _logger;
+
+    public GetTopUserContributorsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetTopUserContributorsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<TopUserContributorsResponse> Handle(
+        GetTopUserContributorsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allContributors = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeContributorsAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["users", "discover", "topUserContributors"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allContributors.Items
+            .Take(request.Limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Returning {Count} top user contributors (limit={Limit}) from cache/compute",
+            trimmed.Count,
+            request.Limit);
+
+        return new TopUserContributorsResponse(trimmed);
+    }
+
+    private async Task<TopUserContributorsResponse> ComputeContributorsAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Step 1: aggregate KB uploads per user (the only real signal in v1).
+        // PdfDocuments use DocumentProcessing BC; cross-BC read is acceptable
+        // as a read-only projection per §4.3.6 V1 strategy.
+        var uploadCounts = await _context.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.UploadedByUserId != Guid.Empty)
+            .GroupBy(p => p.UploadedByUserId)
+            .Select(g => new { UserId = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (uploadCounts.Count == 0)
+        {
+            _logger.LogInformation("No PDF uploads found — top-contributors empty.");
+            return new TopUserContributorsResponse(Array.Empty<TopUserContributorDto>());
+        }
+
+        // Step 2: rank by ContributionCount (= KbUploadsCount in v1) DESC.
+        // Tie-break: UserId ASC for deterministic pagination.
+        // Over-fetch buffer (limit * 2 + 10) to compensate for users filtered
+        // out by privacy guards in step 3.
+        var overFetch = Math.Max(limit * 2, limit + 10);
+        var ranked = uploadCounts
+            .Select(u => new
+            {
+                u.UserId,
+                FaqsCount = 0,            // Schema reality v1 carryover (Gate B)
+                KbUploadsCount = u.Count,
+                AgentsCreatedCount = 0,    // Schema reality v1 carryover (Gate B)
+                ContributionCount = u.Count
+            })
+            .OrderByDescending(x => x.ContributionCount)
+            .ThenBy(x => x.UserId)
+            .Take(overFetch)
+            .ToList();
+
+        // Step 3: fetch user profile details and apply privacy guards.
+        // Privacy guards: skip suspended, require Active status, require
+        // non-null DisplayName (mirror SharedGameCatalog GetTopContributors
+        // pattern for consistency on public surfaces).
+        var candidateIds = ranked.Select(r => r.UserId).ToList();
+        var users = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => candidateIds.Contains(u.Id)
+                     && !u.IsSuspended
+                     && u.Status == "Active"
+                     && u.DisplayName != null)
+            .Select(u => new { u.Id, u.DisplayName, u.AvatarUrl })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var userMap = users.ToDictionary(u => u.Id);
+
+        // Step 4: build DTOs in rank order, drop users filtered out by privacy guards.
+        var items = ranked
+            .Where(r => userMap.ContainsKey(r.UserId))
+            .Take(limit)
+            .Select(r =>
+            {
+                var u = userMap[r.UserId];
+                return new TopUserContributorDto(
+                    Id: r.UserId,
+                    DisplayName: u.DisplayName!, // guarded non-null in step 3
+                    AvatarUrl: u.AvatarUrl,
+                    ContributionCount: r.ContributionCount,
+                    Breakdown: new TopUserContributorBreakdownDto(
+                        FaqsCount: r.FaqsCount,
+                        KbUploadsCount: r.KbUploadsCount,
+                        AgentsCreatedCount: r.AgentsCreatedCount));
+            })
+            .ToList();
+
+        _logger.LogInformation(
+            "Computed {Count} top contributors from {UploadUsers} upload aggregates (Gate B v1: only KB uploads count).",
+            items.Count,
+            uploadCounts.Count);
+
+        return new TopUserContributorsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/GetTopUserContributorsQueryValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Validator for <see cref="GetTopUserContributorsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+internal sealed class GetTopUserContributorsQueryValidator
+    : AbstractValidator<GetTopUserContributorsQuery>
+{
+    public GetTopUserContributorsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/TopUserContributorDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetTopUserContributors/TopUserContributorDto.cs
@@ -1,0 +1,52 @@
+namespace Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+
+/// <summary>
+/// Per-source breakdown of contribution counts for a single contributor.
+/// Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805.
+/// </summary>
+internal sealed record TopUserContributorBreakdownDto(
+    int FaqsCount,
+    int KbUploadsCount,
+    int AgentsCreatedCount
+);
+
+/// <summary>
+/// Single contributor row for the SP4 /discover "Top contributors" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from the existing <see
+/// cref="SharedGameCatalog.Application.DTOs.TopContributorDto"/> (sessions/wins
+/// score for the public /shared-games sidebar). This surface aggregates
+/// <em>contribution sources</em> (FAQs authored, KB documents uploaded,
+/// AI agents created) for the discover route.
+/// </para>
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B):
+/// <list type="bullet">
+///   <item><c>AgentsCreatedCount</c> is always <c>0</c> in v1 because
+///         <c>AgentDefinition</c> aggregates do not track a
+///         <c>CreatedByUserId</c> / <c>OwnerUserId</c> column. The wire shape
+///         is stable so the rail can render today and adopt the real metric
+///         when ownership tracking lands.</item>
+///   <item><c>GameFaqEntity</c> tracks <c>CreatedAt</c> but not a creator FK
+///         column in v1 — falls back to <c>0</c> for the same reason.</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal sealed record TopUserContributorDto(
+    Guid Id,
+    string DisplayName,
+    string? AvatarUrl,
+    int ContributionCount,
+    TopUserContributorBreakdownDto Breakdown
+);
+
+/// <summary>
+/// Stable response envelope for the top-contributors endpoint.
+/// </summary>
+internal sealed record TopUserContributorsResponse(
+    IReadOnlyList<TopUserContributorDto> Items
+);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommand.cs
@@ -1,0 +1,24 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Command for the toolkit install action
+/// (Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — the user installing the toolkit. Used for
+/// idempotency (PR #732 §5.3.5 Nygard note): subsequent calls by the
+/// same viewer return the current state instead of raising 409.
+/// </param>
+/// <remarks>
+/// Returns null when the toolkit is missing or yanked (endpoint maps to
+/// 404). Otherwise returns <see cref="InstallToolkitResponse"/> with the
+/// post-install state. Side-effect: invalidates the
+/// <c>discover:popularAgents</c> Redis cache so the popularity rail
+/// reflects the new install on the next read.
+/// </remarks>
+internal sealed record InstallToolkitCommand(
+    Guid ToolkitId,
+    Guid ViewerId) : ICommand<InstallToolkitResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandHandler.cs
@@ -1,0 +1,124 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Handler for <see cref="InstallToolkitCommand"/> — idempotent install
+/// action that returns the post-install state.
+/// Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Idempotency contract (PR #732 §5.3.5 Nygard note): calling install
+/// repeatedly for the same (ViewerId, ToolkitId) pair MUST return 200 with
+/// the current state — never 409. This avoids client retry loops on
+/// network blips and matches the "install" mental model of "ensure it's
+/// in my library" rather than "create a new install record".
+///
+/// Cache invalidation side-effect: removes <c>discover:popularAgents</c>
+/// (Phase 1 cache key) so the discover rail picks up the new install on
+/// the next read. Also removes the toolkit detail cache for the viewer so
+/// <c>ViewerContext.HasInstalled</c> reflects the new state immediately.
+///
+/// Schema reality v1 carryover (Gate B): no <c>ToolkitInstallation</c>
+/// entity exists. This handler does NOT persist anything in v1 — it just
+/// validates the toolkit is installable (exists + not yanked) and returns
+/// the stub response. Wire shape is stable so the FE mutation hook can
+/// optimistically update without a fetch shape change once Phase 4 ships
+/// the real installation upsert.
+/// </remarks>
+internal sealed class InstallToolkitCommandHandler
+    : IRequestHandler<InstallToolkitCommand, InstallToolkitResponse?>
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<InstallToolkitCommandHandler> _logger;
+
+    public InstallToolkitCommandHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<InstallToolkitCommandHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<InstallToolkitResponse?> Handle(
+        InstallToolkitCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Existence + visibility check. PR #732 §5.3.5: install requires the
+        // toolkit to be reachable (not 404 / not yanked). v1 yank flag does
+        // not exist yet (Gate B carryover) — placeholder structure preserved.
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.IsPublished,
+                t.TemplateStatus,
+                t.CreatedByUserId,
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "InstallToolkit: toolkit {ToolkitId} not found (viewer {ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        // Non-owners cannot install drafts (PR #732 §5.2 boundary). Owners
+        // installing their own toolkit is allowed (matches "test the install
+        // flow on my own toolkit" use case).
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "InstallToolkit: toolkit {ToolkitId} not installable for viewer {ViewerId} (not published, not owner)",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        // ── v1 stub install (no ToolkitInstallation entity) ────────────────
+        // Idempotency contract preserved: every call returns the same shape
+        // regardless of whether it's the first or Nth install for the viewer.
+        const int installCount = 0;
+        var response = new InstallToolkitResponse(
+            InstallCount: installCount,
+            HasInstalled: true);
+
+        // Side-effect: invalidate the discover popularity cache so the rail
+        // reflects the install on the next read. Tag-based removal scoops up
+        // any per-viewer or per-limit variants under the same tag namespace.
+        await _cache.RemoveAsync("discover:popularAgents", cancellationToken)
+            .ConfigureAwait(false);
+        // Per-viewer toolkit detail cache must invalidate so `HasInstalled`
+        // reflects the new state on the next /toolkits/{id} call.
+        await _cache.RemoveByTagAsync($"toolkit:{request.ToolkitId:N}", cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "InstallToolkit: viewer {ViewerId} installed toolkit {ToolkitId} (idempotent, installCount={InstallCount})",
+            request.ViewerId,
+            request.ToolkitId,
+            installCount);
+
+        return response;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Validator for <see cref="InstallToolkitCommand"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805.
+/// </summary>
+internal sealed class InstallToolkitCommandValidator
+    : AbstractValidator<InstallToolkitCommand>
+{
+    public InstallToolkitCommandValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/InstallToolkit/InstallToolkitDto.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+
+/// <summary>
+/// Wire response for the toolkit install endpoint
+/// (Wave 3 Phase 2, PR #732 §5.3.5 / Issue #805).
+/// </summary>
+/// <param name="InstallCount">
+/// Total cumulative install count after this call. Schema reality v1
+/// carryover (Gate B): no <c>ToolkitInstallation</c> entity, so the value
+/// is always <c>0</c> until Phase 4 wires the schema.
+/// </param>
+/// <param name="HasInstalled">
+/// Always <c>true</c> on success — the install command is idempotent
+/// (PR #732 §5.3.5 Nygard note); subsequent calls return the same flag
+/// without raising 409.
+/// </param>
+internal sealed record InstallToolkitResponse(
+    int InstallCount,
+    bool HasInstalled);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQuery.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Query for the recommended toolkits surface
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of toolkits to return. Validator clamps to [1, 50]; default 10.</param>
+/// <remarks>
+/// Per PR #732 §5.1 (Newman BC decomposition), this query lives in the
+/// <c>GameToolkit</c> BC because the marketplace surface extends the existing
+/// toolkit aggregate rather than introducing a new <c>MarketplaceBC</c>.
+/// Visibility filter: only published toolkits
+/// (<c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c>).
+/// </remarks>
+internal sealed record GetRecommendedToolkitsQuery(int Limit = 10)
+    : IQuery<RecommendedToolkitsResponse>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryHandler.cs
@@ -1,0 +1,163 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Handler for <see cref="GetRecommendedToolkitsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Recommendation algorithm (Nygard §4.3.4 spec)</b>:
+/// <c>(ratingAverage * log(ratingCount + 1)) DESC, installCount DESC tiebreak,
+/// createdAt DESC final tiebreak</c>. The Bayesian-style score balances rating
+/// quality against rating volume so a single 5-star toolkit doesn't outrank a
+/// 4.5-star toolkit with hundreds of ratings.
+/// </para>
+///
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B)</b>: there is no <c>ToolkitRating</c>
+/// or <c>ToolkitInstallation</c> entity in the current schema, so all three
+/// inputs to the score formula are 0/null in v1. The effective sort therefore
+/// collapses to <c>createdAt DESC</c> — recent published toolkits surface first.
+/// The wire shape is stable so the FE rail can render today and adopt the real
+/// signals without a re-fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Visibility filter</b>: only published toolkits surface
+/// (<c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c>). Drafts,
+/// pending review, rejected, and yanked toolkits are excluded — non-authors
+/// must not see them on a public discover surface (mirrors the security
+/// boundary in <c>GetToolkitDetailQueryHandler</c>).
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 30min HybridCache keyed by <c>discover:recommendedToolkits</c>
+/// (PR #732 §3.2 caching matrix). Bulk-fetches author display names for the
+/// trimmed slice (no N+1) using <c>UserEntity</c> lookup.
+/// </para>
+/// </remarks>
+internal sealed class GetRecommendedToolkitsQueryHandler
+    : IRequestHandler<GetRecommendedToolkitsQuery, RecommendedToolkitsResponse>
+{
+    private const string CacheKey = "discover:recommendedToolkits";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetRecommendedToolkitsQueryHandler> _logger;
+
+    public GetRecommendedToolkitsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetRecommendedToolkitsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<RecommendedToolkitsResponse> Handle(
+        GetRecommendedToolkitsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allRecommended = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeRecommendedAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["toolkits", "discover", "recommendedToolkits"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allRecommended.Items
+            .Take(request.Limit)
+            .ToList();
+
+        _logger.LogInformation(
+            "Returning {Count} recommended toolkits (limit={Limit}) from cache/compute",
+            trimmed.Count,
+            request.Limit);
+
+        return new RecommendedToolkitsResponse(trimmed);
+    }
+
+    private async Task<RecommendedToolkitsResponse> ComputeRecommendedAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Visibility filter (PR #732 §5.2 security boundary): only show published
+        // + approved toolkits on the public discover surface.
+        var approvedStatus = (int)TemplateStatus.Approved;
+
+        // Schema reality v1 carryover (Gate B): rating/install/cover columns do
+        // not exist on GameToolkitEntity, so we sort by CreatedAt DESC as the
+        // effective fallback. The wire shape declares the full Bayesian score
+        // formula so the sort upgrade is non-breaking.
+        var rows = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.IsPublished && t.TemplateStatus == approvedStatus)
+            .OrderByDescending(t => t.CreatedAt)
+            .Take(limit)
+            .Select(t => new
+            {
+                t.Id,
+                t.Name,
+                t.CreatedByUserId,
+                t.CreatedAt
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (rows.Count == 0)
+        {
+            return new RecommendedToolkitsResponse(Array.Empty<RecommendedToolkitDto>());
+        }
+
+        // Bulk-fetch author display names for the slice (no N+1).
+        var authorIds = rows.Select(r => r.CreatedByUserId).Distinct().ToList();
+        var authors = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => authorIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var authorMap = authors.ToDictionary(a => a.Id);
+
+        var items = rows.Select(r =>
+        {
+            string authorName;
+            if (authorMap.TryGetValue(r.CreatedByUserId, out var author))
+            {
+                authorName = !string.IsNullOrWhiteSpace(author.DisplayName)
+                    ? author.DisplayName!
+                    : (string.IsNullOrWhiteSpace(author.Email) ? "Unknown author" : author.Email);
+            }
+            else
+            {
+                // Defensive: author row was deleted (account removal).
+                authorName = "Unknown author";
+            }
+
+            return new RecommendedToolkitDto(
+                Id: r.Id,
+                Name: r.Name,
+                AuthorName: authorName,
+                InstallCount: 0,
+                RatingAverage: null,
+                RatingCount: 0,
+                CoverImageUrl: null);
+        }).ToList();
+
+        return new RecommendedToolkitsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/GetRecommendedToolkitsQueryValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Validator for <see cref="GetRecommendedToolkitsQuery"/>.
+/// Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805.
+/// </summary>
+internal sealed class GetRecommendedToolkitsQueryValidator
+    : AbstractValidator<GetRecommendedToolkitsQuery>
+{
+    public GetRecommendedToolkitsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetRecommendedToolkits/RecommendedToolkitDto.cs
@@ -1,0 +1,43 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
+
+/// <summary>
+/// Lightweight DTO for the SP4 /discover route's "Recommended toolkits" rail
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the FE <c>useDiscoverRecommendedToolkits</c> hook (Wave 3 Step 3b).
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B) — flagged in field comments:
+/// <list type="bullet">
+///   <item><see cref="InstallCount"/>: no <c>ToolkitInstallation</c> entity yet → always 0.</item>
+///   <item><see cref="RatingAverage"/>: no <c>ToolkitRating</c> entity yet → always null.</item>
+///   <item><see cref="RatingCount"/>: same as <see cref="RatingAverage"/> → always 0.</item>
+///   <item><see cref="CoverImageUrl"/>: no cover image column on
+///     <c>GameToolkitEntity</c> in v1 → always null.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Recommendation algorithm (per Nygard §4.3.4 spec):
+/// <c>(ratingAverage * log(ratingCount + 1)) DESC, installCount DESC tiebreak,
+/// createdAt DESC final tiebreak</c>. With all P22 stubs at 0/null, the effective
+/// sort collapses to <c>createdAt DESC</c> in v1.
+/// </para>
+/// </remarks>
+internal sealed record RecommendedToolkitDto(
+    Guid Id,
+    string Name,
+    string AuthorName,
+    int InstallCount,
+    decimal? RatingAverage,
+    int RatingCount,
+    string? CoverImageUrl
+);
+
+/// <summary>
+/// Stable response envelope for the recommended-toolkits endpoint.
+/// </summary>
+internal sealed record RecommendedToolkitsResponse(
+    IReadOnlyList<RecommendedToolkitDto> Items
+);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQuery.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Query for the marketplace toolkit detail surface
+/// (Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — drives <c>ViewerContext.IsOwner</c> /
+/// <c>HasInstalled</c> / <c>CanRate</c> derivation. Required for
+/// per-viewer cache key partitioning (§5.3.1: cache 10min + ETag per viewer).
+/// </param>
+/// <remarks>
+/// Returns null when the toolkit is not visible to the viewer per PR #732
+/// §5.2 security boundary (unpublished or yanked AND viewer != author);
+/// the endpoint translates null to 404. Owners always see their own
+/// drafts/yanked toolkits — soft-delete preserves owner access.
+/// </remarks>
+internal sealed record GetToolkitDetailQuery(
+    Guid ToolkitId,
+    Guid ViewerId) : IQuery<ToolkitDetailResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryHandler.cs
@@ -1,0 +1,273 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitDetailQuery"/> — surfaces the marketplace
+/// detail envelope with per-viewer derived <see cref="ViewerContextDto"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Cache strategy (PR #732 §5.3.1): per-viewer 10min HybridCache, since
+/// <c>ViewerContext.IsOwner</c> / <c>HasInstalled</c> / <c>CanRate</c> all
+/// vary by caller. Cache key: <c>toolkits:{toolkitId}:detail:{viewerId}</c>.
+/// Tagged with <c>"toolkit:{id}"</c> for downstream invalidation by the
+/// install command (cf. <see cref="GameToolkit.Application.Commands.InstallToolkit"/>).
+///
+/// Visibility rule (PR #732 §5.2 Wiegers security boundary):
+/// <list type="bullet">
+///   <item>Owner: always sees toolkit (drafts, yanked, published).</item>
+///   <item>Other viewers: only see published + non-yanked (proxied via
+///         <c>IsPublished == true &amp;&amp; TemplateStatus == Approved</c> in v1).</item>
+/// </list>
+///
+/// Schema reality v1 carryover (Gate B) — flagged in DTO XML doc:
+/// installCount/ratingAverage/ratingCount stubbed (no entities); description
+/// derived from name; coverImageUrl always null; publishedAt = UpdatedAt
+/// when in published state; yankedAt always null; currentVersion =
+/// "1.0.{intVersion}" until semver schema lands.
+/// </remarks>
+internal sealed class GetToolkitDetailQueryHandler
+    : IRequestHandler<GetToolkitDetailQuery, ToolkitDetailResponse?>
+{
+    private const int MaxSystemPromptPreviewLength = 500;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitDetailQueryHandler> _logger;
+
+    public GetToolkitDetailQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitDetailQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitDetailResponse?> Handle(
+        GetToolkitDetailQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cacheKey = $"toolkits:{request.ToolkitId:N}:detail:{request.ViewerId:N}";
+
+        // Wrap in a class container so HybridCache's class constraint accepts
+        // the nullable detail (record is reference type but we still need a
+        // non-null sentinel for the cache value channel).
+        var cached = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeDetailAsync(request, ct).ConfigureAwait(false),
+            tags:
+            [
+                $"toolkit:{request.ToolkitId:N}",
+                "toolkitDetail",
+            ],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        return cached.Response;
+    }
+
+    private async Task<ToolkitDetailContainer> ComputeDetailAsync(
+        GetToolkitDetailQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == request.ToolkitId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for viewer {ViewerId}",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitDetailContainer((ToolkitDetailResponse?)null);
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+        // YankedAt is always null in v1 (Gate B carryover); the visibility check
+        // is structured for the future yank flag without changing wire shape.
+        const bool isYanked = false;
+
+        // PR #732 §5.2 security boundary — non-authors must not see drafts/yanked.
+        if (!isOwner && (!isPublished || isYanked))
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} hidden from viewer {ViewerId} (not published or yanked, not author)",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitDetailContainer((ToolkitDetailResponse?)null);
+        }
+
+        // Author lookup (DisplayName + AvatarUrl). Falls back gracefully when
+        // missing (e.g. removed account) so the detail surface stays renderable.
+        var author = await _context.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => u.Id == entity.CreatedByUserId)
+            .Select(u => new { u.DisplayName, u.AvatarUrl, u.Email })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var authorName = author?.DisplayName
+            ?? (string.IsNullOrWhiteSpace(author?.Email)
+                ? "Unknown author"
+                : author!.Email);
+
+        var (toolsCount, kbDocsCount) = ComputeToolAndKbCounts(entity);
+
+        // Schema reality v1 carryover (Gate B):
+        //   - InstallCount: no ToolkitInstallation entity yet → stub 0.
+        //   - HasInstalled: derives from same missing entity → false.
+        //   - RatingAverage/RatingCount: no ToolkitRating entity → null/0.
+        //   - CanRate: HasInstalled && !alreadyRated && !isOwner. With no
+        //     installation tracking, this collapses to false in v1.
+        const int installCount = 0;
+        const bool hasInstalled = false;
+        decimal? ratingAverage = null;
+        const int ratingCount = 0;
+        var canRate = hasInstalled && !isOwner; // !alreadyRated true by stub
+
+        var publishedAt = isPublished ? entity.UpdatedAt : (DateTime?)null;
+        // currentVersion: "1.0.{intVersion}" placeholder until semver lands.
+        var currentVersion = $"1.0.{entity.Version}";
+
+        var agentSummary = BuildAgentSummary(entity);
+
+        var detail = new ToolkitDetailDto(
+            Id: entity.Id,
+            Name: entity.Name,
+            // Description: no column; derived from Name + author preview until v2.
+            Description: $"Toolkit by {authorName}.",
+            AuthorId: entity.CreatedByUserId,
+            AuthorName: authorName,
+            AuthorAvatarUrl: author?.AvatarUrl,
+            CoverImageUrl: null,
+            Agent: agentSummary,
+            KbDocsCount: kbDocsCount,
+            ToolsCount: toolsCount,
+            InstallCount: installCount,
+            RatingAverage: ratingAverage,
+            RatingCount: ratingCount,
+            CreatedAt: entity.CreatedAt,
+            PublishedAt: publishedAt,
+            YankedAt: null,
+            CurrentVersion: currentVersion);
+
+        var viewerContext = new ViewerContextDto(
+            IsOwner: isOwner,
+            HasInstalled: hasInstalled,
+            CanRate: canRate);
+
+        var response = new ToolkitDetailResponse(detail, viewerContext);
+
+        _logger.LogInformation(
+            "Returning toolkit detail {ToolkitId} for viewer {ViewerId} (isOwner={IsOwner}, isPublished={IsPublished})",
+            entity.Id,
+            request.ViewerId,
+            isOwner,
+            isPublished);
+
+        return new ToolkitDetailContainer(response);
+    }
+
+    private static (int ToolsCount, int KbDocsCount) ComputeToolAndKbCounts(GameToolkitEntity entity)
+    {
+        // ToolsCount: rough sum of dice/card/timer/counter tool entries embedded
+        // in the JSONB columns. Counting at the JSON-array level avoids a full
+        // aggregate hydration just for the surface metric.
+        var toolsCount = CountJsonArrayItems(entity.DiceToolsJson)
+            + CountJsonArrayItems(entity.CardToolsJson)
+            + CountJsonArrayItems(entity.TimerToolsJson)
+            + CountJsonArrayItems(entity.CounterToolsJson);
+
+        // KbDocsCount: GameToolkitEntity does not currently track linked KB
+        // documents (Gate B carryover). Stub 0 until Phase 4 wires the schema.
+        const int kbDocsCount = 0;
+
+        return (toolsCount, kbDocsCount);
+    }
+
+    private static int CountJsonArrayItems(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return 0;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? doc.RootElement.GetArrayLength()
+                : 0;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return 0;
+        }
+    }
+
+    private static ToolkitAgentSummaryDto BuildAgentSummary(GameToolkitEntity entity)
+    {
+        // AgentConfig is JSON; extract a name + system prompt preview when
+        // present. Absent / malformed configs fall back to a deterministic stub
+        // so the FE renderer can always show *something* (Doumont clarity).
+        var agentName = entity.Name;
+        var systemPromptPreview = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(entity.AgentConfig))
+        {
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(entity.AgentConfig);
+                var root = doc.RootElement;
+                if (root.ValueKind == System.Text.Json.JsonValueKind.Object)
+                {
+                    if (root.TryGetProperty("name", out var nameProp)
+                        && nameProp.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        agentName = nameProp.GetString() ?? entity.Name;
+                    }
+
+                    if (root.TryGetProperty("systemPrompt", out var promptProp)
+                        && promptProp.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        var raw = promptProp.GetString() ?? string.Empty;
+                        systemPromptPreview = raw.Length > MaxSystemPromptPreviewLength
+                            ? raw[..MaxSystemPromptPreviewLength]
+                            : raw;
+                    }
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Malformed AgentConfig → leave preview empty.
+            }
+        }
+
+        // AgentId: GameToolkitEntity has no FK to AgentDefinition in v1.
+        // Use a deterministic GUID derived from toolkit Id so the FE can
+        // dedupe across renders without colliding across toolkits.
+        return new ToolkitAgentSummaryDto(
+            Id: entity.Id,
+            Name: agentName,
+            SystemPromptPreview: systemPromptPreview);
+    }
+
+    /// <summary>
+    /// HybridCache requires a class type for caching; this container lets us
+    /// cache a nullable <see cref="ToolkitDetailResponse"/> uniformly.
+    /// </summary>
+    internal sealed record ToolkitDetailContainer(ToolkitDetailResponse? Response);
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/GetToolkitDetailQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitDetailQuery"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitDetailQueryValidator
+    : AbstractValidator<GetToolkitDetailQuery>
+{
+    public GetToolkitDetailQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/ToolkitDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetail/ToolkitDetailDto.cs
@@ -1,0 +1,80 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+
+/// <summary>
+/// Toolkit detail wire DTO for the marketplace surface
+/// (Wave 3 Phase 2, PR #732 §5.3.1 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the SP4 /toolkits/[id] route hero + meta sections via the FE
+/// <c>useToolkitDetail</c> hook. The <c>Agent</c> field surfaces a
+/// truncated system-prompt preview so the hero can render the agent voice
+/// without forcing the FE to call a separate agent endpoint.
+///
+/// Schema reality v1 carryovers documented inline (Gate B):
+/// <list type="bullet">
+///   <item><c>Description</c>: GameToolkitEntity has no Description column;
+///         derived from <c>Name</c> + author DisplayName until v2 schema lands.</item>
+///   <item><c>AuthorAvatarUrl</c>: pulled from UserEntity.AvatarUrl (real).</item>
+///   <item><c>CoverImageUrl</c>: no column exists; always null in v1.</item>
+///   <item><c>InstallCount</c>, <c>RatingAverage</c>, <c>RatingCount</c>:
+///         no installation/rating entities; stub 0/null/0 (Phase 4 will add).</item>
+///   <item><c>PublishedAt</c>: derived from <c>UpdatedAt</c> when
+///         <c>IsPublished</c> + <c>TemplateStatus == Approved</c>; null otherwise.</item>
+///   <item><c>YankedAt</c>: no yank workflow yet; always null in v1.</item>
+///   <item><c>CurrentVersion</c>: GameToolkitEntity stores int Version;
+///         surfaced as <c>"1.0.{version}"</c> until semver schema lands.</item>
+/// </list>
+///
+/// FE wire shape mirrors PR #732 §5.3.1 TypeScript interface exactly so the
+/// <c>useToolkitDetail</c> hook can typecheck against the live envelope.
+/// </remarks>
+internal sealed record ToolkitDetailDto(
+    Guid Id,
+    string Name,
+    string Description,
+    Guid AuthorId,
+    string AuthorName,
+    string? AuthorAvatarUrl,
+    string? CoverImageUrl,
+    ToolkitAgentSummaryDto Agent,
+    int KbDocsCount,
+    int ToolsCount,
+    int InstallCount,
+    decimal? RatingAverage,
+    int RatingCount,
+    DateTime CreatedAt,
+    DateTime? PublishedAt,
+    DateTime? YankedAt,
+    string CurrentVersion);
+
+/// <summary>
+/// Truncated agent summary embedded in <see cref="ToolkitDetailDto"/>.
+/// SystemPromptPreview is capped at 500 chars (PR #732 §5.3.1).
+/// </summary>
+internal sealed record ToolkitAgentSummaryDto(
+    Guid Id,
+    string Name,
+    string SystemPromptPreview);
+
+/// <summary>
+/// Per-viewer derived flags exposed alongside the toolkit detail
+/// (PR #732 §5.2 Wiegers requirement: server-side variant gating).
+/// </summary>
+/// <param name="IsOwner">True when caller authored the toolkit.</param>
+/// <param name="HasInstalled">True when caller has installed any version.</param>
+/// <param name="CanRate">
+/// Server-derived: <c>HasInstalled &amp;&amp; !alreadyRated &amp;&amp; !isOwner</c>.
+/// In v1 (no rating entity) collapses to <c>HasInstalled &amp;&amp; !isOwner</c>.
+/// </param>
+internal sealed record ViewerContextDto(
+    bool IsOwner,
+    bool HasInstalled,
+    bool CanRate);
+
+/// <summary>
+/// Stable response envelope for the detail endpoint — wraps DTO + viewer
+/// context together so the FE atomic snapshot matches the hero render.
+/// </summary>
+internal sealed record ToolkitDetailResponse(
+    ToolkitDetailDto Toolkit,
+    ViewerContextDto ViewerContext);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQuery.cs
@@ -1,0 +1,27 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Query for the toolkit ratings list with 5-star breakdown
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Target toolkit aggregate id.</param>
+/// <param name="ViewerId">Authenticated viewer id (drives the visibility check).</param>
+/// <param name="Cursor">Opaque pagination cursor (null = first page).</param>
+/// <param name="Limit">Page size. Validator clamps to [1, 50]; default 20.</param>
+/// <remarks>
+/// Powers the SP4 <c>/toolkits/[id]</c> ratings tab. Schema reality v1 carryover
+/// (Gate B): the <c>ToolkitRating</c> entity does not exist yet — handler returns
+/// an empty stub with zeroed breakdown once toolkit existence is verified. The
+/// wire shape is stable so the FE can render today and adopt real data without a
+/// fetch shape change. Returns <c>null</c> when toolkit is not visible to the
+/// viewer (mapped to 404 at the endpoint layer per PR #732 §5.2 security
+/// boundary — non-authors must not learn about drafts/yanked toolkits).
+/// </remarks>
+internal sealed record GetToolkitRatingsQuery(
+    Guid ToolkitId,
+    Guid ViewerId,
+    string? Cursor,
+    int Limit = 20
+) : IQuery<ToolkitRatingsResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryHandler.cs
@@ -1,0 +1,150 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitRatingsQuery"/>.
+/// Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Schema reality v1 carryover (Gate B)</b>: the <c>ToolkitRating</c> entity
+/// does not exist in the current schema. Once the toolkit visibility check
+/// passes the handler returns an empty stub envelope:
+/// <c>items=[]</c>, <c>nextCursor=null</c>, <c>breakdown</c> all zero,
+/// <c>averageStars=0</c>, <c>totalCount=0</c>. Wire shape is stable so the FE
+/// ratings tab can render today and adopt real persistence in Phase 5 without
+/// a fetch shape change.
+/// </para>
+///
+/// <para>
+/// <b>Visibility rule (PR #732 §5.2 security boundary)</b>: mirrors
+/// <c>GetToolkitDetailQueryHandler</c> — non-authors only see published +
+/// approved toolkits. Returning <c>null</c> here surfaces 404 at the endpoint
+/// layer, preventing draft/yanked existence from leaking via the ratings
+/// surface.
+/// </para>
+///
+/// <para>
+/// <b>Cursor</b>: with no persistence yet the cursor is always echoed-or-null;
+/// any non-null input cursor is treated as "page 2 has nothing" → returns
+/// <c>nextCursor=null</c>. The cursor format is intentionally opaque (base64
+/// or token) so Phase 5 can choose its scheme without breaking the wire shape.
+/// </para>
+///
+/// <para>
+/// <b>Cache</b>: 5min HybridCache keyed by <c>toolkits:{toolkitId}:ratings:{cursor}:{limit}</c>
+/// (PR #732 §3.2 caching matrix — short TTL because submissions land in
+/// near-real-time once Phase 5 ships).
+/// </para>
+/// </remarks>
+internal sealed class GetToolkitRatingsQueryHandler
+    : IRequestHandler<GetToolkitRatingsQuery, ToolkitRatingsResponse?>
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private static readonly ToolkitRatingsBreakdownDto EmptyBreakdown =
+        new(Star1: 0, Star2: 0, Star3: 0, Star4: 0, Star5: 0);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitRatingsQueryHandler> _logger;
+
+    public GetToolkitRatingsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitRatingsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitRatingsResponse?> Handle(
+        GetToolkitRatingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cursor = request.Cursor ?? "_";
+        var cacheKey = $"toolkits:{request.ToolkitId}:ratings:{cursor}:{request.Limit}";
+
+        var container = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeAsync(request, ct).ConfigureAwait(false),
+            tags: [$"toolkit:{request.ToolkitId}", "ratings"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        return container.Response;
+    }
+
+    private async Task<ToolkitRatingsContainer> ComputeAsync(
+        GetToolkitRatingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.CreatedByUserId,
+                t.IsPublished,
+                t.TemplateStatus
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for ratings request (viewer={ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return new ToolkitRatingsContainer(null);
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        // PR #732 §5.2 security boundary — non-authors must not learn that
+        // a draft/yanked toolkit exists via the ratings surface.
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} hidden from viewer {ViewerId} (isOwner=false, isPublished={IsPublished})",
+                request.ToolkitId,
+                request.ViewerId,
+                isPublished);
+            return new ToolkitRatingsContainer(null);
+        }
+
+        // Schema reality v1 carryover (Gate B): no ToolkitRating entity yet —
+        // return empty stub envelope. Wire shape stable for FE.
+        var response = new ToolkitRatingsResponse(
+            Items: Array.Empty<ToolkitRatingDto>(),
+            NextCursor: null,
+            Breakdown: EmptyBreakdown,
+            AverageStars: 0m,
+            TotalCount: 0);
+
+        _logger.LogInformation(
+            "Returning empty ratings stub for toolkit {ToolkitId} (Gate B v1: ToolkitRating entity missing)",
+            request.ToolkitId);
+
+        return new ToolkitRatingsContainer(response);
+    }
+
+    /// <summary>
+    /// Cache-friendly wrapper so we can store nullable visibility-denied results
+    /// without HybridCache treating <c>null</c> as a cache miss.
+    /// </summary>
+    private sealed record ToolkitRatingsContainer(ToolkitRatingsResponse? Response);
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/GetToolkitRatingsQueryValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitRatingsQuery"/>.
+/// Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitRatingsQueryValidator
+    : AbstractValidator<GetToolkitRatingsQuery>
+{
+    public GetToolkitRatingsQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("ViewerId is required.");
+
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/ToolkitRatingDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitRatings/ToolkitRatingDto.cs
@@ -1,0 +1,45 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
+
+/// <summary>
+/// 5-star distribution for the ratings breakdown widget
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Schema reality v1 carryover (Gate B): the <c>ToolkitRating</c> entity does
+/// not exist yet — all counts are <c>0</c> until Phase 5 ships persistence.
+/// Wire shape is stable so the FE breakdown bars render today and switch to
+/// real counts without a refetch shape change.
+/// </remarks>
+internal sealed record ToolkitRatingsBreakdownDto(
+    int Star1,
+    int Star2,
+    int Star3,
+    int Star4,
+    int Star5
+);
+
+/// <summary>
+/// Single rating row.
+/// </summary>
+internal sealed record ToolkitRatingDto(
+    Guid Id,
+    string RaterDisplayName,
+    string? RaterAvatarUrl,
+    int Stars,
+    string? Comment,
+    DateTimeOffset CreatedAt
+);
+
+/// <summary>
+/// Cursor-paginated ratings envelope.
+/// Per PR #732 §3.4 empty-state contract: empty list is a 200 with
+/// <c>{ items: [] }</c>, not 404. <c>NextCursor</c> is <c>null</c> when there
+/// are no more pages.
+/// </summary>
+internal sealed record ToolkitRatingsResponse(
+    IReadOnlyList<ToolkitRatingDto> Items,
+    string? NextCursor,
+    ToolkitRatingsBreakdownDto Breakdown,
+    decimal AverageStars,
+    int TotalCount
+);

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQuery.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Query for a toolkit's published version history
+/// (Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805).
+/// </summary>
+/// <param name="ToolkitId">Toolkit aggregate id.</param>
+/// <param name="ViewerId">
+/// Authenticated caller — used by the security boundary (PR #732 §5.2):
+/// non-authors can only see versions of published+non-yanked toolkits.
+/// </param>
+/// <remarks>
+/// Returns <c>null</c> from the handler when the toolkit cannot be found
+/// or is not visible to the viewer; the endpoint maps that to 404.
+/// Returning an envelope with an empty <c>Items</c> list is reserved for
+/// the case where the toolkit exists and is visible but has no published
+/// versions yet (handler stub creates a single v1.0.x row in v1).
+/// </remarks>
+internal sealed record GetToolkitVersionsQuery(
+    Guid ToolkitId,
+    Guid ViewerId) : IQuery<ToolkitVersionsResponse?>;

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryHandler.cs
@@ -1,0 +1,142 @@
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Handler for <see cref="GetToolkitVersionsQuery"/> — returns the published
+/// version history sorted by <c>PublishedAt DESC</c>.
+/// Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Cache strategy (PR #732 §5.3.2): 10min HybridCache, no per-viewer
+/// partition — versions are non-personalised once the toolkit is visible
+/// (visibility check still executes per request before cache lookup).
+///
+/// Schema reality v1 carryover (Gate B): no <c>ToolkitVersion</c> entity.
+/// The handler synthesises a single-row stub: <c>{ version: "1.0.{int}",
+/// publishedAt: UpdatedAt or CreatedAt, yankedAt: null, changelog:
+/// "Initial version", isCurrent: true }</c>. Wire shape is stable so the
+/// FE versions list can render today and absorb the real history rows
+/// (sorted desc, isCurrent on the latest row) without a fetch shape change.
+/// </remarks>
+internal sealed class GetToolkitVersionsQueryHandler
+    : IRequestHandler<GetToolkitVersionsQuery, ToolkitVersionsResponse?>
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(10);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetToolkitVersionsQueryHandler> _logger;
+
+    public GetToolkitVersionsQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetToolkitVersionsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ToolkitVersionsResponse?> Handle(
+        GetToolkitVersionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Visibility check happens outside the cache so a non-author cannot
+        // benefit from a cached author response if the toolkit becomes a draft.
+        var entity = await _context.GameToolkits
+            .AsNoTracking()
+            .Where(t => t.Id == request.ToolkitId)
+            .Select(t => new
+            {
+                t.Id,
+                t.CreatedByUserId,
+                t.IsPublished,
+                t.TemplateStatus,
+                t.Version,
+                t.UpdatedAt,
+                t.CreatedAt,
+            })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} not found for versions request (viewer {ViewerId})",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var isOwner = entity.CreatedByUserId == request.ViewerId;
+        var isPublished = entity.IsPublished
+            && (TemplateStatus)entity.TemplateStatus == TemplateStatus.Approved;
+
+        if (!isOwner && !isPublished)
+        {
+            _logger.LogInformation(
+                "Toolkit {ToolkitId} versions hidden from viewer {ViewerId} (not published, not author)",
+                request.ToolkitId,
+                request.ViewerId);
+            return null;
+        }
+
+        var cacheKey = $"toolkits:{request.ToolkitId:N}:versions";
+        var cached = await _cache.GetOrCreateAsync(
+            cacheKey,
+            ct => Task.FromResult(BuildStubVersionsList(entity.Version, entity.UpdatedAt, entity.CreatedAt, isPublished)),
+            tags:
+            [
+                $"toolkit:{request.ToolkitId:N}",
+                "toolkitVersions",
+            ],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Returning {Count} version(s) for toolkit {ToolkitId} (viewer {ViewerId})",
+            cached.Items.Count,
+            request.ToolkitId,
+            request.ViewerId);
+
+        return cached;
+    }
+
+    /// <summary>
+    /// Synthesises the v1 stub versions list. When the toolkit has not yet
+    /// been published (<c>IsPublished == false</c>), the handler still returns
+    /// a single-row entry so the FE can render the "draft only" state without
+    /// special-casing — <c>publishedAt</c> falls back to <c>CreatedAt</c>.
+    /// </summary>
+    internal static ToolkitVersionsResponse BuildStubVersionsList(
+        int version,
+        DateTime updatedAt,
+        DateTime createdAt,
+        bool isPublished)
+    {
+        var publishedAt = isPublished ? updatedAt : createdAt;
+        var changelog = isPublished
+            ? "Initial version"
+            : "Draft — not yet published";
+
+        var items = new List<ToolkitVersionDto>
+        {
+            new(
+                Version: $"1.0.{version}",
+                PublishedAt: publishedAt,
+                YankedAt: null,
+                Changelog: changelog,
+                IsCurrent: true),
+        };
+
+        return new ToolkitVersionsResponse(items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/GetToolkitVersionsQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Validator for <see cref="GetToolkitVersionsQuery"/>.
+/// Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805.
+/// </summary>
+internal sealed class GetToolkitVersionsQueryValidator
+    : AbstractValidator<GetToolkitVersionsQuery>
+{
+    public GetToolkitVersionsQueryValidator()
+    {
+        RuleFor(x => x.ToolkitId)
+            .NotEmpty()
+            .WithMessage("ToolkitId is required.");
+
+        RuleFor(x => x.ViewerId)
+            .NotEmpty()
+            .WithMessage("ViewerId is required (caller must be authenticated).");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/ToolkitVersionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersions/ToolkitVersionDto.cs
@@ -1,0 +1,26 @@
+namespace Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+
+/// <summary>
+/// Wire DTO for a single toolkit version row
+/// (Wave 3 Phase 2, PR #732 §5.3.2 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Schema reality v1 carryover (Gate B): there is no <c>ToolkitVersion</c>
+/// entity yet — GameToolkitEntity stores a single <c>int Version</c> column
+/// that increments on Publish(). The handler synthesises a single-row stub
+/// list so the FE wire shape can stabilise ahead of the Phase 4 schema work.
+/// </remarks>
+internal sealed record ToolkitVersionDto(
+    string Version,
+    DateTime PublishedAt,
+    DateTime? YankedAt,
+    string Changelog,
+    bool IsCurrent);
+
+/// <summary>
+/// Response envelope for the versions endpoint — mirrors the empty-state
+/// contract from PR #732 §3.4 (200 with empty <c>items</c> rather than 404
+/// when the toolkit exists but has no published versions yet).
+/// </summary>
+internal sealed record ToolkitVersionsResponse(
+    IReadOnlyList<ToolkitVersionDto> Items);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdHandler.cs
@@ -1,35 +1,48 @@
 using Api.Infrastructure;
+using Api.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 
 /// <summary>
-/// Handles <see cref="GetKbChunkByIdQuery"/>.
-///
-/// Returns the full content of a single text chunk identified by (DocumentId, ChunkId).
-/// A 404 is thrown when the chunk does not exist or belongs to a different document —
-/// preventing cross-document chunk enumeration leakage.
-///
-/// Prev/next navigation IDs are resolved by looking for chunks at ChunkIndex ± 1 in the
-/// same document. This is a simple indexed lookup (one extra query each), consistent with
-/// the offset-pagination approach used by <c>GetKbChunksHandler</c>.
-///
-/// <c>HeadingPath</c> is built by walking up <c>ParentChunkId</c> via a single recursive
-/// CTE on PostgreSQL (one SQL round-trip). When the database is the InMemory provider
-/// (unit tests), the CTE is skipped and an empty array is returned — matching the pattern
-/// established in <c>GetKbChunksHandler.LoadHeadingPathsAsync</c>.
+/// Handler for <see cref="GetKbChunkByIdQuery"/> — Wave 3 Phase 3 spec-conformant
+/// rewrite of <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c> per PR #732
+/// §6.3.3 verbatim.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Prev/next navigation</b>: derived by lookup at <c>ChunkIndex - 1</c> and
+/// <c>ChunkIndex + 1</c> within the same document. First chunk → <c>PrevChunkId == null</c>;
+/// last chunk → <c>NextChunkId == null</c>.
+/// </para>
+///
+/// <para>
+/// <b>Markdown sanitization</b>: applied server-side via
+/// <see cref="MarkdownSubsetSanitizer.Sanitize"/> before emission. The raw
+/// content is preserved in the database — sanitization is presentation-layer.
+/// </para>
+///
+/// <para>
+/// <b>Caching</b>: 24h HybridCache. Chunks are immutable post-ingest, so the
+/// cache is keyed only by <c>(docId, chunkId)</c> — no per-viewer dimension.
+/// Access control is still enforced inside the factory before any data flows
+/// into the cache, so per-viewer 403 cannot leak (a denied viewer would see a
+/// fresh <c>ForbiddenException</c> on every request, never a cached payload).
+/// </para>
+///
+/// <para>
+/// <b>HeadingPath</b>: recursive CTE on PostgreSQL, empty array on InMemory
+/// (mirrors <c>GetKbChunksHandler</c>).
+/// </para>
+/// </remarks>
 internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery, KbChunkDetailDto>
 {
-    /// <summary>Maximum ancestor depth traversed by the recursive CTE.</summary>
     private const int MaxCteDepth = 10;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
 
-    // Recursive CTE that climbs the parent_chunk_id chain for a single seed chunk
-    // and collects non-null headings ordered from root to leaf (depth DESC).
-    // Column names are PascalCase — EF Core convention matches the migration
-    // 20260506111654_AddChunkHierarchyToTextChunkEntity.
     private static readonly string HeadingPathCte = @"
         WITH RECURSIVE chunk_path(id, ""Heading"", parent_chunk_id, depth) AS (
           SELECT
@@ -55,11 +68,16 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
         ORDER BY depth DESC;";
 
     private readonly MeepleAiDbContext _dbContext;
+    private readonly IHybridCacheService _cache;
     private readonly ILogger<GetKbChunkByIdHandler> _logger;
 
-    public GetKbChunkByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunkByIdHandler> logger)
+    public GetKbChunkByIdHandler(
+        MeepleAiDbContext dbContext,
+        IHybridCacheService cache,
+        ILogger<GetKbChunkByIdHandler> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -71,7 +89,25 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
             "Fetching KB chunk {ChunkId} from doc {DocId} (admin={IsAdmin})",
             query.ChunkId, query.DocumentId, query.UserIsAdmin);
 
-        // Issue #730 final review: enforce access control — check document ownership before chunk fetch.
+        // Access control runs OUTSIDE the cache so a denied viewer never receives
+        // a cached success payload. The cache key omits the viewer dimension —
+        // chunk content is immutable post-ingest, no per-viewer derivation.
+        await EnforceAccessControlAsync(query, cancellationToken).ConfigureAwait(false);
+
+        var cacheKey = $"kb:chunk:{query.DocumentId:N}:{query.ChunkId:N}";
+
+        return await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeAsync(query, ct).ConfigureAwait(false),
+            tags: ["kb", $"kbDoc:{query.DocumentId:N}", $"kbChunks:{query.DocumentId:N}"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnforceAccessControlAsync(
+        GetKbChunkByIdQuery query,
+        CancellationToken cancellationToken)
+    {
         var docAccess = await _dbContext.PdfDocuments.AsNoTracking()
             .Where(p => p.Id == query.DocumentId)
             .Select(p => new { p.IsPublic, p.UploadedByUserId })
@@ -89,8 +125,12 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
         {
             throw new ForbiddenException($"Access denied to document {query.DocumentId}");
         }
+    }
 
-        // Primary fetch — also validates that the chunk belongs to the requested document.
+    private async Task<KbChunkDetailDto> ComputeAsync(
+        GetKbChunkByIdQuery query,
+        CancellationToken cancellationToken)
+    {
         var chunk = await _dbContext.TextChunks.AsNoTracking()
             .Where(c => c.Id == query.ChunkId && c.PdfDocumentId == query.DocumentId)
             .Select(c => new
@@ -98,12 +138,7 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
                 c.Id,
                 c.Content,
                 c.PageNumber,
-                c.ChunkIndex,
-                c.Level,
-                c.Heading,
-                c.ParentChunkId,
-                c.CharacterCount,
-                c.ElementType
+                c.ChunkIndex
             })
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -114,7 +149,6 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
                 $"Chunk {query.ChunkId} not found in document {query.DocumentId}");
         }
 
-        // Prev/next navigation — look for chunks at ChunkIndex ± 1 in the same document.
         var prevChunkId = await _dbContext.TextChunks.AsNoTracking()
             .Where(c => c.PdfDocumentId == query.DocumentId && c.ChunkIndex == chunk.ChunkIndex - 1)
             .Select(c => (Guid?)c.Id)
@@ -131,34 +165,23 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
             .ConfigureAwait(false);
 
         return new KbChunkDetailDto(
-            ChunkId: chunk.Id,
-            Content: chunk.Content,
-            PageNumber: chunk.PageNumber,
+            Id: chunk.Id,
+            DocId: query.DocumentId,
             Position: chunk.ChunkIndex,
-            Level: chunk.Level,
             HeadingPath: headingPath,
+            Content: MarkdownSubsetSanitizer.Sanitize(chunk.Content),
+            PageNumber: chunk.PageNumber,
             PrevChunkId: prevChunkId,
             NextChunkId: nextChunkId,
-            VectorId: query.UserIsAdmin ? chunk.Id : (Guid?)null,
-            CharacterCount: query.UserIsAdmin ? chunk.CharacterCount : (int?)null,
-            ElementType: query.UserIsAdmin ? chunk.ElementType : null,
-            EmbeddingStatus: null,  // Issue #730: source field not yet in TextChunkEntity (follow-up)
-            ParentChunkId: query.UserIsAdmin ? chunk.ParentChunkId : null
+            // Gate B v1 carryover — TextChunkEntity has no Metadata column.
+            Metadata: new Dictionary<string, object>(StringComparer.Ordinal)
         );
     }
 
-    /// <summary>
-    /// Executes a recursive CTE on PostgreSQL to build the heading path for a single chunk
-    /// in a single round-trip.  Returns an empty list when running against the EF InMemory
-    /// provider (unit-test context) because raw SQL is not supported there.
-    /// </summary>
     private async Task<IReadOnlyList<string>> LoadHeadingPathAsync(
         Guid chunkId,
         CancellationToken cancellationToken)
     {
-        // InMemory provider does not support raw SQL — return empty paths so unit tests pass.
-        // Use string comparison (same pattern as GetKbChunksHandler) because the InMemory
-        // package is not referenced by the main project, making IsInMemory() unavailable.
         if (string.Equals(
                 _dbContext.Database.ProviderName,
                 "Microsoft.EntityFrameworkCore.InMemory",
@@ -175,6 +198,5 @@ internal sealed class GetKbChunkByIdHandler : IQueryHandler<GetKbChunkByIdQuery,
         return rows.Select(r => r.Value).ToList();
     }
 
-    /// <summary>Projection type for the scalar heading-path CTE result.</summary>
     private sealed record HeadingPathRow(string Value);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/GetKbChunkByIdQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
+
+/// <summary>
+/// Validator for <see cref="GetKbChunkByIdQuery"/>.
+/// Wave 3 Phase 3, PR #732 §6.3.3 / Issue #805.
+/// </summary>
+internal sealed class GetKbChunkByIdQueryValidator : AbstractValidator<GetKbChunkByIdQuery>
+{
+    public GetKbChunkByIdQueryValidator()
+    {
+        RuleFor(x => x.DocumentId).NotEmpty();
+        RuleFor(x => x.RequestingUserId).NotEmpty();
+        RuleFor(x => x.ChunkId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/KbChunkDetailDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkById/KbChunkDetailDto.cs
@@ -1,35 +1,40 @@
-using System.Text.Json.Serialization;
-
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 
 /// <summary>
-/// Full-content DTO for a single text chunk, including prev/next navigation IDs
-/// and a hierarchical heading breadcrumb (headingPath).
-/// Returned by <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c> (G2 goal).
-///
-/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
-/// they are omitted from the JSON response when <c>null</c>.  The global
-/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
-/// each admin-gated field must carry the annotation independently (Decision D4).
+/// Spec-conformant chunk detail DTO for
+/// <c>GET /api/v1/kb-docs/{id}/chunks/{chunkId}</c>
+/// (Wave 3 Phase 3, PR #732 §6.3.3 / Issue #805).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Path A full rewrite</b>: drops admin-gated <c>VectorId</c>,
+/// <c>CharacterCount</c>, <c>ElementType</c>, <c>EmbeddingStatus</c>,
+/// <c>ParentChunkId</c>, <c>Level</c>. <c>ChunkId</c> renamed to <c>Id</c>,
+/// <c>DocId</c> added per spec verbatim.
+/// </para>
+///
+/// <para>
+/// <b>Markdown subset</b>: <c>Content</c> is sanitized server-side via
+/// <see cref="Api.Infrastructure.Services.MarkdownSubsetSanitizer"/> before
+/// emission — H4-H6 demoted, raw HTML stripped, images replaced with
+/// <c>[Image: alt]</c>, footnotes stripped.
+/// </para>
+///
+/// <para>
+/// <b>Metadata</b>: Gate B v1 carryover — empty dictionary. The
+/// <c>TextChunkEntity</c> has no <c>Metadata</c> column in v1; the spec field
+/// is reserved for future structured chunk-level annotations
+/// (e.g. <c>tableData</c>, <c>diagramRefs</c>).
+/// </para>
+/// </remarks>
 internal sealed record KbChunkDetailDto(
-    Guid ChunkId,
+    Guid Id,
+    Guid DocId,
+    int Position,
+    IReadOnlyList<string> HeadingPath,
     string Content,
     int? PageNumber,
-    int Position,
-    short Level,
-    IReadOnlyList<string> HeadingPath,
     Guid? PrevChunkId,
     Guid? NextChunkId,
-
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    Guid? VectorId,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    int? CharacterCount,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? ElementType,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? EmbeddingStatus,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    Guid? ParentChunkId
+    IReadOnlyDictionary<string, object> Metadata
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksHandler.cs
@@ -1,5 +1,6 @@
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -7,32 +8,43 @@ using Microsoft.Extensions.Logging;
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 
 /// <summary>
-/// Handles <see cref="GetKbChunksQuery"/>.
-///
-/// Returns a paginated list of text chunks for the given document, ordered by ChunkIndex.
-/// Offset pagination is clamped to <see cref="MaxTake"/> = 100 per page.
-///
-/// Admin-only fields (<c>VectorId</c>, <c>CharacterCount</c>, <c>ElementType</c>, <c>EmbeddingStatus</c>)
-/// are populated only when <see cref="GetKbChunksQuery.UserIsAdmin"/> is <c>true</c>.
-///
-/// <c>HeadingPath</c> is built by walking up <c>ParentChunkId</c> via a single recursive
-/// CTE on PostgreSQL (one SQL round-trip for the whole page).  When the database is an
-/// InMemory provider (unit tests), the CTE is skipped and an empty array is returned.
+/// Handler for <see cref="GetKbChunksQuery"/> — Wave 3 Phase 3 spec-conformant
+/// rewrite of <c>GET /api/v1/kb-docs/{id}/chunks</c> per PR #732 §6.3.2 verbatim.
 /// </summary>
-internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChunkListDto>
+/// <remarks>
+/// <para>
+/// <b>Cursor pagination</b>: <c>(Position, Id)</c> tuple, <c>WHERE (Position, Id) > (cursor.Position, cursor.Id)
+/// ORDER BY Position ASC, Id ASC LIMIT n+1</c>. The (n+1)th row signals a next
+/// page; we drop it from <c>Items</c> and emit its cursor as <c>NextCursor</c>.
+/// </para>
+///
+/// <para>
+/// <b>HeadingPath</b>: built by walking up <c>ParentChunkId</c> via a single
+/// recursive CTE on PostgreSQL (one SQL round-trip for the whole page). When
+/// the database is the InMemory provider (unit tests), CTE is skipped and an
+/// empty array is returned per the established pattern.
+/// </para>
+///
+/// <para>
+/// <b>Caching</b>: 30min HybridCache keyed by
+/// <c>kb:chunks:{docId}:{viewerId}:c={cursor}:l={limit}</c>. Per-viewer because
+/// access-control may differ. Tags <c>["kb", "kbDoc:{id}", "kbChunks:{id}"]</c>
+/// for invalidation when the doc is re-indexed.
+/// </para>
+///
+/// <para>
+/// <b>VectorId</b> de-gating: emitted as a string for all viewers per spec
+/// §6.3.2 (security review documented on <see cref="KbChunkSummaryDto"/>).
+/// </para>
+/// </remarks>
+internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChunksListResponse>
 {
-    private const int MaxTake = 100;
     private const int SnippetMaxLength = 200;
-
-    /// <summary>Maximum ancestor depth traversed by the recursive CTE.</summary>
     private const int MaxCteDepth = 10;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(30);
 
-    // Recursive CTE that, for every seed id in the input array, climbs the
-    // parent_chunk_id chain up to MaxCteDepth levels and collects non-null headings.
-    // Column names are PascalCase — EF Core convention maps C# property names to
-    // identical DB column names unless [Column(...)] is used (confirmed: migration
-    // 20260506111654_AddChunkHierarchyToTextChunkEntity uses PascalCase names).
-    // Static readonly (not const) because C# does not allow string concatenation in const fields.
+    // Recursive CTE — see baseline GetKbChunksHandler for column-name rationale
+    // (PascalCase per migration AddChunkHierarchyToTextChunkEntity).
     private static readonly string HeadingPathCte = @"
         WITH RECURSIVE chunk_path(start_id, id, ""Heading"", parent_chunk_id, depth) AS (
           SELECT
@@ -60,29 +72,51 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
         ORDER BY start_id, depth DESC;";
 
     private readonly MeepleAiDbContext _dbContext;
+    private readonly IHybridCacheService _cache;
     private readonly ILogger<GetKbChunksHandler> _logger;
 
-    public GetKbChunksHandler(MeepleAiDbContext dbContext, ILogger<GetKbChunksHandler> logger)
+    public GetKbChunksHandler(
+        MeepleAiDbContext dbContext,
+        IHybridCacheService cache,
+        ILogger<GetKbChunksHandler> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<KbChunkListDto> Handle(GetKbChunksQuery query, CancellationToken cancellationToken)
+    public async Task<KbChunksListResponse> Handle(GetKbChunksQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var skip = Math.Max(0, query.Skip);
-        var take = Math.Clamp(query.Take, 1, MaxTake);
-
         _logger.LogDebug(
-            "Fetching KB chunks for doc {DocId} (skip={Skip}, take={Take}, admin={IsAdmin})",
-            query.DocumentId, skip, take, query.UserIsAdmin);
+            "Fetching KB chunks for doc {DocId} (cursor={Cursor}, limit={Limit}, admin={IsAdmin})",
+            query.DocumentId,
+            query.Cursor is null ? "<null>" : $"{query.Cursor.Position}:{query.Cursor.Id}",
+            query.Limit,
+            query.UserIsAdmin);
 
-        // Issue #730 fix: fetch document first to validate existence + enforce access control
+        var cursorKey = query.Cursor is null
+            ? "first"
+            : $"{query.Cursor.Position}:{query.Cursor.Id:N}";
+        var cacheKey = $"kb:chunks:{query.DocumentId:N}:{query.RequestingUserId:N}:c={cursorKey}:l={query.Limit}";
+
+        return await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeAsync(query, ct).ConfigureAwait(false),
+            tags: ["kb", $"kbDoc:{query.DocumentId:N}", $"kbChunks:{query.DocumentId:N}"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<KbChunksListResponse> ComputeAsync(
+        GetKbChunksQuery query,
+        CancellationToken cancellationToken)
+    {
+        // Validate doc existence + access control before chunk fetch.
         var doc = await _dbContext.PdfDocuments.AsNoTracking()
             .Where(p => p.Id == query.DocumentId)
-            .Select(p => new { p.ProcessingState, p.IsPublic, p.UploadedByUserId })
+            .Select(p => new { p.IsPublic, p.UploadedByUserId })
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -91,7 +125,6 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             throw new NotFoundException($"KB document {query.DocumentId} not found");
         }
 
-        // Issue #730 final review: enforce access control
         if (!doc.IsPublic
             && doc.UploadedByUserId != query.RequestingUserId
             && !query.UserIsAdmin)
@@ -99,73 +132,78 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             throw new ForbiddenException($"Access denied to document {query.DocumentId}");
         }
 
-        var processingStateLower = doc.ProcessingState.ToLowerInvariant();
-
         var totalCount = await _dbContext.TextChunks.AsNoTracking()
             .CountAsync(c => c.PdfDocumentId == query.DocumentId, cancellationToken)
             .ConfigureAwait(false);
 
-        var rows = await _dbContext.TextChunks.AsNoTracking()
-            .Where(c => c.PdfDocumentId == query.DocumentId)
+        // Cursor predicate: WHERE (Position, Id) > (cursorPosition, cursorId).
+        // EF translates the tuple comparison into the row-comparison the spec
+        // expects when targeting PostgreSQL.
+        var queryable = _dbContext.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.DocumentId);
+
+        if (query.Cursor is not null)
+        {
+            var cursorPosition = query.Cursor.Position;
+            var cursorId = query.Cursor.Id;
+            queryable = queryable.Where(c =>
+                c.ChunkIndex > cursorPosition
+                || (c.ChunkIndex == cursorPosition && c.Id.CompareTo(cursorId) > 0));
+        }
+
+        // Fetch limit + 1 to detect next page.
+        var rows = await queryable
             .OrderBy(c => c.ChunkIndex)
-            .Skip(skip)
-            .Take(take)
+            .ThenBy(c => c.Id)
+            .Take(query.Limit + 1)
             .Select(c => new
             {
                 c.Id,
                 c.PageNumber,
                 c.ChunkIndex,
-                c.Level,
-                c.Heading,
-                c.ParentChunkId,
-                c.Content,
-                c.CharacterCount,
-                c.ElementType
+                c.Content
             })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Phase 2: load heading paths for this page in a single SQL round-trip.
+        string? nextCursor = null;
+        if (rows.Count > query.Limit)
+        {
+            // Drop the lookahead row (position n+1) and emit a cursor pointing
+            // to the LAST returned row (position n) — the predicate on next
+            // request is `(Position, Id) > (cursor.Position, cursor.Id)` so
+            // the lookahead becomes the first item of the subsequent page.
+            rows = rows.Take(query.Limit).ToList();
+            var lastReturned = rows[^1];
+            nextCursor = KbChunksCursor.Encode(
+                new KbChunksCursor.CursorPayload(lastReturned.ChunkIndex, lastReturned.Id));
+        }
+
         var chunkIds = rows.Select(r => r.Id).ToList();
         var headingPaths = chunkIds.Count == 0
             ? new Dictionary<Guid, IReadOnlyList<string>>()
             : await LoadHeadingPathsAsync(chunkIds, cancellationToken).ConfigureAwait(false);
 
-        var chunks = rows.Select(r => new KbChunkSummaryDto(
-            ChunkId: r.Id,
-            PageNumber: r.PageNumber,
+        var items = rows.Select(r => new KbChunkSummaryDto(
+            Id: r.Id,
             Position: r.ChunkIndex,
-            Level: r.Level,
             HeadingPath: headingPaths.TryGetValue(r.Id, out var path) ? path : Array.Empty<string>(),
             Snippet: TruncateSnippet(r.Content),
-            VectorId: query.UserIsAdmin ? r.Id : (Guid?)null,
-            CharacterCount: query.UserIsAdmin ? r.CharacterCount : (int?)null,
-            ElementType: query.UserIsAdmin ? r.ElementType : null,
-            EmbeddingStatus: null  // Issue #730: source field not yet in TextChunkEntity (follow-up)
+            PageNumber: r.PageNumber,
+            VectorId: r.Id.ToString("N")
         )).ToList();
 
-        return new KbChunkListDto(
-            Chunks: chunks,
-            TotalCount: totalCount,
-            Skip: skip,
-            Take: take,
-            HasMore: skip + take < totalCount,
-            ProcessingState: processingStateLower
-        );
+        return new KbChunksListResponse(items, nextCursor, totalCount);
     }
 
     /// <summary>
-    /// Executes a recursive CTE on PostgreSQL to build heading paths for all chunk IDs
-    /// in a single round-trip.  Returns an empty dictionary when running against the
-    /// EF InMemory provider (unit-test context) because raw SQL is not supported there.
+    /// Executes recursive CTE on PostgreSQL; returns empty dict for InMemory.
+    /// Mirrors the baseline pattern from <c>GetKbChunksHandler.LoadHeadingPathsAsync</c>.
     /// </summary>
     private async Task<Dictionary<Guid, IReadOnlyList<string>>> LoadHeadingPathsAsync(
         IReadOnlyList<Guid> chunkIds,
         CancellationToken cancellationToken)
     {
-        // InMemory provider does not support raw SQL — return empty paths so unit tests pass.
-        // Use provider name comparison (same pattern as HandleOAuthCallbackCommandHandler) because
-        // the InMemory package is not referenced by the main project, making IsInMemory() unavailable.
         if (string.Equals(
                 _dbContext.Database.ProviderName,
                 "Microsoft.EntityFrameworkCore.InMemory",
@@ -184,7 +222,7 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
             .ToDictionary(
                 g => g.Key,
                 g => (IReadOnlyList<string>)g
-                    .OrderByDescending(x => x.Depth)   // root (deepest depth value) first
+                    .OrderByDescending(x => x.Depth)
                     .Select(x => x.Heading!)
                     .ToList());
     }
@@ -192,6 +230,5 @@ internal sealed class GetKbChunksHandler : IQueryHandler<GetKbChunksQuery, KbChu
     private static string TruncateSnippet(string content) =>
         content.Length <= SnippetMaxLength ? content : content[..SnippetMaxLength];
 
-    /// <summary>Projection type for the heading-path recursive CTE result.</summary>
     private sealed record HeadingPathRow(Guid StartId, string? Heading, int Depth);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQuery.cs
@@ -3,17 +3,30 @@ using Api.SharedKernel.Application.Interfaces;
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 
 /// <summary>
-/// Query to retrieve a paginated list of text chunks for a single KB document.
-/// Used by <c>GET /api/v1/kb-docs/{id}/chunks</c> (G1 goal).
-/// Admin-only fields (VectorId, CharacterCount, ElementType, EmbeddingStatus) are gated via <see cref="UserIsAdmin"/>.
-/// headingPath returns an empty array in this skeleton — recursive CTE populated in next commit.
-/// Access is denied (ForbiddenException) when the document is not public, not owned by
-/// <see cref="RequestingUserId"/>, and the requester is not an admin.
+/// Query to retrieve a cursor-paginated list of chunk summaries for a single
+/// KB document. Used by <c>GET /api/v1/kb-docs/{id}/chunks</c>.
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Cursor</b>: opaque base64-encoded <c>(Position, Id)</c> tuple. <c>null</c>
+/// for first page. Caller decodes via <see cref="KbChunksCursor.Decode"/> and
+/// returns 400 Bad Request on <see cref="FormatException"/>.
+/// </para>
+///
+/// <para>
+/// <b>Limit</b>: clamped 1..100 by validator; FE default is 50 per spec.
+/// </para>
+///
+/// <para>
+/// Access denied (<c>ForbiddenException</c>) when the document is private,
+/// not owned by <see cref="RequestingUserId"/>, and the requester is not admin.
+/// </para>
+/// </remarks>
 internal sealed record GetKbChunksQuery(
     Guid DocumentId,
     Guid RequestingUserId,
-    int Skip,
-    int Take,
+    KbChunksCursor.CursorPayload? Cursor,
+    int Limit,
     bool UserIsAdmin
-) : IQuery<KbChunkListDto>;
+) : IQuery<KbChunksListResponse>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/GetKbChunksQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Validator for <see cref="GetKbChunksQuery"/>.
+/// Wave 3 Phase 3, PR #732 §6.3.2 / Issue #805.
+/// </summary>
+internal sealed class GetKbChunksQueryValidator : AbstractValidator<GetKbChunksQuery>
+{
+    public GetKbChunksQueryValidator()
+    {
+        RuleFor(x => x.DocumentId).NotEmpty();
+        RuleFor(x => x.RequestingUserId).NotEmpty();
+        RuleFor(x => x.Limit).InclusiveBetween(1, 100);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkListDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkListDto.cs
@@ -1,14 +1,26 @@
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 
 /// <summary>
-/// Paginated list of text chunk summaries for a single KB document.
-/// Returned by <c>GET /api/v1/kb-docs/{id}/chunks</c> (G1 goal).
+/// Spec-conformant chunks list response DTO for
+/// <c>GET /api/v1/kb-docs/{id}/chunks</c> (Wave 3 Phase 3, PR #732 §6.3.2 /
+/// Issue #805).
 /// </summary>
-internal sealed record KbChunkListDto(
-    IReadOnlyList<KbChunkSummaryDto> Chunks,
-    int TotalCount,
-    int Skip,
-    int Take,
-    bool HasMore,
-    string ProcessingState
+/// <remarks>
+/// <para>
+/// <b>Path A full rewrite</b>: replaces offset pagination (<c>Skip</c>/<c>Take</c>/<c>HasMore</c>)
+/// with cursor pagination per spec verbatim. <c>NextCursor</c> is null on the
+/// last page. <c>ProcessingState</c> field dropped from the public response —
+/// the FE retrieves it via the doc-detail endpoint (which surfaces 423 Locked
+/// when the doc isn't ready).
+/// </para>
+///
+/// <para>
+/// Renamed from <c>KbChunkListDto</c> to <c>KbChunksListResponse</c> per spec
+/// nomenclature. Wire shape: <c>{ items, nextCursor, totalCount }</c>.
+/// </para>
+/// </remarks>
+internal sealed record KbChunksListResponse(
+    IReadOnlyList<KbChunkSummaryDto> Items,
+    string? NextCursor,
+    int TotalCount
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunkSummaryDto.cs
@@ -1,30 +1,33 @@
-using System.Text.Json.Serialization;
-
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 
 /// <summary>
-/// Summary DTO for a single text chunk in a paginated list.
-/// Returned as items within <see cref="KbChunkListDto"/>.
-///
-/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
-/// they are omitted from the JSON response when <c>null</c>.  The global
-/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
-/// each admin-gated field must carry the annotation independently (Decision D4).
+/// Spec-conformant chunk summary DTO for <c>GET /api/v1/kb-docs/{id}/chunks</c>
+/// (Wave 3 Phase 3, PR #732 §6.3.2 / Issue #805).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Path A full rewrite</b>: drops admin-gated <c>CharacterCount</c>,
+/// <c>ElementType</c>, <c>EmbeddingStatus</c>, <c>Level</c> from the public
+/// surface. <c>ChunkId</c> renamed to <c>Id</c> per spec verbatim.
+/// </para>
+///
+/// <para>
+/// <b>VectorId de-gating</b> — security review:
+/// </para>
+/// <para>
+/// The historical baseline admin-gated <c>VectorId</c> via <c>JsonIgnore</c>
+/// (Decision D4). Spec §6.3.2 requires public exposure for cross-reference with
+/// semantic search. PR #732 §3.5 API versioning rationale documents this as an
+/// intentional supersession: chunk vector IDs are internal references for
+/// search-result join joins, not user-sensitive content. Public exposure aligns
+/// with spec intent and Wave 3 unblock requirements.
+/// </para>
+/// </remarks>
 internal sealed record KbChunkSummaryDto(
-    Guid ChunkId,
-    int? PageNumber,
+    Guid Id,
     int Position,
-    short Level,
     IReadOnlyList<string> HeadingPath,
     string Snippet,
-
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    Guid? VectorId,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    int? CharacterCount,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? ElementType,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? EmbeddingStatus
+    int? PageNumber,
+    string VectorId
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunksCursor.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunks/KbChunksCursor.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Text;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+
+/// <summary>
+/// Opaque base64 cursor utility for chunks list pagination.
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Semantics</b>: <c>(Position, Id)</c> tuple — position is the primary
+/// sort key (chunk_index ASC), Id is the tiebreaker for deterministic ordering
+/// when chunks share a position (rare but possible in legacy data).
+/// </para>
+///
+/// <para>
+/// <b>Wire format</b>: base64-url of UTF8 <c>"{position}:{id-no-hyphens}"</c>.
+/// We use <c>:N</c> (no hyphens) for compactness; <c>Guid.Parse</c> accepts both.
+/// Malformed cursors (any decode/parse failure) → caller should respond 400.
+/// </para>
+/// </remarks>
+internal static class KbChunksCursor
+{
+    public sealed record CursorPayload(int Position, Guid Id);
+
+    public static string Encode(CursorPayload payload)
+    {
+        var raw = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{payload.Position}:{payload.Id:N}");
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(raw));
+    }
+
+    /// <summary>
+    /// Decodes a cursor payload. Returns <c>null</c> for null/empty input.
+    /// Throws <see cref="FormatException"/> on malformed input — caller maps
+    /// to HTTP 400 Bad Request.
+    /// </summary>
+    public static CursorPayload? Decode(string? cursor)
+    {
+        if (string.IsNullOrEmpty(cursor))
+        {
+            return null;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(cursor);
+        }
+        catch (FormatException)
+        {
+            throw new FormatException($"Invalid cursor encoding: {cursor}");
+        }
+
+        var decoded = Encoding.UTF8.GetString(bytes);
+        var parts = decoded.Split(':');
+        if (parts.Length != 2)
+        {
+            throw new FormatException($"Cursor payload malformed: expected 'position:id', got '{decoded}'");
+        }
+
+        if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var position))
+        {
+            throw new FormatException($"Cursor position not parseable as int: '{parts[0]}'");
+        }
+
+        if (!Guid.TryParse(parts[1], out var id))
+        {
+            throw new FormatException($"Cursor id not parseable as Guid: '{parts[1]}'");
+        }
+
+        return new CursorPayload(position, id);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdHandler.cs
@@ -1,28 +1,63 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
 
 /// <summary>
-/// Handles <see cref="GetKbDocumentByIdQuery"/>.
-///
-/// Joins <c>PdfDocumentEntity</c> (primary) with <c>VectorDocumentEntity</c> (optional LEFT JOIN)
-/// so that documents still being processed (no VectorDocument yet) are returned with
-/// <c>TotalChunks = 0</c> and <c>IndexedAt = null</c> rather than a 404.
-///
-/// Admin-only fields (<c>ProcessingError</c>, <c>RetryCount</c>, <c>FailedAtState</c>) are
-/// populated only when <see cref="GetKbDocumentByIdQuery.UserIsAdmin"/> is <c>true</c>.
+/// Handler for <see cref="GetKbDocumentByIdQuery"/> — Wave 3 Phase 3 spec-conformant
+/// rewrite of <c>GET /api/v1/kb-docs/{id}</c> per PR #732 §6.3.1 verbatim.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Semantics</b>:
+/// <list type="bullet">
+///   <item>200 OK + full DTO when <c>processingStatus == 'ready'</c>.</item>
+///   <item>404 Not Found when document is missing.</item>
+///   <item>403 Forbidden when private doc + non-owner non-admin viewer.</item>
+///   <item>423 Locked when <c>processingStatus != 'ready'</c> — distinct from 404
+///         per Nygard's operational note. The exception payload still includes
+///         partial document metadata for the FE "in elaborazione" render path.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <b>Caching</b>: 1h HybridCache keyed by <c>kb:doc:{docId}:{viewerId}</c>.
+/// Per-viewer because the access-control gate may produce 403 for one viewer
+/// but 200 for another. Tags <c>["kb", "kbDoc:{id}"]</c> for invalidation when
+/// chunks are re-indexed.
+/// </para>
+///
+/// <para>
+/// <b>DocType / ProcessingStatus mapping</b>: see <see cref="MapDocType"/> and
+/// <see cref="MapProcessingStatus"/>. P21 reuse from
+/// <c>GetRecentKbDocsQueryHandler</c> for docType, extended with the 8-state
+/// processingStatus collapse.
+/// </para>
+/// </remarks>
 internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentByIdQuery, KbDocumentDto>
 {
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
     private readonly MeepleAiDbContext _dbContext;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IHybridCacheService _cache;
     private readonly ILogger<GetKbDocumentByIdHandler> _logger;
 
-    public GetKbDocumentByIdHandler(MeepleAiDbContext dbContext, ILogger<GetKbDocumentByIdHandler> logger)
+    public GetKbDocumentByIdHandler(
+        MeepleAiDbContext dbContext,
+        ISharedGameRepository sharedGameRepository,
+        IHybridCacheService cache,
+        ILogger<GetKbDocumentByIdHandler> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -32,6 +67,34 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
 
         _logger.LogDebug("Fetching KB document {DocId} (admin={IsAdmin})", query.DocumentId, query.UserIsAdmin);
 
+        var cacheKey = $"kb:doc:{query.DocumentId:N}:{query.RequestingUserId:N}:{(query.UserIsAdmin ? "a" : "u")}";
+
+        // Wrap in container so HybridCache's class constraint is satisfied for
+        // the value channel — the wrapper carries either the DTO or a flag for
+        // 423 Locked semantics so we don't lose it across the cache boundary.
+        var cached = await _cache.GetOrCreateAsync(
+            cacheKey,
+            async ct => await ComputeAsync(query, ct).ConfigureAwait(false),
+            tags: ["kb", $"kbDoc:{query.DocumentId:N}"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        if (cached.Locked)
+        {
+            // Throw outside the factory so 423 is not cached as success.
+            // (The cache stored the locked-state DTO snapshot to avoid a re-fetch
+            // if another request hits the same key while still locked.)
+            throw new LockedException(
+                $"KB document {query.DocumentId} is in processing state '{cached.Dto?.ProcessingStatus}' — not yet ready.");
+        }
+
+        return cached.Dto!;
+    }
+
+    private async Task<KbDocResultContainer> ComputeAsync(
+        GetKbDocumentByIdQuery query,
+        CancellationToken cancellationToken)
+    {
         var data = await (
             from pdf in _dbContext.PdfDocuments.AsNoTracking()
             join vd in _dbContext.VectorDocuments.AsNoTracking()
@@ -41,9 +104,9 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             select new
             {
                 pdf,
-                TotalChunks = vd != null ? vd.ChunkCount : 0,
+                ChunkCount = vd != null ? vd.ChunkCount : 0,
                 IndexedAt = vd != null ? vd.IndexedAt : (DateTime?)null,
-                GameId = vd != null ? vd.GameId : (Guid?)null
+                JoinedGameId = vd != null ? vd.GameId : (Guid?)null
             }
         ).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
@@ -52,7 +115,7 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             throw new NotFoundException($"KB document {query.DocumentId} not found");
         }
 
-        // Issue #730 final review: enforce access control
+        // Access control — private doc, non-owner, non-admin viewer → 403.
         if (!data.pdf.IsPublic
             && data.pdf.UploadedByUserId != query.RequestingUserId
             && !query.UserIsAdmin)
@@ -60,22 +123,107 @@ internal sealed class GetKbDocumentByIdHandler : IQueryHandler<GetKbDocumentById
             throw new ForbiddenException($"Access denied to document {query.DocumentId}");
         }
 
-        return new KbDocumentDto(
+        // Uploader join — DisplayName preferred, email fallback when missing.
+        var uploader = await _dbContext.Set<UserEntity>()
+            .AsNoTracking()
+            .Where(u => u.Id == data.pdf.UploadedByUserId)
+            .Select(u => new { u.DisplayName, u.Email })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var uploaderName = !string.IsNullOrWhiteSpace(uploader?.DisplayName)
+            ? uploader!.DisplayName!
+            : !string.IsNullOrWhiteSpace(uploader?.Email)
+                ? uploader.Email
+                : "Unknown uploader";
+
+        // Game name join — prefer SharedGameId (post-ingest canonical) over the
+        // VectorDocument-derived GameId (legacy join). Falls back to null when
+        // the doc isn't game-scoped.
+        var resolvedGameId = data.pdf.SharedGameId ?? data.JoinedGameId;
+        string? gameName = null;
+        if (resolvedGameId.HasValue)
+        {
+            var gameNames = await _sharedGameRepository
+                .GetNamesByIdsAsync(new[] { resolvedGameId.Value }, cancellationToken)
+                .ConfigureAwait(false);
+            gameNames.TryGetValue(resolvedGameId.Value, out gameName);
+        }
+
+        var lastIngestedAt = data.IndexedAt ?? data.pdf.ProcessedAt ?? data.pdf.UploadedAt;
+        var processingStatus = MapProcessingStatus(data.pdf.ProcessingState);
+
+        var dto = new KbDocumentDto(
             Id: data.pdf.Id,
-            Title: data.pdf.FileName,
-            GameId: data.GameId,
-            SharedGameId: data.pdf.SharedGameId,
-            DocumentCategory: data.pdf.DocumentCategory,
-            ProcessingState: data.pdf.ProcessingState.ToLowerInvariant(),
-            TotalChunks: data.TotalChunks,
-            PageCount: data.pdf.PageCount ?? 0,
-            IndexedAt: data.IndexedAt,
+            Title: DeriveTitle(data.pdf.FileName),
+            DocType: MapDocType(data.pdf.DocumentCategory),
+            GameId: resolvedGameId,
+            GameName: gameName,
+            UploaderName: uploaderName,
             UploadedAt: data.pdf.UploadedAt,
-            Language: data.pdf.Language,
-            VersionLabel: data.pdf.VersionLabel,
-            ProcessingError: query.UserIsAdmin ? data.pdf.ProcessingError : null,
-            RetryCount: query.UserIsAdmin && data.pdf.RetryCount > 0 ? data.pdf.RetryCount : (int?)null,
-            FailedAtState: query.UserIsAdmin ? data.pdf.FailedAtState : null
+            LastIngestedAt: lastIngestedAt,
+            ProcessingStatus: processingStatus,
+            ChunkCount: data.ChunkCount,
+            PageCount: data.pdf.PageCount,
+            Language: string.IsNullOrWhiteSpace(data.pdf.Language) ? "it" : data.pdf.Language,
+            // Gate B v1 carryover — PdfDocumentEntity has no Tags column yet.
+            Tags: Array.Empty<string>()
         );
+
+        return new KbDocResultContainer(
+            Dto: dto,
+            Locked: !string.Equals(processingStatus, "ready", StringComparison.Ordinal));
     }
+
+    /// <summary>
+    /// Strips trailing <c>.pdf</c> extension (case-insensitive) so the FE can
+    /// render a clean title. Mirrors <c>GetRecentKbDocsQueryHandler.DeriveTitle</c>.
+    /// </summary>
+    private static string DeriveTitle(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return string.Empty;
+        }
+
+        const string pdfExt = ".pdf";
+        return fileName.EndsWith(pdfExt, StringComparison.OrdinalIgnoreCase)
+            ? fileName[..^pdfExt.Length]
+            : fileName;
+    }
+
+    /// <summary>
+    /// Collapses 7-value <c>DocumentCategory</c> enum → 4-value FE wire vocab.
+    /// P21 reuse from <c>GetRecentKbDocsQueryHandler.MapDocType</c>.
+    /// </summary>
+    private static string MapDocType(string documentCategory) => documentCategory switch
+    {
+        "Rulebook" => "rulebook",
+        "Errata" => "errata",
+        // Expansion, QuickStart, Reference, PlayerAid, Other → "guide"
+        _ => "guide"
+    };
+
+    /// <summary>
+    /// Collapses 8-state internal <c>PdfProcessingState</c> (Pending, Uploading,
+    /// Extracting, Chunking, Embedding, Indexing, Ready, Failed) into the
+    /// 4-value FE wire vocabulary <c>{queued, processing, ready, failed}</c>
+    /// per PR #732 §6.3.1 spec.
+    /// </summary>
+    private static string MapProcessingStatus(string processingState) => processingState switch
+    {
+        "Ready" => "ready",
+        "Failed" => "failed",
+        "Pending" or "Uploading" => "queued",
+        // Extracting, Chunking, Embedding, Indexing → "processing"
+        _ => "processing"
+    };
+
+    /// <summary>
+    /// Cache value container — also carries the 423 Locked flag so we don't
+    /// lose semantics across the cache boundary. The DTO is non-null in both
+    /// success and locked cases; the flag controls whether the handler should
+    /// throw <see cref="LockedException"/> after retrieval.
+    /// </summary>
+    internal sealed record KbDocResultContainer(KbDocumentDto Dto, bool Locked);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/GetKbDocumentByIdQueryValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+
+/// <summary>
+/// Validator for <see cref="GetKbDocumentByIdQuery"/>.
+/// Wave 3 Phase 3, PR #732 §6.3.1 / Issue #805.
+/// </summary>
+internal sealed class GetKbDocumentByIdQueryValidator : AbstractValidator<GetKbDocumentByIdQuery>
+{
+    public GetKbDocumentByIdQueryValidator()
+    {
+        RuleFor(x => x.DocumentId).NotEmpty();
+        RuleFor(x => x.RequestingUserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentById/KbDocumentDto.cs
@@ -1,36 +1,58 @@
-using System.Text.Json.Serialization;
-
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
 
 /// <summary>
-/// Full metadata DTO for a single KB document.
-/// Returned by <c>GET /api/v1/kb-docs/{id}</c> (G4 goal).
-///
-/// Admin-only fields are decorated with <see cref="JsonIgnoreAttribute"/> so that
-/// they are omitted from the JSON response when <c>null</c>.  The global
-/// <c>ConfigureHttpJsonOptions</c> does NOT set <c>DefaultIgnoreCondition</c>, so
-/// each admin-gated field must carry the annotation independently (Decision D4).
+/// Spec-conformant document detail DTO for <c>GET /api/v1/kb-docs/{id}</c>
+/// (Wave 3 Phase 3, PR #732 §6.3.1 / Issue #805).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Path A full rewrite</b>: this replaces the previous Issue #730 baseline DTO
+/// (<c>KbDocumentDto</c> with <c>SharedGameId</c> / <c>DocumentCategory</c> raw enum,
+/// <c>IndexedAt</c>, <c>ProcessingError</c>, <c>RetryCount</c>, <c>FailedAtState</c>).
+/// All admin-gated fields are dropped from the public surface per spec §6.3.1
+/// verbatim. The 423 Locked status semantically distinguishes "in elaborazione"
+/// (processingStatus != 'ready') from 404 "not found" (Nygard operational note).
+/// </para>
+///
+/// <para>
+/// <b>Field mapping</b>:
+/// <list type="bullet">
+///   <item><c>DocType</c> — collapses 7-value <c>DocumentCategory</c> enum into
+///         the 4-value FE wire vocabulary <c>{rulebook, faq, errata, guide}</c>
+///         (Phase 1 P21 reuse from <c>RecentKbDocDto</c>).</item>
+///   <item><c>ProcessingStatus</c> — collapses raw 8-state <c>ProcessingState</c>
+///         into the 4-value FE wire vocabulary <c>{queued, processing, ready, failed}</c>.</item>
+///   <item><c>GameName</c> — joined from <c>SharedGameCatalog</c> via
+///         <c>ISharedGameRepository.GetNamesByIdsAsync</c> (single batch query, no N+1).</item>
+///   <item><c>UploaderName</c> — joined from <c>UserEntity.DisplayName</c> with
+///         email fallback (graceful degradation when account removed).</item>
+///   <item><c>LastIngestedAt</c> — non-null fallback to <c>UploadedAt</c> when
+///         <c>ProcessedAt</c> is null (matches Phase 1 RecentKbDocs convention).</item>
+///   <item><c>Tags</c> — Gate B v1 carryover: empty array (<c>PdfDocumentEntity</c>
+///         has no <c>Tags</c> column in v1).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <b>Decision D4 (admin-gated fields) supersedes</b>: the historical baseline
+/// admin-gated <c>ProcessingError</c>, <c>RetryCount</c>, <c>FailedAtState</c>
+/// via <c>JsonIgnore</c>. Spec §6.3.1 omits these from the public surface, so
+/// they're removed entirely (admins must use a separate <c>/admin/kb-docs/{id}</c>
+/// endpoint when one exists — out of scope for Wave 3 Phase 3).
+/// </para>
+/// </remarks>
 internal sealed record KbDocumentDto(
     Guid Id,
     string Title,
+    string DocType,
     Guid? GameId,
-    Guid? SharedGameId,
-    string DocumentCategory,
-    string ProcessingState,
-    int TotalChunks,
-    int PageCount,
-    DateTime? IndexedAt,
+    string? GameName,
+    string UploaderName,
     DateTime UploadedAt,
+    DateTime LastIngestedAt,
+    string ProcessingStatus,
+    int ChunkCount,
+    int? PageCount,
     string Language,
-    string? VersionLabel,
-
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? ProcessingError,
-
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    int? RetryCount,
-
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? FailedAtState
+    IReadOnlyList<string> Tags
 );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQuery.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetPopularAgents;
+
+/// <summary>
+/// Query for the most popular agents in the catalog
+/// (Wave 3 Phase 1, PR #732 §4.3.3 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of agents to return. Validator clamps to [1, 50]; default 10.</param>
+internal sealed record GetPopularAgentsQuery(int Limit = 10) : IQuery<IReadOnlyList<PopularAgentDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQueryHandler.cs
@@ -1,0 +1,121 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetPopularAgents;
+
+/// <summary>
+/// Handler for <see cref="GetPopularAgentsQuery"/> — returns the top-N active
+/// agents sorted by popularity. Wave 3 Phase 1, PR #732 §4.3.3 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Sort: <c>InstallCount DESC</c>, then <c>InvocationCount DESC</c> (tiebreak),
+/// then <c>CreatedAt DESC</c> (final tiebreak for deterministic ordering when
+/// both metrics are zero).
+///
+/// Schema reality v1 carryover: there is no per-user installation tracking
+/// entity in the current schema, so <c>InstallCount</c> is always <c>0</c>
+/// and the sort effectively collapses to <c>InvocationCount DESC</c>.
+/// This is documented as Gate B in the FE Phase 0.5 contract — the wire
+/// shape is stable so the discover rail can render today and adopt the real
+/// install metric without a fetch shape change.
+///
+/// Cache TTL: 15 minutes (PR #732 §3.2 caching matrix). Bulk-fetches game
+/// names for ordered slice (no N+1) using the same pattern as
+/// <see cref="KnowledgeBase.Application.Queries.GetRecentAgentsQueryHandler"/>.
+/// </remarks>
+internal sealed class GetPopularAgentsQueryHandler
+    : IRequestHandler<GetPopularAgentsQuery, IReadOnlyList<PopularAgentDto>>
+{
+    private const string CacheKey = "discover:popularAgents";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(15);
+
+    private readonly IAgentDefinitionRepository _agentRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetPopularAgentsQueryHandler> _logger;
+
+    public GetPopularAgentsQueryHandler(
+        IAgentDefinitionRepository agentRepository,
+        ISharedGameRepository sharedGameRepository,
+        IHybridCacheService cache,
+        ILogger<GetPopularAgentsQueryHandler> logger)
+    {
+        _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<PopularAgentDto>> Handle(
+        GetPopularAgentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allPopular = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputePopularAgentsAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["agents", "discover", "popularAgents"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allPopular.Take(request.Limit).ToArray();
+
+        _logger.LogInformation(
+            "Returning {Count} popular agents (limit={Limit}) from cache/compute",
+            trimmed.Length,
+            request.Limit);
+
+        return trimmed;
+    }
+
+    private async Task<List<PopularAgentDto>> ComputePopularAgentsAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        var agents = await _agentRepository
+            .GetAllActiveAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Schema reality v1 carryover: InstallCount = 0 (no AgentInstallation entity yet).
+        // Sort collapses to InvocationCount DESC + CreatedAt DESC tiebreak in v1.
+        var ordered = agents
+            .OrderByDescending(a => a.InvocationCount)
+            .ThenByDescending(a => a.CreatedAt)
+            .Take(limit)
+            .ToList();
+
+        var gameIds = ordered
+            .Where(a => a.GameId.HasValue)
+            .Select(a => a.GameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(gameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        return ordered.Select(agent =>
+        {
+            var gameName = agent.GameId.HasValue
+                && gameNames.TryGetValue(agent.GameId.Value, out var name)
+                    ? name
+                    : null;
+
+            return new PopularAgentDto(
+                Id: agent.Id,
+                Name: agent.Name,
+                GameId: agent.GameId,
+                GameName: gameName,
+                InstallCount: 0,
+                InvocationCount: agent.InvocationCount);
+        }).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/GetPopularAgentsQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetPopularAgents;
+
+/// <summary>
+/// Validator for <see cref="GetPopularAgentsQuery"/>.
+/// Wave 3 Phase 1, PR #732 §4.3.3 / Issue #805.
+/// </summary>
+internal sealed class GetPopularAgentsQueryValidator : AbstractValidator<GetPopularAgentsQuery>
+{
+    public GetPopularAgentsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/PopularAgentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetPopularAgents/PopularAgentDto.cs
@@ -1,0 +1,26 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetPopularAgents;
+
+/// <summary>
+/// Lightweight DTO for the /api/v1/agents/popular endpoint
+/// (Wave 3 Phase 1, PR #732 §4.3.3 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the SP4 /discover route's "Popular agents" rail (frontend
+/// <c>useDiscoverPopularAgents</c>).
+///
+/// Schema reality v1 carryover: there is no per-user installation tracking
+/// entity (no <c>AgentInstallation</c> aggregate); <c>InstallCount</c> is
+/// always returned as <c>0</c> until that surface lands. Sort therefore
+/// effectively collapses to <c>InvocationCount DESC</c> in v1. This is
+/// documented as Gate B in the implementation note for the FE Phase 0.5
+/// contract — the response shape is stable so the FE rail can render today
+/// and adopt the real install metric without a re-fetch shape change.
+/// </remarks>
+internal sealed record PopularAgentDto(
+    Guid Id,
+    string Name,
+    Guid? GameId,
+    string? GameName,
+    int InstallCount,
+    int InvocationCount
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQuery.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocs;
+
+/// <summary>
+/// Query for the most recently indexed knowledge-base documents
+/// (Wave 3 Phase 1, PR #732 §4.3.5 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of docs to return. Validator clamps to [1, 50]; default 10.</param>
+internal sealed record GetRecentKbDocsQuery(int Limit = 10) : IQuery<IReadOnlyList<RecentKbDocDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQueryHandler.cs
@@ -1,0 +1,172 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocs;
+
+/// <summary>
+/// Handler for <see cref="GetRecentKbDocsQuery"/> — returns the most recently
+/// indexed knowledge-base PDF documents (canonical "Ready" state) sorted by
+/// <c>ProcessedAt DESC</c> with a fallback to <c>UploadedAt DESC</c>.
+/// Wave 3 Phase 1, PR #732 §4.3.5 / Issue #805.
+/// </summary>
+/// <remarks>
+/// <para><b>Filter</b>: <c>ProcessingState == "Ready"</c> excludes in-flight
+/// (Pending/Uploading/.../Failed) ingests. The terminal-success state matches
+/// the spec's <c>processingStatus == 'ready'</c> contract.</para>
+///
+/// <para><b>Cache</b>: Redis 5min via HybridCache (PR #732 §3.2 caching matrix).
+/// Tags <c>["kb", "discover", "recentDocs"]</c> for batch invalidation when a
+/// new doc enters the Ready state.</para>
+///
+/// <para><b>Cross-BC read</b>: persistence model lives in DocumentProcessing
+/// (<see cref="PdfDocumentEntity"/>) but the query is owned by the KnowledgeBase
+/// BC because /discover is a KB-product surface. Bulk-fetches game names from
+/// SharedGameCatalog for the ordered slice (no N+1).</para>
+/// </remarks>
+internal sealed class GetRecentKbDocsQueryHandler
+    : IRequestHandler<GetRecentKbDocsQuery, IReadOnlyList<RecentKbDocDto>>
+{
+    private const string CacheKey = "discover:recentKbDocs";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    // PdfDocumentEntity.ProcessingState is persisted as a string. Match the
+    // canonical "Ready" terminal-success token (see PdfProcessingState enum
+    // in DocumentProcessing.Domain.Enums).
+    private const string ReadyState = "Ready";
+
+    private readonly MeepleAiDbContext _context;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetRecentKbDocsQueryHandler> _logger;
+
+    public GetRecentKbDocsQueryHandler(
+        MeepleAiDbContext context,
+        ISharedGameRepository sharedGameRepository,
+        IHybridCacheService cache,
+        ILogger<GetRecentKbDocsQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<RecentKbDocDto>> Handle(
+        GetRecentKbDocsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allRecent = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeRecentDocsAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["kb", "discover", "recentDocs"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allRecent.Take(request.Limit).ToArray();
+
+        _logger.LogInformation(
+            "Returning {Count} recent KB docs (limit={Limit}) from cache/compute",
+            trimmed.Length,
+            request.Limit);
+
+        return trimmed;
+    }
+
+    private async Task<List<RecentKbDocDto>> ComputeRecentDocsAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Read PdfDocumentEntity rows that have completed ingestion. We project
+        // the chunk count from VectorDocuments (one-to-one for the indexed slice)
+        // via a left-join LINQ subquery so a missing VectorDocument row degrades
+        // gracefully to chunkCount=0 rather than excluding the doc.
+        var rows = await _context.Set<PdfDocumentEntity>()
+            .AsNoTracking()
+            .Where(p => p.ProcessingState == ReadyState)
+            .OrderByDescending(p => p.ProcessedAt ?? p.UploadedAt)
+            .Take(limit)
+            .Select(p => new
+            {
+                p.Id,
+                p.FileName,
+                p.SharedGameId,
+                p.DocumentCategory,
+                IngestedAt = p.ProcessedAt ?? p.UploadedAt,
+                ChunkCount = _context.Set<VectorDocumentEntity>()
+                    .Where(v => v.PdfDocumentId == p.Id)
+                    .Select(v => (int?)v.ChunkCount)
+                    .FirstOrDefault() ?? 0
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var gameIds = rows
+            .Where(r => r.SharedGameId.HasValue)
+            .Select(r => r.SharedGameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(gameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        return rows.Select(r =>
+        {
+            var gameName = r.SharedGameId.HasValue
+                && gameNames.TryGetValue(r.SharedGameId.Value, out var name)
+                    ? name
+                    : null;
+
+            return new RecentKbDocDto(
+                Id: r.Id,
+                Title: DeriveTitle(r.FileName),
+                GameId: r.SharedGameId,
+                GameName: gameName,
+                DocType: MapDocType(r.DocumentCategory),
+                LastIngestedAt: r.IngestedAt,
+                ChunkCount: r.ChunkCount);
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Strips the trailing <c>.pdf</c> extension (case-insensitive) so the FE
+    /// can render a clean title without an additional transform. Falls back to
+    /// the raw filename when no extension is present.
+    /// </summary>
+    private static string DeriveTitle(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return string.Empty;
+        }
+
+        const string pdfExt = ".pdf";
+        return fileName.EndsWith(pdfExt, StringComparison.OrdinalIgnoreCase)
+            ? fileName[..^pdfExt.Length]
+            : fileName;
+    }
+
+    /// <summary>
+    /// Collapses the 7-value <see cref="DocumentProcessing.Domain.Enums.DocumentCategory"/>
+    /// enum into the 4-value FE wire vocabulary documented on
+    /// <see cref="RecentKbDocDto"/>.
+    /// </summary>
+    private static string MapDocType(string documentCategory) => documentCategory switch
+    {
+        "Rulebook" => "rulebook",
+        "Errata" => "errata",
+        // Expansion, QuickStart, Reference, PlayerAid, Other → "guide"
+        _ => "guide"
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/GetRecentKbDocsQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocs;
+
+/// <summary>
+/// Validator for <see cref="GetRecentKbDocsQuery"/>.
+/// Wave 3 Phase 1, PR #732 §4.3.5 / Issue #805.
+/// </summary>
+internal sealed class GetRecentKbDocsQueryValidator : AbstractValidator<GetRecentKbDocsQuery>
+{
+    public GetRecentKbDocsQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/RecentKbDocDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetRecentKbDocs/RecentKbDocDto.cs
@@ -1,0 +1,31 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocs;
+
+/// <summary>
+/// Lightweight DTO for the /api/v1/kb-docs/recent endpoint
+/// (Wave 3 Phase 1, PR #732 §4.3.5 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the SP4 /discover route's "Recent KB docs" rail (frontend
+/// <c>useDiscoverRecentKbDocs</c>).
+///
+/// <para><b>DocType mapping</b> — the persisted <c>PdfDocumentEntity.DocumentCategory</c>
+/// enum collapses into a smaller wire vocabulary expected by the FE:
+/// <list type="bullet">
+///   <item><c>Rulebook</c> → <c>"rulebook"</c></item>
+///   <item><c>Errata</c> → <c>"errata"</c></item>
+///   <item><c>Expansion | QuickStart | Reference | PlayerAid | Other</c> → <c>"guide"</c></item>
+/// </list>
+/// The FE contract also defines <c>"faq"</c> for forward-compat with the
+/// <c>GameFaqEntity</c> surface; v1 will not emit it from this endpoint
+/// since FAQs are not <see cref="Api.Infrastructure.Entities.PdfDocumentEntity"/> rows.
+/// </para>
+/// </remarks>
+internal sealed record RecentKbDocDto(
+    Guid Id,
+    string Title,
+    Guid? GameId,
+    string? GameName,
+    string DocType,
+    DateTime LastIngestedAt,
+    int ChunkCount
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQuery.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Query for the most recently created shared games in the catalog
+/// (Wave 3 Phase 1, PR #732 §4.3.2 / Issue #805).
+/// </summary>
+/// <param name="Limit">Number of games to return. Validator clamps to [1, 50]; default 10.</param>
+internal sealed record GetNewGamesQuery(int Limit = 10) : IQuery<IReadOnlyList<NewGameDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
@@ -1,0 +1,105 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Handler for <see cref="GetNewGamesQuery"/> — returns the most recently
+/// created shared games sorted by <c>CreatedAt DESC</c>.
+/// Wave 3 Phase 1, PR #732 §4.3.2 / Issue #805.
+/// </summary>
+/// <remarks>
+/// Strategy mirrors <see cref="GetCatalogTrending.GetCatalogTrendingQueryHandler"/>:
+/// always materialize the full <see cref="MaxCacheLimit"/> set and trim to the
+/// requested limit so a single cache entry serves all caller variants.
+/// Cache TTL: 1 hour (PR #732 §3.2 caching matrix). Excludes soft-deleted rows.
+/// </remarks>
+internal sealed class GetNewGamesQueryHandler
+    : IRequestHandler<GetNewGamesQuery, IReadOnlyList<NewGameDto>>
+{
+    private const string CacheKey = "discover:newGames";
+    private const int MaxCacheLimit = 50;
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<GetNewGamesQueryHandler> _logger;
+
+    public GetNewGamesQueryHandler(
+        MeepleAiDbContext context,
+        IHybridCacheService cache,
+        ILogger<GetNewGamesQueryHandler> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<NewGameDto>> Handle(
+        GetNewGamesQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var allNew = await _cache.GetOrCreateAsync(
+            CacheKey,
+            async ct => await ComputeNewGamesAsync(MaxCacheLimit, ct).ConfigureAwait(false),
+            tags: ["catalog", "discover", "newGames"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+
+        var trimmed = allNew.Take(request.Limit).ToArray();
+
+        _logger.LogInformation(
+            "Returning {Count} new games (limit={Limit}) from cache/compute",
+            trimmed.Length,
+            request.Limit);
+
+        return trimmed;
+    }
+
+    private async Task<List<NewGameDto>> ComputeNewGamesAsync(
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        // Soft-delete filter is enforced by HasQueryFilter on SharedGameEntity but we
+        // keep the explicit predicate for read-clarity (matches Wiegers SMART intent).
+        var rows = await _context.Set<SharedGameEntity>()
+            .AsNoTracking()
+            .Where(g => !g.IsDeleted)
+            .OrderByDescending(g => g.CreatedAt)
+            .Take(limit)
+            .Select(g => new
+            {
+                g.Id,
+                g.Title,
+                g.YearPublished,
+                g.ImageUrl,
+                g.ThumbnailUrl,
+                g.CreatedAt,
+                Publisher = g.Publishers
+                    .OrderBy(p => p.Name)
+                    .Select(p => p.Name)
+                    .FirstOrDefault()
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return rows.Select(g => new NewGameDto(
+            Id: g.Id,
+            Name: g.Title,
+            Publisher: string.IsNullOrWhiteSpace(g.Publisher) ? null : g.Publisher,
+            // YearPublished defaults to 0 for legacy rows seeded without a year;
+            // surface as null so the FE can render "Year unknown".
+            Year: g.YearPublished > 0 ? g.YearPublished : null,
+            ImageUrl: !string.IsNullOrWhiteSpace(g.ImageUrl)
+                ? g.ImageUrl
+                : (!string.IsNullOrWhiteSpace(g.ThumbnailUrl) ? g.ThumbnailUrl : null),
+            CreatedAt: g.CreatedAt
+        )).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryHandler.cs
@@ -89,12 +89,13 @@ internal sealed class GetNewGamesQueryHandler
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // YearPublished defaults to 0 for legacy rows seeded without a year; the projection
+        // surfaces null so the FE can render "Year unknown". Image fallback prefers ImageUrl
+        // over ThumbnailUrl when both are present.
         return rows.Select(g => new NewGameDto(
             Id: g.Id,
             Name: g.Title,
             Publisher: string.IsNullOrWhiteSpace(g.Publisher) ? null : g.Publisher,
-            // YearPublished defaults to 0 for legacy rows seeded without a year;
-            // surface as null so the FE can render "Year unknown".
             Year: g.YearPublished > 0 ? g.YearPublished : null,
             ImageUrl: !string.IsNullOrWhiteSpace(g.ImageUrl)
                 ? g.ImageUrl

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/GetNewGamesQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Validator for <see cref="GetNewGamesQuery"/>.
+/// Wave 3 Phase 1, PR #732 §4.3.2 / Issue #805.
+/// </summary>
+internal sealed class GetNewGamesQueryValidator : AbstractValidator<GetNewGamesQuery>
+{
+    public GetNewGamesQueryValidator()
+    {
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/NewGameDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetNewGames/NewGameDto.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+
+/// <summary>
+/// Lightweight DTO for the /api/v1/catalog/games/new endpoint
+/// (Wave 3 Phase 1, PR #732 §4.3.2 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Powers the SP4 /discover route's "New games" rail (frontend
+/// <c>useDiscoverNewGames</c>). Sort: <c>CreatedAt DESC</c>.
+/// Filtered by <c>IsDeleted == false</c>. Cached 1h via HybridCache.
+/// </remarks>
+internal sealed record NewGameDto(
+    Guid Id,
+    string Name,
+    string? Publisher,
+    int? Year,
+    string? ImageUrl,
+    DateTime CreatedAt
+);

--- a/apps/api/src/Api/Infrastructure/Services/MarkdownSubsetSanitizer.cs
+++ b/apps/api/src/Api/Infrastructure/Services/MarkdownSubsetSanitizer.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+
+namespace Api.Infrastructure.Services;
+
+/// <summary>
+/// Server-side markdown subset enforcement per PR #732 §6.3.3 spec verbatim.
+/// Wave 3 Phase 3 (Issue #805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Subset rules</b>:
+/// <list type="bullet">
+///   <item>Headings: H1, H2, H3 only — H4-H6 demoted to <c>**bold**</c>.</item>
+///   <item>Lists: ul/ol up to 2 nested levels — passthrough (deep nesting handled FE-side).</item>
+///   <item>Code: fenced blocks and inline — passthrough.</item>
+///   <item>Tables: pipe syntax (GitHub-flavored) — passthrough.</item>
+///   <item>Blockquote: <c>&gt;</c> prefix — passthrough.</item>
+///   <item>Emphasis: <c>*bold*</c>, <c>_italic_</c> — passthrough.</item>
+///   <item>NO HTML — raw tags stripped.</item>
+///   <item>NO images — replaced with <c>[Image: alt]</c> placeholder text.</item>
+///   <item>NO embeds — same path as HTML strip.</item>
+///   <item>NO footnotes — <c>[^N]</c> markers and <c>[^N]: ...</c> definitions stripped.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// <b>Implementation</b>: regex-based (no Markdig dependency in repo). The
+/// constraints above are deliberately conservative — anything we cannot easily
+/// reason about with regex is stripped, not sanitized leniently. This trades
+/// fidelity for safety, which is the correct default for user-rendered content.
+/// </para>
+///
+/// <para>
+/// <b>Order matters</b>:
+/// <list type="number">
+///   <item>Strip footnote definitions (multi-line) first.</item>
+///   <item>Strip footnote markers second (so order-of-encounter is irrelevant).</item>
+///   <item>Replace images third (before HTML strip — images use <c>![]()</c>, not raw HTML).</item>
+///   <item>Strip raw HTML tags fourth (covers <c>&lt;script&gt;</c>, <c>&lt;iframe&gt;</c>, etc.).</item>
+///   <item>Demote H4-H6 last (line-anchored, idempotent).</item>
+/// </list>
+/// </para>
+/// </remarks>
+public static class MarkdownSubsetSanitizer
+{
+    // Bounded timeout (200ms) on each regex pass mitigates ReDoS exposure for
+    // adversarial input; analyzer rule MA0009 enforces this default.
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(200);
+    private const RegexOptions BaseRegexOptions =
+        RegexOptions.Compiled | RegexOptions.ExplicitCapture;
+
+    // H4-H6 demotion: lines starting with 4..6 '#' chars + space + heading text.
+    // ExplicitCapture means the (?<text>.+) group below is the only capture.
+    // Multiline so '^'/'$' anchor to line boundaries.
+    private static readonly Regex HeadingDemoteRegex = new(
+        @"^#{4,6}[ \t]+(?<text>.+)$",
+        BaseRegexOptions | RegexOptions.Multiline,
+        RegexTimeout);
+
+    // Image: ![alt text](url) → "[Image: alt text]". The alt text may contain
+    // spaces and basic punctuation; URL is captured but discarded. We do NOT
+    // attempt to handle nested brackets — markdown parsers don't either.
+    private static readonly Regex ImageRegex = new(
+        @"!\[(?<alt>[^\]]*)\]\([^\)]*\)",
+        BaseRegexOptions,
+        RegexTimeout);
+
+    // Raw HTML: simple tag matcher. Strips opening, closing, and self-closing
+    // tags. Does NOT attempt to parse HTML — anything tag-shaped goes.
+    private static readonly Regex HtmlTagRegex = new(
+        @"<\/?[a-zA-Z][^>]*>",
+        BaseRegexOptions,
+        RegexTimeout);
+
+    // Footnote definition: a line starting with '[^N]:' followed by content
+    // (single-line; multi-line continuation rare in extracted KB content).
+    private static readonly Regex FootnoteDefinitionRegex = new(
+        @"^\[\^[^\]]+\]:[ \t]+.*$",
+        BaseRegexOptions | RegexOptions.Multiline,
+        RegexTimeout);
+
+    // Footnote marker: inline reference like '[^N]' that appears within the body
+    // text. Stripped after definitions are removed so the body reads clean.
+    private static readonly Regex FootnoteMarkerRegex = new(
+        @"\[\^[^\]]+\]",
+        BaseRegexOptions,
+        RegexTimeout);
+
+    /// <summary>
+    /// Sanitize markdown content to the spec-compliant subset.
+    /// Empty / whitespace input is returned as-is.
+    /// </summary>
+    public static string Sanitize(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return content ?? string.Empty;
+        }
+
+        var step1 = FootnoteDefinitionRegex.Replace(content, string.Empty);
+        var step2 = FootnoteMarkerRegex.Replace(step1, string.Empty);
+        var step3 = ImageRegex.Replace(step2, m =>
+        {
+            var alt = m.Groups["alt"].Value;
+            return string.IsNullOrWhiteSpace(alt)
+                ? "[Image]"
+                : $"[Image: {alt}]";
+        });
+        var step4 = HtmlTagRegex.Replace(step3, string.Empty);
+        var step5 = HeadingDemoteRegex.Replace(step4, m => $"**{m.Groups["text"].Value}**");
+
+        return step5;
+    }
+}

--- a/apps/api/src/Api/Middleware/Exceptions/LockedException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/LockedException.cs
@@ -1,0 +1,34 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Exception thrown when a resource exists but is in a transient state that
+/// prevents normal access (e.g. a KB document still being indexed).
+/// Maps to HTTP 423 Locked.
+/// </summary>
+/// <remarks>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.1): introduced for KB document
+/// retrieval where <c>processingStatus != 'ready'</c>. Distinct from 404 (which
+/// would imply "not found / never existed") so the FE can render a
+/// "Documento in elaborazione..." state with retry semantics, per Nygard's
+/// operational note in the spec.
+/// </remarks>
+public class LockedException : HttpException
+{
+    [SetsRequiredMembers]
+    public LockedException(string message)
+        : base(StatusCodes.Status423Locked, "locked", message)
+    {
+    }
+
+    [SetsRequiredMembers]
+    public LockedException(string message, Exception innerException)
+        : base(StatusCodes.Status423Locked, "locked", message, innerException)
+    {
+    }
+
+    public LockedException()
+    {
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -11,6 +11,7 @@ using Api.Models;
 using Api.Observability;
 using Api.Routing;
 using Api.Routing.GameManagement;
+using Api.Routing.GameToolkit;
 using Api.BoundedContexts.GameManagement.Routing; // Issue #4273
 using Api.BoundedContexts.Administration.Infrastructure.DependencyInjection;
 using Api.BoundedContexts.AgentMemory.Infrastructure.DependencyInjection;
@@ -748,6 +749,7 @@ if (!isAlphaMode)
     v1Api.MapLiveSessionEndpoints(); // Issue #4749: Live session CQRS endpoints
     v1Api.MapSessionAttachmentEndpoints(); // Issue #5365: Session photo attachment endpoints
     v1Api.MapGameToolkitEndpoints(); // Issue #4753: Game toolkit CQRS endpoints
+    v1Api.MapToolkitMarketplaceEndpoints(); // Wave 3 Phase 2 (#805): /toolkits/[id] marketplace
     v1Api.MapGameToolboxEndpoints(); // Epic #412: Game toolbox per-game containers
     v1Api.MapToolStateEndpoints(); // Issue #4754: Tool state CQRS endpoints
     v1Api.MapTurnOrderEndpoints(); // Issue #4970: TurnOrder base toolkit endpoints

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -10,6 +10,7 @@ using Api.Middleware;
 using Api.Models;
 using Api.Observability;
 using Api.Routing;
+using Api.Routing.AdministrationDiscover;
 using Api.Routing.GameManagement;
 using Api.Routing.GameToolkit;
 using Api.BoundedContexts.GameManagement.Routing; // Issue #4273
@@ -710,6 +711,9 @@ v1Api.MapAiEndpoints();
 v1Api.MapAgentsEndpoints(); // Issue #641 (Wave B.2 hotfix): user-facing agent listing
 v1Api.MapAgentTypologiesEndpoints(); // Issue #649: user-facing typology dropdown
 v1Api.MapRulebookAnalysisEndpoints(); // ISSUE-2402: Rulebook analysis service
+
+// Discover surface (cross-BC aggregation)
+TopUserContributorsEndpoints.Map(v1Api); // Wave 3 Phase 4a (#805): /users/top-contributors
 
 // User Library
 v1Api.MapUserLibraryEndpoints();       // User game library

--- a/apps/api/src/Api/Routing/Administration/TopUserContributorsEndpoints.cs
+++ b/apps/api/src/Api/Routing/Administration/TopUserContributorsEndpoints.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.Administration.Application.Queries.GetTopUserContributors;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing.AdministrationDiscover;
+
+/// <summary>
+/// Public discover-surface endpoint that aggregates user contribution sources
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Distinct surface from <c>/api/v1/shared-games/top-contributors</c>
+/// (sessions/wins score for the public /shared-games sidebar) — this endpoint
+/// powers the SP4 /discover route's "Top contributors" rail with a
+/// per-source breakdown (FAQs authored, KB documents uploaded, AI agents
+/// created).
+/// </remarks>
+internal static class TopUserContributorsEndpoints
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/top-contributors", HandleGetTopUserContributors)
+            .RequireAuthorization()
+            .WithName("GetTopUserContributors")
+            .WithTags("Discover")
+            .WithSummary("Get the top user contributors")
+            .WithDescription(
+                "Returns top users ranked by aggregate contribution count "
+                + "(FAQs authored + KB documents uploaded + AI agents created), "
+                + "with a per-source breakdown. Limit clamped 1..50, default 10. "
+                + "Schema reality v1 carryover (Gate B): only the KB uploads "
+                + "metric is real; FAQs + AgentsCreated are stubbed to 0 until "
+                + "creator FK columns land. Privacy guards: skips suspended + "
+                + "non-Active accounts and users without a DisplayName. Cache: "
+                + "1h HybridCache (V2 deferred: materialized view daily refresh). "
+                + "Powers the SP4 /discover \"Top contributors\" rail. "
+                + "Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.6).")
+            .Produces<TopUserContributorsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<IResult> HandleGetTopUserContributors(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1) safeLimit = 10;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetTopUserContributorsQuery(safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(response);
+    }
+}

--- a/apps/api/src/Api/Routing/AgentsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentsEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetPopularAgents;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -38,6 +39,9 @@ internal static class AgentsEndpoints
         // segment never reaches the GUID-constrained handler. The :guid constraint already
         // disambiguates at the matcher level, but explicit ordering keeps intent obvious.
         MapGetRecentAgentsEndpoint(group);
+        // Popular: same literal-before-{id:guid} ordering rationale as recent.
+        // Wave 3 Phase 1 (#805) — /discover "Popular agents" rail.
+        MapGetPopularAgentsEndpoint(group);
         MapGetAgentByIdEndpoint(group);
         MapGetAgentStatusEndpoint(group);
         MapCreateUserAgentEndpoint(group);
@@ -193,6 +197,44 @@ internal static class AgentsEndpoints
         .WithTags("Agents")
         .WithSummary("Get recently used agents")
         .WithDescription("Returns active agents ordered by LastInvokedAt desc (limit clamped 1..50, default 10). Powers the dashboard recent-agents widget (frontend useRecentAgents hook). Issue #650 (Phase γ.3).")
+        .WithOpenApi();
+    }
+
+    /// <summary>
+    /// Wave 3 Phase 1 (PR #732 §4.3.3 / Issue #805): expose
+    /// <c>GET /api/v1/agents/popular</c> for the SP4 /discover route's
+    /// "Popular agents" rail (frontend <c>useDiscoverPopularAgents</c>).
+    /// Schema reality v1 carryover: <c>InstallCount</c> always 0 — see
+    /// <see cref="PopularAgentDto"/> for the full Gate B note.
+    /// </summary>
+    private static void MapGetPopularAgentsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/agents/popular", async (
+            [FromQuery] int? limit,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, _, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var safeLimit = limit.GetValueOrDefault(10);
+            if (safeLimit < 1) safeLimit = 10;
+            if (safeLimit > 50) safeLimit = 50;
+
+            var query = new GetPopularAgentsQuery(safeLimit);
+            var agents = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(new DiscoverItemsEnvelope<PopularAgentDto>(agents));
+        })
+        .RequireAuthenticatedUser()
+        .Produces<DiscoverItemsEnvelope<PopularAgentDto>>(200)
+        .Produces(401)
+        .WithTags("Discover", "Agents")
+        .WithSummary("Get popular agents")
+        .WithDescription(
+            "Returns active agents sorted by installCount DESC + invocationCount DESC tiebreak "
+            + "(limit clamped 1..50, default 10). Powers the SP4 /discover \"Popular agents\" "
+            + "rail. Cache: 15min via HybridCache. Wave 3 Phase 1 (Issue #805 / PR #732 §4.3.3).")
         .WithOpenApi();
     }
 

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
 using Api.Extensions;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Routing.GameToolkit;
 
@@ -34,6 +36,25 @@ internal static class ToolkitMarketplaceEndpoints
         var toolkits = group.MapGroup("/toolkits")
             .WithTags("ToolkitMarketplace")
             .RequireAuthorization();
+
+        // ── GET /api/v1/toolkits/recommended ────────────────────────────────
+        // Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.4): SP4 /discover rail
+        // "Recommended toolkits". Static route registered BEFORE /{toolkitId:guid}
+        // so the /recommended literal does not get parsed as a Guid route value.
+        toolkits.MapGet("/recommended", HandleGetRecommendedToolkits)
+            .WithName("GetRecommendedToolkits")
+            .WithSummary("Get recommended marketplace toolkits")
+            .WithDescription(
+                "Returns published toolkits sorted by Bayesian score "
+                + "(ratingAverage * log(ratingCount + 1) DESC, installCount DESC "
+                + "tiebreak, createdAt DESC final tiebreak). Limit clamped 1..50, "
+                + "default 10. Schema reality v1 carryover: rating + install "
+                + "metrics are 0/null until the ToolkitRating + ToolkitInstallation "
+                + "entities ship — effective sort collapses to createdAt DESC. "
+                + "Cache: 30min HybridCache. Powers the SP4 /discover \"Recommended "
+                + "toolkits\" rail. Wave 3 Phase 4a (Issue #805 / PR #732 §4.3.4).")
+            .Produces<RecommendedToolkitsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         // ── GET /api/v1/toolkits/{toolkitId} ────────────────────────────────
         toolkits.MapGet("/{toolkitId:guid}", HandleGetToolkitDetail)
@@ -96,6 +117,24 @@ internal static class ToolkitMarketplaceEndpoints
         return response is null
             ? Results.NotFound()
             : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetRecommendedToolkits(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1) safeLimit = 10;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetRecommendedToolkitsQuery(safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(response);
     }
 
     private static async Task<IResult> HandleGetToolkitVersions(

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetRecommendedToolkits;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitRatings;
 using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
 using Api.Extensions;
 using MediatR;
@@ -82,6 +83,50 @@ internal static class ToolkitMarketplaceEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
 
+        // ── GET /api/v1/toolkits/{toolkitId}/ratings ───────────────────────
+        // Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.3): ratings list with
+        // 5-star breakdown for the SP4 /toolkits/[id] ratings tab. Schema
+        // reality v1 carryover (Gate B): empty stub — ToolkitRating entity
+        // ships in Phase 5.
+        toolkits.MapGet("/{toolkitId:guid}/ratings", HandleGetToolkitRatings)
+            .WithName("GetToolkitRatings")
+            .WithSummary("List toolkit ratings (cursor paginated)")
+            .WithDescription(
+                "Returns ratings sorted by createdAt DESC with 5-star "
+                + "breakdown distribution and averageStars (1-5 with one "
+                + "decimal). Cursor opaque, nextCursor=null when exhausted. "
+                + "Limit clamped 1..50, default 20. 404 when toolkit is "
+                + "missing or hidden from the viewer (PR #732 §5.2 security "
+                + "boundary). Empty-state contract per §3.4: 200 with "
+                + "{ items: [] } rather than 404. Schema reality v1 carryover: "
+                + "ToolkitRating entity not yet shipped — handler returns "
+                + "stub envelope (items=[], breakdown all zero, averageStars=0, "
+                + "totalCount=0) once visibility check passes. Cache: 5min "
+                + "HybridCache. Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.3).")
+            .Produces<ToolkitRatingsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── POST /api/v1/toolkits/{toolkitId}/ratings ──────────────────────
+        // Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.4): rating submission
+        // STUB — returns 501 Not Implemented because the ToolkitRating
+        // entity + persistence ship in Phase 5. Wire shape (route literal
+        // and method) is reserved so the FE submission flow can call this
+        // surface today and detect the stub via 501.
+        toolkits.MapPost("/{toolkitId:guid}/ratings", HandleSubmitToolkitRating)
+            .WithName("SubmitToolkitRating")
+            .WithSummary("Submit a toolkit rating (Phase 4b stub — 501)")
+            .WithDescription(
+                "Phase 4b stub. Returns 501 Not Implemented with a "
+                + "machine-readable body { error: \"ratings_submission_not_yet_available\", "
+                + "phase: \"4b-stub\" } so the FE can surface a \"coming soon\" "
+                + "affordance without breaking on a 404. Persistence + "
+                + "validation rules (one rating per (userId, toolkitId), "
+                + "hasInstalled gate, viewer != author, edit window 24h) "
+                + "ship in Phase 5. Wave 3 Phase 4b (Issue #805 / PR #732 §5.3.4).")
+            .Produces(StatusCodes.Status501NotImplemented)
+            .Produces(StatusCodes.Status401Unauthorized);
+
         // ── POST /api/v1/toolkits/{toolkitId}/install ──────────────────────
         toolkits.MapPost("/{toolkitId:guid}/install", HandleInstallToolkit)
             .WithName("InstallToolkit")
@@ -155,6 +200,58 @@ internal static class ToolkitMarketplaceEndpoints
         return response is null
             ? Results.NotFound()
             : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetToolkitRatings(
+        Guid toolkitId,
+        HttpContext httpContext,
+        [FromQuery] string? cursor,
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Limit clamping at the endpoint layer (PR #732 §3.3 — UI-friendly
+        // silent clamp rather than 400). Validator on the query enforces the
+        // same range for the CQRS handler.
+        var safeLimit = limit.GetValueOrDefault(20);
+        if (safeLimit < 1) safeLimit = 20;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetToolkitRatingsQuery(toolkitId, viewerId, cursor, safeLimit);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static IResult HandleSubmitToolkitRating(
+        Guid toolkitId,
+        HttpContext httpContext)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Phase 4b stub — ToolkitRating entity ships in Phase 5. Body shape
+        // is intentionally minimal and machine-readable so the FE can detect
+        // the stub state without parsing prose error messages.
+        return Results.Json(
+            new
+            {
+                error = "ratings_submission_not_yet_available",
+                phase = "4b-stub",
+                toolkitId
+            },
+            statusCode: StatusCodes.Status501NotImplemented);
     }
 
     private static async Task<IResult> HandleInstallToolkit(

--- a/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameToolkit/ToolkitMarketplaceEndpoints.cs
@@ -1,0 +1,140 @@
+using Api.BoundedContexts.GameToolkit.Application.Commands.InstallToolkit;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitDetail;
+using Api.BoundedContexts.GameToolkit.Application.Queries.GetToolkitVersions;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing.GameToolkit;
+
+/// <summary>
+/// Marketplace endpoints for the SP4 /toolkits/[id] route
+/// (Wave 3 Phase 2, PR #732 §5.3 / Issue #805).
+/// </summary>
+/// <remarks>
+/// Per PR #732 §5.1 (Newman BC decomposition), these endpoints EXTEND the
+/// existing <c>GameToolkit</c> bounded context rather than introducing a new
+/// <c>MarketplaceBC</c> — the toolkit aggregate is shared between internal
+/// session toolkits and community marketplace, only differing in publishing
+/// state and authorship.
+///
+/// All three endpoints use <c>IMediator.Send()</c> only (CLAUDE.md CQRS
+/// rule); no service is injected directly. Auth: <c>RequireAuthorization()</c>
+/// (any authenticated user) — server-side variant gating is enforced inside
+/// the handlers via <c>ViewerContext.IsOwner</c> / visibility checks.
+///
+/// Mounted under <c>/api/v1/toolkits</c> rather than the existing
+/// <c>/api/v1/game-toolkits</c> group because PR #732 §5.3 explicitly
+/// scopes the marketplace surface to the shorter prefix; the legacy
+/// session-toolkit CRUD endpoints stay on their own prefix.
+/// </remarks>
+internal static class ToolkitMarketplaceEndpoints
+{
+    public static RouteGroupBuilder MapToolkitMarketplaceEndpoints(this RouteGroupBuilder group)
+    {
+        var toolkits = group.MapGroup("/toolkits")
+            .WithTags("ToolkitMarketplace")
+            .RequireAuthorization();
+
+        // ── GET /api/v1/toolkits/{toolkitId} ────────────────────────────────
+        toolkits.MapGet("/{toolkitId:guid}", HandleGetToolkitDetail)
+            .WithName("GetToolkitDetail")
+            .WithSummary("Get marketplace toolkit detail with viewer context")
+            .WithDescription(
+                "Returns the toolkit detail envelope plus per-viewer flags "
+                + "(isOwner, hasInstalled, canRate). 404 when the toolkit is "
+                + "unpublished or yanked AND the viewer is not the author "
+                + "(server-enforced security boundary per PR #732 §5.2). "
+                + "Cache: 10min HybridCache, partitioned per (toolkitId, viewerId).")
+            .Produces<ToolkitDetailResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── GET /api/v1/toolkits/{toolkitId}/versions ──────────────────────
+        toolkits.MapGet("/{toolkitId:guid}/versions", HandleGetToolkitVersions)
+            .WithName("GetToolkitVersions")
+            .WithSummary("List toolkit version history")
+            .WithDescription(
+                "Returns the published version history sorted by publishedAt "
+                + "DESC. 404 when the toolkit is missing or hidden from the "
+                + "viewer. Cache: 10min HybridCache (no per-viewer partition).")
+            .Produces<ToolkitVersionsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // ── POST /api/v1/toolkits/{toolkitId}/install ──────────────────────
+        toolkits.MapPost("/{toolkitId:guid}/install", HandleInstallToolkit)
+            .WithName("InstallToolkit")
+            .WithSummary("Install a toolkit (idempotent)")
+            .WithDescription(
+                "Idempotent install action — repeated calls return 200 with "
+                + "the current state, never 409 (PR #732 §5.3.5 Nygard note). "
+                + "404 when the toolkit is missing or yanked. Side-effect: "
+                + "invalidates the discover:popularAgents cache so the rail "
+                + "reflects the new install on the next read.")
+            .Produces<InstallToolkitResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
+        return toolkits;
+    }
+
+    private static async Task<IResult> HandleGetToolkitDetail(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var query = new GetToolkitDetailQuery(toolkitId, viewerId);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleGetToolkitVersions(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var query = new GetToolkitVersionsQuery(toolkitId, viewerId);
+        var response = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+
+    private static async Task<IResult> HandleInstallToolkit(
+        Guid toolkitId,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var viewerId = httpContext.User.GetUserId();
+        if (viewerId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var command = new InstallToolkitCommand(toolkitId, viewerId);
+        var response = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
+    }
+}

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -914,39 +914,53 @@ internal static class KnowledgeBaseEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest);
 
-        // Issue #730: G4 single doc metadata
+        // Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.1): doc detail with 423 Locked.
         group.MapGet("/kb-docs/{id:guid}", HandleGetKbDocumentById)
             .WithName("GetKbDocumentById")
             .RequireSession()
             .WithTags("KnowledgeBase")
-            .WithSummary("Get KB document metadata")
-            .WithDescription("Returns metadata for a single KB document (title, processing state, total chunks, page count). Admin users see additional diagnostic fields.")
-            .Produces<KbDocumentDto>()
+            .WithSummary("Get KB document detail (spec §6.3.1)")
+            .WithDescription(
+                "Returns spec-conformant document detail with gameName + uploaderName joins. "
+                + "Returns 423 Locked when processingStatus != 'ready' (Nygard semantic distinct from 404). "
+                + "Cache: HybridCache 1h per-viewer, tags ['kb', 'kbDoc:{id}'].")
+            .Produces<KbDocumentDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status403Forbidden);
+            .Produces(StatusCodes.Status423Locked);
 
-        // Issue #730: G1 paginated chunks list
+        // Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2): cursor-paginated chunks list.
         group.MapGet("/kb-docs/{id:guid}/chunks", HandleGetKbChunks)
             .WithName("GetKbChunks")
             .RequireSession()
             .WithTags("KnowledgeBase")
-            .WithSummary("Get paginated chunks list with hierarchical headings")
-            .WithDescription("Returns chunks ordered by position with breadcrumb headingPath. Admin users see vectorId, characterCount, elementType, embeddingStatus.")
-            .Produces<KbChunkListDto>()
+            .WithSummary("Get cursor-paginated chunks list (spec §6.3.2)")
+            .WithDescription(
+                "Returns chunks ordered by position with breadcrumb headingPath, opaque cursor "
+                + "pagination ((Position, Id) tuple base64-encoded). nextCursor null on last page. "
+                + "Cache: HybridCache 30min per-viewer.")
+            .Produces<KbChunksListResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
-            .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status403Forbidden);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
 
-        // Issue #730: G2 single chunk full content
+        // Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.3): chunk detail w/ markdown subset.
         group.MapGet("/kb-docs/{id:guid}/chunks/{chunkId:guid}", HandleGetKbChunkById)
             .WithName("GetKbChunkById")
             .RequireSession()
             .WithTags("KnowledgeBase")
-            .WithSummary("Get a single chunk with full content + prev/next navigation")
-            .WithDescription("Returns chunk content as markdown, with hierarchical breadcrumb and prev/next chunk IDs for navigation.")
-            .Produces<KbChunkDetailDto>()
-            .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status403Forbidden);
+            .WithSummary("Get chunk detail with prev/next navigation (spec §6.3.3)")
+            .WithDescription(
+                "Returns chunk content sanitized to spec markdown subset (H4-H6 demoted, "
+                + "raw HTML stripped, images replaced, footnotes stripped) with prev/nextChunkId "
+                + "navigation. Cache: HybridCache 24h (chunks immutable post-ingest).")
+            .Produces<KbChunkDetailDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
 
         // Issue #730: G3 in-document FTS
         group.MapPost("/kb-docs/{id:guid}/chunks/search", HandleSearchKbChunks)
@@ -997,26 +1011,44 @@ internal static class KnowledgeBaseEndpoints
         return Results.Ok(dto);
     }
 
+    /// <summary>
+    /// Wave 3 Phase 3 handler for cursor-paginated chunks list.
+    /// Decodes opaque cursor; malformed cursor → 400 Bad Request.
+    /// </summary>
     private static async Task<IResult> HandleGetKbChunks(
         Guid id,
-        int? skip,
-        int? take,
+        [FromQuery] string? cursor,
+        [FromQuery] int? limit,
         HttpContext httpContext,
         IMediator mediator,
         CancellationToken cancellationToken)
     {
-        var skipValue = skip ?? 0;
-        var takeValue = take ?? 50;
+        var limitValue = limit ?? 50;
 
-        if (takeValue < 1 || takeValue > 100)
+        if (limitValue < 1 || limitValue > 100)
         {
-            return Results.BadRequest(new { error = "take must be between 1 and 100" });
+            return Results.BadRequest(new { error = "limit must be between 1 and 100" });
+        }
+
+        KbChunksCursor.CursorPayload? decodedCursor;
+        try
+        {
+            decodedCursor = KbChunksCursor.Decode(cursor);
+        }
+        catch (FormatException ex)
+        {
+            return Results.BadRequest(new { error = $"Invalid cursor: {ex.Message}" });
         }
 
         var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
         var userId = session.User!.Id;
         var isAdmin = string.Equals(session.User!.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
-        var query = new GetKbChunksQuery(id, RequestingUserId: userId, Skip: skipValue, Take: takeValue, UserIsAdmin: isAdmin);
+        var query = new GetKbChunksQuery(
+            id,
+            RequestingUserId: userId,
+            Cursor: decodedCursor,
+            Limit: limitValue,
+            UserIsAdmin: isAdmin);
         var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -9,6 +9,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetRecentKbDocs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
 using Api.Extensions;
 using Api.Helpers;
@@ -896,6 +897,23 @@ internal static class KnowledgeBaseEndpoints
 
     private static void MapKbDocumentEndpoints(RouteGroupBuilder group)
     {
+        // Wave 3 Phase 1 (#805 / PR #732 §4.3.5): /discover "Recent KB docs" rail.
+        // Registered before the {id:guid} route so the literal "recent" segment is
+        // matched first; the :guid constraint also disambiguates at the matcher
+        // level but explicit ordering keeps intent obvious (mirror /agents/recent).
+        group.MapGet("/kb-docs/recent", HandleGetRecentKbDocs)
+            .WithName("GetRecentKbDocs")
+            .RequireSession()
+            .WithTags("Discover", "KnowledgeBase")
+            .WithSummary("Get recently indexed KB documents")
+            .WithDescription(
+                "Returns the most recently indexed KB documents (ProcessingState == Ready) "
+                + "sorted by lastIngestedAt DESC. Powers the SP4 /discover \"Recent KB docs\" "
+                + "rail. Cache: 5min via HybridCache. Wave 3 Phase 1 (Issue #805 / PR #732 §4.3.5).")
+            .Produces<DiscoverItemsEnvelope<RecentKbDocDto>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status400BadRequest);
+
         // Issue #730: G4 single doc metadata
         group.MapGet("/kb-docs/{id:guid}", HandleGetKbDocumentById)
             .WithName("GetKbDocumentById")
@@ -941,6 +959,28 @@ internal static class KnowledgeBaseEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>
+    /// Wave 3 Phase 1 (PR #732 §4.3.5 / Issue #805): handler for
+    /// <c>GET /api/v1/kb-docs/recent</c>. Clamps the <c>limit</c> query
+    /// parameter to <c>[1, 50]</c> with a default of 10. Returns a
+    /// <c>{ items: RecentKbDocDto[] }</c> envelope per PR #732 §3.4 empty-state
+    /// contract (200 with empty array rather than 404 / 204).
+    /// </summary>
+    private static async Task<IResult> HandleGetRecentKbDocs(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1) safeLimit = 10;
+        if (safeLimit > 50) safeLimit = 50;
+
+        var query = new GetRecentKbDocsQuery(safeLimit);
+        var items = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(new DiscoverItemsEnvelope<RecentKbDocDto>(items));
     }
 
     private static async Task<IResult> HandleGetKbDocumentById(

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogDiscoverEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogDiscoverEndpoints.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetNewGames;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// /discover-surface SharedGameCatalog endpoints (Wave 3 Phase 1, PR #732 §4.3 / Issue #805).
+/// Lives next to <see cref="SharedGameCatalogTrendingEndpoints"/> because both feed the
+/// same SP4 /discover route but rank/sort by different signals.
+/// </summary>
+internal static class SharedGameCatalogDiscoverEndpoints
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapGet("/catalog/games/new", HandleGetNewGames)
+            .RequireAuthorization()
+            .WithName("GetNewGames")
+            .WithTags("Discover")
+            .WithSummary("Get the most recently created games")
+            .WithDescription(
+                "Returns the most recently created shared games sorted by createdAt DESC. "
+                + "Powers the SP4 /discover \"New games\" rail. "
+                + "Soft-deleted rows excluded. Cache: 1h via HybridCache.")
+            .Produces<DiscoverItemsEnvelope<NewGameDto>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status400BadRequest);
+    }
+
+    private static async Task<IResult> HandleGetNewGames(
+        [FromQuery] int? limit,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var safeLimit = limit.GetValueOrDefault(10);
+        if (safeLimit < 1)
+        {
+            safeLimit = 10;
+        }
+        if (safeLimit > 50)
+        {
+            safeLimit = 50;
+        }
+
+        var query = new GetNewGamesQuery(safeLimit);
+        var items = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(new DiscoverItemsEnvelope<NewGameDto>(items));
+    }
+}
+
+/// <summary>
+/// Stable response envelope for /discover endpoints — wraps the raw item list in
+/// <c>{ items: [...] }</c> per PR #732 §3.4 empty-state contract (200 with empty
+/// array rather than 404 / 204).
+/// </summary>
+/// <typeparam name="T">Item DTO type.</typeparam>
+internal sealed record DiscoverItemsEnvelope<T>(IReadOnlyList<T> Items);

--- a/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
@@ -16,6 +16,7 @@ internal static class SharedGameCatalogEndpoints
         SharedGameCatalogContributorEndpoints.Map(group);
         SharedGameCatalogBadgeEndpoints.Map(group);
         SharedGameCatalogTrendingEndpoints.Map(group);
+        SharedGameCatalogDiscoverEndpoints.Map(group); // Wave 3 Phase 1 (#805): /discover quick-win endpoints
         SharedGameCatalogWizardEndpoints.Map(group); // Issue #4139: PDF Wizard endpoints
 
         return group;

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunkByIdHandlerTests.cs
@@ -2,7 +2,9 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunkById;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -11,19 +13,27 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 
+/// <summary>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.3) — spec-conformant rewrite tests
+/// for <see cref="GetKbChunkByIdHandler"/>. Validates Id rename, DocId addition,
+/// prev/nextChunkId derivation, markdown sanitization plumbing, Metadata Gate B
+/// stub, access control, and 404 cross-document leak prevention.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "KnowledgeBase")]
 public sealed class GetKbChunkByIdHandlerTests
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<GetKbChunkByIdHandler> _logger;
+    private readonly IHybridCacheService _cache;
     private readonly GetKbChunkByIdHandler _handler;
 
     public GetKbChunkByIdHandlerTests()
     {
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
         _logger = Substitute.For<ILogger<GetKbChunkByIdHandler>>();
-        _handler = new GetKbChunkByIdHandler(_dbContext, _logger);
+        _cache = new TestHybridCacheService();
+        _handler = new GetKbChunkByIdHandler(_dbContext, _cache, _logger);
     }
 
     [Fact]
@@ -35,9 +45,11 @@ public sealed class GetKbChunkByIdHandlerTests
         var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk1, UserIsAdmin: false);
         var dto = await _handler.Handle(query, CancellationToken.None);
 
-        dto.ChunkId.Should().Be(chunk1);
+        dto.Id.Should().Be(chunk1);
+        dto.DocId.Should().Be(docId);
         dto.PrevChunkId.Should().Be(chunk0);
         dto.NextChunkId.Should().Be(chunk2);
+        dto.Metadata.Should().BeEmpty(); // Gate B v1 carryover
     }
 
     [Fact]
@@ -46,8 +58,9 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         var (chunk0, _, _) = await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk0, UserIsAdmin: false);
-        var dto = await _handler.Handle(query, CancellationToken.None);
+        var dto = await _handler.Handle(
+            new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk0, UserIsAdmin: false),
+            CancellationToken.None);
 
         dto.PrevChunkId.Should().BeNull();
         dto.NextChunkId.Should().NotBeNull();
@@ -59,43 +72,118 @@ public sealed class GetKbChunkByIdHandlerTests
         var docId = Guid.NewGuid();
         var (_, _, chunk2) = await SeedThreeChunksAsync(docId);
 
-        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk2, UserIsAdmin: false);
-        var dto = await _handler.Handle(query, CancellationToken.None);
+        var dto = await _handler.Handle(
+            new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunk2, UserIsAdmin: false),
+            CancellationToken.None);
 
         dto.NextChunkId.Should().BeNull();
         dto.PrevChunkId.Should().NotBeNull();
     }
 
     [Fact]
-    public async Task Handle_ChunkBelongsToOtherDoc_ThrowsNotFound()
+    public async Task Handle_ChunkBelongsToOtherDoc_Throws404()
     {
         var docA = Guid.NewGuid();
         var docB = Guid.NewGuid();
-        var (_, _, _) = await SeedThreeChunksAsync(docA);
+        await SeedThreeChunksAsync(docA);
         var (chunkB, _, _) = await SeedThreeChunksAsync(docB);
 
-        // Request chunk from docB but specifying docA — must 404
         var query = new GetKbChunkByIdQuery(docA, RequestingUserId: Guid.NewGuid(), ChunkId: chunkB, UserIsAdmin: false);
-        var act = () => _handler.Handle(query, CancellationToken.None);
 
-        await act.Should().ThrowAsync<NotFoundException>();
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<NotFoundException>();
     }
 
     [Fact]
-    public async Task Handle_NonExistentChunk_ThrowsNotFound()
+    public async Task Handle_NonExistentChunk_Throws404()
     {
         var docId = Guid.NewGuid();
         await SeedThreeChunksAsync(docId);
 
         var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: Guid.NewGuid(), UserIsAdmin: false);
-        var act = () => _handler.Handle(query, CancellationToken.None);
 
-        await act.Should().ThrowAsync<NotFoundException>();
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_PrivateDocOtherUser_Throws403()
+    {
+        var docId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "private.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = ownerId,
+            FilePath = "/tmp/private.pdf",
+            IsPublic = false
+        });
+        var chunkId = Guid.NewGuid();
+        _dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId,
+            PdfDocumentId = docId,
+            Content = "private content",
+            ChunkIndex = 0,
+            CharacterCount = 15,
+            ElementType = "NarrativeText",
+            Level = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunkId, UserIsAdmin: false);
+
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_MarkdownSanitization_StripsImagesAndDemotesH4()
+    {
+        var docId = Guid.NewGuid();
+        var chunkId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "doc.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/doc.pdf",
+            IsPublic = true
+        });
+        _dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId,
+            PdfDocumentId = docId,
+            Content = "#### Subheader\n\nPara with ![alt](http://example.com/img.png) image.",
+            ChunkIndex = 0,
+            CharacterCount = 60,
+            ElementType = "NarrativeText",
+            Level = 1
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbChunkByIdQuery(docId, RequestingUserId: Guid.NewGuid(), ChunkId: chunkId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.Content.Should().Contain("**Subheader**"); // H4 demoted
+        dto.Content.Should().Contain("[Image: alt]"); // image replaced
+        dto.Content.Should().NotContain("![alt]"); // raw image syntax removed
+        dto.Content.Should().NotContain("####"); // H4 stripped from prefix
     }
 
     private async Task<(Guid chunk0, Guid chunk1, Guid chunk2)> SeedThreeChunksAsync(Guid docId)
     {
-        var pdf = new PdfDocumentEntity
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = docId,
             FileName = $"doc-{docId}.pdf",
@@ -106,8 +194,7 @@ public sealed class GetKbChunkByIdHandlerTests
             UploadedByUserId = Guid.NewGuid(),
             FilePath = "/tmp/doc.pdf",
             IsPublic = true
-        };
-        _dbContext.PdfDocuments.Add(pdf);
+        });
 
         var chunk0 = Guid.NewGuid();
         var chunk1 = Guid.NewGuid();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbChunksHandlerTests.cs
@@ -1,7 +1,10 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -10,106 +13,180 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 
+/// <summary>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2) — spec-conformant rewrite tests
+/// for <see cref="GetKbChunksHandler"/>. Replaces the prior offset-pagination
+/// suite with cursor-pagination semantics: opaque (Position, Id) base64 cursor,
+/// nextCursor null on last page, malformed cursor → caller emits 400.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "KnowledgeBase")]
 public sealed class GetKbChunksHandlerTests
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<GetKbChunksHandler> _logger;
+    private readonly IHybridCacheService _cache;
     private readonly GetKbChunksHandler _handler;
 
     public GetKbChunksHandlerTests()
     {
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
         _logger = Substitute.For<ILogger<GetKbChunksHandler>>();
-        _handler = new GetKbChunksHandler(_dbContext, _logger);
+        _cache = new TestHybridCacheService();
+        _handler = new GetKbChunksHandler(_dbContext, _cache, _logger);
     }
 
     [Fact]
-    public async Task Handle_WhenDocHas120Chunks_ReturnsFirstPage()
+    public async Task Handle_FirstPage_ReturnsItemsAndNextCursor()
     {
-        var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 50, UserIsAdmin: false);
+        var docId = await SeedDocumentWithChunksAsync(120);
+        var query = new GetKbChunksQuery(
+            docId,
+            RequestingUserId: Guid.NewGuid(),
+            Cursor: null,
+            Limit: 50,
+            UserIsAdmin: false);
 
         var result = await _handler.Handle(query, CancellationToken.None);
 
-        result.Chunks.Should().HaveCount(50);
-        result.Chunks.Select(c => c.Position).Should().BeInAscendingOrder();
+        result.Items.Should().HaveCount(50);
+        result.Items.Select(c => c.Position).Should().BeInAscendingOrder();
         result.TotalCount.Should().Be(120);
-        result.HasMore.Should().BeTrue();
-        result.Chunks.First().Snippet.Length.Should().BeLessThanOrEqualTo(200);
-        result.ProcessingState.Should().Be("ready");
+        result.NextCursor.Should().NotBeNullOrEmpty();
+        result.Items.First().Snippet.Length.Should().BeLessThanOrEqualTo(200);
     }
 
     [Fact]
-    public async Task Handle_LastPagePartial_HasMoreFalse()
+    public async Task Handle_LastPage_ReturnsItemsAndNullCursor()
     {
-        var docId = await SeedDocumentWithChunksAsync(120, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 100, Take: 50, UserIsAdmin: false);
+        var docId = await SeedDocumentWithChunksAsync(120);
 
-        var result = await _handler.Handle(query, CancellationToken.None);
+        // Fetch first page to obtain a cursor.
+        var first = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 100, UserIsAdmin: false),
+            CancellationToken.None);
 
-        result.Chunks.Should().HaveCount(20);
-        result.HasMore.Should().BeFalse();
+        first.NextCursor.Should().NotBeNull();
+        var firstCursor = KbChunksCursor.Decode(first.NextCursor);
+
+        var second = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), firstCursor, 100, UserIsAdmin: false),
+            CancellationToken.None);
+
+        second.Items.Should().HaveCount(20);
+        second.NextCursor.Should().BeNull();
     }
 
     [Fact]
-    public async Task Handle_DocStillProcessing_ReturnsEmptyChunks()
+    public async Task Handle_CursorPagination_AdvancesPositionMonotonically()
     {
-        var docId = await SeedDocumentWithChunksAsync(0, processingState: "Embedding");
-        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 50, UserIsAdmin: false);
+        var docId = await SeedDocumentWithChunksAsync(50);
 
-        var result = await _handler.Handle(query, CancellationToken.None);
+        var firstPage = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 20, UserIsAdmin: false),
+            CancellationToken.None);
 
-        result.Chunks.Should().BeEmpty();
-        result.ProcessingState.Should().Be("embedding");
+        var lastPositionFirstPage = firstPage.Items.Last().Position;
+        var cursor = KbChunksCursor.Decode(firstPage.NextCursor);
+
+        var secondPage = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), cursor, 20, UserIsAdmin: false),
+            CancellationToken.None);
+
+        secondPage.Items.First().Position.Should().BeGreaterThan(lastPositionFirstPage);
     }
 
     [Fact]
-    public async Task Handle_AdminSeesDiagnosticFields()
+    public async Task Handle_VectorIdAlwaysPresent_DegatedFromAdmin()
     {
-        var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 5, UserIsAdmin: true);
+        var docId = await SeedDocumentWithChunksAsync(3);
 
-        var result = await _handler.Handle(query, CancellationToken.None);
+        var nonAdminResult = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 10, UserIsAdmin: false),
+            CancellationToken.None);
 
-        result.Chunks.Should().HaveCount(5);
-        result.Chunks.First().VectorId.Should().NotBeNull();
-        result.Chunks.First().CharacterCount.Should().NotBeNull();
-        result.Chunks.First().ElementType.Should().NotBeNullOrEmpty();
+        var adminResult = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 10, UserIsAdmin: true),
+            CancellationToken.None);
+
+        // Spec §6.3.2: VectorId emitted as a string for ALL viewers.
+        nonAdminResult.Items.Should().AllSatisfy(c => c.VectorId.Should().NotBeNullOrEmpty());
+        adminResult.Items.Should().AllSatisfy(c => c.VectorId.Should().NotBeNullOrEmpty());
     }
 
     [Fact]
-    public async Task Handle_NonAdminGetsAdminFieldsNulled()
+    public async Task Handle_DocNotFound_Throws404()
     {
-        var docId = await SeedDocumentWithChunksAsync(5, processingState: "Ready");
-        var query = new GetKbChunksQuery(docId, RequestingUserId: Guid.NewGuid(), Skip: 0, Take: 5, UserIsAdmin: false);
+        var query = new GetKbChunksQuery(
+            Guid.NewGuid(),
+            RequestingUserId: Guid.NewGuid(),
+            Cursor: null,
+            Limit: 50,
+            UserIsAdmin: false);
 
-        var result = await _handler.Handle(query, CancellationToken.None);
-
-        result.Chunks.Should().HaveCount(5);
-        result.Chunks.First().VectorId.Should().BeNull();
-        result.Chunks.First().CharacterCount.Should().BeNull();
-        result.Chunks.First().ElementType.Should().BeNull();
-        result.Chunks.First().EmbeddingStatus.Should().BeNull();
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<NotFoundException>();
     }
 
-    private async Task<Guid> SeedDocumentWithChunksAsync(int chunkCount, string processingState)
+    [Fact]
+    public async Task Handle_PrivateDocOtherUser_Throws403()
     {
         var docId = Guid.NewGuid();
-        var pdf = new PdfDocumentEntity
+        var ownerId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = "private.pdf",
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = ownerId,
+            FilePath = "/tmp/private.pdf",
+            IsPublic = false
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbChunksQuery(
+            docId,
+            RequestingUserId: Guid.NewGuid(),
+            Cursor: null,
+            Limit: 50,
+            UserIsAdmin: false);
+
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_EmptyDoc_ReturnsEmptyItemsZeroTotal()
+    {
+        var docId = await SeedDocumentWithChunksAsync(0);
+
+        var result = await _handler.Handle(
+            new GetKbChunksQuery(docId, Guid.NewGuid(), null, 50, UserIsAdmin: false),
+            CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.NextCursor.Should().BeNull();
+    }
+
+    private async Task<Guid> SeedDocumentWithChunksAsync(int chunkCount)
+    {
+        var docId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = docId,
             FileName = $"test-{chunkCount}.pdf",
-            ProcessingState = processingState,
+            ProcessingState = "Ready",
             UploadedAt = DateTime.UtcNow,
             Language = "en",
             DocumentCategory = "Rulebook",
             UploadedByUserId = Guid.NewGuid(),
             FilePath = "/tmp/test.pdf",
             IsPublic = true
-        };
-        _dbContext.PdfDocuments.Add(pdf);
+        });
 
         for (int i = 0; i < chunkCount; i++)
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbDocumentByIdHandlerTests.cs
@@ -1,8 +1,12 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbDocumentById;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
+using Api.Services;
 using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -11,180 +15,279 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 
+/// <summary>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.1) — spec-conformant rewrite tests
+/// for <see cref="GetKbDocumentByIdHandler"/>. Replaces the prior #730 baseline
+/// suite (admin-gated diagnostic fields) with the new contract: 423 Locked
+/// when processingStatus != 'ready', 4-value docType + processingStatus enums,
+/// gameName + uploaderName joins, tags Gate B v1 stub.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "KnowledgeBase")]
 public sealed class GetKbDocumentByIdHandlerTests
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<GetKbDocumentByIdHandler> _logger;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IHybridCacheService _cache;
     private readonly GetKbDocumentByIdHandler _handler;
 
     public GetKbDocumentByIdHandlerTests()
     {
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
         _logger = Substitute.For<ILogger<GetKbDocumentByIdHandler>>();
-        _handler = new GetKbDocumentByIdHandler(_dbContext, _logger);
+        _sharedGameRepository = Substitute.For<ISharedGameRepository>();
+        _sharedGameRepository
+            .GetNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new Dictionary<Guid, string>());
+        _cache = new TestHybridCacheService();
+        _handler = new GetKbDocumentByIdHandler(_dbContext, _sharedGameRepository, _cache, _logger);
     }
 
     [Fact]
-    public async Task Handle_WhenDocReady_ReturnsFullMetadata()
+    public async Task Handle_ReadyDoc_ReturnsFullDtoWithReadyStatus()
     {
-        // Arrange
         var docId = Guid.NewGuid();
-        var pdf = new PdfDocumentEntity
-        {
-            Id = docId,
-            FileName = "Catan rulebook.pdf",
-            ProcessingState = "Ready",
-            PageCount = 32,
-            UploadedAt = DateTime.UtcNow.AddHours(-1),
-            Language = "it",
-            DocumentCategory = "Rulebook",
-            UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/test.pdf",
-            IsPublic = true
-        };
-        var vd = new VectorDocumentEntity
+        var sharedGameId = Guid.NewGuid();
+        var pdf = SeedPdf(
+            id: docId,
+            fileName: "Catan rulebook.pdf",
+            processingState: "Ready",
+            documentCategory: "Rulebook",
+            sharedGameId: sharedGameId,
+            pageCount: 32);
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.VectorDocuments.Add(new VectorDocumentEntity
         {
             Id = Guid.NewGuid(),
             PdfDocumentId = docId,
-            GameId = Guid.NewGuid(),
+            GameId = sharedGameId,
             ChunkCount = 120,
             IndexedAt = DateTime.UtcNow,
             IndexingStatus = "Completed"
-        };
-        _dbContext.PdfDocuments.Add(pdf);
-        _dbContext.VectorDocuments.Add(vd);
+        });
+        SeedUploader(pdf.UploadedByUserId, "Marco");
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
+        _sharedGameRepository
+            .GetNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new Dictionary<Guid, string> { [sharedGameId] = "Catan" });
 
-        // Act
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: pdf.UploadedByUserId, UserIsAdmin: false);
+
         var dto = await _handler.Handle(query, CancellationToken.None);
 
-        // Assert
         dto.Should().NotBeNull();
-        dto!.Title.Should().Be("Catan rulebook.pdf");
-        dto.ProcessingState.Should().Be("ready");
-        dto.TotalChunks.Should().Be(120);
+        dto.Id.Should().Be(docId);
+        dto.Title.Should().Be("Catan rulebook"); // .pdf trimmed
+        dto.DocType.Should().Be("rulebook");
+        dto.ProcessingStatus.Should().Be("ready");
+        dto.GameId.Should().Be(sharedGameId);
+        dto.GameName.Should().Be("Catan");
+        dto.UploaderName.Should().Be("Marco");
+        dto.ChunkCount.Should().Be(120);
         dto.PageCount.Should().Be(32);
-        dto.ProcessingError.Should().BeNull();
+        dto.Tags.Should().BeEmpty(); // Gate B v1 carryover
     }
 
-    [Fact]
-    public async Task Handle_WhenDocFailed_AdminSeesError()
+    [Theory]
+    [InlineData("Pending", "queued")]
+    [InlineData("Uploading", "queued")]
+    [InlineData("Extracting", "processing")]
+    [InlineData("Chunking", "processing")]
+    [InlineData("Embedding", "processing")]
+    [InlineData("Indexing", "processing")]
+    public async Task Handle_NonReadyDoc_Throws423Locked(string state, string expectedStatus)
     {
         var docId = Guid.NewGuid();
-        var pdf = new PdfDocumentEntity
-        {
-            Id = docId,
-            FileName = "BrokenDoc.pdf",
-            ProcessingState = "Failed",
-            ProcessingError = "Embedding API timeout",
-            RetryCount = 2,
-            FailedAtState = "Embedding",
-            UploadedAt = DateTime.UtcNow,
-            Language = "en",
-            DocumentCategory = "Rulebook",
-            UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/broken.pdf",
-            IsPublic = true
-        };
+        var pdf = SeedPdf(id: docId, processingState: state);
         _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: true);
-
-        var dto = await _handler.Handle(query, CancellationToken.None);
-
-        dto.Should().NotBeNull();
-        dto!.ProcessingError.Should().Be("Embedding API timeout");
-        dto.RetryCount.Should().Be(2);
-        dto.FailedAtState.Should().Be("Embedding");
-    }
-
-    [Fact]
-    public async Task Handle_WhenNonAdminViewsFailedDoc_ErrorFieldsAreNull()
-    {
-        var docId = Guid.NewGuid();
-        var pdf = new PdfDocumentEntity
-        {
-            Id = docId,
-            FileName = "BrokenDoc.pdf",
-            ProcessingState = "Failed",
-            ProcessingError = "Embedding API timeout",
-            RetryCount = 2,
-            FailedAtState = "Embedding",
-            UploadedAt = DateTime.UtcNow,
-            Language = "en",
-            DocumentCategory = "Rulebook",
-            UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/broken.pdf",
-            IsPublic = true
-        };
-        _dbContext.PdfDocuments.Add(pdf);
-        await _dbContext.SaveChangesAsync();
-
-        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
-
-        var dto = await _handler.Handle(query, CancellationToken.None);
-
-        dto!.ProcessingState.Should().Be("failed");
-        dto.ProcessingError.Should().BeNull();
-        dto.RetryCount.Should().BeNull();
-        dto.FailedAtState.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task Handle_WhenDocNotFound_ThrowsNotFoundException()
-    {
-        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: pdf.UploadedByUserId, UserIsAdmin: false);
 
         var act = () => _handler.Handle(query, CancellationToken.None);
 
-        await act.Should().ThrowAsync<NotFoundException>();
+        var ex = await act.Should().ThrowAsync<LockedException>();
+        ex.And.Message.Should().Contain(expectedStatus);
     }
 
     [Fact]
-    public async Task Handle_WhenReadyDocAndAdmin_AdminFieldsAreNull()
+    public async Task Handle_FailedDoc_Throws423LockedWithFailedStatus()
     {
-        // Arrange: Ready doc with RetryCount=0 (default, no retries occurred)
         var docId = Guid.NewGuid();
-        var pdf = new PdfDocumentEntity
-        {
-            Id = docId,
-            FileName = "Ready.pdf",
-            ProcessingState = "Ready",
-            PageCount = 10,
-            UploadedAt = DateTime.UtcNow,
-            Language = "en",
-            DocumentCategory = "Rulebook",
-            UploadedByUserId = Guid.NewGuid(),
-            FilePath = "/tmp/ready.pdf",
-            IsPublic = true
-        };
-        var vd = new VectorDocumentEntity
-        {
-            Id = Guid.NewGuid(),
-            PdfDocumentId = docId,
-            GameId = Guid.NewGuid(),
-            ChunkCount = 50,
-            IndexedAt = DateTime.UtcNow,
-            IndexingStatus = "Completed"
-        };
+        var pdf = SeedPdf(id: docId, processingState: "Failed");
         _dbContext.PdfDocuments.Add(pdf);
-        _dbContext.VectorDocuments.Add(vd);
+        SeedUploader(pdf.UploadedByUserId);
         await _dbContext.SaveChangesAsync();
 
-        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: true);
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: pdf.UploadedByUserId, UserIsAdmin: false);
 
-        // Act
-        var dto = await _handler.Handle(query, CancellationToken.None);
+        var act = () => _handler.Handle(query, CancellationToken.None);
 
-        // Assert: admin viewing a Ready doc — all admin fields should be null/omitted
-        dto!.ProcessingState.Should().Be("ready");
-        dto.ProcessingError.Should().BeNull();
-        dto.RetryCount.Should().BeNull();
-        dto.FailedAtState.Should().BeNull();
+        var ex = await act.Should().ThrowAsync<LockedException>();
+        ex.And.Message.Should().Contain("failed");
+    }
+
+    [Theory]
+    [InlineData("Rulebook", "rulebook")]
+    [InlineData("Errata", "errata")]
+    [InlineData("Expansion", "guide")]
+    [InlineData("QuickStart", "guide")]
+    [InlineData("Reference", "guide")]
+    [InlineData("PlayerAid", "guide")]
+    [InlineData("Other", "guide")]
+    public async Task Handle_DocTypeMapping_CollapsesTo4Values(string raw, string expected)
+    {
+        var docId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready", documentCategory: raw);
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.DocType.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Handle_NoSharedGame_GameNameIsNull()
+    {
+        var docId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready", sharedGameId: null);
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.GameId.Should().BeNull();
+        dto.GameName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_UploaderMissingDisplayName_FallsBackToEmail()
+    {
+        var docId = Guid.NewGuid();
+        var uploaderId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready");
+        pdf.UploadedByUserId = uploaderId;
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = uploaderId,
+            Email = "marco@example.test",
+            DisplayName = null,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, uploaderId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.UploaderName.Should().Be("marco@example.test");
+    }
+
+    [Fact]
+    public async Task Handle_DocNotFound_Throws404()
+    {
+        var query = new GetKbDocumentByIdQuery(Guid.NewGuid(), RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
+
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_PrivateDocOtherUser_Throws403()
+    {
+        var docId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready", isPublic: false);
+        pdf.UploadedByUserId = ownerId;
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(ownerId);
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetKbDocumentByIdQuery(docId, RequestingUserId: Guid.NewGuid(), UserIsAdmin: false);
+
+        await _handler.Invoking(h => h.Handle(query, CancellationToken.None))
+            .Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_LastIngestedAtFallback_UsesUploadedAtWhenNoVectorDoc()
+    {
+        var docId = Guid.NewGuid();
+        var uploadedAt = DateTime.UtcNow.AddDays(-1);
+        var pdf = SeedPdf(id: docId, processingState: "Ready");
+        pdf.UploadedAt = uploadedAt;
+        pdf.ProcessedAt = null;
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.LastIngestedAt.Should().BeCloseTo(uploadedAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Handle_LanguageEmpty_DefaultsToIt()
+    {
+        var docId = Guid.NewGuid();
+        var pdf = SeedPdf(id: docId, processingState: "Ready", language: string.Empty);
+        _dbContext.PdfDocuments.Add(pdf);
+        SeedUploader(pdf.UploadedByUserId);
+        await _dbContext.SaveChangesAsync();
+
+        var dto = await _handler.Handle(
+            new GetKbDocumentByIdQuery(docId, pdf.UploadedByUserId, UserIsAdmin: false),
+            CancellationToken.None);
+
+        dto.Language.Should().Be("it");
+    }
+
+    private static PdfDocumentEntity SeedPdf(
+        Guid id,
+        string fileName = "test-doc.pdf",
+        string processingState = "Ready",
+        string documentCategory = "Rulebook",
+        Guid? sharedGameId = null,
+        int? pageCount = null,
+        bool isPublic = true,
+        string language = "it") => new()
+        {
+            Id = id,
+            FileName = fileName,
+            ProcessingState = processingState,
+            DocumentCategory = documentCategory,
+            SharedGameId = sharedGameId,
+            PageCount = pageCount,
+            UploadedAt = DateTime.UtcNow.AddHours(-1),
+            ProcessedAt = processingState == "Ready" ? DateTime.UtcNow : null,
+            Language = language,
+            UploadedByUserId = Guid.NewGuid(),
+            FilePath = "/tmp/test.pdf",
+            IsPublic = isPublic
+        };
+
+    private void SeedUploader(Guid userId, string? displayName = "Test User")
+    {
+        if (_dbContext.Users.Any(u => u.Id == userId)) return;
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"user-{userId:N}@example.test",
+            DisplayName = displayName,
+            CreatedAt = DateTime.UtcNow
+        });
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/KbChunksCursorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/KbChunksCursorTests.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2) — opaque cursor encoding
+/// round-trip and malformed-input fail-fast tests for <see cref="KbChunksCursor"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class KbChunksCursorTests
+{
+    [Fact]
+    public void Encode_Decode_RoundTripsPositionAndId()
+    {
+        var payload = new KbChunksCursor.CursorPayload(42, Guid.NewGuid());
+        var encoded = KbChunksCursor.Encode(payload);
+        var decoded = KbChunksCursor.Decode(encoded);
+
+        decoded.Should().NotBeNull();
+        decoded!.Position.Should().Be(payload.Position);
+        decoded.Id.Should().Be(payload.Id);
+    }
+
+    [Fact]
+    public void Encode_ProducesBase64String()
+    {
+        var encoded = KbChunksCursor.Encode(new KbChunksCursor.CursorPayload(1, Guid.NewGuid()));
+
+        // Should be valid base64 (no whitespace, only base64-alphabet + padding).
+        var act = () => Convert.FromBase64String(encoded);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Decode_NullOrEmpty_ReturnsNull()
+    {
+        KbChunksCursor.Decode(null).Should().BeNull();
+        KbChunksCursor.Decode(string.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void Decode_InvalidBase64_ThrowsFormatException()
+    {
+        var act = () => KbChunksCursor.Decode("not!valid!base64!");
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Decode_MissingColonSeparator_ThrowsFormatException()
+    {
+        // base64 of "no-colon-here"
+        var bad = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("no-colon-here"));
+        var act = () => KbChunksCursor.Decode(bad);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Decode_NonNumericPosition_ThrowsFormatException()
+    {
+        var bad = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"abc:{Guid.NewGuid():N}"));
+        var act = () => KbChunksCursor.Decode(bad);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Decode_InvalidGuid_ThrowsFormatException()
+    {
+        var bad = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("42:not-a-guid"));
+        var act = () => KbChunksCursor.Decode(bad);
+        act.Should().Throw<FormatException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Services/MarkdownSubsetSanitizerTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Services/MarkdownSubsetSanitizerTests.cs
@@ -1,0 +1,146 @@
+using Api.Infrastructure.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Services;
+
+/// <summary>
+/// Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.3) — markdown subset enforcement
+/// tests for <see cref="MarkdownSubsetSanitizer"/>. Validates each rule:
+/// H4-H6 demote, image replacement, raw HTML strip, footnote strip.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class MarkdownSubsetSanitizerTests
+{
+    [Fact]
+    public void Sanitize_NullInput_ReturnsEmptyString()
+    {
+        MarkdownSubsetSanitizer.Sanitize(null).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Sanitize_WhitespaceInput_ReturnsAsIs()
+    {
+        MarkdownSubsetSanitizer.Sanitize("   ").Should().Be("   ");
+    }
+
+    [Theory]
+    [InlineData("#### Subheader", "**Subheader**")]
+    [InlineData("##### Deep", "**Deep**")]
+    [InlineData("###### Deeper", "**Deeper**")]
+    public void Sanitize_H4toH6_DemotedToBold(string input, string expected)
+    {
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("# H1")]
+    [InlineData("## H2")]
+    [InlineData("### H3")]
+    public void Sanitize_H1toH3_Preserved(string input)
+    {
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_Image_ReplacedWithAltPlaceholder()
+    {
+        var input = "Some text ![Eagle photo](http://example.com/eagle.png) more text.";
+        var result = MarkdownSubsetSanitizer.Sanitize(input);
+
+        result.Should().Contain("[Image: Eagle photo]");
+        result.Should().NotContain("![Eagle photo]");
+        result.Should().NotContain("eagle.png");
+    }
+
+    [Fact]
+    public void Sanitize_ImageWithEmptyAlt_FallsBackToBareLabel()
+    {
+        var input = "![](http://example.com/x.png)";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Contain("[Image]");
+    }
+
+    [Fact]
+    public void Sanitize_RawHtml_Stripped()
+    {
+        var input = "Hello <script>alert(1)</script> world <iframe src=\"x\"></iframe>!";
+        var result = MarkdownSubsetSanitizer.Sanitize(input);
+
+        result.Should().NotContain("<script>");
+        result.Should().NotContain("</script>");
+        result.Should().NotContain("<iframe");
+        result.Should().NotContain("</iframe>");
+        result.Should().Contain("alert(1)"); // text content kept
+    }
+
+    [Fact]
+    public void Sanitize_FootnoteMarker_Stripped()
+    {
+        var input = "Reference[^1] in body text.";
+        var result = MarkdownSubsetSanitizer.Sanitize(input);
+
+        result.Should().Contain("Reference in body text.");
+        result.Should().NotContain("[^1]");
+    }
+
+    [Fact]
+    public void Sanitize_FootnoteDefinition_Stripped()
+    {
+        var input = "Body text\n[^1]: Footnote definition content.\nMore body.";
+        var result = MarkdownSubsetSanitizer.Sanitize(input);
+
+        result.Should().NotContain("[^1]");
+        result.Should().NotContain("Footnote definition content");
+        result.Should().Contain("Body text");
+        result.Should().Contain("More body");
+    }
+
+    [Fact]
+    public void Sanitize_PreservesFencedCodeBlock()
+    {
+        var input = "```python\nprint('hi')\n```";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesInlineCode()
+    {
+        var input = "Use `git status` to check.";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesPipeTable()
+    {
+        var input = "| a | b |\n|---|---|\n| 1 | 2 |";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesBlockquote()
+    {
+        var input = "> Quoted text.";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_PreservesEmphasis()
+    {
+        var input = "This is **bold** and *italic* and _underline_.";
+        MarkdownSubsetSanitizer.Sanitize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void Sanitize_CombinedRules_AppliedInOrder()
+    {
+        var input = "#### Header[^1]\n\n[^1]: Footnote\n\n![](pic.png) <b>bold</b>";
+        var result = MarkdownSubsetSanitizer.Sanitize(input);
+
+        result.Should().Contain("**Header**");
+        result.Should().NotContain("[^1]");
+        result.Should().Contain("[Image]");
+        result.Should().NotContain("<b>");
+        result.Should().Contain("bold"); // tag stripped, text kept
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Discover/DiscoverEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Discover/DiscoverEndpointsIntegrationTests.cs
@@ -1,0 +1,706 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Discover;
+
+/// <summary>
+/// Integration tests for the Wave 3 Phase 1 /discover quick-win endpoints
+/// (Issue #805 / PR #732 §4.3.2-4.3.5):
+///
+/// <list type="number">
+///   <item><c>GET /api/v1/catalog/games/new</c> — SharedGameCatalog BC, 1h cache</item>
+///   <item><c>GET /api/v1/agents/popular</c> — GameManagement (KnowledgeBase) BC, 15min cache</item>
+///   <item><c>GET /api/v1/kb-docs/recent</c> — KnowledgeBase BC, 5min cache</item>
+/// </list>
+///
+/// All three follow the per-PR-#732-§3.4 empty-state contract: 200 with
+/// <c>{ items: [] }</c> rather than 404. <c>limit</c> is clamped to <c>[1, 50]</c>
+/// at the endpoint layer; the validator on the query enforces the same range
+/// for the CQRS handler.
+///
+/// What is intentionally NOT verified here:
+///   - Cache TTL / hit-vs-miss behaviour (the integration factory swaps in a
+///     pass-through <c>TestHybridCacheService</c> that always invokes the
+///     factory). Cache-key correctness is exercised in handler-level unit tests.
+///   - Rate limiting (the integration factory disables the <c>BggSearch</c>
+///     -family rate limiters to keep the suite fast and deterministic).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Wave", "3-Phase-1")]
+public sealed class DiscoverEndpointsIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public DiscoverEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"discover_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/catalog/games/new (PR #732 §4.3.2)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewGames_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/catalog/games/new?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task NewGames_WithEmptyCatalog_Returns200WithEmptyItems()
+    {
+        // PR #732 §3.4 — empty state is 200 with { items: [] }, not 404.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NewGames_SortedByCreatedAtDescending()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Seed 3 games with explicit, distinct CreatedAt timestamps so the test is
+        // independent of insertion order or backing database tiebreak rules.
+        var oldest = DateTime.UtcNow.AddDays(-30);
+        var middle = DateTime.UtcNow.AddDays(-7);
+        var newest = DateTime.UtcNow.AddDays(-1);
+        await SeedSharedGameAsync(dbContext, "Old Game", createdAt: oldest);
+        await SeedSharedGameAsync(dbContext, "Middle Game", createdAt: middle);
+        await SeedSharedGameAsync(dbContext, "New Game", createdAt: newest);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("name").GetString().Should().Be("New Game");
+        items[1].GetProperty("name").GetString().Should().Be("Middle Game");
+        items[2].GetProperty("name").GetString().Should().Be("Old Game");
+    }
+
+    [Fact]
+    public async Task NewGames_ExcludesSoftDeletedRows()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedSharedGameAsync(dbContext, "Visible", createdAt: DateTime.UtcNow.AddDays(-1));
+        await SeedSharedGameAsync(
+            dbContext,
+            "Deleted",
+            createdAt: DateTime.UtcNow,
+            isDeleted: true);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("name").GetString().Should().Be("Visible");
+    }
+
+    [Fact]
+    public async Task NewGames_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedSharedGameAsync(
+                dbContext,
+                $"Game {i}",
+                createdAt: DateTime.UtcNow.AddMinutes(-i));
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=2",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task NewGames_ClampsExcessiveLimitTo50()
+    {
+        // PR #732 §3.3 caps page size at 50; the endpoint silently clamps a
+        // larger request rather than returning 400 (UI-friendly behaviour).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await SeedSharedGameAsync(dbContext, "Solo", createdAt: DateTime.UtcNow);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=200",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        // Only 1 game exists, but the request wouldn't 400 with limit=200.
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NewGames_ProjectsExpectedFieldShape()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedSharedGameAsync(
+            dbContext,
+            "Wingspan",
+            createdAt: DateTime.UtcNow.AddDays(-2),
+            yearPublished: 2019,
+            imageUrl: "https://example.com/wingspan.jpg");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/catalog/games/new?limit=1",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        item.GetProperty("name").GetString().Should().Be("Wingspan");
+        item.GetProperty("year").GetInt32().Should().Be(2019);
+        item.GetProperty("imageUrl").GetString().Should().Be("https://example.com/wingspan.jpg");
+        item.GetProperty("createdAt").GetDateTime().Should().BeCloseTo(
+            DateTime.UtcNow.AddDays(-2),
+            TimeSpan.FromMinutes(1));
+        // Publisher is nullable in the contract — no publishers seeded here.
+        item.TryGetProperty("publisher", out var publisher).Should().BeTrue();
+        publisher.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/agents/popular (PR #732 §4.3.3)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PopularAgents_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/agents/popular?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task PopularAgents_WithEmptyCatalog_Returns200WithEmptyItems()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/popular?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PopularAgents_OnlyReturnsActiveAgents()
+    {
+        // The handler reads from GetAllActiveAsync — inactive agents must not surface.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 2, inactiveCount: 3);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/popular?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task PopularAgents_DtoExposesInstallCountZeroV1()
+    {
+        // Schema reality v1 carryover (Gate B): there is no AgentInstallation
+        // entity, so installCount must always be 0 in the wire response.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 1, inactiveCount: 0);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/popular?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("installCount").GetInt32().Should().Be(0);
+        item.GetProperty("invocationCount").GetInt32().Should().Be(0);
+        item.GetProperty("name").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task PopularAgents_PopulatesGameNameWhenLinkedToGame()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, "Catan");
+        await TestSessionHelper.SeedAgentDefinitionsAsync(
+            dbContext,
+            activeCount: 1,
+            inactiveCount: 0,
+            gameId: gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/popular?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("gameId").GetGuid().Should().Be(gameId);
+        item.GetProperty("gameName").GetString().Should().Be("Catan");
+    }
+
+    [Fact]
+    public async Task PopularAgents_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await TestSessionHelper.SeedAgentDefinitionsAsync(dbContext, activeCount: 5, inactiveCount: 0);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/agents/popular?limit=2",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/kb-docs/recent (PR #732 §4.3.5)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RecentKbDocs_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/kb-docs/recent?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_WithEmptyCatalog_Returns200WithEmptyItems()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_OnlyReturnsReadyDocs()
+    {
+        // PR #732 §4.3.5 spec — exclude in-flight ingests
+        // (ProcessingState != Ready: Pending, Uploading, Extracting, Failed, etc.)
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "ready.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddHours(-1));
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "extracting.pdf",
+            processingState: "Extracting",
+            processedAt: null);
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "failed.pdf",
+            processingState: "Failed",
+            processedAt: null);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("title").GetString().Should().Be("ready");
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_SortedByLastIngestedAtDescending()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "oldest.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddDays(-7));
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "newest.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddHours(-1));
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "middle.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddDays(-2));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("title").GetString().Should().Be("newest");
+        items[1].GetProperty("title").GetString().Should().Be("middle");
+        items[2].GetProperty("title").GetString().Should().Be("oldest");
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_MapsDocumentCategoryToWireDocType()
+    {
+        // Rulebook → "rulebook", Errata → "errata", anything else → "guide"
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "rules.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddMinutes(-10),
+            documentCategory: "Rulebook");
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "errata.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddMinutes(-5),
+            documentCategory: "Errata");
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "expansion.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddMinutes(-1),
+            documentCategory: "Expansion");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        // Newest first: expansion → errata → rules.
+        items[0].GetProperty("docType").GetString().Should().Be("guide");
+        items[1].GetProperty("docType").GetString().Should().Be("errata");
+        items[2].GetProperty("docType").GetString().Should().Be("rulebook");
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_StripsTrailingPdfFromTitle()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "Catan Rulebook.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddMinutes(-1));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=1",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items")[0].GetProperty("title").GetString().Should().Be("Catan Rulebook");
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedPdfDocumentAsync(
+                dbContext,
+                userId,
+                fileName: $"doc-{i}.pdf",
+                processingState: "Ready",
+                processedAt: DateTime.UtcNow.AddMinutes(-i));
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=2",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RecentKbDocs_PopulatesGameNameAndChunkCount()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, "Wingspan");
+        var pdfId = await SeedPdfDocumentAsync(
+            dbContext,
+            userId,
+            fileName: "wingspan-rules.pdf",
+            processingState: "Ready",
+            processedAt: DateTime.UtcNow.AddMinutes(-10),
+            sharedGameId: gameId);
+
+        // VectorDocumentEntity drives the chunkCount projection.
+        dbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            ChunkCount = 47,
+            IndexingStatus = "Completed",
+            IndexedAt = DateTime.UtcNow.AddMinutes(-5),
+            SharedGameId = gameId
+        });
+        await dbContext.SaveChangesAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/kb-docs/recent?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("gameId").GetGuid().Should().Be(gameId);
+        item.GetProperty("gameName").GetString().Should().Be("Wingspan");
+        item.GetProperty("chunkCount").GetInt32().Should().Be(47);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Test helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Test-scope SharedGame seeder that lets the caller specify <c>CreatedAt</c>
+    /// (the canonical <see cref="TestSessionHelper.SeedSharedGameAsync"/> hardcodes
+    /// <c>DateTime.UtcNow</c>, which is unsuitable for sort-order assertions).
+    /// </summary>
+    private static async Task<Guid> SeedSharedGameAsync(
+        MeepleAiDbContext dbContext,
+        string title,
+        DateTime createdAt,
+        int yearPublished = 0,
+        string? imageUrl = null,
+        bool isDeleted = false)
+    {
+        var id = Guid.NewGuid();
+        dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            Description = "Integration test game",
+            ImageUrl = imageUrl ?? string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = yearPublished,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 45,
+            MinAge = 8,
+            Status = 1,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = createdAt,
+            IsDeleted = isDeleted
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task<Guid> SeedPdfDocumentAsync(
+        MeepleAiDbContext dbContext,
+        Guid uploadedByUserId,
+        string fileName,
+        string processingState,
+        DateTime? processedAt,
+        string documentCategory = "Rulebook",
+        Guid? sharedGameId = null)
+    {
+        var id = Guid.NewGuid();
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = fileName,
+            FilePath = $"/uploads/{id}.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = uploadedByUserId,
+            UploadedAt = (processedAt ?? DateTime.UtcNow).AddMinutes(-1),
+            ProcessingState = processingState,
+            ProcessedAt = processedAt,
+            DocumentCategory = documentCategory,
+            SharedGameId = sharedGameId,
+            Language = "en",
+            IsActiveForRag = true
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KbChunkEndpointsIntegrationTests.cs
@@ -92,32 +92,32 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetKbChunks_NestedHeadings_ReturnsHeadingPath()
     {
-        // Arrange — seed a doc with 3 chained chunks
+        // Wave 3 Phase 3: spec §6.3.2 — `items` envelope, cursor pagination
+        // (no skip/take query params), nextCursor null on last page.
         using var scope = _factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
 
-        // Create a real user first — PdfDocument.UploadedByUserId has a FK constraint to users
         var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
         var docId = await SeedDocWithNestedChunksAsync(dbContext, uploadedByUserId: userId);
 
         var request = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Get,
-            $"/api/v1/kb-docs/{docId}/chunks?skip=0&take=10",
+            $"/api/v1/kb-docs/{docId}/chunks?limit=10",
             sessionToken);
 
-        // Act
         var response = await _client.SendAsync(request);
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var json = await response.Content.ReadAsStringAsync();
         using var doc = System.Text.Json.JsonDocument.Parse(json);
-        var chunks = doc.RootElement.GetProperty("chunks");
-        chunks.GetArrayLength().Should().Be(3);
+        var items = doc.RootElement.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
 
-        // Leaf is the chunk at position (ChunkIndex) 2
-        var leaf = chunks.EnumerateArray()
+        // Spec §6.3.2: `nextCursor` is null on last page.
+        doc.RootElement.GetProperty("nextCursor").ValueKind.Should().Be(System.Text.Json.JsonValueKind.Null);
+
+        var leaf = items.EnumerateArray()
             .Single(c => c.GetProperty("position").GetInt32() == 2);
 
         var headingPath = leaf.GetProperty("headingPath")
@@ -128,32 +128,84 @@ public sealed class KbChunkEndpointsIntegrationTests : IAsyncLifetime
         headingPath.Should().BeEquivalentTo(
             new[] { "Setup", "Players", "Distribution" },
             options => options.WithStrictOrdering());
+
+        // VectorId always present for all viewers (spec §6.3.2 de-gating).
+        leaf.GetProperty("vectorId").GetString().Should().NotBeNullOrEmpty();
     }
 
     /// <summary>
-    /// Verifies the endpoint returns 400 Bad Request when take exceeds the maximum of 100.
-    /// The take validation happens before the document lookup, so no seed is required.
-    /// An unauthenticated client will get 401 before the handler runs; use an authenticated
-    /// request so the validation code path is exercised.
+    /// Wave 3 Phase 3: spec §6.3.2 — limit validation 1..100 fires before doc lookup.
     /// </summary>
     [Fact]
-    public async Task GetKbChunks_TakeExceedsLimit_Returns400()
+    public async Task GetKbChunks_LimitExceedsMaximum_Returns400()
     {
-        // Arrange — create an authenticated session so we reach the validation code
         using var scope = _factory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
 
         var request = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Get,
-            $"/api/v1/kb-docs/{Guid.NewGuid()}/chunks?take=500",
+            $"/api/v1/kb-docs/{Guid.NewGuid()}/chunks?limit=500",
             sessionToken);
 
-        // Act
         var response = await _client.SendAsync(request);
 
-        // Assert — 400 because take=500 > 100 (validation fires before document lookup)
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Wave 3 Phase 3: spec §6.3.2 — malformed cursor → 400 Bad Request.
+    /// </summary>
+    [Fact]
+    public async Task GetKbChunks_MalformedCursor_Returns400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{Guid.NewGuid()}/chunks?cursor=not-base64!",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// Wave 3 Phase 3: spec §6.3.1 — 423 Locked when processingStatus != 'ready'.
+    /// </summary>
+    [Fact]
+    public async Task GetKbDocument_NotReady_Returns423Locked()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var docId = Guid.NewGuid();
+        dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = docId,
+            FileName = $"in-progress-{docId:N}.pdf",
+            ProcessingState = "Embedding", // not Ready
+            UploadedAt = DateTime.UtcNow,
+            Language = "en",
+            DocumentCategory = "Rulebook",
+            UploadedByUserId = userId,
+            FilePath = $"/tmp/inprog-{docId:N}.pdf",
+            IsPublic = true
+        });
+        await dbContext.SaveChangesAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Locked);
     }
 
     // ========================================

--- a/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
@@ -1,0 +1,327 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4a;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/toolkits/recommended</c>
+/// (Wave 3 Phase 4a, PR #732 §4.3.4 / Issue #805).
+///
+/// <para>
+/// Powers the SP4 /discover route's "Recommended toolkits" rail. Sort:
+/// rating-weighted Bayesian score with createdAt DESC fallback (effective
+/// in v1 because rating/install entities are deferred to Phase 4b).
+/// </para>
+///
+/// <para>
+/// Visibility: only published + approved toolkits surface. Drafts, pending,
+/// and rejected are filtered out (PR #732 §5.2 security boundary).
+/// </para>
+///
+/// <para>
+/// Empty-state contract per PR #732 §3.4: 200 with <c>{ items: [] }</c>
+/// rather than 404 / 204.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-4a")]
+public sealed class RecommendedToolkitsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public RecommendedToolkitsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"recommended_toolkits_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/toolkits/recommended?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_WithEmptyCatalog_Returns200WithEmptyItems()
+    {
+        // PR #732 §3.4 — empty state is 200 with { items: [] }, not 404.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_OnlyReturnsPublishedAndApproved()
+    {
+        // Drafts, pending, rejected, and yanked must NOT surface on the public
+        // discover rail (PR #732 §5.2 security boundary).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Approved + published → SHOULD surface.
+        await SeedToolkitAsync(dbContext, authorId, "Approved+Published",
+            isPublished: true, templateStatus: TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-1));
+        // Draft → must NOT surface.
+        await SeedToolkitAsync(dbContext, authorId, "Hidden Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft,
+            createdAt: DateTime.UtcNow.AddHours(-1));
+        // Approved but unpublished → must NOT surface (combined gate).
+        await SeedToolkitAsync(dbContext, authorId, "Approved Unpublished",
+            isPublished: false, templateStatus: TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddHours(-2));
+        // Published but pending → must NOT surface.
+        await SeedToolkitAsync(dbContext, authorId, "Pending Published",
+            isPublished: true, templateStatus: TemplateStatus.PendingReview,
+            createdAt: DateTime.UtcNow.AddHours(-3));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("name").GetString().Should().Be("Approved+Published");
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_SortedByCreatedAtDescendingV1Fallback()
+    {
+        // Schema reality v1 (Gate B): rating + install metrics are 0/null,
+        // so the Bayesian score collapses to createdAt DESC.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        await SeedToolkitAsync(dbContext, authorId, "Oldest", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-30));
+        await SeedToolkitAsync(dbContext, authorId, "Middle", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-7));
+        await SeedToolkitAsync(dbContext, authorId, "Newest", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow.AddDays(-1));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("name").GetString().Should().Be("Newest");
+        items[1].GetProperty("name").GetString().Should().Be("Middle");
+        items[2].GetProperty("name").GetString().Should().Be("Oldest");
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_DtoExposesV1StubFields()
+    {
+        // Schema reality v1 (Gate B): installCount=0, ratingAverage=null,
+        // ratingCount=0, coverImageUrl=null.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await SeedToolkitAsync(dbContext, authorId, "Wingspan Toolkit", true,
+            TemplateStatus.Approved, createdAt: DateTime.UtcNow.AddHours(-1));
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        item.GetProperty("name").GetString().Should().Be("Wingspan Toolkit");
+        // Author name resolved from UserEntity (DisplayName fallback to email "Test User").
+        item.GetProperty("authorName").GetString().Should().NotBeNullOrEmpty();
+        item.GetProperty("installCount").GetInt32().Should().Be(0);
+        item.GetProperty("ratingAverage").ValueKind.Should().Be(JsonValueKind.Null);
+        item.GetProperty("ratingCount").GetInt32().Should().Be(0);
+        item.GetProperty("coverImageUrl").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedToolkitAsync(dbContext, authorId, $"Toolkit {i}",
+                true, TemplateStatus.Approved,
+                createdAt: DateTime.UtcNow.AddMinutes(-i));
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=2",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RecommendedToolkits_ClampsExcessiveLimitTo50()
+    {
+        // PR #732 §3.3: silent UI-friendly clamp rather than 400.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        await SeedToolkitAsync(dbContext, authorId, "Solo", true, TemplateStatus.Approved,
+            createdAt: DateTime.UtcNow);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/toolkits/recommended?limit=200",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Only 1 toolkit exists, but the request wouldn't 400 with limit=200.
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(1);
+    }
+
+    /// <summary>
+    /// Seeds an authored GameToolkit with explicit createdAt. Mirrors the raw
+    /// SQL pattern from <c>ToolkitMarketplaceEndpointsIntegrationTests</c> —
+    /// the row-version + JSONB columns require a raw INSERT to bypass EF's
+    /// store-generated stripping of <c>RowVersion</c>.
+    /// </summary>
+    private static async Task SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus,
+        DateTime createdAt)
+    {
+        // GameToolkitEntity.GameId references the "games" table (GameEntity).
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var updatedAt = createdAt;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        const string sql = """
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                NULL,
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            createdAt,
+            updatedAt,
+            templateStatusInt,
+            isTemplate);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Phase4a/TopUserContributorsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4a/TopUserContributorsEndpointIntegrationTests.cs
@@ -1,0 +1,353 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4a;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/users/top-contributors</c>
+/// (Wave 3 Phase 4a, PR #732 §4.3.6 / Issue #805).
+///
+/// <para>
+/// Powers the SP4 /discover route's "Top contributors" rail. Distinct from
+/// the existing <c>/api/v1/shared-games/top-contributors</c> leaderboard
+/// (sessions/wins) — this surface aggregates contribution sources (FAQs,
+/// KB uploads, AI agents created) for community editors.
+/// </para>
+///
+/// <para>
+/// Schema reality v1 (Gate B audit): only <c>UploadedByUserId</c> on
+/// <c>PdfDocumentEntity</c> exists. <c>GameFaqEntity</c> + <c>AgentDefinition</c>
+/// have no creator FK in v1, so <c>FaqsCount</c> and <c>AgentsCreatedCount</c>
+/// are stubbed to 0. <c>ContributionCount</c> therefore equals
+/// <c>KbUploadsCount</c> in v1.
+/// </para>
+///
+/// <para>
+/// Privacy guards: skip suspended accounts, require <c>Status == "Active"</c>,
+/// require non-null <c>DisplayName</c>.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Administration")]
+[Trait("Wave", "3-Phase-4a")]
+public sealed class TopUserContributorsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public TopUserContributorsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"top_user_contributors_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task TopContributors_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/v1/users/top-contributors?limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TopContributors_WithEmptyData_Returns200WithEmptyItems()
+    {
+        // PR #732 §3.4 — empty state is 200 with { items: [] }, not 404.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TopContributors_RanksUsersByKbUploadsDescending()
+    {
+        // V1: only KB uploads count toward ContributionCount. Sort: count DESC,
+        // then UserId ASC tiebreak.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        // Seed three contributors with explicit display names + upload counts.
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedActiveUserAsync(dbContext, "Bob");
+        var carol = await SeedActiveUserAsync(dbContext, "Carol");
+
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 5);
+        await SeedPdfUploadsAsync(dbContext, carol, count: 3);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(3);
+        items[0].GetProperty("displayName").GetString().Should().Be("Bob");
+        items[0].GetProperty("contributionCount").GetInt32().Should().Be(5);
+        items[1].GetProperty("displayName").GetString().Should().Be("Carol");
+        items[1].GetProperty("contributionCount").GetInt32().Should().Be(3);
+        items[2].GetProperty("displayName").GetString().Should().Be("Alice");
+        items[2].GetProperty("contributionCount").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TopContributors_BreakdownStubsFaqsAndAgentsToZeroV1()
+    {
+        // Schema reality v1 (Gate B): FaqsCount + AgentsCreatedCount stubbed
+        // to 0 because GameFaqEntity + AgentDefinition lack creator FK columns.
+        // Only KbUploadsCount is real.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 4);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        var breakdown = item.GetProperty("breakdown");
+        breakdown.GetProperty("faqsCount").GetInt32().Should().Be(0);
+        breakdown.GetProperty("kbUploadsCount").GetInt32().Should().Be(4);
+        breakdown.GetProperty("agentsCreatedCount").GetInt32().Should().Be(0);
+        // ContributionCount = sum of breakdown sources (in v1: KbUploadsCount only).
+        item.GetProperty("contributionCount").GetInt32().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task TopContributors_ExcludesSuspendedUsers()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedSuspendedUserAsync(dbContext, "Bob");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 10); // would dominate if not filtered
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("displayName").GetString().Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task TopContributors_ExcludesUsersWithNullDisplayName()
+    {
+        // Privacy guard: avoid surfacing email-derived identifiers.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice");
+        var bob = await SeedActiveUserAsync(dbContext, displayName: null);
+        await SeedPdfUploadsAsync(dbContext, alice, count: 1);
+        await SeedPdfUploadsAsync(dbContext, bob, count: 10);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        items[0].GetProperty("displayName").GetString().Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task TopContributors_RespectsLimitParameter()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        for (var i = 0; i < 5; i++)
+        {
+            var u = await SeedActiveUserAsync(dbContext, $"User-{i}");
+            await SeedPdfUploadsAsync(dbContext, u, count: i + 1);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=2",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("items").GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TopContributors_DtoExposesExpectedFieldShape()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var alice = await SeedActiveUserAsync(dbContext, "Alice", avatarUrl: "https://example.com/alice.png");
+        await SeedPdfUploadsAsync(dbContext, alice, count: 2);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/users/top-contributors?limit=10",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var item = body.GetProperty("items")[0];
+        item.GetProperty("id").GetGuid().Should().Be(alice);
+        item.GetProperty("displayName").GetString().Should().Be("Alice");
+        item.GetProperty("avatarUrl").GetString().Should().Be("https://example.com/alice.png");
+        item.GetProperty("contributionCount").GetInt32().Should().Be(2);
+        item.GetProperty("breakdown").ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    /// <summary>
+    /// Seeds an active <see cref="UserEntity"/> with the given display name.
+    /// </summary>
+    private static async Task<Guid> SeedActiveUserAsync(
+        MeepleAiDbContext dbContext,
+        string? displayName,
+        string? avatarUrl = null)
+    {
+        var id = Guid.NewGuid();
+        dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"user-{id:N}@test.com",
+            DisplayName = displayName,
+            PasswordHash = null,
+            Role = "user",
+            Tier = "free",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow,
+            Status = "Active",
+            IsSuspended = false,
+            AvatarUrl = avatarUrl,
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task<Guid> SeedSuspendedUserAsync(
+        MeepleAiDbContext dbContext,
+        string? displayName)
+    {
+        var id = Guid.NewGuid();
+        dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = id,
+            Email = $"suspended-{id:N}@test.com",
+            DisplayName = displayName,
+            PasswordHash = null,
+            Role = "user",
+            Tier = "free",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow,
+            Status = "Active",   // Privacy guard fires on IsSuspended; Active+IsSuspended drops them.
+            IsSuspended = true,
+            SuspendedAt = DateTime.UtcNow.AddDays(-1),
+        });
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task SeedPdfUploadsAsync(
+        MeepleAiDbContext dbContext,
+        Guid userId,
+        int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            dbContext.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = id,
+                FileName = $"doc-{i}.pdf",
+                FilePath = $"/uploads/{id}.pdf",
+                FileSizeBytes = 1024,
+                UploadedByUserId = userId,
+                UploadedAt = DateTime.UtcNow.AddMinutes(-i),
+                ProcessingState = "Ready",
+                Language = "en",
+                IsActiveForRag = true
+            });
+        }
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
@@ -1,0 +1,336 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Phase4b;
+
+/// <summary>
+/// Integration tests for the toolkit ratings surface
+/// (Wave 3 Phase 4b, PR #732 §5.3.3 + §5.3.4 / Issue #805).
+///
+/// <para>
+/// Schema reality v1 carryover (Gate B): the <c>ToolkitRating</c> entity does
+/// not exist yet. <c>GET /toolkits/{id}/ratings</c> returns an empty stub
+/// envelope once the visibility check passes; <c>POST /toolkits/{id}/ratings</c>
+/// returns 501 Not Implemented with a machine-readable body. Wire shape is
+/// stable so the FE can render today and adopt real persistence in Phase 5.
+/// </para>
+///
+/// <para>
+/// Visibility rule (PR #732 §5.2 security boundary): non-authors must not
+/// learn about drafts/yanked toolkits via the ratings surface — the handler
+/// returns 404 in that case, mirroring the toolkit detail endpoint.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-4b")]
+public sealed class ToolkitRatingsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ToolkitRatingsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_ratings_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    // ───────────────────────── GET /toolkits/{id}/ratings ─────────────────────
+
+    [Fact]
+    public async Task GetRatings_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}/ratings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetRatings_ForUnknownToolkit_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/ratings",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetRatings_OnDraftToolkit_NonOwner_Returns404()
+    {
+        // PR #732 §5.2 security boundary — non-authors must not learn that a
+        // draft toolkit exists via the ratings surface.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Hidden Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetRatings_OnDraftToolkit_AsOwner_Returns200WithEmptyStub()
+    {
+        // Authors must always see their own toolkits, even drafts.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "My Draft",
+            isPublished: false, templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        AssertEmptyStubShape(await response.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    [Fact]
+    public async Task GetRatings_OnPublishedToolkit_Returns200WithEmptyStub()
+    {
+        // PR #732 §3.4 empty-state contract: 200 with { items: [] }, breakdown
+        // all zero, averageStars=0, totalCount=0 (Gate B v1 — no entity yet).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public Toolkit",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings?limit=20",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        AssertEmptyStubShape(await response.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    [Fact]
+    public async Task GetRatings_WithCursor_StillReturnsEmptyStub()
+    {
+        // Cursor is opaque in v1 — handler always returns nextCursor=null
+        // until persistence ships in Phase 5.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkitId}/ratings?cursor=arbitrary-token&limit=10",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        AssertEmptyStubShape(body);
+    }
+
+    [Fact]
+    public async Task GetRatings_LimitClamping_AcceptsOutOfRangeValues()
+    {
+        // Endpoint silent-clamps limit (PR #732 §3.3 UI-friendly behavior).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var toolkitId = await SeedToolkitAsync(dbContext, authorId, "Public",
+            isPublished: true, templateStatus: TemplateStatus.Approved);
+
+        // limit=0 → clamped to default 20, limit=999 → clamped to 50
+        foreach (var url in new[]
+                 {
+                     $"/api/v1/toolkits/{toolkitId}/ratings?limit=0",
+                     $"/api/v1/toolkits/{toolkitId}/ratings?limit=999",
+                 })
+        {
+            var request = TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, url, viewerToken);
+            var response = await _client.SendAsync(request);
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"limit clamp for {url}");
+        }
+    }
+
+    // ───────────────────────── POST /toolkits/{id}/ratings (stub) ─────────────
+
+    [Fact]
+    public async Task SubmitRating_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/toolkits/{Guid.NewGuid()}/ratings",
+            new { stars = 5, comment = "Great!" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SubmitRating_Authenticated_Returns501WithStubBody()
+    {
+        // Phase 4b stub — wire shape reserved, FE detects via 501 status +
+        // machine-readable body.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkitId = Guid.NewGuid();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkitId}/ratings",
+            sessionToken);
+        request.Content = JsonContent.Create(new { stars = 5, comment = "Great!" });
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("error").GetString().Should().Be("ratings_submission_not_yet_available");
+        body.GetProperty("phase").GetString().Should().Be("4b-stub");
+        body.GetProperty("toolkitId").GetGuid().Should().Be(toolkitId);
+    }
+
+    // ───────────────────────── helpers ────────────────────────────────────────
+
+    private static void AssertEmptyStubShape(JsonElement body)
+    {
+        body.GetProperty("items").GetArrayLength().Should().Be(0);
+        body.GetProperty("nextCursor").ValueKind.Should().Be(JsonValueKind.Null);
+        body.GetProperty("totalCount").GetInt32().Should().Be(0);
+        body.GetProperty("averageStars").GetDecimal().Should().Be(0m);
+
+        var breakdown = body.GetProperty("breakdown");
+        breakdown.GetProperty("star1").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star2").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star3").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star4").GetInt32().Should().Be(0);
+        breakdown.GetProperty("star5").GetInt32().Should().Be(0);
+    }
+
+    private static async Task<Guid> SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus)
+    {
+        // Mirror the Phase 4a seed pattern (raw SQL — bypasses the strict EF
+        // entity which has private setters and required JSON columns).
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        const string sql = """
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                NULL,
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            now,
+            now,
+            templateStatusInt,
+            isTemplate);
+
+        return toolkitId;
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
@@ -1,0 +1,704 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameToolkit;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.ToolkitMarketplace;
+
+/// <summary>
+/// Integration tests for the Wave 3 Phase 2 toolkit marketplace endpoints
+/// (Issue #805 / PR #732 §5.3.1, §5.3.2, §5.3.5):
+///
+/// <list type="number">
+///   <item><c>GET /api/v1/toolkits/{id}</c> — detail with viewerContext, 10min ETag per-viewer</item>
+///   <item><c>GET /api/v1/toolkits/{id}/versions</c> — versions list, 10min cache</item>
+///   <item><c>POST /api/v1/toolkits/{id}/install</c> — idempotent install</item>
+/// </list>
+///
+/// Per PR #732 §5.1 (Newman BC decomposition), these endpoints EXTEND the
+/// existing GameToolkit BC rather than creating a new MarketplaceBC. Schema
+/// reality v1 carryovers are documented inline in the handlers (Gate B):
+/// installCount stub 0, ratingAverage null, currentVersion "1.0.{int}",
+/// publishedAt = UpdatedAt for approved, yankedAt always null in v1.
+///
+/// Security boundary (PR #732 §5.2): non-author viewers must receive 404
+/// when the toolkit is not yet published / approved.
+///
+/// Idempotency contract (PR #732 §5.3.5 Nygard): the install endpoint
+/// returns 200 on every call (never 409) regardless of whether it is the
+/// first or Nth call for the same (viewer, toolkit) pair.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameToolkit")]
+[Trait("Wave", "3-Phase-2")]
+public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ToolkitMarketplaceEndpointsIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"toolkit_marketplace_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/toolkits/{toolkitId}  (PR #732 §5.3.1)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToolkitDetail_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenPublished_AnyAuthUser_Returns200WithViewerContext()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Public Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var detail = body.GetProperty("toolkit");
+        detail.GetProperty("id").GetString().Should().Be(toolkit.Id.ToString());
+        detail.GetProperty("name").GetString().Should().Be("Public Toolkit");
+        detail.GetProperty("authorId").GetString().Should().Be(authorId.ToString());
+        // Schema reality v1 carryover (Gate B): installCount stubbed to 0.
+        detail.GetProperty("installCount").GetInt32().Should().Be(0);
+        // ratingAverage is null; ratingCount is 0.
+        detail.GetProperty("ratingAverage").ValueKind.Should().Be(JsonValueKind.Null);
+        detail.GetProperty("ratingCount").GetInt32().Should().Be(0);
+        // currentVersion shape: "1.0.{int}".
+        detail.GetProperty("currentVersion").GetString().Should().StartWith("1.0.");
+        // publishedAt populated for approved+published toolkit.
+        detail.GetProperty("publishedAt").ValueKind.Should().Be(JsonValueKind.String);
+        // yankedAt always null in v1.
+        detail.GetProperty("yankedAt").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var viewerContext = body.GetProperty("viewerContext");
+        viewerContext.GetProperty("isOwner").GetBoolean().Should().BeFalse();
+        viewerContext.GetProperty("hasInstalled").GetBoolean().Should().BeFalse();
+        // canRate = hasInstalled && !isOwner. With v1 stub hasInstalled=false → canRate=false.
+        viewerContext.GetProperty("canRate").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenOwnDraft_OwnerSeesIsOwnerTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "My Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("viewerContext").GetProperty("isOwner").GetBoolean().Should().BeTrue();
+        // publishedAt null for unpublished draft.
+        body.GetProperty("toolkit").GetProperty("publishedAt").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenUnpublishedDraft_NonAuthorReceives404()
+    {
+        // PR #732 §5.2 security boundary — server-side enforcement.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Hidden Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_WhenPendingReview_NonAuthorReceives404()
+    {
+        // Even PendingReview does not equal Approved; non-authors cannot see.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Pending Review",
+            isPublished: true,
+            templateStatus: TemplateStatus.PendingReview);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_OwnerStillSeesUnpublishedToolkit()
+    {
+        // Owners always see their own toolkits (parallel to "yanked-but-mine"
+        // soft-delete owner access carved out by PR #732 §5.2).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "My Pending",
+            isPublished: true,
+            templateStatus: TemplateStatus.PendingReview);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("viewerContext").GetProperty("isOwner").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_AgentSummary_TruncatesSystemPromptTo500Chars()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var longPrompt = new string('a', 750);
+        var agentConfigJson = JsonSerializer.Serialize(new
+        {
+            name = "TestAgent",
+            systemPrompt = longPrompt,
+        });
+
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Toolkit With Agent",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved,
+            agentConfig: agentConfigJson);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var agent = body.GetProperty("toolkit").GetProperty("agent");
+        agent.GetProperty("name").GetString().Should().Be("TestAgent");
+        agent.GetProperty("systemPromptPreview").GetString()!.Length.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task ToolkitDetail_PopulatesAuthorNameFromUser()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        // Set DisplayName on the author so the wire shape exposes a real label.
+        var authorEntity = await dbContext.Users.FirstAsync(u => u.Id == authorId);
+        authorEntity.DisplayName = "Marco Designer";
+        authorEntity.AvatarUrl = "https://example.com/marco.jpg";
+        await dbContext.SaveChangesAsync();
+
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Marco's Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var detail = body.GetProperty("toolkit");
+        detail.GetProperty("authorName").GetString().Should().Be("Marco Designer");
+        detail.GetProperty("authorAvatarUrl").GetString().Should().Be("https://example.com/marco.jpg");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  GET /api/v1/toolkits/{toolkitId}/versions  (PR #732 §5.3.2)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ToolkitVersions_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/toolkits/{Guid.NewGuid()}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_ToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/versions",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_PublishedToolkit_Returns200WithStubV1()
+    {
+        // Schema reality v1 carryover (Gate B): single-row stub list.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Versioned Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        var first = items[0];
+        first.GetProperty("version").GetString().Should().StartWith("1.0.");
+        first.GetProperty("isCurrent").GetBoolean().Should().BeTrue();
+        first.GetProperty("yankedAt").ValueKind.Should().Be(JsonValueKind.Null);
+        first.GetProperty("changelog").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_NonAuthorOnDraft_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Draft Versions",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ToolkitVersions_OwnerOnDraft_Returns200WithDraftChangelog()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Owner Draft",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/toolkits/{toolkit.Id}/versions",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var items = body.GetProperty("items");
+        items.GetArrayLength().Should().Be(1);
+        // The handler labels the stub row as "Draft — not yet published" when
+        // the toolkit hasn't crossed the publish threshold yet.
+        items[0].GetProperty("changelog").GetString().Should().Contain("Draft");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  POST /api/v1/toolkits/{toolkitId}/install  (PR #732 §5.3.5)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task InstallToolkit_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsync(
+            $"/api/v1/toolkits/{Guid.NewGuid()}/install",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_ToolkitNotFound_Returns404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{Guid.NewGuid()}/install",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_PublishedToolkit_Returns200WithHasInstalledTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Installable Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("hasInstalled").GetBoolean().Should().BeTrue();
+        // Schema reality v1 carryover (Gate B): installCount stub 0.
+        body.GetProperty("installCount").GetInt32().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_Idempotent_RepeatedInstallsAlwaysReturn200()
+    {
+        // PR #732 §5.3.5 Nygard: repeated installs must NOT raise 409.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Idempotent Toolkit",
+            isPublished: true,
+            templateStatus: TemplateStatus.Approved);
+
+        // First install.
+        var request1 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+        var response1 = await _client.SendAsync(request1);
+        response1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Second install (should be idempotent → still 200).
+        var request2 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+        var response2 = await _client.SendAsync(request2);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body2 = await response2.Content.ReadFromJsonAsync<JsonElement>();
+        body2.GetProperty("hasInstalled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InstallToolkit_NonAuthorOnDraft_Returns404()
+    {
+        // PR #732 §5.2 boundary — viewers cannot install drafts.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (_, viewerToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Draft Toolkit",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            viewerToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task InstallToolkit_OwnerCanInstallOwnDraft()
+    {
+        // Owners installing their own toolkit (e.g. for testing) is allowed.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (authorId, authorToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var toolkit = await SeedToolkitAsync(
+            dbContext,
+            authorId: authorId,
+            name: "Owner Self Install",
+            isPublished: false,
+            templateStatus: TemplateStatus.Draft);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/toolkits/{toolkit.Id}/install",
+            authorToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a <see cref="GameToolkitEntity"/> directly via raw SQL because
+    /// EF treats the <c>RowVersion</c> column as <c>IsRowVersion()</c> which
+    /// strips the value from INSERT statements. The migration declares the
+    /// column NOT NULL with no DB-side default, so the EF path produces a
+    /// constraint violation when seeding outside the production aggregate
+    /// repository (which similarly omits RowVersion but is exercised through
+    /// SaveChangesAsync paths that EF rewrites server-side).
+    ///
+    /// Using raw SQL bypasses the EF generator and gives us full control of
+    /// the IsPublished / TemplateStatus combinations needed for the security
+    /// boundary tests (PR #732 §5.2). FK to <see cref="SharedGameEntity"/>
+    /// (via <see cref="GameEntity"/> mapping that points to the SharedGame
+    /// row) is satisfied by inserting a sibling SharedGame first.
+    /// </summary>
+    private static async Task<GameToolkitEntity> SeedToolkitAsync(
+        MeepleAiDbContext dbContext,
+        Guid authorId,
+        string name,
+        bool isPublished,
+        TemplateStatus templateStatus,
+        string? agentConfig = null)
+    {
+        // GameToolkitEntity.GameId references the "games" table (GameEntity),
+        // NOT SharedGames. Seed a GameEntity row so the FK constraint holds.
+        var game = new GameEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Game for {name}",
+            CreatedAt = DateTime.UtcNow,
+        };
+        dbContext.Games.Add(game);
+        await dbContext.SaveChangesAsync();
+
+        var toolkitId = Guid.NewGuid();
+        var createdAt = DateTime.UtcNow.AddDays(-1);
+        var updatedAt = DateTime.UtcNow;
+        var templateStatusInt = (int)templateStatus;
+        var isTemplate = templateStatus == TemplateStatus.Approved;
+
+        // Raw INSERT that explicitly sets RowVersion. EF treats RowVersion as
+        // store-generated under IsRowVersion(), which strips the value during
+        // INSERT and produces a NOT-NULL violation when seeding outside the
+        // production aggregate path. The aggregate's repository takes the same
+        // path through SaveChangesAsync but EF's update pipeline rewrites the
+        // RowVersion side-effect for IsRowVersion()-tagged properties — that
+        // does not happen for raw entity inserts via Add() in tests.
+        //
+        // We embed the agentConfig literal directly when present (escaping
+        // single quotes for SQL safety AND escaping curly braces because the
+        // composite format-string under ExecuteSqlRawAsync interprets {n} as
+        // positional placeholders) instead of using a parameter, because
+        // mixing positional {N} and named @pN parameters in the same SQL
+        // produces ambiguous parameter bindings under Npgsql.
+        var agentConfigSql = agentConfig is null
+            ? "NULL"
+            : $"'{agentConfig.Replace("'", "''", StringComparison.Ordinal).Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal)}'::jsonb";
+
+        var sql = $$"""
+            INSERT INTO "GameToolkits" (
+                "Id", "GameId", "PrivateGameId", "Name", "Version",
+                "CreatedByUserId", "IsPublished",
+                "OverridesTurnOrder", "OverridesScoreboard", "OverridesDiceSet",
+                "CreatedAt", "UpdatedAt",
+                "DiceToolsJson", "CardToolsJson", "TimerToolsJson",
+                "CounterToolsJson", "UserDicePresetsJson",
+                "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
+                "AgentConfig",
+                "TemplateStatus", "IsTemplate",
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
+                "RowVersion"
+            ) VALUES (
+                {0}, {1}, NULL, {2}, 1,
+                {3}, {4},
+                FALSE, FALSE, FALSE,
+                {5}, {6},
+                NULL, NULL, NULL,
+                NULL, NULL,
+                NULL, NULL, NULL,
+                {{agentConfigSql}},
+                {7}, {8},
+                NULL, NULL, NULL,
+                E'\\x01'
+            )
+            """;
+
+        await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            toolkitId,
+            game.Id,
+            name,
+            authorId,
+            isPublished,
+            createdAt,
+            updatedAt,
+            templateStatusInt,
+            isTemplate);
+
+        return new GameToolkitEntity
+        {
+            Id = toolkitId,
+            GameId = game.Id,
+            Name = name,
+            Version = 1,
+            CreatedByUserId = authorId,
+            IsPublished = isPublished,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            TemplateStatus = templateStatusInt,
+            IsTemplate = isTemplate,
+            AgentConfig = agentConfig,
+            RowVersion = new byte[] { 1 },
+        };
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverNewGames unit tests — Wave 3 Phase 1 (Issue #805 / PR #732 §4.3.2).
+ *
+ * Coverage:
+ *   - Default limit (10) when no option passed
+ *   - Limit clamping (1..50, NaN/negative → default 10)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validation forwards typed items
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_NEW_GAMES_DEFAULT_LIMIT,
+  DISCOVER_NEW_GAMES_STALE_TIME_MS,
+  useDiscoverNewGames,
+} from '../useDiscoverNewGames';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_NEW_GAMES = {
+  items: [
+    {
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Wingspan',
+      publisher: 'Stonemaier',
+      year: 2019,
+      imageUrl: 'https://example.com/wingspan.jpg',
+      createdAt: '2026-04-01T12:00:00Z',
+    },
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      name: 'Catan',
+      publisher: null,
+      year: null,
+      imageUrl: null,
+      createdAt: '2026-03-30T08:30:00Z',
+    },
+  ],
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useDiscoverNewGames — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_NEW_GAMES_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 1h staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_NEW_GAMES_STALE_TIME_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverNewGames — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_NEW_GAMES);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverNewGames(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=10', expect.anything());
+  });
+
+  it('clamps a limit > 50 to the validator ceiling', async () => {
+    const { result } = renderHook(() => useDiscoverNewGames({ limit: 200 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=50', expect.anything());
+  });
+
+  it('clamps a non-positive limit to the default', async () => {
+    const { result } = renderHook(() => useDiscoverNewGames({ limit: -5 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverNewGames — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_NEW_GAMES);
+
+    const { result } = renderHook(() => useDiscoverNewGames(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_NEW_GAMES.items);
+  });
+
+  it('returns an empty array when the backend returns the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverNewGames(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns an empty array when the backend returns null (401/circuit-open)', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useDiscoverNewGames(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverNewGames({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    const apiError = new Error('Catalog unavailable');
+    mockGet.mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useDiscoverNewGames(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Catalog unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverPopularAgents unit tests — Wave 3 Phase 1
+ * (Issue #805 / PR #732 §4.3.3).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates Gate-B-aware DTO (installCount: 0)
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_POPULAR_AGENTS_DEFAULT_LIMIT,
+  DISCOVER_POPULAR_AGENTS_STALE_TIME_MS,
+  useDiscoverPopularAgents,
+} from '../useDiscoverPopularAgents';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_POPULAR_AGENTS = {
+  items: [
+    {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'Catan tutor',
+      gameId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      gameName: 'Catan',
+      // Gate B v1: backend always returns 0 until AgentInstallation lands.
+      installCount: 0,
+      invocationCount: 1283,
+    },
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      name: 'Generic Q&A',
+      gameId: null,
+      gameName: null,
+      installCount: 0,
+      invocationCount: 472,
+    },
+  ],
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useDiscoverPopularAgents — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_POPULAR_AGENTS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 15min staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_POPULAR_AGENTS_STALE_TIME_MS).toBe(15 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverPopularAgents — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_POPULAR_AGENTS);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverPopularAgents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/agents/popular?limit=10', expect.anything());
+  });
+
+  it('clamps an oversize limit to 50', async () => {
+    const { result } = renderHook(() => useDiscoverPopularAgents({ limit: 75 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/agents/popular?limit=50', expect.anything());
+  });
+});
+
+describe('useDiscoverPopularAgents — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_POPULAR_AGENTS);
+
+    const { result } = renderHook(() => useDiscoverPopularAgents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_POPULAR_AGENTS.items);
+    // Gate B sanity check — every emitted agent has installCount = 0 in v1.
+    expect(result.current.data!.every(a => a.installCount === 0)).toBe(true);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverPopularAgents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverPopularAgents({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('Agents service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverPopularAgents(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Agents service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverRecentKbDocs unit tests — Wave 3 Phase 1
+ * (Issue #805 / PR #732 §4.3.5).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates the 4-value docType wire vocabulary
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_RECENT_KB_DOCS_DEFAULT_LIMIT,
+  DISCOVER_RECENT_KB_DOCS_STALE_TIME_MS,
+  useDiscoverRecentKbDocs,
+} from '../useDiscoverRecentKbDocs';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_RECENT_KB_DOCS = {
+  items: [
+    {
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      title: 'Wingspan rulebook',
+      gameId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+      gameName: 'Wingspan',
+      docType: 'rulebook' as const,
+      lastIngestedAt: '2026-05-01T10:00:00Z',
+      chunkCount: 47,
+    },
+    {
+      id: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      title: 'Catan errata',
+      gameId: null,
+      gameName: null,
+      docType: 'errata' as const,
+      lastIngestedAt: '2026-04-29T08:30:00Z',
+      chunkCount: 5,
+    },
+  ],
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useDiscoverRecentKbDocs — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_RECENT_KB_DOCS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 5min staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_RECENT_KB_DOCS_STALE_TIME_MS).toBe(5 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverRecentKbDocs — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_RECENT_KB_DOCS);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverRecentKbDocs(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=10', expect.anything());
+  });
+
+  it('clamps a fractional limit downward to integer', async () => {
+    // Math.floor(7.9) = 7
+    const { result } = renderHook(() => useDiscoverRecentKbDocs({ limit: 7.9 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=7', expect.anything());
+  });
+
+  it('clamps a NaN limit to the default', async () => {
+    const { result } = renderHook(() => useDiscoverRecentKbDocs({ limit: Number.NaN }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverRecentKbDocs — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_RECENT_KB_DOCS);
+
+    const { result } = renderHook(() => useDiscoverRecentKbDocs(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_RECENT_KB_DOCS.items);
+    // Surface vocabulary check — backend collapses DocumentCategory into
+    // a 4-value enum: rulebook | faq | errata | guide.
+    expect(['rulebook', 'faq', 'errata', 'guide']).toContain(result.current.data![0].docType);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverRecentKbDocs(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverRecentKbDocs({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('KB service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverRecentKbDocs(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('KB service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverRecommendedToolkits unit tests — Wave 3 Phase 4a
+ * (Issue #805 / PR #732 §4.3.4).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates Gate-B-aware DTO (installCount: 0, ratingAverage: null)
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT,
+  DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS,
+  useDiscoverRecommendedToolkits,
+} from '../useDiscoverRecommendedToolkits';
+
+// Mocks
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_RECOMMENDED = {
+  items: [
+    {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'Catan Strategy Toolkit',
+      authorName: 'Alice',
+      // Gate B v1: backend always returns 0 / null until rating + install entities ship.
+      installCount: 0,
+      ratingAverage: null,
+      ratingCount: 0,
+      coverImageUrl: null,
+    },
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      name: 'Wingspan Helper',
+      authorName: 'Bob',
+      installCount: 0,
+      ratingAverage: null,
+      ratingCount: 0,
+      coverImageUrl: null,
+    },
+  ],
+};
+
+describe('useDiscoverRecommendedToolkits — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 30min staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverRecommendedToolkits — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_RECOMMENDED);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+  });
+
+  it('clamps an oversize limit to 50', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits({ limit: 200 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=50', expect.anything());
+  });
+
+  it('clamps a sub-1 limit to default 10', async () => {
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits({ limit: 0 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverRecommendedToolkits — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_RECOMMENDED);
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_RECOMMENDED.items);
+    // Gate B sanity: all items have installCount=0 and ratingAverage=null in v1.
+    expect(result.current.data!.every(t => t.installCount === 0)).toBe(true);
+    expect(result.current.data!.every(t => t.ratingAverage === null)).toBe(true);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverRecommendedToolkits({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('Toolkits service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverRecommendedToolkits(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Toolkits service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useDiscoverTopContributors unit tests — Wave 3 Phase 4a
+ * (Issue #805 / PR #732 §4.3.6).
+ *
+ * Coverage:
+ *   - Default limit (10) + clamp (1..50)
+ *   - Empty-state contract (200 with { items: [] } → [] from hook)
+ *   - Schema validates Gate-B-aware breakdown (faqsCount: 0,
+ *     agentsCreatedCount: 0; only kbUploadsCount carries a real signal)
+ *   - `enabled: false` defers the request
+ *   - Error path surfaces the rejection
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT,
+  DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS,
+  useDiscoverTopContributors,
+} from '../useDiscoverTopContributors';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SAMPLE_TOP_CONTRIBUTORS = {
+  items: [
+    {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      displayName: 'Alice',
+      avatarUrl: 'https://example.com/alice.png',
+      contributionCount: 7,
+      breakdown: {
+        // Gate B v1: backend stubs faqsCount + agentsCreatedCount to 0.
+        faqsCount: 0,
+        kbUploadsCount: 7,
+        agentsCreatedCount: 0,
+      },
+    },
+    {
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      displayName: 'Bob',
+      avatarUrl: null,
+      contributionCount: 3,
+      breakdown: {
+        faqsCount: 0,
+        kbUploadsCount: 3,
+        agentsCreatedCount: 0,
+      },
+    },
+  ],
+};
+
+describe('useDiscoverTopContributors — constants', () => {
+  it('exports a default limit of 10', () => {
+    expect(DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT).toBe(10);
+  });
+
+  it('exports a 1h staleTime to mirror the backend HybridCache TTL', () => {
+    expect(DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('useDiscoverTopContributors — limit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_TOP_CONTRIBUTORS);
+  });
+
+  it('uses default limit=10 when no option is passed', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+  });
+
+  it('clamps an oversize limit to 50', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors({ limit: 999 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=50', expect.anything());
+  });
+
+  it('clamps a sub-1 limit to default 10', async () => {
+    const { result } = renderHook(() => useDiscoverTopContributors({ limit: -5 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+  });
+});
+
+describe('useDiscoverTopContributors — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the items array on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_TOP_CONTRIBUTORS);
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_TOP_CONTRIBUTORS.items);
+    // Gate B sanity: faqsCount and agentsCreatedCount are 0 in v1.
+    expect(result.current.data!.every(u => u.breakdown.faqsCount === 0)).toBe(true);
+    expect(result.current.data!.every(u => u.breakdown.agentsCreatedCount === 0)).toBe(true);
+    // contributionCount equals kbUploadsCount in v1.
+    expect(
+      result.current.data!.every(u => u.contributionCount === u.breakdown.kbUploadsCount)
+    ).toBe(true);
+  });
+
+  it('returns an empty array on the empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useDiscoverTopContributors({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('Contributors service unavailable'));
+
+    const { result } = renderHook(() => useDiscoverTopContributors(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Contributors service unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useInstallToolkit unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.5).
+ *
+ * Coverage:
+ *   - POST /toolkits/{id}/install with empty body.
+ *   - Schema validation forwards typed payload.
+ *   - Idempotency contract: repeated mutateAsync calls succeed.
+ *   - Detail-cache invalidation runs on success (so viewerContext.has
+ *     Installed flips on next render).
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { toolkitDetailKeys } from '../useToolkitDetail';
+import { useInstallToolkit } from '../useInstallToolkit';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockPost = apiClient.post as ReturnType<typeof vi.fn>;
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_INSTALL = {
+  installCount: 0,
+  hasInstalled: true,
+};
+
+function renderInstallHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const { result } = renderHook(() => useInstallToolkit(), { wrapper: Wrapper });
+  return { result, queryClient };
+}
+
+describe('useInstallToolkit — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('POSTs to /toolkits/{id}/install with no body', async () => {
+    const { result } = renderInstallHook();
+    await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      `/toolkits/${TOOLKIT_ID}/install`,
+      undefined,
+      expect.anything()
+    );
+  });
+
+  it('returns the parsed install response on success', async () => {
+    const { result } = renderInstallHook();
+    const response = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(response).toEqual(SAMPLE_INSTALL);
+  });
+});
+
+describe('useInstallToolkit — idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('repeated installs all return success (PR #732 §5.3.5 Nygard)', async () => {
+    const { result } = renderInstallHook();
+    const r1 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+    const r2 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+    const r3 = await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    expect(r1.hasInstalled).toBe(true);
+    expect(r2.hasInstalled).toBe(true);
+    expect(r3.hasInstalled).toBe(true);
+    expect(mockPost).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('useInstallToolkit — cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue(SAMPLE_INSTALL);
+  });
+
+  it('invalidates the toolkit-detail query on success', async () => {
+    const { result, queryClient } = renderInstallHook();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: toolkitDetailKeys.byId(TOOLKIT_ID),
+      });
+    });
+  });
+});
+
+describe('useInstallToolkit — error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces an error on rejection', async () => {
+    mockPost.mockRejectedValue(new Error('install failed'));
+    const { result } = renderInstallHook();
+
+    await expect(result.current.mutateAsync({ toolkitId: TOOLKIT_ID })).rejects.toThrow(
+      'install failed'
+    );
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useKbChunkDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbChunkDetail.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useKbChunkDetail unit tests — Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.3).
+ *
+ * Coverage:
+ *   - GET /kb-docs/{id}/chunks/{chunkId} URL shape.
+ *   - 24h staleTime constant (chunks immutable post-ingest).
+ *   - 200 → typed payload with prev/nextChunkId.
+ *   - 401/404 → null fallback.
+ *   - Missing docId / chunkId → no fire.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { KB_CHUNK_DETAIL_STALE_TIME_MS, useKbChunkDetail } from '../useKbChunkDetail';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const DOC_ID = '11111111-1111-1111-1111-111111111111';
+const CHUNK_ID = '22222222-2222-2222-2222-222222222222';
+const PREV_ID = '33333333-3333-3333-3333-333333333333';
+const NEXT_ID = '44444444-4444-4444-4444-444444444444';
+
+const SAMPLE = {
+  id: CHUNK_ID,
+  docId: DOC_ID,
+  position: 5,
+  headingPath: ['Setup', 'Players'],
+  content: '# Hello',
+  pageNumber: 2,
+  prevChunkId: PREV_ID,
+  nextChunkId: NEXT_ID,
+  metadata: {},
+};
+
+describe('useKbChunkDetail — constants', () => {
+  it('exports 24h staleTime (chunks immutable)', () => {
+    expect(KB_CHUNK_DETAIL_STALE_TIME_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe('useKbChunkDetail — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE);
+  });
+
+  it('issues GET /kb-docs/{id}/chunks/{chunkId}', async () => {
+    const { result } = renderHook(() => useKbChunkDetail({ docId: DOC_ID, chunkId: CHUNK_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      `/kb-docs/${DOC_ID}/chunks/${CHUNK_ID}`,
+      expect.anything()
+    );
+    expect(result.current.data?.position).toBe(5);
+    expect(result.current.data?.prevChunkId).toBe(PREV_ID);
+    expect(result.current.data?.nextChunkId).toBe(NEXT_ID);
+  });
+});
+
+describe('useKbChunkDetail — null fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null);
+  });
+
+  it('returns null when apiClient yields null (401/404)', async () => {
+    const { result } = renderHook(() => useKbChunkDetail({ docId: DOC_ID, chunkId: CHUNK_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useKbChunkDetail — guard rails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE);
+  });
+
+  it('does not fire when docId is null', () => {
+    renderHook(() => useKbChunkDetail({ docId: null, chunkId: CHUNK_ID }), {
+      wrapper: createWrapper(),
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when chunkId is null', () => {
+    renderHook(() => useKbChunkDetail({ docId: DOC_ID, chunkId: null }), {
+      wrapper: createWrapper(),
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useKbChunkDetail({ docId: DOC_ID, chunkId: CHUNK_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useKbChunksList.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbChunksList.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useKbChunksList unit tests — Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.2).
+ *
+ * Coverage:
+ *   - First-page request URL has no `cursor` param, default `limit=50`.
+ *   - Custom `limit` reflected in URL.
+ *   - `getNextPageParam` follows server-emitted `nextCursor`.
+ *   - Last page (`nextCursor === null`) terminates pagination.
+ *   - 30min staleTime constant.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { KB_CHUNKS_LIST_STALE_TIME_MS, useKbChunksList } from '../useKbChunksList';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const DOC_ID = '11111111-1111-1111-1111-111111111111';
+
+function makeItem(idx: number) {
+  return {
+    id: `00000000-0000-0000-0000-${String(idx).padStart(12, '0')}`,
+    position: idx,
+    headingPath: [],
+    snippet: `chunk ${idx}`,
+    pageNumber: 1,
+    vectorId: `v${idx}`,
+  };
+}
+
+describe('useKbChunksList — constants', () => {
+  it('exports 30min staleTime to mirror backend HybridCache', () => {
+    expect(KB_CHUNKS_LIST_STALE_TIME_MS).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('useKbChunksList — first page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({
+      items: [makeItem(0), makeItem(1)],
+      nextCursor: null,
+      totalCount: 2,
+    });
+  });
+
+  it('requests with default limit 50 and no cursor on initial fetch', async () => {
+    const { result } = renderHook(() => useKbChunksList({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    const calledPath = mockGet.mock.calls[0][0] as string;
+    expect(calledPath).toBe(`/kb-docs/${DOC_ID}/chunks?limit=50`);
+  });
+
+  it('reflects custom limit in URL', async () => {
+    const { result } = renderHook(() => useKbChunksList({ docId: DOC_ID, limit: 25 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const calledPath = mockGet.mock.calls[0][0] as string;
+    expect(calledPath).toContain('limit=25');
+  });
+
+  it('terminates pagination when nextCursor is null', async () => {
+    const { result } = renderHook(() => useKbChunksList({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});
+
+describe('useKbChunksList — pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards nextCursor from previous page on fetchNextPage', async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        items: [makeItem(0)],
+        nextCursor: 'opaque-cursor-1',
+        totalCount: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [makeItem(1)],
+        nextCursor: null,
+        totalCount: 2,
+      });
+
+    const { result } = renderHook(() => useKbChunksList({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+
+    const secondCallPath = mockGet.mock.calls[1][0] as string;
+    expect(secondCallPath).toContain('cursor=opaque-cursor-1');
+  });
+});
+
+describe('useKbChunksList — guard rails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ items: [], nextCursor: null, totalCount: 0 });
+  });
+
+  it('does not fire when docId is null', () => {
+    renderHook(() => useKbChunksList({ docId: null }), { wrapper: createWrapper() });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useKbChunksList({ docId: DOC_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useKbDocDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbDocDetail.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useKbDocDetail unit tests — Wave 3 Phase 3 (Issue #805 / PR #732 §6.3.1).
+ *
+ * Coverage:
+ *   - GET /kb-docs/{id} URL shape + 1h staleTime constant.
+ *   - 200 → ready envelope with doc payload.
+ *   - 423 Locked → locked envelope with parsed processingStatus.
+ *   - 401/404 → null fallback.
+ *   - enabled:false / missing docId → no fire.
+ *   - Locked path does NOT throw (terminal state, no retry).
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ApiError } from '@/lib/api/core/errors';
+
+import { KB_DOC_DETAIL_STALE_TIME_MS, useKbDocDetail } from '../useKbDocDetail';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const DOC_ID = '11111111-1111-1111-1111-111111111111';
+
+const READY_DOC = {
+  id: DOC_ID,
+  title: 'Catan rulebook',
+  docType: 'rulebook',
+  gameId: '22222222-2222-2222-2222-222222222222',
+  gameName: 'Catan',
+  uploaderName: 'Marco',
+  uploadedAt: '2026-04-01T12:00:00Z',
+  lastIngestedAt: '2026-04-01T12:30:00Z',
+  processingStatus: 'ready',
+  chunkCount: 120,
+  pageCount: 32,
+  language: 'it',
+  tags: [],
+} as const;
+
+describe('useKbDocDetail — constants', () => {
+  it('exports a 1h staleTime to mirror backend HybridCache', () => {
+    expect(KB_DOC_DETAIL_STALE_TIME_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+describe('useKbDocDetail — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(READY_DOC);
+  });
+
+  it('issues GET /kb-docs/{id} and returns ready envelope', async () => {
+    const { result } = renderHook(() => useKbDocDetail({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(`/kb-docs/${DOC_ID}`, expect.anything());
+    expect(result.current.data?.status).toBe('ready');
+    if (result.current.data?.status === 'ready') {
+      expect(result.current.data.doc.title).toBe('Catan rulebook');
+    }
+  });
+});
+
+describe('useKbDocDetail — 423 Locked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns locked envelope when backend responds 423', async () => {
+    const lockedError = new ApiError({
+      message: "KB document xxx is in processing state 'processing' — not yet ready.",
+      statusCode: 423,
+      endpoint: `/kb-docs/${DOC_ID}`,
+    });
+    mockGet.mockRejectedValue(lockedError);
+
+    const { result } = renderHook(() => useKbDocDetail({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.status).toBe('locked');
+    if (result.current.data?.status === 'locked') {
+      expect(result.current.data.processingStatus).toBe('processing');
+      expect(result.current.data.doc).toBeNull();
+    }
+  });
+
+  it('parses failed processingStatus from 423 message', async () => {
+    mockGet.mockRejectedValue(
+      new ApiError({
+        message: "Doc is in state 'failed' — not ready.",
+        statusCode: 423,
+      })
+    );
+
+    const { result } = renderHook(() => useKbDocDetail({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    if (result.current.data?.status === 'locked') {
+      expect(result.current.data.processingStatus).toBe('failed');
+    }
+  });
+});
+
+describe('useKbDocDetail — null fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(null); // apiClient returns null on 401
+  });
+
+  it('returns null when apiClient yields null', async () => {
+    const { result } = renderHook(() => useKbDocDetail({ docId: DOC_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useKbDocDetail — guard rails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(READY_DOC);
+  });
+
+  it('does not fire when docId is null', () => {
+    renderHook(() => useKbDocDetail({ docId: null }), { wrapper: createWrapper() });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when docId is empty', () => {
+    renderHook(() => useKbDocDetail({ docId: '' }), { wrapper: createWrapper() });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useKbDocDetail({ docId: DOC_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitDetail unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.1).
+ *
+ * Coverage:
+ *   - Stable URL shape `/toolkits/{id}` and 10min staleTime mirror.
+ *   - Schema validation forwards typed envelope.
+ *   - 404 / 401 / null fallback (apiClient returns null) → null result.
+ *   - `enabled: false` defers the request.
+ *   - Empty / invalid toolkitId is a no-op.
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TOOLKIT_DETAIL_STALE_TIME_MS, useToolkitDetail } from '../useToolkitDetail';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_DETAIL = {
+  toolkit: {
+    id: TOOLKIT_ID,
+    name: 'Test Toolkit',
+    description: 'Toolkit by Test Author.',
+    authorId: '22222222-2222-2222-2222-222222222222',
+    authorName: 'Test Author',
+    authorAvatarUrl: null,
+    coverImageUrl: null,
+    agent: {
+      id: TOOLKIT_ID,
+      name: 'Test Toolkit',
+      systemPromptPreview: '',
+    },
+    kbDocsCount: 0,
+    toolsCount: 0,
+    installCount: 0,
+    ratingAverage: null,
+    ratingCount: 0,
+    createdAt: '2026-04-01T12:00:00Z',
+    publishedAt: '2026-05-01T08:30:00Z',
+    yankedAt: null,
+    currentVersion: '1.0.1',
+  },
+  viewerContext: {
+    isOwner: false,
+    hasInstalled: false,
+    canRate: false,
+  },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useToolkitDetail — constants', () => {
+  it('exports a 10-minute staleTime to mirror the backend HybridCache TTL', () => {
+    expect(TOOLKIT_DETAIL_STALE_TIME_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+describe('useToolkitDetail — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_DETAIL);
+  });
+
+  it('issues GET /toolkits/{id} for the supplied toolkitId', async () => {
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}`, expect.anything());
+  });
+
+  it('does not fire when toolkitId is null', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when toolkitId is empty string', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: '' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToolkitDetail — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the parsed envelope on success', async () => {
+    mockGet.mockResolvedValue(SAMPLE_DETAIL);
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_DETAIL);
+  });
+
+  it('returns null when the backend returns null (401/404/circuit-open)', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useToolkitDetail({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('network down');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitRatings unit tests — Wave 3 Phase 4b
+ * (Issue #805 / PR #732 §5.3.3).
+ *
+ * Coverage:
+ *   - Default limit (20) + clamp (1..50)
+ *   - Empty-state contract (Gate B v1 stub: items=[], breakdown all 0)
+ *   - Cursor passed through to URL
+ *   - `enabled: false` and missing toolkitId defer the request
+ *   - Error path surfaces the rejection
+ *   - Schema validates the v1 stub shape
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  TOOLKIT_RATINGS_DEFAULT_LIMIT,
+  TOOLKIT_RATINGS_STALE_TIME_MS,
+  useToolkitRatings,
+} from '../useToolkitRatings';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const STUB_EMPTY_RESPONSE = {
+  items: [],
+  nextCursor: null,
+  breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 0 },
+  averageStars: 0,
+  totalCount: 0,
+};
+
+const STUB_WITH_RATINGS = {
+  items: [
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      raterDisplayName: 'Alice',
+      raterAvatarUrl: null,
+      stars: 5,
+      comment: 'Great toolkit!',
+      createdAt: '2026-05-01T12:00:00Z',
+    },
+  ],
+  nextCursor: 'cursor-page-2',
+  breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 },
+  averageStars: 5,
+  totalCount: 1,
+};
+
+describe('useToolkitRatings', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('exports default limit + stale time constants matching backend cache', () => {
+    expect(TOOLKIT_RATINGS_DEFAULT_LIMIT).toBe(20);
+    expect(TOOLKIT_RATINGS_STALE_TIME_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('fetches with default limit when none is supplied', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet.mock.calls[0]![0]).toBe(`/toolkits/${TOOLKIT_ID}/ratings?limit=20`);
+  });
+
+  it('returns the v1 empty stub envelope unchanged', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(STUB_EMPTY_RESPONSE);
+  });
+
+  it('passes cursor + limit through to the URL', async () => {
+    mockGet.mockResolvedValueOnce(STUB_WITH_RATINGS);
+
+    const { result } = renderHook(
+      () => useToolkitRatings({ toolkitId: TOOLKIT_ID, cursor: 'cursor-page-1', limit: 5 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const url = mockGet.mock.calls[0]![0] as string;
+    expect(url).toContain('limit=5');
+    expect(url).toContain('cursor=cursor-page-1');
+  });
+
+  it('clamps limit values outside [1, 50]', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, limit: 999 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet.mock.calls[0]![0]).toContain('limit=50');
+  });
+
+  it('uses default limit when limit is zero or negative', async () => {
+    mockGet.mockResolvedValueOnce(STUB_EMPTY_RESPONSE);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, limit: 0 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet.mock.calls[0]![0]).toContain('limit=20');
+  });
+
+  it('does not fire the request when toolkitId is null', () => {
+    renderHook(() => useToolkitRatings({ toolkitId: null }), { wrapper: createWrapper() });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire the request when enabled is false', () => {
+    renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a stub envelope when the client returns null (204 safety)', async () => {
+    mockGet.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(STUB_EMPTY_RESPONSE);
+  });
+
+  it('surfaces upstream errors via the query result', async () => {
+    mockGet.mockRejectedValueOnce(new Error('API failure'));
+
+    const { result } = renderHook(() => useToolkitRatings({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('API failure');
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useToolkitVersions unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.2).
+ *
+ * Coverage:
+ *   - Stable URL `/toolkits/{id}/versions` and 10min staleTime mirror.
+ *   - Schema validation forwards typed array (items unwrapped).
+ *   - Empty / null fallback returns empty array.
+ *   - `enabled: false` and missing toolkitId defer the request.
+ *   - Error path surfaces the rejection.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TOOLKIT_VERSIONS_STALE_TIME_MS, useToolkitVersions } from '../useToolkitVersions';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api/client';
+
+const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_VERSIONS = {
+  items: [
+    {
+      version: '1.0.2',
+      publishedAt: '2026-05-01T10:00:00Z',
+      yankedAt: null,
+      changelog: 'Initial version',
+      isCurrent: true,
+    },
+  ],
+};
+
+describe('useToolkitVersions — constants', () => {
+  it('exports a 10-minute staleTime to mirror the backend HybridCache TTL', () => {
+    expect(TOOLKIT_VERSIONS_STALE_TIME_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+describe('useToolkitVersions — request shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(SAMPLE_VERSIONS);
+  });
+
+  it('issues GET /toolkits/{id}/versions', async () => {
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}/versions`, expect.anything());
+  });
+
+  it('does not fire when toolkitId is null', () => {
+    renderHook(() => useToolkitVersions({ toolkitId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToolkitVersions — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('unwraps items and returns the typed array', async () => {
+    mockGet.mockResolvedValue(SAMPLE_VERSIONS);
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_VERSIONS.items);
+  });
+
+  it('returns an empty array on null response (401/404/circuit-open)', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns an empty array on empty-state envelope', async () => {
+    mockGet.mockResolvedValue({ items: [] });
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    mockGet.mockRejectedValue(new Error('versions fetch failed'));
+
+    const { result } = renderHook(() => useToolkitVersions({ toolkitId: TOOLKIT_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('versions fetch failed');
+  });
+});

--- a/apps/web/src/hooks/queries/useDiscoverNewGames.ts
+++ b/apps/web/src/hooks/queries/useDiscoverNewGames.ts
@@ -1,0 +1,68 @@
+/**
+ * useDiscoverNewGames — TanStack Query hook for the /discover route's
+ * "New games" rail (Wave 3 Phase 1, Issue #805 / PR #732 §4.3.2).
+ *
+ * Backend contract: `GET /api/v1/catalog/games/new?limit={n}` returns
+ * `{ items: NewGame[] }`. Empty state is a 200 with `{ items: [] }` per the
+ * PR #732 §3.4 empty-state contract.
+ *
+ * Cache: backend caches 1h via HybridCache; FE staleTime mirrors that to
+ * avoid wasteful re-fetches while users browse the discover surface.
+ *
+ * Backend gate: `RequireAuthorization()` — any authenticated user.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  NewGamesResponseSchema,
+  type NewGame,
+  type NewGamesResponse,
+} from '@/lib/api/schemas/discover.schemas';
+
+export const DISCOVER_NEW_GAMES_DEFAULT_LIMIT = 10;
+export const DISCOVER_NEW_GAMES_STALE_TIME_MS = 60 * 60 * 1000; // 1h, mirrors backend cache
+
+export const discoverNewGamesKeys = {
+  all: ['discover', 'newGames'] as const,
+  list: (limit: number) => [...discoverNewGamesKeys.all, limit] as const,
+};
+
+/** Clamp the limit to the same window the backend validator enforces. */
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_NEW_GAMES_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverNewGamesOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the most recently created games for the /discover "New games" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverNewGames({ limit: 8 });
+ * // data — NewGame[] (empty array on empty state)
+ */
+export function useDiscoverNewGames(
+  options: UseDiscoverNewGamesOptions = {}
+): UseQueryResult<NewGame[], Error> {
+  const { limit = DISCOVER_NEW_GAMES_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<NewGame[], Error>({
+    queryKey: discoverNewGamesKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<NewGamesResponse>(
+        `/catalog/games/new?limit=${safeLimit}`,
+        NewGamesResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_NEW_GAMES_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useDiscoverPopularAgents.ts
+++ b/apps/web/src/hooks/queries/useDiscoverPopularAgents.ts
@@ -1,0 +1,68 @@
+/**
+ * useDiscoverPopularAgents — TanStack Query hook for the /discover route's
+ * "Popular agents" rail (Wave 3 Phase 1, Issue #805 / PR #732 §4.3.3).
+ *
+ * Backend contract: `GET /api/v1/agents/popular?limit={n}` returns
+ * `{ items: PopularAgent[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Schema reality v1 carryover (Gate B): `installCount` is always 0 until
+ * the AgentInstallation tracking surface lands. The wire shape is stable —
+ * the rail can adopt the real metric without a fetch shape change.
+ *
+ * Cache: backend caches 15min via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  PopularAgentsResponseSchema,
+  type PopularAgent,
+  type PopularAgentsResponse,
+} from '@/lib/api/schemas/discover.schemas';
+
+export const DISCOVER_POPULAR_AGENTS_DEFAULT_LIMIT = 10;
+export const DISCOVER_POPULAR_AGENTS_STALE_TIME_MS = 15 * 60 * 1000; // 15min, mirrors backend cache
+
+export const discoverPopularAgentsKeys = {
+  all: ['discover', 'popularAgents'] as const,
+  list: (limit: number) => [...discoverPopularAgentsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_POPULAR_AGENTS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverPopularAgentsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the top agents for the /discover "Popular agents" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverPopularAgents({ limit: 8 });
+ * // data — PopularAgent[] (empty array on empty state)
+ */
+export function useDiscoverPopularAgents(
+  options: UseDiscoverPopularAgentsOptions = {}
+): UseQueryResult<PopularAgent[], Error> {
+  const { limit = DISCOVER_POPULAR_AGENTS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<PopularAgent[], Error>({
+    queryKey: discoverPopularAgentsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<PopularAgentsResponse>(
+        `/agents/popular?limit=${safeLimit}`,
+        PopularAgentsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_POPULAR_AGENTS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useDiscoverRecentKbDocs.ts
+++ b/apps/web/src/hooks/queries/useDiscoverRecentKbDocs.ts
@@ -1,0 +1,70 @@
+/**
+ * useDiscoverRecentKbDocs — TanStack Query hook for the /discover route's
+ * "Recent KB docs" rail (Wave 3 Phase 1, Issue #805 / PR #732 §4.3.5).
+ *
+ * Backend contract: `GET /api/v1/kb-docs/recent?limit={n}` returns
+ * `{ items: RecentKbDoc[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Filter: backend only emits docs with `processingState == 'Ready'` —
+ * in-flight ingests (Pending, Extracting, Failed, …) are excluded.
+ *
+ * Cache: backend caches 5min via HybridCache; FE staleTime mirrors that.
+ * Shorter than New Games / Popular Agents because freshly indexed docs
+ * benefit from quick visibility on the discover surface.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  RecentKbDocsResponseSchema,
+  type RecentKbDoc,
+  type RecentKbDocsResponse,
+} from '@/lib/api/schemas/discover.schemas';
+
+export const DISCOVER_RECENT_KB_DOCS_DEFAULT_LIMIT = 10;
+export const DISCOVER_RECENT_KB_DOCS_STALE_TIME_MS = 5 * 60 * 1000; // 5min, mirrors backend cache
+
+export const discoverRecentKbDocsKeys = {
+  all: ['discover', 'recentKbDocs'] as const,
+  list: (limit: number) => [...discoverRecentKbDocsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_RECENT_KB_DOCS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverRecentKbDocsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the most recently indexed KB documents for the /discover
+ * "Recent KB docs" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverRecentKbDocs({ limit: 6 });
+ * // data — RecentKbDoc[] (empty array on empty state)
+ */
+export function useDiscoverRecentKbDocs(
+  options: UseDiscoverRecentKbDocsOptions = {}
+): UseQueryResult<RecentKbDoc[], Error> {
+  const { limit = DISCOVER_RECENT_KB_DOCS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<RecentKbDoc[], Error>({
+    queryKey: discoverRecentKbDocsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<RecentKbDocsResponse>(
+        `/kb-docs/recent?limit=${safeLimit}`,
+        RecentKbDocsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_RECENT_KB_DOCS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
+++ b/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
@@ -1,0 +1,69 @@
+/**
+ * useDiscoverRecommendedToolkits — TanStack Query hook for the /discover route's
+ * "Recommended toolkits" rail (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3.4).
+ *
+ * Backend contract: `GET /api/v1/toolkits/recommended?limit={n}` returns
+ * `{ items: RecommendedToolkit[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Schema reality v1 carryovers (Gate B): `installCount: 0`, `ratingAverage: null`,
+ * `ratingCount: 0`, `coverImageUrl: null` until the rating + install entities ship
+ * in Phase 4b. The wire shape is stable — the rail can adopt the real metrics
+ * without a fetch shape change.
+ *
+ * Cache: backend caches 30min via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  RecommendedToolkitsResponseSchema,
+  type RecommendedToolkit,
+  type RecommendedToolkitsResponse,
+} from '@/lib/api/schemas/discover-cross-cutting.schemas';
+
+export const DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT = 10;
+export const DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS = 30 * 60 * 1000; // 30min, mirrors backend cache
+
+export const discoverRecommendedToolkitsKeys = {
+  all: ['discover', 'recommendedToolkits'] as const,
+  list: (limit: number) => [...discoverRecommendedToolkitsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverRecommendedToolkitsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the recommended toolkits for the /discover "Recommended toolkits" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverRecommendedToolkits({ limit: 8 });
+ * // data — RecommendedToolkit[] (empty array on empty state)
+ */
+export function useDiscoverRecommendedToolkits(
+  options: UseDiscoverRecommendedToolkitsOptions = {}
+): UseQueryResult<RecommendedToolkit[], Error> {
+  const { limit = DISCOVER_RECOMMENDED_TOOLKITS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<RecommendedToolkit[], Error>({
+    queryKey: discoverRecommendedToolkitsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<RecommendedToolkitsResponse>(
+        `/toolkits/recommended?limit=${safeLimit}`,
+        RecommendedToolkitsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_RECOMMENDED_TOOLKITS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
+++ b/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
@@ -1,0 +1,75 @@
+/**
+ * useDiscoverTopContributors — TanStack Query hook for the /discover route's
+ * "Top contributors" rail (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3.6).
+ *
+ * Backend contract: `GET /api/v1/users/top-contributors?limit={n}` returns
+ * `{ items: TopUserContributor[] }`. Empty state is a 200 with `{ items: [] }`
+ * per the PR #732 §3.4 empty-state contract.
+ *
+ * Distinct from the existing /api/v1/shared-games/top-contributors endpoint
+ * (which scores by sessions + wins for the public /shared-games sidebar).
+ * This surface aggregates contribution sources (FAQs authored, KB documents
+ * uploaded, AI agents created) for the SP4 /discover community editors rail.
+ *
+ * Schema reality v1 carryovers (Gate B): `breakdown.faqsCount` and
+ * `breakdown.agentsCreatedCount` are stubbed to 0 (no creator FK columns on
+ * GameFaqEntity / AgentDefinition). Only `breakdown.kbUploadsCount` carries
+ * a real signal in v1, and `contributionCount` therefore equals
+ * `breakdown.kbUploadsCount`.
+ *
+ * Cache: backend caches 1h via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  TopUserContributorsResponseSchema,
+  type TopUserContributor,
+  type TopUserContributorsResponse,
+} from '@/lib/api/schemas/discover-cross-cutting.schemas';
+
+export const DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT = 10;
+export const DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS = 60 * 60 * 1000; // 1h, mirrors backend cache
+
+export const discoverTopContributorsKeys = {
+  all: ['discover', 'topContributors'] as const,
+  list: (limit: number) => [...discoverTopContributorsKeys.all, limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseDiscoverTopContributorsOptions {
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the top user contributors for the /discover "Top contributors" rail.
+ *
+ * @example
+ * const { data, isLoading } = useDiscoverTopContributors({ limit: 5 });
+ * // data — TopUserContributor[] (empty array on empty state)
+ */
+export function useDiscoverTopContributors(
+  options: UseDiscoverTopContributorsOptions = {}
+): UseQueryResult<TopUserContributor[], Error> {
+  const { limit = DISCOVER_TOP_CONTRIBUTORS_DEFAULT_LIMIT, enabled = true } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<TopUserContributor[], Error>({
+    queryKey: discoverTopContributorsKeys.list(safeLimit),
+    queryFn: async () => {
+      const response = await apiClient.get<TopUserContributorsResponse>(
+        `/users/top-contributors?limit=${safeLimit}`,
+        TopUserContributorsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled,
+    staleTime: DISCOVER_TOP_CONTRIBUTORS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useInstallToolkit.ts
+++ b/apps/web/src/hooks/queries/useInstallToolkit.ts
@@ -1,0 +1,67 @@
+/**
+ * useInstallToolkit — TanStack Query mutation hook for the toolkit
+ * install action (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.5).
+ *
+ * Backend contract: `POST /api/v1/toolkits/{toolkitId}/install` returns
+ * `{ installCount, hasInstalled }`. 404 when the toolkit is missing or
+ * yanked. Idempotent (PR #732 §5.3.5 Nygard) — repeated calls return 200
+ * with the current state, NEVER 409.
+ *
+ * Side-effects: backend invalidates the discover popularity cache; this
+ * hook also invalidates the toolkit-detail query so `viewerContext.has
+ * Installed` flips to true on the next render.
+ *
+ * Schema reality v1 carryover (Gate B): `installCount` is always 0 until
+ * Phase 4 wires the ToolkitInstallation entity. The `hasInstalled` flag
+ * still flips to `true` on success so the FE button-state machine can
+ * render the "Installed" pill.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  InstallToolkitResponseSchema,
+  type InstallToolkitResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+import { toolkitDetailKeys } from './useToolkitDetail';
+
+export interface InstallToolkitVariables {
+  readonly toolkitId: string;
+}
+
+/**
+ * Install (or re-install, idempotently) a marketplace toolkit.
+ *
+ * @example
+ * const installToolkit = useInstallToolkit();
+ * await installToolkit.mutateAsync({ toolkitId: 'xxx' });
+ */
+export function useInstallToolkit(): UseMutationResult<
+  InstallToolkitResponse,
+  Error,
+  InstallToolkitVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation<InstallToolkitResponse, Error, InstallToolkitVariables>({
+    mutationFn: async ({ toolkitId }) => {
+      // apiClient.post returns the parsed body; schema validates wire shape.
+      return await apiClient.post<InstallToolkitResponse>(
+        `/toolkits/${toolkitId}/install`,
+        // Empty body — install endpoint takes no payload.
+        undefined,
+        InstallToolkitResponseSchema
+      );
+    },
+    onSuccess: async (_data, variables) => {
+      // Refresh the detail envelope so viewerContext.hasInstalled flips on
+      // the next render. The backend invalidates the per-viewer cache too;
+      // this client-side invalidation just shortens the round-trip.
+      await queryClient.invalidateQueries({
+        queryKey: toolkitDetailKeys.byId(variables.toolkitId),
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/queries/useKbChunkDetail.ts
+++ b/apps/web/src/hooks/queries/useKbChunkDetail.ts
@@ -1,0 +1,71 @@
+/**
+ * useKbChunkDetail — TanStack Query hook for a single chunk's full content
+ * (Wave 3 Phase 3, Issue #805 / PR #732 §6.3.3).
+ *
+ * Backend contract: `GET /api/v1/kb-docs/{id}/chunks/{chunkId}`.
+ *  - 200: KbChunkDetail with sanitized markdown content + prev/nextChunkId
+ *    navigation.
+ *  - 404: chunk not found OR chunk belongs to a different document.
+ *  - 403: private doc, non-owner, non-admin.
+ *
+ * Cache: backend 24h (chunks immutable post-ingest); FE staleTime mirrors.
+ *
+ * Markdown content is sanitized server-side to a strict subset:
+ *  - H4-H6 demoted to **bold**.
+ *  - Raw HTML tags stripped.
+ *  - Images replaced with `[Image: alt]` placeholder.
+ *  - Footnotes stripped.
+ *
+ * The FE can render `content` directly with a markdown library configured for
+ * the same subset — no additional sanitization needed.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import { KbChunkDetailSchema, type KbChunkDetail } from '@/lib/api/schemas/kb-chunks.schemas';
+
+export const KB_CHUNK_DETAIL_STALE_TIME_MS = 24 * 60 * 60 * 1000; // 24h, immutable post-ingest.
+
+export const kbChunkDetailKeys = {
+  all: ['kb', 'docs', 'chunk'] as const,
+  byPair: (docId: string, chunkId: string) => [...kbChunkDetailKeys.all, docId, chunkId] as const,
+};
+
+export interface UseKbChunkDetailOptions {
+  readonly docId: string | null | undefined;
+  readonly chunkId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the full content of a single chunk. Returns `null` on 401/404.
+ *
+ * @example
+ * const { data, isLoading } = useKbChunkDetail({ docId, chunkId });
+ * if (data) renderMarkdown(data.content);
+ */
+export function useKbChunkDetail(
+  options: UseKbChunkDetailOptions
+): UseQueryResult<KbChunkDetail | null, Error> {
+  const { docId, chunkId, enabled = true } = options;
+  const isValid =
+    typeof docId === 'string' &&
+    docId.length > 0 &&
+    typeof chunkId === 'string' &&
+    chunkId.length > 0;
+
+  return useQuery<KbChunkDetail | null, Error>({
+    queryKey: isValid ? kbChunkDetailKeys.byPair(docId, chunkId) : kbChunkDetailKeys.all,
+    queryFn: async () => {
+      if (!isValid) return null;
+      const response = await apiClient.get<KbChunkDetail>(
+        `/kb-docs/${docId}/chunks/${chunkId}`,
+        KbChunkDetailSchema
+      );
+      return response ?? null;
+    },
+    enabled: enabled && isValid,
+    staleTime: KB_CHUNK_DETAIL_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useKbChunksList.ts
+++ b/apps/web/src/hooks/queries/useKbChunksList.ts
@@ -1,0 +1,87 @@
+/**
+ * useKbChunksList — TanStack Query useInfiniteQuery hook for the /kb/[id]
+ * chunks list (Wave 3 Phase 3, Issue #805 / PR #732 §6.3.2).
+ *
+ * Backend contract: `GET /api/v1/kb-docs/{id}/chunks?cursor=&limit=`.
+ *  - 200: KbChunksListResponse with `items`, `nextCursor` (null on last page),
+ *    `totalCount`.
+ *  - 400: malformed cursor (apiClient throws).
+ *  - 404: doc not found.
+ *  - 403: private doc, non-owner, non-admin.
+ *
+ * Cache: backend 30min HybridCache; FE staleTime mirrors that. Cursor is
+ * opaque — pass `nextCursor` from the previous page to fetch the next.
+ */
+
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  KbChunksListResponseSchema,
+  type KbChunksListResponse,
+} from '@/lib/api/schemas/kb-chunks.schemas';
+
+export const KB_CHUNKS_LIST_STALE_TIME_MS = 30 * 60 * 1000; // 30 min.
+
+export const kbChunksListKeys = {
+  all: ['kb', 'docs', 'chunks'] as const,
+  byDoc: (docId: string, limit: number) => [...kbChunksListKeys.all, docId, limit] as const,
+};
+
+export interface UseKbChunksListOptions {
+  readonly docId: string | null | undefined;
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Fetch the cursor-paginated chunks list for a single KB document.
+ *
+ * @example
+ * const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+ *   useKbChunksList({ docId: 'xxx' });
+ * const chunks = data?.pages.flatMap(p => p.items) ?? [];
+ */
+export function useKbChunksList(
+  options: UseKbChunksListOptions
+): UseInfiniteQueryResult<InfiniteData<KbChunksListResponse, string | null>, Error> {
+  const { docId, limit = DEFAULT_LIMIT, enabled = true } = options;
+  const isValid = typeof docId === 'string' && docId.length > 0;
+  const safeDocId = isValid ? docId : 'noop';
+
+  return useInfiniteQuery<
+    KbChunksListResponse,
+    Error,
+    InfiniteData<KbChunksListResponse, string | null>,
+    readonly unknown[],
+    string | null
+  >({
+    queryKey: isValid ? kbChunksListKeys.byDoc(safeDocId, limit) : kbChunksListKeys.all,
+    initialPageParam: null,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams();
+      params.set('limit', String(limit));
+      if (pageParam) params.set('cursor', pageParam);
+      const path = `/kb-docs/${safeDocId}/chunks?${params.toString()}`;
+      const response = await apiClient.get<KbChunksListResponse>(path, KbChunksListResponseSchema);
+      // apiClient may return null on 401 — translate to an empty page so the
+      // infinite query terminates cleanly without leaking a non-throwing null.
+      return (
+        response ?? {
+          items: [],
+          nextCursor: null,
+          totalCount: 0,
+        }
+      );
+    },
+    getNextPageParam: lastPage => lastPage.nextCursor,
+    enabled: enabled && isValid,
+    staleTime: KB_CHUNKS_LIST_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useKbDocDetail.ts
+++ b/apps/web/src/hooks/queries/useKbDocDetail.ts
@@ -1,0 +1,108 @@
+/**
+ * useKbDocDetail — TanStack Query hook for the /kb/[id] hero metadata
+ * (Wave 3 Phase 3, Issue #805 / PR #732 §6.3.1).
+ *
+ * Backend contract: `GET /api/v1/kb-docs/{id}`.
+ *  - 200: full KbDocDetail when processingStatus === 'ready'.
+ *  - 404: doc not found (hook surfaces as null via apiClient).
+ *  - 403: private doc, non-owner, non-admin (apiClient throws).
+ *  - 423 Locked: doc exists but is in queued/processing/failed state.
+ *    The hook intercepts this status and returns a structured
+ *    `KbDocLockedEnvelope` rather than throwing — so the FE can render
+ *    "Documento in elaborazione" without a try/catch.
+ *
+ * Cache: backend caches 1h via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import { ApiError } from '@/lib/api/core/errors';
+import {
+  KbDocDetailSchema,
+  type KbDocDetail,
+  type KbDocEnvelope,
+  type KbProcessingStatus,
+} from '@/lib/api/schemas/kb-chunks.schemas';
+
+export const KB_DOC_DETAIL_STALE_TIME_MS = 60 * 60 * 1000; // 1h, mirrors backend cache.
+
+export const kbDocDetailKeys = {
+  all: ['kb', 'docs', 'detail'] as const,
+  byId: (docId: string) => [...kbDocDetailKeys.all, docId] as const,
+};
+
+export interface UseKbDocDetailOptions {
+  readonly docId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+interface ApiErrorWithStatus extends Error {
+  statusCode?: number;
+}
+
+function isLockedError(err: unknown): err is ApiErrorWithStatus {
+  return err instanceof ApiError && err.statusCode === 423;
+}
+
+/**
+ * Best-effort extractor for the processingStatus from a 423 response payload.
+ * Returns 'processing' as a sentinel default when the message can't be
+ * parsed — the FE will render the "in elaborazione" state regardless.
+ */
+function extractProcessingStatus(err: ApiErrorWithStatus): KbProcessingStatus {
+  const msg = err.message ?? '';
+  if (msg.includes("'failed'")) return 'failed';
+  if (msg.includes("'queued'")) return 'queued';
+  if (msg.includes("'processing'")) return 'processing';
+  return 'processing';
+}
+
+/**
+ * Fetch the spec-conformant doc detail envelope. Result is a discriminated
+ * union: `{ status: 'ready', doc }` or `{ status: 'locked', ... }`.
+ *
+ * @example
+ * const { data } = useKbDocDetail({ docId: 'xxx' });
+ * if (data?.status === 'ready') { showHero(data.doc); }
+ * else if (data?.status === 'locked') { showInProgressBanner(); }
+ */
+export function useKbDocDetail(
+  options: UseKbDocDetailOptions
+): UseQueryResult<KbDocEnvelope | null, Error> {
+  const { docId, enabled = true } = options;
+  const isValid = typeof docId === 'string' && docId.length > 0;
+
+  return useQuery<KbDocEnvelope | null, Error>({
+    queryKey: isValid ? kbDocDetailKeys.byId(docId) : kbDocDetailKeys.all,
+    queryFn: async () => {
+      if (!isValid) return null;
+      try {
+        const doc = await apiClient.get<KbDocDetail>(`/kb-docs/${docId}`, KbDocDetailSchema);
+        if (!doc) return null;
+        return { status: 'ready', doc } satisfies KbDocEnvelope;
+      } catch (err) {
+        if (isLockedError(err)) {
+          return {
+            status: 'locked',
+            processingStatus: extractProcessingStatus(err),
+            // The 423 response from the backend does not carry the partial
+            // DTO in the v1 wire shape (the spec leaves this implicit). The
+            // hook surfaces null and the FE renders an in-progress banner
+            // without metadata. A follow-up may attach the partial DTO to
+            // the 423 body.
+            doc: null,
+          } satisfies KbDocEnvelope;
+        }
+        throw err;
+      }
+    },
+    enabled: enabled && isValid,
+    staleTime: KB_DOC_DETAIL_STALE_TIME_MS,
+    // 423 is a terminal state for this query — never retry.
+    retry: (failureCount, error) => {
+      if (isLockedError(error)) return false;
+      return failureCount < 2;
+    },
+  });
+}

--- a/apps/web/src/hooks/queries/useToolkitDetail.ts
+++ b/apps/web/src/hooks/queries/useToolkitDetail.ts
@@ -1,0 +1,67 @@
+/**
+ * useToolkitDetail — TanStack Query hook for the /toolkits/[id] hero
+ * + meta sections (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.1).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}` returns
+ * `{ toolkit, viewerContext }`. 404 when the toolkit is unpublished or
+ * yanked AND the viewer is not the author (server-enforced security
+ * boundary per PR #732 §5.2). 401 when unauthenticated.
+ *
+ * Cache: backend caches 10min via HybridCache (per-viewer ETag); FE
+ * staleTime mirrors that to avoid wasteful re-fetches while users browse
+ * the marketplace.
+ *
+ * Schema reality v1 carryovers documented in the schema file (Gate B):
+ * installCount/ratingAverage/etc. are stubbed — wire shape is stable so
+ * the hook contract survives the Phase 4 schema work without changes.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitDetailResponseSchema,
+  type ToolkitDetailResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+export const TOOLKIT_DETAIL_STALE_TIME_MS = 10 * 60 * 1000; // 10 min, mirrors backend cache.
+
+export const toolkitDetailKeys = {
+  all: ['toolkits', 'detail'] as const,
+  byId: (toolkitId: string) => [...toolkitDetailKeys.all, toolkitId] as const,
+};
+
+export interface UseToolkitDetailOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the marketplace detail envelope for a single toolkit.
+ *
+ * @example
+ * const { data, isLoading, isError } = useToolkitDetail({ toolkitId: 'xxx' });
+ * // data — { toolkit: ToolkitDetail, viewerContext: ViewerContext } | null
+ */
+export function useToolkitDetail(
+  options: UseToolkitDetailOptions
+): UseQueryResult<ToolkitDetailResponse | null, Error> {
+  const { toolkitId, enabled = true } = options;
+  const isValid = typeof toolkitId === 'string' && toolkitId.length > 0;
+
+  return useQuery<ToolkitDetailResponse | null, Error>({
+    queryKey: isValid ? toolkitDetailKeys.byId(toolkitId) : toolkitDetailKeys.all,
+    queryFn: async () => {
+      if (!isValid) return null;
+      const response = await apiClient.get<ToolkitDetailResponse>(
+        `/toolkits/${toolkitId}`,
+        ToolkitDetailResponseSchema
+      );
+      // null is returned by apiClient on 401/404/circuit-open — surface as
+      // null so the FE can render the not-found state.
+      return response ?? null;
+    },
+    enabled: enabled && isValid,
+    staleTime: TOOLKIT_DETAIL_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useToolkitRatings.ts
+++ b/apps/web/src/hooks/queries/useToolkitRatings.ts
@@ -1,0 +1,94 @@
+/**
+ * useToolkitRatings — TanStack Query hook for the SP4 `/toolkits/[id]`
+ * ratings tab (Wave 3 Phase 4b, Issue #805 / PR #732 §5.3.3).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}/ratings?cursor=&limit=20`
+ * returns `{ items, nextCursor, breakdown, averageStars, totalCount }`. Empty
+ * state is a 200 with an empty stub envelope per the PR #732 §3.4 contract.
+ *
+ * Schema reality v1 carryover (Gate B): the `ToolkitRating` entity has not
+ * shipped yet — the backend returns an empty stub once toolkit visibility
+ * passes. The wire shape is stable so the FE can render today and adopt real
+ * persistence in Phase 5 without a fetch shape change.
+ *
+ * Cache: backend caches 5min via HybridCache; FE staleTime mirrors that.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitRatingsResponseSchema,
+  type ToolkitRatingsResponse,
+} from '@/lib/api/schemas/toolkit-ratings.schemas';
+
+export const TOOLKIT_RATINGS_DEFAULT_LIMIT = 20;
+export const TOOLKIT_RATINGS_STALE_TIME_MS = 5 * 60 * 1000; // 5min, mirrors backend cache
+
+export const toolkitRatingsKeys = {
+  all: ['toolkits', 'ratings'] as const,
+  list: (toolkitId: string, cursor: string | null, limit: number) =>
+    [...toolkitRatingsKeys.all, toolkitId, cursor ?? '_first', limit] as const,
+};
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit) || limit < 1) return TOOLKIT_RATINGS_DEFAULT_LIMIT;
+  return Math.min(50, Math.floor(limit));
+}
+
+export interface UseToolkitRatingsOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly cursor?: string | null;
+  readonly limit?: number;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch toolkit ratings for the `/toolkits/[id]` ratings tab.
+ *
+ * @example
+ * const { data } = useToolkitRatings({ toolkitId, limit: 20 });
+ * // data?.items — ToolkitRating[] (empty array in v1 stub)
+ * // data?.breakdown.star5 — distribution count (always 0 in v1)
+ * // data?.averageStars — number (0 in v1)
+ */
+export function useToolkitRatings(
+  options: UseToolkitRatingsOptions
+): UseQueryResult<ToolkitRatingsResponse, Error> {
+  const {
+    toolkitId,
+    cursor = null,
+    limit = TOOLKIT_RATINGS_DEFAULT_LIMIT,
+    enabled = true,
+  } = options;
+  const safeLimit = clampLimit(limit);
+
+  return useQuery<ToolkitRatingsResponse, Error>({
+    queryKey: toolkitRatingsKeys.list(toolkitId ?? '_disabled', cursor, safeLimit),
+    queryFn: async () => {
+      if (!toolkitId) {
+        throw new Error('toolkitId is required');
+      }
+      const params = new URLSearchParams();
+      params.set('limit', String(safeLimit));
+      if (cursor) params.set('cursor', cursor);
+      const response = await apiClient.get<ToolkitRatingsResponse>(
+        `/toolkits/${toolkitId}/ratings?${params.toString()}`,
+        ToolkitRatingsResponseSchema
+      );
+      // apiClient returns null on 204; the backend guarantees a body for 200,
+      // so non-null is the happy path. Fall back to an empty stub for safety.
+      return (
+        response ?? {
+          items: [],
+          nextCursor: null,
+          breakdown: { star1: 0, star2: 0, star3: 0, star4: 0, star5: 0 },
+          averageStars: 0,
+          totalCount: 0,
+        }
+      );
+    },
+    enabled: enabled && !!toolkitId,
+    staleTime: TOOLKIT_RATINGS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/hooks/queries/useToolkitVersions.ts
+++ b/apps/web/src/hooks/queries/useToolkitVersions.ts
@@ -1,0 +1,65 @@
+/**
+ * useToolkitVersions — TanStack Query hook for the /toolkits/[id]
+ * versions list (Wave 3 Phase 2, Issue #805 / PR #732 §5.3.2).
+ *
+ * Backend contract: `GET /api/v1/toolkits/{toolkitId}/versions` returns
+ * `{ items: ToolkitVersion[] }` sorted by `publishedAt DESC`. 404 when
+ * the toolkit is missing or hidden from the viewer.
+ *
+ * Cache: backend caches 10min via HybridCache (no per-viewer partition);
+ * FE staleTime mirrors that.
+ *
+ * Schema reality v1 carryover (Gate B): backend currently synthesises a
+ * single-row stub list because there is no ToolkitVersion entity — wire
+ * shape is stable so the FE list can render today and pick up multi-row
+ * history once Phase 4 ships the schema.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { apiClient } from '@/lib/api/client';
+import {
+  ToolkitVersionsResponseSchema,
+  type ToolkitVersion,
+  type ToolkitVersionsResponse,
+} from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+export const TOOLKIT_VERSIONS_STALE_TIME_MS = 10 * 60 * 1000; // 10 min, mirrors backend cache.
+
+export const toolkitVersionsKeys = {
+  all: ['toolkits', 'versions'] as const,
+  byId: (toolkitId: string) => [...toolkitVersionsKeys.all, toolkitId] as const,
+};
+
+export interface UseToolkitVersionsOptions {
+  readonly toolkitId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the published version history for a toolkit.
+ *
+ * @example
+ * const { data, isLoading } = useToolkitVersions({ toolkitId: 'xxx' });
+ * // data — ToolkitVersion[] (empty array when not visible)
+ */
+export function useToolkitVersions(
+  options: UseToolkitVersionsOptions
+): UseQueryResult<ToolkitVersion[], Error> {
+  const { toolkitId, enabled = true } = options;
+  const isValid = typeof toolkitId === 'string' && toolkitId.length > 0;
+
+  return useQuery<ToolkitVersion[], Error>({
+    queryKey: isValid ? toolkitVersionsKeys.byId(toolkitId) : toolkitVersionsKeys.all,
+    queryFn: async () => {
+      if (!isValid) return [];
+      const response = await apiClient.get<ToolkitVersionsResponse>(
+        `/toolkits/${toolkitId}/versions`,
+        ToolkitVersionsResponseSchema
+      );
+      return response?.items ?? [];
+    },
+    enabled: enabled && isValid,
+    staleTime: TOOLKIT_VERSIONS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/lib/api/schemas/discover-cross-cutting.schemas.ts
+++ b/apps/web/src/lib/api/schemas/discover-cross-cutting.schemas.ts
@@ -1,0 +1,70 @@
+/**
+ * /discover Cross-Cutting Schemas (Wave 3 Phase 4a, Issue #805 / PR #732 §4.3)
+ *
+ * Zod schemas for the SP4 /discover route's Phase 4a rails. Backend contract:
+ *   - §4.3.4 — GET /api/v1/toolkits/recommended       (RecommendedToolkit)
+ *   - §4.3.6 — GET /api/v1/users/top-contributors      (TopUserContributor)
+ *
+ * Both follow the PR #732 §3.4 empty-state contract: response shape is
+ * `{ items: [...] }` and an empty list is a 200 (not 404 / 204).
+ *
+ * Schema reality v1 carryovers (Gate B) — backend stubs documented inline:
+ *   - RecommendedToolkit.installCount: 0 (no ToolkitInstallation entity)
+ *   - RecommendedToolkit.ratingAverage: null (no ToolkitRating entity)
+ *   - RecommendedToolkit.ratingCount: 0 (same)
+ *   - RecommendedToolkit.coverImageUrl: null (no cover column)
+ *   - TopUserContributor.breakdown.faqsCount: 0 (no FAQ creator FK)
+ *   - TopUserContributor.breakdown.agentsCreatedCount: 0 (no agent owner FK)
+ *
+ * In v1 only `breakdown.kbUploadsCount` carries a real signal, and
+ * `contributionCount` therefore equals `kbUploadsCount`.
+ */
+
+import { z } from 'zod';
+
+// ========== /api/v1/toolkits/recommended (PR #732 §4.3.4) ==========
+
+export const RecommendedToolkitSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  authorName: z.string().min(1),
+  // Gate B v1: backend always returns 0 until ToolkitInstallation lands.
+  installCount: z.number().int().nonnegative(),
+  // Gate B v1: backend always returns null until ToolkitRating lands.
+  ratingAverage: z.number().nullable(),
+  ratingCount: z.number().int().nonnegative(),
+  // Gate B v1: backend always returns null until a cover-image column lands.
+  coverImageUrl: z.string().nullable(),
+});
+export type RecommendedToolkit = z.infer<typeof RecommendedToolkitSchema>;
+
+export const RecommendedToolkitsResponseSchema = z.object({
+  items: z.array(RecommendedToolkitSchema),
+});
+export type RecommendedToolkitsResponse = z.infer<typeof RecommendedToolkitsResponseSchema>;
+
+// ========== /api/v1/users/top-contributors (PR #732 §4.3.6) ==========
+
+export const TopUserContributorBreakdownSchema = z.object({
+  // Gate B v1: GameFaqEntity has no creator FK column → always 0.
+  faqsCount: z.number().int().nonnegative(),
+  // Real signal in v1 — derived from PdfDocumentEntity.UploadedByUserId.
+  kbUploadsCount: z.number().int().nonnegative(),
+  // Gate B v1: AgentDefinition has no owner FK column → always 0.
+  agentsCreatedCount: z.number().int().nonnegative(),
+});
+export type TopUserContributorBreakdown = z.infer<typeof TopUserContributorBreakdownSchema>;
+
+export const TopUserContributorSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string().min(1),
+  avatarUrl: z.string().nullable(),
+  contributionCount: z.number().int().nonnegative(),
+  breakdown: TopUserContributorBreakdownSchema,
+});
+export type TopUserContributor = z.infer<typeof TopUserContributorSchema>;
+
+export const TopUserContributorsResponseSchema = z.object({
+  items: z.array(TopUserContributorSchema),
+});
+export type TopUserContributorsResponse = z.infer<typeof TopUserContributorsResponseSchema>;

--- a/apps/web/src/lib/api/schemas/discover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/discover.schemas.ts
@@ -1,0 +1,82 @@
+/**
+ * /discover Schemas (Wave 3 Phase 1, Issue #805)
+ *
+ * Zod schemas for the /discover route's quick-win rails. Backend contract
+ * is defined in PR #732 §4.3:
+ *   - §4.3.2 — GET /api/v1/catalog/games/new       (NewGame)
+ *   - §4.3.3 — GET /api/v1/agents/popular          (PopularAgent)
+ *   - §4.3.5 — GET /api/v1/kb-docs/recent          (RecentKbDoc)
+ *
+ * All three follow the PR #732 §3.4 empty-state contract: response shape is
+ * `{ items: [...] }` and an empty list is a 200 (not a 404 / 204).
+ */
+
+import { z } from 'zod';
+
+// ========== /api/v1/catalog/games/new (PR #732 §4.3.2) ==========
+
+export const NewGameSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  publisher: z.string().nullable(),
+  // Year is nullable because legacy SharedGame rows can have YearPublished == 0
+  // which the backend surfaces as null.
+  year: z.number().int().nullable(),
+  imageUrl: z.string().nullable(),
+  // ISO 8601 timestamp; backend serialises with offset.
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type NewGame = z.infer<typeof NewGameSchema>;
+
+export const NewGamesResponseSchema = z.object({
+  items: z.array(NewGameSchema),
+});
+export type NewGamesResponse = z.infer<typeof NewGamesResponseSchema>;
+
+// ========== /api/v1/agents/popular (PR #732 §4.3.3) ==========
+
+export const PopularAgentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  // Schema reality v1 carryover (Gate B): backend always returns 0 until
+  // AgentInstallation tracking lands. The field is part of the wire contract
+  // so the rail UI can adopt the real metric without a fetch shape change.
+  installCount: z.number().int().nonnegative(),
+  invocationCount: z.number().int().nonnegative(),
+});
+export type PopularAgent = z.infer<typeof PopularAgentSchema>;
+
+export const PopularAgentsResponseSchema = z.object({
+  items: z.array(PopularAgentSchema),
+});
+export type PopularAgentsResponse = z.infer<typeof PopularAgentsResponseSchema>;
+
+// ========== /api/v1/kb-docs/recent (PR #732 §4.3.5) ==========
+
+/**
+ * KB document type vocabulary for the wire contract (PR #732 §4.3.5).
+ *
+ * Backend collapses the 7-value `DocumentCategory` enum into this 4-value
+ * surface. `'faq'` is reserved for forward-compat with the
+ * `GameFaqEntity` surface (currently not emitted by /kb-docs/recent in v1).
+ */
+export const RecentKbDocTypeSchema = z.enum(['rulebook', 'faq', 'errata', 'guide']);
+export type RecentKbDocType = z.infer<typeof RecentKbDocTypeSchema>;
+
+export const RecentKbDocSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  docType: RecentKbDocTypeSchema,
+  lastIngestedAt: z.string().datetime({ offset: true }),
+  chunkCount: z.number().int().nonnegative(),
+});
+export type RecentKbDoc = z.infer<typeof RecentKbDocSchema>;
+
+export const RecentKbDocsResponseSchema = z.object({
+  items: z.array(RecentKbDocSchema),
+});
+export type RecentKbDocsResponse = z.infer<typeof RecentKbDocsResponseSchema>;

--- a/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
@@ -1,0 +1,120 @@
+/**
+ * /kb/[id] KB Chunks Schemas (Wave 3 Phase 3, Issue #805 / PR #732 §6.3)
+ *
+ * Zod schemas for the SP4 /kb/[id] split-view surface. Backend contract is
+ * defined in PR #732 §6.3 verbatim:
+ *   - §6.3.1 — GET /api/v1/kb-docs/{id}                        (KbDocDetail)
+ *   - §6.3.2 — GET /api/v1/kb-docs/{id}/chunks?cursor=&limit=  (KbChunksList)
+ *   - §6.3.3 — GET /api/v1/kb-docs/{id}/chunks/{chunkId}        (KbChunkDetail)
+ *
+ * Schema reality v1 carryovers (Gate B) — backend stubs documented inline:
+ *   - tags: empty array (PdfDocumentEntity has no Tags column yet).
+ *   - metadata: empty object (TextChunkEntity has no Metadata column yet).
+ *
+ * 423 Locked semantics (spec §6.3.1):
+ *   - Returned when processingStatus !== 'ready'.
+ *   - useKbDocDetail handles this status semantically (returns isLocked + status,
+ *     rather than throwing) so the FE can render "Documento in elaborazione"
+ *     instead of error-state.
+ */
+
+import { z } from 'zod';
+
+// ========== Wire vocabularies (PR #732 §6.3.1) ==========
+
+export const KbDocTypeSchema = z.enum(['rulebook', 'faq', 'errata', 'guide']);
+export type KbDocType = z.infer<typeof KbDocTypeSchema>;
+
+export const KbProcessingStatusSchema = z.enum(['queued', 'processing', 'ready', 'failed']);
+export type KbProcessingStatus = z.infer<typeof KbProcessingStatusSchema>;
+
+// ========== /api/v1/kb-docs/{id} (PR #732 §6.3.1) ==========
+
+export const KbDocDetailSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1),
+  docType: KbDocTypeSchema,
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  uploaderName: z.string().min(1),
+  uploadedAt: z.string().datetime({ offset: true }),
+  lastIngestedAt: z.string().datetime({ offset: true }),
+  processingStatus: KbProcessingStatusSchema,
+  chunkCount: z.number().int().nonnegative(),
+  pageCount: z.number().int().nonnegative().nullable(),
+  language: z.string().min(1),
+  // Schema reality v1 carryover (Gate B): empty array until tags entity lands.
+  tags: z.array(z.string()),
+});
+export type KbDocDetail = z.infer<typeof KbDocDetailSchema>;
+
+// ========== /api/v1/kb-docs/{id}/chunks (PR #732 §6.3.2) ==========
+
+export const KbChunkSummarySchema = z.object({
+  id: z.string().uuid(),
+  position: z.number().int().nonnegative(),
+  headingPath: z.array(z.string()),
+  snippet: z.string(),
+  pageNumber: z.number().int().positive().nullable(),
+  // Spec §6.3.2: vectorId always present, de-gated from admin per §3.5
+  // versioning rationale (security review documented backend-side).
+  vectorId: z.string().min(1),
+});
+export type KbChunkSummary = z.infer<typeof KbChunkSummarySchema>;
+
+export const KbChunksListResponseSchema = z.object({
+  items: z.array(KbChunkSummarySchema),
+  nextCursor: z.string().nullable(),
+  totalCount: z.number().int().nonnegative(),
+});
+export type KbChunksListResponse = z.infer<typeof KbChunksListResponseSchema>;
+
+// ========== /api/v1/kb-docs/{id}/chunks/{chunkId} (PR #732 §6.3.3) ==========
+
+export const KbChunkDetailSchema = z.object({
+  id: z.string().uuid(),
+  docId: z.string().uuid(),
+  position: z.number().int().nonnegative(),
+  headingPath: z.array(z.string()),
+  // Spec markdown subset (server-enforced): H4-H6 demoted, raw HTML stripped,
+  // images replaced with [Image: alt], footnotes stripped.
+  content: z.string(),
+  pageNumber: z.number().int().positive().nullable(),
+  prevChunkId: z.string().uuid().nullable(),
+  nextChunkId: z.string().uuid().nullable(),
+  // Schema reality v1 carryover (Gate B): empty object until chunk metadata
+  // entity lands.
+  metadata: z.record(z.string(), z.unknown()),
+});
+export type KbChunkDetail = z.infer<typeof KbChunkDetailSchema>;
+
+// ========== Locked-state envelope for useKbDocDetail ==========
+
+/**
+ * Hook-shaped result envelope for the doc-detail query.
+ *
+ * - Success (200): `{ status: 'ready', doc }`
+ * - Locked (423): `{ status: 'locked', processingStatus, doc }` — the FE
+ *   renders an "in elaborazione" panel rather than a hard error state.
+ *
+ * Implementation note: the backend embeds the partial DTO inside the 423
+ * response message via the spec, but to keep the hook contract simple we
+ * request the doc detail twice in the locked case (once to surface the 423,
+ * once via the same payload returned in the LockedException). The hook
+ * abstracts this so callers see a single non-throwing query result.
+ */
+export const KbDocLockedEnvelopeSchema = z.object({
+  status: z.literal('locked'),
+  processingStatus: KbProcessingStatusSchema,
+  // The hook may surface a `null` doc when the 423 message-only path is taken.
+  doc: KbDocDetailSchema.nullable(),
+});
+export type KbDocLockedEnvelope = z.infer<typeof KbDocLockedEnvelopeSchema>;
+
+export const KbDocReadyEnvelopeSchema = z.object({
+  status: z.literal('ready'),
+  doc: KbDocDetailSchema,
+});
+export type KbDocReadyEnvelope = z.infer<typeof KbDocReadyEnvelopeSchema>;
+
+export type KbDocEnvelope = KbDocReadyEnvelope | KbDocLockedEnvelope;

--- a/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
@@ -1,0 +1,95 @@
+/**
+ * /toolkits Marketplace Schemas (Wave 3 Phase 2, Issue #805)
+ *
+ * Zod schemas for the SP4 /toolkits/[id] marketplace surface. Backend
+ * contract is defined in PR #732 §5.3:
+ *   - §5.3.1 — GET  /api/v1/toolkits/{id}             (ToolkitDetailResponse)
+ *   - §5.3.2 — GET  /api/v1/toolkits/{id}/versions    (ToolkitVersionsResponse)
+ *   - §5.3.5 — POST /api/v1/toolkits/{id}/install     (InstallToolkitResponse)
+ *
+ * Schema reality v1 carryovers (Gate B) — backend stubs documented inline:
+ *   - installCount: always 0 (no ToolkitInstallation entity yet).
+ *   - ratingAverage / ratingCount: null / 0 (no ToolkitRating entity yet).
+ *   - currentVersion: "1.0.{int}" until semver schema lands.
+ *   - publishedAt: derived from UpdatedAt for approved toolkits, else null.
+ *   - yankedAt: always null in v1 (no yank workflow yet).
+ *
+ * Wire shape is stable so the FE surface can adopt the real metrics in
+ * Phase 4 without a fetch-shape change.
+ */
+
+import { z } from 'zod';
+
+// ========== /api/v1/toolkits/{id} (PR #732 §5.3.1) ==========
+
+export const ToolkitAgentSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  systemPromptPreview: z.string(),
+});
+export type ToolkitAgentSummary = z.infer<typeof ToolkitAgentSummarySchema>;
+
+export const ToolkitDetailSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  description: z.string(),
+  authorId: z.string().uuid(),
+  authorName: z.string().min(1),
+  authorAvatarUrl: z.string().nullable(),
+  coverImageUrl: z.string().nullable(),
+  agent: ToolkitAgentSummarySchema,
+  kbDocsCount: z.number().int().nonnegative(),
+  toolsCount: z.number().int().nonnegative(),
+  // Schema reality v1 carryover (Gate B): backend always returns 0 until
+  // ToolkitInstallation tracking lands.
+  installCount: z.number().int().nonnegative(),
+  // Schema reality v1 carryover (Gate B): null/0 until ToolkitRating lands.
+  ratingAverage: z.number().nullable(),
+  ratingCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime({ offset: true }),
+  publishedAt: z.string().datetime({ offset: true }).nullable(),
+  yankedAt: z.string().datetime({ offset: true }).nullable(),
+  // Schema reality v1 carryover (Gate B): "1.0.{int}" until semver lands.
+  currentVersion: z.string().min(1),
+});
+export type ToolkitDetail = z.infer<typeof ToolkitDetailSchema>;
+
+export const ViewerContextSchema = z.object({
+  isOwner: z.boolean(),
+  hasInstalled: z.boolean(),
+  // Server-derived: hasInstalled && !alreadyRated && !isOwner. With v1 stub
+  // hasInstalled=false the flag collapses to false.
+  canRate: z.boolean(),
+});
+export type ViewerContext = z.infer<typeof ViewerContextSchema>;
+
+export const ToolkitDetailResponseSchema = z.object({
+  toolkit: ToolkitDetailSchema,
+  viewerContext: ViewerContextSchema,
+});
+export type ToolkitDetailResponse = z.infer<typeof ToolkitDetailResponseSchema>;
+
+// ========== /api/v1/toolkits/{id}/versions (PR #732 §5.3.2) ==========
+
+export const ToolkitVersionSchema = z.object({
+  version: z.string().min(1),
+  publishedAt: z.string().datetime({ offset: true }),
+  yankedAt: z.string().datetime({ offset: true }).nullable(),
+  changelog: z.string(),
+  isCurrent: z.boolean(),
+});
+export type ToolkitVersion = z.infer<typeof ToolkitVersionSchema>;
+
+export const ToolkitVersionsResponseSchema = z.object({
+  items: z.array(ToolkitVersionSchema),
+});
+export type ToolkitVersionsResponse = z.infer<typeof ToolkitVersionsResponseSchema>;
+
+// ========== POST /api/v1/toolkits/{id}/install (PR #732 §5.3.5) ==========
+
+export const InstallToolkitResponseSchema = z.object({
+  // Schema reality v1 carryover (Gate B): always 0 until installation entity.
+  installCount: z.number().int().nonnegative(),
+  hasInstalled: z.boolean(),
+});
+export type InstallToolkitResponse = z.infer<typeof InstallToolkitResponseSchema>;

--- a/apps/web/src/lib/api/schemas/toolkit-ratings.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit-ratings.schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * Toolkit Ratings Schemas (Wave 3 Phase 4b, Issue #805 / PR #732 §5.3.3)
+ *
+ * Zod schemas for the SP4 `/toolkits/[id]` ratings tab. Backend contract:
+ *   - `GET /api/v1/toolkits/{toolkitId}/ratings?cursor={nullable}&limit=20`
+ *
+ * Response follows the PR #732 §3.4 empty-state contract: shape is always
+ * `{ items, nextCursor, breakdown, averageStars, totalCount }` and an empty
+ * list is a 200 (not 404 / 204).
+ *
+ * Schema reality v1 carryover (Gate B): the `ToolkitRating` entity does not
+ * exist yet. Once toolkit visibility passes, the backend returns:
+ *   - `items: []`
+ *   - `nextCursor: null`
+ *   - `breakdown: { star1..star5: 0 }`
+ *   - `averageStars: 0`
+ *   - `totalCount: 0`
+ * Wire shape is stable so the ratings tab can render today and adopt real
+ * data without a fetch shape change in Phase 5.
+ *
+ * The companion `POST /toolkits/{id}/ratings` returns 501 in Phase 4b — no
+ * FE submission hook ships in this PR; the form can show "coming soon"
+ * affordances without an API call until Phase 5.
+ */
+
+import { z } from 'zod';
+
+export const ToolkitRatingsBreakdownSchema = z.object({
+  star1: z.number().int().nonnegative(),
+  star2: z.number().int().nonnegative(),
+  star3: z.number().int().nonnegative(),
+  star4: z.number().int().nonnegative(),
+  star5: z.number().int().nonnegative(),
+});
+export type ToolkitRatingsBreakdown = z.infer<typeof ToolkitRatingsBreakdownSchema>;
+
+export const ToolkitRatingSchema = z.object({
+  id: z.string().uuid(),
+  raterDisplayName: z.string().min(1),
+  raterAvatarUrl: z.string().nullable(),
+  stars: z.number().int().min(1).max(5),
+  comment: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type ToolkitRating = z.infer<typeof ToolkitRatingSchema>;
+
+export const ToolkitRatingsResponseSchema = z.object({
+  items: z.array(ToolkitRatingSchema),
+  nextCursor: z.string().nullable(),
+  breakdown: ToolkitRatingsBreakdownSchema,
+  averageStars: z.number().nonnegative(),
+  totalCount: z.number().int().nonnegative(),
+});
+export type ToolkitRatingsResponse = z.infer<typeof ToolkitRatingsResponseSchema>;

--- a/docs/for-developers/operations/deploy-staging-runbook.md
+++ b/docs/for-developers/operations/deploy-staging-runbook.md
@@ -1,0 +1,149 @@
+# Deploy to Staging — Runbook
+
+> Ultima revisione: 2026-05-07 (P1 fix — pipeline trustworthy minimal viable)
+
+## Modello deploy
+
+Il workflow `.github/workflows/deploy-staging.yml` deploya `https://meepleai.app` (staging che funge da unico ambiente pubblico al momento — produzione `meepleai.com` non provisionata).
+
+**Trigger**:
+
+- `push: branches: [main-staging]` — modello canonico: merge da `main-dev → main-staging` via release PR triggera deploy
+- `workflow_dispatch` — escape hatch manuale (emergency / retry / hotfix)
+
+**Pipeline jobs** (in ordine):
+
+1. `gate` — CI Quality Gate (sempre passa post-P1; observability-only)
+2. `notify-start` — Slack notification
+3. `detect-changes` — paths-filter su API / Web / infra
+4. `pre-deploy-check` — backend build + frontend build verification
+5. `build` — Docker images push to GHCR (ARM64)
+6. `migrate-db` — idempotent SQL migration via dotnet ef + pre-migration backup
+7. `snapshot-baseline` — read previous DEPLOYMENT.json performance metrics
+8. `deploy` — SSH-based blue-green deploy
+9. `validate` — Deep Health Check + Web Health Check + Smoke Tests + K6 smoke + perf regression
+10. `e2e-staging` — Playwright smoke spec
+11. `notify-end` — Slack completion
+
+## Promote main-dev → main-staging
+
+```bash
+# 1. Verify CI is green on main-dev (manual check)
+gh pr checks <latest-merged-pr-number>
+
+# 2. Create release PR
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/main-dev-YYYY-MM-DD
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging"
+git push -u origin release/main-dev-YYYY-MM-DD
+
+# 3. Create + merge PR
+gh pr create --base main-staging --head release/main-dev-YYYY-MM-DD \
+  --title "chore(release): main-dev → main-staging" \
+  --body "Promote latest main-dev for staging deployment"
+gh pr merge <PR_NUM> --merge --delete-branch
+
+# 4. Watch deploy
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Smoke testing meepleai.app dietro CF Access
+
+`meepleai.app` è dietro Cloudflare Access. Curl pubblici ricevono `HTTP/1.1 302 Found` redirect a login.
+
+**Per smoke locale o ad-hoc**:
+
+Il service token è salvato in `infra/secrets/cf-access.secret` (gitignored). Template documentale a `infra/secrets/cf-access.secret.example`.
+
+```bash
+# Carica credentials da file gitignored
+set -a; source infra/secrets/cf-access.secret; set +a
+
+# Smoke health
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        https://meepleai.app/health | jq
+
+# Smoke API endpoint
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        "https://meepleai.app/api/v1/discover/recent-games?pageSize=1" | jq
+
+# Cleanup env vars
+unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+```
+
+**Per CI runner**: i secrets `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET` sono iniettati nei step `validate` job di `deploy-staging.yml` via `env:` block. Non serve azione manuale.
+
+**Storage del token**: il token è salvato in CF Zero Trust dashboard. Rotazione raccomandata annuale. Per emettere nuovo token:
+
+1. CF dashboard → Access → Service Auth → Create Service Token (TTL ≥ 1 anno)
+2. Aggiungi nuovo token alla policy "Service auth for staging smoke" già attaccata all'application meepleai.app
+3. Aggiorna `infra/secrets/cf-access.secret` con nuovi valori
+4. Re-popola GitHub secrets:
+   ```bash
+   set -a; source infra/secrets/cf-access.secret; set +a
+   printf '%s' "$CF_ACCESS_CLIENT_ID"    | gh secret set CF_ACCESS_CLIENT_ID
+   printf '%s' "$CF_ACCESS_CLIENT_SECRET" | gh secret set CF_ACCESS_CLIENT_SECRET
+   unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+   ```
+5. Verifica deploy success al prossimo run, poi revoca il token vecchio in CF dashboard
+
+## Distinguere skip vacuo da real success run
+
+Pre-P1, deploy-staging.yml mostrava `conclusion=success` su run dove TUTTI i job critici erano skippati (gate condition `workflow_run.head_branch=='main-staging'` non soddisfatta da CI completion su main-dev). Solo `notify-end` (senza `needs: gate`) eseguiva.
+
+**Per verificare un run è realmente eseguito**:
+
+```bash
+gh run view <RUN_ID> --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name: .name, conclusion: .conclusion}]'
+```
+
+Expected per run reale: 4 entries con `conclusion="success"` (no `"skipped"`).
+Expected per run vacuo (pre-P1): tutti `"skipped"` con run-level conclusion=success → BUG.
+
+Post-P1 il trigger è `push: [main-staging]` quindi non si verificano più run vacui.
+
+## Rollback procedure
+
+`deploy-staging.yml` non ha auto-rollback. Manual rollback richiede:
+
+```bash
+# 1. Identifica merge commit responsabile
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H' --merges
+
+# 2. Crea revert PR
+git checkout -b revert/staging-deploy-YYYY-MM-DD
+git revert -m 1 <MERGE_SHA> --no-edit
+git push -u origin revert/staging-deploy-YYYY-MM-DD
+gh pr create --base main-staging --head revert/staging-deploy-YYYY-MM-DD \
+  --title "revert: staging deploy <MERGE_SHA>" \
+  --body "Rollback. Cause: <DESCRIBE_FAILURE>"
+
+# 3. Merge → triggera nuovo deploy con codice precedente
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Observability
+
+- Slack: notifiche via `notify-start` + `notify-end` jobs (channel configurato in repo secrets `SLACK_GITNOTIFY_WEBHOOK_URL` + `SLACK_CRITICAL_WEBHOOK_URL`)
+- Run history: `gh run list --workflow "Deploy to Staging" --limit 20`
+- DEPLOYMENT.json on staging server: `/opt/meepleai/repo/infra/DEPLOYMENT.json` — contiene version + commit + perf baseline ultimo deploy success
+
+## Known limitations (P1 minimal)
+
+- Trigger `push: [main-staging]` accetta qualsiasi push, anche con CI rosso. Affidamento al disciplinare merge process: chi mergia main-dev → main-staging deve aver verificato CI green pre-merge.
+- Smoke test K6 + perf regression sono `continue-on-error: true` — non bloccanti.
+- Auto-rollback assente — richiede manual revert PR.
+
+Future hardening (out of scope P1):
+
+- Reintroduzione branch protection rule che richiede CI Success su main-staging
+- Auto-rollback workflow su validate failure
+- RUM Web Vitals per p75 reali post-deploy
+- CF Access bypass per `/health` endpoint (consentirebbe smoke pubblico senza service token, trade-off security)

--- a/docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md
+++ b/docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md
@@ -1,0 +1,505 @@
+# A1 — Promote main-dev → main-staging (visibilità v2 su meepleai.app) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sincronizzare `main-staging` con `main-dev` (6 commit Wave 3 backend) e verificare che le 16+ rotte v2 siano effettivamente raggiungibili e funzionanti su `https://meepleai.app`. Goal A1 dello SMART set 2026-05-07.
+
+**Architecture:** `meepleai.app` è **staging**, deploy-staging.yml fires automaticamente via `workflow_run` quando CI su `main-staging` passa. Il lavoro è una release PR `main-dev → main-staging` + verifica end-to-end del risultato del deploy automatico. **NESSUN cambiamento a workflow o codice applicativo**.
+
+**Scope chiarification — fuori scope:**
+- Riabilitazione `deploy-production.yml.disabled` (= production a `meepleai.com`) — separato in goal futuro
+- Token redesign A11y (#807 / #808 freeze) — è goal A2
+- Implementazione rotte v2 ancora pending (`/discover`, `/game-nights`, `/kb/[id]`, `/toolkits/[id]`) — sbloccate solo post #807 Fase 2
+
+**Tech Stack:** GitHub CLI (`gh`), git, GitHub Actions (deploy-staging.yml), curl per smoke.
+
+---
+
+## File Structure
+
+Nessun file di codice applicativo modificato. L'unico artefatto creato è la PR di release.
+
+- **Crea (transitorio)**: branch `release/main-dev-to-main-staging-2026-05-07`
+- **Crea (transitorio)**: PR di release `main-dev → main-staging`
+- **Modifica**: nessun file repo (la PR contiene solo merge commit dei 6 commit di Wave 3 backend)
+- **Verifica**: deploy-staging.yml run + `https://meepleai.app/health` + 3 rotte v2 random sample
+
+---
+
+## Task 1: Pre-flight verification
+
+**Files:**
+- Lettura: stato `origin/main-dev` vs `origin/main-staging`
+
+- [ ] **Step 1: Verifica fetch fresco e count divergenza**
+
+Run:
+```bash
+git fetch origin main-dev main-staging --prune
+git log origin/main-staging..origin/main-dev --oneline
+```
+
+Expected:
+```
+b787ed460 fix(discover): resolve Sonar S125 false-positive in GetNewGamesQueryHandler (#823)
+91bfb8951 feat(toolkit-ratings): Wave 3 Phase 4b — ratings endpoints (#805) (#819)
+f6a0bc70a feat(discover): Wave 3 Phase 4a — 2 cross-cutting endpoints (#805) (#816)
+38f35eaf7 feat(kb-chunks): Wave 3 Phase 3 — full spec-conformant rewrite (#805) (#815)
+8cfd5fee8 feat(toolkit-marketplace): Wave 3 Phase 2 — 3 marketplace endpoints (#805) (#814)
+2d8f0bdbc feat(discover): Wave 3 Phase 1 — 3 quick-win endpoints (#805) (#812)
+```
+
+Se la divergenza eccede 6 commit O include commit non-backend (es. cambi `apps/web/**`), STOP e ri-valuta scope con utente prima di procedere.
+
+- [ ] **Step 2: Verifica CI verde su `main-dev` HEAD**
+
+Run:
+```bash
+gh run list --branch main-dev --limit 5 --workflow CI --json conclusion,headSha,createdAt,url
+```
+
+Expected: top entry ha `"conclusion": "success"` e `"headSha"` inizia con `b787ed460`.
+
+Se top run è `failure` o `in_progress`, STOP. Non promuovere a staging finché CI non è verde.
+
+- [ ] **Step 3: Verifica staging attualmente sano (baseline pre-deploy)**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq -r '.status' || echo "STAGING UNHEALTHY"
+```
+
+Expected output: `Healthy` (o codice di stato 200 con qualsiasi struttura JSON valida).
+
+Se `STAGING UNHEALTHY` o curl fallisce → investiga prima di procedere (potenziale stato pre-rotto).
+
+- [ ] **Step 4: Snapshot baseline rotte v2 attualmente live**
+
+Run:
+```bash
+for route in / /games /agents /library /sessions /discover /gamebook; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://meepleai.app${route}")
+  echo "  ${route} → ${status}"
+done
+```
+
+Expected: tutte le rotte ritornano 200, 301, 302 (login redirect), o 401 (unauth) — **NESSUN 5xx**.
+
+Salva l'output in commento PR successivo per confronto post-deploy.
+
+---
+
+## Task 2: Crea release PR main-dev → main-staging
+
+**Files:**
+- Crea (transitorio): branch e PR su GitHub
+
+- [ ] **Step 1: Verifica working tree pulito**
+
+Run:
+```bash
+git status --porcelain
+```
+
+Expected: output vuoto. Se non vuoto, stash o committa modifiche locali prima di procedere.
+
+- [ ] **Step 2: Aggiorna `main-staging` locale dal remote**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+```
+
+Expected: `Already up to date.` oppure fast-forward pulito.
+
+Se non fast-forward, STOP — divergenza inaspettata su `main-staging`.
+
+- [ ] **Step 3: Crea branch di release**
+
+Run:
+```bash
+git checkout -b release/main-dev-to-main-staging-2026-05-07
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging
+
+Promotes 6 commits (Wave 3 backend Phase 0-4):
+- BGG search public exposure (#811)
+- /discover Phase 1+4a quick-wins (#812, #816)
+- toolkit marketplace Phase 2 (#814)
+- KB chunks Phase 3 rewrite (#815)
+- toolkit ratings Phase 4b (#819)
+- Sonar S125 fix (#823)
+
+Refs A1 SMART goal docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md"
+```
+
+Expected: merge commit creato senza conflitti. Se conflitti, STOP — non risolverli a mano in questo branch.
+
+- [ ] **Step 4: Push branch**
+
+Run:
+```bash
+git push -u origin release/main-dev-to-main-staging-2026-05-07
+```
+
+Expected: push successful, link PR suggerito.
+
+- [ ] **Step 5: Crea PR target main-staging**
+
+Run:
+```bash
+gh pr create \
+  --base main-staging \
+  --head release/main-dev-to-main-staging-2026-05-07 \
+  --title "chore(release): main-dev → main-staging — Wave 3 backend Phase 0-4 (6 commits)" \
+  --body "$(cat <<'EOF'
+## Scope
+
+Release PR per A1 SMART goal: visibilità v2 su `meepleai.app`.
+
+Promuove **6 commit backend-only** da `main-dev` a `main-staging`:
+
+| SHA | Titolo | Issue |
+|-----|--------|-------|
+| `b787ed460` | fix(discover): Sonar S125 false-positive | #823 |
+| `91bfb8951` | feat(toolkit-ratings): Wave 3 Phase 4b ratings | #805 / #819 |
+| `f6a0bc70a` | feat(discover): Wave 3 Phase 4a cross-cutting | #805 / #816 |
+| `38f35eaf7` | feat(kb-chunks): Wave 3 Phase 3 spec rewrite | #805 / #815 |
+| `8cfd5fee8` | feat(toolkit-marketplace): Wave 3 Phase 2 | #805 / #814 |
+| `2d8f0bdbc` | feat(discover): Wave 3 Phase 1 quick-wins | #805 / #812 |
+
+## Out of scope
+
+- Frontend: nessun cambio a `apps/web/**`
+- Production deploy (meepleai.com): A1 termina al deploy staging
+- A11y token redesign: vedi A2 / #807
+
+## Verifica post-merge
+
+CI su `main-staging` deve passare → `deploy-staging.yml` parte automatico via `workflow_run` → smoke su `https://meepleai.app/health`.
+
+Refs:
+- Goal SMART: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md`
+- Plan: `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`
+EOF
+)"
+```
+
+Expected: PR URL stampato, es. `https://github.com/meepleAi-app/meepleai-monorepo/pull/<N>`. Annota il numero PR per i task successivi (sostituisci `<PR_NUM>` ovunque).
+
+- [ ] **Step 6: Posta snapshot baseline come PR comment**
+
+Run (sostituisci `<PR_NUM>` con il numero PR):
+```bash
+gh pr comment <PR_NUM> --body "$(cat <<'EOF'
+## Baseline pre-deploy snapshot
+
+Output di `curl -s -o /dev/null -w "%{http_code}"` per rotte v2 critical-path catturato pre-merge:
+
+\`\`\`
+  / → <STATUS>
+  /games → <STATUS>
+  /agents → <STATUS>
+  /library → <STATUS>
+  /sessions → <STATUS>
+  /discover → <STATUS>
+  /gamebook → <STATUS>
+\`\`\`
+
+Codici accettabili: 200/301/302/401. Qualsiasi 5xx invalida la baseline.
+EOF
+)"
+```
+
+Sostituisci i `<STATUS>` con i valori effettivi catturati in Task 1 Step 4 prima di postare.
+
+---
+
+## Task 3: Attendi CI verde su PR e mergia
+
+**Files:** nessuno locale.
+
+- [ ] **Step 1: Polling CI status su PR (background)**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr checks <PR_NUM> --watch
+```
+
+Expected: tutti i check passano (esce con exit 0). Tempo atteso: 15-30 minuti per CI completa.
+
+Se check fallisce, STOP — leggi log del check fallito (`gh run view <run-id> --log-failed`) prima di decidere se è flake retry-able o blocker reale.
+
+- [ ] **Step 2: Verifica mergeability stato finale**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr view <PR_NUM> --json mergeable,mergeStateStatus,statusCheckRollup
+```
+
+Expected: `"mergeable": "MERGEABLE"` AND `"mergeStateStatus": "CLEAN"`.
+
+Se `BLOCKED` o `BEHIND`, STOP — investiga.
+
+- [ ] **Step 3: Mergia PR (squash NON desiderato — usa merge commit per release)**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr merge <PR_NUM> --merge --delete-branch
+```
+
+Expected: `✓ Merged pull request #<N>` + `✓ Deleted branch release/...`.
+
+**RAZIONALE merge commit (no squash)**: una release PR conserva la cronologia atomica dei 6 commit Wave 3 backend; `git log main-staging` deve continuare a mostrare i commit originali per traceability per-feature.
+
+- [ ] **Step 4: Pull `main-staging` aggiornato e verifica**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H %s'
+```
+
+Expected: HEAD è il merge commit appena creato; `git log` mostra `b787ed460` raggiungibile da `main-staging`.
+
+---
+
+## Task 4: Verifica deploy-staging.yml fires automaticamente
+
+**Files:** nessuno.
+
+- [ ] **Step 1: Localizza CI run su main-staging post-merge**
+
+Run:
+```bash
+sleep 30  # let GitHub register the push
+gh run list --branch main-staging --limit 3 --workflow CI --json status,conclusion,headSha,createdAt,databaseId
+```
+
+Expected: top entry `"status": "in_progress"` o `"queued"` con `headSha` corrispondente al merge commit.
+
+- [ ] **Step 2: Watch CI su main-staging fino a green**
+
+Run (sostituisci `<RUN_ID>` con `databaseId` da step precedente):
+```bash
+gh run watch <RUN_ID>
+```
+
+Expected: `✓ <run name>` quando completa con success.
+
+Se fallisce, **NON**provare hotfix — apri issue `[A1 fail] CI red on main-staging post-merge` e investiga separatamente. La auto-rollback su staging non esiste; il deploy semplicemente non parte.
+
+- [ ] **Step 3: Verifica deploy-staging.yml triggered via workflow_run**
+
+Run:
+```bash
+sleep 60  # workflow_run lag
+gh run list --branch main-staging --limit 3 --workflow "Deploy to Staging" --json status,conclusion,headSha,createdAt,databaseId
+```
+
+Expected: top entry esiste con `"status": "in_progress"` o `"queued"` e stesso `headSha` del CI run.
+
+Se nessun run "Deploy to Staging" appare entro 2 minuti dal CI green, STOP — leggi `deploy-staging.yml` riga 89-95 (gate condition workflow_run); possibile mismatch su `head_branch` o `conclusion`.
+
+- [ ] **Step 4: Watch deploy completo**
+
+Run (sostituisci `<DEPLOY_RUN_ID>`):
+```bash
+gh run watch <DEPLOY_RUN_ID>
+```
+
+Expected: completion success. Tempo atteso: 20-40 minuti (build + migrate-db + deploy + validate + e2e-staging).
+
+Se job `validate` o `e2e-staging` falliscono → STOP — staging potenzialmente in stato degradato. Vedi Task 6 rollback.
+
+---
+
+## Task 5: Smoke test post-deploy contro meepleai.app
+
+**Files:** nessuno modificato. Solo verifica.
+
+- [ ] **Step 1: API health structured response**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq '{status, checks: [.checks[] | {name, status}]}'
+```
+
+Expected:
+```json
+{
+  "status": "Healthy",
+  "checks": [
+    {"name": "postgres", "status": "Healthy"},
+    {"name": "redis", "status": "Healthy"},
+    ...
+  ]
+}
+```
+
+Se `status != "Healthy"` o postgres/redis non Healthy → escalate.
+
+- [ ] **Step 2: Verifica DEPLOYMENT.json riflette nuovo SHA**
+
+Run (richiede SSH key staging — se non disponibile, skippa e usa `gh run view`):
+```bash
+gh run view <DEPLOY_RUN_ID> --log | grep -A2 "Version recorded"
+```
+
+Expected: log contiene `Version recorded: staging-2026<...>-<SHA::7>` dove `<SHA::7>` corrisponde a `b787ed4` o al merge commit.
+
+- [ ] **Step 3: Smoke test rotte v2 vs baseline**
+
+Run:
+```bash
+echo "Post-deploy snapshot:"
+for route in / /games /agents /library /sessions /discover /gamebook; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://meepleai.app${route}")
+  echo "  ${route} → ${status}"
+done
+```
+
+Expected: stessa serie di codici 200/301/302/401 della baseline (Task 1 Step 4). **NESSUN 5xx** o cambio inaspettato (es. da 200 a 404 ⇒ regressione).
+
+- [ ] **Step 4: Smoke test endpoint Wave 3 backend nuovi (verifica core scope)**
+
+Run:
+```bash
+echo "Wave 3 backend endpoint smoke:"
+curl -s -o /dev/null -w "  /api/v1/discover/recent-games → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/discover/recent-games?pageSize=1"
+curl -s -o /dev/null -w "  /api/v1/discover/popular-agents → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/discover/popular-agents?pageSize=1"
+curl -s -o /dev/null -w "  /api/v1/toolkit-marketplace → %{http_code}\n" \
+  --max-time 10 "https://meepleai.app/api/v1/toolkit-marketplace?pageSize=1"
+```
+
+Expected: tutti 200 o 401 (auth required). **NON 404** — un 404 significa che gli endpoint Wave 3 NON sono live e il deploy non ha funzionato per i nuovi commit.
+
+- [ ] **Step 5: Browser visual check (manuale)**
+
+Apri https://meepleai.app in browser, autentica con credenziali test, e verifica:
+
+1. `/library` renderizza `LibraryHubV2` (cerca `data-slot="v2-*"` in DevTools, oppure cerca classe `library-hybrid-grid`)
+2. `/games?tab=library` renderizza v2 (`GamesLibraryView`)
+3. `/sessions` renderizza v2 (cards con OutcomeBadge visibile)
+4. `/gamebook` mostra hero + grid (componenti SP6 Phase B)
+
+Screenshot delle 4 rotte allegati come PR comment chiusura.
+
+- [ ] **Step 6: Posta closure comment su PR**
+
+Run (sostituisci `<PR_NUM>` con il PR di release già mergiato):
+```bash
+gh pr comment <PR_NUM> --body "$(cat <<'EOF'
+## ✅ A1 SMART goal verified — meepleai.app live
+
+### Deploy summary
+
+- CI on main-staging: ✅
+- Deploy-Staging workflow: ✅
+- API /health: Healthy
+- Postgres + Redis: Healthy
+- 7 frontend routes smoke: <PASTE Task 5 Step 3 OUTPUT>
+- 3 Wave 3 backend endpoint smoke: <PASTE Task 5 Step 4 OUTPUT>
+- Visual check (4 rotte v2): <PASTE LINK SCREENSHOTS>
+
+### Acceptance criteria status (vs SMART goal A1)
+
+- [x] 16+ rotte v2 raggiungibili pubblicamente su meepleai.app
+- [x] Smoke E2E green
+- [x] No 5xx su rotte critical path
+- [x] Wave 3 backend endpoints rispondono
+
+A1 chiusa. Prossimo: A2 (#807 token redesign) per lift freeze e abilitare Wave 3 frontend.
+EOF
+)"
+```
+
+---
+
+## Task 6: Rollback procedure (eseguire SOLO se Task 4 o Task 5 falliscono)
+
+**Files:** nessuno locale. Operazioni remote tramite `gh` e GitHub UI.
+
+> **NB**: deploy-staging.yml NON ha auto-rollback. Manual rollback è git revert + nuova promote.
+
+- [ ] **Step 1: Identifica merge commit da revertire**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git log -1 --pretty='%H' --merges
+```
+
+Expected: SHA del merge commit appena creato.
+
+- [ ] **Step 2: Crea revert PR**
+
+Run:
+```bash
+git checkout -b revert/main-dev-promotion-2026-05-07
+git revert -m 1 <MERGE_COMMIT_SHA> --no-edit
+git push -u origin revert/main-dev-promotion-2026-05-07
+gh pr create \
+  --base main-staging \
+  --head revert/main-dev-promotion-2026-05-07 \
+  --title "revert: main-dev → main-staging promotion (A1 rollback)" \
+  --body "Rollback A1 deploy. Cause: <DESCRIVI FALLIMENTO>. Refs PR <PR_NUM>."
+```
+
+- [ ] **Step 3: Mergia revert PR + monitora redeploy**
+
+Run (sostituisci):
+```bash
+gh pr checks <REVERT_PR_NUM> --watch
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run list --branch main-staging --limit 1 --workflow "Deploy to Staging"
+```
+
+Expected: nuovo deploy parte automatico, restora staging allo stato pre-A1.
+
+- [ ] **Step 4: Verifica staging restaurato**
+
+Run:
+```bash
+curl -sf https://meepleai.app/health | jq -r '.status'
+```
+
+Expected: `Healthy`.
+
+---
+
+## Definition of Done — A1 chiusa
+
+- [ ] PR release `main-dev → main-staging` mergiata in main-staging
+- [ ] CI su main-staging post-merge: success
+- [ ] deploy-staging.yml run: success (build + migrate-db + deploy + validate + e2e-staging tutti green)
+- [ ] `https://meepleai.app/health` ritorna `{"status": "Healthy"}` con postgres + redis Healthy
+- [ ] Smoke test 7 rotte v2 frontend: nessun 5xx, codici stessi della baseline
+- [ ] Smoke test 3 endpoint Wave 3 backend nuovi: 200 o 401 (mai 404)
+- [ ] Visual check manuale 4 rotte v2 (library / games / sessions / gamebook): componenti v2 presenti nel DOM
+- [ ] Closure comment postato su PR di release
+
+**Tempo stimato totale**: 1-2 ore di wall-clock (di cui ~45-60 min CI + ~30 min deploy + ~15 min smoke). Lavoro attivo umano: ~20-30 minuti spread on touchpoint.
+
+---
+
+## Self-review checklist (skill enforcement)
+
+- ✅ **Spec coverage**: ogni acceptance criteria del SMART goal A1 è coperto da un Task con verifica concreta
+- ✅ **No placeholder**: ogni step ha comando esatto + expected output (eccezione: `<PR_NUM>`, `<RUN_ID>`, `<SHA>` che sono variabili runtime)
+- ✅ **Type consistency**: nomi workflow/branch consistenti — `deploy-staging.yml`, `main-staging`, `release/main-dev-to-main-staging-2026-05-07`
+- ✅ **Scope check**: focused su solo A1 (staging promotion); produzione e A2/B*/freeze esplicitamente fuori scope
+- ✅ **Rollback path**: Task 6 documentato esplicitamente con trigger condition
+
+## Riferimenti
+
+- Goal SMART: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md` (TBD — comporlo se richiesto)
+- Workflow staging: `.github/workflows/deploy-staging.yml`
+- Workflow production (disabled): `.github/workflows/deploy-production.yml.disabled`
+- v2 migration matrix: `docs/for-developers/frontend/v2-migration-matrix.md`
+- Freeze policy: GitHub issue #808
+- A11y audit: GitHub issue #807

--- a/docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md
+++ b/docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md
@@ -1,0 +1,920 @@
+# P1 — Pipeline staging trustworthy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere `deploy-staging.yml` end-to-end fidato: trigger fires consistentemente, tutti job critici eseguono (no vacuum success da gate skip), smoke test job verifica HTTP 200 reale dietro CF Access. Goal P1 dello SMART set 2026-05-07.
+
+**Architecture:** Tre fix indipendenti su `.github/workflows/deploy-staging.yml`: (1) trigger semplificato a `push: [main-staging]` (rimuove workflow_run + gate complessità); (2) smoke test passa header CF Access service token via secret per bypass 302; (3) runbook documenta il modello "promote PR main-dev → main-staging quando ready to deploy" + come usare il bypass. Verifica via 3 deploy consecutivi success-no-skip.
+
+**Tech Stack:** GitHub Actions (workflow YAML), Bash (smoke test functions), curl con CF-Access-Client-Id/Secret headers, Markdown runbook.
+
+---
+
+## Diagnosi pre-plan (osservata 2026-05-07)
+
+Stato attuale verificato:
+
+```
+event=workflow_run, headBranch=main-dev, conclusion=success → tutti i 9 job CRITICI in stato "skipped", solo notify-end gira (= vacuum success)
+event=workflow_dispatch, headBranch=main-staging, conclusion=failure → tutti job girano fino a Post-deploy Validation che FALLISCE (smoke test riceve 302 da CF Access invece di 200)
+```
+
+Root causes:
+1. **Trigger `workflow_run` + gate `head_branch=='main-staging'` non si parlano**: GitHub fires workflow_run su main-dev ma gate skippa, lasciando `notify-end` (senza `needs: gate`) come unico job → "success" vacuamente
+2. **Smoke test `curl -sf https://meepleai.app/health` riceve 302** da Cloudflare Access redirect invece del 200 atteso → `validate` job fail
+3. **CF Access service token non disponibile** ai GitHub Actions runner (secrets `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` non esistono nei repo/env secrets di GitHub — verificato via `gh secret list`)
+
+Fix scope: 1 file YAML modificato (`deploy-staging.yml`) + 1 markdown runbook nuovo + 2 GitHub secrets aggiunti dall'utente owner.
+
+---
+
+## File Structure
+
+- **Modify**: `.github/workflows/deploy-staging.yml` (~10-15 righe modificate, suddivise in 2 commit logici: trigger fix + smoke fix)
+- **Create**: `docs/for-developers/operations/deploy-staging-runbook.md` (~150 righe nuovo doc)
+- **Modify (out-of-tree, manual via GitHub UI)**: GitHub repository secrets — aggiungere `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET`
+
+Nessun file applicativo (`apps/api/**`, `apps/web/**`) modificato.
+
+---
+
+## Task 1: CF Access service token discovery + GitHub secrets setup
+
+**Files:**
+- Read: Cloudflare Zero Trust dashboard (esterno al repo)
+- Modify: GitHub repository secrets (manual via UI o `gh secret set`)
+- No code/file commits in repo
+
+> **Razionale**: il servizio Cloudflare Access wrappa `meepleai.app/*`. Il GitHub Actions runner ha bisogno di credenziali di service-token per bypass HTTP 302. User indica che "abbiamo già lavorato sui token di accesso" — Task 1 è appurare DOVE sono e renderli disponibili al runner.
+
+- [ ] **Step 1: Owner verifica esistenza service token Cloudflare Access**
+
+Apri https://one.dash.cloudflare.com → Access → Service Auth → Service Tokens.
+
+Cerca un token già emesso per `meepleai.app` con scope che include `/health` o `/*` (lista tutti).
+
+Output atteso: almeno un token esistente con CLIENT_ID + CLIENT_SECRET. Se NON esiste, crea uno nuovo nominato `github-actions-staging-smoke` con TTL ≥ 1 anno.
+
+- [ ] **Step 2: Verifica policy CF Access permette il service token**
+
+Dashboard CF → Access → Applications → seleziona l'app coprente `meepleai.app` → Policies.
+
+Conferma esiste policy "Service Auth" che include il service token. Se non esiste, crea con: action=Allow, include=Service Auth + nome token sopra.
+
+Test from local:
+```bash
+curl -H "CF-Access-Client-Id: <CLIENT_ID>.access" \
+     -H "CF-Access-Client-Secret: <CLIENT_SECRET>" \
+     -sf -o /dev/null -w "%{http_code}\n" \
+     https://meepleai.app/health
+```
+
+Expected: `200` (non 302).
+
+Se 302 ancora → policy non abbinata correttamente, ferma e correggi policy in CF dashboard.
+
+- [ ] **Step 3: Aggiungi service token come GitHub repository secrets**
+
+Run (sostituisci `<CLIENT_ID>` e `<CLIENT_SECRET>` con valori reali, mai committarli):
+```bash
+gh secret set CF_ACCESS_CLIENT_ID --body "<CLIENT_ID>.access"
+gh secret set CF_ACCESS_CLIENT_SECRET --body "<CLIENT_SECRET>"
+```
+
+Verify:
+```bash
+gh secret list --json name | jq -r '.[] | select(.name | test("CF_ACCESS")) | .name'
+```
+
+Expected: 2 righe `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET`.
+
+- [ ] **Step 4: Commit "preparazione" doc nel repo**
+
+Crea file segnaposto che traccia il setup avvenuto:
+```bash
+echo "# CF Access secrets setup — Task 1 P1 (2026-05-07)
+- CF_ACCESS_CLIENT_ID added to GitHub repo secrets
+- CF_ACCESS_CLIENT_SECRET added to GitHub repo secrets
+- Service token configured in CF Zero Trust for meepleai.app /* with policy 'Service Auth'
+" > /tmp/cf-access-setup-note.md
+```
+
+NB: Non committare il /tmp file. Questa è solo una traccia per Task 4 runbook.
+
+---
+
+## Task 2: Smoke test usa CF Access bypass headers
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`:797-833 (job `validate`, sezione "Smoke Tests")
+- Modify: `.github/workflows/deploy-staging.yml`:745-786 (job `validate`, sezione "Deep Health Check")
+
+> **Razionale**: tutti i `curl` contro `https://meepleai.app/*` nel job `validate` ricevono 302 da CF Access. Aggiungiamo CF Access service token headers a ogni curl, passando i secrets via env.
+
+- [ ] **Step 1: Controlla baseline corrente del job `validate`**
+
+Run:
+```bash
+sed -n '745,855p' .github/workflows/deploy-staging.yml
+```
+
+Verifica che esistano:
+- "Deep Health Check" step con `HEALTH=$(curl -sf https://api.meepleai.app/health ...)`
+- "Web Health Check" step con `curl ... https://meepleai.app`
+- "Smoke Tests" step con funzione `smoke_test()` che fa curl
+
+- [ ] **Step 2: Modifica step "Deep Health Check" — passa CF Access headers**
+
+Edit `.github/workflows/deploy-staging.yml`. Trova la riga ~745 con step `name: Deep Health Check` e modifica come segue:
+
+Sostituisci:
+```yaml
+      - name: Deep Health Check
+        run: |
+          echo "🔍 Running deep health checks..."
+
+          # Wait for API with structured health response
+          HEALTH=""
+          for i in {1..30}; do
+            HEALTH=$(curl -sf https://api.meepleai.app/health 2>/dev/null || true)
+            if [ -n "$HEALTH" ]; then
+```
+
+Con:
+```yaml
+      - name: Deep Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          echo "🔍 Running deep health checks..."
+
+          # CF Access bypass headers reused for all curls in this step
+          CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
+
+          # Wait for API with structured health response (CF Access bypass)
+          HEALTH=""
+          for i in {1..30}; do
+            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
+            if [ -n "$HEALTH" ]; then
+```
+
+- [ ] **Step 3: Modifica step "Web Health Check" — passa CF Access headers**
+
+Sostituisci:
+```yaml
+      - name: Web Health Check
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://meepleai.app)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Web returned status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✅ Web healthy (HTTP $HTTP_STATUS)"
+```
+
+Con:
+```yaml
+      - name: Web Health Check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Web returned status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✅ Web healthy (HTTP $HTTP_STATUS)"
+```
+
+- [ ] **Step 4: Modifica step "Smoke Tests" — funzione smoke_test riceve CF headers**
+
+Sostituisci:
+```yaml
+      - name: Smoke Tests
+        run: |
+          echo "🧪 Running staging smoke tests..."
+          FAIL=0
+          RESULTS=""
+
+          smoke_test() {
+            local name="$1" url="$2" expect="$3"
+            local status
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+```
+
+Con:
+```yaml
+      - name: Smoke Tests
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          echo "🧪 Running staging smoke tests..."
+          FAIL=0
+          RESULTS=""
+
+          smoke_test() {
+            local name="$1" url="$2" expect="$3"
+            local status
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+              -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+              "$url" 2>/dev/null || echo "000")
+```
+
+E nello stesso step più sotto, modifica anche la chiamata `HEALTH_JSON=$(curl ...)`:
+
+Sostituisci:
+```bash
+          HEALTH_JSON=$(curl -sf --max-time 10 https://meepleai.app/health 2>/dev/null || true)
+```
+
+Con:
+```bash
+          HEALTH_JSON=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app/health 2>/dev/null || true)
+```
+
+E ancora la response time check:
+Sostituisci:
+```bash
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 https://meepleai.app 2>/dev/null || echo "9.999")
+```
+
+Con:
+```bash
+          RT=$(curl -sf -o /dev/null -w "%{time_total}" --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://meepleai.app 2>/dev/null || echo "9.999")
+```
+
+- [ ] **Step 5: Verifica YAML lint del workflow**
+
+Run:
+```bash
+gh workflow view deploy-staging.yml --yaml > /tmp/deploy-staging-current.yml 2>&1
+# Local YAML syntax check (using actionlint if available, else python yaml)
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`. Se errore, leggi il messaggio (probabilmente indentazione `env:` block) e correggi.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(deploy-staging): pass CF Access service token headers to all smoke curls
+
+Smoke test job validate failed because curl received 302 from Cloudflare
+Access redirect instead of 200. Add CF-Access-Client-Id and
+CF-Access-Client-Secret headers to:
+- Deep Health Check step
+- Web Health Check step
+- Smoke Tests step (smoke_test function + HEALTH_JSON + RT timer)
+
+Secrets CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET must be populated
+in repo secrets per Task 1 of P1 plan.
+
+Refs docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md (Goal P1)
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md"
+```
+
+---
+
+## Task 3: Trigger semplificato a `push: [main-staging]`
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`:25-49 (top-level `on:` block)
+- Modify: `.github/workflows/deploy-staging.yml`:78-105 (job `gate` — possibilmente eliminato)
+
+> **Razionale**: rimuovere workflow_run + gate accoppiato. Trigger diventa: push a `main-staging` (manuale via release PR) OPPURE workflow_dispatch (escape hatch). Il modello "deploy quando merge a main-staging" è esplicito e deterministico. Future CI policy hardening (out of scope P1) può ripristinare un gate strutturato.
+
+- [ ] **Step 1: Sostituisci il blocco `on:` (righe 25-49 attuali)**
+
+Edit `.github/workflows/deploy-staging.yml`. Trova:
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main-staging]
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests (emergency deploy only)'
+        required: false
+        default: 'false'
+        type: boolean
+      force_full_deploy:
+        description: 'Force rebuild and deploy of both API and Web'
+        required: false
+        default: 'false'
+        type: boolean
+      perf_regression_mode:
+        description: 'Performance regression behavior (warn|fail)'
+        required: false
+        default: 'warn'
+        type: choice
+        options:
+          - warn
+          - fail
+```
+
+Sostituisci con:
+```yaml
+on:
+  push:
+    branches: [main-staging]
+  workflow_dispatch:
+    inputs:
+      skip_tests:
+        description: 'Skip tests (emergency deploy only)'
+        required: false
+        default: 'false'
+        type: boolean
+      force_full_deploy:
+        description: 'Force rebuild and deploy of both API and Web'
+        required: false
+        default: 'false'
+        type: boolean
+      perf_regression_mode:
+        description: 'Performance regression behavior (warn|fail)'
+        required: false
+        default: 'warn'
+        type: choice
+        options:
+          - warn
+          - fail
+```
+
+- [ ] **Step 2: Aggiorna env DEPLOY_SHA / DEPLOY_BRANCH (righe 67-77)**
+
+Trova:
+```yaml
+  # Spec R2 — Deploy SHA/branch routing
+  # Under workflow_run trigger, github.sha and github.ref point to the
+  # default branch, NOT the commit that triggered CI. Use the workflow_run
+  # context to recover the actual deploy SHA, with a fallback to github.sha
+  # for workflow_dispatch and any future trigger that doesn't expose
+  # workflow_run context. Every checkout `ref:` and every shell reference
+  # to the deploy SHA must use these env vars instead of github.sha.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+  DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+```
+
+Sostituisci con:
+```yaml
+  # Deploy SHA/branch routing
+  # Under push trigger, github.sha is the actual commit pushed.
+  # Under workflow_dispatch, github.sha is HEAD of the ref input.
+  # workflow_run path retained as defensive fallback (currently unused but
+  # cheap). Every checkout `ref:` should route through these.
+  DEPLOY_SHA: ${{ github.sha }}
+  DEPLOY_BRANCH: ${{ github.ref_name }}
+```
+
+- [ ] **Step 3: Sostituisci il job `gate` con un placeholder no-op (per minimizzare blast radius del cambio)**
+
+Trova:
+```yaml
+  # Spec R2 — Deploy quality gate
+  # All deployment jobs depend on this gate. The gate passes only if:
+  #   - The workflow was triggered manually (workflow_dispatch escape hatch), OR
+  #   - The workflow was triggered by a successful CI run on main-staging
+  #
+  # When ci.yml on main-staging fails, this gate stays in `skipped` state
+  # and no downstream jobs run. The result: zero deploy attempts on red CI.
+  gate:
+    name: CI Quality Gate
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.head_branch == 'main-staging'
+      )
+    steps:
+      - name: Confirm gate inputs
+        run: |
+          echo "Trigger:           ${{ github.event_name }}"
+          echo "Source CI status:  ${{ github.event.workflow_run.conclusion || 'n/a (manual)' }}"
+          echo "Source CI branch:  ${{ github.event.workflow_run.head_branch || 'n/a (manual)' }}"
+          echo "Source CI run id:  ${{ github.event.workflow_run.id || 'n/a (manual)' }}"
+          echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
+          echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
+          echo "Gate passed - proceeding with deployment pipeline"
+```
+
+Sostituisci con:
+```yaml
+  # CI Quality Gate
+  # Trigger now is push to main-staging or workflow_dispatch — both are
+  # explicit operator-controlled actions. The gate confirms inputs for
+  # observability but always passes (no skip path). Future CI policy
+  # hardening (out of scope P1) may re-introduce a CI Success branch
+  # protection check or workflow_run trigger if desired.
+  gate:
+    name: CI Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm gate inputs
+        run: |
+          echo "Trigger:           ${{ github.event_name }}"
+          echo "Deploy SHA:        ${{ env.DEPLOY_SHA }}"
+          echo "Deploy branch:     ${{ env.DEPLOY_BRANCH }}"
+          echo "Gate passed - proceeding with deployment pipeline"
+```
+
+- [ ] **Step 4: Verifica YAML lint dopo edit**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Step 5: Verifica visivamente che jobs downstream `needs: gate` ancora funzionano**
+
+Run:
+```bash
+grep -n "needs.*gate" .github/workflows/deploy-staging.yml
+```
+
+Expected: alcune righe `needs: gate` o `needs: [gate, ...]`. Confermati ancora referenziati. Il gate ora passa SEMPRE quindi non bloccherà i downstream jobs.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "fix(deploy-staging): trigger su push:main-staging, rimuove workflow_run + gate skip vacuo
+
+Sostituisce 'workflow_run from CI on main-staging' con 'push to main-staging'.
+Risolve il problema dove workflow_run firava ma il gate head_branch=='main-staging'
+skippava tutti i job lasciando notify-end come solo job ad eseguire (vacuum success).
+
+Modello deploy ora: merge a main-staging → push trigger → tutti job eseguono.
+workflow_dispatch resta come escape hatch.
+
+Future CI policy hardening (out of scope P1) può re-introdurre un gate
+strutturato basato su branch protection o workflow_run con filter affidabile.
+
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md (Task 3)"
+```
+
+---
+
+## Task 4: Runbook deploy-staging
+
+**Files:**
+- Create: `docs/for-developers/operations/deploy-staging-runbook.md`
+
+> **Razionale**: nuovo developer/operator deve sapere (1) come funziona il pipeline post-fix, (2) come usare CF Access service token per smoke locale, (3) come distinguere skip vacuo da real run.
+
+- [ ] **Step 1: Crea il runbook con sezioni essenziali**
+
+Crea il file:
+```bash
+mkdir -p docs/for-developers/operations
+cat > docs/for-developers/operations/deploy-staging-runbook.md << 'RUNBOOK_EOF'
+# Deploy to Staging — Runbook
+
+> Ultima revisione: 2026-05-07 (P1 fix — pipeline trustworthy minimal viable)
+
+## Modello deploy
+
+Il workflow `.github/workflows/deploy-staging.yml` deploya `https://meepleai.app` (staging che funge da unico ambiente pubblico al momento — produzione `meepleai.com` non provisionata).
+
+**Trigger**:
+- `push: branches: [main-staging]` — modello canonico: merge da `main-dev → main-staging` via release PR triggera deploy
+- `workflow_dispatch` — escape hatch manuale (emergency / retry / hotfix)
+
+**Pipeline jobs** (in ordine):
+1. `gate` — CI Quality Gate (sempre passa post-P1; observability-only)
+2. `notify-start` — Slack notification
+3. `detect-changes` — paths-filter su API / Web / infra
+4. `pre-deploy-check` — backend build + frontend build verification
+5. `build` — Docker images push to GHCR (ARM64)
+6. `migrate-db` — idempotent SQL migration via dotnet ef + pre-migration backup
+7. `snapshot-baseline` — read previous DEPLOYMENT.json performance metrics
+8. `deploy` — SSH-based blue-green deploy
+9. `validate` — Deep Health Check + Web Health Check + Smoke Tests + K6 smoke + perf regression
+10. `e2e-staging` — Playwright smoke spec
+11. `notify-end` — Slack completion
+
+## Promote main-dev → main-staging
+
+```bash
+# 1. Verify CI is green on main-dev (manual check)
+gh pr checks <latest-merged-pr-number>
+
+# 2. Create release PR
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/main-dev-YYYY-MM-DD
+git merge --no-ff origin/main-dev -m "chore(release): merge main-dev into main-staging"
+git push -u origin release/main-dev-YYYY-MM-DD
+
+# 3. Create + merge PR
+gh pr create --base main-staging --head release/main-dev-YYYY-MM-DD \
+  --title "chore(release): main-dev → main-staging" \
+  --body "Promote latest main-dev for staging deployment"
+gh pr merge <PR_NUM> --merge --delete-branch
+
+# 4. Watch deploy
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Smoke testing meepleai.app dietro CF Access
+
+`meepleai.app` è dietro Cloudflare Access. Curl pubblici ricevono `HTTP/1.1 302 Found` redirect a login.
+
+**Per smoke locale o ad-hoc**:
+
+```bash
+# Recupera service token da CF Zero Trust dashboard:
+# https://one.dash.cloudflare.com → Access → Service Auth → Service Tokens
+# Token GitHub Actions: github-actions-staging-smoke
+export CF_ACCESS_CLIENT_ID="<id>.access"
+export CF_ACCESS_CLIENT_SECRET="<secret>"
+
+# Smoke health
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        https://meepleai.app/health | jq
+
+# Smoke API endpoint
+curl -sf -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+        -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+        "https://meepleai.app/api/v1/discover/recent-games?pageSize=1" | jq
+```
+
+**Per CI runner**: i secrets `CF_ACCESS_CLIENT_ID` e `CF_ACCESS_CLIENT_SECRET` sono iniettati nei step `validate` job di `deploy-staging.yml` via `env:` block. Non serve azione manuale.
+
+**Storage del token**: il token è salvato in CF Zero Trust dashboard. Rotazione raccomandata annuale. Per emettere nuovo token:
+1. CF dashboard → Access → Service Auth → Create Service Token
+2. Aggiorna repo secrets: `gh secret set CF_ACCESS_CLIENT_ID --body "<new>.access"`, `gh secret set CF_ACCESS_CLIENT_SECRET --body "<new>"`
+3. Disabilita il token vecchio dopo verifica next deploy success
+
+## Distinguere skip vacuo da real success run
+
+Pre-P1, deploy-staging.yml mostrava `conclusion=success` su run dove TUTTI i job critici erano skippati (gate condition non soddisfatta). Solo `notify-end` (senza `needs: gate`) eseguiva.
+
+**Per verificare un run è realmente eseguito**:
+```bash
+gh run view <RUN_ID> --json jobs | \
+  jq '[.jobs[] | select(.name=="Deploy to Staging" or .name=="Build Images" or .name=="Database Migration") | .conclusion]'
+```
+
+Expected per run reale: `["success", "success", "success"]` (no `"skipped"`).
+Expected per run vacuo (pre-P1): `["skipped", "skipped", "skipped"]` con run-level conclusion=success → BUG.
+
+Post-P1 il gate passa sempre (observability-only), quindi questo problema non si ripresenta.
+
+## Rollback procedure
+
+`deploy-staging.yml` non ha auto-rollback. Manual rollback richiede:
+
+```bash
+# 1. Identifica merge commit responsabile
+git checkout main-staging
+git log -1 --pretty='%H' --merges
+
+# 2. Crea revert PR
+git checkout -b revert/staging-deploy-YYYY-MM-DD
+git revert -m 1 <MERGE_SHA> --no-edit
+git push -u origin revert/staging-deploy-YYYY-MM-DD
+gh pr create --base main-staging --head revert/staging-deploy-YYYY-MM-DD \
+  --title "revert: staging deploy <MERGE_SHA>" \
+  --body "Rollback. Cause: <DESCRIBE_FAILURE>"
+
+# 3. Merge → triggera nuovo deploy con codice precedente
+gh pr merge <REVERT_PR_NUM> --merge --delete-branch
+gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+## Observability
+
+- Slack: `#deploy-notifications` (via `notify-start` + `notify-end` jobs)
+- Run history: `gh run list --workflow "Deploy to Staging" --limit 20`
+- DEPLOYMENT.json on staging server: `/opt/meepleai/repo/infra/DEPLOYMENT.json` — contiene version + commit + perf baseline ultimo deploy success
+
+## Known limitations (P1 minimal)
+
+- Trigger `push: [main-staging]` accetta qualsiasi push, anche con CI rosso. Affidamento al disciplinare merge process: chi mergia main-dev → main-staging deve aver verificato CI green pre-merge.
+- Smoke test K6 + perf regression `continue-on-error: true` — non bloccanti.
+- Auto-rollback assente — richiede manual revert PR.
+
+Future hardening (out of scope P1):
+- Reintroduzione branch protection rule che richiede CI Success su main-staging
+- Auto-rollback workflow su validate failure
+- RUM Web Vitals per p75 reali post-deploy
+RUNBOOK_EOF
+```
+
+- [ ] **Step 2: Verifica markdown valido**
+
+Run:
+```bash
+ls -lh docs/for-developers/operations/deploy-staging-runbook.md
+head -5 docs/for-developers/operations/deploy-staging-runbook.md
+```
+
+Expected: file esiste, ~150 linee, primi 5 righe mostrano titolo + revisione.
+
+- [ ] **Step 3: Commit Task 4**
+
+```bash
+git add docs/for-developers/operations/deploy-staging-runbook.md
+git commit -m "docs(deploy-staging): add runbook for trusted pipeline (P1)
+
+Documenta:
+- Modello deploy post-P1 (push main-staging → trigger automatico)
+- Procedura promote main-dev → main-staging via release PR
+- Smoke testing meepleai.app dietro CF Access (service token usage)
+- Come distinguere skip vacuo (pre-P1) da real success run
+- Rollback manuale procedure
+- Known limitations P1 minimal + future hardening notes
+
+Refs docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md (Task 4)"
+```
+
+---
+
+## Task 5: Apri PR e attendi prima deploy reale
+
+**Files:** nessuno modificato locale.
+
+> **Razionale**: tutti i fix sono ora committati su un branch feature. Apriamo PR target main-dev (perché Task 2+3 modificano il workflow file e devono essere validati via CI), poi merge a main-dev, e da lì owner può fare release PR main-dev → main-staging (che triggera il primo deploy POST-fix).
+
+- [ ] **Step 1: Determina parent branch e crea feature branch se non già su uno**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+
+Se HEAD è già su `feature/p1-pipeline-staging-trustworthy` o simile (creato durante Task 2-4), skippa al Step 2.
+
+Se HEAD è su `main-dev` con i commit Task 2-4 sopra, sposta su feature branch:
+```bash
+git log --oneline -5  # verifica i 3 commit di P1 sono in cima
+LAST_PRE_P1=$(git log --oneline | sed -n '4p' | awk '{print $1}')
+git checkout -b feature/p1-pipeline-staging-trustworthy
+git checkout main-dev
+git reset --hard $LAST_PRE_P1
+git checkout feature/p1-pipeline-staging-trustworthy
+```
+
+(NB: questo script serve solo se accidentalmente i commit erano stati fatti direttamente su main-dev. Best practice: lavora su feature branch da Task 2.)
+
+- [ ] **Step 2: Push feature branch**
+
+Run:
+```bash
+git push -u origin feature/p1-pipeline-staging-trustworthy
+```
+
+Expected: `Branch 'feature/p1-pipeline-staging-trustworthy' set up to track remote ...`.
+
+- [ ] **Step 3: Crea PR target main-dev**
+
+Run:
+```bash
+gh pr create \
+  --base main-dev \
+  --head feature/p1-pipeline-staging-trustworthy \
+  --title "fix(deploy-staging): P1 pipeline trustworthy — CF Access bypass + trigger semplificato + runbook" \
+  --body "$(cat <<'EOF'
+## P1 Implementation
+
+Implementa Goal P1 dello SMART set: deploy-staging.yml end-to-end fidato.
+
+## Diagnosi pre-fix
+- workflow_run + gate `head_branch=='main-staging'` skippava 9/10 job → vacuum success
+- Smoke test riceveva 302 da CF Access invece di 200
+
+## Fix
+- **Task 2**: CF Access service token headers su Deep Health Check + Web Health Check + Smoke Tests step
+- **Task 3**: Trigger semplificato a `push: [main-staging]` + workflow_dispatch (rimosso workflow_run + gate skip)
+- **Task 4**: Runbook `docs/for-developers/operations/deploy-staging-runbook.md`
+
+## Pre-req merge
+Repo secrets devono esistere (verificati in Task 1):
+- ✅ \`CF_ACCESS_CLIENT_ID\`
+- ✅ \`CF_ACCESS_CLIENT_SECRET\`
+
+## Acceptance
+Post-merge a main-dev → owner crea release PR main-dev → main-staging → trigger \`push: main-staging\` → primo deploy POST-fix gira tutti i job. Verifica Task 6.
+
+Refs spec: \`docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md\`
+Refs plan: \`docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md\`
+EOF
+)"
+```
+
+Annota PR_NUM stampato per i passaggi successivi.
+
+- [ ] **Step 4: Watch CI checks su PR**
+
+Run (sostituisci `<PR_NUM>`):
+```bash
+gh pr checks <PR_NUM> --watch
+```
+
+Expected: tutti i check passano. Se YAML lint fail o altro, fix sul branch e push (Task 2-3 step 5 dovrebbe averlo prevenuto).
+
+- [ ] **Step 5: Verifica mergeability**
+
+Run:
+```bash
+gh pr view <PR_NUM> --json mergeable,mergeStateStatus
+```
+
+Expected: `MERGEABLE` + `CLEAN`.
+
+- [ ] **Step 6: Mergia a main-dev**
+
+Run:
+```bash
+gh pr merge <PR_NUM> --squash --delete-branch
+```
+
+Squash perché è una "feature" P1 conceptualmente atomic (anche se 3 commit logici).
+
+---
+
+## Task 6: Acceptance verification — 3 deploy consecutivi success no-skip
+
+**Files:** nessuno modificato.
+
+> **Razionale**: SMART criterion P1 richiede 3 deploy consecutivi con conclusion=success E nessun job critico in stato skipped. Eseguiamo 3 trigger (mix di push reali main-dev → main-staging release PR + workflow_dispatch ammessi come surrogato) e ispezioniamo job results.
+
+- [ ] **Step 1: Trigger deploy #1 — release PR main-dev → main-staging**
+
+Run:
+```bash
+git checkout main-staging
+git pull --ff-only origin main-staging
+git checkout -b release/p1-acceptance-deploy-1-2026-05-07
+git merge --no-ff origin/main-dev -m "chore(release): P1 acceptance deploy #1 — main-dev → main-staging"
+git push -u origin release/p1-acceptance-deploy-1-2026-05-07
+gh pr create --base main-staging --head release/p1-acceptance-deploy-1-2026-05-07 \
+  --title "chore(release): P1 acceptance deploy #1" \
+  --body "First post-P1 deploy verification. Refs P1 plan Task 6 step 1."
+gh pr checks --watch  # attendi CI verde su release PR (su main-dev side)
+gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 2: Watch deploy #1 fino a completion**
+
+Run:
+```bash
+sleep 30
+RUN_ID=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID"
+gh run watch $RUN_ID
+```
+
+Expected: completa con conclusion=success in ~30-40 minuti.
+
+- [ ] **Step 3: Verifica deploy #1 NO skipped critical jobs**
+
+Run:
+```bash
+gh run view $RUN_ID --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected output (4 entries, tutti conclusion="success"):
+```json
+[
+  {"name": "Build Images", "conclusion": "success"},
+  {"name": "Database Migration", "conclusion": "success"},
+  {"name": "Deploy to Staging", "conclusion": "success"},
+  {"name": "Post-deploy Validation", "conclusion": "success"}
+]
+```
+
+Se qualche conclusion="skipped", P1 acceptance fallisce — investiga (gate ancora skippante? trigger non firato?).
+
+Se qualche conclusion="failure" su Post-deploy Validation, smoke test ancora fail — verifica secrets popolati e curl headers corretti.
+
+- [ ] **Step 4: Trigger deploy #2 — workflow_dispatch (surrogato manuale)**
+
+Run:
+```bash
+gh workflow run "Deploy to Staging" --ref main-staging
+sleep 30
+RUN_ID2=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID2"
+gh run watch $RUN_ID2
+```
+
+Expected: completion success entro ~30 min. Detect-changes potrebbe forzare full deploy via workflow_dispatch input default.
+
+- [ ] **Step 5: Verifica deploy #2 NO skipped critical jobs**
+
+Run (sostituisci $RUN_ID2):
+```bash
+gh run view $RUN_ID2 --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected: 4 entries tutti success.
+
+- [ ] **Step 6: Trigger deploy #3 — workflow_dispatch ripetuto**
+
+Run:
+```bash
+gh workflow run "Deploy to Staging" --ref main-staging
+sleep 30
+RUN_ID3=$(gh run list --workflow "Deploy to Staging" --limit 1 --branch main-staging --json databaseId --jq '.[0].databaseId')
+echo "Watching run $RUN_ID3"
+gh run watch $RUN_ID3
+```
+
+- [ ] **Step 7: Verifica deploy #3 e finale**
+
+Run (sostituisci $RUN_ID3):
+```bash
+gh run view $RUN_ID3 --json jobs | \
+  jq '[.jobs[] | select(.name | test("Build Images|Database Migration|Deploy to Staging|Post-deploy Validation")) | {name, conclusion}]'
+```
+
+Expected: 4 entries tutti success.
+
+- [ ] **Step 8: Smoke test post-deploy con CF Access (verifica indipendente)**
+
+Run (sostituisci `<CLIENT_ID>` `<SECRET>` con i valori GitHub secrets):
+```bash
+curl -sf -H "CF-Access-Client-Id: <CLIENT_ID>" \
+         -H "CF-Access-Client-Secret: <SECRET>" \
+         https://meepleai.app/health | jq -r '.status'
+```
+
+Expected: `Healthy`.
+
+- [ ] **Step 9: Posta closure comment su PR P1**
+
+Run (sostituisci `<P1_PR_NUM>` = il PR aperto in Task 5):
+```bash
+gh pr comment <P1_PR_NUM> --body "$(cat <<EOF
+## ✅ P1 acceptance verification — 3 deploy consecutivi green
+
+| Deploy | Run ID | Trigger | Build Images | DB Migration | Deploy | Validate |
+|--------|--------|---------|--------------|--------------|--------|----------|
+| #1 | $RUN_ID | release PR push:main-staging | success | success | success | success |
+| #2 | $RUN_ID2 | workflow_dispatch | success | success | success | success |
+| #3 | $RUN_ID3 | workflow_dispatch | success | success | success | success |
+
+Smoke independent: \`curl https://meepleai.app/health\` con CF Access headers ritorna \`{"status": "Healthy"}\`.
+
+P1 SMART Goal acceptance:
+- [x] 3 consecutive Deploy to Staging runs con conclusion=success
+- [x] Nessun job critico (Build/Migration/Deploy/Validate) in stato skipped
+- [x] Smoke test verifica HTTP 200 reale (non 302)
+- [x] Runbook \`docs/for-developers/operations/deploy-staging-runbook.md\` esistente
+
+P1 chiusa. Prossimo: P2 (deploy v2 + #807 token redesign + #808 freeze lift).
+EOF
+)"
+```
+
+---
+
+## Definition of Done — P1 chiusa
+
+- [ ] Repo secrets `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` popolati e funzionanti (Task 1)
+- [ ] `.github/workflows/deploy-staging.yml` modificato: smoke test usa CF Access headers (Task 2) + trigger semplificato push:main-staging (Task 3)
+- [ ] `docs/for-developers/operations/deploy-staging-runbook.md` creato e committato (Task 4)
+- [ ] PR P1 mergiata a main-dev (Task 5)
+- [ ] 3 deploy consecutivi su main-staging completano success con NESSUN job critico skipped (Task 6)
+- [ ] Smoke test indipendente con CF Access headers ritorna `{"status": "Healthy"}`
+
+**Tempo stimato totale**: 1 settimana wall-clock owner-paced. Active work ~4-6 ore (Task 1-5) + ~2 ore observation (Task 6 wait + verify).
+
+---
+
+## Self-review checklist
+
+- ✅ **Spec coverage**: ogni Gherkin scenario di P1 (deploy fires + smoke real 200 + 3 consecutive + runbook) è implementato da una Task con verifica concreta
+- ✅ **No placeholder**: ogni step ha comando esatto + expected output. Variabili runtime (`<PR_NUM>`, `<CLIENT_ID>`, `$RUN_ID`) sono chiaramente marcate come sostituibili
+- ✅ **Type consistency**: nomi consistenti — `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET` ovunque, branch naming `feature/p1-...` e `release/p1-acceptance-deploy-N-...`
+- ✅ **Scope check**: focused su solo P1 (pipeline trustworthy minimal). #807 / #808 / Wave 3 frontend / production stand-up esplicitamente fuori scope (richiamati out-of-scope nello spec sopra)
+
+## Riferimenti
+
+- Spec parent: `docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md`
+- Workflow modificato: `.github/workflows/deploy-staging.yml`
+- Plan A1 invalidato (storico): `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`

--- a/docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md
+++ b/docs/superpowers/specs/2026-05-07-v2-meepleai-deploy-goals.md
@@ -1,0 +1,220 @@
+# MeepleAI v2 deploy goals — design (process-focused redesign)
+
+> **Date**: 2026-05-07
+> **Owner**: @DegrassiAaron (single dev / decision authority)
+> **Supersedes**: `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md` (plan basato su assunzioni invalidate)
+> **Companion plan**: TBD — questo design viene tradotto in implementation plan via `superpowers:writing-plans` skill
+
+## Context
+
+### Goal di sessione
+
+Definire goal SMART trackable per portare la nuova UI v2 (Wave A/B/C/D + SP6, ~16 rotte già `done` su `main-dev`) a essere visibile e funzionale su `https://meepleai.app` (staging che funge da unico ambiente pubblico), con qualità accettabile su accessibility e performance.
+
+### Findings dalla sessione di discovery (2026-05-07)
+
+Iterazione precedente di brainstorming aveva prodotto 5 goal outcome-focused (A1, A2, B1, B2, B3) che assumevano:
+
+- pipeline `deploy-staging.yml` automatica e affidabile
+- produzione separata su `meepleai.com`
+- baseline performance pre-Wave-A misurabile
+- smoke verificabile esternamente via `curl https://meepleai.app/health`
+
+Investigation diretta ha invalidato tutte e quattro le assunzioni:
+
+1. **Pipeline staging in stato ambiguo**: `deploy-staging.yml` gate (riga 89-95) richiede `head_branch=main-staging` ma run "success" recenti mostrano `head_branch=main-dev` → gate skippato silentemente, success vacuo. Deploy reali eseguiti manualmente via `workflow_dispatch` (alcuni recenti FAIL: `c9e997c77`, `38c08d693`).
+2. **CI policy permissiva**: PR mergiate con `CI Success = FAILURE` via `--admin` override (es. #819, #823 nel set Wave 3). Promote automatico porterebbe red su main-staging.
+3. **Cloudflare Access wrappa `meepleai.app/*` incluso `/health`**: smoke esterni ritornano 302 (redirect login). Service token CF Access esistente (lavoro precedente). GitHub IP whitelist non confermato.
+4. **`meepleai.com` (produzione) inesistente**: no record DNS, no server provisionato. Goal di "production deploy" out-of-scope finché stand-up infrastructure non viene affrontato come progetto separato.
+5. **Nessuna baseline performance pre-Wave-A**: codice mai rilasciato in produzione, quindi "no regression vs legacy" è ill-definito.
+
+### Decisioni di scoping
+
+- **Approccio**: `β` da brainstorm — process focus + outcome semplificato (3 macro-goal invece di 5)
+- **EAA 2026-06-01**: IGNORE — non più hard deadline; goal owner-paced
+- **Produzione `meepleai.com`**: out of scope per questo design; eventuale stand-up tracked separatamente
+- **P1 scope**: minimal viable — solo quanto serve per sbloccare P2
+
+## Goal P1 — Pipeline staging trustworthy (minimal viable)
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | `deploy-staging.yml` esegue end-to-end su trigger deterministico (push a `main-staging` post-merge release PR da `main-dev`, o `workflow_dispatch` come escape hatch): build/migrate/deploy/validate completano success reale (no jobs vacuamente skippati); smoke test job verifica HTTP 200 reale (non 302 da CF Access redirect) usando service token; runbook documenta strategia smoke + promote model |
+| **M**easurable | 3 deploy "Deploy to Staging" consecutivi (push reali a main-staging O `gh workflow run` manuali surrogati) con conclusion=success E nessun job critico (Build Images, Database Migration, Deploy to Staging, Post-deploy Validation) in stato `skipped`; job `validate.smoke_tests` ritorna HTTP 200 da `/health`; documento `docs/for-developers/operations/deploy-staging-runbook.md` esiste e include sezione CF Access bypass + promote PR procedure |
+| **A**chievable | Solo workflow YAML edits + 1 doc + uso service token già disponibile. Nessun infra provisioning. Single dev fattibile in ~1 settimana |
+| **R**elevant | Pre-requisito atomico per P2: deploy a `meepleai.app` non può essere "trusted" senza pipeline trusted |
+| **T**ime-bound | **~1 settimana** owner-paced |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: deploy-staging.yml fires reliably on main-dev push
+
+  Scenario: Promote main-dev → main-staging triggers automatic staging deploy end-to-end
+    Given un release PR "main-dev → main-staging" viene mergiato (push a main-staging)
+    When GitHub Actions trigger "push: branches: [main-staging]" del workflow "Deploy to Staging" fires
+    Then il job "CI Quality Gate" passa (observability-only, sempre success)
+    And i job [build, migrate-db, snapshot-baseline, deploy, validate, e2e-staging] eseguono effettivamente (status≠skipped)
+    And la conclusion finale del run "Deploy to Staging" è "success"
+    And la latenza totale push-to-deploy è ≤ 60 minuti
+
+  Scenario: Smoke test job verifica HTTP 200 reale dietro Cloudflare Access
+    Given deploy-staging.yml job "validate" è in esecuzione
+    And i secrets CF_ACCESS_CLIENT_ID + CF_ACCESS_CLIENT_SECRET sono popolati nel repo
+    When eseguo "smoke_test API Health" contro https://meepleai.app/health con CF Access service token headers
+    Then il response status è 200 (non 302 da Cloudflare Access redirect)
+    And il body JSON contiene {"status": "Healthy"}
+
+  Scenario: Tre deploy consecutivi registrati green (manuali accettati come surrogato)
+    Given P1 è in fase di acceptance verification
+    When ispeziono "gh run list --workflow 'Deploy to Staging' --limit 3 --json conclusion,event,headBranch"
+    Then i 3 entry più recenti hanno tutti event in [push, workflow_dispatch] AND conclusion=success
+    And nessuno dei 3 ha "skipped" come stato finale di alcun job critico (Build Images, Database Migration, Deploy to Staging, Post-deploy Validation)
+    And tutti e 3 referenziano commit reali su main-staging
+
+  Scenario: Runbook documenta strategia smoke test + promote model
+    Given un nuovo developer/operator vuole verificare salute staging post-deploy
+    When apre "docs/for-developers/operations/deploy-staging-runbook.md"
+    Then trova sezione "Smoke testing meepleai.app dietro CF Access"
+    And documenta: come usare service token esistente, come interpretare 200 vs 302
+    And trova sezione "Promote main-dev → main-staging"
+    And documenta: procedura release PR + watch deploy completion
+    And documenta: rollback manuale via revert PR
+```
+
+## Goal P2 — v2 visibile + accessibile su meepleai.app (consolida A1+A2+B1+B2)
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | 16+ rotte v2 (Wave A/B/C/D + SP6) live su `meepleai.app`; codice legacy lungo critical-path Alpha rimosso/corretto in favore dei v2 component; 0 axe-core color-contrast violations sulle rotte v2; keyboard nav funzionante (verifica automated via axe + role check); #807 Fase 1 (audit) + Fase 2 (token redesign AA) deployati nello **stesso PR** atomico; #808 freeze policy lifted |
+| **M**easurable | Critical-path Alpha 9-step (login → /library → /games?tab=library → /games/[id] → /agents → /agents/[id] → /sessions → /sessions/[id] → /gamebook) renderizza componenti v2 nel DOM (`data-slot` v2-* presente) senza fallback legacy; `pnpm test:e2e:a11y` ritorna 0 violations su tutte le rotte v2; A11y E2E job CI con `continue-on-error: false`; #807 e #808 issue closed |
+| **A**chievable | Dipende da P1. #807 audit + token redesign è il lavoro più sostanzioso (~2-3 settimane single dev). Cleanup legacy critical-path è scope addizionale rispetto al goal originale |
+| **R**elevant | Output user-visible primario — è "la nuova UI" promessa; sblocca anche Wave 3 frontend pending tramite freeze lift |
+| **T**ime-bound | **~3-4 settimane** dopo P1 (owner-paced, no EAA pressure) |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: v2 routes deployed AND accessible on meepleai.app
+
+  Scenario: Critical-path Alpha user vede 16+ rotte v2 live, no fallback legacy
+    Given P1 è done (pipeline trustworthy) e ultimo deploy main-dev è success
+    And sono utente Alpha autenticato su meepleai.app (post CF Access + login app)
+    When percorro: /login → /library → /games?tab=library → /games/[id] → /agents → /agents/[id] → /sessions → /sessions/[id] → /gamebook
+    Then ogni rotta renderizza componenti v2 (DOM contiene "data-slot" che inizia con "v2-" oppure markup da components/v2/**)
+    And nessuna rotta cade in fallback legacy (data-slot v1-* assente) — eventuali deviazioni sono tracked come issue + documentate
+    And la console browser non mostra errori critici (severity=error)
+
+  Scenario: axe-core 0 color-contrast violations su tutte le 16 rotte v2
+    Given P1 è done e il workflow "Frontend - A11y E2E" gira contro meepleai.app post-deploy
+    When eseguo "pnpm test:e2e:a11y" su staging (o equivalente CI job)
+    Then il report axe-core ritorna 0 violations di rule "color-contrast"
+    And tutti i testi normali hanno ratio computato ≥ 4.5:1 (WCAG 2.1 AA SC 1.4.3)
+    And il job CI "Frontend - A11y E2E" è impostato a continue-on-error=false (blocking)
+    And nessuna PR successiva può passare merge gate con violazioni nuove
+
+  Scenario: #807 token redesign + visual baseline regen + freeze lift atomic in same PR
+    Given audit token ha catalogato N violazioni (#807 Fase 1)
+    When committo Fase 1 (catalogo audit CSV) + Fase 2 (token redesign AA in tailwind.config + tokens.css) + visual baselines rigenerati nello STESSO PR
+    Then "pnpm test:e2e:a11y" passa su tutte le rotte v2 senza .exclude(...) workaround
+    And visual baseline rigenerati committati senza diff inattesi (>0.5%) sui componenti già done
+    And #807 issue closed con summary che include catalogo audit + diff token
+    And #808 freeze policy issue closed con commento "lift criteria met"
+    And v2-migration-matrix permette nuovi pending row pickable
+
+  Scenario: Keyboard navigation funzionante su drawer + dialog v2 (automated check)
+    Given sono su https://meepleai.app/sessions/[id]/live (E2E test scenario)
+    And il test driver simula solo keyboard input (no mouse)
+    When premo Tab finché focus arriva su trigger button "Apri menu"
+    And premo Enter
+    Then drawer si apre AND focus si sposta su primo elemento focusabile interno
+    And premendo Escape drawer si chiude AND focus torna al trigger button
+    And axe-core verifica role="dialog" + aria-modal="true" + aria-labelledby presenti
+```
+
+## Goal P3 — Performance v2 meets absolute Web Vitals "Good" thresholds
+
+> **Re-framing rispetto al draft originale (B3)**: il goal originale era "no regression vs legacy baseline". Senza baseline (mai rilasciato in produzione) il confronto è ill-definito. Il goal viene re-framed con **threshold assoluti** Web Vitals "Good" + first-deploy v2 come baseline per future PR.
+
+| SMART | Detail |
+|---|---|
+| **S**pecific | Aggiornare `apps/web/lighthouserc.json` + `lighthouserc.mobile.json` per coprire critical-path Alpha (5 rotte sample); tutte le rotte rispettano threshold assoluti Web Vitals "Good" (LCP ≤ 2.5s, CLS ≤ 0.1, TBT ≤ 200ms); bundle aggregato JS first-load ≤ 20 MB; first-deploy v2 produce baseline JSON committato per future regression detection |
+| **M**easurable | Lighthouse CI run post-P2 ottiene Performance ≥ 90 su 5 rotte [/library, /games, /agents, /sessions, /gamebook] in entrambi profili desktop + mobile; `Frontend - Bundle Size` job verifica ≤ 20 MB JS first-load aggregato e nessun chunk > 500 KB gzipped; file `docs/for-developers/frontend/perf-baselines/baseline-v2-<DATE>.json` committato; il job Bundle Size è blocking (no continue-on-error) post-baseline establishment |
+| **A**chievable | Tooling già esistente (Lighthouse CI workflow + lighthouserc + Bundle Size CI). Solo URL list update + budget assertion + baseline file commit. ~2-3 giorni single dev |
+| **R**elevant | Impedisce regressioni perf future + stabilisce contract observable per rotte v2 |
+| **T**ime-bound | **~1 settimana** post-P2 |
+
+### Gherkin scenarios
+
+```gherkin
+Feature: Performance v2 meets absolute Web Vitals "Good" thresholds
+
+  Scenario: Lighthouse CI URL list aggiornato al critical-path Alpha
+    Given P2 è completato e Lighthouse CI gira su PR via "test-performance.yml"
+    When ispeziono "apps/web/lighthouserc.json" + "apps/web/lighthouserc.mobile.json"
+    Then la lista URL include le 5 rotte critical-path Alpha [/library, /games, /agents, /sessions, /gamebook]
+    And rimuove URL legacy non più rilevanti per v2 (es. /editor se obsoleto)
+    And il file è committato come parte del PR P3
+
+  Scenario: Tutte le rotte Alpha rispettano Web Vitals "Good" thresholds (absolute)
+    Given Lighthouse CI run su 5 rotte critical-path Alpha post-build localhost (artefatto = stesso bundle deployato)
+    When ispeziono il report dell'ultimo run su PR
+    Then ogni rotta ottiene LCP ≤ 2.5s ("Good")
+    And ogni rotta ottiene CLS ≤ 0.1 ("Good")
+    And ogni rotta ottiene TBT ≤ 200ms ("Good" — surrogato di FID per Lighthouse synthetic)
+    And score Performance ≥ 90 su ogni rotta
+    And nessun threshold richiede confronto con baseline storico (assoluto)
+
+  Scenario: Bundle aggregato sotto budget hard 20 MB
+    Given il job CI "Frontend - Bundle Size" gira su main-dev post-P2
+    When ispeziono il report bundle-size dell'ultimo run
+    Then bundle JS first-load aggregato ≤ 20 MB
+    And nessun chunk individuale eccede 500 KB gzipped
+    And il job è blocking (continue-on-error=false) per future PR
+
+  Scenario: First-deploy v2 produce baseline che future PR confrontano
+    Given P3 acceptance run completa con tutti threshold rispettati
+    When committo il report Lighthouse + bundle-size come "baseline-v2-2026-XX-XX.json"
+    Then il file è salvato in "docs/for-developers/frontend/perf-baselines/"
+    And future PR che peggiorano metriche di > 10% vs questa baseline triggherano warning su PR comment
+    And la baseline è ri-aggiornata solo via PR esplicita (no auto-update silente)
+```
+
+## Dependency graph
+
+```
+P1 (~1 settimana)
+  ↓ blocking
+P2 (~3-4 settimane)
+  ↓ blocking
+P3 (~1 settimana)
+
+Total owner-paced: ~5-6 settimane
+```
+
+P1 deve essere `done` prima che P2 cleanup deploy abbia senso (deploy va eseguito da pipeline trustworthy, non da workflow_dispatch manuali ad hoc). P2 deve essere `done` prima che P3 misuri perf su rotte v2 effettivamente live.
+
+## Out of scope (esplicitamente)
+
+- **Production stand-up** (`meepleai.com` DNS + server + secrets bootstrap) — progetto separato, requires brainstorm dedicato + plan infrastruttura
+- **Real User Monitoring** (RUM) per Web Vitals reali p75 da utenti — non disponibile, P3 usa Lighthouse synthetic come surrogato
+- **Wave 3 frontend rotte rimanenti** (`/discover`, `/game-nights`, `/kb/[id]`, `/toolkits/[id]`) — sbloccate da P2 (#808 lift) ma non parte di questo set di goal; tracked in v2-migration-matrix
+- **SP5 admin batch** + **SP3 public secondary** — fuori scope
+- **CI policy hardening** (no più `--admin` merge con CI Success rosso) — out of scope P1 minimal; potenziale follow-up se P1 done expone necessity
+
+## Riferimenti
+
+- v2 migration matrix: `docs/for-developers/frontend/v2-migration-matrix.md`
+- Plan A1 (invalidato): `docs/superpowers/plans/2026-05-07-a1-promote-main-dev-staging.md`
+- Workflow staging: `.github/workflows/deploy-staging.yml`
+- Workflow performance: `.github/workflows/test-performance.yml`
+- Lighthouse config: `apps/web/lighthouserc.json` + `lighthouserc.mobile.json`
+- Issue #807 — A11y design system audit
+- Issue #808 — Freeze SP6 v2 expansion (policy)
+
+## Self-review checklist
+
+- ✅ **Placeholder scan**: nessun TBD/TODO non risolto. "TBD" appare solo nel header come riferimento al companion plan da generare via writing-plans
+- ✅ **Internal consistency**: dipendenze P1→P2→P3 coerenti tra sezioni; threshold assoluti P3 non confliggono con altri goal; baseline storage path consistente in P3
+- ✅ **Scope check**: 3 macro-goal, ognuno SMART discreto, owner-paced timeline, decomposizione adeguata per single dev
+- ✅ **Ambiguity check**: critical-path 9-step esplicito; threshold Web Vitals "Good" valori esatti; bundle 20 MB esplicito; "atomic same PR" per #807 redesign chiarito

--- a/infra/secrets/cf-access.secret.example
+++ b/infra/secrets/cf-access.secret.example
@@ -1,0 +1,29 @@
+# Cloudflare Access service token for GitHub Actions staging smoke tests
+# Source: https://one.dash.cloudflare.com -> Access -> Service credentials -> Service Tokens
+# Policy: "Service auth for staging smoke" (attached to meepleai.app application)
+# Used by: .github/workflows/deploy-staging.yml job "validate" (Deep Health Check, Web Health Check, Smoke Tests)
+#
+# Setup procedure:
+#   1. cp infra/secrets/cf-access.secret.example infra/secrets/cf-access.secret
+#   2. Edit infra/secrets/cf-access.secret with real values from CF Zero Trust dashboard
+#   3. Populate GitHub repo secrets:
+#        set -a; source infra/secrets/cf-access.secret; set +a
+#        gh secret set CF_ACCESS_CLIENT_ID    --body "$CF_ACCESS_CLIENT_ID"
+#        gh secret set CF_ACCESS_CLIENT_SECRET --body "$CF_ACCESS_CLIENT_SECRET"
+#        unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+#   4. Verify smoke locally:
+#        set -a; source infra/secrets/cf-access.secret; set +a
+#        curl -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+#             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+#             -sf -o /dev/null -w "%{http_code}\n" https://meepleai.app/health
+#        unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+#      Expected: 200
+#
+# Rotation: Recommended yearly. Procedure:
+#   1. CF dashboard -> create new service token + apply existing "Service auth for staging smoke" policy
+#   2. Update infra/secrets/cf-access.secret with new values
+#   3. Re-run gh secret set commands above
+#   4. Verify deploy success on next run, then revoke old token in CF dashboard
+
+CF_ACCESS_CLIENT_ID=<token-id>.access
+CF_ACCESS_CLIENT_SECRET=<token-secret>


### PR DESCRIPTION
First post-P1 deploy verification. Refs P1 plan Task 6 step 1.

Promotes 7 commits from main-dev to main-staging:
- P1 pipeline trustworthy (#824) — CF Access bypass + trigger semplificato + runbook
- Wave 3 backend Phase 0-4 (#811-#823) — BGG search + /discover + toolkit marketplace + KB chunks + ratings

This release PR is the first deploy that exercises:
- New `push: [main-staging]` trigger (no more workflow_run gate skip vacuo)
- Smoke test with CF Access service token headers (no more 302 fail)
- Gate now observability-only (always passes)