### PR TITLE
feat(seeder): align Badsworm seed → badsworm@gmail.com + SuperAdmin

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommand.cs
@@ -3,8 +3,12 @@ using Api.SharedKernel.Application.Interfaces;
 namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
-/// Command to seed the badsworm demo user account.
-/// Creates badsworm@alice.it with password from SEED_BADSWORM_PASSWORD secret.
-/// Runs in all environments (Dev, Staging, Prod) when the secret is present.
+/// Command to seed the project owner / Nanolith demo account.
+/// Creates badsworm@gmail.com (role=SuperAdmin) with password from
+/// SEED_BADSWORM_PASSWORD secret. Runs in all environments (Dev, Staging, Prod)
+/// when the secret is present.
+///
+/// Aligned with the staging allowlist (DevOps wave 1) — this is the email
+/// pre-populated in STAGING_ALLOWED_EMAILS on the staging VPS.
 /// </summary>
 public sealed record SeedBadswormUserCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
@@ -13,14 +13,18 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 
 /// <summary>
 /// Handler for SeedBadswormUserCommand.
-/// Creates demo user (badsworm@alice.it) with password from SEED_BADSWORM_PASSWORD secret.
+/// Creates project owner account (badsworm@gmail.com, role=SuperAdmin) with
+/// password from SEED_BADSWORM_PASSWORD secret. Used for Nanolith demo runthrough
+/// (docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md) and as
+/// the staging allowlist whitelisted user (DevOps wave 1, devops-policy.md §4).
+///
 /// Idempotent: Only executes if user doesn't exist.
 /// Runs in all environments (Dev, Staging, Prod) when SEED_BADSWORM_PASSWORD secret is present.
 /// Remove or leave the secret absent in environments where this account should not exist.
 /// </summary>
 internal sealed class SeedBadswormUserCommandHandler : ICommandHandler<SeedBadswormUserCommand>
 {
-    private const string BadswormEmail = "badsworm@alice.it";
+    private const string BadswormEmail = "badsworm@gmail.com";
     private const string BadswormDisplayName = "Badsworm";
 
     private readonly IUserRepository _userRepository;
@@ -69,7 +73,7 @@ internal sealed class SeedBadswormUserCommandHandler : ICommandHandler<SeedBadsw
             email: emailValue,
             displayName: BadswormDisplayName,
             passwordHash: PasswordHash.Create(password),
-            role: Role.User
+            role: Role.SuperAdmin
         );
         user.VerifyEmail(); // Developer account: pre-verified, no email flow required
 

--- a/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
@@ -64,9 +64,9 @@ public sealed class SeedBadswormUserCommandHandlerTests
 
         _userRepositoryMock.Verify(
             x => x.AddAsync(It.Is<User>(u =>
-                u.Email.Value == "badsworm@alice.it" &&
+                u.Email.Value == "badsworm@gmail.com" &&
                 u.DisplayName == "Badsworm" &&
-                u.Role == Role.User &&
+                u.Role == Role.SuperAdmin &&
                 u.EmailVerified
             ), It.IsAny<CancellationToken>()),
             Times.Once
@@ -114,7 +114,7 @@ public sealed class SeedBadswormUserCommandHandlerTests
     {
         return new User(
             Guid.NewGuid(),
-            new Email("badsworm@alice.it"),
+            new Email("badsworm@gmail.com"),
             "Badsworm",
             PasswordHash.Create(BadswormPassword),
             Role.User


### PR DESCRIPTION
## Summary
Allinea il seeder dell'account Badsworm con l'identità project owner usata su staging.

**Before**:
- email: `badsworm@alice.it`
- role: `Role.User`

**After**:
- email: `badsworm@gmail.com`
- role: `Role.SuperAdmin`
- password: invariata, da `SEED_BADSWORM_PASSWORD` secret

## Rationale
L'account Badsworm è l'identità del project owner, usata da:
- **Nanolith demo runthrough** (docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md): persona "Aaron, badsworm@gmail.com, superadmin"
- **Staging email allowlist** (devops-policy.md §4): `STAGING_ALLOWED_EMAILS=badsworm@gmail.com`
- **Local dev / CI**: account convenience pre-promosso a superadmin

L'email `@alice.it` era un placeholder inconsistente con il valore di staging admin.secret. Ora seeder + DevOps wave 1 + spec runthrough sono allineati su `badsworm@gmail.com`.

## Files
- `SeedBadswormUserCommandHandler.cs`: const `BadswormEmail` aggiornato + `Role.SuperAdmin`
- `SeedBadswormUserCommand.cs`: docstring rifletti il nuovo scope (project owner / Nanolith demo / staging allowlist)
- `SeedBadswormUserCommandHandlerTests.cs`: assert su email + Role.SuperAdmin

## Test plan
- [x] `dotnet test --filter SeedBadswormUserCommandHandlerTests` → 4/4 PASS
- [x] Local: delete user esistente + restart api → re-seed con nuova email/role
- [x] Login locale `badsworm@gmail.com` / `TestNanolith2026!` → 200, role superadmin

## Post-merge action
- **Local DB**: developer con `badsworm@alice.it` esistente devono `DELETE FROM users WHERE "Email" = 'badsworm@alice.it'` + restart per re-seed
- **Staging VPS**: nessuna azione — il seeder è idempotente e `STAGING_ALLOWED_EMAILS` già contiene `badsworm@gmail.com`. Al prossimo deploy con account assente, viene creato direttamente con la nuova email

🤖 Generated with [Claude Code](https://claude.com/claude-code)