### PR TITLE
fix(seed,infra): seed-nanolith-demo polling + agent shape + pip timeouts

### DIFF
--- a/apps/embedding-service/Dockerfile
+++ b/apps/embedding-service/Dockerfile
@@ -17,7 +17,10 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# PyPI/pythonhosted occasionally times out on large packages (torch ~700MB).
+# Extend pip's 15s socket timeout and add resumable retries.
+ENV PIP_DEFAULT_TIMEOUT=300
+RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download the model so runtime container starts fast
 ARG EMBEDDING_MODEL=intfloat/multilingual-e5-base

--- a/apps/smoldocling-service/Dockerfile
+++ b/apps/smoldocling-service/Dockerfile
@@ -17,7 +17,8 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+ENV PIP_DEFAULT_TIMEOUT=300
+RUN pip install --no-cache-dir --retries 5 -r /tmp/requirements.txt
 
 # Download model weights at build time (speeds up first startup)
 ENV HF_HOME=/opt/model-cache

--- a/apps/unstructured-service/Dockerfile
+++ b/apps/unstructured-service/Dockerfile
@@ -18,7 +18,8 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+ENV PIP_DEFAULT_TIMEOUT=300
+RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download NLTK datasets
 ENV NLTK_DATA=/nltk_data

--- a/infra/scripts/seed-nanolith-demo.sh
+++ b/infra/scripts/seed-nanolith-demo.sh
@@ -269,21 +269,29 @@ echo "game,$NANOLITH_GAME_TITLE,$GAME_ID,OK" >> "$RESULTS_FILE"
 # Returns the document id on stdout (empty string if absent).
 lookup_pdf_id() {
   local filename="$1"
-  curl -sS -b "$ADMIN_COOKIE_JAR" "$API_BASE/admin/shared-games/$GAME_ID/documents" 2>/dev/null \
-    | jq -r --arg f "$filename" \
-        '(.items // .documents // . // [])[] | select((.fileName // .filename // .name // "") == $f) | (.id // .Id // .documentId // empty)' \
+  # /admin/pdfs is the authoritative listing; per-game documents endpoint
+  # returns [] until processing reaches Ready (game-document link is created
+  # at the end of the pipeline, not at upload).
+  curl -sS -b "$ADMIN_COOKIE_JAR" "$API_BASE/admin/pdfs" 2>/dev/null \
+    | jq -r --arg f "$filename" --arg gid "$GAME_ID" \
+        '.items[]? | select(.fileName == $f and (.gameId // "") == $gid) | .id' 2>/dev/null \
     | head -1
 }
 
 # Helper to wait for a PDF to reach Ready/Failed state.
+# Polls /admin/pdfs (authoritative EF state) instead of /pdfs/{id}/progress
+# which has been observed returning stale "Uploading" snapshots during chunking.
 wait_for_pdf() {
   local pdf_id="$1" filename="$2"
   local elapsed=0
   while [ "$elapsed" -lt "$POLL_MAX_SEC" ]; do
-    STATUS=$(curl -sS -b "$ADMIN_COOKIE_JAR" "$API_BASE/pdfs/$pdf_id/progress" 2>/dev/null || echo "{}")
-    STATE=$(echo "$STATUS" | jq -r '.currentStep // .currentState // "unknown"')
-    PCT=$(echo "$STATUS" | jq -r '.percentComplete // .overallProgress // 0')
-    printf "  [%4ds] %s — %s (%s%%)\n" "$elapsed" "$filename" "$STATE" "$PCT"
+    STATUS=$(curl -sS -b "$ADMIN_COOKIE_JAR" "$API_BASE/admin/pdfs" 2>/dev/null || echo '{"items":[]}')
+    DOC=$(echo "$STATUS" | jq -c --arg id "$pdf_id" '.items[]? | select(.id == $id)')
+    STATE=$(echo "$DOC" | jq -r '.processingState // "unknown"')
+    PCT=$(echo "$DOC" | jq -r '.progressPercentage // 0')
+    CHUNKS=$(echo "$DOC" | jq -r '.chunkCount // 0')
+    PAGES=$(echo "$DOC" | jq -r '.pageCount // 0')
+    printf "  [%4ds] %s — %s (%s%% pages=%s chunks=%s)\n" "$elapsed" "$filename" "$STATE" "$PCT" "$PAGES" "$CHUNKS" >&2
     case "$STATE" in
       Ready|Completed|Indexed)  return 0 ;;
       Failed)                   return 1 ;;
