### PR TITLE
fix(seed): idempotent password sync for Badsworm seed (#870)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormUserCommandHandler.cs
@@ -18,7 +18,13 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// (docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md) and as
 /// the staging allowlist whitelisted user (DevOps wave 1, devops-policy.md §4).
 ///
-/// Idempotent: Only executes if user doesn't exist.
+/// Idempotent with password sync (issue #870):
+/// - User missing → create with secret password.
+/// - User exists, password matches secret → skip (no DB write).
+/// - User exists, password differs from secret → admin-style password reset
+///   so the secret remains the source of truth across rotations and dev DB
+///   restores.
+///
 /// Runs in all environments (Dev, Staging, Prod) when SEED_BADSWORM_PASSWORD secret is present.
 /// Remove or leave the secret absent in environments where this account should not exist.
 /// </summary>
@@ -64,7 +70,21 @@ internal sealed class SeedBadswormUserCommandHandler : ICommandHandler<SeedBadsw
         var existingUser = await _userRepository.GetByEmailAsync(emailValue, cancellationToken).ConfigureAwait(false);
         if (existingUser != null)
         {
-            _logger.LogInformation("Badsworm user already exists. Skipping seed.");
+            // Issue #870: keep the secret as source of truth. If the secret has
+            // been rotated since user creation (or the dev DB was seeded with
+            // a stale value), sync the password so manual login still works.
+            if (existingUser.VerifyPassword(password))
+            {
+                _logger.LogInformation("Badsworm user already exists with matching password. Skipping seed.");
+                return;
+            }
+
+            existingUser.UpdatePassword(PasswordHash.Create(password));
+            await _userRepository.UpdateAsync(existingUser, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Badsworm user password synced from SEED_BADSWORM_PASSWORD secret: {Email}",
+                DataMasking.MaskEmail(BadswormEmail));
             return;
         }
 

--- a/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Administration/SeedBadswormUserCommandHandlerTests.cs
@@ -41,16 +41,47 @@ public sealed class SeedBadswormUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenBadswormUserExists_ShouldSkipSeed()
+    public async Task Handle_WhenBadswormUserExistsWithMatchingPassword_ShouldSkipUpdate()
     {
+        // Existing user has a password that matches the configured secret —
+        // no DB write should happen.
         _userRepositoryMock
             .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateBadswormUser());
+            .ReturnsAsync(CreateBadswormUser(BadswormPassword));
 
         await _handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
 
         _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _userRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
         _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenBadswormUserExistsWithDifferentPassword_ShouldUpdatePassword()
+    {
+        // Issue #870: secret has rotated since user creation (or the local DB
+        // was seeded with a stale value) — handler must update the password
+        // so the secret remains the source of truth.
+        const string staleStoredPassword = "OldPasswordRotated2025!"; // gitguardian:ignore
+        var existingUser = CreateBadswormUser(staleStoredPassword);
+
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingUser);
+
+        await _handler.Handle(new SeedBadswormUserCommand(), CancellationToken.None);
+
+        // Repository AddAsync should NOT be called — user already exists.
+        _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        // UpdateAsync called once with the same existing user instance.
+        _userRepositoryMock.Verify(
+            x => x.UpdateAsync(It.Is<User>(u => u.Id == existingUser.Id), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        // Domain side-effect: VerifyPassword should now succeed against the
+        // configured secret (not the stale stored password).
+        existingUser.VerifyPassword(BadswormPassword).Should().BeTrue();
+        existingUser.VerifyPassword(staleStoredPassword).Should().BeFalse();
     }
 
     [Fact]
@@ -110,13 +141,13 @@ public sealed class SeedBadswormUserCommandHandlerTests
         _userRepositoryMock.Verify(x => x.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    private static User CreateBadswormUser()
+    private static User CreateBadswormUser(string password = BadswormPassword)
     {
         return new User(
             Guid.NewGuid(),
             new Email("badsworm@gmail.com"),
             "Badsworm",
-            PasswordHash.Create(BadswormPassword),
+            PasswordHash.Create(password),
             Role.User
         );
     }


### PR DESCRIPTION
## Summary

- `SeedBadswormUserCommandHandler` previously skipped if user existed → secret rotation = stale password forever
- Now: user missing → create; user exists with matching password → skip; user exists with different password → `User.UpdatePassword` + `UpdateAsync` + `SaveChanges`
- Secret remains source of truth across rotations and dev DB restores

## Test plan

- [x] Unit: `dotnet test --filter SeedBadswormUserCommandHandlerTests` — **5/5 passing**
  - `WhenBadswormUserExistsWithMatchingPassword_ShouldSkipUpdate` (renamed)
  - `WhenBadswormUserExistsWithDifferentPassword_ShouldUpdatePassword` (new)
  - existing 3 tests untouched (create / no-secret / short-secret)
- [x] Build: `dotnet build` — clean (0 errors, 0 new warnings)
- [ ] Manual smoke: deferred to merge — restart `meepleai-api` container, re-run seed, attempt login as `badsworm@gmail.com` with `SEED_BADSWORM_PASSWORD` from `infra/secrets/admin.secret`

## Scope

- ✅ Badsworm seed only (per #870 issue body)
- ❌ NOT included: `INITIAL_ADMIN_PASSWORD` / `ADMIN_PASSWORD` — those remain idempotent skip-only (boot-time validation, not a credential to rotate)

## Why this matters

Unblocks E2E real-login spec from PR #867 step 5. Without this fix the local DB drifts from `admin.secret` permanently after the first seed, requiring DB surgery or password reset flow to recover.

## Refs

- Closes #870
- Related: PR #867 (gamebook routing fix that needs real login for E2E)
- Domain method: `User.UpdatePassword(PasswordHash)` (admin-style reset, no current password required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)