### PR TITLE
fix(smoke): bump INITIAL_ADMIN_PASSWORD to 12 chars (closes #877 #832)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -53,7 +53,7 @@ jobs:
           HYPERDX_OTLP_ENDPOINT=http://meepleai-hyperdx:4317
           HYPERDX_API_KEY=demo
           INITIAL_ADMIN_EMAIL=smoke-user@meepleai.test
-          INITIAL_ADMIN_PASSWORD=SmokeUser1!
+          INITIAL_ADMIN_PASSWORD=SmokeUser1!!
           INITIAL_ADMIN_DISPLAY_NAME=Smoke User
           APIENV
           # n8n.env.dev — minimal (n8n unused by smoke specs but referenced by compose)
@@ -122,7 +122,7 @@ jobs:
         env:
           SMOKE_API_BASE: http://localhost:8080
           SMOKE_USER_EMAIL: smoke-user@meepleai.test
-          SMOKE_USER_PASSWORD: SmokeUser1!
+          SMOKE_USER_PASSWORD: SmokeUser1!!
           # docker compose already provides web on :3000 (see infra/compose.dev.yml:72)
           # — skip Playwright's own webServer to avoid port collision
           PLAYWRIGHT_SKIP_WEB_SERVER: '1'

--- a/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
@@ -14,7 +14,7 @@ import type { APIRequestContext, Page } from '@playwright/test';
 
 const API_BASE = process.env.SMOKE_API_BASE ?? 'http://localhost:8080';
 const SEED_EMAIL = process.env.SMOKE_USER_EMAIL ?? 'smoke-user@meepleai.test';
-const SEED_PASSWORD = process.env.SMOKE_USER_PASSWORD ?? 'SmokeUser1!';
+const SEED_PASSWORD = process.env.SMOKE_USER_PASSWORD ?? 'SmokeUser1!!';
 
 export async function smokeLogin(request: APIRequestContext): Promise<{ cookieHeader: string }> {
   const res = await request.post(`${API_BASE}/api/v1/auth/login`, {


### PR DESCRIPTION
## Summary

Login fix per smoke nightly red 5 nights (#877, #832). Risolve **una** delle due failure modes — non chiude i tracking issue ricorrenti.

### Root cause risolto
- `INITIAL_ADMIN_PASSWORD=SmokeUser1!` (11 char) ma `SeedAdminUserCommandHandler.cs:89` rifiuta `< 12` char → `InvalidOperationException` swallowed → admin mai creato → login 400 su tutti i test che chiamano `smokeLogin`.
- Fix: `SmokeUser1!` → `SmokeUser1!!` (12 char) in workflow env + auth helper fallback.

### Validazione
Workflow dispatch run [25595537011](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25595537011): zero `smokeLogin failed 400` errors post-fix (vs 6+ pre-fix). ✅

### Residuo (NON chiuso da questo PR)
Test `/{agents,games,players}/[id]` no-auth falliscono ancora con `TimeoutError waitForSelector`. Causa: il container web nel workflow smoke esegue middleware `proxy.ts:386` con `PLAYWRIGHT_AUTH_BYPASS=true` non passato (l'env è settato solo da `playwright.config.ts:434` quando Playwright spawna il webserver, ma in smoke compose-up il web container è separato). Page redirige a `/login` → selector mai disponibile.

Tracking separato necessario — issue #877/#832 NON auto-chiusi qui.

## Test plan

- [x] Workflow dispatch validation: no `smokeLogin failed 400` post-fix
- [ ] Follow-up issue da filare per residuo timeout no-auth (out-of-scope)

Refs #877 #832