### PR TITLE
promote: DevOps staging allowlist follow-up (#854) → staging

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Json;
 using Api.BoundedContexts.Authentication.Application.Services;
+using Microsoft.Extensions.Configuration;
 
 #pragma warning disable MA0048 // File name must match type name - middleware folder convention groups class + extensions
 
@@ -35,11 +36,20 @@ namespace Api.BoundedContexts.Authentication.Infrastructure.Middleware;
 /// </remarks>
 internal sealed class StagingAccessMiddleware
 {
-    private readonly RequestDelegate _next;
+    /// <summary>
+    /// Fallback contact when <c>Staging:ContactEmail</c> is not configured.
+    /// Project owner per <c>devops-policy.md §4</c>.
+    /// </summary>
+    private const string DefaultContactEmail = "badsworm@gmail.com";
 
-    public StagingAccessMiddleware(RequestDelegate next)
+    private readonly RequestDelegate _next;
+    private readonly string _contactEmail;
+
+    public StagingAccessMiddleware(RequestDelegate next, IConfiguration configuration)
     {
         _next = next;
+        var configured = configuration["Staging:ContactEmail"];
+        _contactEmail = string.IsNullOrWhiteSpace(configured) ? DefaultContactEmail : configured;
     }
 
     public async Task InvokeAsync(HttpContext context, IStagingAccessGuard guard)
@@ -61,19 +71,20 @@ internal sealed class StagingAccessMiddleware
         await _next(context).ConfigureAwait(false);
     }
 
-    private static async Task WriteDeniedAsync(HttpContext context)
+    private async Task WriteDeniedAsync(HttpContext context)
     {
         context.Response.StatusCode = StatusCodes.Status403Forbidden;
         context.Response.ContentType = "application/json; charset=utf-8";
-        // Wave 1 simplification: contact email embedded in the user-facing message so
-        // the existing frontend error handler (login _content.tsx:93 setError(err.message))
-        // displays it without code-specific branching. The structured `code` and
-        // `contactEmail` fields remain for future wave-2 typed handling.
+        // Contact email comes from Staging:ContactEmail config (fallback: project owner).
+        // Embedded in user-facing message so existing frontend error handler
+        // (login _content.tsx:93 setError(err.message)) displays it without
+        // code-specific branching. The structured `code` and `contactEmail` fields
+        // remain for future typed handling.
         var payload = JsonSerializer.Serialize(new
         {
             code = "STAGING_ACCESS_DENIED",
-            message = "Staging access by invite only — contact badsworm@gmail.com to request access.",
-            contactEmail = "badsworm@gmail.com"
+            message = $"Staging access by invite only — contact {_contactEmail} to request access.",
+            contactEmail = _contactEmail
         });
         await context.Response.WriteAsync(payload).ConfigureAwait(false);
     }

--- a/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
+++ b/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
@@ -171,15 +171,15 @@ internal static class WebApplicationExtensions
         // Staging+empty (misconfiguration window detection). See devops-policy.md §4.
         if (app.Environment.IsEnvironment("Staging"))
         {
-            using (var scope = app.Services.CreateScope())
+            // Resolve singleton directly from root container — no scope needed since
+            // IStagingAccessGuard is registered as Singleton and has no IDisposable
+            // dependencies. Startup code, no concurrency hazard.
+            var guard = app.Services.GetRequiredService<IStagingAccessGuard>();
+            if (!guard.HasNonEmptyAllowlist)
             {
-                var guard = scope.ServiceProvider.GetRequiredService<IStagingAccessGuard>();
-                if (!guard.HasNonEmptyAllowlist)
-                {
-                    app.Logger.LogWarning(
-                        "STAGING_ACCESS: middleware active but STAGING_ALLOWED_EMAILS is empty. " +
-                        "All authenticated users will pass through. Set STAGING_ALLOWED_EMAILS to enable allowlist.");
-                }
+                app.Logger.LogWarning(
+                    "STAGING_ACCESS: middleware active but STAGING_ALLOWED_EMAILS is empty. " +
+                    "All authenticated users will pass through. Set STAGING_ALLOWED_EMAILS to enable allowlist.");
             }
             app.UseStagingAccessGuard();
         }

--- a/apps/api/src/Api/appsettings.Staging.json
+++ b/apps/api/src/Api/appsettings.Staging.json
@@ -28,5 +28,8 @@
     "MaxConcurrentFactories": 1,
     "EnableTags": true,
     "MaxTagsPerEntry": 10
+  },
+  "Staging": {
+    "ContactEmail": "badsworm@gmail.com"
   }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessGateIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessGateIntegrationTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Security.Claims;
