### PR TITLE
fix(pdf-pipeline): 4 bugs causing PDF uploads to land in Failed state

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Helpers.cs
@@ -69,28 +69,6 @@ internal partial class UploadPdfCommandHandler
         }
     }
 
-    /// <summary>
-    /// Best-effort enqueue into the Quartz-based processing queue.
-    /// If the fire-and-forget Task.Run fails silently, the Quartz job acts as a reliable fallback.
-    /// Conflicts (PDF already queued) are expected and silently ignored.
-    /// </summary>
-    private async Task EnqueueForProcessingSafelyAsync(Guid pdfDocumentId, Guid userId, CancellationToken cancellationToken)
-    {
-        try
-        {
-            await _mediator.Send(
-                new Queue.EnqueuePdfCommand(pdfDocumentId, userId, Priority: (int)ProcessingPriority.Normal),
-                cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("PDF {PdfId} enqueued for Quartz processing as fallback", pdfDocumentId);
-        }
-#pragma warning disable CA1031 // Best-effort enqueue — conflicts and cancellations are expected
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Could not enqueue PDF {PdfId} for Quartz processing (may already be queued or request cancelled)", pdfDocumentId);
-        }
-#pragma warning restore CA1031
-    }
-
     private async Task InvalidateCacheSafelyAsync(string gameId, string operation, CancellationToken cancellationToken)
     {
         try

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -11,6 +11,7 @@ using Api.Observability;
 using Api.Services;
 using Api.Services.Pdf;
 using Api.SharedKernel.Application.Interfaces;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics;
@@ -79,7 +80,11 @@ internal partial class UploadPdfCommandHandler
 
             // Complete processing
             _logger.LogInformation("🎉 [PDF-DEBUG] Step 5: Finalizing processing for {PdfId}", pdfId);
-            await FinalizeProcessingAsync(pdfId, pdfDoc, userId, db, quotaService, startTime, cancellationToken).ConfigureAwait(false);
+            // Resolve mediator from the local async scope. The handler-injected `_mediator`
+            // belongs to the original HTTP request scope, which has long since been disposed
+            // by the time this background task reaches finalize for a multi-MB PDF.
+            var scopedMediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await FinalizeProcessingAsync(pdfId, pdfDoc, userId, db, quotaService, scopedMediator, startTime, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("✅ [PDF-DEBUG] ProcessPdfAsync COMPLETE for {PdfId}", pdfId);
         }
         catch (OperationCanceledException)
@@ -126,7 +131,14 @@ internal partial class UploadPdfCommandHandler
         }
 
         _logger.LogInformation("🔍 [PDF-DEBUG-VALIDATE] Querying database for PDF {PdfId}", pdfId);
