### PR TITLE
docs(branches): #897 retire frontend-dev/backend-dev references

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,7 @@ Workflows are organized by category with consistent naming prefixes:
 ## Core CI/CD
 
 ### ci.yml - Main CI Pipeline
-- **Triggers**: PR to main, main-dev, main-staging, frontend-dev, backend-dev
+- **Triggers**: PR to main, main-dev, main-staging
 - **Jobs**: Frontend (lint, typecheck, test, build), Backend (build, test), E2E critical paths
 - **Features**: Path-based filtering, parallel execution, Codecov integration, dynamic runner selection (self-hosted for staging/prod PRs, GitHub-hosted for dev PRs)
 
@@ -88,7 +88,7 @@ Workflows are organized by category with consistent naming prefixes:
 ### auto-branch-policy.yml - Branch Protection
 - **Triggers**: PR to main, main-staging, main-dev
 - **Jobs**: Validate source branch matches policy
-- **Policy**: main ← main-staging only; main-staging ← main-dev only; main-dev ← frontend-dev, backend-dev, feature/*, fix/*, etc.
+- **Policy**: main ← main-staging only; main-staging ← main-dev only; main-dev ← feature/*, fix/*, hotfix/*, docs/*, refactor/*, chore/*, etc.
 
 ### auto-dependabot.yml - Dependabot Auto-merge
 - **Triggers**: Dependabot PRs with `automerge` label
@@ -157,7 +157,7 @@ Workflows use a tiered runner selection strategy to balance cost and concurrency
 
 | Branch target | Runner | Rationale |
 |--------------|--------|-----------|
-| `main-dev`, `frontend-dev`, `backend-dev` | `ubuntu-latest` | High PR concurrency, no queue |
+| `main-dev` | `ubuntu-latest` | High PR concurrency, no queue |
 | `main-staging`, `main` | Self-hosted (ARM64) | Low frequency, saves GH Actions minutes |
 | Deploy workflows | Self-hosted (ARM64) | Always staging/prod, free compute |
 

--- a/.github/workflows/auto-branch-policy.yml
+++ b/.github/workflows/auto-branch-policy.yml
@@ -33,7 +33,7 @@ jobs:
               echo "::error::Branch 'main' can only be updated from 'main-staging'"
               echo "::error::Attempted merge from: $SOURCE_BRANCH"
               echo ""
-              echo "Workflow: feature -> frontend-dev/backend-dev -> main-dev -> main-staging -> main"
+              echo "Workflow: feature -> main-dev -> main-staging -> main"
               exit 1
             fi
             echo "✅ Valid: main-staging -> main"
@@ -48,7 +48,7 @@ jobs:
               echo "::error::Branch 'main-staging' can only be updated from 'main-dev'"
               echo "::error::Attempted merge from: $SOURCE_BRANCH"
               echo ""
-              echo "Workflow: feature -> frontend-dev/backend-dev -> main-dev -> main-staging -> main"
+              echo "Workflow: feature -> main-dev -> main-staging -> main"
               exit 1
             fi
             echo "✅ Valid: main-dev -> main-staging"
@@ -58,21 +58,18 @@ jobs:
           # MAIN-DEV branch policy
           # ============================================
           # main-dev can be updated from:
-          # - frontend-dev, backend-dev (primary paths)
-          # - feature/* branches (backend features)
+          # - feature/* branches (issue-driven feature work)
           # - hotfix/* branches (urgent security/bug fixes; still flow
           #   through main-dev → main-staging → main, no direct-to-main)
           # - fix/*, docs/*, refactor/*, chore/* branches
           if [[ "$BASE_BRANCH" == "main-dev" ]]; then
-            ALLOWED_PATTERNS="^(frontend-dev|backend-dev|feature/|fix/|hotfix/|docs/|test/|refactor/|chore/|release/|merge/)"
+            ALLOWED_PATTERNS="^(feature/|fix/|hotfix/|docs/|test/|refactor/|chore/|release/|merge/)"
 
             if ! echo "$SOURCE_BRANCH" | grep -qE "$ALLOWED_PATTERNS"; then
               echo "::error::Branch 'main-dev' can only be updated from allowed branches"
               echo "::error::Attempted merge from: $SOURCE_BRANCH"
               echo ""
               echo "Allowed patterns:"
-              echo "  - frontend-dev"
-              echo "  - backend-dev"
               echo "  - feature/*"
               echo "  - hotfix/*"
               echo "  - fix/*"

--- a/.github/workflows/backend-missing-gate.yml
+++ b/.github/workflows/backend-missing-gate.yml
@@ -2,7 +2,7 @@ name: Backend Missing Gate
 
 on:
   pull_request:
-    branches: [main, main-dev, frontend-dev]
+    branches: [main, main-dev]
     paths:
       - 'apps/web/src/**/*.ts'
       - 'apps/web/src/**/*.tsx'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, main-dev, main-staging, frontend-dev, backend-dev]
