### PR TITLE
fix(gamebook): route card click to /library/games/[gameId]/play (#865)

### DIFF
--- a/apps/web/e2e/gamebook-card-routing.spec.ts
+++ b/apps/web/e2e/gamebook-card-routing.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Routing fix — /gamebook card click navigates to /library/games/[gameId]/play.
+ *
+ * Issue #865: GamebookIndexView.tsx:174 previously pushed to `/gamebook/${gameId}`
+ * which is a non-existent route → 404. The play surface lives at
+ * `/library/games/[gameId]/play` (PR #794+). This spec asserts the routing fix.
+ *
+ * Why fixture override and not real backend:
+ *   `useGamebooks` is a v1 carryover STUB (see
+ *   `apps/web/src/hooks/queries/useGamebooks.ts`) — backend
+ *   `GET /api/v1/gamebooks` is NOT exposed. The fixture override
+ *   `?fixture=default` produces a deterministic ready card whose `gameId`
+ *   matches `gamebookIndexFixtures.default.gamebooks[0].gameId`.
+ *
+ * Auth bypass: triple helper (Wave B.1 pattern, Issue #633) — `(authenticated)`
+ * routes layout requires session-like cookie present.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from './_helpers/seedAuthSession';
+import { seedCookieConsent } from './_helpers/seedCookieConsent';
+
+async function seedAuth(page: Page): Promise<void> {
+  await seedAuthSession(page);
+  await seedCookieConsent(page);
+  await mockAuthEndpoints(page);
+}
+
+test.describe('Gamebook card routing', () => {
+  test.describe.configure({ retries: 0 });
+
+  test('click on ready card navigates to /library/games/[gameId]/play', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedAuth(page);
+
+    await page.goto('/gamebook?fixture=default', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-slot="gamebook-index-view"]', { timeout: 30_000 });
+
+    const readyCard = page.locator('[data-slot="gamebook-card"][data-status="ready"]').first();
+    await expect(readyCard).toBeVisible();
+
+    const gamebookId = await readyCard.getAttribute('data-gamebook-id');
+    expect(gamebookId).toBeTruthy();
+
+    await readyCard.click();
+
+    await expect(page).toHaveURL(/\/library\/games\/[^/]+\/play(?:\?.*)?$/);
+  });
+});

--- a/apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx
@@ -171,7 +171,10 @@ export function GamebookIndexView(): ReactElement {
       const gamebooks = extractGamebooks(fsmCell);
       const gamebook = gamebooks.find(g => g.id === gamebookId);
       if (gamebook && gamebook.status === 'ready') {
-        router.push(`/gamebook/${gamebook.gameId}`);
+        // Navigate to the existing play route under /library/games/[gameId]/play.
+        // The /gamebook/[id] route was never implemented (issue #865) — the play
+        // surface lives under /library/games for historical reasons (PR #794+).
+        router.push(`/library/games/${gamebook.gameId}/play`);
       }
     },
     [fsmCell, router]

--- a/apps/web/src/app/(authenticated)/gamebook/_components/__tests__/GamebookIndexView.test.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/_components/__tests__/GamebookIndexView.test.tsx
@@ -344,7 +344,7 @@ describe('GamebookIndexView — navigation', () => {
     expect(routerPush).toHaveBeenCalledWith('/gamebook/upload');
   });
 
-  it('GamebookCard click (status=ready) navigates to /gamebook/[gameId]', () => {
+  it('GamebookCard click (status=ready) navigates to /library/games/[gameId]/play', () => {
     setHookSuccess();
     renderView();
     // Pick the first ready gamebook (Nanolith)
@@ -356,11 +356,14 @@ describe('GamebookIndexView — navigation', () => {
     expect(firstReadyId).toBeTruthy();
     // The card is a button when ready — click it.
     fireEvent.click(readyCards[0] as HTMLElement);
-    // Expected gameId from default fixture: Nanolith → '00000000-0000-4000-8000-0000000c0001'
-    expect(routerPush).toHaveBeenCalledWith(expect.stringMatching(/^\/gamebook\//));
+    // Expected target: /library/games/{gameId}/play (existing route under
+    // /library — the /gamebook/[id] route was never implemented, see issue #865).
+    expect(routerPush).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/library\/games\/[^/]+\/play$/)
+    );
     // Specifically, the first ready gamebook is Nanolith.
     const expectedGameId = gamebookIndexFixtures.default.gamebooks[0].gameId;
-    expect(routerPush).toHaveBeenCalledWith(`/gamebook/${expectedGameId}`);
+    expect(routerPush).toHaveBeenCalledWith(`/library/games/${expectedGameId}/play`);
   });
 
   it('GamebookCard click does NOT fire push for status=indexing card', () => {

--- a/apps/web/src/components/v2/gamebook/GamebookCard.tsx
+++ b/apps/web/src/components/v2/gamebook/GamebookCard.tsx
@@ -75,7 +75,7 @@ export interface GamebookCardLabels {
 
 export interface GamebookCardProps {
   readonly gamebook: GamebookCardData;
-  /** Click handler — orchestrator navigates to /gamebook/[gameId]/play. */
+  /** Click handler — orchestrator navigates to /library/games/[gameId]/play. */
   readonly onClick: (gamebookId: string) => void;
   readonly labels: GamebookCardLabels;
   readonly className?: string;


### PR DESCRIPTION
## Summary

- `/gamebook` card click went to non-existent `/gamebook/[id]` (404). Route now points to `/library/games/[gameId]/play` (the actually-implemented play surface from PR #794+)
- Aligned `GamebookCard.onClick` JSDoc with the new target
- Added E2E spec `gamebook-card-routing.spec.ts` + updated existing unit test to assert the new URL

## Test plan

- [x] Unit: `pnpm vitest run src/app/(authenticated)/gamebook/_components/__tests__/GamebookIndexView.test.tsx` — 29/29 passing
- [x] Typecheck: `pnpm typecheck` — clean
- [x] Lint: no new lint issues introduced (1 pre-existing error in `gamebook-iter1a.spec.ts:104` unrelated)
- [ ] CI: Frontend Build & Test, A11y E2E, Migrated Routes Baseline (depends on visual-regression-migrated workflow)
- [ ] E2E: `gamebook-card-routing.spec.ts` runs as part of the standard E2E suite

## Compatibility with SP6 v2 freeze (#808)

✅ **Compatible** — pure bugfix on existing v2 surface. No new components under `apps/web/src/components/v2/**`. No new routes. No design token changes.

## Out of scope

- Real `GET /api/v1/gamebooks` backend wiring (replaces v1 stub `useGamebooks` per Gate B). Tracked separately.
- Login flow / seed credentials mismatch observed during manual test (`infra/secrets/admin.secret` vs DB) — separate ops issue.
- IA consolidation `/gamebook/*` ↔ `/library/games/*/play` — deferred post #807 Fase 2 (token redesign).

## Refs

- Closes #865
- Spec-panel discussion 2026-05-08 (Fowler routing decision: opzione B)
- Mockup `admin-mockups/design_files/sp6-libro-game-index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)