### PR TITLE
fix(api): suppress S125 false-positives via SuppressMessageAttribute

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs
@@ -1,6 +1,7 @@
 using Api.SharedKernel.Domain.Exceptions;
 using Api.SharedKernel.Domain.ValueObjects;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -27,6 +28,7 @@ public sealed class PasswordHash : ValueObject
     // (NIST SP 800-63B Rev 4) prioritises length over composition rules;
     // 12 chars makes brute-force pricing meaningfully harder for any
     // policy-compliant password.
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about NIST SP 800-63B Rev 4 password guidance, false-positive on parenthetical citation.")]
     private const int MinPasswordLength = 12;
 
     // I7: maximum password length capped at 128 to prevent

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/EmailOutboxBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/EmailOutboxBackgroundService.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.UserNotifications.Infrastructure.Entities;
 using Api.Infrastructure;
 using Api.Services;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Api.Infrastructure.BackgroundServices;
 
@@ -98,6 +99,7 @@ internal sealed class EmailOutboxBackgroundService : BackgroundService
         }
     }
 
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comments about flush-per-row semantics — false-positive on parentheticals like 'Sent / AttemptCount++' and inline em-dashes.")]
     private async Task DrainOnceAsync(CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
@@ -138,6 +140,7 @@ internal sealed class EmailOutboxBackgroundService : BackgroundService
         }
     }
 
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about ScheduledAt mutation strategy — false-positive on em-dashes and semicolons.")]
     private async Task TrySendAsync(
         EmailOutboxEntity row,
         MeepleAiDbContext dbContext,

--- a/apps/api/src/Api/Routing/CookieHelpers.cs
+++ b/apps/api/src/Api/Routing/CookieHelpers.cs
@@ -3,6 +3,7 @@ using Api.Models;
 using Api.Services;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 namespace Api.Routing;
@@ -17,6 +18,7 @@ internal static class CookieHelpers
 
     // C4: legacy plaintext role cookie. Read-only during the grace period;
     // every WriteUserRoleCookie call lazy-deletes it.
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about C4 legacy cookie semantics — false-positive on semicolon punctuation.")]
     private const string UserRoleCookieNameV1 = "meepleai_user_role";
 
     // C4: HMAC-protected role cookie. Always issued on login / role change.


### PR DESCRIPTION
## Discovery

Deploy run 25551519940 Build Images stage failed con 4 Sonar S125 errors in:
- `PasswordHash.cs:27`
- `EmailOutboxBackgroundService.cs:131, 186`
- `CookieHelpers.cs:18`

S125 false-positive su parentheticals e em-dashes nei commenti esplicativi legittimi.

## Fix

`[SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification=...)]` attribute su enclosing member. Pattern idiomatic Roslyn, preserves comment text AS-IS, self-documenting.

## Verifica

`dotnet build --configuration Release`: 0 warnings, 0 errors.

## Refs

- PR #823 (precedente S125 fix)
- Sblocca P1 plan acceptance (deploy reale post-traefik-cleanup)