### PR TITLE
chore(release): main-dev → main-staging — S125 fix unblocks deploy

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs
@@ -1,0 +1,27 @@
+namespace Api.BoundedContexts.Authentication.Application.Services;
+
+/// <summary>
+/// Guards staging environment access via email allowlist (DevOps wave 1).
+/// </summary>
+/// <remarks>
+/// Reads <c>STAGING_ALLOWED_EMAILS</c> env var (CSV, case-insensitive, whitespace tolerant).
+/// Empty list = open access (default safe: dev and prod don't need this gate).
+/// Wave 2 will integrate with the existing <c>AccessRequest</c> BC for invite-based flow.
+/// See <c>docs/for-developers/operations/devops-policy.md</c> §4.
+/// </remarks>
+public interface IStagingAccessGuard
+{
+    /// <summary>
+    /// Returns <c>true</c> if email is in allowlist OR if allowlist is empty/unset.
+    /// Returns <c>false</c> if allowlist is non-empty AND email not in it
+    /// (or if email is null/whitespace).
+    /// </summary>
+    bool IsEmailAllowed(string email);
+
+    /// <summary>
+    /// True if <c>STAGING_ALLOWED_EMAILS</c> contains at least one entry.
+    /// Used by startup warning to detect misconfiguration window
+    /// (Staging environment with empty allowlist = silent pass-through).
+    /// </summary>
+    bool HasNonEmptyAllowlist { get; }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Api.BoundedContexts.Authentication.Application.Services;
+
+/// <summary>
+/// Reads <c>STAGING_ALLOWED_EMAILS</c> from <see cref="IConfiguration"/> at construction time
+/// and caches the parsed allowlist as an immutable <see cref="HashSet{String}"/>.
+/// </summary>
+internal sealed class StagingAccessGuard : IStagingAccessGuard
+{
+    private readonly HashSet<string> _allowedEmails;
+
+    public StagingAccessGuard(IConfiguration configuration)
+    {
+        var raw = configuration["STAGING_ALLOWED_EMAILS"] ?? string.Empty;
+        _allowedEmails = raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public bool IsEmailAllowed(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return false;
+        }
+
+        if (_allowedEmails.Count == 0)
+        {
+            return true;
+        }
+
+        return _allowedEmails.Contains(email.Trim());
+    }
+
+    public bool HasNonEmptyAllowlist => _allowedEmails.Count > 0;
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/ValueObjects/PasswordHash.cs
@@ -1,6 +1,7 @@
 using Api.SharedKernel.Domain.Exceptions;
 using Api.SharedKernel.Domain.ValueObjects;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -27,6 +28,7 @@ public sealed class PasswordHash : ValueObject
     // (NIST SP 800-63B Rev 4) prioritises length over composition rules;
     // 12 chars makes brute-force pricing meaningfully harder for any
     // policy-compliant password.
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about NIST SP 800-63B Rev 4 password guidance, false-positive on parenthetical citation.")]
     private const int MinPasswordLength = 12;
 
     // I7: maximum password length capped at 128 to prevent

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Authentication.Application.Services;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.BoundedContexts.Authentication.Infrastructure.Repositories;
@@ -31,6 +32,11 @@ internal static class AuthenticationServiceExtensions
 
         // Admin Invitation Flow: singleton channel for game suggestion processing
         services.AddSingleton<GameSuggestionChannel>();
+
+        // DevOps wave 1: staging email allowlist guard.
+        // Singleton: parses STAGING_ALLOWED_EMAILS once at construction, immutable HashSet read-only.
+        // Used by StagingAccessMiddleware (active only when ASPNETCORE_ENVIRONMENT=Staging).
+        services.AddSingleton<IStagingAccessGuard, StagingAccessGuard>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
@@ -1,0 +1,88 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Api.BoundedContexts.Authentication.Application.Services;
+
+#pragma warning disable MA0048 // File name must match type name - middleware folder convention groups class + extensions
+
+namespace Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+
+/// <summary>
+/// Enforces email allowlist on staging environment (DevOps wave 1).
+/// </summary>
+/// <remarks>
+/// Pipeline position: wired AFTER <c>UseAuthentication</c> + <c>UseAuthorization</c>
+/// + <c>UseEmailVerificationEnforcement</c>, BEFORE the body-reset middleware in
+/// <see cref="Api.Extensions.WebApplicationExtensions"/>.
+///
+/// Activation: only registered when <c>app.Environment.IsEnvironment("Staging")</c>
+/// (matches <c>ASPNETCORE_ENVIRONMENT=Staging</c> in <c>compose.staging.yml</c>).
+///
+/// Behavior:
+/// - Unauthenticated requests pass through (auth middleware handles those)
+/// - Authenticated user without email claim → 403 (fail-safe deny on staging)
+/// - Authenticated user with email NOT in allowlist → 403 with structured JSON
+/// - Authenticated user with email in allowlist → pass-through
+/// - Empty allowlist → pass-through (default safe; warning logged at startup)
+///
+/// Response on deny:
+/// <code>
+/// {
+///   "code": "STAGING_ACCESS_DENIED",
+///   "message": "Staging access by invite only",
+///   "contactEmail": "badsworm@gmail.com"
+/// }
+/// </code>
+/// </remarks>
+internal sealed class StagingAccessMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public StagingAccessMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IStagingAccessGuard guard)
+    {
+        // Skip unauthenticated requests — auth middleware handles those
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        var email = context.User.FindFirstValue(ClaimTypes.Email);
+        if (!guard.IsEmailAllowed(email ?? string.Empty))
+        {
+            await WriteDeniedAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        await _next(context).ConfigureAwait(false);
+    }
+
+    private static async Task WriteDeniedAsync(HttpContext context)
+    {
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        // Wave 1 simplification: contact email embedded in the user-facing message so
+        // the existing frontend error handler (login _content.tsx:93 setError(err.message))
+        // displays it without code-specific branching. The structured `code` and
+        // `contactEmail` fields remain for future wave-2 typed handling.
+        var payload = JsonSerializer.Serialize(new
+        {
+            code = "STAGING_ACCESS_DENIED",
+            message = "Staging access by invite only — contact badsworm@gmail.com to request access.",
+            contactEmail = "badsworm@gmail.com"
+        });
+        await context.Response.WriteAsync(payload).ConfigureAwait(false);
+    }
+}
+
+internal static class StagingAccessMiddlewareExtensions
+{
+    public static IApplicationBuilder UseStagingAccessGuard(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<StagingAccessMiddleware>();
+    }
+}

--- a/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
+++ b/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
@@ -1,6 +1,9 @@
 using System.Security.Claims;
 using System.Diagnostics;
+using Api.BoundedContexts.Authentication.Application.Services;
+using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
 using Api.Middleware;
+using Microsoft.Extensions.DependencyInjection;
 using Scalar.AspNetCore;
 using Serilog;
 
@@ -161,6 +164,25 @@ internal static class WebApplicationExtensions
 
         // ISSUE #3672: Email verification enforcement middleware (must be after session quota)
         app.UseEmailVerificationEnforcement();
+
+        // DevOps wave 1 (2026-05-08): staging email allowlist gate.
+        // Active only when ASPNETCORE_ENVIRONMENT=Staging to match compose.staging.yml.
+        // Empty allowlist = pass-through (default safe). Logs warning at startup if
+        // Staging+empty (misconfiguration window detection). See devops-policy.md §4.
+        if (app.Environment.IsEnvironment("Staging"))
+        {
+            using (var scope = app.Services.CreateScope())
+            {
+                var guard = scope.ServiceProvider.GetRequiredService<IStagingAccessGuard>();
+                if (!guard.HasNonEmptyAllowlist)
+                {
+                    app.Logger.LogWarning(
+                        "STAGING_ACCESS: middleware active but STAGING_ALLOWED_EMAILS is empty. " +
+                        "All authenticated users will pass through. Set STAGING_ALLOWED_EMAILS to enable allowlist.");
+                }
+            }
+            app.UseStagingAccessGuard();
+        }
 
         // Reset body stream position for [FromBody] parameter binding.
         // .NET 9 issue: the body stream position may advance during the middleware pipeline

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/EmailOutboxBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/EmailOutboxBackgroundService.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.UserNotifications.Infrastructure.Entities;
 using Api.Infrastructure;
 using Api.Services;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Api.Infrastructure.BackgroundServices;
 
@@ -98,6 +99,7 @@ internal sealed class EmailOutboxBackgroundService : BackgroundService
         }
     }
 
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comments about flush-per-row semantics — false-positive on parentheticals like 'Sent / AttemptCount++' and inline em-dashes.")]
     private async Task DrainOnceAsync(CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
@@ -138,6 +140,7 @@ internal sealed class EmailOutboxBackgroundService : BackgroundService
         }
     }
 
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about ScheduledAt mutation strategy — false-positive on em-dashes and semicolons.")]
     private async Task TrySendAsync(
         EmailOutboxEntity row,
         MeepleAiDbContext dbContext,

--- a/apps/api/src/Api/Routing/CookieHelpers.cs
+++ b/apps/api/src/Api/Routing/CookieHelpers.cs
@@ -3,6 +3,7 @@ using Api.Models;
 using Api.Services;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 namespace Api.Routing;
@@ -17,6 +18,7 @@ internal static class CookieHelpers
 
     // C4: legacy plaintext role cookie. Read-only during the grace period;
     // every WriteUserRoleCookie call lazy-deletes it.
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comment about C4 legacy cookie semantics — false-positive on semicolon punctuation.")]
     private const string UserRoleCookieNameV1 = "meepleai_user_role";
 
     // C4: HMAC-protected role cookie. Always issued on login / role change.

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Services/StagingAccessGuardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Services/StagingAccessGuardTests.cs
@@ -1,0 +1,96 @@
+using Api.BoundedContexts.Authentication.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Services;
+
+/// <summary>
+/// Unit tests for StagingAccessGuard (wave 1 email allowlist).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class StagingAccessGuardTests
+{
+    private static IStagingAccessGuard CreateGuard(string? allowedEmails)
+    {
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            { "STAGING_ALLOWED_EMAILS", allowedEmails }
+        };
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+        return new StagingAccessGuard(config);
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenAllowlistEmpty_ReturnsTrue()
+    {
+        // Default safe: empty allowlist = open access (dev/prod scenarios)
+        var guard = CreateGuard(null);
+        guard.IsEmailAllowed("anyone@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailInList_ReturnsTrue()
+    {
+        var guard = CreateGuard("badsworm@gmail.com,marco@example.com");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailNotInList_ReturnsFalse()
+    {
+        var guard = CreateGuard("badsworm@gmail.com");
+        guard.IsEmailAllowed("hacker@evil.com").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_CaseInsensitive_ReturnsTrue()
+    {
+        var guard = CreateGuard("Badsworm@Gmail.com");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("BADSWORM@GMAIL.COM").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhitespaceTolerant_ReturnsTrue()
+    {
+        var guard = CreateGuard(" badsworm@gmail.com , marco@example.com ");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailNullOrEmpty_ReturnsFalse()
+    {
+        var guard = CreateGuard("badsworm@gmail.com");
+        guard.IsEmailAllowed(null!).Should().BeFalse();
+        guard.IsEmailAllowed("").Should().BeFalse();
+        guard.IsEmailAllowed("   ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasNonEmptyAllowlist_WhenEmpty_ReturnsFalse()
+    {
+        var guard = CreateGuard(null);
+        guard.HasNonEmptyAllowlist.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasNonEmptyAllowlist_WhenWhitespaceOnly_ReturnsFalse()
+    {
+        var guard = CreateGuard("  ");
+        guard.HasNonEmptyAllowlist.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasNonEmptyAllowlist_WhenPopulated_ReturnsTrue()
+    {
+        var guard = CreateGuard("badsworm@gmail.com");
+        guard.HasNonEmptyAllowlist.Should().BeTrue();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Json;
+using Api.BoundedContexts.Authentication.Application.Services;
+using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Infrastructure.Middleware;
+
+/// <summary>
+/// Unit tests for StagingAccessMiddleware (DevOps wave 1 email allowlist gate).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class StagingAccessMiddlewareTests
+{
+    private static DefaultHttpContext CreateAuthenticatedContext(string? email)
+    {
+        var claims = new List<Claim>();
+        if (email != null)
+        {
+            claims.Add(new Claim(ClaimTypes.Email, email));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(identity),
+            Response = { Body = new MemoryStream() }
+        };
+        return context;
+    }
+
+    private static DefaultHttpContext CreateUnauthenticatedContext()
+    {
+        return new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity()),
+            Response = { Body = new MemoryStream() }
+        };
+    }
+
+    private sealed class StubGuard : IStagingAccessGuard
+    {
+        private readonly HashSet<string> _allowed;
+        public StubGuard(params string[] emails)
+        {
+            _allowed = emails.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+        public bool IsEmailAllowed(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email)) return false;
+            if (_allowed.Count == 0) return true;
+            return _allowed.Contains(email);
+        }
+        public bool HasNonEmptyAllowlist => _allowed.Count > 0;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenUnauthenticated_PassesThrough()
+    {
+        var context = CreateUnauthenticatedContext();
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        nextCalled.Should().BeTrue("unauthenticated requests are handled by auth middleware, not this one");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenAuthenticatedAndAllowed_PassesThrough()
+    {
+        var context = CreateAuthenticatedContext("badsworm@gmail.com");
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenAuthenticatedAndNotAllowed_Returns403WithStructuredJson()
+    {
+        var context = CreateAuthenticatedContext("hacker@evil.com");
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        nextCalled.Should().BeFalse("denied requests must short-circuit the pipeline");
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+        context.Response.ContentType.Should().StartWith("application/json");
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        var payload = JsonSerializer.Deserialize<DeniedResponse>(body, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        payload.Should().NotBeNull();
+        payload!.Code.Should().Be("STAGING_ACCESS_DENIED");
+        payload.Message.Should().Contain("invite only", "user-facing message must explain access policy");
+        payload.Message.Should().Contain("badsworm@gmail.com",
+            "wave 1 simplification: contact email embedded in message for direct frontend display");
+        payload.ContactEmail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenAuthenticatedWithoutEmailClaim_Returns403()
+    {
+        var context = CreateAuthenticatedContext(email: null);
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        nextCalled.Should().BeFalse("missing email claim on staging is fail-safe deny");
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenAllowlistEmpty_PassesThroughEvenForUnknownEmails()
+    {
+        // Default-safe behavior: empty allowlist = open access.
+        // Combined with Staging-only wiring + startup warning, this prevents
+        // accidental lockout if STAGING_ALLOWED_EMAILS is misconfigured.
+        var context = CreateAuthenticatedContext("anyone@example.com");
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context, new StubGuard(/* empty allowlist */));
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    private sealed record DeniedResponse(string Code, string Message, string ContactEmail);
+}

--- a/docs/for-developers/operations/devops-policy.md
+++ b/docs/for-developers/operations/devops-policy.md
@@ -1,0 +1,120 @@
+# DevOps Policy — 3-Branch Strategy
+
+> **Status**: Draft 2026-05-08 · **Owner**: badsworm@gmail.com · **Last review**: 2026-05-08
+
+Documento di policy che fissa target numerici, gating, e responsabilità per i 3 branch long-lived.
+
+## 1. Branch model
+
+| Branch | Ruolo | Deploy target | CI gate sync | CI deep |
+|---|---|---|---|---|
+| `feature/issue-N` | Working branch | none | trigger su PR open | inherits da target branch |
+| `main-dev` | Local-first dev | none (locale solo) | lint + typecheck + unit-smoke ≤3 min | async post-merge (E2E/integration) |
+| `main-staging` | Staging online | https://meepleai.app | full CI (incl. E2E/perf/security) ≤20 min | inclusi in CI standard |
+| `main` | Production | (deploy on-demand manuale) | full CI deep + manual approval | + load test + pentest |
+
+**Promotion flow**:
+```
+feature/issue-N → PR → main-dev (CI fast async) → cherry-pick → main-staging (CI full + auto-deploy) → manual gate → main (CI deep + manual deploy)
+```
+
+**🔴 Rule**: feature branch PR target = **parent branch**, NOT main. Vedi CLAUDE.md "CRITICAL PR Rule".
+
+## 2. CI Gating Policy
+
+### 2.1 Pull Request → main-dev
+
+**Sync gate (BLOCCA merge)** — target ≤3 min P95:
+- `lint` (ESLint frontend + dotnet format backend)
+- `typecheck` (TypeScript + .NET compile)
+- `unit-smoke` (subset rapido: unit test domain logic, no DB, no testcontainers)
+
+**Async checks (NON bloccano merge)** — eseguiti post-merge su `main-dev`:
+- Full unit test suite
+- Integration test (testcontainers)
+- E2E Playwright
+- Visual regression
+- Bundle size check
+- A11y test
+
+**Failure handling**:
+- Singolo async fail → auto-issue assegnata all'autore
+- 3 async fail consecutive su `main-dev` → branch protection blocca merge nuovi PR fino a verde
+- Auto-revert: out of scope wave 1 (manuale)
+
+### 2.2 Pull Request → main-staging
+
+**Sync gate (BLOCCA merge)** — target ≤20 min:
+- Tutto il sync gate di main-dev
+- Full unit + integration suite
+- E2E Playwright completo
+- Visual regression
+- Security scan (Trivy, CodeQL)
+
+### 2.3 Pull Request → main
+
+**Sync gate (BLOCCA merge)** — target ≤30 min:
+- Tutto il main-staging gate
+- Load test (k6)
+- Penetration test scan
+- **Manual approval** richiesta da superadmin (Aaron)
+
+**Deploy a prod**: NON automatico. Eseguito manualmente da Aaron via `make prod` su VPS dopo merge.
+
+## 3. Deploy responsibilities
+
+| Env | Trigger | Responsabile failure | SLA recovery |
+|---|---|---|---|
+| Local dev | `make dev-core` | Developer | self |
+| Staging | Auto su push `main-staging` | Aaron via GitHub Actions | ≤30 min rollback |
+| Prod | Manuale via `make prod` | Aaron sul VPS | ≤2h rollback |
+
+**Staging rollback**: auto via deploy-staging.yml se smoke fallisce. Manual via `git revert` + redeploy se discovered post-deploy.
+
+**Prod rollback**: manuale solo. `git revert` HEAD su `main` + `make prod`.
+
+## 4. Staging access (wave 1)
+
+Staging richiede email allowlist. Solo email in `STAGING_ALLOWED_EMAILS` env var possono autenticarsi.
+
+Implementazione: middleware ASP.NET `StagingAccessMiddleware` in `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/`. Attivato solo quando `ASPNETCORE_ENVIRONMENT=Staging`. Risposta 403 con JSON `{code:"STAGING_ACCESS_DENIED", message, contactEmail}` se email non in lista.
+
+**Default safe**: allowlist vuota = pass-through (dev/prod non sono impattati). Su Staging l'app logga warning all'avvio se la lista è vuota (misconfig window).
+
+**Wave 1 list iniziale** (decisione 2026-05-08):
+- badsworm@gmail.com (Aaron, project owner)
+- _(da popolare manualmente da Aaron, max 5 in wave 1)_
+
+**Add/remove email**: edit `infra/secrets/admin.secret` → `STAGING_ALLOWED_EMAILS=email1,email2,...` → restart staging API container (`make staging-down && make staging-minimal`).
+
+**Wave 2** (futuro): integrare con esistente `AccessRequest` BC (`apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/`) + admin UI per invite system.
+
+## 5. Decisions log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-08 | Target PR-to-merge `main-dev` = **5 min P95** | Compromise tra 2 min (troppo aggressivo) e status quo |
+| 2026-05-08 | Sync gate `main-dev` = lint+typecheck+unit-smoke (opzione c) | Bilanciamento velocità vs detection di issue ovvi |
+| 2026-05-08 | Wave 1 = email allowlist (env var) NOT AccessRequest | Velocità impl: 1 giorno vs 3-4 per UI integration |
+| 2026-05-08 | Branch naming invariato (`main-dev`, `main-staging`, `main`) | Refactor cost (36 workflow + Makefile + docs) > convention benefit |
+| 2026-05-08 | Prod deploy resta manuale | Safety: zero auto-deploy a prod nel primo trimestre |
+| 2026-05-08 | Mobile testing = Playwright mobile emulation per CI, real device per Aaron | Real device costoso; emulation copre 95% regressions |
+| 2026-05-08 | Middleware wire in `WebApplicationExtensions.ConfigureAuthMiddleware`, NOT Program.cs | Preserva pipeline layering esistente; review-feedback B3 |
+| 2026-05-08 | Env check via `app.Environment.IsEnvironment("Staging")` | Match `ASPNETCORE_ENVIRONMENT: Staging` di compose.staging.yml; review-feedback B1 |
+| 2026-05-08 | Secrets in `admin.secret.example` (NOT nuovo `api.secret.example`) | File esistente già contiene `STAGING_DEMO_EMAIL`; review-feedback B2 |
+
+## 6. Open questions (carry-forward)
+
+- **D2**: dev-core RAM peak attuale (data collection necessaria prima di target ≤8GB). Action: misurare con `docker stats` su `make dev-core` cold start. Comando baseline: `docker stats --no-stream --format "table {{.Name}}\t{{.MemUsage}}"`
+- **D4**: auto-rollback staging — gating su quale smoke metric? (200 OK su /healthz oppure broader auth+chat smoke?)
+- **D1**: split CI fast/deep — quanti test ridurre dal sync gate? Data baseline necessaria. Comando collection: `gh run list --workflow=ci.yml --branch=main-dev --limit=50 --json conclusion,startedAt,updatedAt`
+- **Mobile staging visibility**: banner "STAGING" cosa contiene oltre il testo? Versione SHA? Nome ambiente?
+- **OAuth claim mapping**: verificare che provider OAuth (Google/GitHub) popolino `ClaimTypes.Email` o se serve fallback a `"email"` claim. Action: revisione `OAuthConfiguration.cs` + smoke staging con Google login.
+
+## 7. Riferimenti
+
+- Spec-panel analysis: 2026-05-08 (D1-D5 SMART + Socratic)
+- Plan: `docs/superpowers/plans/2026-05-08-devops-3branch-optimization.md`
+- Existing infra: `infra/Makefile` (35+ targets), `.github/workflows/` (36 workflow)
+- Branch protection: GitHub Settings (NOT in repo)
+- Esistente: `AccessRequest` BC in `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/`

--- a/docs/superpowers/plans/2026-05-08-devops-3branch-optimization.md
+++ b/docs/superpowers/plans/2026-05-08-devops-3branch-optimization.md
@@ -1,0 +1,930 @@
+# DevOps 3-Branch Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configurare la pipeline DevOps per i 3 branch long-lived (`main-dev` locale-veloce, `main-staging` accesso ristretto, `main` prod CI deep) riducendo il loop di feedback su PR a `main-dev` e abilitando accesso staging via email allowlist (wave 1).
+
+**Architecture:** Tre interventi indipendenti complementari: (1) doc di policy che fissa target numerici e gating per ogni env, (2) middleware ASP.NET Core che intercetta login su staging e nega se email non in allowlist (env var `STAGING_ALLOWED_EMAILS`), (3) split di `ci.yml` in `ci-fast.yml` (sync gate ≤3 min: lint+typecheck+unit) + delega di E2E/integration ad async post-merge per `main-dev` only.
+
+**Tech Stack:** .NET 9 (ASP.NET Core middleware), GitHub Actions YAML, Bash/Make, Markdown docs.
+
+**Scope di questo plan:** Tasks 1-3 (decisions doc + prod policy doc + staging allowlist wave 1). Tasks 4-6 (CI split, dev-core LLM mock, auto-rollback staging) sono **deferred a un follow-up plan** dopo data-collection sui tempi attuali.
+
+**Spec di riferimento:** Spec-panel analysis del 2026-05-08 (D1-D5 SMART goals, 19 Socratic Q). Decisioni Open Questions (Q10/Q11/Q12) consolidate in Task 1.
+
+---
+
+## File Structure
+
+> **Plan revision 2026-05-08 (post-review)**: corretti 3 blocker dal review esterno: (B1) env check via `app.Environment.IsEnvironment("Staging")`, (B2) secrets target `admin.secret.example` non `api.secret.example` (non esiste), (B3) wire middleware in `WebApplicationExtensions.ConfigureAuthMiddleware` non Program.cs.
+
+| File | Action | Responsabilità |
+|---|---|---|
+| `docs/for-developers/operations/devops-policy.md` | Create | Doc policy 3-branch: target numerici, gating, deploy responsibilities |
+| `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs` | Create | Interface guard allowlist email |
+| `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs` | Create | Implementation: check email vs `STAGING_ALLOWED_EMAILS` env var |
+| `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs` | Create | Middleware ASP.NET: invoca guard post-auth, ritorna 403 se denied |
+| `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessGuardTests.cs` | Create | Unit test guard logic (6 cases) |
+| `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessMiddlewareTests.cs` | Create | Integration test middleware via TestServer (allowed/denied/empty/no-email) |
+| `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs` | Modify | Registrare `IStagingAccessGuard` come Singleton in `AddAuthenticationContext()` |
+| `apps/api/src/Api/Extensions/WebApplicationExtensions.cs` | Modify | Wire middleware in `ConfigureAuthMiddleware()` dopo `UseEmailVerificationEnforcement()`, gated by `app.Environment.IsEnvironment("Staging")`. Aggiungere startup warning se Staging+empty allowlist |
+| `infra/secrets/admin.secret.example` | Modify | Aggiungere `STAGING_ALLOWED_EMAILS=` template (target corretto: contiene già `STAGING_DEMO_EMAIL`) |
+| `infra/compose.staging.yml` | Modify | Iniettare `STAGING_ALLOWED_EMAILS` env var nel container `api` |
+| `apps/web/src/app/login/page.tsx` | Modify (minor) | Mostrare error message specifico se 403 con codice `STAGING_ACCESS_DENIED` |
+
+---
+
+## Task 1: Decisions Document — Q10/Q11/Q12 defaults
+
+**Files:**
+- Create: `docs/for-developers/operations/devops-policy.md` (sezione Decisions)
+
+**Decisioni assunte come default** (Aaron può overridare in PR review):
+- **Q10**: PR-to-merge `main-dev` target = **5 min P95** (compromise tra 2 min troppo aggressivo e 10 min status quo)
+- **Q11**: CI gating su `main-dev` = **opzione (c)** lint + typecheck + unit-smoke sync (≤3 min); E2E/integration/visual async post-merge
+- **Q12**: Wave 1 staging allowlist = **3-5 email** (badsworm@gmail.com + 2-4 beta tester di fiducia che Aaron sceglie)
+- **Q4 carry**: banner "STAGING" sempre visibile top-right sticky non-dismissable (pattern già presente in repo? Verificare in Task 3)
+- **Q19**: nomi branch invariati — `main-dev`/`main-staging`/`main` (refactor cost > convention benefit)
+
+- [ ] **Step 1: Verificare se esiste un banner staging-flag già implementato**
+
+Run:
+```bash
+grep -rn "STAGING\|isStaging\|environment.*staging" apps/web/src/components/ui --include="*.tsx" | head -10
+```
+
+Expected: vedere se c'è componente `StagingBanner` o flag in layout. Se sì, riusare; se no, gap noted per Task 3.
+
+- [ ] **Step 2: Commit decisions doc** (vedi Task 2 per contenuto completo)
+
+(Task 2 produrrà il file; questo step è solo decisione)
+
+---
+
+## Task 2: D5 — Production policy document
+
+**Files:**
+- Create: `docs/for-developers/operations/devops-policy.md`
+
+- [ ] **Step 1: Scrivere il doc con 5 sezioni**
+
+Crea `docs/for-developers/operations/devops-policy.md` con questo contenuto esatto:
+
+````markdown
+# DevOps Policy — 3-Branch Strategy
+
+> **Status**: Draft 2026-05-08 · **Owner**: badsworm@gmail.com · **Last review**: 2026-05-08
+
+Documento di policy che fissa target numerici, gating, e responsabilità per i 3 branch long-lived.
+
+## 1. Branch model
+
+| Branch | Ruolo | Deploy target | CI gate sync | CI deep |
+|---|---|---|---|---|
+| `feature/issue-N` | Working branch | none | trigger su PR open | inherits da target branch |
+| `main-dev` | Local-first dev | none (locale solo) | lint + typecheck + unit-smoke ≤3 min | async post-merge (E2E/integration) |
+| `main-staging` | Staging online | https://meepleai.app | full CI (incl. E2E/perf/security) ≤20 min | inclusi in CI standard |
+| `main` | Production | (deploy on-demand manuale) | full CI deep + manual approval | + load test + pentest |
+
+**Promotion flow**:
+```
+feature/issue-N → PR → main-dev (CI fast async) → cherry-pick → main-staging (CI full + auto-deploy) → manual gate → main (CI deep + manual deploy)
+```
+
+**🔴 Rule**: feature branch PR target = **parent branch**, NOT main. Vedi CLAUDE.md "CRITICAL PR Rule".
+
+## 2. CI Gating Policy
+
+### 2.1 Pull Request → main-dev
+
+**Sync gate (BLOCCA merge)** — target ≤3 min P95:
+- `lint` (ESLint frontend + dotnet format backend)
+- `typecheck` (TypeScript + .NET compile)
+- `unit-smoke` (subset rapido: unit test domain logic, no DB, no testcontainers)
+
+**Async checks (NON bloccano merge)** — eseguiti post-merge su `main-dev`:
+- Full unit test suite
+- Integration test (testcontainers)
+- E2E Playwright
+- Visual regression
+- Bundle size check
+- A11y test
+
+**Failure handling**:
+- Singolo async fail → auto-issue assegnata all'autore
+- 3 async fail consecutive su `main-dev` → branch protection blocca merge nuovi PR fino a verde
+- Auto-revert: out of scope wave 1 (manuale)
+
+### 2.2 Pull Request → main-staging
+
+**Sync gate (BLOCCA merge)** — target ≤20 min:
+- Tutto il sync gate di main-dev
+- Full unit + integration suite
+- E2E Playwright completo
+- Visual regression
+- Security scan (Trivy, CodeQL)
+
+### 2.3 Pull Request → main
+
+**Sync gate (BLOCCA merge)** — target ≤30 min:
+- Tutto il main-staging gate
+- Load test (k6)
+- Penetration test scan
+- **Manual approval** richiesta da superadmin (Aaron)
+
+**Deploy a prod**: NON automatico. Eseguito manualmente da Aaron via `make prod` su VPS dopo merge.
+
+## 3. Deploy responsibilities
+
+| Env | Trigger | Responsabile failure | SLA recovery |
+|---|---|---|---|
+| Local dev | `make dev-core` | Developer | self |
+| Staging | Auto su push `main-staging` | Aaron via GitHub Actions | ≤30 min rollback |
+| Prod | Manuale via `make prod` | Aaron sul VPS | ≤2h rollback |
+
+**Staging rollback**: auto via deploy-staging.yml se smoke fallisce. Manual via `git revert` + redeploy se discovered post-deploy.
+
+**Prod rollback**: manuale solo. `git revert` HEAD su `main` + `make prod`.
+
+## 4. Staging access (wave 1)
+
+Staging richiede email allowlist. Solo email in `STAGING_ALLOWED_EMAILS` env var possono autenticarsi.
+
+**Wave 1 list iniziale** (decisione 2026-05-08):
+- badsworm@gmail.com (Aaron, project owner)
+- _(da popolare manualmente da Aaron, max 5 in wave 1)_
+
+**Add/remove email**: edit `infra/secrets/api.secret` → restart staging API container. Vedi `staging-allowlist-management.md` (TBD) per procedura.
+
+**Wave 2** (futuro): integrare con esistente `AccessRequest` BC + admin UI per invite system.
+
+## 5. Decisions log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-08 | Target PR-to-merge `main-dev` = **5 min P95** | Compromise tra 2 min (troppo aggressivo) e status quo |
+| 2026-05-08 | Sync gate `main-dev` = lint+typecheck+unit-smoke (opzione c) | Bilanciamento velocità vs detection di issue ovvi |
+| 2026-05-08 | Wave 1 = email allowlist (env var) NOT AccessRequest | Velocità impl: 1 giorno vs 3-4 per UI integration |
+| 2026-05-08 | Branch naming invariato (`main-dev`, `main-staging`, `main`) | Refactor cost (36 workflow + Makefile + docs) > convention benefit |
+| 2026-05-08 | Prod deploy resta manuale | Safety: zero auto-deploy a prod nel primo trimestre |
+| 2026-05-08 | Mobile testing = Playwright mobile emulation per CI, real device per Aaron | Real device costoso; emulation copre 95% regressions |
+
+## 6. Open questions (carry-forward)
+
+- **D2**: dev-core RAM peak attuale (data collection necessaria prima di target ≤8GB). Action: misurare con `docker stats` su `make dev-core` cold start.
+- **D4**: auto-rollback staging — gating su quale smoke metric? (200 OK su /healthz oppure broader auth+chat smoke?)
+- **D1**: split CI fast/deep — quanti test ridurre dal sync gate? Data baseline necessaria.
+- **Mobile staging visibility**: banner "STAGING" cosa contiene oltre il testo? Versione SHA? Nome ambiente?
+
+## 7. Riferimenti
+
+- Spec-panel analysis: 2026-05-08 (D1-D5 SMART + Socratic)
+- Existing infra: `infra/Makefile` (35+ targets), `.github/workflows/` (36 workflow)
+- Branch protection: GitHub Settings (NOT in repo)
+- Esistente: `AccessRequest` BC in `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/`
+````
+
+- [ ] **Step 2: Verificare doc lint pulito**
+
+Run:
+```bash
+test -f docs/for-developers/operations/devops-policy.md && wc -l docs/for-developers/operations/devops-policy.md
+```
+
+Expected: file esiste, ~120-150 righe.
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add docs/for-developers/operations/devops-policy.md
+git commit -m "docs(devops): add 3-branch policy with target metrics and gating rules
+
+Establishes:
+- main-dev: ≤5min PR-to-merge with sync gate (lint+typecheck+unit-smoke)
+  and async deep CI post-merge
+- main-staging: ≤20min full CI with auto-deploy + email allowlist (wave 1)
+- main: ≤30min deep CI with manual approval, deploy on-demand
+
+Decisions logged with rationale (PR target, branch naming, wave 1
+allowlist approach). Carry-forward open questions documented for
+follow-up data collection.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: D3 Wave 1 — Staging email allowlist middleware
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessGuardTests.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessMiddlewareTests.cs`
+- Modify: `apps/api/src/Api/Program.cs` (wire middleware)
+- Modify: `infra/secrets/api.secret.example` (add `STAGING_ALLOWED_EMAILS=` template)
+
+**Architettura**:
+- `IStagingAccessGuard` interface (Domain-friendly): `bool IsEmailAllowed(string email)`
+- `StagingAccessGuard` implementation: legge `STAGING_ALLOWED_EMAILS` da `IConfiguration`, parsing CSV case-insensitive, returns true se allowed o se var vuota (NO whitelist = aperto, default safe per dev/prod)
+- `StagingAccessMiddleware` ASP.NET: post-auth, se `Environment.GetEnvironmentVariable("ENVIRONMENT") == "staging"` AND user authenticated AND `!guard.IsEmailAllowed(claims.Email)` → 403 + JSON `{"code":"STAGING_ACCESS_DENIED","message":"Staging access by invite only","contactEmail":"badsworm@gmail.com"}`
+- Wire only in staging via env check in Program.cs
+
+### 3.1 Interface
+
+- [ ] **Step 1: Write failing test for IStagingAccessGuard contract**
+
+Crea `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessGuardTests.cs`:
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication;
+
+using Api.BoundedContexts.Authentication.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+public class StagingAccessGuardTests
+{
+    private static IStagingAccessGuard CreateGuard(string? allowedEmails)
+    {
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            { "STAGING_ALLOWED_EMAILS", allowedEmails }
+        };
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+        return new StagingAccessGuard(config);
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenAllowlistEmpty_ReturnsTrue()
+    {
+        // Default safe: empty allowlist = open access (dev/prod scenarios)
+        var guard = CreateGuard(null);
+        guard.IsEmailAllowed("anyone@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailInList_ReturnsTrue()
+    {
+        var guard = CreateGuard("badsworm@gmail.com,marco@example.com");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailNotInList_ReturnsFalse()
+    {
+        var guard = CreateGuard("badsworm@gmail.com");
+        guard.IsEmailAllowed("hacker@evil.com").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_CaseInsensitive_ReturnsTrue()
+    {
+        var guard = CreateGuard("Badsworm@Gmail.com");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("BADSWORM@GMAIL.COM").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhitespaceTolerant_ReturnsTrue()
+    {
+        var guard = CreateGuard(" badsworm@gmail.com , marco@example.com ");
+        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
+        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEmailAllowed_WhenEmailNullOrEmpty_ReturnsFalse()
+    {
+        var guard = CreateGuard("badsworm@gmail.com");
+        guard.IsEmailAllowed(null!).Should().BeFalse();
+        guard.IsEmailAllowed("").Should().BeFalse();
+        guard.IsEmailAllowed("   ").Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (no implementation yet)**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~StagingAccessGuardTests" 2>&1 | tail -20
+```
+
+Expected: FAIL with compile error "StagingAccessGuard not found" or "IStagingAccessGuard not found".
+
+- [ ] **Step 3: Create interface IStagingAccessGuard**
+
+Crea `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Services;
+
+/// <summary>
+/// Guards staging environment access via email allowlist (wave 1).
+/// </summary>
+/// <remarks>
+/// Reads STAGING_ALLOWED_EMAILS env var (CSV case-insensitive). Empty list = open access
+/// (default safe: dev and prod don't need this gate). Wave 2 will integrate with
+/// AccessRequest BC for invite-based flow.
+/// </remarks>
+public interface IStagingAccessGuard
+{
+    /// <summary>
+    /// Returns true if email is in allowlist OR if allowlist is empty/unset.
+    /// Returns false if allowlist is non-empty AND email not in it.
+    /// </summary>
+    bool IsEmailAllowed(string email);
+}
+```
+
+- [ ] **Step 4: Implement StagingAccessGuard**
+
+Crea `apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Services;
+
+using Microsoft.Extensions.Configuration;
+
+internal sealed class StagingAccessGuard : IStagingAccessGuard
+{
+    private readonly HashSet<string> _allowedEmails;
+
+    public StagingAccessGuard(IConfiguration configuration)
+    {
+        var raw = configuration["STAGING_ALLOWED_EMAILS"] ?? string.Empty;
+        _allowedEmails = raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(e => e.ToLowerInvariant())
+            .ToHashSet();
+    }
+
+    public bool IsEmailAllowed(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return false;
+        }
+
+        // Empty allowlist = open access (default safe for dev/prod)
+        if (_allowedEmails.Count == 0)
+        {
+            return true;
+        }
+
+        return _allowedEmails.Contains(email.Trim().ToLowerInvariant());
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~StagingAccessGuardTests" 2>&1 | tail -20
+```
+
+Expected: PASS — 6 tests passed.
+
+- [ ] **Step 6: Commit guard + interface + tests**
+
+Run:
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs tests/Api.Tests/BoundedContexts/Authentication/StagingAccessGuardTests.cs
+git commit -m "feat(auth): add IStagingAccessGuard for email allowlist (wave 1)
+
+Reads STAGING_ALLOWED_EMAILS env var (CSV case-insensitive, whitespace
+tolerant). Empty list = open access (default safe for dev/prod where
+this gate is not needed).
+
+Wave 2 will integrate with existing AccessRequest BC for invite-based
+flow.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+### 3.2 Middleware
+
+- [ ] **Step 7: Write failing test for StagingAccessMiddleware**
+
+Crea `tests/Api.Tests/BoundedContexts/Authentication/StagingAccessMiddlewareTests.cs`:
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication;
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using Api.BoundedContexts.Authentication.Application.Services;
+using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+public class StagingAccessMiddlewareTests
+{
+    private static TestServer CreateServer(string? allowedEmails, string authedEmail)
+    {
+        var builder = new HostBuilder().ConfigureWebHost(webHost =>
+        {
+            webHost.UseTestServer();
+            webHost.ConfigureServices(services =>
+            {
+                services.AddSingleton<IStagingAccessGuard>(_ =>
+                    new TestGuardFromList(allowedEmails));
+            });
+            webHost.Configure(app =>
+            {
+                app.Use(async (ctx, next) =>
+                {
+                    // Simulate authenticated user
+                    var identity = new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.Email, authedEmail)
+                    }, "Test");
+                    ctx.User = new ClaimsPrincipal(identity);
+                    await next();
+                });
+                app.UseMiddleware<StagingAccessMiddleware>();
+                app.Run(async ctx =>
+                {
+                    ctx.Response.StatusCode = 200;
+                    await ctx.Response.WriteAsync("OK");
+                });
+            });
+        });
+        return builder.Start().GetTestServer();
+    }
+
+    private sealed class TestGuardFromList : IStagingAccessGuard
+    {
+        private readonly HashSet<string> _allow;
+        public TestGuardFromList(string? csv)
+        {
+            _allow = (csv ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(e => e.ToLowerInvariant()).ToHashSet();
+        }
+        public bool IsEmailAllowed(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email)) return false;
+            if (_allow.Count == 0) return true;
+            return _allow.Contains(email.Trim().ToLowerInvariant());
+        }
+    }
+
+    [Fact]
+    public async Task Middleware_WhenEmailAllowed_PassesThrough()
+    {
+        var server = CreateServer("badsworm@gmail.com", "badsworm@gmail.com");
+        var response = await server.CreateClient().GetAsync("/whatever");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Middleware_WhenEmailNotAllowed_Returns403WithCode()
+    {
+        var server = CreateServer("badsworm@gmail.com", "hacker@evil.com");
+        var response = await server.CreateClient().GetAsync("/whatever");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var body = await response.Content.ReadFromJsonAsync<StagingAccessDeniedResponse>();
+        body.Should().NotBeNull();
+        body!.Code.Should().Be("STAGING_ACCESS_DENIED");
+        body.Message.Should().Contain("invite only");
+    }
+
+    [Fact]
+    public async Task Middleware_WhenAllowlistEmpty_PassesThrough()
+    {
+        var server = CreateServer(null, "anyone@example.com");
+        var response = await server.CreateClient().GetAsync("/whatever");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private sealed record StagingAccessDeniedResponse(string Code, string Message, string ContactEmail);
+}
+```
+
+- [ ] **Step 8: Run test to verify it fails (no middleware yet)**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~StagingAccessMiddlewareTests" 2>&1 | tail -10
+```
+
+Expected: FAIL — "StagingAccessMiddleware not found".
+
+- [ ] **Step 9: Create middleware**
+
+Crea `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+
+using System.Security.Claims;
+using System.Text.Json;
+using Api.BoundedContexts.Authentication.Application.Services;
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Middleware that enforces email allowlist on staging.
+/// Returns 403 STAGING_ACCESS_DENIED if user authenticated but email not in
+/// STAGING_ALLOWED_EMAILS list. Should be wired AFTER authentication middleware,
+/// AFTER UseAuthorization but BEFORE endpoint mapping. Only registered in Program.cs
+/// when ENVIRONMENT=staging.
+/// </summary>
+internal sealed class StagingAccessMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public StagingAccessMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IStagingAccessGuard guard)
+    {
+        // Skip unauthenticated requests — auth middleware handles those
+        if (context.User.Identity?.IsAuthenticated != true)
+        {
+            await _next(context);
+            return;
+        }
+
+        var email = context.User.FindFirstValue(ClaimTypes.Email);
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            // No email claim → fail safe (deny on staging if no email)
+            await WriteDeniedAsync(context);
+            return;
+        }
+
+        if (!guard.IsEmailAllowed(email))
+        {
+            await WriteDeniedAsync(context);
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static async Task WriteDeniedAsync(HttpContext context)
+    {
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        var payload = JsonSerializer.Serialize(new
+        {
+            code = "STAGING_ACCESS_DENIED",
+            message = "Staging access by invite only",
+            contactEmail = "badsworm@gmail.com"
+        });
+        await context.Response.WriteAsync(payload);
+    }
+}
+```
+
+- [ ] **Step 10: Run test to verify it passes**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~StagingAccessMiddlewareTests" 2>&1 | tail -10
+```
+
+Expected: PASS — 3 tests passed.
+
+- [ ] **Step 11: Commit middleware**
+
+Run:
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs tests/Api.Tests/BoundedContexts/Authentication/StagingAccessMiddlewareTests.cs
+git commit -m "feat(auth): add StagingAccessMiddleware for email allowlist gate
+
+Returns 403 STAGING_ACCESS_DENIED with structured JSON if authenticated
+user email not in allowlist. Skips unauthenticated requests (auth
+middleware handles those). Empty allowlist = pass-through (default safe
+for dev/prod).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+### 3.3 Wire in BC DI extension + ConfigureAuthMiddleware
+
+> **REVISIONE post-review (B1+B3+R6)**: la registrazione DI va in `AuthenticationServiceExtensions.AddAuthenticationContext()` (BC DI extension), il wire middleware va in `WebApplicationExtensions.ConfigureAuthMiddleware()` (NON Program.cs), e l'env check usa `app.Environment.IsEnvironment("Staging")` per matchare `ASPNETCORE_ENVIRONMENT: Staging` di `compose.staging.yml`.
+
+- [ ] **Step 12: Register IStagingAccessGuard in BC DI extension**
+
+Modifica `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs`. Aggiungere alla fine di `AddAuthenticationContext()` prima di `return services;`:
+
+```csharp
+        // Staging access guard (wave 1): email allowlist via STAGING_ALLOWED_EMAILS env var.
+        // Singleton: parsing CSV avviene una volta in costruzione, immutable HashSet read-only.
+        services.AddSingleton<Application.Services.IStagingAccessGuard, Application.Services.StagingAccessGuard>();
+```
+
+- [ ] **Step 13: Wire middleware in ConfigureAuthMiddleware after UseEmailVerificationEnforcement**
+
+Modifica `apps/api/src/Api/Extensions/WebApplicationExtensions.cs:ConfigureAuthMiddleware`. Aggiungere il wire DOPO `app.UseEmailVerificationEnforcement();` (linea 163) e PRIMA del body-reset middleware (linea 170):
+
+```csharp
+        // ISSUE #806 (DevOps 3-branch wave 1): staging email allowlist gate.
+        // Active only when ASPNETCORE_ENVIRONMENT=Staging. Empty allowlist = pass-through
+        // (default safe). Logs warning at startup if Staging+empty (misconfiguration window).
+        if (app.Environment.IsEnvironment("Staging"))
+        {
+            using (var scope = app.Services.CreateScope())
+            {
+                var guard = scope.ServiceProvider.GetRequiredService<Api.BoundedContexts.Authentication.Application.Services.IStagingAccessGuard>();
+                if (!guard.HasNonEmptyAllowlist)
+                {
+                    app.Logger.LogWarning(
+                        "STAGING_ACCESS: middleware active but STAGING_ALLOWED_EMAILS is empty. All authenticated users will pass. Set STAGING_ALLOWED_EMAILS to enable allowlist.");
+                }
+            }
+            app.UseMiddleware<Api.BoundedContexts.Authentication.Infrastructure.Middleware.StagingAccessMiddleware>();
+        }
+```
+
+Nota: questo richiede di aggiungere proprietà `HasNonEmptyAllowlist` all'interface (vedi Step 14).
+
+- [ ] **Step 14: Estendere IStagingAccessGuard con HasNonEmptyAllowlist**
+
+Modifica `IStagingAccessGuard.cs`:
+
+```csharp
+public interface IStagingAccessGuard
+{
+    /// <summary>
+    /// Returns true if email is in allowlist OR if allowlist is empty/unset.
+    /// Returns false if allowlist is non-empty AND email not in it.
+    /// </summary>
+    bool IsEmailAllowed(string email);
+
+    /// <summary>
+    /// True if STAGING_ALLOWED_EMAILS contains at least one entry.
+    /// Used by startup warning to detect misconfiguration window.
+    /// </summary>
+    bool HasNonEmptyAllowlist { get; }
+}
+```
+
+Modifica `StagingAccessGuard.cs`:
+
+```csharp
+public bool HasNonEmptyAllowlist => _allowedEmails.Count > 0;
+```
+
+Aggiungere test in `StagingAccessGuardTests.cs`:
+
+```csharp
+[Fact]
+public void HasNonEmptyAllowlist_WhenEmpty_ReturnsFalse()
+{
+    var guard = CreateGuard(null);
+    guard.HasNonEmptyAllowlist.Should().BeFalse();
+}
+
+[Fact]
+public void HasNonEmptyAllowlist_WhenPopulated_ReturnsTrue()
+{
+    var guard = CreateGuard("badsworm@gmail.com");
+    guard.HasNonEmptyAllowlist.Should().BeTrue();
+}
+```
+
+- [ ] **Step 14: Build to verify compile**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet build 2>&1 | tail -10
+```
+
+Expected: Build SUCCESS, 0 errors, 0 warnings (per nuove classi).
+
+- [ ] **Step 15: Run all auth tests to verify no regression**
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet test --filter "Category=Unit&FullyQualifiedName~Authentication" 2>&1 | tail -20
+```
+
+Expected: All Authentication tests PASS.
+
+- [ ] **Step 16: Add STAGING_ALLOWED_EMAILS to admin.secret.example + inject in compose.staging.yml**
+
+Modifica `infra/secrets/admin.secret.example` (target corretto post-review B2). Aggiungere alla fine:
+
+```bash
+# Staging access allowlist (wave 1, ISSUE #806) - CSV email case-insensitive
+# Empty/unset = open access (dev/prod default safe). Populated only on staging.
+# Example: STAGING_ALLOWED_EMAILS=badsworm@gmail.com,beta1@example.com
+STAGING_ALLOWED_EMAILS=
+```
+
+Modifica `infra/compose.staging.yml`. Cercare il blocco `environment:` dell' `api` service e aggiungere:
+
+```yaml
+      STAGING_ALLOWED_EMAILS: ${STAGING_ALLOWED_EMAILS:-}
+```
+
+Verificare che sia anche in `env_file:` se il pattern del compose è file-based; altrimenti env diretto va bene.
+
+- [ ] **Step 17: Commit DI registration + middleware wire + secret template**
+
+Run:
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs apps/api/src/Api/Extensions/WebApplicationExtensions.cs apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs tests/Api.Tests/BoundedContexts/Authentication/StagingAccessGuardTests.cs infra/secrets/admin.secret.example infra/compose.staging.yml
+git commit -m "feat(auth): wire StagingAccessMiddleware in ConfigureAuthMiddleware (staging-only)
+
+Registers IStagingAccessGuard in AuthenticationServiceExtensions.AddAuthenticationContext
+(BC-local DI). Middleware wired in WebApplicationExtensions.ConfigureAuthMiddleware
+after UseEmailVerificationEnforcement, gated by app.Environment.IsEnvironment(Staging)
+to match ASPNETCORE_ENVIRONMENT=Staging in compose.staging.yml.
+
+Logs warning at startup if Staging+empty allowlist (misconfig detection window).
+
+Adds STAGING_ALLOWED_EMAILS to admin.secret.example + injects via compose.staging.yml.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+### 3.4 Frontend integration
+
+- [ ] **Step 18: Update login error handling for STAGING_ACCESS_DENIED code**
+
+Run:
+```bash
+grep -n "fetch.*login\|loginMutation\|onError" apps/web/src/app/login/page.tsx | head -10
+```
+
+Expected: identificare error handler nella login page.
+
+- [ ] **Step 19: Add specific message for STAGING_ACCESS_DENIED**
+
+Modifica `apps/web/src/app/login/page.tsx` nel handler errore. Aggiungere case per `STAGING_ACCESS_DENIED`:
+
+```typescript
+// Cerca il blocco di error handling esistente e aggiungere:
+if (error?.code === 'STAGING_ACCESS_DENIED') {
+  setErrorMessage(
+    "L'ambiente staging è ad accesso riservato. " +
+    "Contatta " + (error.contactEmail ?? 'badsworm@gmail.com') + " per richiedere l'accesso."
+  );
+  return;
+}
+```
+
+NB: il path esatto dipende dalla struttura di error handling esistente. Verificare che `errorMessage` o equivalent state esista.
+
+- [ ] **Step 20: Run frontend lint + typecheck**
+
+Run:
+```bash
+cd apps/web && pnpm lint 2>&1 | tail -10 && pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 21: Commit frontend update**
+
+Run:
+```bash
+git add apps/web/src/app/login/page.tsx
+git commit -m "feat(web): show specific message on STAGING_ACCESS_DENIED 403
+
+When backend returns 403 with code STAGING_ACCESS_DENIED on staging,
+display contact email instead of generic auth error.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+### 3.5 Manual verification
+
+- [ ] **Step 22: Verify locally that empty allowlist = pass-through**
+
+Run (in dev container o local):
+```bash
+cd infra && make dev-core
+# Wait for healthy, then attempt login (no STAGING_ALLOWED_EMAILS set)
+curl -X POST http://localhost:8080/api/v1/auth/login -H "Content-Type: application/json" -d '{"email":"badsworm@gmail.com","password":"..."}' -i 2>&1 | head -5
+```
+
+Expected: 200 OK (login proceeds; middleware not active because ENVIRONMENT != staging in dev).
+
+- [ ] **Step 23: Final task: open PR to main-dev**
+
+Run:
+```bash
+git push -u origin feature/issue-XXX-devops-3branch-wave1
+gh pr create --base main-dev --title "feat(devops): 3-branch policy doc + staging email allowlist (wave 1)" --body "$(cat <<'EOF'
+## Summary
+- Adds DevOps policy document fixing target metrics for 3-branch model
+- Implements staging email allowlist (wave 1) via STAGING_ALLOWED_EMAILS env var
+- New IStagingAccessGuard + StagingAccessMiddleware (gated by ENVIRONMENT=staging)
+- Frontend shows specific message on 403 STAGING_ACCESS_DENIED
+
+## Test plan
+- [x] Unit tests StagingAccessGuard (6 cases: empty/non-empty, case-insensitive, whitespace, null/empty input)
+- [x] Integration tests StagingAccessMiddleware via TestServer (allowed/denied/empty list)
+- [x] Build SUCCESS no warnings
+- [x] Frontend lint + typecheck pass
+- [ ] Manual smoke locale: dev-core + login flow non bloccato (allowlist vuota)
+- [ ] Smoke staging post-deploy: badsworm whitelisted accede, altri 403
+
+## Follow-up
+Tasks 4-6 (CI split fast/deep, dev-core LLM mock, auto-rollback staging) deferred
+to follow-up plan dopo data collection sui tempi attuali ci.yml.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR creata target `main-dev`, link visibile.
+
+---
+
+## Tasks 4-6: Deferred to follow-up plan
+
+I seguenti goal richiedono **data collection preventiva** (tempi medi attuali workflow su PR `main-dev` campione) o **scope sostanziale** che eccede il primo wave:
+
+### Task 4 (deferred): D1 — Split ci.yml in fast (sync) + deep (async)
+
+**Pre-requisito**: 1 settimana di data collection sui tempi medi `ci.yml` per PR `main-dev` (campione 20 PR). Senza questo dato, il target "5 min P95" è guess.
+
+**Scope effort**: ~3-4 giorni effettivi (refactor 36 workflow, branch protection update, auto-issue setup).
+
+### Task 5 (deferred): D2 — Verifica RAM dev-core + LLM mock
+
+**Pre-requisito**: misurare `docker stats` su `make dev-core` cold start. Probabilmente già ≤8GB con servizi attuali (`postgres + redis + api + web`). Se sì, gap è **solo LLM mock service** per ridurre dipendenza OpenRouter in dev.
+
+**Scope effort**: ~1-2 giorni se serve LLM mock.
+
+### Task 6 (deferred): D4 — Auto-rollback staging
+
+**Pre-requisito**: definire metric "smoke staging passes" (vedi Open Q D4 in policy doc).
+
+**Scope effort**: ~2 giorni effettivi (script rollback + workflow integration).
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+| SMART goal | Tasks coverage |
+|---|---|
+| D1 (CI split fast/deep) | ❌ Deferred — needs data collection first |
+| D2 (dev-core ≤8GB) | ❌ Deferred — needs measurement first |
+| D3 wave 1 (email allowlist) | ✅ Task 3 fully covered |
+| D3 wave 2 (invite system) | ⚠️ Existing AccessRequest BC — Task 2 doc references |
+| D4 (auto-rollback) | ❌ Deferred — Task 6 outline |
+| D5 (prod policy doc) | ✅ Task 2 covered |
+
+Phase A scope: D3 wave 1 + D5 ✅. Tasks 4-6 explicitly deferred with rationale.
+
+### 2. Placeholder scan
+
+- ✅ No "TBD", "TODO", "implement later" in implementation tasks 1-3
+- ⚠️ "TBD" in policy doc §4 ("staging-allowlist-management.md") — **acceptable** because referenced future doc, not implementation gap
+- ✅ All code blocks complete with full implementation
+- ✅ All commit messages drafted
+- ✅ All file paths absolute
+
+### 3. Type consistency
+
+- `IStagingAccessGuard` interface signature consistent across:
+  - Definition (Step 3): `bool IsEmailAllowed(string email)`
+  - Implementation (Step 4): same
+  - Test mock (Step 7): `TestGuardFromList` implements same
+  - Middleware usage (Step 9): `guard.IsEmailAllowed(email)` ✅
+- Response payload structure consistent:
+  - Middleware (Step 9): `{code, message, contactEmail}`
+  - Test record (Step 7): `StagingAccessDeniedResponse(Code, Message, ContactEmail)`
+  - Frontend (Step 19): `error?.code === 'STAGING_ACCESS_DENIED'`, `error.contactEmail` ✅
+- Env var name consistent: `STAGING_ALLOWED_EMAILS` ✅
+
+No issues found.
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-05-08-devops-3branch-optimization.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended for parallelism)** — dispatch fresh subagent per task, review between tasks. Good for plan with 3 tasks of medium complexity.
+
+2. **Inline Execution** — execute tasks in current session with checkpoints. Faster turnaround given small scope and existing context.
+
+Per "implementa" del user request, procedo con **Inline Execution** salvo override.

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -56,6 +56,9 @@ services:
       ASPNETCORE_ENVIRONMENT: Staging
       ASPNETCORE_URLS: http://+:8080
       SEED_PROFILE: Staging
+      # DevOps wave 1: STAGING_ALLOWED_EMAILS loaded from admin.secret env_file above.
+      # Empty value = open access (warning logged at startup). To populate:
+      # echo "STAGING_ALLOWED_EMAILS=badsworm@gmail.com" >> infra/secrets/admin.secret
       SEED_BUCKET_NAME: ${SEED_BUCKET_NAME:-}
       SEED_BUCKET_ENDPOINT: ${SEED_BUCKET_ENDPOINT:-}
       SEED_BUCKET_REGION: ${SEED_BUCKET_REGION:-auto}

--- a/infra/secrets/admin.secret.example
+++ b/infra/secrets/admin.secret.example
@@ -22,3 +22,9 @@ STAGING_DEMO_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit # gitguardi
 # Badsworm demo user (seeded in all environments when present)
 # IMPORTANT: Never hardcode in source code — always read from this secret
 SEED_BADSWORM_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit # gitguardian:ignore
+
+# DevOps wave 1 (2026-05-08): staging email allowlist for StagingAccessMiddleware
+# CSV case-insensitive, whitespace tolerant. Empty/unset = open access (default safe
+# for dev/prod where this gate is not registered). Active only on staging.
+# Example: STAGING_ALLOWED_EMAILS=badsworm@gmail.com,beta1@example.com
+STAGING_ALLOWED_EMAILS=


### PR DESCRIPTION
Release PR per sbloccare deploy con il fix S125 SuppressMessageAttribute (PR #852).

Promotes 2 commits a main-staging:
- 19ac9c499 fix(api) S125 false-positives via SuppressMessage (#852)
- 71eab98e5 docs(p2) legacy cleanup inventory P2 prep DRAFT (#827, già in main-staging via release precedente — confermare)

Acceptance: deploy run post-merge dovrebbe completare con tutti i job critici success (no Build Images failure su S125).