### PR TITLE
fix(infra): Iter 2 hotfix — rimuovi --no-restore da Dockerfile publish

### DIFF
--- a/apps/api/src/Api/Dockerfile
+++ b/apps/api/src/Api/Dockerfile
@@ -31,13 +31,15 @@ COPY data ./data
 
 # Patch 1: SkipAnalyzers=true durante publish (analyzer suite consumer
 #          principale di memory peak — SonarAnalyzer + NetAnalyzers + Meziantou).
-# Patch 2: --no-restore + cache reuse.
+# Patch 2: NuGet cache mount riusato dal restore step → no re-download packages.
+#          NB: NO --no-restore qui — il publish ha bisogno di project's obj/
+#          (project.assets.json) che NON persiste cross-layer; cache mount copre
+#          solo /root/.nuget/packages. Il restore con cache è veloce comunque.
 # GenerateDocumentationFile=false: -10MB image size + minor memory savings.
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet publish ./apps/api/src/Api/Api.csproj \
         -c Release \
         -o /app/publish \
-        --no-restore \
         -p:SkipAnalyzers=true \
         -p:GenerateDocumentationFile=false
 


### PR DESCRIPTION
## Summary

Hotfix per PR #858 (Iter 2 Docker OOM mitigation): durante verifica empirica build su Windows WSL2 Docker Desktop, il `dotnet publish --no-restore` ha fallito con `error NETSDK1064: Package AWSSDK.S3 not found`.

## Root cause

`--no-restore` flag combinato con `--mount=type=cache,target=/root/.nuget/packages`:
- Cache mount preserva **NuGet global cache** (downloaded packages)
- NON preserva `project's obj/project.assets.json` (generato dal restore step, cleared between layers)
- `publish --no-restore` cerca `obj/project.assets.json` per resolution → fallisce

## Fix

Rimuovere `--no-restore` dal publish step. Il cache mount continua a fornire benefit (no re-download NuGet packages cross-build), e il restore con cache è veloce comunque.

## Verifica empirica post-fix

```bash
DOCKER_BUILDKIT=1 docker build --no-cache --progress=plain \
  -f apps/api/src/Api/Dockerfile -t meepleai-api-iter2-test .
```

Risultato:
- ✅ Exit code 0 (vs exit 1 PR #858 + exit 137 OOM pre-Iter-2)
- ✅ Image `meepleai-api-iter2-test:latest` creata (800 MB)
- ✅ SHA `19d9b06c2e6f...` final
- ✅ Build time ~3 min su WSL2 Docker Desktop

**Iter 2 OOM fix CONFIRMED working** — Patch 1 (SkipAnalyzers) + Patch 2 (cache mount) + Patch 3 (DOTNET_GCServer=0) effective. Hotfix solo per `--no-restore` incompatibility con cache mount setup.

## Test plan

- [x] `docker build --no-cache` exit 0 su Windows WSL2 Docker Desktop
- [x] Image `meepleai-api-iter2-test:latest` creata size ~800 MB
- [ ] CI build su GitHub Actions (Linux runner) — verifica replicata
- [ ] Staging server `make staging-minimal` build verde post-merge

## Refs

- PR #858 (Iter 2 baseline patches): mergiato ma con bug `--no-restore`
- PR #856 (Phase A): origin documentazione OOM symptoms cross-environment

🤖 Iter 2 verifica + hotfix