+using Api.BoundedContexts.Authentication.Application.Services;
+using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Infrastructure.Middleware;
+
+/// <summary>
+/// Integration tests for the conditional registration of <see cref="StagingAccessMiddleware"/>
+/// based on <c>ASPNETCORE_ENVIRONMENT</c>. Replicates the wiring logic of
+/// <c>WebApplicationExtensions.ConfigureAuthMiddleware</c> via TestServer to verify the gate
+/// condition without booting the full app (which would require DB/Redis stack).
+/// </summary>
+/// <remarks>
+/// Why TestServer instead of WebApplicationFactory&lt;Program&gt;: Program.cs has heavy startup
+/// dependencies (DbContext, Redis, embedding services). For testing JUST the env-based gate
+/// activation, TestServer with replicated wiring logic gives identical coverage without the
+/// startup cost.
+///
+/// What is replicated from production: the env check (<c>IsEnvironment("Staging")</c>) and
+/// the <c>app.UseMiddleware&lt;StagingAccessMiddleware&gt;()</c> call. What is NOT replicated:
+/// the eager root-container resolve of <see cref="IStagingAccessGuard"/> at startup and the
+/// empty-allowlist warning log (those are tested via unit tests). If you change the
+/// production wiring, this test should be updated to keep the mirror accurate.
+/// </remarks>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Authentication")]
+public class StagingAccessGateIntegrationTests
+{
+    [Theory]
+    [InlineData("Staging", "allowed@example.com", "allowed@example.com", HttpStatusCode.OK,
+        "staging gate active + email in allowlist => pass")]
+    [InlineData("Staging", "allowed@example.com", "blocked@example.com", HttpStatusCode.Forbidden,
+        "staging gate active + email NOT in allowlist => 403")]
+    [InlineData("Development", "allowed@example.com", "blocked@example.com", HttpStatusCode.OK,
+        "dev environment => gate not registered, all authenticated requests pass")]
+    [InlineData("Production", "allowed@example.com", "blocked@example.com", HttpStatusCode.OK,
+        "prod environment => gate not registered, all authenticated requests pass")]
+    [InlineData("Staging", "", "anyone@example.com", HttpStatusCode.OK,
+        "staging gate active but allowlist empty => default-safe pass-through")]
+    public async Task ConditionalGate_OnlyDeniesAuthenticatedRequests_OnStagingWithPopulatedAllowlist(
+        string aspNetCoreEnvironment,
+        string allowlist,
+        string authenticatedEmail,
+        HttpStatusCode expectedStatus,
+        string scenario)
+    {
+        using var server = CreateServer(aspNetCoreEnvironment, allowlist, authenticatedEmail);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/probe", UriKind.Relative));
+
+        response.StatusCode.Should().Be(expectedStatus, scenario);
+    }
+
+    [Fact]
+    public async Task ConditionalGate_DoesNotInterfere_WithUnauthenticatedRequests()
+    {
+        // Even on Staging with populated allowlist, unauthenticated requests must
+        // pass through the staging gate (auth middleware handles 401 separately).
+        using var server = CreateServer(
+            aspNetCoreEnvironment: "Staging",
+            allowlist: "allowed@example.com",
+            authenticatedEmail: null /* unauthenticated */);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/probe", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "unauthenticated requests must NOT be denied by the staging gate (auth middleware territory)");
+    }
+
+    /// <summary>
+    /// Builds a TestServer that replicates the wiring logic of
+    /// <c>WebApplicationExtensions.ConfigureAuthMiddleware</c>:
+    /// register <see cref="IStagingAccessGuard"/>, then conditionally insert
+    /// <see cref="StagingAccessMiddleware"/> only when environment is "Staging".
+    /// </summary>
+    private static TestServer CreateServer(
+        string aspNetCoreEnvironment,
+        string allowlist,
+        string? authenticatedEmail)
+    {
+        var hostBuilder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.UseEnvironment(aspNetCoreEnvironment);
+
+                webHost.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["STAGING_ALLOWED_EMAILS"] = allowlist,
+                        ["Staging:ContactEmail"] = "test-contact@example.com",
+                    });
+                });
+
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddSingleton<IStagingAccessGuard, StagingAccessGuard>();
+                });
+
+                webHost.Configure((context, app) =>
+                {
+                    // Simulate authentication: inject ClaimsPrincipal if email provided
+                    app.Use(async (ctx, next) =>
+                    {
+                        if (authenticatedEmail != null)
+                        {
+                            var identity = new ClaimsIdentity(
+                                new[] { new Claim(ClaimTypes.Email, authenticatedEmail) },
+                                "TestAuth");
+                            ctx.User = new ClaimsPrincipal(identity);
+                        }
+                        await next().ConfigureAwait(false);
+                    });
+
+                    // Mirror of WebApplicationExtensions.ConfigureAuthMiddleware staging gate.
+                    // If this block diverges from production, this test is the regression
+                    // signal: the production wiring should be updated too.
+                    if (context.HostingEnvironment.IsEnvironment("Staging"))
+                    {
+                        app.UseMiddleware<StagingAccessMiddleware>();
+                    }
+
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.StatusCode = 200;
+                        await ctx.Response.WriteAsync("OK").ConfigureAwait(false);
+                    });
+                });
+            });
+
+        return hostBuilder.Start().GetTestServer();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.Authentication.Infrastructure.Middleware;
@@ -59,12 +60,24 @@ public class StagingAccessMiddlewareTests
         public bool HasNonEmptyAllowlist => _allowed.Count > 0;
     }
 
