### PR TITLE
fix(health-monitor): #885 cleanup orphan service_health_states rows on startup

### DIFF
--- a/apps/api/src/Api/Infrastructure/BackgroundServices/HealthStateOrphanCleanup.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/HealthStateOrphanCleanup.cs
@@ -1,0 +1,55 @@
+using Api.Infrastructure.Entities.Administration;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Issue #885: removes orphan rows from <c>service_health_states</c> that no longer
+/// correspond to any registered health check.
+///
+/// <para>
+/// Background: <see cref="InfrastructureHealthMonitorService"/> persists health-state
+/// transitions to the DB. When a health check is de-registered between deploys (e.g.
+/// optional providers Unstructured/SmolDocling/Ollama deselected via configuration after
+/// PR #883), the corresponding row is never updated again — it remains frozen at the
+/// last persisted status. Staging investigation found rows stuck for >30 days.
+/// </para>
+/// <para>
+/// Extracted as a static helper so the cleanup invariant is unit-testable without
+/// spinning up the full <c>BackgroundService</c> host.
+/// </para>
+/// </summary>
+internal static class HealthStateOrphanCleanup
+{
+    /// <summary>
+    /// Removes rows from <see cref="MeepleAiDbContext.ServiceHealthStates"/> whose
+    /// <c>ServiceName</c> is not present in <paramref name="registeredNames"/>.
+    /// </summary>
+    /// <returns>The names of removed rows (may be empty).</returns>
+    public static async Task<IReadOnlyList<string>> RemoveOrphansAsync(
+        MeepleAiDbContext db,
+        IReadOnlySet<string> registeredNames,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(registeredNames);
+
+        var allRows = await db.ServiceHealthStates
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var orphans = allRows
+            .Where(r => !registeredNames.Contains(r.ServiceName))
+            .ToList();
+
+        if (orphans.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        db.ServiceHealthStates.RemoveRange(orphans);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return orphans.Select(o => o.ServiceName).ToArray();
+    }
+}

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
@@ -95,6 +95,28 @@ internal sealed class InfrastructureHealthMonitorService : BackgroundService
             using var scope = _scopeFactory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
 
+            // Issue #885: clean up orphan rows for services that are no longer registered.
+            // Optional providers (Unstructured, SmolDocling, Ollama after #883) become
+            // unregistered between deploys. Without cleanup their rows remain frozen at
+            // the last persisted state forever — see the staging investigation that found
+            // 3 rows stuck in "Degraded since 2026-04-11" after a month of no monitor writes.
+            var healthOptions = scope.ServiceProvider
+                .GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+            var registeredNames = healthOptions.Registrations
+                .Select(r => r.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var removedNames = await HealthStateOrphanCleanup.RemoveOrphansAsync(
+                db, registeredNames, cancellationToken).ConfigureAwait(false);
+
+            if (removedNames.Count > 0)
+            {
+                _logger.LogInformation(
+                    "[HealthMonitor] Removed {OrphanCount} orphan service_health_states rows: {Names}",
+                    removedNames.Count,
+                    string.Join(", ", removedNames));
+            }
+
             var entities = await db.ServiceHealthStates
                 .AsNoTracking()
                 .ToListAsync(cancellationToken)

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
@@ -106,15 +106,29 @@ internal sealed class InfrastructureHealthMonitorService : BackgroundService
                 .Select(r => r.Name)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            var removedNames = await HealthStateOrphanCleanup.RemoveOrphansAsync(
-                db, registeredNames, cancellationToken).ConfigureAwait(false);
-
-            if (removedNames.Count > 0)
+            // Code-review safeguard on PR #895: an empty Registrations set is suspicious —
+            // it can happen during DI startup races or in misconfigured hosting paths, and
+            // the helper would treat ALL rows as orphans and wipe the table. Skip cleanup
+            // and log loudly so ops can investigate. The hydration step continues normally.
+            if (registeredNames.Count == 0)
             {
-                _logger.LogInformation(
-                    "[HealthMonitor] Removed {OrphanCount} orphan service_health_states rows: {Names}",
-                    removedNames.Count,
-                    string.Join(", ", removedNames));
+                _logger.LogWarning(
+                    "[HealthMonitor] HealthCheckServiceOptions.Registrations is empty; "
+                    + "skipping orphan cleanup to avoid wiping all rows. "
+                    + "Investigate the host's health-check registration path.");
+            }
+            else
+            {
+                var removedNames = await HealthStateOrphanCleanup.RemoveOrphansAsync(
+                    db, registeredNames, cancellationToken).ConfigureAwait(false);
+
+                if (removedNames.Count > 0)
+                {
+                    _logger.LogInformation(
+                        "[HealthMonitor] Removed {OrphanCount} orphan service_health_states rows: {Names}",
+                        removedNames.Count,
+                        string.Join(", ", removedNames));
+                }
             }
 
             var entities = await db.ServiceHealthStates

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthStateOrphanCleanupTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthStateOrphanCleanupTests.cs
@@ -1,0 +1,141 @@
+using Api.Infrastructure;
+using Api.Infrastructure.BackgroundServices;
+using Api.Infrastructure.Entities.Administration;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Unit tests for <see cref="HealthStateOrphanCleanup"/> (Issue #885).
+/// Verifies that rows for unregistered services are removed and rows for active
+/// services are preserved.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Issue", "885")]
+public sealed class HealthStateOrphanCleanupTests
+{
+    private static MeepleAiDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"orphan-cleanup-{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    private static ServiceHealthStateEntity SeedRow(string serviceName) => new()
+    {
+        Id = Guid.NewGuid(),
+        ServiceName = serviceName,
+        CurrentStatus = "Healthy",
+        PreviousStatus = "Healthy",
+        ConsecutiveFailures = 0,
+        ConsecutiveSuccesses = 1,
+        LastTransitionAt = DateTime.UtcNow.AddDays(-30),
+        Tags = "[]",
+        CreatedAt = DateTime.UtcNow.AddDays(-30),
+        UpdatedAt = DateTime.UtcNow.AddDays(-30),
+    };
+
+    [Fact]
+    public async Task RemoveOrphansAsync_With_All_Registered_Removes_Nothing()
+    {
+        using var db = CreateContext();
+        db.ServiceHealthStates.AddRange(
+            SeedRow("postgres"),
+            SeedRow("redis"),
+            SeedRow("openrouter"));
+        await db.SaveChangesAsync();
+
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "postgres", "redis", "openrouter"
+        };
+
+        var removed = await HealthStateOrphanCleanup.RemoveOrphansAsync(db, registered, CancellationToken.None);
+
+        removed.Should().BeEmpty();
+        (await db.ServiceHealthStates.CountAsync()).Should().Be(3);
+    }
+
+    [Fact]
+    public async Task RemoveOrphansAsync_With_Some_Unregistered_Removes_Only_Orphans()
+    {
+        // Reproduces the staging scenario after PR #883 deploy: unstructured/smoldocling/
+        // ollama were Degraded for a month, then de-registered. Their rows must be cleaned
+        // up while postgres/redis/openrouter rows are preserved untouched.
+        using var db = CreateContext();
+        db.ServiceHealthStates.AddRange(
+            SeedRow("postgres"),
+            SeedRow("redis"),
+            SeedRow("openrouter"),
+            SeedRow("unstructured"),
+            SeedRow("smoldocling"),
+            SeedRow("ollama"));
+        await db.SaveChangesAsync();
+
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "postgres", "redis", "openrouter"
+        };
+
+        var removed = await HealthStateOrphanCleanup.RemoveOrphansAsync(db, registered, CancellationToken.None);
+
+        removed.Should().BeEquivalentTo(new[] { "unstructured", "smoldocling", "ollama" });
+
+        var remaining = await db.ServiceHealthStates.Select(r => r.ServiceName).ToListAsync();
+        remaining.Should().BeEquivalentTo(new[] { "postgres", "redis", "openrouter" });
+    }
+
+    [Fact]
+    public async Task RemoveOrphansAsync_Match_Is_Case_Insensitive()
+    {
+        // Defensive: HealthCheckServiceOptions.Registrations may differ in casing across
+        // EF Core versions or registration paths. The cleanup must not delete a real
+        // service just because casing drifted.
+        using var db = CreateContext();
+        db.ServiceHealthStates.Add(SeedRow("PostGres"));
+        await db.SaveChangesAsync();
+
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "postgres" };
+
+        var removed = await HealthStateOrphanCleanup.RemoveOrphansAsync(db, registered, CancellationToken.None);
+
+        removed.Should().BeEmpty();
+        (await db.ServiceHealthStates.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RemoveOrphansAsync_With_Empty_DB_Returns_Empty()
+    {
+        using var db = CreateContext();
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "postgres" };
+
+        var removed = await HealthStateOrphanCleanup.RemoveOrphansAsync(db, registered, CancellationToken.None);
+
+        removed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveOrphansAsync_With_All_Unregistered_Removes_All()
+    {
+        using var db = CreateContext();
+        db.ServiceHealthStates.AddRange(SeedRow("foo"), SeedRow("bar"));
+        await db.SaveChangesAsync();
+
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var removed = await HealthStateOrphanCleanup.RemoveOrphansAsync(db, registered, CancellationToken.None);
+
+        removed.Should().BeEquivalentTo(new[] { "foo", "bar" });
+        (await db.ServiceHealthStates.CountAsync()).Should().Be(0);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthStateOrphanCleanupTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthStateOrphanCleanupTests.cs
@@ -125,8 +125,20 @@ public sealed class HealthStateOrphanCleanupTests
     }
 
     [Fact]
-    public async Task RemoveOrphansAsync_With_All_Unregistered_Removes_All()
+    public async Task RemoveOrphansAsync_With_Empty_Registered_Set_Wipes_All_Rows_And_Caller_Must_Guard()
     {
+        // CONTRACT: the helper does NOT special-case an empty registeredNames set —
+        // it removes every row, by design. This is *correct* mathematically (no row
+        // matches an empty whitelist) but DANGEROUS in production where an empty set
+        // can result from a DI startup race or misconfigured host.
+        //
+        // The consumer (InfrastructureHealthMonitorService.HydrateStateFromDatabaseAsync)
+        // guards against this case explicitly. This test pins the helper's contract so a
+        // future refactor that "fixes" the helper to skip empty sets does not silently
+        // change the contract assumed by the consumer.
+        //
+        // See the matching guard:
+        //   InfrastructureHealthMonitorService.cs — "if (registeredNames.Count == 0)".
         using var db = CreateContext();
         db.ServiceHealthStates.AddRange(SeedRow("foo"), SeedRow("bar"));
         await db.SaveChangesAsync();


### PR DESCRIPTION
## Summary

Closes #885. Cleans up orphan rows in `service_health_states` on `InfrastructureHealthMonitorService` startup. Empirically validated against the staging DB.

## Empirical investigation (staging)

Direct SQL query revealed the latent bug is real:

```
service_name | current_status | last_transition_at  | updated_at
-------------+----------------+---------------------+--------------------
unstructured | Degraded       | 2026-04-11 08:20:45 | 2026-04-11 08:20:46
smoldocling  | Degraded       | 2026-04-11 08:20:46 | 2026-04-11 08:20:46
ollama       | Degraded       | 2026-04-11 08:20:46 | 2026-04-11 08:20:47
... (22 rows total, all timestamps 2026-04-11)
```

- **Today's date**: 2026-05-09 (one month later)
- **API logs**: `[HealthMonitor]` runs every 30 minutes, currently logs the 3 services as `Reminder — still Unhealthy`
- **DB state**: frozen at `Degraded since 2026-04-11`, never updated

The `HealthMonitor` persists only **state transitions**, not regular check results. When PR #883 deploys to `main-staging`, these 3 services will be de-registered (provider conditional registration), the monitor will never see them again, and their rows will remain frozen forever.

This PR cleans them up at startup.

## Changes

### `HealthStateOrphanCleanup.RemoveOrphansAsync` (new)

Static helper taking `(db, registeredNames, ct)`. Pure logic, trivially unit-testable. Returns names of removed rows.

```csharp
public static async Task<IReadOnlyList<string>> RemoveOrphansAsync(
    MeepleAiDbContext db,
    IReadOnlySet<string> registeredNames,
    CancellationToken cancellationToken)
{
    var allRows = await db.ServiceHealthStates.ToListAsync(cancellationToken);
    var orphans = allRows.Where(r => !registeredNames.Contains(r.ServiceName)).ToList();
    if (orphans.Count == 0) return Array.Empty<string>();
    db.ServiceHealthStates.RemoveRange(orphans);
    await db.SaveChangesAsync(cancellationToken);
    return orphans.Select(o => o.ServiceName).ToArray();
}
```

### `InfrastructureHealthMonitorService.HydrateStateFromDatabaseAsync`

Now resolves `IOptions<HealthCheckServiceOptions>` to build the active-name `HashSet`, calls the helper before hydrating the in-memory `_states` dict.

- Idempotent: empty orphan set on subsequent startups → no-op
- Case-insensitive matching: defensive against casing drift in registration paths

## Tests (5/5 GREEN)

| Scenario | Verifies |
|---|---|
| `RemoveOrphansAsync_With_All_Registered_Removes_Nothing` | No false positives — current rows preserved |
| `RemoveOrphansAsync_With_Some_Unregistered_Removes_Only_Orphans` | **Direct repro of staging scenario** — postgres/redis/openrouter kept, unstructured/smoldocling/ollama removed |
| `RemoveOrphansAsync_Match_Is_Case_Insensitive` | "PostGres" matches "postgres" |
| `RemoveOrphansAsync_With_Empty_DB_Returns_Empty` | Edge case |
| `RemoveOrphansAsync_With_All_Unregistered_Removes_All` | Edge case (full purge) |

## Out of scope (separate issues to follow)

The investigation surfaced a related discrepancy: the API logs say `unstructured: still Unhealthy` while the DB shows `Degraded`. This implies the live `HealthMonitor.PollHealthChecksAsync` produces a different status than what's persisted on transition. Likely a separate issue — to be tracked in a follow-up after merge if it persists.

## Test plan

- [x] Build: 0 errors
- [x] 5/5 cleanup tests GREEN
- [ ] CI Backend - Unit Tests green
- [ ] After deploy to staging: verify the 3 stuck rows are removed on next API restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