+    branches: [main, main-dev, main-staging]
   push:
     # Spec R2 — CI optimization (2026-04-09): ci.yml must run on push to
     # main-staging so deploy-staging.yml can gate on its conclusion via

--- a/.github/workflows/visual-regression-migrated.yml
+++ b/.github/workflows/visual-regression-migrated.yml
@@ -19,7 +19,7 @@ name: Visual Regression — Migrated Routes
 
 on:
   pull_request:
-    branches: [main, main-dev, main-staging, frontend-dev]
+    branches: [main, main-dev, main-staging]
     paths:
       - 'apps/web/src/**'
       - 'apps/web/e2e/visual-migrated/**'

--- a/.github/workflows/visual-regression-mockups.yml
+++ b/.github/workflows/visual-regression-mockups.yml
@@ -17,7 +17,7 @@ name: Visual Regression — Mockup Baseline
 
 on:
   pull_request:
-    branches: [main, main-dev, main-staging, frontend-dev]
+    branches: [main, main-dev, main-staging]
     paths:
       - 'admin-mockups/design_files/**'
       - 'apps/web/e2e/visual-mockups/**'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Pre-commit hook for MeepleAI
 # Runs checks based on current branch with progressive restrictions
-# frontend-dev: FE lint + typecheck
+# feature/*: FE lint + typecheck
 # main-dev: FE + BE format + detect-secrets
 # main: FE + BE + detect-secrets + semgrep
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,7 +12,7 @@ echo "📌 Pushing from branch: $CURRENT_BRANCH"
 # Protected Branch Safety (delete & force-push)
 # ============================================
 
-PROTECTED_BRANCHES="main main-staging main-dev backend-dev frontend-dev"
+PROTECTED_BRANCHES="main main-staging main-dev"
 
 # Read stdin: pre-push hook receives lines of "local_ref local_sha remote_ref remote_sha"
 while read local_ref local_sha remote_ref remote_sha; do
@@ -55,7 +55,7 @@ done
 if [ "$CURRENT_BRANCH" = "main" ]; then
   echo ""
   echo "⚠️  WARNING: Pushing directly to main!"
-  echo "   Recommended flow: feature → frontend-dev → main-dev → main"
+  echo "   Recommended flow: feature → main-dev → main-staging → main"
   echo ""
 fi
 
@@ -134,20 +134,18 @@ fi
 # ============================================
 
 if [ -n "$CURRENT_BRANCH" ]; then
-  # Expected patterns based on parent branch:
-  # - feature/frontend-dev-{issue}-{desc} for frontend-dev children
-  # - feature/{type}-{desc} for main-dev children
-  # - main, main-dev, frontend-dev for main branches
+  # Expected patterns:
+  # - feature/issue-{n}-{desc} or feature/{descriptive-name}
+  # - main, main-dev, main-staging for main branches
 
