### PR TITLE
fix(scripts): seed-nanolith-demo em-dash + PDF idempotency

### DIFF
--- a/infra/scripts/seed-nanolith-demo.sh
+++ b/infra/scripts/seed-nanolith-demo.sh
@@ -220,7 +220,7 @@ else
     '{
       title: $title,
       yearPublished: 2024,
-      description: "Nanolith — campaign-driven gamebook for the Iter 1 dogfooding demo (multi-day storybook + on-demand encounter book).",
+      description: "Nanolith - campaign-driven gamebook for the Iter 1 dogfooding demo (multi-day storybook + on-demand encounter book).",
       minPlayers: 1,
       maxPlayers: 4,
       playingTimeMinutes: 240,
@@ -329,7 +329,10 @@ upload_or_skip_pdf() {
   fi
 
   local pdf_id
-  pdf_id=$(echo "$up_body" | jq -r '.documentId // .id // .Id // empty' 2>/dev/null || true)
+  # Idempotency: when the same PDF was already uploaded in a previous run,
+  # the API returns {"existingKbFound": true, "existingKb": {"pdfDocumentId": "..."}}
+  # instead of {"documentId": "..."}. Accept both response shapes.
+  pdf_id=$(echo "$up_body" | jq -r '.documentId // .id // .Id // .existingKb.pdfDocumentId // empty' 2>/dev/null || true)
   [ -z "$pdf_id" ] && fail "  Upload OK but documentId missing in response: $up_body"
   ok "  Upload accepted: $pdf_id"
 


### PR DESCRIPTION
## Summary
Due failure modes scoperti durante il run locale di `make seed-nanolith-demo` (post-#862 admin search fix):

### 1. Em-dash Unicode crash JSON parse
La description nel payload `CreateSharedGameRequest` conteneva `Nanolith — campaign-driven` (em-dash U+2014). Su Windows Git Bash con jq + curl, il payload veniva rifiutato dall'endpoint:
```
HTTP 400: The JSON value could not be converted to CreateSharedGameRequest.
Path: \$.description | LineNumber: 3 | BytePositionInLine: 135
```
**Fix**: ASCII hyphen.

### 2. PDF idempotency response shape mismatch
Al secondo run, il `lookup_pdf_id` può mancare il PDF esistente (KB belongs to user-context query, miss del filtro). Lo script fall through to upload. L'API correttamente rileva esistenza e ritorna:
```json
{"existingKbFound": true,
 "existingKb": {"pdfDocumentId": "...", "processingState": "Chunking"}}
```
invece del first-upload shape `{"documentId": "..."}`. Lo script falliva a estrarre l'id.

**Fix**: aggiunto `.existingKb.pdfDocumentId` al jq fallback chain. Lo script ora accetta entrambe le shapes.

## Test plan
- [x] Run `make seed-nanolith-demo` con DB partial-progress → procede past upload step
- [x] Browser E2E (vedi sessione precedente): shared catalog search → Nanolith trovato → add to library → "Nuova campagna libro game" → campagna attiva at `/library/games/{id}/play/{campaignId}`

## Surfaced from
Sessione di dogfooding Nanolith demo Iter 1, con admin search bug fixato in #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)