@@ -355,10 +363,17 @@ upload_or_skip_pdf "$PDF_PRESS_START_FILENAME"  "pdf_press_start"
 log "Ensuring agent '$NANOLITH_AGENT_NAME' exists"
 
 # Look up existing user agents for this game (badsworm session).
-AGENT_LIST=$(curl -sS -b "$USER_COOKIE_JAR" "$API_BASE/agents?gameId=$GAME_ID" 2>/dev/null || echo "[]")
-AGENT_ID=$(echo "$AGENT_LIST" | jq -r --arg name "$NANOLITH_AGENT_NAME" \
-  '(.items // .data // . // [])[] | select((.name // .Name // "") == $name) | (.id // .Id // empty)' \
-  2>/dev/null | head -1)
+# /agents returns {success, agents:[], count}. Some endpoints return arrays directly,
+# so try multiple shapes via `try ... catch empty`.
+AGENT_LIST=$(curl -sS -b "$USER_COOKIE_JAR" "$API_BASE/agents?gameId=$GAME_ID" 2>/dev/null || echo '{"agents":[]}')
+AGENT_ID=$(echo "$AGENT_LIST" \
+  | jq -r --arg name "$NANOLITH_AGENT_NAME" '
+      ((.agents // .items // .data // (try . | arrays) // [])
+       | .[]?
+       | select((.name // .Name // "") == $name)
+       | (.id // .Id // empty)
+      )' 2>/dev/null \
+  | head -1 || true)
 
 if [ -n "$AGENT_ID" ] && [ "$AGENT_ID" != "null" ]; then
   ok "Agent already exists: $AGENT_ID"
@@ -372,7 +387,7 @@ else
     '{
       gameId: $gameId,
       addToCollection: true,
-      agentType: "rulebook",
+      agentType: "rag",
       agentName: $name,
       strategyName: "rag-default",
       strategyParameters: {},


### PR DESCRIPTION
## Summary
Tre fix per far girare end-to-end \`make seed-nanolith-demo\` contro stack \`make dev\`:

### Seed script (4 bug)
1. **lookup_pdf_id**: usava \`/admin/shared-games/{id}/documents\` (ritorna \`[]\` finché Ready) invece di \`/admin/pdfs\` (state authoritative)
2. **wait_for_pdf**: pollava \`/pdfs/{id}/progress\` che restituisce stato stale "Uploading 20%" anche durante Chunking — switch a \`/admin/pdfs\`
3. **agent lookup**: jq pattern non gestiva shape \`{agents:[], count}\` ritornato da GET /agents
4. **agentType "rulebook"** rifiutato da \`AgentType.Parse\` (validi: RAG/CITATION/CONFIDENCE/RULESINTERPRETER/CONVERSATION/STRATEGIST/NARRATOR) → uso \`"rag"\`

### Dockerfiles AI (timeout pip)
\`pip install\` faceva timeout su torch (~700MB) + CUDA libs (~600MB) col default 15s socket timeout.
Aggiunto \`PIP_DEFAULT_TIMEOUT=300\` + \`--retries 5\` su \`embedding-service\`, \`smoldocling-service\`, \`unstructured-service\`.
Reranker (wheels locali) invariato.

## Verified
End-to-end run riuscito contro local stack:
\`\`\`
step,resource,id,status
account,badsworm@gmail.com,...,OK
game,Nanolith,...,OK
pdf_rules,Nanolith Rules ENG.pdf,...,COMPLETE     (332 chunks)
pdf_press_start,Nanolith Press Start ENG.pdf,...,COMPLETE  (29 chunks)
agent,Nanolith Tutor,...,ACTIVE
\`\`\`

## Note (non in scope di questa PR)
Durante i test sono emersi due bug API che sono stati workaround-ati ma andrebbero tracciati come issue separate:
- \`UploadPdfCommandHandler\` lancia \`ObjectDisposedException\` nello step finalize → DB resta \`Chunking\` invece di \`Completed\` (vector_documents corretto, sono solo i metadati pdf_documents)
- \`RaptorSummaries\` ha FK su \`games\` ma quando il PDF è di una \`SharedGame\`, il GameId non esiste in \`games\` → 23503 FK violation. Workaround SQL durante seed; il path del codice andrebbe rivisto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)