-  VALID_PATTERN='^(feature|fix|docs|test|refactor|chore|release)/|^main$|^main-dev$|^frontend-dev$'
+  VALID_PATTERN='^(feature|fix|docs|test|refactor|chore|release|hotfix|merge)/|^main$|^main-dev$|^main-staging$'
 
   if ! echo "$CURRENT_BRANCH" | grep -qE "$VALID_PATTERN"; then
     echo ""
     echo "Warning: Branch name $CURRENT_BRANCH does not follow naming convention."
     echo "   Expected patterns:"
-    echo "     - feature/frontend-dev-{issue}-{desc}  (from frontend-dev)"
-    echo "     - feature/{issue}-{desc}              (from main-dev)"
-    echo "     - fix/*, docs/*, test/*, refactor/*, chore/*, release/*"
+    echo "     - feature/issue-{n}-{desc}  (from main-dev)"
+    echo "     - fix/*, docs/*, test/*, refactor/*, chore/*, release/*, hotfix/*"
     echo "   This is a warning only - push will continue."
     echo ""
   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,27 +122,29 @@ cd ../../infra && make dev        # All services (make dev-core = no AI/monitori
 
 ### Git Workflow
 
-**Branches**: `main-dev` (dev) | `frontend-dev` (frontend) | `main` (prod) | `feature/issue-{n}-{desc}`
+**Branches**: `main-dev` (dev) | `main-staging` (release) | `main` (prod) | `feature/issue-{n}-{desc}`
 
-**🔴 PR Target Rule**: Feature branches MUST merge to their parent branch
+**🔴 PR Target Rule**: Feature branches MUST merge to their parent branch (typically `main-dev`)
 
 ```bash
-git checkout frontend-dev && git pull
+git checkout main-dev && git pull
 git checkout -b feature/issue-123-desc
-git config branch.feature/issue-123-desc.parent frontend-dev
+git config branch.feature/issue-123-desc.parent main-dev
 # work → commit → test → push
 git push -u origin feature/issue-123-desc
-# PR to frontend-dev (NOT main!) → merge → git branch -D feature/issue-123-desc
+# PR to main-dev → merge (auto-deletes branch on merge)
 ```