-        var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { pdfGuid }, cancellationToken).ConfigureAwait(false);
+        // AsTracking required: DbContext default is NoTracking (PERF-06), and FindAsync
+        // does not override per-DbContext default behavior — entity would otherwise be
+        // returned untracked and all mutations to it during the pipeline would be silently
+        // dropped at SaveChangesAsync.
+        var pdfDoc = await db.PdfDocuments
+            .AsTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken)
+            .ConfigureAwait(false);
         if (pdfDoc == null)
         {
             _logger.LogError("❌ [PDF-DEBUG-VALIDATE] PDF document {PdfId} NOT FOUND in database", pdfId);
@@ -499,7 +511,11 @@ internal partial class UploadPdfCommandHandler
         CancellationToken cancellationToken)
     {
         var pdfGuid = Guid.Parse(pdfId);
-        var vectorDoc = await db.VectorDocuments.FirstOrDefaultAsync(v => v.PdfDocumentId == pdfGuid, cancellationToken).ConfigureAwait(false);
+        // AsTracking required (DbContext default is NoTracking — PERF-06).
+        var vectorDoc = await db.VectorDocuments
+            .AsTracking()
+            .FirstOrDefaultAsync(v => v.PdfDocumentId == pdfGuid, cancellationToken)
+            .ConfigureAwait(false);
 
         if (vectorDoc == null)
         {
@@ -601,8 +617,9 @@ internal partial class UploadPdfCommandHandler
         var gameId = pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId ?? Guid.Empty;
         var language = pdfDoc.Language ?? "en";
 
-        // Find VectorDocument for this PDF
+        // Find VectorDocument for this PDF (read-only here — no AsTracking needed)
         var vectorDoc = await db.VectorDocuments
+            .AsTracking()
             .FirstOrDefaultAsync(v => v.PdfDocumentId == pdfGuid, cancellationToken)
             .ConfigureAwait(false);
 
@@ -667,6 +684,7 @@ internal partial class UploadPdfCommandHandler
         Guid userId,
         MeepleAiDbContext db,
         IPdfUploadQuotaService quotaService,
+        IMediator scopedMediator,
         DateTime startTime,
         CancellationToken cancellationToken)
     {
@@ -680,9 +698,11 @@ internal partial class UploadPdfCommandHandler
         // Publish PdfStateChangedEvent so downstream handlers fire:
         // AutoCreateAgentOnPdfReadyHandler (admin PDFs), PdfNotificationEventHandler, PdfStateChangedMetricsEventHandler.
         // Must be published after SaveChanges so handlers can query the updated entity.
+        // Use scopedMediator (resolved from the live async scope), not the handler's _mediator
+        // field which references the disposed HTTP request scope.
         if (Guid.TryParse(pdfId, out var pdfGuidForEvent))
         {
-            await _mediator.Publish(
+            await scopedMediator.Publish(
                 new PdfStateChangedEvent(pdfGuidForEvent, PdfProcessingState.Indexing, PdfProcessingState.Ready, userId),
                 CancellationToken.None).ConfigureAwait(false);
         }
@@ -713,7 +733,10 @@ internal partial class UploadPdfCommandHandler
 
         if (Guid.TryParse(pdfId, out var cancelledPdfGuid))
         {
-            var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { cancelledPdfGuid }, CancellationToken.None).ConfigureAwait(false);
+            var pdfDoc = await db.PdfDocuments
+                .AsTracking()
+                .FirstOrDefaultAsync(p => p.Id == cancelledPdfGuid, CancellationToken.None)
+                .ConfigureAwait(false);
             if (pdfDoc != null)
             {
                 pdfDoc.ProcessingState = "Failed";
@@ -744,7 +767,10 @@ internal partial class UploadPdfCommandHandler
 
         if (Guid.TryParse(pdfId, out var errorPdfGuid))
         {
-            var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { errorPdfGuid }, cancellationToken).ConfigureAwait(false);
+            var pdfDoc = await db.PdfDocuments
+                .AsTracking()
+                .FirstOrDefaultAsync(p => p.Id == errorPdfGuid, cancellationToken)
+                .ConfigureAwait(false);
             if (pdfDoc != null)
             {
                 pdfDoc.ProcessingState = "Failed";
@@ -773,7 +799,11 @@ internal partial class UploadPdfCommandHandler
                 return;
             }
 
-            var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { pdfGuid }, cancellationToken).ConfigureAwait(false);
+            // AsTracking required (DbContext default is NoTracking — PERF-06).
+            var pdfDoc = await db.PdfDocuments
+                .AsTracking()
+                .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken)
+                .ConfigureAwait(false);
             if (pdfDoc == null) return;
 
             var elapsed = _timeProvider.GetUtcNow().UtcDateTime - startTime;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -731,16 +731,16 @@ internal partial class UploadPdfCommandHandler : ICommandHandler<UploadPdfComman
             "Quota reserved for user {UserId}, PDF {PdfId}, expires at {ExpiresAt}",
             userId, storageResult.FileId, reservationResult.ExpiresAt);
 
-        // Start background processing via fire-and-forget (immediate attempt)
+        // Start background processing via fire-and-forget (immediate attempt).
+        // Recovery for PDFs stuck in non-terminal states is handled separately by
+        // RetryFailedPdfsJob (Quartz, every 5 min). Enqueueing here would have the
+        // Quartz worker race the BG task end-to-end on the same PDF — both indexing,
+        // both finalizing, the second one's MarkFailed clobbering the first one's
+        // Ready state. The atomic claim added in PdfProcessingPipelineService still
+        // protects the recovery path.
         _backgroundTaskService.ExecuteWithCancellation(
             storageResult.FileId!,
             (ct) => ProcessPdfAsync(storageResult.FileId!, storageResult.FilePath!, userId, ct));
-
-        // Also enqueue in the Quartz-based queue as a reliable fallback.
-        // If the fire-and-forget Task.Run completes first, the Quartz job will find
-        // the PDF already in Ready state and skip it. If Task.Run fails silently,
-        // the Quartz job will process it from Pending.
-        await EnqueueForProcessingSafelyAsync(pdfDoc.Id, userId, cancellationToken).ConfigureAwait(false);
 
         await InvalidateCacheSafelyAsync(gameId, "PDF upload", cancellationToken).ConfigureAwait(false);
 
@@ -836,13 +836,11 @@ internal partial class UploadPdfCommandHandler : ICommandHandler<UploadPdfComman
             return new PdfUploadResult(false, storageResult.ErrorMessage ?? "Failed to store file", null);
         }
 