+    private static IConfiguration ConfigWithContact(string? contactEmail)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Staging:ContactEmail", contactEmail }
+            })
+            .Build();
+    }
+
     [Fact]
     public async Task InvokeAsync_WhenUnauthenticated_PassesThrough()
     {
         var context = CreateUnauthenticatedContext();
         var nextCalled = false;
-        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("badsworm@gmail.com"));
 
         await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
 
@@ -77,7 +90,9 @@ public class StagingAccessMiddlewareTests
     {
         var context = CreateAuthenticatedContext("badsworm@gmail.com");
         var nextCalled = false;
-        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("badsworm@gmail.com"));
 
         await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
 
@@ -90,7 +105,9 @@ public class StagingAccessMiddlewareTests
     {
         var context = CreateAuthenticatedContext("hacker@evil.com");
         var nextCalled = false;
-        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("badsworm@gmail.com"));
 
         await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
 
@@ -109,8 +126,66 @@ public class StagingAccessMiddlewareTests
         payload!.Code.Should().Be("STAGING_ACCESS_DENIED");
         payload.Message.Should().Contain("invite only", "user-facing message must explain access policy");
         payload.Message.Should().Contain("badsworm@gmail.com",
-            "wave 1 simplification: contact email embedded in message for direct frontend display");
-        payload.ContactEmail.Should().NotBeNullOrWhiteSpace();
+            "contact email from Staging:ContactEmail config is embedded in message for direct frontend display");
+        payload.ContactEmail.Should().Be("badsworm@gmail.com");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenContactEmailFromConfig_UsesConfiguredAddress()
+    {
+        var context = CreateAuthenticatedContext("hacker@evil.com");
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("admin@meepleai.app"));
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        nextCalled.Should().BeFalse();
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        var payload = JsonSerializer.Deserialize<DeniedResponse>(body, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        payload!.Message.Should().Contain("admin@meepleai.app",
+            "configured contact email must be used (no hardcoded fallback when config present)");
+        payload.Message.Should().NotContain("badsworm@gmail.com");
+        payload.ContactEmail.Should().Be("admin@meepleai.app");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task InvokeAsync_WhenContactEmailNullEmptyOrWhitespace_FallsBackToProjectOwner(
+        string? contactEmail)
+    {
+        // Defensive: if Staging:ContactEmail is unset (null), empty, or whitespace-only,
+        // fall back to project owner so the user always has a way to request access.
+        // Operators see WARN at startup. The triangle null/empty/whitespace is covered
+        // by `string.IsNullOrWhiteSpace` in the middleware constructor.
+        var context = CreateAuthenticatedContext("hacker@evil.com");
+        var nextCalled = false;
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact(contactEmail));
+
+        await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
+
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
+        var payload = JsonSerializer.Deserialize<DeniedResponse>(body, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        payload!.ContactEmail.Should().Be("badsworm@gmail.com",
+            "fallback to project owner when Staging:ContactEmail null/empty/whitespace");
     }
 
     [Fact]
@@ -118,7 +193,9 @@ public class StagingAccessMiddlewareTests
     {
         var context = CreateAuthenticatedContext(email: null);
         var nextCalled = false;
-        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("badsworm@gmail.com"));
 
         await middleware.InvokeAsync(context, new StubGuard("badsworm@gmail.com"));
 
@@ -134,7 +211,9 @@ public class StagingAccessMiddlewareTests
         // accidental lockout if STAGING_ALLOWED_EMAILS is misconfigured.
         var context = CreateAuthenticatedContext("anyone@example.com");
         var nextCalled = false;
-        var middleware = new StagingAccessMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var middleware = new StagingAccessMiddleware(
+            _ => { nextCalled = true; return Task.CompletedTask; },
+            ConfigWithContact("badsworm@gmail.com"));
 
         await middleware.InvokeAsync(context, new StubGuard(/* empty allowlist */));
 


### PR DESCRIPTION
## Summary
Promote PR #854 da `main-dev` a `main-staging` per attivare il StagingAccessMiddleware in produzione-staging.

**Single commit**: `8faeac3d0` — refactor(devops): staging allowlist follow-up — config + tests (#854)

## Modifiche già su main-staging (post-#853 promotion)
- ✅ `StagingAccessMiddleware` + `IStagingAccessGuard` (PR #851)
- ✅ Wire in `WebApplicationExtensions.ConfigureAuthMiddleware` gated by `Environment.IsEnvironment("Staging")`
- ✅ DI registration in `AuthenticationServiceExtensions.AddAuthenticationContext`
- ✅ `STAGING_ALLOWED_EMAILS` template in `admin.secret.example` + comment in `compose.staging.yml`
- ✅ Sonar S125 suppression (PR #852)

## Nuove modifiche da questo promote (#854)
- 🔧 `Staging:ContactEmail` letto da `IConfiguration` (no hardcode)
- 🔧 Scope ceremony semplificato (resolve singleton da root container)
- ✅ Integration test ASPNETCORE_ENVIRONMENT gate (TestServer-based, 6 cases)
- ✅ Theory test fallback null/empty/whitespace contact email (3 inline data)

## Pre-condizioni VPS staging già preparate
- ✅ `STAGING_ALLOWED_EMAILS=badsworm@gmail.com` populato in `/opt/meepleai/repo/infra/secrets/admin.secret` (sessione precedente)
- ✅ `admin.secret` già in `env_file` di `compose.staging.yml` linea 47
- ✅ `DataProtection:KeysPath` configurato con volume persistente sul VPS

## Test plan
Tested locally end-to-end (24/24 unit+integration verde + 5/5 E2E manual smoke):
- [x] Login allowlisted → 200
- [x] GET /me allowlisted → 200 (gate passes)
- [x] Login non-allowlisted → 200 (login bypass gate by design)
- [x] GET /me non-allowlisted → 403 STAGING_ACCESS_DENIED with structured JSON
- [x] Empty allowlist + Staging env → startup WRN + default-safe pass-through
- [x] `IConfiguration["Staging:ContactEmail"]` correttamente honored

## Post-merge
Deploy staging triggers automaticamente da push a `main-staging` (deploy-staging.yml workflow). Atteso comportamento sul VPS:
1. CI pass su main-staging
2. Image rebuilt with new middleware code
3. Container restart pickups `STAGING_ALLOWED_EMAILS=badsworm@gmail.com` da `admin.secret`
4. Login + auth flow a `https://meepleai.app` consente solo Aaron, denies altri con 403 strutturato

## Smoke staging post-deploy
- [ ] `make smoke-staging` (or curl https://meepleai.app/healthz) → 200
- [ ] Login badsworm → 200
- [ ] Login altro → 200 + GET /api/v1/auth/me → 403 STAGING_ACCESS_DENIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)