### PR TITLE
chore(web): polish — Zod schema + a11y main landmark (B7+B8)

### DIFF
--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -27,7 +27,9 @@ export function DesktopShell({ children }: DesktopShellProps) {
 
       <SessionBanner />
 
-      <main className="flex-1 overflow-y-auto overflow-x-clip">{children}</main>
+      <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
+        {children}
+      </main>
 
       <MobileCTAPill />
       <ChatSlideOverPanel />

--- a/apps/web/src/components/layouts/AuthLayout.tsx
+++ b/apps/web/src/components/layouts/AuthLayout.tsx
@@ -88,7 +88,10 @@ export function AuthLayout({
       </header>
 
       {/* Main Content - Centered Card */}
-      <main className="flex-1 flex items-center justify-center px-4 py-8 sm:px-6 lg:px-8">
+      <main
+        id="main-content"
+        className="flex-1 flex items-center justify-center px-4 py-8 sm:px-6 lg:px-8"
+      >
         <div className={cn('w-full max-w-md', className)}>
           {/* Optional Title Section */}
           {(title || subtitle) && (

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -18,7 +18,9 @@ export const GameSchema = z.object({
   maxPlayers: z.number().int().positive().nullable(),
   minPlayTimeMinutes: z.number().int().positive().nullable(),
   maxPlayTimeMinutes: z.number().int().positive().nullable(),
-  bggId: z.number().int().positive().nullable(),
+  // API returns 0 for unknown/unsynced bgg ids (not nullable on the wire);
+  // accept 0 as a sentinel rather than rejecting it via .positive().
+  bggId: z.number().int().nonnegative().nullable(),
   createdAt: z.string().datetime({ offset: true }),
   // Issue #1830: UI-003 GameCard enhancements
   imageUrl: z.string().url().nullable().optional(),


### PR DESCRIPTION
## Summary

### B7 — Zod \`/api/v1/games\` mismatch
\`bggId: z.number().int().positive().nullable()\` rifiutava \`0\` (sentinel API per "unknown/unsynced"). Browser mostrava \"Schema validation failed\" su \`/games\`.

**Fix**: relax a \`nonnegative()\`.

### B8 — Skip-link target mancante
\`AccessibleSkipLink\` punta a \`#main-content\`. AdminShell aveva l'id. UserShell DesktopShell e AuthLayout NO → axe \"No skip link target\".

**Fix**: aggiunto \`id=\"main-content\"\` su entrambi i \`<main>\`.

### B4 — non in questa PR
Investigando: \`BulkSelectionBar.onArchive\` → \`useRemoveGameFromLibrary\` esiste. La funzione c'è già via selection mode. Il finding dell'audit era sulla discoverability del toggle selezione, non una mancanza di CRUD. Da trattare come UX improvement separato (non bug).

## Verified

- typecheck ✅
- ESLint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)