### PR TITLE
fix(pipeline): RAPTOR/GraphRAG FK violation on SharedGame PDFs

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -197,25 +197,39 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 #pragma warning restore CA1031
             }
 
+            // RAPTOR.RaptorSummaries and GraphRAG.GameEntityRelations both have FK
+            // on games.Id. For PDFs uploaded against a SharedGame, resolve the
+            // matching games row via PdfGameIdResolver (returns null if no
+            // games-table peer exists). Naively using pdfDoc.SharedGameId
+            // produces FK violations because shared_games.id ≠ games.Id.
+            var raptorGameId = await PdfGameIdResolver
+                .ResolveAsync(_db, pdfDoc, cancellationToken)
+                .ConfigureAwait(false);
+
             // === RAPTOR: Build hierarchical summary tree (optional, non-blocking) ===
             // Check if raptor-retrieval enhancement is globally enabled before spending LLM tokens
             var raptorEnabled = _featureFlagService != null
                 && await _featureFlagService.IsEnabledAsync("rag.enhancement.raptor-retrieval").ConfigureAwait(false);
 
-            if (_raptorIndexer != null && raptorEnabled && chunks.Count > 3)
+            if (raptorEnabled && _raptorIndexer != null && raptorGameId is null)
+            {
+                _logger.LogInformation(
+                    "[PdfPipeline] Skipping RAPTOR for PDF {PdfId}: no games-table peer (SharedGameId={SharedId}, PrivateGameId={PrivateId})",
+                    pdfDoc.Id, pdfDoc.SharedGameId, pdfDoc.PrivateGameId);
+            }
+            else if (_raptorIndexer != null && raptorEnabled && chunks.Count > 3 && raptorGameId is { } gid)
             {
                 try
                 {
                     var chunkTexts = chunks.Select(c => c.Text).ToList();
-                    var gameId = pdfDoc.SharedGameId ?? Guid.Empty;
                     var raptorResult = await _raptorIndexer.BuildTreeAsync(
-                        pdfDoc.Id, gameId,
+                        pdfDoc.Id, gid,
                         chunkTexts, maxLevels: 3, cancellationToken).ConfigureAwait(false);
 
                     if (raptorResult.TotalNodes > 0)
                     {
                         await SaveRaptorSummariesAsync(
-                            pdfDoc.Id, gameId,
+                            pdfDoc.Id, gid,
                             raptorResult.Summaries, cancellationToken).ConfigureAwait(false);
 
                         _logger.LogInformation(
@@ -229,7 +243,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                     _logger.LogWarning(ex,
                         "[PdfPipeline] RAPTOR indexing failed for PDF {PdfId}, continuing without hierarchical summaries",
                         pdfDoc.Id);
-                    // Non-blocking: document processing continues even if RAPTOR fails
+                    DetachUnsavedChanges<RaptorSummaryEntity>();
                 }
 #pragma warning restore CA1031
             }
@@ -239,14 +253,19 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             var graphRagEnabled = _featureFlagService != null
                 && await _featureFlagService.IsEnabledAsync("rag.enhancement.graph-traversal").ConfigureAwait(false);
 
-            if (_entityExtractor is not null && graphRagEnabled && fullText.Length >= 200)
+            if (graphRagEnabled && _entityExtractor is not null && raptorGameId is null)
+            {
+                _logger.LogInformation(
+                    "[PdfPipeline] Skipping Graph RAG for PDF {PdfId}: no games-table peer",
+                    pdfDoc.Id);
+            }
+            else if (_entityExtractor is not null && graphRagEnabled && fullText.Length >= 200 && raptorGameId is { } graphGid)
             {
                 try
                 {
-                    var gameId = pdfDoc.SharedGameId ?? Guid.Empty;
                     var gameTitle = pdfDoc.FileName ?? "Unknown";
                     var extraction = await _entityExtractor.ExtractEntitiesAsync(
-                        gameId, gameTitle,
+                        graphGid, gameTitle,
                         fullText[..Math.Min(fullText.Length, 8000)],
                         cancellationToken).ConfigureAwait(false);
 
@@ -255,7 +274,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         var entities = extraction.Relations.Select(r => new GameEntityRelationEntity
                         {
                             Id = Guid.NewGuid(),
-                            GameId = gameId,
+                            GameId = graphGid,
                             SourceEntity = r.SourceEntity,
                             SourceType = r.SourceType,
                             Relation = r.Relation,
@@ -279,6 +298,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                     _logger.LogWarning(ex,
                         "[PdfPipeline] Graph RAG extraction failed for PDF {PdfId}, continuing",
                         pdfDoc.Id);
+                    DetachUnsavedChanges<GameEntityRelationEntity>();
                 }
 #pragma warning restore CA1031
             }
@@ -650,6 +670,23 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             _db.RaptorSummaries.Add(entity);
         }
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Detaches Added/Modified entities of a given type from the change tracker.
+    /// Used in catch blocks of optional, non-blocking enhancement steps so a
+    /// failed SaveChangesAsync does not poison subsequent saves with the same
+    /// unflushed entities (and thus the same error).
+    /// </summary>
+    private void DetachUnsavedChanges<TEntity>() where TEntity : class
+    {
+        var entries = _db.ChangeTracker.Entries<TEntity>()
+            .Where(e => e.State is EntityState.Added or EntityState.Modified)
+            .ToList();
+        foreach (var entry in entries)
+        {
+            entry.State = EntityState.Detached;
+        }
     }
 
     private async Task MarkFailedAsync(PdfDocumentEntity pdfDoc, string errorMessage)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
@@ -190,9 +190,11 @@ public sealed class RaptorPipelineIntegrationTests : IDisposable
     }
 
     [Fact]
-    public async Task ProcessAsync_WithNullGameId_PassesGuidEmpty()
+    public async Task ProcessAsync_WithNoGameLink_SkipsRaptor()
     {
-        // Arrange — seed PDF with null GameId
+        // Arrange — PDF without PrivateGameId or SharedGameId.
+        // Without a games-table peer, RAPTOR.RaptorSummaries.GameId would
+        // violate FK_RaptorSummaries_games_GameId, so the pipeline must skip.
         var pdfDoc = new PdfDocumentEntity
         {
             Id = _pdfDocumentId,
@@ -212,25 +214,66 @@ public sealed class RaptorPipelineIntegrationTests : IDisposable
         SetupEmbeddingsToReturn(4);
         SetupBlobStorageToReturn();
 
-        _raptorIndexerMock
-            .Setup(r => r.BuildTreeAsync(
-                _pdfDocumentId, Guid.Empty,
-                It.IsAny<IReadOnlyList<string>>(), 3,
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RaptorTreeResult(0, 0, new List<RaptorSummaryNode>()));
+        var sut = CreatePipelineService(withRaptor: true);
+
+        // Act
+        await sut.ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        // Assert: RAPTOR was skipped (no FK violation), pipeline still completes
+        _raptorIndexerMock.Verify(
+            r => r.BuildTreeAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var doc = await _db.PdfDocuments.FindAsync(_pdfDocumentId);
+        doc!.ProcessingState.Should().Be("Ready");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SharedGameWithoutMatchingGameRow_SkipsRaptor()
+    {
+        // Arrange — SharedGame PDF whose SharedGameId has NO matching games row.
+        // Reproduces the FK violation observed during Nanolith dogfood seed:
+        // FK_RaptorSummaries_games_GameId would fail at SaveChangesAsync.
+        var sharedGameId = Guid.NewGuid();
+        var pdfDoc = new PdfDocumentEntity
+        {
+            Id = _pdfDocumentId,
+            SharedGameId = sharedGameId,
+            FileName = "test.pdf",
+            FilePath = "/fake/path/test.pdf",
+            ContentType = "application/pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Uploading",
+            UploadedAt = DateTime.UtcNow
+        };
+        _db.PdfDocuments.Add(pdfDoc);
+        _db.SaveChanges();
+
+        SetupExtractorToReturn("chunk1. chunk2. chunk3. chunk4.", 4);
+        SetupChunkingToReturn(4);
+        SetupEmbeddingsToReturn(4);
+        SetupBlobStorageToReturn();
 
         var sut = CreatePipelineService(withRaptor: true);
 
         // Act
         await sut.ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
 
-        // Assert: called with Guid.Empty for null GameId
+        // Assert: RAPTOR skipped, no summaries persisted, PDF reaches Ready
         _raptorIndexerMock.Verify(
             r => r.BuildTreeAsync(
-                _pdfDocumentId, Guid.Empty,
-                It.IsAny<IReadOnlyList<string>>(), 3,
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
-            Times.Once);
+            Times.Never);
+
+        (await _db.RaptorSummaries.ToListAsync()).Should().BeEmpty();
+        var doc = await _db.PdfDocuments.FindAsync(_pdfDocumentId);
+        doc!.ProcessingState.Should().Be("Ready");
     }
 
     private PdfProcessingPipelineService CreatePipelineService(bool withRaptor)
@@ -259,10 +302,12 @@ public sealed class RaptorPipelineIntegrationTests : IDisposable
 
     private PdfDocumentEntity SeedPdfDocument(string state)
     {
+        // Use PrivateGameId so PdfGameIdResolver returns _gameId directly without a games-table lookup.
+        // SharedGameId path is exercised by dedicated tests below.
         var pdfDoc = new PdfDocumentEntity
         {
             Id = _pdfDocumentId,
-            SharedGameId = _gameId,
+            PrivateGameId = _gameId,
             FileName = "test.pdf",
             FilePath = "/fake/path/test.pdf",
             ContentType = "application/pdf",


### PR DESCRIPTION
## Problem

Durante il seed Nanolith dogfood, l'upload PDF su un \`SharedGame\` falliva nel pipeline async con:

\`\`\`
Npgsql.PostgresException: 23503: insert or update on table 'RaptorSummaries'
violates foreign key constraint 'FK_RaptorSummaries_games_GameId'
\`\`\`

**Root cause**: \`RaptorSummaries.GameId\` e \`GameEntityRelations.GameId\` sono FK su \`games.Id\`, ma \`PdfProcessingPipelineService\` passava \`pdfDoc.SharedGameId ?? Guid.Empty\`. \`shared_games\` è una tabella separata → FK violation.

**Sintomo composto**: il \`SaveChangesAsync\` fallito lasciava le \`RaptorSummaryEntity\` aggiunte nel change tracker. I save successivi (finalize, error handler) le riprovano → cascade FK violations → \`ObjectDisposedException\` quando lo scope viene disposto.

## Fix

1. Uso il \`PdfGameIdResolver\` già esistente (gestisce PrivateGameId diretto + SharedGameId → Game.SharedGameId lookup, ritorna null se non c'è peer)
2. Skip RAPTOR + GraphRAG con info log quando resolver è null (sono optional non-blocking, comportamento corretto pre-#867)
3. \`DetachUnsavedChanges<TEntity>()\` per detach delle entries Added/Modified su catch

## Tests

- \`ProcessAsync_WithNoGameLink_SkipsRaptor\`
- \`ProcessAsync_SharedGameWithoutMatchingGameRow_SkipsRaptor\` (riproduce esattamente il caso Nanolith)
- Test esistenti adeguati a usare \`PrivateGameId\` (resolver lo ritorna diretto)

**Nota**: 6 test failures pre-esistenti su main-dev (EF Core 9 InMemory provider con \`IReadOnlyList<string>\` value converter, non legato a questo fix) restano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)