-        // Start background processing (no quota needed for private game PDFs)
+        // Start background processing (no quota needed for private game PDFs).
+        // Recovery handled by RetryFailedPdfsJob — see comment in the regular path.
         _backgroundTaskService.ExecuteWithCancellation(
             pdfDoc!.Id.ToString(),
             ct => ProcessPdfAsync(pdfDoc.Id.ToString(), pdfDoc.FilePath, userId, ct));
-
-        // Quartz fallback (same pattern as regular game path)
-        await EnqueueForProcessingSafelyAsync(pdfDoc.Id, userId, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "PDF uploaded successfully for private game {PrivateGameId}: {FileName} ({FileSize} bytes)",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -83,33 +83,40 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
         try
         {
-            // Load and validate
+            // Atomic claim: transition Pending → Extracting in a single UPDATE.
+            // - Returns 1 row if this worker successfully claimed the job.
+            // - Returns 0 rows if any other state (Uploading, Ready, Failed, …)
+            //   meaning another worker (e.g. the upload-time background task) owns it
+            //   or the PDF is already terminal. Stuck-state recovery is handled
+            //   separately by RetryFailedPdfsJob, not here.
+            // FindAsync would suffer L1-cache staleness when another scope writes the
+            // row mid-flight; an atomic UPDATE bypasses that entirely.
+            var rowsClaimed = await _db.Database.ExecuteSqlInterpolatedAsync(
+                $@"UPDATE pdf_documents
+                   SET processing_state = 'Extracting', ""ProcessingError"" = NULL
+                   WHERE ""Id"" = {pdfDocumentId} AND processing_state = 'Pending'",
+                cancellationToken).ConfigureAwait(false);
+
+            if (rowsClaimed == 0)
+            {
+                _logger.LogInformation(
+                    "[PdfPipeline] PDF {PdfId} not in Pending state (already claimed or terminal), skipping",
+                    pdfId);
+                return;
+            }
+
+            // Re-load with tracked entity for the rest of the pipeline.
             var pdfDoc = await _db.PdfDocuments
                 .FindAsync(new object[] { pdfDocumentId }, cancellationToken)
                 .ConfigureAwait(false);
 
             if (pdfDoc == null)
             {
-                _logger.LogError("[PdfPipeline] PDF document {PdfId} not found in database", pdfId);
+                _logger.LogError("[PdfPipeline] PDF document {PdfId} disappeared after claim", pdfId);
                 return;
             }
-
-            // Idempotency: skip if already completed or failed
-            var readyState = nameof(PdfProcessingState.Ready);
-            var failedState = nameof(PdfProcessingState.Failed);
-            if (string.Equals(pdfDoc.ProcessingState, readyState, StringComparison.Ordinal)
-                || string.Equals(pdfDoc.ProcessingState, failedState, StringComparison.Ordinal))
-            {
-                _logger.LogInformation(
-                    "[PdfPipeline] PDF {PdfId} already in terminal state ({Status}), skipping",
-                    pdfId, pdfDoc.ProcessingState);
-                return;
-            }
-
-            // Issue #4215: Transition to Extracting state
-            pdfDoc.ProcessingState = "Extracting";
-            pdfDoc.ProcessingError = null;
-            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            // Refresh tracked entity to reflect the UPDATE we just executed.
+            await _db.Entry(pdfDoc).ReloadAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 1: Extract text
             _logger.LogInformation("[PdfPipeline] Step 1/4: Extracting text from {PdfId}", pdfId);


### PR DESCRIPTION
## Problem

PDF uploads su \`SharedGame\` finivano in stato \`Failed\` nonostante il vector indexing completasse correttamente (332 embeddings persistiti, ma \`pdf_documents.processing_state\` stuck a \`Pending\`/\`Failed\`).

## Root cause: 4 bug compounding

### Bug 1 — RAPTOR/GraphRAG FK violation (PR #868 fix #1)

Già coperto in #868: \`RaptorSummaries.GameId\` ha FK su \`games\` ma SharedGameId punta a \`shared_games\`. Fix: \`PdfGameIdResolver\` + skip se nessun peer.

### Bug 2 — \`ObjectDisposedException\` al finalize step

\`_mediator\` field su \`UploadPdfCommandHandler\` appartiene al request scope HTTP, già disposed quando il BG task finisce processing (8+ min dopo).

**Fix**: resolved \`IMediator\` dallo scope async locale, passato a \`FinalizeProcessingAsync\`.

### Bug 3 — Race tra BG task e Quartz fallback

Upload schedulava BG task **AND** enqueueva Quartz job → entrambi processavano in parallelo lo stesso PDF; il secondo MarkFailed sovrascriveva il primo Ready.

**Fix**: rimosso enqueue Quartz a upload time. Recovery solo via \`RetryFailedPdfsJob\` (5 min, solo PDF Failed). Aggiunto atomic UPDATE-and-claim in \`PdfProcessingPipelineService.ProcessAsync\` per future race.

### Bug 4 — NoTracking default droppa silenziosamente UPDATE (root cause)

DbContext configurato \`QueryTrackingBehavior.NoTracking\` (PERF-06). \`FindAsync\` non override il default → entità ritornate untracked → \`pdfDoc.ProcessingState = "Ready"\` + \`SaveChangesAsync\` era **no-op** per pdf_documents.

\`vector_documents\` funzionava perché \`db.VectorDocuments.Add(...)\` traccia esplicitamente l'insert; UPDATE su pdf_documents droppati silently.

**Fix**: ogni \`FindAsync\`/\`FirstOrDefaultAsync\` nel BG processing path → \`.AsTracking().FirstOrDefaultAsync(...)\`.

## Verified end-to-end

\`\`\`
step,resource,id,status
account,badsworm@gmail.com,...,OK
game,Nanolith,...,OK
pdf_rules,Nanolith Rules ENG.pdf,...,COMPLETE     (332 chunks, state=Ready)
pdf_press_start,Nanolith Press Start ENG.pdf,...,COMPLETE  (29 chunks, state=Ready)
agent,Nanolith Tutor,...,ACTIVE
\`\`\`

API logs confirmati clean: nessun FK violation, nessun ObjectDisposedException, nessun PdfPipeline race, nessun silent UPDATE drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)