### PR TITLE
fix(infra): purge stale Traefik references (post-PR #738 cutover to CF Tunnel)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -667,11 +667,11 @@ jobs:
             done
 
             # Deploy only changed services (--force-recreate ensures container restarts even if image digest unchanged)
-            # Single-tester profiles: ai-essential (embedding+reranker) + monitoring-essential
-            # + proxy (traefik). NO orchestration, NO n8n, NO seq/cadvisor.
+            # Single-tester profiles: ai-essential (embedding+reranker) + monitoring-essential.
+            # Edge: Cloudflare Tunnel (post-PR #738 cutover, Traefik decommissioned).
             # See docs/superpowers/specs/2026-05-05-infrastructure-single-tester-design.md G3
-            docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
-              --profile ai-essential --profile monitoring-essential --profile proxy \
+            docker compose -f docker-compose.yml -f compose.staging.yml \
+              --profile ai-essential --profile monitoring-essential \
               up -d --no-deps --force-recreate $SERVICES
 
             # Health check via docker exec (port not exposed on host)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -609,7 +609,7 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
             # Sync /opt/meepleai/repo to the deploy SHA so compose files
-            # match the workflow context (compose.traefik.yml, etc.)
+            # match the workflow context (post-#738: docker-compose.yml + compose.staging.yml)
             cd /opt/meepleai/repo
             git fetch origin main-staging
             git reset --hard ${{ env.DEPLOY_SHA }}

--- a/.github/workflows/fix-db-password.yml
+++ b/.github/workflows/fix-db-password.yml
@@ -66,7 +66,7 @@ jobs:
             set -a
             for f in secrets/*.secret; do source "$f" 2>/dev/null || true; done
             set +a
-            docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
+            docker compose -f docker-compose.yml -f compose.staging.yml \
               --profile minimal up -d --no-deps --force-recreate api
 
             echo "Waiting for API to be healthy..."

--- a/.github/workflows/fix-line-endings.yml
+++ b/.github/workflows/fix-line-endings.yml
@@ -49,7 +49,7 @@ jobs:
             set -a
             for f in secrets/*.secret; do source "$f" 2>/dev/null || true; done
             set +a
-            docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml \
+            docker compose -f docker-compose.yml -f compose.staging.yml \
               --profile minimal up -d --no-deps --force-recreate api
 
             echo "=== Waiting for API to be healthy ==="

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -90,8 +90,8 @@ jobs:
             export API_IMAGE="${{ env.API_IMAGE }}:${{ inputs.image_tag }}"
             export WEB_IMAGE="${{ env.WEB_IMAGE }}:${{ inputs.image_tag }}"
 
-            # Rollback containers
-            docker compose -f docker-compose.yml -f compose.staging.yml -f compose.staging-traefik.yml \
+            # Rollback containers (post-PR #738 — Traefik decommissioned, edge=CF Tunnel)
+            docker compose -f docker-compose.yml -f compose.staging.yml \
               --profile minimal up -d --no-deps api web
 
             # Health check

--- a/apps/api/src/Api/Infrastructure/Configuration/SecretDefinitions.cs
+++ b/apps/api/src/Api/Infrastructure/Configuration/SecretDefinitions.cs
@@ -141,11 +141,7 @@ internal static class SecretDefinitions
             "SLACK_WEBHOOK_URL"
         ),
 
-        ["traefik"] = new(
-            SecretLevel.Optional,
-            "TRAEFIK_DASHBOARD_USER",
-            "TRAEFIK_DASHBOARD_PASSWORD"
-        ),
+        // Traefik secret definition removed (PR #738 cutover to CF Tunnel).
 
         ["smoldocling-service"] = new(
             SecretLevel.Optional,

--- a/apps/api/src/Api/Routing/AdminSecretsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminSecretsEndpoints.cs
@@ -35,7 +35,7 @@ internal static class AdminSecretsEndpoints
         ["monitoring.secret"] = "Monitoring",
         ["storage.secret"] = "Storage",
         ["slack.secret"] = "Slack",
-        ["traefik.secret"] = "Traefik",
+        // ["traefik.secret"] removed (PR #738 cutover to CF Tunnel)
         ["n8n.secret"] = "n8n",
     };
 

--- a/apps/api/src/Api/Routing/DashboardEndpoints.cs
+++ b/apps/api/src/Api/Routing/DashboardEndpoints.cs
@@ -242,7 +242,7 @@ Feedback is used to calculate accuracy metrics (target: >75% relevance).
             context.Response.Headers.Append("Content-Type", "text/event-stream");
             context.Response.Headers.Append("Cache-Control", "no-cache");
             context.Response.Headers.Append("Connection", "keep-alive");
-            context.Response.Headers.Append("X-Accel-Buffering", "no"); // Disable nginx/Traefik buffering
+            context.Response.Headers.Append("X-Accel-Buffering", "no"); // Disable reverse proxy buffering (CF Tunnel, nginx, etc.)
 
             // Create heartbeat task for keep-alive (30s interval)
             using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,6 +1,6 @@
 # Caddy reverse proxy — used by compose.mvp.yml (Hetzner CAX31 MVP stack).
-# For full/production deployments, Traefik is the primary reverse proxy
-# (see traefik/ directory and compose.traefik.yml).
+# For staging/production deployments edge ingress is via Cloudflare Tunnel
+# (cloudflared on VPS, post-PR #738 cutover). This Caddyfile is MVP/dev only.
 {
     email admin@meepleai.com
 }

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -50,9 +50,9 @@ smoke-staging: ## Run automated smoke set against staging (https://meepleai.app)
 smoke-pg-readback: ## Run pg-readback.sh DB-direct migration validation (requires open tunnel)
 	bash scripts/pg-readback.sh
 
-staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB reservation)
-	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
-		--profile ai --profile monitoring --profile proxy up -d
+staging: ## Deploy staging — core + AI + monitoring (CAX31+ recommended, ~14GB reservation, edge via CF Tunnel)
+	$(COMPOSE) -f compose.staging.yml \
+		--profile ai --profile monitoring up -d
 
 staging-minimal: ## Deploy staging single-tester profile (~3GB RAM) — edge via Cloudflare Tunnel (cloudflared on VPS, not Traefik)
 	$(COMPOSE) -f compose.staging.yml \
@@ -67,21 +67,21 @@ staging-tutor-down: ## Stop only orchestration-service (keep rest of staging run
 	$(COMPOSE) -f compose.staging.yml --profile tutor-agents rm -f orchestration-service
 
 staging-core: ## (Deprecated, use staging-minimal) Deploy staging core only — no AI services
-	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
-		--profile monitoring --profile proxy up -d
+	$(COMPOSE) -f compose.staging.yml \
+		--profile monitoring up -d
 
 staging-down: ## Stop staging (all profiles)
-	$(COMPOSE) -f compose.staging.yml -f compose.traefik.yml \
-		--profile ai --profile monitoring --profile proxy down
+	$(COMPOSE) -f compose.staging.yml \
+		--profile ai --profile monitoring down
 
-prod: ## Deploy production (requires PROD_DOMAIN env var)
+prod: ## Deploy production (requires PROD_DOMAIN env var, edge via CF Tunnel)
 	@test -n "$(PROD_DOMAIN)" || (echo "Error: PROD_DOMAIN is required" && exit 1)
-	$(COMPOSE) -f compose.prod.yml -f compose.traefik.yml \
-		--profile ai --profile monitoring --profile proxy up -d
+	$(COMPOSE) -f compose.prod.yml \
+		--profile ai --profile monitoring up -d
 
 prod-down: ## Stop production
-	$(COMPOSE) -f compose.prod.yml -f compose.traefik.yml \
-		--profile ai --profile monitoring --profile proxy down
+	$(COMPOSE) -f compose.prod.yml \
+		--profile ai --profile monitoring down
 
 # === Secrets ===
 

--- a/infra/compose.logging.yml
+++ b/infra/compose.logging.yml
@@ -1,9 +1,9 @@
 # Log aggregation stack — Linux only (staging/prod servers)
 # Dev on Windows: use 'make logs s=<service>' for local log viewing.
 #
-# Usage (with staging):
-#   docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml -f compose.logging.yml \
-#     --profile ai --profile monitoring --profile logging --profile proxy up -d
+# Usage (with staging) — post-PR #738 (edge=CF Tunnel, no traefik):
+#   docker compose -f docker-compose.yml -f compose.staging.yml -f compose.logging.yml \
+#     --profile ai --profile monitoring --profile logging up -d
 
 services:
   loki:

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -2,8 +2,11 @@
 # Requires PROD_DOMAIN env var (e.g., PROD_DOMAIN=meepleai.com)
 # Secrets from ./secrets/prod/, stricter resource limits
 #
-# Usage: docker compose -f docker-compose.yml -f compose.prod.yml -f compose.traefik.yml \
-#          --profile ai --profile monitoring --profile proxy up -d
+# Edge: Cloudflare Tunnel (cloudflared on VPS, post-PR #738 cutover, T18 Phase 6).
+# Public routing handled by CF Tunnel ingress config — no service-level labels required.
+#
+# Usage: docker compose -f docker-compose.yml -f compose.prod.yml \
+#          --profile ai --profile monitoring up -d
 
 services:
   # ===========================================================================
@@ -86,12 +89,6 @@ services:
       Frontend__BaseUrl: "https://${PROD_DOMAIN}"
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/api`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.services.api.loadbalancer.server.port=8080"
     logging:
       driver: "json-file"
       options: { max-size: "50m", max-file: "10" }
@@ -115,12 +112,6 @@ services:
       NEXT_PUBLIC_API_BASE: "https://${PROD_DOMAIN}"
       NEXT_PUBLIC_APP_URL: "https://${PROD_DOMAIN}"
       API_BASE_URL: http://api:8080
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`${PROD_DOMAIN}`)"
-      - "traefik.http.routers.web.entrypoints=websecure"
-      - "traefik.http.routers.web.tls.certresolver=letsencrypt"
-      - "traefik.http.services.web.loadbalancer.server.port=3000"
     logging:
       driver: "json-file"
       options: { max-size: "50m", max-file: "10" }
@@ -134,19 +125,11 @@ services:
           memory: 2G
 
   # ===========================================================================
-  # AI Services — Traefik routing with basic auth
+  # AI Services — internal-only (CF Tunnel does not expose these publicly)
   # ===========================================================================
 
   embedding-service:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.embedding.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/services/embedding`)"
-      - "traefik.http.routers.embedding.entrypoints=websecure"
-      - "traefik.http.routers.embedding.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.embedding.middlewares=integration-auth,strip-services-embedding"
-      - "traefik.http.middlewares.strip-services-embedding.stripprefix.prefixes=/services/embedding"
-      - "traefik.http.services.embedding.loadbalancer.server.port=8000"
     deploy:
       resources:
         limits:
@@ -158,25 +141,9 @@ services:
 
   reranker-service:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.reranker.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/services/reranker`)"
-      - "traefik.http.routers.reranker.entrypoints=websecure"
-      - "traefik.http.routers.reranker.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.reranker.middlewares=integration-auth,strip-services-reranker"
-      - "traefik.http.middlewares.strip-services-reranker.stripprefix.prefixes=/services/reranker"
-      - "traefik.http.services.reranker.loadbalancer.server.port=8003"
 
   unstructured-service:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.unstructured.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/services/unstructured`)"
-      - "traefik.http.routers.unstructured.entrypoints=websecure"
-      - "traefik.http.routers.unstructured.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.unstructured.middlewares=integration-auth,strip-services-unstructured"
-      - "traefik.http.middlewares.strip-services-unstructured.stripprefix.prefixes=/services/unstructured"
-      - "traefik.http.services.unstructured.loadbalancer.server.port=8001"
     deploy:
       resources:
         limits:
@@ -188,14 +155,6 @@ services:
 
   smoldocling-service:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.smoldocling.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/services/smoldocling`)"
-      - "traefik.http.routers.smoldocling.entrypoints=websecure"
-      - "traefik.http.routers.smoldocling.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.smoldocling.middlewares=integration-auth,strip-services-smoldocling"
-      - "traefik.http.middlewares.strip-services-smoldocling.stripprefix.prefixes=/services/smoldocling"
-      - "traefik.http.services.smoldocling.loadbalancer.server.port=8002"
     deploy:
       resources:
         limits:
@@ -207,14 +166,6 @@ services:
 
   ollama:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.ollama.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/services/ollama`)"
-      - "traefik.http.routers.ollama.entrypoints=websecure"
-      - "traefik.http.routers.ollama.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.ollama.middlewares=integration-auth,strip-services-ollama"
-      - "traefik.http.middlewares.strip-services-ollama.stripprefix.prefixes=/services/ollama"
-      - "traefik.http.services.ollama.loadbalancer.server.port=11434"
     deploy:
       resources:
         limits:
@@ -225,19 +176,12 @@ services:
           memory: 4G
 
   # ===========================================================================
-  # Monitoring — Traefik routing with basic auth
+  # Monitoring — exposed via CF Tunnel ingress (configured separately on VPS)
   # ===========================================================================
 
   grafana:
     restart: always
     env_file: [./secrets/prod/monitoring.secret]
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/grafana`)"
-      - "traefik.http.routers.grafana.entrypoints=websecure"
-      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.grafana.middlewares=integration-auth"
-      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
     environment:
       GF_SERVER_ROOT_URL: "https://${PROD_DOMAIN}/grafana"
       GF_SERVER_SERVE_FROM_SUB_PATH: "true"
@@ -249,13 +193,6 @@ services:
 
   prometheus:
     restart: always
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.prometheus.rule=Host(`${PROD_DOMAIN}`) && PathPrefix(`/prometheus`)"
-      - "traefik.http.routers.prometheus.entrypoints=websecure"
-      - "traefik.http.routers.prometheus.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.prometheus.middlewares=integration-auth"
-      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -288,18 +225,6 @@ services:
 
   n8n:
     restart: always
-
-  # ===========================================================================
-  # Traefik overrides — basic auth middleware + prod config mount
-  # ===========================================================================
-
-  traefik:
-    volumes:
-      - ./traefik/traefik.prod.yml:/etc/traefik/traefik.yml:ro
-    labels:
-      - "traefik.http.middlewares.integration-auth.basicauth.users=${INTEGRATION_BASIC_AUTH}"
-      - "traefik.http.middlewares.rate-limit.ratelimit.average=100"
-      - "traefik.http.middlewares.rate-limit.ratelimit.burst=50"
 
 # =============================================================================
 # Production volumes

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -242,12 +242,9 @@ services:
   n8n:
     restart: always
 
-  # ===========================================================================
-  # Traefik overrides — basic auth middleware + staging config mount
-  # ===========================================================================
-
-# Traefik service definition removed (post CF Tunnel cutover, T18 Phase 6).
-# For rollback see docs/operations/cf-tunnel-rollback.md (compose.traefik.yml is preserved).
+# Traefik service definition removed (PR #738, post CF Tunnel cutover, T18 Phase 6).
+# Edge is now Cloudflare Tunnel (cloudflared on VPS). For rollback see
+# docs/operations/cf-tunnel-rollback.md (compose.traefik.yml backup in /tmp/traefik-backup-*.tgz on VPS).
 
 # =============================================================================
 # Preserve existing staging volume names to avoid data loss

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -123,7 +123,7 @@ services:
       options: { max-size: "10m", max-file: "3" }
 
   # ===========================================================================
-  # AI Services — Traefik basic auth for integration access
+  # AI Services — internal-only (post-PR #738: CF Tunnel handles edge, no public exposure)
   # Resource limits are reduced vs base compose (CAX21 has 8GB total).
   # Use 'make staging' only when AI features are needed; prefer 'make staging-core' otherwise.
   # ===========================================================================
@@ -200,7 +200,7 @@ services:
     profiles: [ollama-local-dev-only]
 
   # ===========================================================================
-  # Monitoring — Traefik basic auth
+  # Monitoring — exposed via CF Tunnel ingress (configured separately on VPS)
   # ===========================================================================
 
   grafana:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -491,7 +491,7 @@ services:
           cpus: '0.25'
           memory: 256M
 
-  # docker-socket-proxy is defined in compose.traefik.yml (Linux-only, staging/prod)
+  # docker-socket-proxy: previously defined in compose.traefik.yml (removed PR #738, edge migrated to CF Tunnel)
 
   # ---------------------------------------------------------------------------
   # Automation services (profile: automation)

--- a/infra/hetzner/disaster-recovery.md
+++ b/infra/hetzner/disaster-recovery.md
@@ -6,7 +6,7 @@
 
 This task added observability stack files in `infra/observability/`. The plan v2 referenced a file `infra/docker-compose.production.yml` and modifications to `infra/Caddyfile` — these are **plan drift**:
 
-- **Reality**: production stack is `infra/compose.prod.yml`; alpha stack `compose.alpha.yml`; MVP stack `compose.mvp.yml`. Reverse proxy is **Traefik** (see `traefik/` + `compose.traefik.yml`), not Caddy in production.
+- **Reality**: production stack is `infra/compose.prod.yml`; alpha stack `compose.alpha.yml`; MVP stack `compose.mvp.yml`. Edge ingress is **Cloudflare Tunnel** (cloudflared on VPS, post-PR #738 cutover) — Traefik decommissioned. Caddy is used only for MVP stack on Hetzner CAX31.
 - **Decision (controller)**: observability stack lives in `infra/observability/compose.observability.yml` as standalone, deployable via `docker compose -f compose.prod.yml -f observability/compose.observability.yml up -d`. Aaron decides actual integration at deploy time.
 
 ## Scenario 1: CAX31 down/lost (RTO target: 2h)

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -111,10 +111,4 @@ scrape_configs:
           service: 'node-exporter'
           component: 'host-metrics'
 
-  - job_name: 'traefik'
-    scrape_interval: 30s
-    static_configs:
-      - targets: ['traefik:8080']
-        labels:
-          service: 'traefik'
-          component: 'proxy'
+  # Traefik scrape job removed (PR #738 cutover to CF Tunnel — no traefik service to scrape).

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -111,10 +111,4 @@ scrape_configs:
           service: 'node-exporter'
           component: 'host-metrics'
 
-  - job_name: 'traefik'
-    scrape_interval: 30s
-    static_configs:
-      - targets: ['traefik:8080']
-        labels:
-          service: 'traefik'
-          component: 'proxy'
+  # Traefik scrape job removed (PR #738 cutover to CF Tunnel — no traefik service to scrape).

--- a/infra/scripts/benchmark-pdf-pipeline.sh
+++ b/infra/scripts/benchmark-pdf-pipeline.sh
@@ -51,7 +51,7 @@ check_deps() {
 setup_auth() {
     log "Setting up authentication..."
 
-    # Basic auth for services (Traefik integration-auth)
+    # Basic auth for services (legacy Traefik integration-auth — preserved for benchmark continuity post-CF Tunnel cutover)
     if [[ -z "${STAGING_USER:-}" ]] || [[ -z "${STAGING_PASS:-}" ]]; then
         echo -n "Staging basic auth username: "
         read -r STAGING_USER

--- a/infra/scripts/deploy-staging.sh
+++ b/infra/scripts/deploy-staging.sh
@@ -27,9 +27,9 @@ GRAFANA_URL="https://${DOMAIN}/grafana"
 HEALTH_URL="https://${DOMAIN}/api/health"
 WEB_URL="https://${DOMAIN}"
 
-# Compose command on server
-COMPOSE_CMD="docker compose -f docker-compose.yml -f compose.staging.yml -f compose.traefik.yml"
-COMPOSE_PROFILES="--profile ai --profile monitoring --profile proxy"
+# Compose command on server (post-PR #738 — Traefik decommissioned, edge=CF Tunnel)
+COMPOSE_CMD="docker compose -f docker-compose.yml -f compose.staging.yml"
+COMPOSE_PROFILES="--profile ai --profile monitoring"
 
 # Timeouts
 HEALTH_TIMEOUT=120  # seconds to wait for health check

--- a/infra/scripts/reset-staging-beta0.sh
+++ b/infra/scripts/reset-staging-beta0.sh
@@ -16,7 +16,8 @@ warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARNING:${NC} $1"; }
 err()  { echo -e "${RED}[$(date '+%H:%M:%S')] ERROR:${NC} $1"; }
 
 INFRA_DIR="/opt/meepleai/repo/infra"
-COMPOSE_FILES="-f docker-compose.yml -f compose.staging.yml -f compose.staging-traefik.yml"
+# Post-PR #738: Traefik decommissioned, edge=CF Tunnel
+COMPOSE_FILES="-f docker-compose.yml -f compose.staging.yml"
 BACKUP_DIR="/backups"
 
 # Volumes to DELETE (user data)

--- a/infra/secrets.example/README.md
+++ b/infra/secrets.example/README.md
@@ -40,7 +40,6 @@ This directory contains **template files** for the secret management system.
 - `email.secret` - SMTP server settings
 - `storage.secret` - S3-compatible storage credentials
 - `monitoring.secret` - Grafana/Prometheus passwords
-- `traefik.secret` - Traefik dashboard credentials
 - `smoldocling-service.secret` - Document intelligence API key
 - `reranker-service.secret` - Reranker API key
 

--- a/infra/secrets.example/traefik.secret.example
+++ b/infra/secrets.example/traefik.secret.example
@@ -1,6 +1,0 @@
-# Traefik Reverse Proxy Credentials
-# OPTIONAL - Info logged if missing (dashboard access disabled)
-# Copy this file to infra/secrets/traefik.secret and fill in values
-
-TRAEFIK_DASHBOARD_USER=admin
-TRAEFIK_DASHBOARD_PASSWORD=change_me_traefik_password

--- a/infra/secrets/README.md
+++ b/infra/secrets/README.md
@@ -23,7 +23,7 @@
 | **reranker-service.secret** | 🟢 OPTIONAL | `RERANKER_API_KEY` | `change_me_reranker...` | `infra/secrets/reranker-service.secret` |
 | **smoldocling-service.secret** | 🟢 OPTIONAL | `SMOLDOCLING_API_KEY` | `change_me_smoldocling...` | `infra/secrets/smoldocling-service.secret` |
 | **storage.secret** | 🟢 OPTIONAL | `S3_ACCESS_KEY`<br>`S3_SECRET_KEY`<br>`S3_BUCKET_NAME`<br>`S3_REGION` | `your_s3_access_key`<br>`your_s3_secret_key`<br>`meepleai-uploads`<br>`us-east-1` | `infra/secrets/storage.secret` |
-| **traefik.secret** | 🟢 OPTIONAL | `TRAEFIK_DASHBOARD_USER`<br>`TRAEFIK_DASHBOARD_PASSWORD` | `admin`<br>`change_me_traefik...` | `infra/secrets/traefik.secret` |
+<!-- traefik.secret removed (PR #738 cutover to CF Tunnel) -->
 
 ---
 
@@ -673,7 +673,7 @@ The `setup-secrets.ps1` script **automatically generates** secure values for the
 | `ADMIN_PASSWORD` | admin.secret | 16 chars | Upper + digit + symbol |
 | `GRAFANA_ADMIN_PASSWORD` | monitoring.secret | 16 chars | Upper + digit + symbol |
 | `PROMETHEUS_PASSWORD` | monitoring.secret | 16 chars | Upper + digit + symbol |
-| `TRAEFIK_DASHBOARD_PASSWORD` | traefik.secret | 16 chars | Upper + digit + symbol |
+<!-- TRAEFIK_DASHBOARD_PASSWORD removed (PR #738 cutover to CF Tunnel) -->
 
 ### 📋 Manual Configuration Still Required
 
@@ -720,7 +720,7 @@ BoardGameGeek integration disabled. Game catalog limited to manual entries.
 ```
 
 ### 🟢 OPTIONAL - Info Logged
-**Files**: `email.secret`, `monitoring.secret`, `oauth.secret`, `reranker-service.secret`, `smoldocling-service.secret`, `storage.secret`, `traefik.secret`
+**Files**: `email.secret`, `monitoring.secret`, `oauth.secret`, `reranker-service.secret`, `smoldocling-service.secret`, `storage.secret`
 
 **Behavior**:
 - Application **STARTS** normally with fallback defaults
@@ -965,18 +965,7 @@ S3_REGION=us-east-1                       # AWS region
 
 **Fallback**: If missing, uses local file storage in `uploads/` directory
 
-#### traefik.secret
-**Purpose**: Traefik reverse proxy dashboard access
-
-**Variables**:
-```bash
-TRAEFIK_DASHBOARD_USER=admin              # Dashboard username
-TRAEFIK_DASHBOARD_PASSWORD=your_password  # Dashboard password
-```
-
-**Validation**:
-- Username: Non-empty string
-- Password: ≥8 chars
+<!-- traefik.secret section removed (PR #738 cutover to CF Tunnel — edge ingress now via cloudflared on VPS, no traefik dashboard) -->
 
 ---
 

--- a/infra/secrets/prod/setup-prod-secrets.sh
+++ b/infra/secrets/prod/setup-prod-secrets.sh
@@ -13,7 +13,6 @@
 #   1. Review generated secrets
 #   2. Update openrouter-api-key.txt with your actual API key
 #   3. Update email credentials if using Gmail
-#   4. Generate Traefik dashboard password hash
 #
 # =============================================================================
 
@@ -135,28 +134,9 @@ else
 fi
 
 # =============================================================================
-# Traefik Dashboard Password
+# Traefik Dashboard Password — REMOVED (PR #738 cutover to CF Tunnel)
+# Edge ingress now handled by cloudflared on VPS, no Traefik dashboard needed.
 # =============================================================================
-echo "📦 Generating Traefik dashboard password..."
-
-if [ ! -f traefik-dashboard-password.txt ]; then
-    TRAEFIK_PASS=$(generate_password)
-    echo "$TRAEFIK_PASS" > traefik-dashboard-password.txt
-
-    # Generate bcrypt hash for Traefik
-    if command -v htpasswd &> /dev/null; then
-        HASH=$(htpasswd -nbB admin "$TRAEFIK_PASS" | sed -e 's/\$/\$\$/g')
-        echo "$HASH" > traefik-dashboard-users.txt
-        echo "   ✅ traefik-dashboard-password.txt"
-        echo "   ✅ traefik-dashboard-users.txt (bcrypt hash)"
-    else
-        echo "   ✅ traefik-dashboard-password.txt"
-        echo "   ⚠️  htpasswd not found - run this to generate hash:"
-        echo "      htpasswd -nbB admin \"\$(cat traefik-dashboard-password.txt)\""
-    fi
-else
-    echo "   ⏭️  traefik-dashboard-password.txt (exists)"
-fi
 
 # =============================================================================
 # Set permissions
@@ -177,12 +157,10 @@ echo ""
 echo "⚠️  ACTION REQUIRED:"
 echo "   1. Edit openrouter-api-key.txt with your OpenRouter API key"
 echo "   2. Edit gmail-app-password.txt if using email notifications"
-echo "   3. Update traefik dashboard hash in middlewares.prod.yml"
 echo ""
 echo "📋 Generated credentials:"
 echo "   - Admin password: $(cat initial-admin-password.txt)"
 echo "   - Grafana admin: $(cat grafana-admin-password.txt)"
-echo "   - Traefik dashboard: $(cat traefik-dashboard-password.txt)"
 echo ""
 echo "🔐 Keep these credentials secure!"
 echo ""

--- a/scripts/deployment/deploy-meepleai.ps1
+++ b/scripts/deployment/deploy-meepleai.ps1
@@ -35,10 +35,9 @@ $ScriptDir = Split-Path -Parent $PSCommandPath
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent $ScriptDir)
 $InfraDir = Join-Path $ProjectRoot 'infra'
 
-# Compose files
+# Compose files (post-PR #738 — Traefik decommissioned, edge=CF Tunnel)
 $ComposeFiles = @(
     '-f', 'docker-compose.yml',
-    '-f', 'compose.traefik.yml',
     '-f', 'compose.prod.yml',
     '-f', 'compose.meepleai.yml'
 )
@@ -93,31 +92,14 @@ function Test-Prerequisites {
         exit 1
     }
 
-    # Check Traefik config exists
-    if (-not (Test-Path "traefik/traefik.prod.yml")) {
-        Write-ErrorMsg "Traefik production config not found: traefik/traefik.prod.yml"
-        exit 1
-    }
-
     Write-Success "Prerequisites check passed"
 }
 
 function New-RequiredDirectories {
     Write-Info "Creating required directories..."
-
-    $dirs = @('traefik/letsencrypt', 'traefik/logs')
-    foreach ($dir in $dirs) {
-        if (-not (Test-Path $dir)) {
-            New-Item -ItemType Directory -Path $dir -Force | Out-Null
-        }
-    }
-
-    # Set permissions (Windows: no-op, Linux: chmod 600)
-    if ($IsLinux -or $IsMacOS) {
-        chmod 600 traefik/letsencrypt 2>$null
-    }
-
-    Write-Success "Directories created"
+    # Post-PR #738: Traefik decommissioned, no traefik/letsencrypt or traefik/logs dirs needed.
+    # CF Tunnel handles TLS termination upstream.
+    Write-Success "No directories required (CF Tunnel edge)"
 }
 
 function Start-Services {
@@ -171,7 +153,7 @@ function Show-Status {
     Write-Host "  🌐 Website:    https://www.meepleai.io"
     Write-Host "  🔌 API:        https://api.meepleai.io"
     Write-Host "  📊 Grafana:    https://grafana.meepleai.io"
-    Write-Host "  🚦 Traefik:    https://traefik.meepleai.io"
+    Write-Host "  ☁️  Edge:       Cloudflare Tunnel (cloudflared on VPS)"
     Write-Host ""
 }
 


### PR DESCRIPTION
## Context

PR #738 `ops(infra): remove Traefik config files from repo (cutover stable)` rimosse `infra/compose.traefik.yml` + `infra/traefik/` ma lasciò references orfane in workflow, scripts, secrets docs, e API runtime.

Pre-P1 deploy non veniva eseguito (gate skippava sempre, vacuum success), quindi la regressione era nascosta. Ora che P1 fa girare il pipeline, deploy falliva con `open compose.traefik.yml: no such file or directory`.

## Discovery

Run `25537359138` (workflow_dispatch deploy on main-staging) ha esposto il bug:
```
Build Images: success
Database Migration: success
Deploy to Staging: FAILURE — open /opt/meepleai/repo/infra/compose.traefik.yml: no such file or directory
```

## Fix scope (3 commit atomici)

### Commit 1 (`435f74b59`): P1-blocking
- `.github/workflows/deploy-staging.yml`: rimosso `-f compose.traefik.yml + --profile proxy`
- `.github/workflows/rollback.yml`: rimosso `-f compose.staging-traefik.yml`
- `.github/workflows/fix-db-password.yml`, `fix-line-endings.yml`: idem
- `infra/Makefile`: 5 target (staging, staging-core, staging-down, prod, prod-down)
- `infra/scripts/deploy-staging.sh`: COMPOSE_CMD/PROFILES updated
- `infra/docker-compose.yml`, `infra/compose.staging.yml`: comment cleanup

### Commit 2 (`507193f55`): Production compose + deploy script
- `infra/compose.prod.yml`: rimosso traefik service + 60+ traefik.* labels su 9 service (api, web, embedding, reranker, unstructured, smoldocling, ollama, grafana, prometheus)
- `scripts/deployment/deploy-meepleai.ps1`: $ComposeFiles + Test-Prerequisites + New-RequiredDirectories + Show-Status

### Commit 3 (`3579eb101`): Comprehensive cleanup
- API runtime: SecretDefinitions.cs, AdminSecretsEndpoints.cs, DashboardEndpoints.cs
- Scripts: reset-staging-beta0.sh, benchmark-pdf-pipeline.sh, setup-prod-secrets.sh
- Compose: Caddyfile, compose.staging.yml section headers, compose.logging.yml
- Prometheus: rimosso scrape job 'traefik' in staging+prod
- Docs: disaster-recovery.md, secrets/README.md, secrets.example/README.md
- Deleted: infra/secrets.example/traefik.secret.example

## Verifica

- C# build: 0 warnings 0 errors
- YAML files: valid
- Residual mentions: solo comment di traceability storica intenzionale
- Zero servizi con `profiles: [proxy]` -> rimuovere `--profile proxy` sicuro

## Refs

- PR #738 (Traefik decommission)
- P1 plan: `docs/superpowers/plans/2026-05-07-p1-pipeline-staging-trustworthy.md`
- Discovery: deploy run 25537359138