### PR TITLE
fix(devops): staging deploy reliability — 3 bugs from #851 promote incident

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -270,10 +270,16 @@ jobs:
           NEXT_PUBLIC_API_BASE: http://localhost:8080
           NODE_OPTIONS: '--max-old-space-size=4096'
 
-  # Build and push Docker images (only changed components)
+  # Build and push Docker images (only changed components).
+  # ALWAYS runs on ubuntu-latest (cloud) — never on self-hosted runner.
+  # The self-hosted runner is the staging VPS itself (CAX31, 7.5GB RAM); when
+  # build runs there the dotnet publish + next build inside docker buildx
+  # ARM64 cross-compile drove the VPS into swap thrashing (load avg >90,
+  # SSH unresponsive). Cloud runner has more RAM and isolates build pressure.
+  # See incident 2026-05-08: deploy run 25563055758.
   build:
     name: Build Images
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [pre-deploy-check, detect-changes]
     if: always() && (needs.pre-deploy-check.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true)) && (needs.detect-changes.outputs.deploy_api == 'true' || needs.detect-changes.outputs.deploy_web == 'true')

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -36,6 +36,14 @@ services:
 
   api:
     restart: always
+    # Staging must NEVER fall back to the local `meepleai-api:latest` image
+    # (built by compose.dev.yml). Manual restarts (`make staging-minimal`)
+    # would otherwise silently run stale code. The deploy workflow injects
+    # API_IMAGE from `needs.build.outputs.api_image`; for manual recovery on
+    # the VPS use:
+    #   export API_IMAGE=ghcr.io/meepleai-app/meepleai-monorepo/api:staging-<sha>
+    image: ${API_IMAGE:?API_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
     # CF Tunnel exposure: bind 8080 on localhost (IPv4 + IPv6 dual-stack)
     # cloudflared resolves localhost → ::1 first; without IPv6 binding it returns 502.
     ports:
@@ -56,6 +64,10 @@ services:
       ASPNETCORE_ENVIRONMENT: Staging
       ASPNETCORE_URLS: http://+:8080
       SEED_PROFILE: Staging
+      # F4 (hotfix #818): DataProtection keys must persist across container
+      # restarts. Without persisted keys every API restart invalidates every
+      # meepleai_user_role_v2 cookie. Path matches the named volume mount below.
+      DATAPROTECTION__KEYSPATH: /app/dataprotection
       # DevOps wave 1: STAGING_ALLOWED_EMAILS loaded from admin.secret env_file above.
       # Empty value = open access (warning logged at startup). To populate:
       # echo "STAGING_ALLOWED_EMAILS=badsworm@gmail.com" >> infra/secrets/admin.secret
@@ -88,6 +100,10 @@ services:
       PdfProcessing__Extractor__Unstructured__ApiUrl: "http://unstructured-service:8001"
     volumes:
       - ./secrets:/app/infra/secrets:ro
+      # F4: persisted DataProtection key ring (see DATAPROTECTION__KEYSPATH above).
+      # Dedicated named volume — must NOT share with /app/pdf_uploads which is
+      # rotated when uploads are pruned.
+      - dataprotection-keys-staging:/app/dataprotection
     # Traefik labels removed — staging now via Cloudflare Tunnel (cloudflared service on VPS).
     # Routes meepleai.app/* and api.meepleai.app/* are configured in CF dashboard tunnel public hostnames.
     logging:
@@ -96,6 +112,9 @@ services:
 
   web:
     restart: always
+    # Same rationale as api.image above — explicit GHCR image required.
+    image: ${WEB_IMAGE:?WEB_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
     # CF Tunnel exposure: bind 3000 on localhost (IPv4 + IPv6 dual-stack)
     # cloudflared resolves localhost → ::1 first; without IPv6 binding it returns 502.
     ports:
@@ -261,3 +280,10 @@ volumes:
     name: meepleai-prometheus-staging
   grafana-staging:
     name: meepleai-grafana-staging
+  # F4 (hotfix #818): persistent DataProtection key ring for the API.
+  # Mounted at /app/dataprotection in the api service and read via
+  # DATAPROTECTION__KEYSPATH. Must survive container recreate; no PII inside,
+  # but rotation is non-trivial — invalidates all meepleai_user_role_v2
+  # cookies in the wild.
+  dataprotection-keys-staging:
+    name: meepleai-dataprotection-keys-staging


### PR DESCRIPTION
## Summary
Tre bug operativi emersi durante il promote main-dev → main-staging della PR #855 (DevOps wave 1 staging allowlist).

### 🐛 Bug 1: `DataProtection:KeysPath` missing on staging
F4 (hotfix #818, 2026-05-07) introdusse il check `required in Staging` ma non aggiornò `compose.staging.yml`. Container crash su startup con `InvalidOperationException` al primo deploy con immagine fresh post-#818.

**Fix**:
- Volume named `dataprotection-keys-staging` (separato da `/app/pdf_uploads`)
- Mount `/app/dataprotection`
- `DATAPROTECTION__KEYSPATH` env var

### 🐛 Bug 2: silent fallback a image locale stale
`docker-compose.yml` ha `image: \${API_IMAGE:-meepleai-api}` con fallback locale. Su staging VPS, `make staging-minimal` senza `export API_IMAGE` usava silenziosamente `meepleai-api:latest` (residuo da `compose.dev.yml` builds).

**Fix**:
- `compose.staging.yml` override con `image: \${API_IMAGE:?API_IMAGE required}`
- `pull_policy: always`
- Stesso pattern per web service

### 🐛 Bug 3: build runner = self-hosted VPS → swap thrashing
`deploy-staging.yml` `build` job runs su `vars.RUNNER` = self-hosted = staging VPS (CAX31 7.5GB RAM). Docker buildx ARM64 build (`dotnet publish` + `next build`) driva load avg >90, swap full, SSH unresponsive.

**Fix**:
- Force `build` job a `ubuntu-latest` (cloud, più RAM, isolato)
- Database Migration + Deploy via SSH restano self-hosted (DB tunnel + SSH proximity)

## Test verification (locale)
- `docker compose ... config` PASS con `API_IMAGE`/`WEB_IMAGE` set
- FAIL chiaro con messaggio se env unset
- `DATAPROTECTION__KEYSPATH` + volume mount visibili in merged config

## ⚠️ Post-merge action richiesta
Prima volta che il deploy crea `dataprotection-keys-staging` volume → key ring fresh → tutti i `meepleai_user_role_v2` cookies invalidati → utenti devono ri-login una volta. Comunicare agli stakeholder staging.

## Incident reference
- Deploy run [25563055758](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25563055758) — VPS swap thrashing
- Deploy run [25564128425](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25564128425) — DataProtection startup crash + image fallback issue (manualmente fixato in incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)