+
+> **Note**: `frontend-dev` and `backend-dev` were retired on 2026-05-09 (issue #897). All feature branches now target `main-dev` directly. Auto-delete on merge is enabled at repo level — no need to `git branch -D` after PR merge.
 
 **🔴 Branch Hygiene Rule** (issue #806): ALWAYS switch to the parent branch BEFORE creating a feature branch. Never run `git checkout -b feature/...` while HEAD is on another in-progress feature branch — it absorbs the other branch's commits into your new branch's ancestry. Concurrent multi-terminal workflows (incl. AI agentic sessions) are particularly prone to this.
 
 **Pre-creation safety check** — run before `git checkout -b`:
 
 ```bash
-# Verify HEAD is on the intended parent (main-dev / frontend-dev / main),
+# Verify HEAD is on the intended parent (main-dev / main),
 # NOT on another feature/* branch
-git branch --show-current  # MUST print main-dev, frontend-dev, or main
+git branch --show-current  # MUST print main-dev or main
 git status                 # MUST show clean tree
 git pull --ff-only         # MUST succeed (no divergence)
 git checkout -b feature/issue-{n}-{desc}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,7 @@ Discussion happens in the issue thread before implementation begins.
 
 1. **Fork the repository** (external contributors) or create a feature branch (organization members).
 2. **Branch naming**: `feature/<short-description>` or `feature/issue-<n>-<desc>` for issue work.
-3. **Branch from the correct parent**:
-   - `main-dev` for general work
-   - `frontend-dev` for frontend-only changes
-   - See [`CLAUDE.md`](./CLAUDE.md#git-workflow) §"Git Workflow" for details
+3. **Branch from `main-dev`**: see [`CLAUDE.md`](./CLAUDE.md#git-workflow) §"Git Workflow" for the canonical flow.
 4. **Keep PRs focused** — one logical change per PR. Easier to review, easier to revert.
 5. **Self-review before requesting review**:
    - All tests pass locally
@@ -176,8 +173,8 @@ Husky `commit-msg` hook validates on every commit; CI re-validates.
 | Branch | Purpose |
 |--------|---------|
 | `main` | Production releases |
+| `main-staging` | Pre-production release branch (PRs from `main-dev`) |
 | `main-dev` | Active development integration |
-| `frontend-dev` | Frontend-specific feature integration |
 | `feature/issue-<n>-<desc>` | Issue-driven feature work |
 | `feature/<descriptive-name>` | Non-issue feature work |
 

--- a/docs/for-developers/deployment/README.md
+++ b/docs/for-developers/deployment/README.md
@@ -93,16 +93,13 @@ COMPOSE_FILE=docker-compose.yml;compose.dev.yml
 ### Branch Strategy
 
 ```
-feature/*  --PR-->  main-dev  --merge-->  main-staging  (auto-deploy meepleai.app)
-                        |
-                   frontend-dev  (frontend features)
+feature/*  --PR-->  main-dev  --merge-->  main-staging  (auto-deploy meepleai.app)  --PR-->  main
 ```
 
 | Branch | Scopo | Deploy | CI |
 |--------|-------|--------|-----|
 | `feature/*` | Sviluppo feature | Nessuno | PR check |
 | `main-dev` | Integrazione sviluppo | Nessuno | CI completa |
-| `frontend-dev` | Feature frontend | Nessuno | CI completa |
 | `main-staging` | Ambiente attivo | meepleai.app (auto) | CI + Deploy |
 | `main` | Futuro production | Non attivo | Predisposta |
 

--- a/docs/for-developers/specs/2026-04-26-v2-design-migration.md
+++ b/docs/for-developers/specs/2026-04-26-v2-design-migration.md
@@ -5,6 +5,8 @@
 **Scope**: Migrazione frontend `apps/web/` al design system v2 usando i mockup SP3 + SP4 wave 1+2+3+4 come fonte di verità.
 **Status**: APPROVED (utente sign-off 2026-04-26 + amendment 2026-05-04 post Wave C.1 fail RCA)
 
+> **Nota storica (2026-05-09, issue #897)**: questa spec menziona `frontend-dev` come parent branch per le PR delle wave. Il branch `frontend-dev` è stato ritirato; tutte le wave residue/follow-up devono ora targettare `main-dev`.
+
 ---
 
 ## 1. Context & Decisioni utente

--- a/docs/for-developers/workflows/git-workflow.md
+++ b/docs/for-developers/workflows/git-workflow.md
@@ -23,7 +23,9 @@
 
 **main-staging → main Quality Gates**: Backend 90% coverage, Frontend 85%, Integration tests, Security scan, Performance check (optional)
 
-**Child Branches**: `frontend-dev`, `backend-dev` → merge into `main-dev`
+**Feature Branches**: `feature/issue-{n}-{desc}` → PR into `main-dev` (auto-deletes on merge)
+
+> **Historical**: `frontend-dev` and `backend-dev` were retired on 2026-05-09 (issue #897). All feature branches now target `main-dev` directly.
 
 ---
 
@@ -50,7 +52,7 @@ git checkout main-dev && git merge feature/issue-123-search && git push
 git branch -D feature/issue-123-search && git push origin --delete feature/issue-123-search
 ```
 
-**Shortcuts**: Direct commit to `main-dev` (small changes) or use `frontend-dev`/`backend-dev` for isolation
+**Shortcuts**: For trivial changes, direct commit to `main-dev` is allowed. For all other work, use a `feature/issue-{n}-{desc}` branch.
 
 ### Release to Staging
 
@@ -116,7 +118,7 @@ git branch -D hotfix/critical-bug && git push origin --delete hotfix/critical-bu
 
 ### main-dev CI (`.github/workflows/main-dev-ci.yml`)
 
-**Trigger**: Push to `main-dev`, `frontend-dev`, `backend-dev`
+**Trigger**: Push to `main-dev`
 
 | Job | Steps | Blocking |
 |-----|-------|----------|

--- a/scripts/git-workflow.sh
+++ b/scripts/git-workflow.sh
@@ -262,7 +262,7 @@ Generated: $(date)" || exit 1
         echo "🌿 Branch Status:"
         git fetch origin --quiet
 
-        for branch in main main-staging main-dev frontend-dev backend-dev; do
+        for branch in main main-staging main-dev; do
             if git show-ref --verify --quiet "refs/heads/$branch" || git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
                 LOCAL_COMMIT=$(git rev-parse "$branch" 2>/dev/null || echo "N/A")
                 REMOTE_COMMIT=$(git rev-parse "origin/$branch" 2>/dev/null || echo "N/A")


### PR DESCRIPTION
## Summary

Closes #897. Removes all references to the retired `frontend-dev` and `backend-dev` branches from canonical docs, CI workflow triggers, branch protection policy, and husky hooks.

**Context**: both branches were deleted on 2026-05-09 after 40+ days of inactivity. Last activity was 2026-03-30 (just a tech merge); all subsequent FE/BE work was merged directly to `main-dev`.

## Changes

**Canonical docs** (user-facing):
- `CLAUDE.md` — Git Workflow section + Pre-creation safety check
- `CONTRIBUTING.md` — PR Process + Branch table
- `docs/for-developers/workflows/git-workflow.md` — Child branches, shortcuts, CI trigger
- `docs/for-developers/deployment/README.md` — Branch strategy diagram + table
- `docs/for-developers/specs/2026-04-26-v2-design-migration.md` — Historical deprecation note

**CI / hooks** (behavioral):
- `.github/workflows/ci.yml` — PR trigger list
- `.github/workflows/backend-missing-gate.yml` — PR trigger list
- `.github/workflows/visual-regression-migrated.yml` — PR trigger list
- `.github/workflows/visual-regression-mockups.yml` — PR trigger list
- `.github/workflows/auto-branch-policy.yml` — `ALLOWED_PATTERNS` regex + error messages
- `.github/workflows/README.md` — Workflow reference
- `.husky/pre-push` — `PROTECTED_BRANCHES` list, recommended flow message, branch-name validator
- `.husky/pre-commit` — Header comment
- `scripts/git-workflow.sh` — Branch status loop

## Out of Scope (Follow-up)

These files still reference the retired branches but require deeper refactoring:

- [ ] `tools/development/open-dual-vscode.{ps1,sh}` — assume worktree setup with these branches
- [ ] `.github/ISSUE_TEMPLATE/site-wide-redesign.md` — historical issue template
- [ ] `apps/web/docs/wave-9-testing-guide.md` — historical guide
- [ ] `docs/superpowers/plans/2026-05-06-auth-flow-security-fixes-plan.md` — recent plan, may be inert
- [ ] `.docs-archive/**` — intentionally frozen, no changes needed

A follow-up issue can address the dev tools refactor if `open-dual-vscode` is still used.

## Test Plan

- [ ] CI passes (the workflow files we touched are configurations only)
- [ ] `auto-branch-policy.yml` regex still accepts `feature/*`, `fix/*`, etc. for PRs to `main-dev`
- [ ] `.husky/pre-push` `VALID_PATTERN` regex still matches all in-flight branches
- [ ] No new docs reference `frontend-dev`/`backend-dev` as active branches (deprecation notes only where historical context is needed)

## Risk

**Low** — all changes are documentation or config alignment with the already-completed branch retirement. The CI trigger lists previously fired on push to non-existent branches (no-op).