### PR TITLE
feat: GET /api/v1/gamebooks endpoint + frontend wiring (#869, Phase 1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/GamebookCardDataDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/GamebookCardDataDto.cs
@@ -1,0 +1,41 @@
+namespace Api.BoundedContexts.UserLibrary.Application.DTOs;
+
+/// <summary>
+/// DTO for `GET /api/v1/gamebooks` (Issue #869).
+///
+/// Mirrors the frontend Zod schema `GamebookCardData` in
+/// `apps/web/src/lib/gamebook-index/schemas.ts`. Drives the SP6 libro game
+/// index card rendering (`apps/web/src/components/v2/gamebook/GamebookCard.tsx`).
+///
+/// MVP scope (Issue #869, Phase 1):
+///   Only the fields backed by `PrivateGame` are populated with real data
+///   (Id, GameId, Title, Year, Cover). The composition fields (Pages,
+///   TotalPages, Chunks, QaCount, SessionsCount, Status, ErrorMsg) require
+///   joins across DocumentProcessing + KnowledgeBase + SessionTracking BCs
+///   and are deferred to a follow-up issue. They return safe defaults so the
+///   frontend can still render meaningful cards (status='ready' placeholder,
+///   counts=0, errorMsg=null).
+///
+/// Follow-up wiring (out of scope here):
+///   - Pages / TotalPages: join PdfDocument by PrivateGameId, map ProgressPercentage
+///   - Chunks: count text_chunks WHERE GameId
+///   - QaCount: count chat_messages WHERE Role='user' AND ChatThread.GameId AND !IsDeleted
+///   - SessionsCount: count gamebook_campaign_sessions WHERE GameId AND OwnerUserId
+///   - Status: map PdfDocument.ProcessingState (Ready→ready, Failed→error, else→indexing)
+///   - ErrorMsg: PdfDocument.ProcessingError when ProcessingState=Failed
+/// </summary>
+public sealed record GamebookCardDataDto(
+    Guid Id,
+    Guid GameId,
+    string Title,
+    string? Publisher,
+    int? Year,
+    int Pages,
+    int TotalPages,
+    int Chunks,
+    string Status,
+    string? Cover,
+    string? Emoji,
+    int QaCount,
+    int SessionsCount,
+    string? ErrorMsg);

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/Gamebooks/GetUserGamebooksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/Gamebooks/GetUserGamebooksQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries.Gamebooks;
+
+/// <summary>
+/// Query for `GET /api/v1/gamebooks` (Issue #869).
+///
+/// Returns the list of gamebook cards for the authenticated user, sourced
+/// from PrivateGame aggregates. See <see cref="GamebookCardDataDto"/> for
+/// the MVP scope and deferred fields.
+/// </summary>
+internal sealed record GetUserGamebooksQuery(Guid UserId) : IQuery<IReadOnlyList<GamebookCardDataDto>>;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/Gamebooks/GetUserGamebooksQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/Gamebooks/GetUserGamebooksQueryHandler.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserLibrary.Application.Queries.Gamebooks;
+
+/// <summary>
+/// Handler for <see cref="GetUserGamebooksQuery"/> (Issue #869).
+///
+/// MVP scope (Phase 1):
+///   Returns one card per PrivateGame owned by the user. Counts and status
+///   are placeholders pending cross-BC composition (see DTO XML doc).
+/// </summary>
+internal sealed class GetUserGamebooksQueryHandler
+    : IQueryHandler<GetUserGamebooksQuery, IReadOnlyList<GamebookCardDataDto>>
+{
+    private readonly IPrivateGameRepository _privateGameRepository;
+
+    public GetUserGamebooksQueryHandler(IPrivateGameRepository privateGameRepository)
+    {
+        _privateGameRepository = privateGameRepository
+            ?? throw new ArgumentNullException(nameof(privateGameRepository));
+    }
+
+    public async Task<IReadOnlyList<GamebookCardDataDto>> Handle(
+        GetUserGamebooksQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var games = await _privateGameRepository
+            .GetByOwnerIdAsync(query.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return games
+            .OrderByDescending(g => g.UpdatedAt ?? g.CreatedAt)
+            .Select(MapToDto)
+            .ToList();
+    }
+
+    private static GamebookCardDataDto MapToDto(PrivateGame game) => new(
+        Id: game.Id,
+        GameId: game.Id,
+        Title: game.Title,
+        Publisher: null,
+        Year: game.YearPublished,
+        Pages: 0,
+        TotalPages: 0,
+        Chunks: 0,
+        Status: "ready",
+        Cover: game.ImageUrl,
+        Emoji: null,
+        QaCount: 0,
+        SessionsCount: 0,
+        ErrorMsg: null);
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -710,6 +710,7 @@ v1Api.MapGamePhaseTemplateEndpoints(); // Game phase templates for session setup
 v1Api.MapBggEndpoints(); // ISSUE-3120: BoardGameGeek integration
 v1Api.MapGameManagementEndpoints(); // Issue #4273: Game search autocomplete
 v1Api.MapPrivateGameEndpoints();       // Private games (Issue #3663)
+v1Api.MapUserGamebooksEndpoints();     // SP6 libro game /gamebook index (Issue #869)
 v1Api.MapRuleSpecEndpoints();
 v1Api.MapGameNightEndpoints(); // Issue #46/#607: Game Night Event + public token-based RSVP (Wave A.5)
 

--- a/apps/api/src/Api/Routing/UserGamebooksEndpoints.cs
+++ b/apps/api/src/Api/Routing/UserGamebooksEndpoints.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.DTOs;
+using Api.BoundedContexts.UserLibrary.Application.Queries.Gamebooks;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// User gamebooks endpoint for the SP6 libro game `/gamebook` index page
+/// (Issue #869).
+///
+/// Replaces the v1 carryover stub `useGamebooks` in
+/// `apps/web/src/hooks/queries/useGamebooks.ts` so the index renders real
+/// data instead of fixture, allowing the routing fix from PR #867 to land
+/// users on a real `/library/games/{gameId}/play` URL.
+/// </summary>
+internal static class UserGamebooksEndpoints
+{
+    public static RouteGroupBuilder MapUserGamebooksEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/gamebooks", async (
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator
+                .Send(new GetUserGamebooksQuery(userId), ct)
+                .ConfigureAwait(false);
+
+            return Results.Ok(result);
+        })
+        .RequireAuthorization()
+        .Produces<IReadOnlyList<GamebookCardDataDto>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .WithName("GetUserGamebooks")
+        .WithTags("Gamebooks")
+        .WithOpenApi(operation =>
+        {
+            operation.Summary = "List the authenticated user's gamebooks";
+            operation.Description = "Returns the gamebook cards displayed on /gamebook (SP6 libro game index). MVP scope: card metadata sourced from PrivateGame; counts and status placeholders deferred to follow-up.";
+            return operation;
+        });
+
+        return group;
+    }
+
+    private static bool TryGetUserId(HttpContext context, SessionStatusDto? session, out Guid userId)
+    {
+        userId = Guid.Empty;
+        if (session != null)
+        {
+            userId = session.User!.Id;
+            return true;
+        }
+
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrEmpty(userIdClaim) && Guid.TryParse(userIdClaim, out userId))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useGamebooks.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGamebooks.test.tsx
@@ -1,22 +1,31 @@
 /**
  * @vitest-environment jsdom
  *
- * useGamebooks / useQuotaInfo unit tests — SP6 Phase B Task 3 (Issue #788).
+ * useGamebooks / useQuotaInfo unit tests — SP6 Phase B Task 3 (Issue #788),
+ * updated for backend wiring (Issue #869).
  *
  * Coverage:
  *   - Stable queryKey contract (gamebookKeys)
- *   - useGamebooks resolves to canonical fixture data
- *   - useQuotaInfo resolves to canonical fixture data
- *   - Hooks remain in sync with `gamebookIndexFixtures.default`
+ *   - useGamebooks fetches via `fetchUserGamebooks` and surfaces the response
+ *   - useGamebooks propagates fetch errors to the query state
+ *   - useQuotaInfo still returns canonical fixture data (Gate B carryover —
+ *     backend GET /api/v1/users/me/quota deferred to follow-up)
  */
 
 import { type ReactNode } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { gamebookIndexFixtures } from '@/lib/gamebook-index';
+import { gamebookIndexFixtures, type GamebookCardData } from '@/lib/gamebook-index';
+
+const fetchUserGamebooksMock =
+  vi.fn<(signal?: AbortSignal) => Promise<readonly GamebookCardData[]>>();
+
+vi.mock('@/lib/api/gamebooks-list', () => ({
+  fetchUserGamebooks: (signal?: AbortSignal) => fetchUserGamebooksMock(signal),
+}));
 
 import { gamebookKeys, useGamebooks, useQuotaInfo } from '../useGamebooks';
 
@@ -28,6 +37,10 @@ function createWrapper() {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 }
+
+beforeEach(() => {
+  fetchUserGamebooksMock.mockReset();
+});
 
 describe('gamebookKeys', () => {
   it('returns stable key for myGamebooks', () => {
@@ -44,22 +57,36 @@ describe('gamebookKeys', () => {
 });
 
 describe('useGamebooks', () => {
-  it('returns canonical fixture gamebooks on success', async () => {
+  it('returns the gamebooks resolved by fetchUserGamebooks', async () => {
+    fetchUserGamebooksMock.mockResolvedValue(gamebookIndexFixtures.default.gamebooks);
+
     const { result } = renderHook(() => useGamebooks(), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(fetchUserGamebooksMock).toHaveBeenCalledTimes(1);
     expect(result.current.data).toEqual(gamebookIndexFixtures.default.gamebooks);
   });
 
-  it('exposes 4 fixture gamebooks (1 ready Nanolith, 1 ready Brass, 1 indexing, 1 error)', async () => {
+  it('returns an empty list without throwing when the user has no gamebooks', async () => {
+    fetchUserGamebooksMock.mockResolvedValue([]);
+
     const { result } = renderHook(() => useGamebooks(), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toHaveLength(4);
-    const statuses = (result.current.data ?? []).map(gb => gb.status);
-    expect(statuses).toEqual(['ready', 'ready', 'indexing', 'error']);
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('exposes the fetch error to the query state', async () => {
+    const failure = new Error('Gamebooks list API error 500: oops');
+    fetchUserGamebooksMock.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useGamebooks(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBe(failure);
   });
 });
 

--- a/apps/web/src/hooks/queries/useGamebooks.ts
+++ b/apps/web/src/hooks/queries/useGamebooks.ts
@@ -1,26 +1,12 @@
 /**
- * useGamebooks — SP6 Phase B v1 carryover STUB hooks (Issue #788).
+ * useGamebooks — SP6 Phase B hooks (Issue #788; backend wired in #869).
  *
- * Schema reality v1 carryover (Gate B):
- *   The backend `GET /api/v1/gamebooks` endpoint and `GET /api/v1/users/me/quota`
- *   (or equivalent) DO NOT exist on main-dev. Verified via:
- *     grep -rn "MapGet.*gamebook\|MapGet.*GameBook" apps/api/src/Api/Routing/
- *     grep -rn "MapGet.*quota\|MapGet.*Quota" apps/api/src/Api/Routing/
- *
- *   To unblock the orchestrator (Phase B Task 3) without coupling to a
- *   non-existent endpoint, this module exposes 2 hooks that resolve via the
- *   canonical visual-test fixture data. Both queries report `isPending=false`
- *   immediately so the FSM never gets stuck in the `loading` cell during real
- *   data flows (the orchestrator simulates the loading cell via the
- *   `?fixture=loading` URL override gated by `STATE_OVERRIDE_ENABLED`).
- *
- *   Real backend integration is deferred to a follow-up issue post-Phase B
- *   that will:
- *     1. Expose `GET /api/v1/gamebooks` returning the canonical
- *        `GamebookCardData[]` shape (or an adapter from the actual DTO).
- *     2. Expose `GET /api/v1/users/me/quota` returning `QuotaInfo`.
- *     3. Replace the fixture-data `queryFn` with `api.gamebooks.list()` and
- *        `api.users.quota()` (or equivalent client paths).
+ * Issue #869 status:
+ *   - `useGamebooks`  → wired to `GET /api/v1/gamebooks` (real data)
+ *   - `useQuotaInfo`  → STILL STUB pending follow-up (`GET /api/v1/users/me/quota`
+ *                       not yet exposed). The stub returns canonical fixture
+ *                       data so the orchestrator FSM keeps rendering correctly
+ *                       until the quota endpoint lands.
  *
  * Used by:
  *   - `apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx`
@@ -30,6 +16,7 @@
 
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+import { fetchUserGamebooks } from '@/lib/api/gamebooks-list';
 import { gamebookIndexFixtures, type GamebookCardData, type QuotaInfo } from '@/lib/gamebook-index';
 
 /**
@@ -47,19 +34,17 @@ export const gamebookKeys = {
 /**
  * Hook to fetch the current user's gamebook library.
  *
- * v1 carryover: returns the canonical fixture data via `gamebookIndexFixtures.default`.
- * The backend `GET /api/v1/gamebooks` endpoint is NOT exposed; integration
- * deferred to a follow-up issue.
+ * Wired to `GET /api/v1/gamebooks` via `fetchUserGamebooks`. The endpoint
+ * returns 200 with `[]` when the user has no gamebooks; 401 when the
+ * session is invalid (TanStack Query surfaces the error and the
+ * orchestrator renders the `error` FSM cell).
  *
  * @returns UseQueryResult with the readonly array of gamebooks.
  */
 export function useGamebooks(): UseQueryResult<readonly GamebookCardData[], Error> {
   return useQuery({
     queryKey: gamebookKeys.myGamebooks(),
-    queryFn: async (): Promise<readonly GamebookCardData[]> => {
-      // v1 carryover stub — return canonical fixture data.
-      return gamebookIndexFixtures.default.gamebooks;
-    },
+    queryFn: ({ signal }) => fetchUserGamebooks(signal),
     staleTime: 60_000,
   });
 }
@@ -69,7 +54,7 @@ export function useGamebooks(): UseQueryResult<readonly GamebookCardData[], Erro
  *
  * v1 carryover: returns the canonical fixture data via `gamebookIndexFixtures.default`.
  * The backend `GET /api/v1/users/me/quota` endpoint is NOT exposed; integration
- * deferred to a follow-up issue.
+ * deferred to a follow-up (issue #869b — split from #869 to keep PR small).
  *
  * @returns UseQueryResult with the QuotaInfo object.
  */

--- a/apps/web/src/lib/api/gamebooks-list.ts
+++ b/apps/web/src/lib/api/gamebooks-list.ts
@@ -1,0 +1,42 @@
+/**
+ * Gamebooks list API client (Issue #869).
+ *
+ * Endpoint: GET /api/v1/gamebooks
+ *
+ * Returns the list of gamebook cards displayed on the SP6 libro game
+ * `/gamebook` index page. Replaces the v1 carryover stub
+ * `gamebookIndexFixtures.default.gamebooks` consumed by the legacy
+ * `useGamebooks` hook.
+ *
+ * Backend handler: `GetUserGamebooksQueryHandler` (UserLibrary BC).
+ */
+
+import { z } from 'zod';
+
+import { gamebookCardDataSchema, type GamebookCardData } from '@/lib/gamebook-index/schemas';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const responseSchema = z.array(gamebookCardDataSchema);
+
+export async function fetchUserGamebooks(
+  signal?: AbortSignal
+): Promise<readonly GamebookCardData[]> {
+  const res = await fetch(`${API_BASE}/api/v1/gamebooks`, {
+    credentials: 'include',
+    signal,
+  });
+
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = await res.text();
+    } catch {
+      /* ignore body read failure */
+    }
+    throw new Error(`Gamebooks list API error ${res.status}: ${detail || res.statusText}`);
+  }
+
+  const raw = (await res.json()) as unknown;
+  return responseSchema.parse(raw);
+}


### PR DESCRIPTION
## Summary

Backend + frontend wiring for the SP6 libro game `/gamebook` index page so it renders the user's actual `PrivateGame` data instead of the v1 carryover stub fixture. Together with PR #867 (routing fix), clicking a card now lands on `/library/games/{realGameId}/play` with a real game id.

## Scope (Phase 1 of #869)

**Included**
- `GET /api/v1/gamebooks` — returns `GamebookCardDataDto[]` for the authenticated user (sourced from `IPrivateGameRepository.GetByOwnerIdAsync`)
- New backend artifacts under `UserLibrary` BC (CQRS): DTO, Query, Handler, Endpoint
- New frontend client `gamebooks-list.ts` with Zod response validation
- `useGamebooks` hook now fetches the real endpoint (abort signal + 60s staleTime)
- 8/8 frontend hook tests passing (success/empty/error/queryKey/quota)
- `dotnet build` clean

**Deferred to follow-up** (#869 Phase 2)
- `GET /api/v1/users/me/quota` — `useQuotaInfo` remains a fixture stub (Gate B documented)
- `user_translation_quotas` table + migration
- Composition fields on the gamebook card (Pages, Chunks, QaCount, SessionsCount, Status, ErrorMsg) — currently safe placeholders. The DTO's XML doc documents the wiring strategy across `DocumentProcessing` + `KnowledgeBase` + `SessionTracking` BCs

## Test plan

- [x] Backend `dotnet build` — 0 errors / 0 warnings
- [x] Frontend `pnpm vitest run useGamebooks.test.tsx` — 8/8 passing
- [x] Frontend `pnpm typecheck` — clean
- [ ] Manual smoke: restart `meepleai-api` container; login as Badsworm; visit `/gamebook` and verify Nanolith card appears with real DB UUID (`c18e11f0...`); click and confirm landing on `/library/games/c18e11f0-.../play`

## Notes — workspace race condition

This PR was completed inside an isolated `git worktree` at `D:/Repositories/meepleai-mono-wt869` because the main workspace was being mutated in parallel (branch checkouts moving HEAD mid-commit). There is one orphan commit (`92365d88c`, identical content to the cherry-picked `c802201c5` here) sitting on `feature/p2-807-token-redesign` from the recovery dance. Safe to leave it (no semantic effect on that branch's #807 work) or drop with `git revert 92365d88c`.

## Refs

- Closes #869 (Phase 1 — gamebooks endpoint). Quota endpoint left open as Phase 2 in the same issue, or split to a new issue if preferred.
- Builds on PR #867 (routing fix) and PR #872 (seed sync)
- Frontend Zod schema: `apps/web/src/lib/gamebook-index/schemas.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)