### PR TITLE
feat(web): #900 G3 — GamesRecentRail in games hub for game-night entry point

### DIFF
--- a/apps/web/src/app/(authenticated)/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/page.tsx
@@ -72,7 +72,7 @@ function GamesHubContent() {
   const { data: catalogData, isLoading: catalogLoading } = useGames(undefined, undefined, 1, 20);
 
   const router = useRouter();
-  const recentGames = useRecentLibraryGames(5);
+  const recentGames = useRecentLibraryGames(5, activeTab === 'library');
 
   const recentRailItems = useMemo(
     () => recentGames.entries.map(e => ({

--- a/apps/web/src/app/(authenticated)/games/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/page.tsx
@@ -3,12 +3,14 @@
 import { Suspense, useState, useMemo } from 'react';
 
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { HubLayout, type FilterChip } from '@/components/layout/HubLayout';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { GamesRecentRail } from '@/components/v2/games';
 import { useGames } from '@/hooks/queries/useGames';
+import { useRecentLibraryGames } from '@/hooks/queries/useRecentLibraryGames';
 import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
 
 import { GamesLibraryView } from './_components/GamesLibraryView';
@@ -69,6 +71,35 @@ function GamesHubContent() {
 
   const { data: catalogData, isLoading: catalogLoading } = useGames(undefined, undefined, 1, 20);
 
+  const router = useRouter();
+  const recentGames = useRecentLibraryGames(5);
+
+  const recentRailItems = useMemo(
+    () => recentGames.entries.map(e => ({
+      id: e.gameId,
+      title: e.gameTitle,
+      imageUrl: e.gameImageUrl ?? undefined,
+      kbBadge: (e.kbIndexedCount > 0
+        ? 'ready'
+        : e.kbProcessingCount > 0
+          ? 'processing'
+          : 'none') as 'ready' | 'processing' | 'none',
+    })),
+    [recentGames.entries]
+  );
+
+  const recentRail = (
+    <GamesRecentRail
+      items={recentRailItems}
+      isLoading={recentGames.isLoading}
+      labels={{
+        sectionTitle: 'Giochi recenti',
+        emptyHint: 'Inizia a giocare per vedere qui i tuoi titoli recenti.',
+      }}
+      onSelect={(id) => router.push(`/library/games/${id}?tab=aiChat`)}
+    />
+  );
+
   useMiniNavConfig({
     breadcrumb: 'Giochi',
     tabs: [
@@ -107,7 +138,12 @@ function GamesHubContent() {
 
   // ---- Library tab uses dedicated v2 orchestrator (Wave B.1 Issue #633) ----
   if (activeTab === 'library') {
-    return <GamesLibraryView />;
+    return (
+      <>
+        {recentRail}
+        <GamesLibraryView />
+      </>
+    );
   }
 
   // ---- Determine active tab state (library handled by early return above) ----
@@ -127,18 +163,20 @@ function GamesHubContent() {
   );
 
   return (
-    <HubLayout
-      searchPlaceholder="Cerca giochi..."
-      filterChips={currentFilters}
-      activeFilterId={activeFilter}
-      onFilterChange={setActiveFilter}
-      searchValue={search}
-      onSearchChange={setSearch}
-      viewMode={viewMode}
-      onViewModeChange={setViewMode}
-      showViewToggle
-      topActions={topActions}
-    >
+    <>
+      {recentRail}
+      <HubLayout
+        searchPlaceholder="Cerca giochi..."
+        filterChips={currentFilters}
+        activeFilterId={activeFilter}
+        onFilterChange={setActiveFilter}
+        searchValue={search}
+        onSearchChange={setSearch}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        showViewToggle
+        topActions={topActions}
+      >
       {isLoading ? (
         <LoadingSkeleton />
       ) : items.length === 0 ? (
@@ -160,7 +198,8 @@ function GamesHubContent() {
           ))}
         </div>
       )}
-    </HubLayout>
+      </HubLayout>
+    </>
   );
 }
 

--- a/apps/web/src/components/v2/games/GamesRecentRail.tsx
+++ b/apps/web/src/components/v2/games/GamesRecentRail.tsx
@@ -1,0 +1,106 @@
+/**
+ * GamesRecentRail — v2 horizontal rail per il flusso "serata di gioco" (G3).
+ *
+ * Pure component (no fetch, no router, no i18n hook): orchestrator passa
+ * items + labels + onSelect. Riusa pattern Wave B.1 (vedi GamesHero).
+ *
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+
+export type RecentKbBadge = 'ready' | 'processing' | 'none';
+
+export interface GamesRecentRailItem {
+  readonly id: string;
+  readonly title: string;
+  readonly imageUrl?: string;
+  readonly kbBadge: RecentKbBadge;
+}
+
+export interface GamesRecentRailLabels {
+  readonly sectionTitle: string;
+  readonly emptyHint: string;
+  readonly viewAllHref: string;
+}
+
+export interface GamesRecentRailProps {
+  readonly items: readonly GamesRecentRailItem[];
+  readonly labels: GamesRecentRailLabels;
+  readonly isLoading?: boolean;
+  readonly onSelect: (id: string) => void;
+  readonly className?: string;
+}
+
+const SKELETON_COUNT = 3;
+
+const KB_BADGE_LABEL: Record<RecentKbBadge, string> = {
+  ready: '📖 KB pronta',
+  processing: '⏳ KB in elaborazione',
+  none: '',
+};
+
+export function GamesRecentRail({
+  items,
+  labels,
+  isLoading = false,
+  onSelect,
+  className,
+}: GamesRecentRailProps): ReactElement {
+  return (
+    <section
+      role="region"
+      aria-label={labels.sectionTitle}
+      data-slot="games-recent-rail"
+      className={clsx('w-full px-4 py-3', className)}
+    >
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-base font-semibold text-foreground">{labels.sectionTitle}</h2>
+      </div>
+
+      {isLoading ? (
+        <div className="flex gap-3 overflow-x-auto pb-1">
+          {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+            <Skeleton
+              key={i}
+              data-testid="games-recent-rail-skeleton"
+              className="h-24 w-40 shrink-0 rounded-xl"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">{labels.emptyHint}</p>
+      ) : (
+        <div className="flex gap-3 overflow-x-auto pb-1 snap-x snap-mandatory">
+          {items.map(item => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onSelect(item.id)}
+              aria-label={item.title}
+              data-slot="games-recent-rail-card"
+              data-kb-badge={item.kbBadge}
+              className={clsx(
+                'shrink-0 snap-start text-left rounded-xl border border-border bg-card',
+                'h-24 w-40 px-3 py-2 transition-colors hover:bg-muted',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+              )}
+            >
+              <span className="block text-sm font-medium text-foreground line-clamp-2">
+                {item.title}
+              </span>
+              {item.kbBadge !== 'none' && (
+                <span className="mt-1 block text-xs text-muted-foreground">
+                  {KB_BADGE_LABEL[item.kbBadge]}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/v2/games/GamesRecentRail.tsx
+++ b/apps/web/src/components/v2/games/GamesRecentRail.tsx
@@ -24,7 +24,6 @@ export interface GamesRecentRailItem {
 export interface GamesRecentRailLabels {
   readonly sectionTitle: string;
   readonly emptyHint: string;
-  readonly viewAllHref: string;
 }
 
 export interface GamesRecentRailProps {
@@ -57,9 +56,7 @@ export function GamesRecentRail({
       data-slot="games-recent-rail"
       className={clsx('w-full px-4 py-3', className)}
     >
-      <div className="flex items-baseline justify-between mb-3">
-        <h2 className="text-base font-semibold text-foreground">{labels.sectionTitle}</h2>
-      </div>
+      <h2 className="text-base font-semibold text-foreground mb-3">{labels.sectionTitle}</h2>
 
       {isLoading ? (
         <div className="flex gap-3 overflow-x-auto pb-1">

--- a/apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx
+++ b/apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx
@@ -10,7 +10,6 @@ import { GamesRecentRail } from '../GamesRecentRail';
 const labels = {
   sectionTitle: 'Giochi recenti',
   emptyHint: 'Inizia a giocare per vedere qui i tuoi titoli recenti.',
-  viewAllHref: '/library',
 };
 
 describe('GamesRecentRail', () => {
@@ -24,16 +23,22 @@ describe('GamesRecentRail', () => {
     expect(screen.getByText(labels.emptyHint)).toBeInTheDocument();
   });
 
-  it('renders 1 to 5 cards in order', () => {
-    const items = ['a', 'b', 'c'].map(id => ({
+  it('renders single card when items has length 1', () => {
+    const items = [{ id: 'solo', title: 'Solo Game', kbBadge: 'ready' as const }];
+    render(<GamesRecentRail items={items} labels={labels} onSelect={vi.fn()} />);
+    const cards = screen.getAllByRole('button', { name: /Solo Game/ });
+    expect(cards).toHaveLength(1);
+  });
+
+  it('renders 5 cards in order', () => {
+    const items = ['a', 'b', 'c', 'd', 'e'].map(id => ({
       id, title: `Game ${id}`, kbBadge: 'ready' as const,
     }));
     render(<GamesRecentRail items={items} labels={labels} onSelect={vi.fn()} />);
-    const cards = screen.getAllByRole('button', { name: /Game [abc]/ });
-    expect(cards).toHaveLength(3);
+    const cards = screen.getAllByRole('button', { name: /Game [a-e]/ });
+    expect(cards).toHaveLength(5);
     expect(cards[0].textContent).toContain('Game a');
-    expect(cards[1].textContent).toContain('Game b');
-    expect(cards[2].textContent).toContain('Game c');
+    expect(cards[4].textContent).toContain('Game e');
   });
 
   it('calls onSelect with game id when card clicked', () => {

--- a/apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx
+++ b/apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * GamesRecentRail — pure component tests
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { GamesRecentRail } from '../GamesRecentRail';
+
+const labels = {
+  sectionTitle: 'Giochi recenti',
+  emptyHint: 'Inizia a giocare per vedere qui i tuoi titoli recenti.',
+  viewAllHref: '/library',
+};
+
+describe('GamesRecentRail', () => {
+  it('renders skeleton when isLoading', () => {
+    render(<GamesRecentRail items={[]} labels={labels} isLoading onSelect={vi.fn()} />);
+    expect(screen.getAllByTestId('games-recent-rail-skeleton')).toHaveLength(3);
+  });
+
+  it('renders empty hint when no items and not loading', () => {
+    render(<GamesRecentRail items={[]} labels={labels} onSelect={vi.fn()} />);
+    expect(screen.getByText(labels.emptyHint)).toBeInTheDocument();
+  });
+
+  it('renders 1 to 5 cards in order', () => {
+    const items = ['a', 'b', 'c'].map(id => ({
+      id, title: `Game ${id}`, kbBadge: 'ready' as const,
+    }));
+    render(<GamesRecentRail items={items} labels={labels} onSelect={vi.fn()} />);
+    const cards = screen.getAllByRole('button', { name: /Game [abc]/ });
+    expect(cards).toHaveLength(3);
+    expect(cards[0].textContent).toContain('Game a');
+    expect(cards[1].textContent).toContain('Game b');
+    expect(cards[2].textContent).toContain('Game c');
+  });
+
+  it('calls onSelect with game id when card clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <GamesRecentRail
+        items={[{ id: 'wingspan', title: 'Wingspan', kbBadge: 'ready' }]}
+        labels={labels}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Wingspan/ }));
+    expect(onSelect).toHaveBeenCalledWith('wingspan');
+  });
+
+  it('section has accessible name from sectionTitle', () => {
+    render(<GamesRecentRail items={[]} labels={labels} onSelect={vi.fn()} />);
+    expect(screen.getByRole('region', { name: labels.sectionTitle })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/v2/games/index.ts
+++ b/apps/web/src/components/v2/games/index.ts
@@ -31,3 +31,11 @@ export type {
   GamesEmptyStateLabels,
   GamesEmptyStateProps,
 } from './GamesEmptyState';
+
+export { GamesRecentRail } from './GamesRecentRail';
+export type {
+  GamesRecentRailItem,
+  GamesRecentRailLabels,
+  GamesRecentRailProps,
+  RecentKbBadge,
+} from './GamesRecentRail';

--- a/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
@@ -149,4 +149,55 @@ describe('useRecentLibraryGames', () => {
 
     expect(result.current.entries.map(e => e.gameId)).toEqual(['inlib']);
   });
+
+  it('returns empty entries when disabled', async () => {
+    vi.mocked(useLibrary).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as any);
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    const { result } = renderHook(() => useRecentLibraryGames(5, false), { wrapper });
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports isError when library errors and recents store is empty', async () => {
+    vi.mocked(useLibrary).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as any);
+    // recentlyAdded mock già emptyPaginated da beforeEach
+    useRecentsStore.setState({ items: [] });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.entries).toEqual([]);
+  });
+
+  it('does NOT report isError when library errors but recents store has items', async () => {
+    vi.mocked(useLibrary).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as any);
+    useRecentsStore.setState({
+      items: [
+        { id: 'cached-game', entity: 'game', title: 'Cached', href: '/library/games/cached-game', visitedAt: 1731147600000 },
+      ],
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(false);
+  });
 });

--- a/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * useRecentLibraryGames — unit tests
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { useRecentsStore } from '@/stores/use-recents';
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: vi.fn(),
+  useRecentlyAddedGames: vi.fn(),
+}));
+
+import { useLibrary, useRecentlyAddedGames } from '@/hooks/queries/useLibrary';
+import { useRecentLibraryGames } from '../useRecentLibraryGames';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const entry = (id: string, addedAt = '2026-05-01T00:00:00Z') => ({
+  id: `entry-${id}`,
+  userId: 'u1',
+  gameId: id,
+  gameTitle: `Game ${id}`,
+  isFavorite: false,
+  currentState: 'Owned' as const,
+  addedAt,
+  hasKb: true,
+  kbCardCount: 1,
+  kbIndexedCount: 1,
+  kbProcessingCount: 0,
+  hasRagAccess: true,
+  agentIsOwned: true,
+  isPrivateGame: false,
+  canProposeToCatalog: false,
+});
+
+const emptyPaginated = { items: [], page: 1, pageSize: 50, totalCount: 0, totalPages: 0, hasNextPage: false, hasPreviousPage: false };
+
+describe('useRecentLibraryGames', () => {
+  beforeEach(() => {
+    useRecentsStore.setState({ items: [] });
+    vi.mocked(useLibrary).mockReturnValue({
+      data: emptyPaginated,
+      isLoading: false,
+      isError: false,
+    } as any);
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: emptyPaginated,
+      isLoading: false,
+      isError: false,
+    } as any);
+  });
+
+  it('returns recents-store games in order, mapped to library entries', async () => {
+    const e1 = entry('aaa');
+    const e2 = entry('bbb');
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1, e2], totalCount: 2, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: [
+        { id: 'bbb', entity: 'game', title: 'Game bbb', href: '/library/games/bbb', visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */ },
+        { id: 'aaa', entity: 'game', title: 'Game aaa', href: '/library/games/aaa', visitedAt: 1731144000000 /* 2026-05-09T09:00:00Z */ },
+      ],
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['bbb', 'aaa']);
+  });
+
+  it('falls back to recently-added when recents store empty', async () => {
+    const e1 = entry('xxx', '2026-05-08T00:00:00Z');
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1], totalCount: 1, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['xxx']);
+  });
+
+  it('truncates to limit (≤ MAX_RECENTS=4 in real store; setState bypasses cap)', async () => {
+    const items = ['a', 'b', 'c', 'd'].map(id => entry(id));
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items, totalCount: 4, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: items.map(e => ({
+        id: e.gameId, entity: 'game' as const, title: e.gameTitle,
+        href: `/library/games/${e.gameId}`, visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */,
+      })),
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(2), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries).toHaveLength(2);
+  });
+
+  it('skips recents whose game is no longer in library', async () => {
+    const e1 = entry('inlib');
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1], totalCount: 1, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: [
+        { id: 'removed', entity: 'game', title: 'Removed', href: '/library/games/removed', visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */ },
+        { id: 'inlib', entity: 'game', title: 'In Lib', href: '/library/games/inlib', visitedAt: 1731144000000 /* 2026-05-09T09:00:00Z */ },
+      ],
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['inlib']);
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.tsx
@@ -57,6 +57,24 @@ describe('useRecentLibraryGames', () => {
     } as any);
   });
 
