### PR TITLE
chore(gitignore): protect data/rulebook subdirs from PDF commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ docs/pages/manifest.json
 # These are seed data for RAG embedding pipeline only
 # Note: data/rulebook/golden/ is explicitly tracked (mechanic extractor validation fixtures)
 data/rulebook/*.pdf
+data/rulebook/**/*.pdf
 data/rulebook/*.sh
 data/rulebook/manifest.json
 data/rulebook/rag-test-results.md


### PR DESCRIPTION
## Summary
`data/rulebook/*.pdf` matcha solo top-level. PDF in subdirs come `nanolith_datasource/` non protetti — rischio commit accidentale di rulebook copyrighted (es. Nanolith Rules 101MB).

**Fix**: aggiunto `data/rulebook/**/*.pdf` per recursive match.

## Verified
```
git check-ignore -v 'data/rulebook/nanolith_datasource/Nanolith Rules ENG.pdf'
→ .gitignore:243:data/rulebook/**/*.pdf
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)