### PR TITLE
feat(gamebook): rename + soft-delete campaign — CRUD complete (B5)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public sealed record DeleteGamebookCampaignCommand(Guid CampaignId, Guid CallerUserId) : IRequest;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandler.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Soft-deletes a gamebook campaign (sets IsDeleted=true + DeletedAt).
+/// EF query filter on the entity hides soft-deleted rows from subsequent reads;
+/// associated photos and glossary entries remain in DB for audit but become
+/// unreachable through normal queries (campaign id no longer resolves).
+/// Only the owner can delete.
+/// </summary>
+public class DeleteGamebookCampaignHandler : IRequestHandler<DeleteGamebookCampaignCommand>
+{
+    private readonly IGamebookCampaignSessionRepository _repo;
+
+    public DeleteGamebookCampaignHandler(IGamebookCampaignSessionRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task Handle(DeleteGamebookCampaignCommand cmd, CancellationToken cancellationToken)
+    {
+        var session = await _repo.GetByIdAsync(cmd.CampaignId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Campaign {cmd.CampaignId} not found");
+
+        if (session.OwnerUserId != cmd.CallerUserId)
+            throw new ConflictException("Only owner can delete campaign");
+
+        session.SoftDelete(cmd.CallerUserId);
+        await _repo.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public sealed class DeleteGamebookCampaignValidator : AbstractValidator<DeleteGamebookCampaignCommand>
+{
+    public DeleteGamebookCampaignValidator()
+    {
+        RuleFor(x => x.CampaignId).NotEmpty();
+        RuleFor(x => x.CallerUserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignCommand.cs
@@ -1,0 +1,7 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public sealed record RenameGamebookCampaignCommand(Guid CampaignId, Guid CallerUserId, string Title)
+    : IRequest<GamebookCampaignDto>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignHandler.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Renames a gamebook campaign. Only the owner can rename.
+/// Returns updated campaign DTO.
+/// </summary>
+public class RenameGamebookCampaignHandler : IRequestHandler<RenameGamebookCampaignCommand, GamebookCampaignDto>
+{
+    private readonly IGamebookCampaignSessionRepository _repo;
+
+    public RenameGamebookCampaignHandler(IGamebookCampaignSessionRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task<GamebookCampaignDto> Handle(RenameGamebookCampaignCommand cmd, CancellationToken cancellationToken)
+    {
+        var session = await _repo.GetByIdAsync(cmd.CampaignId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Campaign {cmd.CampaignId} not found");
+
+        if (session.OwnerUserId != cmd.CallerUserId)
+            throw new ConflictException("Only owner can rename campaign");
+
+        session.Rename(cmd.Title, cmd.CallerUserId);
+        await _repo.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return CreateGamebookCampaignHandler.MapToDto(session);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public sealed class RenameGamebookCampaignValidator : AbstractValidator<RenameGamebookCampaignCommand>
+{
+    public RenameGamebookCampaignValidator()
+    {
+        RuleFor(x => x.CampaignId).NotEmpty();
+        RuleFor(x => x.CallerUserId).NotEmpty();
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .MinimumLength(1)
+            .MaximumLength(200)
+            .Must(t => !string.IsNullOrWhiteSpace(t))
+            .WithMessage("Title cannot be whitespace.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookCampaignSession.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookCampaignSession.cs
@@ -49,6 +49,16 @@ public sealed class GamebookCampaignSession
         UpdatedBy = OwnerUserId;
     }
 
+    public void Rename(string newTitle, Guid updatedBy)
+    {
+        if (string.IsNullOrWhiteSpace(newTitle))
+            throw new ArgumentException("title required", nameof(newTitle));
+
+        Title = newTitle.Trim();
+        UpdatedAt = DateTimeOffset.UtcNow;
+        UpdatedBy = updatedBy;
+    }
+
     public void SoftDelete(Guid deletedBy)
     {
         IsDeleted = true;

--- a/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
@@ -21,6 +21,8 @@ internal static class GamebookCampaignEndpoints
         MapListCampaignsEndpoint(group);
         MapGetCampaignEndpoint(group);
         MapUpdateProgressEndpoint(group);
+        MapRenameCampaignEndpoint(group);
+        MapDeleteCampaignEndpoint(group);
 
         return group;
     }
@@ -154,6 +156,71 @@ internal static class GamebookCampaignEndpoints
         .WithOpenApi();
     }
 
+    private static void MapRenameCampaignEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPatch("/gamebook/campaigns/{id:guid}", async (
+            Guid id,
+            [FromBody] RenameGamebookCampaignRequest body,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var dto = await mediator.Send(
+                new RenameGamebookCampaignCommand(id, userId, body.Title), ct
+            ).ConfigureAwait(false);
+
+            return Results.Ok(dto);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<GamebookCampaignDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
+        .WithTags("Gamebook")
+        .WithSummary("Rename a gamebook campaign")
+        .WithDescription("Updates the title of the campaign. Only the owner may rename.")
+        .WithOpenApi();
+    }
+
+    private static void MapDeleteCampaignEndpoint(RouteGroupBuilder group)
+    {
+        group.MapDelete("/gamebook/campaigns/{id:guid}", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            await mediator.Send(new DeleteGamebookCampaignCommand(id, userId), ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
+        .WithTags("Gamebook")
+        .WithSummary("Soft-delete a gamebook campaign")
+        .WithDescription("Marks the campaign as deleted (IsDeleted=true). Only the owner may delete. Photos and glossary entries are retained for audit but become unreachable.")
+        .WithOpenApi();
+    }
+
     private static bool TryGetUserId(HttpContext context, SessionStatusDto? session, out Guid userId)
     {
         userId = Guid.Empty;
@@ -178,3 +245,6 @@ public sealed record CreateGamebookCampaignRequest(Guid GameId, string Title);
 
 /// <summary>Request body for updating the current paragraph progress.</summary>
 public sealed record UpdateGamebookProgressRequest(int CurrentParagraph);
+
+/// <summary>Request body for renaming a gamebook campaign.</summary>
+public sealed record RenameGamebookCampaignRequest(string Title);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandlerTests.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class DeleteGamebookCampaignHandlerTests
+{
+    private sealed class FakeRepo : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default)
+        {
+            Store.Add(s);
+            return Task.CompletedTask;
+        }
+
+        public int SaveCalls { get; private set; }
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (FakeRepo repo, DeleteGamebookCampaignHandler handler, GamebookCampaignSession session) BuildSut()
+    {
+        var repo = new FakeRepo();
+        var handler = new DeleteGamebookCampaignHandler(repo);
+        var userId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(Guid.NewGuid(), userId, "Doomed Campaign");
+        repo.Store.Add(session);
+        return (repo, handler, session);
+    }
+
+    [Fact]
+    public async Task Handle_SoftDeletes_AndSaves()
+    {
+        var (repo, handler, session) = BuildSut();
+        var cmd = new DeleteGamebookCampaignCommand(session.Id, session.OwnerUserId);
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        session.IsDeleted.Should().BeTrue();
+        session.DeletedAt.Should().NotBeNull();
+        repo.SaveCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionMissing_ThrowsNotFoundException()
+    {
+        var (_, handler, _) = BuildSut();
+        var cmd = new DeleteGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsConflictException()
+    {
+        var (_, handler, session) = BuildSut();
+        var differentUser = Guid.NewGuid();
+        var cmd = new DeleteGamebookCampaignCommand(session.Id, differentUser);
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        session.IsDeleted.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/RenameGamebookCampaignHandlerTests.cs
@@ -1,0 +1,95 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class RenameGamebookCampaignHandlerTests
+{
+    private sealed class FakeRepo : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default)
+        {
+            Store.Add(s);
+            return Task.CompletedTask;
+        }
+
+        public int SaveCalls { get; private set; }
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (FakeRepo repo, RenameGamebookCampaignHandler handler, GamebookCampaignSession session) BuildSut()
+    {
+        var repo = new FakeRepo();
+        var handler = new RenameGamebookCampaignHandler(repo);
+        var userId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(Guid.NewGuid(), userId, "Original Title");
+        repo.Store.Add(session);
+        return (repo, handler, session);
+    }
+
+    [Fact]
+    public async Task Handle_RenamesCampaign_AndSaves()
+    {
+        var (repo, handler, session) = BuildSut();
+        var cmd = new RenameGamebookCampaignCommand(session.Id, session.OwnerUserId, "Renamed Title");
+
+        var dto = await handler.Handle(cmd, CancellationToken.None);
+
+        dto.Title.Should().Be("Renamed Title");
+        session.Title.Should().Be("Renamed Title");
+        repo.SaveCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_TrimsTitle()
+    {
+        var (_, handler, session) = BuildSut();
+        var cmd = new RenameGamebookCampaignCommand(session.Id, session.OwnerUserId, "  Padded   ");
+
+        var dto = await handler.Handle(cmd, CancellationToken.None);
+
+        dto.Title.Should().Be("Padded");
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionMissing_ThrowsNotFoundException()
+    {
+        var (_, handler, _) = BuildSut();
+        var cmd = new RenameGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid(), "X");
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsConflictException()
+    {
+        var (_, handler, session) = BuildSut();
+        var differentUser = Guid.NewGuid();
+        var cmd = new RenameGamebookCampaignCommand(session.Id, differentUser, "X");
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/apps/web/src/app/(authenticated)/library/games/[gameId]/play/_components/GamebookResumeShell.tsx
+++ b/apps/web/src/app/(authenticated)/library/games/[gameId]/play/_components/GamebookResumeShell.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import type { ReactElement } from 'react';
+import { useCallback, type ReactElement } from 'react';
 
-import { useUserCampaigns } from '@/lib/gamebook/hooks/useUserCampaigns';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteCampaign, renameCampaign } from '@/lib/api/gamebook-campaigns';
+import { useUserCampaigns, userCampaignsKeys } from '@/lib/gamebook/hooks/useUserCampaigns';
 
 import { EmptyFirstTime } from './EmptyFirstTime';
 import { MultiCampaignList } from './MultiCampaignList';
@@ -35,6 +38,35 @@ export function GamebookResumeShell({
   onArchive,
 }: GamebookResumeShellProps): ReactElement {
   const { data, isLoading, isError } = useUserCampaigns(gameId);
+  const queryClient = useQueryClient();
+
+  const renameMutation = useMutation({
+    mutationFn: ({ id, title }: { id: string; title: string }) => renameCampaign(id, title),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userCampaignsKeys.list(gameId) });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCampaign(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: userCampaignsKeys.list(gameId) });
+    },
+  });
+
+  const handleRename = useCallback(
+    async (id: string, title: string) => {
+      await renameMutation.mutateAsync({ id, title });
+    },
+    [renameMutation]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await deleteMutation.mutateAsync(id);
+    },
+    [deleteMutation]
+  );
 
   if (isLoading) {
     return (
@@ -82,5 +114,13 @@ export function GamebookResumeShell({
     return <ResumeHero campaign={campaign} gameId={gameId} onCreateNew={onCreateCampaign} />;
   }
 
-  return <MultiCampaignList campaigns={data} gameId={gameId} onCreateNew={onCreateCampaign} />;
+  return (
+    <MultiCampaignList
+      campaigns={data}
+      gameId={gameId}
+      onCreateNew={onCreateCampaign}
+      onRename={handleRename}
+      onDelete={handleDelete}
+    />
+  );
 }

--- a/apps/web/src/app/(authenticated)/library/games/[gameId]/play/_components/MultiCampaignList.tsx
+++ b/apps/web/src/app/(authenticated)/library/games/[gameId]/play/_components/MultiCampaignList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 
 import Link from 'next/link';
 
@@ -10,6 +10,10 @@ export interface MultiCampaignListProps {
   campaigns: UserCampaignWithStale[];
   gameId: string;
   onCreateNew?: () => void;
+  /** Inline rename — handler resolves with new title or rejects on cancel/error. */
+  onRename?: (campaignId: string, newTitle: string) => Promise<void> | void;
+  /** Soft-delete with explicit user confirm (caller is responsible for the confirmation UI cue). */
+  onDelete?: (campaignId: string) => Promise<void> | void;
 }
 
 function daysSince(iso: string, now: Date = new Date()): number {
@@ -29,7 +33,35 @@ export function MultiCampaignList({
   campaigns,
   gameId,
   onCreateNew,
+  onRename,
+  onDelete,
 }: MultiCampaignListProps): ReactElement {
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const handleRename = async (campaignId: string, currentTitle: string) => {
+    if (!onRename) return;
+    const next = window.prompt('Nuovo titolo della campagna:', currentTitle);
+    const trimmed = next?.trim();
+    if (!trimmed || trimmed === currentTitle) return;
+    try {
+      setBusyId(campaignId);
+      await onRename(campaignId, trimmed);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (campaignId: string, currentTitle: string) => {
+    if (!onDelete) return;
+    if (!window.confirm(`Eliminare la campagna "${currentTitle}"? Questa azione è reversibile solo lato server (soft-delete).`)) return;
+    try {
+      setBusyId(campaignId);
+      await onDelete(campaignId);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   return (
     <section
       data-testid="gamebook-resume-multi-list"
@@ -85,6 +117,32 @@ export function MultiCampaignList({
                 >
                   Riprendi → §{next}
                 </Link>
+                {(onRename || onDelete) && (
+                  <div className="flex items-center justify-end gap-1 pt-1">
+                    {onRename && (
+                      <button
+                        type="button"
+                        onClick={() => handleRename(campaign.id, campaign.title)}
+                        disabled={busyId === campaign.id}
+                        data-testid={`gamebook-resume-multi-rename-${campaign.id}`}
+                        className="rounded px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        Rinomina
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(campaign.id, campaign.title)}
+                        disabled={busyId === campaign.id}
+                        data-testid={`gamebook-resume-multi-delete-${campaign.id}`}
+                        className="rounded px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        Elimina
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             </li>
           );

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -2,10 +2,12 @@
  * Gamebook Campaigns API client — Iter 1.A.
  *
  * Endpoints exposed by `GamebookCampaignEndpoints`:
- *   - POST /api/v1/gamebook/campaigns
- *   - GET  /api/v1/gamebook/campaigns?gameId=<guid>
- *   - GET  /api/v1/gamebook/campaigns/{id}
- *   - PUT  /api/v1/gamebook/campaigns/{id}/progress
+ *   - POST   /api/v1/gamebook/campaigns
+ *   - GET    /api/v1/gamebook/campaigns?gameId=<guid>
+ *   - GET    /api/v1/gamebook/campaigns/{id}
+ *   - PUT    /api/v1/gamebook/campaigns/{id}/progress
+ *   - PATCH  /api/v1/gamebook/campaigns/{id}        (rename — owner only)
+ *   - DELETE /api/v1/gamebook/campaigns/{id}        (soft-delete — owner only)
  *
  * All endpoints require authentication via session cookie (`credentials: 'include'`).
  */
@@ -90,4 +92,32 @@ export async function updateProgress(
     }
   );
   return parseJson(res, GamebookCampaignSchema);
+}
+
+export async function renameCampaign(id: string, title: string): Promise<GamebookCampaign> {
+  const res = await fetch(`${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+    credentials: 'include',
+  });
+  return parseJson(res, GamebookCampaignSchema);
+}
+
+export async function deleteCampaign(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = await res.text();
+    } catch {
+      /* ignore */
+    }
+    throw new Error(
+      `Gamebook campaigns API error ${res.status}: ${detail || res.statusText}`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Chiude il gap CRUD sui libro game campaign segnalato da audit browser ieri (B5). Update era limitato a /progress; Delete non aveva alcun endpoint.

## Backend

- \`GamebookCampaignSession.Rename(title, by)\` — metodo dominio (trim + null guard)
- Entity già aveva \`IsDeleted/DeletedAt\` + EF query filter → no migration
- Nuove command CQRS + handler + FluentValidation:
  - \`RenameGamebookCampaignCommand\` → \`PATCH /api/v1/gamebook/campaigns/{id}\`
  - \`DeleteGamebookCampaignCommand\` → \`DELETE /api/v1/gamebook/campaigns/{id}\`
- Owner-only (ConflictException 409)
- 7/7 nuovi test ✅

## Frontend

- \`gamebook-campaigns.ts\`: \`renameCampaign\`, \`deleteCampaign\` client
- \`MultiCampaignList\`: bottoni "Rinomina"/"Elimina" per card (prompt/confirm nativi per Iter 1 — sostituibili con Dialog v2 dopo lift freeze #807 Fase 2)
- \`GamebookResumeShell\`: TanStack mutations + invalidation su \`userCampaignsKeys.list(gameId)\`

## Verified

- typecheck + eslint web ✅
- dotnet test (7 nuovi handler tests) ✅

## Out of scope (next PRs)

- Cascade soft-delete su photos/glossary (unreachable già; cleanup via audit job dedicato)
- Dialog primitive v2 al posto di prompt/confirm nativi (post #807 Fase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)