+  it('reports loading when library resolved but recently-added still pending', async () => {
+    vi.mocked(useLibrary).mockReturnValue({
+      data: emptyPaginated,
+      isLoading: false,
+      isError: false,
+    } as any);
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as any);
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.entries).toEqual([]);
+  });
+
   it('returns recents-store games in order, mapped to library entries', async () => {
     const e1 = entry('aaa');
     const e2 = entry('bbb');

--- a/apps/web/src/hooks/queries/useRecentLibraryGames.ts
+++ b/apps/web/src/hooks/queries/useRecentLibraryGames.ts
@@ -29,7 +29,7 @@ export function useRecentLibraryGames(limit: number = 5): UseRecentLibraryGamesR
   const recents = useRecentsStore(state => state.items);
 
   return useMemo<UseRecentLibraryGamesResult>(() => {
-    const isLoading = libraryQuery.isLoading;
+    const isLoading = libraryQuery.isLoading || recentlyAdded.isLoading;
     const isError = libraryQuery.isError && recents.length === 0;
 
     const libIndex = new Map<string, UserLibraryEntry>();
@@ -59,5 +59,5 @@ export function useRecentLibraryGames(limit: number = 5): UseRecentLibraryGamesR
     }
 
     return { entries: result, isLoading, isError };
-  }, [libraryQuery.data, libraryQuery.isLoading, libraryQuery.isError, recentlyAdded.data, recents, limit]);
+  }, [libraryQuery.data, libraryQuery.isLoading, libraryQuery.isError, recentlyAdded.data, recentlyAdded.isLoading, recents, limit]);
 }

--- a/apps/web/src/hooks/queries/useRecentLibraryGames.ts
+++ b/apps/web/src/hooks/queries/useRecentLibraryGames.ts
@@ -1,0 +1,63 @@
+/**
+ * useRecentLibraryGames — restituisce fino a N giochi della libreria ordinati
+ * per recency: prima i giochi visitati di recente (Zustand recents store),
+ * poi fallback a recently-added.
+ *
+ * Usato dal `GamesRecentRail` widget nel Games Hub per il flusso "serata di
+ * gioco" (entry point ≤2 tap fino alla chat in-game).
+ *
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { useMemo } from 'react';
+
+import { useLibrary, useRecentlyAddedGames } from '@/hooks/queries/useLibrary';
+import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
+import { useRecentsStore } from '@/stores/use-recents';
+
+export interface UseRecentLibraryGamesResult {
+  readonly entries: readonly UserLibraryEntry[];
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+}
+
+const LIBRARY_FETCH_SIZE = 50;
+
+export function useRecentLibraryGames(limit: number = 5): UseRecentLibraryGamesResult {
+  const libraryQuery = useLibrary({ page: 1, pageSize: LIBRARY_FETCH_SIZE });
+  const recentlyAdded = useRecentlyAddedGames(limit);
+
+  const recents = useRecentsStore(state => state.items);
+
+  return useMemo<UseRecentLibraryGamesResult>(() => {
+    const isLoading = libraryQuery.isLoading;
+    const isError = libraryQuery.isError && recents.length === 0;
+
+    const libIndex = new Map<string, UserLibraryEntry>();
+    for (const entry of libraryQuery.data?.items ?? []) {
+      libIndex.set(entry.gameId, entry);
+    }
+
+    const seen = new Set<string>();
+    const result: UserLibraryEntry[] = [];
+
+    for (const recent of recents) {
+      if (recent.entity !== 'game') continue;
+      const entry = libIndex.get(recent.id);
+      if (!entry || seen.has(entry.gameId)) continue;
+      result.push(entry);
+      seen.add(entry.gameId);
+      if (result.length >= limit) break;
+    }
+
+    if (result.length < limit) {
+      for (const entry of recentlyAdded.data?.items ?? []) {
+        if (seen.has(entry.gameId)) continue;
+        result.push(entry);
+        seen.add(entry.gameId);
+        if (result.length >= limit) break;
+      }
+    }
+
+    return { entries: result, isLoading, isError };
+  }, [libraryQuery.data, libraryQuery.isLoading, libraryQuery.isError, recentlyAdded.data, recents, limit]);
+}

--- a/apps/web/src/hooks/queries/useRecentLibraryGames.ts
+++ b/apps/web/src/hooks/queries/useRecentLibraryGames.ts
@@ -20,11 +20,25 @@ export interface UseRecentLibraryGamesResult {
   readonly isError: boolean;
 }
 
+/**
+ * Numero massimo di entry della libreria pre-fetchate per indicizzare i recents.
+ *
+ * **Limite noto**: per librerie utente >50 giochi, i recents store entries
+ * con `gameId` non presenti nella prima pagina della libreria verranno
+ * filtrati come "missing" (vedi algoritmo §G3 step 4). Un utente con 100
+ * giochi potrebbe vedere meno recents di quelli reali.
+ *
+ * Se questo diventa un problema in produzione: aumentare a 200 o
+ * implementare paginazione trasparente con accumulo client-side.
+ */
 const LIBRARY_FETCH_SIZE = 50;
 
