### PR TITLE
fix(admin): /admin/users search 500 — EF Core ILike instead of StringComparison

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAllUsersQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAllUsersQueryHandler.cs
@@ -27,13 +27,15 @@ internal class GetAllUsersQueryHandler : IQueryHandler<GetAllUsersQuery, PagedRe
             .Include(u => u.Sessions)
             .AsNoTracking();
 
-        // Search filter (email or display name)
+        // Search filter (email or display name) — use EF.Functions.ILike for
+        // PostgreSQL case-insensitive match. string.Contains(StringComparison)
+        // is NOT translatable by EF Core (only the single-arg overload is).
         if (!string.IsNullOrWhiteSpace(query.SearchTerm))
         {
-            var term = query.SearchTerm;
+            var pattern = $"%{query.SearchTerm}%";
             dbQuery = dbQuery.Where(u =>
-                (u.Email != null && u.Email.Contains(term, StringComparison.InvariantCultureIgnoreCase)) ||
-                (u.DisplayName != null && u.DisplayName.Contains(term, StringComparison.InvariantCultureIgnoreCase)));
+                (u.Email != null && EF.Functions.ILike(u.Email, pattern)) ||
+                (u.DisplayName != null && EF.Functions.ILike(u.DisplayName, pattern)));
         }
 
         // Role filter
@@ -51,9 +53,12 @@ internal class GetAllUsersQueryHandler : IQueryHandler<GetAllUsersQuery, PagedRe
         }
 
         // Tier filter - Issue #3698
+        // Use EF.Functions.ILike for case-insensitive match (string.Equals
+        // with StringComparison is NOT EF-translatable).
         if (!string.IsNullOrWhiteSpace(query.TierFilter) && !string.Equals(query.TierFilter, "all", StringComparison.OrdinalIgnoreCase))
         {
-            dbQuery = dbQuery.Where(u => u.Tier.Equals(query.TierFilter, StringComparison.OrdinalIgnoreCase));
+            var tierPattern = query.TierFilter;
+            dbQuery = dbQuery.Where(u => EF.Functions.ILike(u.Tier, tierPattern));
         }
 
         // Sorting - Issue #3698: Added tier sorting


### PR DESCRIPTION
## Summary
`GET /api/v1/admin/users?search=...` returned HTTP 500 (`InvalidOperationException` from EF Core query translation). Fix: replace `string.Contains/Equals` with `StringComparison` arg → `EF.Functions.ILike` (Postgres native).

## Bug evidence
```
docker exec meepleai-api curl -sf -b cookies.txt \
  'http://localhost:8080/api/v1/admin/users?search=badsworm&limit=5'
→ 500
   at Api.BoundedContexts.Administration.Application.Queries.GetAllUsersQueryHandler.Handle
   at Microsoft.EntityFrameworkCore.Query.QueryableMethodTranslatingExpressionVisitor.Translate
```

## Root cause
EF Core (Npgsql) supports only single-arg `string.Contains(string)`. The handler used 3-arg overloads with `StringComparison.InvariantCultureIgnoreCase` (search, lines 35-36) and `StringComparison.OrdinalIgnoreCase` (tier filter, line 56) — these are NOT translatable to SQL.

The role filter (line 43) was already using `EF.Functions.ILike` correctly — same pattern applied to email/displayName search and tier.

## Fix
- **Search filter**: `EF.Functions.ILike(u.Email, $"%{term}%")` + same for `DisplayName`
- **Tier filter**: `EF.Functions.ILike(u.Tier, query.TierFilter)`

## Test plan
- [x] Build clean (0 warnings, 0 errors)
- [ ] Runtime: `curl /admin/users?search=badsworm` → 200 (post-rebuild)
- [ ] Existing handler tests pass

## Surfaced from
Nanolith demo seed script (`seed-nanolith-demo.sh`) needed admin search to check pre-existing badsworm user. The 500 caused the seed to fail with confusing "User not found, creating" → 400 already exists race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)