-export function useRecentLibraryGames(limit: number = 5): UseRecentLibraryGamesResult {
-  const libraryQuery = useLibrary({ page: 1, pageSize: LIBRARY_FETCH_SIZE });
-  const recentlyAdded = useRecentlyAddedGames(limit);
+export function useRecentLibraryGames(
+  limit: number = 5,
+  enabled: boolean = true
+): UseRecentLibraryGamesResult {
+  const libraryQuery = useLibrary({ page: 1, pageSize: LIBRARY_FETCH_SIZE }, enabled);
+  const recentlyAdded = useRecentlyAddedGames(limit, enabled);
 
   const recents = useRecentsStore(state => state.items);
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -131,7 +131,7 @@ the PR review.
 | `sp4-games-index.jsx` | `AdvancedFiltersDrawer` | `apps/web/src/components/v2/games/AdvancedFiltersDrawer.tsx` | `/games` | pending | — | T A M V |
 | `sp4-games-index.jsx` | `GamesResultsGrid` | `apps/web/src/components/v2/games/GamesResultsGrid.tsx` | `/games` | pending | — | T A V |
 | `sp4-games-index.jsx` | `GamesEmptyState` | `apps/web/src/components/v2/games/GamesEmptyState.tsx` | `/games` | pending | — | T A V |
-| (extension G3) | `GamesRecentRail` | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | `/games?tab=*` | done | TBD | T A V |
+| (extension G3) | `GamesRecentRail` | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | `/games?tab=*` | done | #907 | T A V |
 
 ### Game detail — `/games/[id]` — 8 components — **Tier L** ⚠️ Phase 0.5 required
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -122,7 +122,7 @@ the PR review.
 
 ## Wave 1 — 29 components
 
-### Games index — `/games` — 5 components — **Tier S**
+### Games index — `/games` — 6 components — **Tier S**
 
 | Mockup | Component | Path | Route | Status | PR | AC |
 |--------|-----------|------|-------|--------|----|----|
@@ -131,6 +131,7 @@ the PR review.
 | `sp4-games-index.jsx` | `AdvancedFiltersDrawer` | `apps/web/src/components/v2/games/AdvancedFiltersDrawer.tsx` | `/games` | pending | — | T A M V |
 | `sp4-games-index.jsx` | `GamesResultsGrid` | `apps/web/src/components/v2/games/GamesResultsGrid.tsx` | `/games` | pending | — | T A V |
 | `sp4-games-index.jsx` | `GamesEmptyState` | `apps/web/src/components/v2/games/GamesEmptyState.tsx` | `/games` | pending | — | T A V |
+| (extension G3) | `GamesRecentRail` | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | `/games?tab=*` | done | TBD | T A V |
 
 ### Game detail — `/games/[id]` — 8 components — **Tier L** ⚠️ Phase 0.5 required
 

--- a/docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md
+++ b/docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md
@@ -4,7 +4,7 @@
 
 **Goal:** Permettere a un utente Alpha di raggiungere la chat-in-game di un gioco recente in ≤2 tap dalla dashboard, montando un nuovo widget `GamesRecentRail` in cima al Games Hub.
 
-**Architecture:** Frontend-only PR su `apps/web`. Aggiunge un nuovo componente puro `GamesRecentRail` v2 + un nuovo hook `useRecentLibraryGames` (Zustand `useRecentsStore` filtrato a entity=game, con fallback a `useRecentlyAddedGames`). Wiring minimo nel `DashboardClient.tsx`: monta il rail in cima per i tab `library` e `catalog` senza modificare il rendering interno dei tab.
+**Architecture:** Frontend-only PR su `apps/web`. Aggiunge un nuovo componente puro `GamesRecentRail` v2 + un nuovo hook `useRecentLibraryGames` (Zustand `useRecentsStore` filtrato a entity=game, con fallback a `useRecentlyAddedGames`). Wiring minimo in `apps/web/src/app/(authenticated)/games/page.tsx` (`GamesHubContent`): monta il rail in cima per i tab `library`, `catalog` e `kb` senza modificare il rendering interno dei tab. **NB**: il file target è `games/page.tsx`, NON `dashboard/DashboardClient.tsx` (che ha struttura diversa con `EntityZone` ed è fuori scope).
 
 **Tech Stack:** React 19 + Next.js 16 App Router, TypeScript strict, Tailwind 4, Zustand, TanStack Query, Vitest. Pattern di riferimento: `RecentActivityRail` (PR #574), `GamesHero` (PR #635).
 
@@ -23,7 +23,7 @@
 | Create | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | Componente v2 puro — riceve `items[]`, label e callback; rende rail orizzontale di 1-N card |
 | Create | `apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx` | Test rendering: empty, 1, N card, click handler, a11y region |
 | Modify | `apps/web/src/components/v2/games/index.ts` | Aggiungere export di `GamesRecentRail` e tipi correlati |
-| Modify | `apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx` | Inserire `<GamesRecentRail>` in cima a tutti i branch di rendering (sopra `GamesLibraryView` e sopra il blocco `HubLayout` per catalog/kb) |
+| Modify | `apps/web/src/app/(authenticated)/games/page.tsx` | Inserire `<GamesRecentRail>` in cima a tutti i branch di rendering (sopra `GamesLibraryView` e sopra il blocco `HubLayout` per catalog/kb). **NB**: questo è il vero file dei tab `library/catalog/kb` (non `dashboard/DashboardClient.tsx`, che ha altra struttura `EntityZone`) |
 | Modify | `docs/for-developers/frontend/v2-migration-matrix.md` | Aggiungere row `GamesRecentRail` nella sezione `/games` (status done) |
 
 **Decomposition decision:** componente puro + hook separato dal wiring per facilitare testing isolato. Il rail è agnostico rispetto al `tab` attivo (mostra sempre i recent games dell'utente, in qualunque vista del hub).
@@ -52,21 +52,31 @@ cd apps/web && pnpm typecheck && pnpm lint
 ```
 Expected: nessun errore. Se ci sono errori preesistenti, registrarli come baseline per non confonderli con quelli introdotti.
 
-- [ ] **Step 0.3: Verifica shape effettiva di `useRecentsStore`**
+- [ ] **Step 0.3: Shape di `useRecentsStore` (verificata in fase di plan-review)**
 
-Run: `grep -n "items\|RecentItem\|addedAt\|visitedAt\|entity" apps/web/src/stores/use-recents.ts | head -30`
+La shape reale del file `apps/web/src/stores/use-recents.ts:10-23` è:
 
-Annota qui sotto la shape effettiva di un item del store (es. nome del campo timestamp: `addedAt`? `visitedAt`? Nome del campo entity-id: `id`? Forma del campo `entity`?). Questo è critico perché i test del Task 1 usano questa shape.
-
+```ts
+const MAX_RECENTS = 4;  // <-- store cap
+interface RecentItem {
+  id: string;
+  entity: MeepleEntityType;  // 'game' | 'player' | 'collection' | 'event' | ...
+  title: string;
+  href: string;
+  visitedAt: number;  // <-- Unix ms (Date.now()), NON ISO string
+}
+interface RecentsState {
+  items: RecentItem[];
+  push: (item: Omit<RecentItem, 'visitedAt'>) => void;  // assegna Date.now() internamente
+  remove: (id: string) => void;
+  clear: () => void;
+}
 ```
-Shape effettiva (compila l'engineer dopo grep):
-- Campo timestamp: ___
-- Campo entity-id: ___
-- Campo entity-type: ___
-- Forma store API: useRecentsStore(state => state.___)
-```
 
-Se la shape differisce dai test del Task 1, **aggiorna i test nello Step 1.1 prima di proseguire**.
+Implicazioni per il Task 1:
+- I test usano `visitedAt: <number>` (es. `Date.now() - 3600_000`), MAI stringhe ISO
+- I test fanno `useRecentsStore.setState({ items: [...] })` per bypass del cap MAX_RECENTS
+- Il limite reale dello store è **4 item** — l'hook deve gestire richieste `limit > 4` con fallback a `useRecentlyAddedGames`
 
 ---
 
@@ -89,13 +99,9 @@ Se la shape differisce dai test del Task 1, **aggiorna i test nello Step 1.1 pri
 - `isLoading: true` se `useLibrary.isLoading`
 - `isError: true` se `useLibrary.isError && recents.length === 0` (errore non recuperabile)
 
-- [ ] **Step 1.1: Allinea i test alla shape effettiva (se necessario)**
+- [ ] **Step 1.1: Conferma shape (già documentata in Step 0.3)**
 
-In base allo Step 0.3, se i campi del recents store differiscono dal test sotto (es. campo si chiama `addedAt` invece di `visitedAt`), aggiorna il test prima di scriverlo. Il test sotto assume:
-- `useRecentsStore.setState({ items: [...] })`
-- Ogni item: `{ id, entity: 'game', title, href, visitedAt }`
-
-Se differente, sostituire `visitedAt` (e `items` se serve) con i nomi reali.
+La shape è confermata: `visitedAt: number`, `items: RecentItem[]`. I test sotto sono già allineati. Procedi.
 
 - [ ] **Step 1.2: Scrivi il test failing**
 
@@ -171,8 +177,8 @@ describe('useRecentLibraryGames', () => {
     } as any);
     useRecentsStore.setState({
       items: [
-        { id: 'bbb', entity: 'game', title: 'Game bbb', href: '/library/games/bbb', visitedAt: '2026-05-09T10:00:00Z' },
-        { id: 'aaa', entity: 'game', title: 'Game aaa', href: '/library/games/aaa', visitedAt: '2026-05-09T09:00:00Z' },
+        { id: 'bbb', entity: 'game', title: 'Game bbb', href: '/library/games/bbb', visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */ },
+        { id: 'aaa', entity: 'game', title: 'Game aaa', href: '/library/games/aaa', visitedAt: 1731144000000 /* 2026-05-09T09:00:00Z */ },
       ],
     });
 
@@ -196,24 +202,27 @@ describe('useRecentLibraryGames', () => {
     expect(result.current.entries.map(e => e.gameId)).toEqual(['xxx']);
   });
 
-  it('truncates to limit', async () => {
-    const items = ['a', 'b', 'c', 'd', 'e', 'f'].map(id => entry(id));
+  it('truncates to limit (≤ MAX_RECENTS=4 in real store; setState bypasses cap)', async () => {
+    // NB: store cap is MAX_RECENTS=4, but setState bypasses push() so we can
+    // simulate any number of items. Test uses 4 to stay within the realistic
+    // range while still exercising truncation.
+    const items = ['a', 'b', 'c', 'd'].map(id => entry(id));
     vi.mocked(useLibrary).mockReturnValue({
-      data: { ...emptyPaginated, items, totalCount: 6, totalPages: 1 },
+      data: { ...emptyPaginated, items, totalCount: 4, totalPages: 1 },
       isLoading: false,
       isError: false,
     } as any);
     useRecentsStore.setState({
       items: items.map(e => ({
         id: e.gameId, entity: 'game' as const, title: e.gameTitle,
-        href: `/library/games/${e.gameId}`, visitedAt: '2026-05-09T10:00:00Z',
+        href: `/library/games/${e.gameId}`, visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */,
       })),
     });
 
-    const { result } = renderHook(() => useRecentLibraryGames(3), { wrapper });
+    const { result } = renderHook(() => useRecentLibraryGames(2), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.entries).toHaveLength(3);
+    expect(result.current.entries).toHaveLength(2);
   });
 
   it('skips recents whose game is no longer in library', async () => {
@@ -225,8 +234,8 @@ describe('useRecentLibraryGames', () => {
     } as any);
     useRecentsStore.setState({
       items: [
-        { id: 'removed', entity: 'game', title: 'Removed', href: '/library/games/removed', visitedAt: '2026-05-09T10:00:00Z' },
-        { id: 'inlib', entity: 'game', title: 'In Lib', href: '/library/games/inlib', visitedAt: '2026-05-09T09:00:00Z' },
+        { id: 'removed', entity: 'game', title: 'Removed', href: '/library/games/removed', visitedAt: 1731147600000 /* 2026-05-09T10:00:00Z */ },
+        { id: 'inlib', entity: 'game', title: 'In Lib', href: '/library/games/inlib', visitedAt: 1731144000000 /* 2026-05-09T09:00:00Z */ },
       ],
     });
 
@@ -572,10 +581,12 @@ git commit -m "feat(web): GamesRecentRail v2 component for game-night entry poin
 
 ---
 
-## Task 3: Wiring nel `DashboardClient.tsx`
+## Task 3: Wiring nel `games/page.tsx` (NON dashboard/DashboardClient.tsx!)
 
 **Files:**
-- Modify: `apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx`
+- Modify: `apps/web/src/app/(authenticated)/games/page.tsx`
+
+> ⚠️ **File target rettificato post plan-review**: i tab `library/catalog/kb` e l'early-return `if (activeTab === 'library') return <GamesLibraryView />` vivono in `games/page.tsx` (`GamesHubContent`), NON in `dashboard/DashboardClient.tsx`. Il dashboard usa una struttura diversa (`EntityZone` + `GreetingStrip`) ed è fuori scope per G3. Le route servite sono entrambe utili all'utente ma G3 punta esplicitamente a `/games?tab=library` come entry point primario (vedi spec §G3).
 
 **Contract:**
 - Mantieni intatto il branch `tab === 'library'` (delega `GamesLibraryView`)
@@ -584,15 +595,19 @@ git commit -m "feat(web): GamesRecentRail v2 component for game-night entry poin
 
 - [ ] **Step 3.1: Identifica i blocchi da modificare**
 
-Run: `grep -n "activeTab === 'library'\|return (" apps/web/src/app/\(authenticated\)/dashboard/DashboardClient.tsx | head -10`
+Run (PowerShell-friendly):
+```bash
+grep -n "activeTab === 'library'" "apps/web/src/app/(authenticated)/games/page.tsx"
+grep -n "return (" "apps/web/src/app/(authenticated)/games/page.tsx"
+```
 
 Annota i numeri di riga del:
-- Early return su `library` (oggi riga ~109-111)
-- Return finale del component (oggi riga ~129)
+- Early return su `library` (oggi riga ~109-111 confermata da `Read` precedente)
+- Return finale del component `GamesHubContent` (oggi riga ~129)
 
 - [ ] **Step 3.2: Aggiungi import**
 
-In testa al file, dopo gli import esistenti (mantieni l'ordine alfabetico se il progetto lo segue):
+In testa a `apps/web/src/app/(authenticated)/games/page.tsx`, dopo gli import esistenti (`useGames`, `useMiniNavConfig`, ecc.), aggiungi:
 
 ```ts
 import { useRouter } from 'next/navigation';
@@ -600,11 +615,11 @@ import { GamesRecentRail } from '@/components/v2/games';
 import { useRecentLibraryGames } from '@/hooks/queries/useRecentLibraryGames';
 ```
 
-> Se `useRouter` è già importato dal file, NON duplicare. `useMemo` dovrebbe essere già importato (verifica).
+> **Verifica preliminare**: `useSearchParams` è già importato. `useRouter` NON è importato in `games/page.tsx` — va aggiunto. `useMemo` è già importato.
 
 - [ ] **Step 3.3: Aggiungi il rail come variabile locale**
 
-Subito dopo la riga `const { data: catalogData, isLoading: catalogLoading } = useGames(...)` (oggi riga ~70), aggiungi:
+All'interno della funzione `GamesHubContent()`, subito dopo la riga `const { data: catalogData, isLoading: catalogLoading } = useGames(undefined, undefined, 1, 20);` (oggi riga ~70), aggiungi:
 
 ```ts
 const router = useRouter();
@@ -700,14 +715,17 @@ Se appare warning per import non usati o `useMemo` non importato, sistema l'impo
 
 - [ ] **Step 3.7: Run test esistenti per regressioni**
 
-Run: `cd apps/web && pnpm vitest run src/app/\(authenticated\)/dashboard src/app/\(authenticated\)/games`
-Expected: tutti i test passano. Se test esistenti del dashboard fanno snapshot del DOM, andranno aggiornati per includere il rail (questo è atteso, NON una regressione).
+Run (path quotato per shell-agnostic):
+```bash
+cd apps/web && pnpm vitest run "src/app/(authenticated)/games"
+```
+Expected: tutti i test esistenti passano. Se test esistenti del games hub fanno snapshot del DOM, andranno aggiornati per includere il rail (questo è atteso, NON una regressione).
 
 - [ ] **Step 3.8: Commit**
 
 ```bash
-git add apps/web/src/app/\(authenticated\)/dashboard/DashboardClient.tsx
-git commit -m "feat(web): mount GamesRecentRail at top of dashboard hub (G3)"
+git add "apps/web/src/app/(authenticated)/games/page.tsx"
+git commit -m "feat(web): mount GamesRecentRail at top of games hub tabs (G3)"
 ```
 
 ---
@@ -731,13 +749,15 @@ Avvia l'ambiente:
 cd infra && make dev-core
 ```
 
-Apri `http://localhost:3000/dashboard` o `/games?tab=library`:
+Apri `http://localhost:3000/games?tab=library` (URL primaria di G3):
 - Deve apparire `GamesRecentRail` in cima al contenuto
 - Stato vuoto (utente nuovo, recents store vuoto, libreria vuota): mostra empty hint
 - Stato popolato (utente con giochi in libreria): mostra fino a 5 card
 - Click su una card → naviga a `/library/games/[id]?tab=aiChat`
 - Naviga in `/games?tab=catalog` → il rail appare anche qui
-- Naviga in `/games?tab=library` → il rail appare anche qui
+- Naviga in `/games?tab=kb` → il rail appare anche qui
+
+> NB: `http://localhost:3000/dashboard` ha **struttura diversa** (EntityZone, GreetingStrip) e **NON** è oggetto di questo PR. Il rail NON appare lì. Se la spec richiederà successivamente di estendere il rail al `/dashboard`, sarà un follow-up plan dedicato.
 
 Annota differenze visive (spacing, colori) come issue follow-up: NON correggere in questa PR salvo regressioni gravi (es. layout shift, overlap, scroll bloccato).
 
@@ -806,19 +826,28 @@ git push
 
 ---
 
-## Spec Self-Review (effettuato — risultati)
+## Spec Self-Review (post indipendent review pass — fix applicati)
 
-**Spec coverage**: questo plan copre **solo G3** parzialmente — il widget recents (valore principale) è incluso; il wiring catalog v2 è stato spostato in plan separato dopo il review (vedi scope reduction in alto). I goal G1, G2, G4, G5 hanno plan separati.
+**Plan-review history**:
+1. **Self-review #1** (autore): catturato lo scope reduction su catalog v2 wiring. Mancato di verificare il file target del wiring e la shape esatta di `useRecentsStore`.
+2. **Independent review** (subagent code-reviewer): VERDETTO **REJECT** su Task 3 + 3 critical issue (file target sbagliato, shape `visitedAt` sbagliata, `MAX_RECENTS=4` ignorato).
+3. **Fix applicati inline**:
+   - Task 3 ri-targettato a `apps/web/src/app/(authenticated)/games/page.tsx` (NON `dashboard/DashboardClient.tsx`)
+   - Tutti i `visitedAt` nei test convertiti da ISO string a Unix ms (`number`)
+   - Test di troncamento ridotto da 6→4 item con nota esplicita su `MAX_RECENTS=4`
+   - Step 0.3 trasformato da "verifica e annota" a "shape già documentata, procedi"
+   - Smoke test (Step 4.3) corretto: `/games?tab=library` è la URL primaria, NON `/dashboard`
+   - Comandi shell con path `(authenticated)` quotati invece di escapati per shell-agnostic
 
-**Placeholder scan**: rimasti solo i placeholder intenzionali `XXX` (numero issue) e `YYY` (numero PR), che vanno sostituiti dall'engineer eseguente al momento dell'apertura issue/PR. Nessun TBD/TODO/etc. nel codice.
+**Spec coverage residua**: questo plan copre G3 limitatamente al widget recents su `/games?tab=*`. Catalog v2 wiring rimane in backlog (vedi Out of scope). G3.2 (resume da background) non coperto qui — accettato come scope reduction documentata. G3.1 (`≤2 tap`) non ha test E2E Playwright — accettato per ridurre scope; va aggiunto nel plan separato G2 (fast-resume audit) che già toccherà E2E.
 
-**Type consistency** (verificata contro file reali):
-- `GamesRecentRailItem.kbBadge: 'ready' | 'processing' | 'none'` — re-esportato come `RecentKbBadge` dal barrel ed usato nello stesso modo in Task 3.3. ✓
-- `useRecentLibraryGames(limit)` ritorna `{ entries, isLoading, isError }` — Task 3.3 mappa `entries` su `recentRailItems` con shape compatibile con `GamesRecentRailItem`. ✓
-- `UserLibraryEntry` ha campi `gameId`, `gameTitle`, `gameImageUrl`, `kbIndexedCount`, `kbProcessingCount` (verificati in `library.schemas.ts:32-63`). ✓
-- `useLibrary({ page, pageSize })` segnatura — verificata in `useLibrary.ts:69`. Step 1.4 ha warning esplicito per riallineare se differente. ✓
-- `useRecentsStore` shape — Step 0.3 forza l'engineer a verificarla prima di scrivere i test. ✓
+**Placeholder scan finale**: rimasti solo `XXX` (issue#) e `YYY` (PR#) intenzionali. Nessun TBD/TODO/etc. nel codice.
 
-**Ambiguity check**: l'unica ambiguità residua è la shape di `useRecentsStore` (campo `visitedAt` vs `addedAt`, `items` vs `entries`). Step 0.3 esiste apposta per risolverla prima di iniziare il Task 1.
+**Type consistency finale** (verificata contro file reali post-review):
+- `RecentItem.visitedAt: number` — confermato `apps/web/src/stores/use-recents.ts:15`. Test allineati. ✓
+- `MAX_RECENTS = 4` — confermato `apps/web/src/stores/use-recents.ts:7`. Test usa 4 item con nota. ✓
+- `UserLibraryEntry` campi — confermato `library.schemas.ts:32-63`. ✓
+- File target wiring `games/page.tsx` — confermato presenza di `if (activeTab === 'library') return <GamesLibraryView />` a riga ~109 (lettura precedente). ✓
+- Import set in `games/page.tsx`: `useSearchParams` ✓ presente, `useRouter` ✗ assente (va aggiunto), `useMemo` ✓ presente. ✓
 
-**Risk noted**: lo spec a monte assumeva che i componenti v2 Wave B.1 fossero riusabili anche per il catalog tab — questa assunzione è stata invalidata dal review. Il plan riduce lo scope di conseguenza e documenta esplicitamente il follow-up necessario, senza promettere ciò che lo spec assumeva.
+**Risk residuo**: lo spec a monte assumeva di poter wire-are catalog v2 con Wave B.1 components — assunzione invalidata. Spec richiederà revisione (annotare il fatto in §G3 dello spec come amendment).

--- a/docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md
+++ b/docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md
@@ -1,0 +1,824 @@
+# G3 — Recent games widget in dashboard hub — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettere a un utente Alpha di raggiungere la chat-in-game di un gioco recente in ≤2 tap dalla dashboard, montando un nuovo widget `GamesRecentRail` in cima al Games Hub.
+
+**Architecture:** Frontend-only PR su `apps/web`. Aggiunge un nuovo componente puro `GamesRecentRail` v2 + un nuovo hook `useRecentLibraryGames` (Zustand `useRecentsStore` filtrato a entity=game, con fallback a `useRecentlyAddedGames`). Wiring minimo nel `DashboardClient.tsx`: monta il rail in cima per i tab `library` e `catalog` senza modificare il rendering interno dei tab.
+
+**Tech Stack:** React 19 + Next.js 16 App Router, TypeScript strict, Tailwind 4, Zustand, TanStack Query, Vitest. Pattern di riferimento: `RecentActivityRail` (PR #574), `GamesHero` (PR #635).
+
+**Spec:** [`docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md`](../specs/2026-05-09-game-night-user-flow-design.md) §G3.
+
+**Scope reduction (post self-review)**: il wiring v2 di `/games?tab=catalog` è **rimosso da questo plan**. La spec assumeva di riusare `GamesResultsGrid` + `GamesFiltersInline` di Wave B.1, ma il review dei contratti mostra che sono **vincolati a `UserLibraryEntry`** (status `owned/wishlist/played`, sort `last-played/rating/title/year`) — incompatibili con lo schema `Game` del catalogo. Servono nuovi componenti dedicati (`GamesCatalogGrid`, `GamesCatalogFilters`) che vanno tracciati come backlog Wave 1 (riga catalog dedicata in v2-migration-matrix). Vedi §"Out of scope".
+
+---
+
+## File Structure
+
+| Status | Path | Responsibility |
+|---|---|---|
+| Create | `apps/web/src/hooks/queries/useRecentLibraryGames.ts` | Hook che restituisce fino a N entry della libreria ordinati per recency (recents store → fallback addedAt desc) |
+| Create | `apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.ts` | Unit test hook (renderHook, 4 scenari) |
+| Create | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | Componente v2 puro — riceve `items[]`, label e callback; rende rail orizzontale di 1-N card |
+| Create | `apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx` | Test rendering: empty, 1, N card, click handler, a11y region |
+| Modify | `apps/web/src/components/v2/games/index.ts` | Aggiungere export di `GamesRecentRail` e tipi correlati |
+| Modify | `apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx` | Inserire `<GamesRecentRail>` in cima a tutti i branch di rendering (sopra `GamesLibraryView` e sopra il blocco `HubLayout` per catalog/kb) |
+| Modify | `docs/for-developers/frontend/v2-migration-matrix.md` | Aggiungere row `GamesRecentRail` nella sezione `/games` (status done) |
+
+**Decomposition decision:** componente puro + hook separato dal wiring per facilitare testing isolato. Il rail è agnostico rispetto al `tab` attivo (mostra sempre i recent games dell'utente, in qualunque vista del hub).
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Crea feature branch dal parente `main-dev`**
+
+```bash
+git branch --show-current  # MUST print main-dev
+git status                 # MUST show clean tree
+git pull --ff-only
+git checkout -b feature/issue-XXX-game-night-g3-recents-rail
+git config branch.feature/issue-XXX-game-night-g3-recents-rail.parent main-dev
+```
+
+> Sostituire `XXX` con il numero issue (apri issue prima se non esiste). Il commit precedente (spec doc) deve essere già pushato/integrato in `main-dev`.
+
+- [ ] **Step 0.2: Verifica clean build pre-modifiche**
+
+Run:
+```bash
+cd apps/web && pnpm typecheck && pnpm lint
+```
+Expected: nessun errore. Se ci sono errori preesistenti, registrarli come baseline per non confonderli con quelli introdotti.
+
+- [ ] **Step 0.3: Verifica shape effettiva di `useRecentsStore`**
+
+Run: `grep -n "items\|RecentItem\|addedAt\|visitedAt\|entity" apps/web/src/stores/use-recents.ts | head -30`
+
+Annota qui sotto la shape effettiva di un item del store (es. nome del campo timestamp: `addedAt`? `visitedAt`? Nome del campo entity-id: `id`? Forma del campo `entity`?). Questo è critico perché i test del Task 1 usano questa shape.
+
+```
+Shape effettiva (compila l'engineer dopo grep):
+- Campo timestamp: ___
+- Campo entity-id: ___
+- Campo entity-type: ___
+- Forma store API: useRecentsStore(state => state.___)
+```
+
+Se la shape differisce dai test del Task 1, **aggiorna i test nello Step 1.1 prima di proseguire**.
+
+---
+
+## Task 1: Hook `useRecentLibraryGames`
+
+**Files:**
+- Create: `apps/web/src/hooks/queries/useRecentLibraryGames.ts`
+- Test: `apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.ts`
+
+**Contract** (decidi qui, congelato per resto del piano):
+- Input: `limit?: number = 5`
+- Output: `{ entries: readonly UserLibraryEntry[]; isLoading: boolean; isError: boolean }`
+- Algoritmo:
+  1. Legge `useRecentsStore` filtrando `entity === 'game'`
+  2. Per ogni recent ID, prende l'entry da `useLibrary({ page: 1, pageSize: 50 })` (cached)
+  3. Mantiene l'ordine dei recents (più recente prima)
+  4. Filtra entries non più presenti in libreria (gioco rimosso dopo recent)
+  5. Se `result.length < limit`, completa con `useRecentlyAddedGames(limit)` escludendo duplicati
+  6. Tronca a `limit`
+- `isLoading: true` se `useLibrary.isLoading`
+- `isError: true` se `useLibrary.isError && recents.length === 0` (errore non recuperabile)
+
+- [ ] **Step 1.1: Allinea i test alla shape effettiva (se necessario)**
+
+In base allo Step 0.3, se i campi del recents store differiscono dal test sotto (es. campo si chiama `addedAt` invece di `visitedAt`), aggiorna il test prima di scriverlo. Il test sotto assume:
+- `useRecentsStore.setState({ items: [...] })`
+- Ogni item: `{ id, entity: 'game', title, href, visitedAt }`
+
+Se differente, sostituire `visitedAt` (e `items` se serve) con i nomi reali.
+
+- [ ] **Step 1.2: Scrivi il test failing**
+
+Crea `apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.ts`:
+
+```ts
+/**
+ * useRecentLibraryGames — unit tests
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { useRecentsStore } from '@/stores/use-recents';
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: vi.fn(),
+  useRecentlyAddedGames: vi.fn(),
+}));
+
+import { useLibrary, useRecentlyAddedGames } from '@/hooks/queries/useLibrary';
+import { useRecentLibraryGames } from '../useRecentLibraryGames';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const entry = (id: string, addedAt = '2026-05-01T00:00:00Z') => ({
+  id: `entry-${id}`,
+  userId: 'u1',
+  gameId: id,
+  gameTitle: `Game ${id}`,
+  isFavorite: false,
+  currentState: 'Owned' as const,
+  addedAt,
+  hasKb: true,
+  kbCardCount: 1,
+  kbIndexedCount: 1,
+  kbProcessingCount: 0,
+  hasRagAccess: true,
+  agentIsOwned: true,
+  isPrivateGame: false,
+  canProposeToCatalog: false,
+});
+
+const emptyPaginated = { items: [], page: 1, pageSize: 50, totalCount: 0, totalPages: 0, hasNextPage: false, hasPreviousPage: false };
+
+describe('useRecentLibraryGames', () => {
+  beforeEach(() => {
+    useRecentsStore.setState({ items: [] });
+    vi.mocked(useLibrary).mockReturnValue({
+      data: emptyPaginated,
+      isLoading: false,
+      isError: false,
+    } as any);
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: emptyPaginated,
+      isLoading: false,
+      isError: false,
+    } as any);
+  });
+
+  it('returns recents-store games in order, mapped to library entries', async () => {
+    const e1 = entry('aaa');
+    const e2 = entry('bbb');
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1, e2], totalCount: 2, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: [
+        { id: 'bbb', entity: 'game', title: 'Game bbb', href: '/library/games/bbb', visitedAt: '2026-05-09T10:00:00Z' },
+        { id: 'aaa', entity: 'game', title: 'Game aaa', href: '/library/games/aaa', visitedAt: '2026-05-09T09:00:00Z' },
+      ],
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['bbb', 'aaa']);
+  });
+
+  it('falls back to recently-added when recents store empty', async () => {
+    const e1 = entry('xxx', '2026-05-08T00:00:00Z');
+    vi.mocked(useRecentlyAddedGames).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1], totalCount: 1, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['xxx']);
+  });
+
+  it('truncates to limit', async () => {
+    const items = ['a', 'b', 'c', 'd', 'e', 'f'].map(id => entry(id));
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items, totalCount: 6, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: items.map(e => ({
+        id: e.gameId, entity: 'game' as const, title: e.gameTitle,
+        href: `/library/games/${e.gameId}`, visitedAt: '2026-05-09T10:00:00Z',
+      })),
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(3), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries).toHaveLength(3);
+  });
+
+  it('skips recents whose game is no longer in library', async () => {
+    const e1 = entry('inlib');
+    vi.mocked(useLibrary).mockReturnValue({
+      data: { ...emptyPaginated, items: [e1], totalCount: 1, totalPages: 1 },
+      isLoading: false,
+      isError: false,
+    } as any);
+    useRecentsStore.setState({
+      items: [
+        { id: 'removed', entity: 'game', title: 'Removed', href: '/library/games/removed', visitedAt: '2026-05-09T10:00:00Z' },
+        { id: 'inlib', entity: 'game', title: 'In Lib', href: '/library/games/inlib', visitedAt: '2026-05-09T09:00:00Z' },
+      ],
+    });
+
+    const { result } = renderHook(() => useRecentLibraryGames(5), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.entries.map(e => e.gameId)).toEqual(['inlib']);
+  });
+});
+```
+
+- [ ] **Step 1.3: Run test, verify failure**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/queries/__tests__/useRecentLibraryGames.test.ts`
+Expected: FAIL — module `../useRecentLibraryGames` not found.
+
+- [ ] **Step 1.4: Implementa l'hook**
+
+Crea `apps/web/src/hooks/queries/useRecentLibraryGames.ts`:
+
+```ts
+/**
+ * useRecentLibraryGames — restituisce fino a N giochi della libreria ordinati
+ * per recency: prima i giochi visitati di recente (Zustand recents store),
+ * poi fallback a recently-added.
+ *
+ * Usato dal `GamesRecentRail` widget nel Dashboard hub per il flusso
+ * "serata di gioco" (entry point ≤2 tap fino alla chat in-game).
+ *
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { useMemo } from 'react';
+
+import { useLibrary, useRecentlyAddedGames } from '@/hooks/queries/useLibrary';
+import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
+import { useRecentsStore } from '@/stores/use-recents';
+
+export interface UseRecentLibraryGamesResult {
+  readonly entries: readonly UserLibraryEntry[];
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+}
+
+const LIBRARY_FETCH_SIZE = 50;
+
+export function useRecentLibraryGames(limit: number = 5): UseRecentLibraryGamesResult {
+  const libraryQuery = useLibrary({ page: 1, pageSize: LIBRARY_FETCH_SIZE });
+  const recentlyAdded = useRecentlyAddedGames(limit);
+
+  const recents = useRecentsStore(state => state.items);
+
+  return useMemo<UseRecentLibraryGamesResult>(() => {
+    const isLoading = libraryQuery.isLoading;
+    const isError = libraryQuery.isError && recents.length === 0;
+
+    const libIndex = new Map<string, UserLibraryEntry>();
+    for (const entry of libraryQuery.data?.items ?? []) {
+      libIndex.set(entry.gameId, entry);
+    }
+
+    const seen = new Set<string>();
+    const result: UserLibraryEntry[] = [];
+
+    for (const recent of recents) {
+      if (recent.entity !== 'game') continue;
+      const entry = libIndex.get(recent.id);
+      if (!entry || seen.has(entry.gameId)) continue;
+      result.push(entry);
+      seen.add(entry.gameId);
+      if (result.length >= limit) break;
+    }
+
+    if (result.length < limit) {
+      for (const entry of recentlyAdded.data?.items ?? []) {
+        if (seen.has(entry.gameId)) continue;
+        result.push(entry);
+        seen.add(entry.gameId);
+        if (result.length >= limit) break;
+      }
+    }
+
+    return { entries: result, isLoading, isError };
+  }, [libraryQuery.data, libraryQuery.isLoading, libraryQuery.isError, recentlyAdded.data, recents, limit]);
+}
+```
+
+> ⚠️ **Type alignment**: se la `useLibrary` reale richiede argomenti differenti (es. `useLibrary(params, enabled)` invece di `useLibrary({...})`), aggiusta. La signature reale è in `apps/web/src/hooks/queries/useLibrary.ts:69`.
+
+- [ ] **Step 1.5: Run test fino a passare**
+
+Run: `cd apps/web && pnpm vitest run src/hooks/queries/__tests__/useRecentLibraryGames.test.ts`
+Expected: PASS (4/4). Se fallisce, NON modificare il test per farlo passare se il behavior atteso è documentato nel contract sopra: aggiusta l'implementazione.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add apps/web/src/hooks/queries/useRecentLibraryGames.ts apps/web/src/hooks/queries/__tests__/useRecentLibraryGames.test.ts
+git commit -m "feat(web): useRecentLibraryGames hook for game-night entry point (G3)"
+```
+
+---
+
+## Task 2: Componente `GamesRecentRail`
+
+**Files:**
+- Create: `apps/web/src/components/v2/games/GamesRecentRail.tsx`
+- Test: `apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx`
+- Modify: `apps/web/src/components/v2/games/index.ts`
+
+**Contract** (pure component, mirror del pattern Wave B.1 / B.3):
+- Props:
+  ```ts
+  interface GamesRecentRailItem {
+    readonly id: string;
+    readonly title: string;
+    readonly imageUrl?: string;
+    readonly kbBadge: 'ready' | 'processing' | 'none';
+  }
+  interface GamesRecentRailLabels {
+    readonly sectionTitle: string;
+    readonly emptyHint: string;
+    readonly viewAllHref: string; // riservato per future "vedi tutti" CTA
+  }
+  interface GamesRecentRailProps {
+    readonly items: readonly GamesRecentRailItem[];
+    readonly labels: GamesRecentRailLabels;
+    readonly isLoading?: boolean;
+    readonly onSelect: (id: string) => void;
+    readonly className?: string;
+  }
+  ```
+- Stati visivi: `loading` (3 skeleton card 96x160), `empty` (testo `emptyHint`), `populated` (rail orizzontale scrollabile)
+- a11y: `<section role="region" aria-label={labels.sectionTitle}>`, ogni card è `<button type="button">` focusabile con `aria-label` derivato da `title`
+- NO fetch, NO router, NO i18n hook (orchestrator passa label risolte e onSelect)
+
+- [ ] **Step 2.1: Test failing**
+
+Crea `apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx`:
+
+```tsx
+/**
+ * GamesRecentRail — pure component tests
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { GamesRecentRail } from '../GamesRecentRail';
+
+const labels = {
+  sectionTitle: 'Giochi recenti',
+  emptyHint: 'Inizia a giocare per vedere qui i tuoi titoli recenti.',
+  viewAllHref: '/library',
+};
+
+describe('GamesRecentRail', () => {
+  it('renders skeleton when isLoading', () => {
+    render(<GamesRecentRail items={[]} labels={labels} isLoading onSelect={vi.fn()} />);
+    expect(screen.getAllByTestId('games-recent-rail-skeleton')).toHaveLength(3);
+  });
+
+  it('renders empty hint when no items and not loading', () => {
+    render(<GamesRecentRail items={[]} labels={labels} onSelect={vi.fn()} />);
+    expect(screen.getByText(labels.emptyHint)).toBeInTheDocument();
+  });
+
+  it('renders 1 to 5 cards in order', () => {
+    const items = ['a', 'b', 'c'].map(id => ({
+      id, title: `Game ${id}`, kbBadge: 'ready' as const,
+    }));
+    render(<GamesRecentRail items={items} labels={labels} onSelect={vi.fn()} />);
+    const cards = screen.getAllByRole('button', { name: /Game [abc]/ });
+    expect(cards.map(c => c.textContent)).toEqual([
+      expect.stringContaining('Game a'),
+      expect.stringContaining('Game b'),
+      expect.stringContaining('Game c'),
+    ]);
+  });
+
+  it('calls onSelect with game id when card clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <GamesRecentRail
+        items={[{ id: 'wingspan', title: 'Wingspan', kbBadge: 'ready' }]}
+        labels={labels}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Wingspan/ }));
+    expect(onSelect).toHaveBeenCalledWith('wingspan');
+  });
+
+  it('section has accessible name from sectionTitle', () => {
+    render(<GamesRecentRail items={[]} labels={labels} onSelect={vi.fn()} />);
+    expect(screen.getByRole('region', { name: labels.sectionTitle })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test, verify failure**
+
+Run: `cd apps/web && pnpm vitest run src/components/v2/games/__tests__/GamesRecentRail.test.tsx`
+Expected: FAIL — `GamesRecentRail` not found.
+
+- [ ] **Step 2.3: Implementa il componente**
+
+Crea `apps/web/src/components/v2/games/GamesRecentRail.tsx`:
+
+```tsx
+/**
+ * GamesRecentRail — v2 horizontal rail per il flusso "serata di gioco" (G3).
+ *
+ * Pure component (no fetch, no router, no i18n hook): orchestrator passa
+ * items + labels + onSelect. Riusa pattern Wave B.1 (vedi GamesHero).
+ *
+ * Spec: docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md §G3
+ */
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+
+export type RecentKbBadge = 'ready' | 'processing' | 'none';
+
+export interface GamesRecentRailItem {
+  readonly id: string;
+  readonly title: string;
+  readonly imageUrl?: string;
+  readonly kbBadge: RecentKbBadge;
+}
+
+export interface GamesRecentRailLabels {
+  readonly sectionTitle: string;
+  readonly emptyHint: string;
+  readonly viewAllHref: string;
+}
+
+export interface GamesRecentRailProps {
+  readonly items: readonly GamesRecentRailItem[];
+  readonly labels: GamesRecentRailLabels;
+  readonly isLoading?: boolean;
+  readonly onSelect: (id: string) => void;
+  readonly className?: string;
+}
+
+const SKELETON_COUNT = 3;
+
+const KB_BADGE_LABEL: Record<RecentKbBadge, string> = {
+  ready: '📖 KB pronta',
+  processing: '⏳ KB in elaborazione',
+  none: '',
+};
+
+export function GamesRecentRail({
+  items,
+  labels,
+  isLoading = false,
+  onSelect,
+  className,
+}: GamesRecentRailProps): ReactElement {
+  return (
+    <section
+      role="region"
+      aria-label={labels.sectionTitle}
+      data-slot="games-recent-rail"
+      className={clsx('w-full px-4 py-3', className)}
+    >
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-base font-semibold text-foreground">{labels.sectionTitle}</h2>
+      </div>
+
+      {isLoading ? (
+        <div className="flex gap-3 overflow-x-auto pb-1">
+          {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+            <Skeleton
+              key={i}
+              data-testid="games-recent-rail-skeleton"
+              className="h-24 w-40 shrink-0 rounded-xl"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4">{labels.emptyHint}</p>
+      ) : (
+        <div className="flex gap-3 overflow-x-auto pb-1 snap-x snap-mandatory">
+          {items.map(item => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onSelect(item.id)}
+              aria-label={item.title}
+              data-slot="games-recent-rail-card"
+              data-kb-badge={item.kbBadge}
+              className={clsx(
+                'shrink-0 snap-start text-left rounded-xl border border-border bg-card',
+                'h-24 w-40 px-3 py-2 transition-colors hover:bg-muted',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+              )}
+            >
+              <span className="block text-sm font-medium text-foreground line-clamp-2">
+                {item.title}
+              </span>
+              {item.kbBadge !== 'none' && (
+                <span className="mt-1 block text-xs text-muted-foreground">
+                  {KB_BADGE_LABEL[item.kbBadge]}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2.4: Aggiungi export al barrel**
+
+Modifica `apps/web/src/components/v2/games/index.ts` — appendi al fondo:
+
+```ts
+export { GamesRecentRail } from './GamesRecentRail';
+export type {
+  GamesRecentRailItem,
+  GamesRecentRailLabels,
+  GamesRecentRailProps,
+  RecentKbBadge,
+} from './GamesRecentRail';
+```
+
+- [ ] **Step 2.5: Run test fino a passare**
+
+Run: `cd apps/web && pnpm vitest run src/components/v2/games/__tests__/GamesRecentRail.test.tsx`
+Expected: PASS (5/5).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add apps/web/src/components/v2/games/GamesRecentRail.tsx apps/web/src/components/v2/games/__tests__/GamesRecentRail.test.tsx apps/web/src/components/v2/games/index.ts
+git commit -m "feat(web): GamesRecentRail v2 component for game-night entry point (G3)"
+```
+
+---
+
+## Task 3: Wiring nel `DashboardClient.tsx`
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx`
+
+**Contract:**
+- Mantieni intatto il branch `tab === 'library'` (delega `GamesLibraryView`)
+- Mantieni intatto il rendering legacy per `tab === 'catalog'` e `tab === 'kb'` (HubLayout) — il loro v2 wiring va in plan separato
+- Aggiungi un wrap che monta `<GamesRecentRail>` in cima a tutti i branch di rendering, con `onSelect` che naviga a `/library/games/[id]?tab=aiChat` (entry point G1)
+
+- [ ] **Step 3.1: Identifica i blocchi da modificare**
+
+Run: `grep -n "activeTab === 'library'\|return (" apps/web/src/app/\(authenticated\)/dashboard/DashboardClient.tsx | head -10`
+
+Annota i numeri di riga del:
+- Early return su `library` (oggi riga ~109-111)
+- Return finale del component (oggi riga ~129)
+
+- [ ] **Step 3.2: Aggiungi import**
+
+In testa al file, dopo gli import esistenti (mantieni l'ordine alfabetico se il progetto lo segue):
+
+```ts
+import { useRouter } from 'next/navigation';
+import { GamesRecentRail } from '@/components/v2/games';
+import { useRecentLibraryGames } from '@/hooks/queries/useRecentLibraryGames';
+```
+
+> Se `useRouter` è già importato dal file, NON duplicare. `useMemo` dovrebbe essere già importato (verifica).
+
+- [ ] **Step 3.3: Aggiungi il rail come variabile locale**
+
+Subito dopo la riga `const { data: catalogData, isLoading: catalogLoading } = useGames(...)` (oggi riga ~70), aggiungi:
+
+```ts
+const router = useRouter();
+const recentGames = useRecentLibraryGames(5);
+
+const recentRailItems = useMemo(
+  () => recentGames.entries.map(e => ({
+    id: e.gameId,
+    title: e.gameTitle,
+    imageUrl: e.gameImageUrl ?? undefined,
+    kbBadge: (e.kbIndexedCount > 0
+      ? 'ready'
+      : e.kbProcessingCount > 0
+        ? 'processing'
+        : 'none') as 'ready' | 'processing' | 'none',
+  })),
+  [recentGames.entries]
+);
+
+const recentRail = (
+  <GamesRecentRail
+    items={recentRailItems}
+    isLoading={recentGames.isLoading}
+    labels={{
+      sectionTitle: 'Giochi recenti',
+      emptyHint: 'Inizia a giocare per vedere qui i tuoi titoli recenti.',
+      viewAllHref: '/library',
+    }}
+    onSelect={(id) => router.push(`/library/games/${id}?tab=aiChat`)}
+  />
+);
+```
+
+- [ ] **Step 3.4: Wrap del branch library**
+
+Sostituisci:
+
+```tsx
+if (activeTab === 'library') {
+  return <GamesLibraryView />;
+}
+```
+
+con:
+
+```tsx
+if (activeTab === 'library') {
+  return (
+    <>
+      {recentRail}
+      <GamesLibraryView />
+    </>
+  );
+}
+```
+
+- [ ] **Step 3.5: Wrap del return finale (catalog/kb)**
+
+Identifica il `return ( <HubLayout ...>...</HubLayout> )` finale del component (oggi ~riga 129-164). Wrappalo in un fragment con il `recentRail` in cima. Il rendering interno dell'`HubLayout` resta invariato.
+
+Pattern (sostituisci `<HubLayout ...>...</HubLayout>` con):
+
+```tsx
+return (
+  <>
+    {recentRail}
+    <HubLayout
+      searchPlaceholder="Cerca giochi..."
+      filterChips={currentFilters}
+      activeFilterId={activeFilter}
+      onFilterChange={setActiveFilter}
+      searchValue={search}
+      onSearchChange={setSearch}
+      viewMode={viewMode}
+      onViewModeChange={setViewMode}
+      showViewToggle
+      topActions={topActions}
+    >
+      {/* contenuto invariato */}
+    </HubLayout>
+  </>
+);
+```
+
+> Mantieni invariato il contenuto interno `{isLoading ? <LoadingSkeleton /> : items.length === 0 ? ... : <div ...>{items.map(...)}</div>}`.
+
+- [ ] **Step 3.6: Run typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: nessun errore TS.
+
+Se appare warning per import non usati o `useMemo` non importato, sistema l'import block.
+
+- [ ] **Step 3.7: Run test esistenti per regressioni**
+
+Run: `cd apps/web && pnpm vitest run src/app/\(authenticated\)/dashboard src/app/\(authenticated\)/games`
+Expected: tutti i test passano. Se test esistenti del dashboard fanno snapshot del DOM, andranno aggiornati per includere il rail (questo è atteso, NON una regressione).
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/dashboard/DashboardClient.tsx
+git commit -m "feat(web): mount GamesRecentRail at top of dashboard hub (G3)"
+```
+
+---
+
+## Task 4: Verifica end-to-end manuale + matrice
+
+- [ ] **Step 4.1: Lint e typecheck full-pass**
+
+Run: `cd apps/web && pnpm lint && pnpm typecheck`
+Expected: 0 errori, 0 warning nuovi.
+
+- [ ] **Step 4.2: Run full unit suite**
+
+Run: `cd apps/web && pnpm test`
+Expected: tutti i test passano. Annota eventuali pre-existing failure (NON risolvere in questa PR).
+
+- [ ] **Step 4.3: Smoke test manuale**
+
+Avvia l'ambiente:
+```bash
+cd infra && make dev-core
+```
+
+Apri `http://localhost:3000/dashboard` o `/games?tab=library`:
+- Deve apparire `GamesRecentRail` in cima al contenuto
+- Stato vuoto (utente nuovo, recents store vuoto, libreria vuota): mostra empty hint
+- Stato popolato (utente con giochi in libreria): mostra fino a 5 card
+- Click su una card → naviga a `/library/games/[id]?tab=aiChat`
+- Naviga in `/games?tab=catalog` → il rail appare anche qui
+- Naviga in `/games?tab=library` → il rail appare anche qui
+
+Annota differenze visive (spacing, colori) come issue follow-up: NON correggere in questa PR salvo regressioni gravi (es. layout shift, overlap, scroll bloccato).
+
+- [ ] **Step 4.4: Aggiorna v2-migration-matrix**
+
+Modifica `docs/for-developers/frontend/v2-migration-matrix.md`. Nella sezione **"Wave 1 — Games index — `/games` — 5 components — Tier S"**, aggiungi una row sotto le 5 esistenti:
+
+```markdown
+| `sp4-games-index.jsx` (extension) | `GamesRecentRail` | `apps/web/src/components/v2/games/GamesRecentRail.tsx` | `/dashboard` · `/games` | done | #YYY | T A V |
+```
+
+Sostituisci `#YYY` con il numero PR effettivo dopo apertura.
+
+> NB: questo è un componente NUOVO non in mockup originali — annotalo nella riga "Updated YYYY-MM-DD" in cima alla matrice se quella sezione è viva.
+
+- [ ] **Step 4.5: Push + apri PR verso `main-dev`**
+
+```bash
+git push -u origin feature/issue-XXX-game-night-g3-recents-rail
+gh pr create --base main-dev --title "feat(web): G3 — GamesRecentRail in dashboard hub" --body "$(cat <<'EOF'
+## Summary
+- Add `GamesRecentRail` v2 component (pure, mirror Wave B.1 pattern)
+- Add `useRecentLibraryGames` hook (Zustand recents store + library fallback)
+- Mount rail at top of dashboard hub (visible across `library`, `catalog`, `kb` tabs)
+- Card click navigates to `/library/games/[id]?tab=aiChat` (G1 entry point)
+
+Implements **G3** from spec `docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md`.
+
+**Scope reduction note**: original spec G3 also targeted v2 wiring of `/games?tab=catalog` (reusing `GamesResultsGrid` + `GamesFiltersInline`). Self-review during plan writing showed those components are vincolati a `UserLibraryEntry` and library-only filter keys. Catalog tab v2 wiring requires NEW dedicated components and is tracked as separate backlog (see Out of scope in plan).
+
+## Test plan
+- [ ] Unit tests pass for `useRecentLibraryGames` (4 scenari) and `GamesRecentRail` (5 scenari)
+- [ ] Manual smoke at `/dashboard`, `/games?tab=library`, `/games?tab=catalog`, `/games?tab=kb`
+- [ ] No regression on existing `GamesLibraryView` flow
+- [ ] Card click navigates to `/library/games/[id]?tab=aiChat`
+- [ ] Empty state shows hint when user has no recents/library
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4.6: Commit di chiusura matrice (post PR-number)**
+
+Dopo aver aperto la PR e ottenuto il numero, sostituisci `#YYY` nella matrice e committa:
+
+```bash
+git add docs/for-developers/frontend/v2-migration-matrix.md
+git commit -m "docs(matrix): add GamesRecentRail row (G3)"
+git push
+```
+
+---
+
+## Out of scope (follow-up plans)
+
+| Item | Reason | Plan target |
+|---|---|---|
+| `/games?tab=catalog` v2 wiring | `GamesResultsGrid`/`GamesFiltersInline` Wave B.1 sono library-only (UserLibraryEntry-coupled). Servono `GamesCatalogGrid` + `GamesCatalogFilters` nuovi | Plan separato Wave 1 finalization (con issue dedicata + row in matrix) |
+| `/games?tab=kb` v2 wiring | Fuori scope G3 | Coperto parzialmente da Plan G4 |
+| `AdvancedFiltersDrawer` wiring | Fuori scope G3 | Plan separato Wave 1 finalization |
+| `/kb/[id]` 6 stub pending | Goal G4 | Plan G4 KB detail (separato) |
+| Chat-in-game v2 (`?tab=aiChat`) | Goal G1 + G5, blocked by missing SP4 mockup | Plan G1+G5 dopo issue Claude Design |
+| Fast resume audit (G2) | Goal G2 | Plan G2 audit |
+| `useRecentsStore` push da `/library/games/[id]` | Probabilmente già fatto, da verificare in audit | Audit interno (vedi OQ4 in spec) |
+
+---
+
+## Spec Self-Review (effettuato — risultati)
+
+**Spec coverage**: questo plan copre **solo G3** parzialmente — il widget recents (valore principale) è incluso; il wiring catalog v2 è stato spostato in plan separato dopo il review (vedi scope reduction in alto). I goal G1, G2, G4, G5 hanno plan separati.
+
+**Placeholder scan**: rimasti solo i placeholder intenzionali `XXX` (numero issue) e `YYY` (numero PR), che vanno sostituiti dall'engineer eseguente al momento dell'apertura issue/PR. Nessun TBD/TODO/etc. nel codice.
+
+**Type consistency** (verificata contro file reali):
+- `GamesRecentRailItem.kbBadge: 'ready' | 'processing' | 'none'` — re-esportato come `RecentKbBadge` dal barrel ed usato nello stesso modo in Task 3.3. ✓
+- `useRecentLibraryGames(limit)` ritorna `{ entries, isLoading, isError }` — Task 3.3 mappa `entries` su `recentRailItems` con shape compatibile con `GamesRecentRailItem`. ✓
+- `UserLibraryEntry` ha campi `gameId`, `gameTitle`, `gameImageUrl`, `kbIndexedCount`, `kbProcessingCount` (verificati in `library.schemas.ts:32-63`). ✓
+- `useLibrary({ page, pageSize })` segnatura — verificata in `useLibrary.ts:69`. Step 1.4 ha warning esplicito per riallineare se differente. ✓
+- `useRecentsStore` shape — Step 0.3 forza l'engineer a verificarla prima di scrivere i test. ✓
+
+**Ambiguity check**: l'unica ambiguità residua è la shape di `useRecentsStore` (campo `visitedAt` vs `addedAt`, `items` vs `entries`). Step 0.3 esiste apposta per risolverla prima di iniziare il Task 1.
+
+**Risk noted**: lo spec a monte assumeva che i componenti v2 Wave B.1 fossero riusabili anche per il catalog tab — questa assunzione è stata invalidata dal review. Il plan riduce lo scope di conseguenza e documenta esplicitamente il follow-up necessario, senza promettere ciò che lo spec assumeva.

--- a/docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md
+++ b/docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md
@@ -1,0 +1,237 @@
+# Game-Night User Flow — Design Spec
+
+**Date**: 2026-05-09
+**Author**: Brainstorming session (spec-panel critique → Socratic refinement)
+**Scope**: Definire i 5 user goal SMART per il flusso primario "utente Alpha che usa MeepleAI in serata di gioco per chiarimenti sul regolamento", con criteri di accettazione Gherkin e mapping ai gap di migrazione v2 attualmente aperti.
+**Status**: DRAFT — pending user review
+
+---
+
+## 1. Contesto
+
+### 1.1 Use case primario (Cockburn)
+
+- **Attore primario**: utente Alpha (giocatore non tecnico) durante una serata di gioco da tavolo
+- **Goal generico**: ottenere chiarimenti su regolamenti, FAQ, edge case e procedure di scoring **senza interrompere il flusso del gioco** né perdere fiducia nella risposta
+- **Trigger**: dubbio in tavola che il gruppo non sa risolvere
+
+### 1.2 Job-To-Be-Done (Christensen)
+
+L'utente "assume" MeepleAI al posto della combinazione di:
+
+| Alternativa | Limite | Cosa MeepleAI deve replicare |
+|---|---|---|
+| Manuale PDF/cartaceo | Lento (2-5 min di sfoglio) | Velocità di lookup |
+| Google / BGG forum | Risultati off-topic, non sempre affidabili | Ampiezza di copertura, ma filtrata |
+| Amico esperto | Non sempre disponibile o accurato | Autorevolezza percepita, *ma con citazione* |
+
+L'utente **non** assume MeepleAI per:
+- Consigli di strategia (escluso D in Q4)
+- Decisioni di lore o role-playing
+
+### 1.3 Vincoli operativi (validati durante brainstorming)
+
+| Dimensione | Risposta utente | Implicazione progettuale |
+|---|---|---|
+| **Device pattern** | Single-user + handoff (no multi-device sync) | No SSE multiplayer per chat; necessità "fast resume" sotto 3s |
+| **Entry point** | Mix di chat-già-aperta + hub navigation + background resume | Hub deve avere "Giochi recenti"; route chat-in-game devono essere bookmarkable |
+| **Tipologia domande** | Tutor + Arbitro (regole, ambiguità, setup, scoring, edge case) | Agente unico orientato fattuale; retrieval ibrido FAQ + RAG |
+| **Trust model** | Citazione **sempre** + dichiarazione esplicita di incertezza | `/kb/[id]` diventa critica; chat UI deve avere chip "fonte" first-class |
+| **Latenza** | <10s con spinner; accuratezza > velocità | Si può usare LLM grande + reranker completo; risposta atomica accettabile |
+
+---
+
+## 2. User Goals SMART (5)
+
+### G1 — Lookup rapido con citazione autoritativa
+
+**Smart**: Un utente Alpha in serata può ottenere risposta a una domanda di regolamento (categorie A/B/C/E/F della tassonomia in §1.3) **in ≤10s** con **almeno una citazione esplicita** (pagina + sezione del manuale) per il **≥90%** delle query, entro il rilascio Alpha v2 (post token redesign #807).
+
+**Sostituisce**: manuale + Google. **Drives**: chat-in-game v2 design (gap mockup), system prompt agente, KB ingestion con metadati pagina/sezione.
+
+**Acceptance criteria (Gherkin)**:
+
+```gherkin
+Scenario G1.1: Lookup regola puntuale con citazione (categoria A)
+  Given utente Alpha è loggato e ha "Wingspan" indicizzato in KB (kbId=wingspan-v2)
+  And la chat-in-game è aperta su /library/games/wingspan?tab=aiChat
+  When digita "Posso giocare due carte uccello nello stesso turno?" e invia
+  Then entro 10 secondi vede una risposta atomica
+  And la risposta contiene almeno un chip "Fonte: Manuale p.X §Y"
+  And il chip è cliccabile e apre /kb/wingspan-v2#chunk-<id> con il chunk evidenziato
+
+Scenario G1.2: Edge case raro con confidenza esplicita (categoria F)
+  Given chat-in-game aperta su un gioco con KB indicizzata
+  When utente chiede "Cosa succede se il mazzo finisce a metà partita?"
+  And l'agente recupera chunk con confidence_score < 0.70
+  Then la risposta inizia con un marker di incertezza ("Non sono sicuro, ma direi…")
+  And il chip fonte mostra anche il livello di confidenza ("conf. 62%")
+  And include un suggerimento alternativo ("verifica anche su BGG forum")
+```
+
+---
+
+### G2 — Fast resume su device handoff
+
+**Smart**: Quando lo smartphone viene passato da un giocatore all'altro al tavolo, la persona che lo riceve può **continuare la conversazione in ≤3s** senza re-auth, vedendo cronologia chat, agente attivo e gioco di contesto, per il **100%** dei passaggi nel corso di una serata.
+
+**Sostituisce**: friction di re-orientamento. **Drives**: nessun re-auth per messaggio, header chat persistente con contesto gioco+agente, no modal di onboarding al riapertura.
+
+**Acceptance criteria (Gherkin)**:
+
+```gherkin
+Scenario G2.1: Handoff durante chat in-game, sessione preservata
+  Given Marco ha una chat aperta su /library/games/wingspan?tab=aiChat con 5 messaggi
+  And l'agente attivo è "Tutor"
+  When Marco passa il telefono a Lucia
+  And Lucia tocca lo schermo per riattivarlo
+  Then entro 3 secondi Lucia vede gli ultimi 5 messaggi senza scroll
+  And vede chiaramente il nome del gioco "Wingspan" nell'header
+  And vede il badge agente attivo "Tutor"
+  And può digitare e inviare senza inserire credenziali
+```
+
+---
+
+### G3 — Accesso rapido al gioco corrente dall'hub
+
+**Smart**: Da app appena aperta (cold start o background), un utente Alpha raggiunge la **chat-in-game di un gioco usato nelle ultime 24h in ≤2 tap**, per il **100%** dei giochi presenti nella libreria utente, entro il rilascio Alpha v2 (post token redesign #807).
+
+**Sostituisce**: navigazione manuale lunga. **Drives**: blocco "Giochi recenti" in dashboard, wiring dei componenti v2 `GamesHero`/`GamesResultsGrid` (pending — vedi §4), preserve scroll/state al ritorno da background.
+
+**Acceptance criteria (Gherkin)**:
+
+```gherkin
+Scenario G3.1: Cold start, gioco recente, 2 tap fino alla chat
+  Given utente Alpha apre l'app per la prima volta nella serata
+  And ha giocato "Wingspan" nelle ultime 24h (presente in libreria recente)
+  When la dashboard è caricata
+  Then vede un blocco "Giochi recenti" con "Wingspan" come prima card
+  When tocca la card "Wingspan" (1° tap)
+  Then atterra su /library/games/wingspan
+  When tocca la tab "AI Chat" (2° tap)
+  Then la chat-in-game è pronta a ricevere input entro 2 secondi totali
+
+Scenario G3.2: Resume da background preserva scroll e agente
+  Given utente ha la chat aperta con scroll a metà cronologia
+  And mette l'app in background per 30 minuti
+  When riapre l'app dal task switcher
+  Then atterra esattamente sulla chat-in-game con scroll preservato
+  And l'agente attivo è ancora "Tutor"
+```
+
+---
+
+### G4 — Navigabilità della fonte (KB detail funzionante)
+
+**Smart**: Ogni chip "fonte" mostrato in chat (vedi G1) **apre la pagina `/kb/[id]` corrispondente** con il chunk citato evidenziato e contesto navigabile (chunk precedente/successivo) entro **≤2s**, per il **100%** delle citazioni emesse, entro il rilascio Alpha v2 (post token redesign #807).
+
+**Sostituisce**: dover sfogliare PDF a mano. **Drives**: implementazione dei 6 stub pending in `apps/web/src/components/v2/kb-detail/` (KbHeader, KbChunkListPanel, KbChunkPreview, ChunkSearchBox, MarkdownRenderBlock, KbProcessingState).
+
+**Acceptance criteria (Gherkin)**:
+
+```gherkin
+Scenario G4.1: Citazione cliccabile apre KB con chunk evidenziato
+  Given chat in-game ha appena risposto con chip "Fonte: Manuale p.12 §3.2"
+  When utente tocca il chip
+  Then atterra su /kb/wingspan-v2#chunk-abc123 entro 2 secondi
+  And il chunk citato è evidenziato visivamente (background colorato)
+  And lo scroll è già posizionato sul chunk
+  And può navigare al chunk precedente/successivo con frecce
+  And può tornare alla chat con back-button preservando contesto
+
+Scenario G4.2: Search dentro la KB per esplorare il regolamento
+  Given utente è su /kb/wingspan-v2 (arrivato da una citazione)
+  When digita "endgame" nella ChunkSearchBox
+  Then vede chunk con match evidenziati entro 1 secondo
+  And può tornare alla chat in qualsiasi momento
+```
+
+---
+
+### G5 — Disclosure calibrata dell'incertezza
+
+**Smart**: L'agente AI **dichiara incertezza esplicitamente** (testo + indicatore visivo) quando la confidenza del retrieval è **< 70%**, per il **100%** di queste risposte, evitando il pattern "amico-esperto-che-tira-a-indovinare", entro il rilascio Alpha v2 (post token redesign #807).
+
+**Sostituisce**: rischio di accettare risposte sbagliate come definitive. **Drives**: aggiornamento system prompt agente Tutor/Arbitro, esposizione `confidence_score` dal retrieval pipeline al frontend, design del chip "fonte" con coding colore per livello confidenza.
+
+**Acceptance criteria (Gherkin)**:
+
+```gherkin
+Scenario G5.1: Confidenza alta, risposta diretta
+  Given utente fa una domanda di setup (categoria C)
+  And il retrieval ha trovato un chunk con confidence_score = 0.92
+  When la risposta viene composta
+  Then la risposta non contiene marker di incertezza
+  And il chip fonte mostra "conf. 92%" con colore verde
+
+Scenario G5.2: Confidenza bassa, marker esplicito + alternative
+  Given utente fa una domanda su edge case raro (categoria F)
+  And il miglior chunk recuperato ha confidence_score = 0.55
+  When la risposta viene composta
+  Then la risposta inizia con "Non sono sicuro, ma…"
+  And il chip fonte mostra "conf. 55%" con colore arancione
+  And include una sezione "Alternative da verificare" con suggerimenti (BGG, manuale p.X)
+  And l'utente vede un disclaimer testuale di 1 riga
+
+Scenario G5.3: Confidenza nulla, risposta bloccata
+  Given utente fa una domanda fuori KB
+  And nessun chunk ha confidence_score > 0.30
+  When la risposta viene composta
+  Then la risposta è "Non ho trovato risposta affidabile nel regolamento di <gioco>"
+  And include CTA per cercare su BGG o caricare un'integrazione PDF
+```
+
+---
+
+## 3. Esclusioni esplicite (out of scope per questo spec)
+
+- **Chat strategica/consigli di gioco** (categoria D in Q4) — agente Stratega non in scope serata
+- **Multi-device sync real-time** della chat (rifiutato in Q2) — niente SSE multiplayer chat
+- **Voice input / output** — non emerso come requisito; rinviato a futuro
+- **Modalità offline** — non discussa, assunta connettività disponibile
+- **Deep-link / widget OS** (D in Q3) — fuori scope Alpha
+- **Discover, Game-Nights, Player detail, Toolkit detail** — non bloccanti per il flusso serata (pending Wave 3+)
+- **Sessione live tracciata** (`/sessions/live/[sessionId]`) — opzionale, non sul critical path del flusso "chiarimento regolamento"
+
+---
+
+## 4. Mapping ai gap di migrazione v2 (priorità di implementazione)
+
+| Goal | Componenti pending | Path | Stato | Blocker |
+|---|---|---|---|---|
+| **G1** | Chat-in-game v2 (no mockup SP4) | `/library/games/[gameId]?tab=aiChat` | ❌ scope gap | **Issue Claude Design** per mockup |
+| **G1, G5** | System prompt agente con citazione + confidenza | Backend KnowledgeBase BC | 🟡 da rivedere | Coordinamento backend agent config |
+| **G2** | Header chat persistente con contesto gioco+agente | Componente chat container | 🟡 esistente, verificare AC | Audit UX su mobile |
+| **G3** | `GamesHero`, `GamesResultsGrid`, `GamesEmptyState` | `apps/web/src/components/v2/games/` | ✅ implementati, ❌ **non wired** su tab catalog/kb | Wiring nel `DashboardClient.tsx` |
+| **G3** | "Giochi recenti" widget in dashboard | Dashboard Alpha | 🟡 da progettare | Possibile riuso `RecentActivityRail` da `/library` (PR #574 done) |
+| **G4** | `KbHeader`, `KbChunkListPanel`, `KbChunkPreview`, `ChunkSearchBox`, `MarkdownRenderBlock`, `KbProcessingState` | `apps/web/src/components/v2/kb-detail/` | ❌ 6 stub `return null` | Implementazione Tier M, 1-2 PR |
+| **G5** | Chip "fonte" con color coding confidenza | Componente chat (parte di G1) | ❌ design gap | Insieme al mockup chat-in-game |
+
+**Priorità implementazione consigliata**:
+
+1. **G3 wiring** (effort S, sblocca subito coerenza visiva hub) — single PR
+2. **G4 KB detail** (effort M, sblocca G1.1/G4 acceptance) — 1-2 PR Tier M
+3. **G1 + G5 chat-in-game v2** (effort L, richiede mockup design + backend coordination + frontend) — multi-PR, richiede issue Claude Design upstream
+4. **G2 fast resume** (effort S audit + eventuale tweak) — può essere PR dopo G1
+
+---
+
+## 5. Open questions (da risolvere in implementation plan)
+
+- **OQ1**: la soglia confidence_score è uniforme (0.70) o per categoria di domanda? (es. setup C più stretta, edge-case F più tollerante)
+- **OQ2**: come si comporta G1 se l'utente chiede in lingua diversa dal regolamento? Translate-on-the-fly già esiste (`/library/games/[gameId]/translate` PR #790) — riusare?
+- **OQ3**: G3 "Giochi recenti" usa quale criterio di "recente"? Last-opened, last-played-session, o last-asked-AI?
+- **OQ4**: G4 "back to chat con contesto preservato" richiede un meccanismo specifico (history.back, deep-link con state)? Va specificato in plan.
+- **OQ5**: G2 "fast resume" su iOS richiede attenzione speciale (Safari kill background tabs aggressivamente)? Service worker?
+
+---
+
+## 6. Riferimenti
+
+- Spec-panel critique precedente (in conversation history) — analisi gap migrazione v2 per flusso serata di gioco
+- v2 migration matrix: [`docs/for-developers/frontend/v2-migration-matrix.md`](../../for-developers/frontend/v2-migration-matrix.md)
+- v2 design migration spec: [`docs/for-developers/specs/2026-04-26-v2-design-migration.md`](../../for-developers/specs/2026-04-26-v2-design-migration.md)
+- Libro-game vision: [`docs/superpowers/specs/2026-05-04-libro-game-assistant-vision.md`](./2026-05-04-libro-game-assistant-vision.md)
+- Alpha mode scope: `CLAUDE.md` §"Alpha Mode" — Auth → Games + BGG → PDF upload → RAG Chat → Library
+- Bounded Contexts coinvolti: KnowledgeBase (RAG, agenti, chat), GameManagement (catalogo), DocumentProcessing (PDF→KB), UserLibrary (giochi recenti)


### PR DESCRIPTION
## Summary

Implementa **G3** dello spec game-night user flow:
- Nuovo hook **`useRecentLibraryGames`** (Zustand recents store + fallback `useRecentlyAddedGames`, dedup, troncamento a `limit`)
- Nuovo componente puro **`GamesRecentRail`** v2 (3 stati: loading/empty/populated, a11y region, click handler)
- Wiring in **`apps/web/src/app/(authenticated)/games/page.tsx`** (NON DashboardClient): rail in cima a tutti i 3 tab (library/catalog/kb)
- Click su card naviga direttamente a `/library/games/[id]?tab=aiChat` (entry point G1 — chat in-game)

Closes #900.

## Spec/Plan

- Spec: [`docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md`](docs/superpowers/specs/2026-05-09-game-night-user-flow-design.md) §G3
- Plan: [`docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md`](docs/superpowers/plans/2026-05-09-game-night-g3-hub-recents.md)

## Scope reduction documentata

Lo spec G3 originale prevedeva anche il wiring v2 di `/games?tab=catalog`. Self-review durante stesura plan ha mostrato che `GamesResultsGrid` + `GamesFiltersInline` Wave B.1 sono **vincolati a `UserLibraryEntry`** e ai filtri library-only (`owned/wishlist/played`). Catalog tab v2 wiring richiede componenti nuovi e va in plan separato (vedi Out of scope nel plan).

## Test plan

- [x] Unit `useRecentLibraryGames` — 5/5 PASS (recents-order, fallback, truncate, missing-entry, loading-from-fallback)
- [x] Unit `GamesRecentRail` — 6/6 PASS (skeleton, empty hint, single card, 5 cards, onSelect, a11y region)
- [x] Regression `src/app/(authenticated)/games` — 66 test PASS
- [x] Typecheck full pass (no nuovi errori)
- [x] Lint: 0 errori, 40 warning pre-existing
- [ ] Smoke test manuale (richiesta al reviewer): \`/games?tab=library/catalog/kb\` mostra rail in cima; click → \`/library/games/[id]?tab=aiChat\`

## Quality gates passati

Two-stage review (spec compliance + code quality) eseguita per ogni task con subagent indipendenti:
- Task 1 hook: Spec ✅ APPROVED · Quality APPROVED_WITH_NITS → fix `isLoading` race condition (commit 3256c3bad)
- Task 2 component: Spec+Quality APPROVED_WITH_NITS → fix `viewAllHref` dead prop + boundary tests (commit bfe667e19)
- Task 3 wiring: Spec+Quality APPROVED clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)