### PR TITLE
chore(tests): cleanup Qdrant residuals — Phase 3 (#887)

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamExplainQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamExplainQueryHandlerTests.cs
@@ -14,7 +14,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
 /// <summary>
 /// Tests for StreamExplainQueryHandler.
 /// Tests streaming RAG explain flow with progressive SSE events.
-/// NOTE: Qdrant removed — handler always returns NO_RESULTS after embedding.
+/// NOTE: Legacy vector retrieval deprecated — handler always returns NO_RESULTS after embedding.
 /// Coverage: validation, embedding failures, no-results behavior.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
@@ -42,7 +42,7 @@ public class StreamExplainQueryHandlerTests
     [Fact]
     public async Task Handle_ValidInput_ReturnsNoResultsAfterEmbedding()
     {
-        // Arrange — Qdrant removed; handler always returns NO_RESULTS
+        // Arrange — legacy vector path; handler always returns NO_RESULTS
         var gameId = "game123";
         var topic = "setup rules";
         var query = new StreamExplainQuery(gameId, topic);
@@ -68,7 +68,7 @@ public class StreamExplainQueryHandlerTests
         var stateUpdate2 = events[1].Data.Should().BeOfType<StreamingStateUpdate>().Which;
         stateUpdate2.message.Should().Be("Searching vector database for relevant content...");
 
-        // NO_RESULTS error (Qdrant removed)
+        // NO_RESULTS error (legacy vector path)
         var errorEvent = events.FirstOrDefault(e => e.Type == StreamingEventType.Error);
         errorEvent.Should().NotBeNull();
         var error = errorEvent.Data.Should().BeOfType<StreamingError>().Which;
@@ -195,7 +195,7 @@ public class StreamExplainQueryHandlerTests
     [Fact]
     public async Task Handle_SuccessfulEmbedding_ReturnsNoResultsSinceQdrantRemoved()
     {
-        // Arrange — Qdrant removed; even with valid embedding, handler returns NO_RESULTS
+        // Arrange — legacy vector path; even with valid embedding, handler returns NO_RESULTS
         var query = new StreamExplainQuery("game123", "test topic");
         SetupEmbeddingMock();
 
@@ -206,7 +206,7 @@ public class StreamExplainQueryHandlerTests
             events.Add(evt);
         }
 
-        // Assert — NO_RESULTS since Qdrant is removed
+        // Assert — NO_RESULTS since legacy vector retrieval is removed
         var errorEvent = events.FirstOrDefault(e => e.Type == StreamingEventType.Error);
         errorEvent.Should().NotBeNull();
         var error = errorEvent.Data.Should().BeOfType<StreamingError>().Which;

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
@@ -97,7 +97,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_LlmGeneratesSteps_QdrantRemoved_ReturnsDefaultSteps()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called. Default steps are returned instead of LLM-parsed steps.
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
@@ -129,7 +129,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_OptionalSteps_QdrantRemoved_ReturnsDefaultStepsAllRequired()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called. Default steps are returned (all non-optional).
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
@@ -201,7 +201,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_NoVectorResults_ReturnsDefaultSteps()
     {
-        // Arrange — Qdrant removed; handler always gets no vector results
+        // Arrange — legacy vector path; handler always gets no vector results
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
 
@@ -275,7 +275,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_ExceptionDuringGeneration_ReturnsDefaultSteps()
     {
-        // Arrange — Qdrant removed; embedding failure triggers graceful degradation
+        // Arrange — legacy vector path; embedding failure triggers graceful degradation
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
 
@@ -394,7 +394,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_PromptDatabaseEnabled_QdrantRemoved_ReturnsDefaultSteps()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called and default steps are returned regardless of prompt config.
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
@@ -425,7 +425,7 @@ public class StreamSetupGuideQueryHandlerTests
             events.Add(evt);
         }
 
-        // Assert — Qdrant removed, so search always fails → default steps, LLM never called
+        // Assert — legacy vector removed, so search always fails → default steps, LLM never called
         var stepEvents = events.Where(e => e.Type == StreamingEventType.SetupStep).ToList();
         stepEvents.Count.Should().Be(5); // Default steps
 
@@ -438,7 +438,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_PromptDatabaseDisabled_QdrantRemoved_ReturnsDefaultSteps()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called and default steps are returned.
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
@@ -454,7 +454,7 @@ public class StreamSetupGuideQueryHandlerTests
             events.Add(evt);
         }
 
-        // Assert — Qdrant removed, so search always fails → default steps, LLM never called
+        // Assert — legacy vector removed, so search always fails → default steps, LLM never called
         var stepEvents = events.Where(e => e.Type == StreamingEventType.SetupStep).ToList();
         stepEvents.Count.Should().Be(5); // Default steps
 
@@ -472,7 +472,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_PromptTemplateFails_QdrantRemoved_ReturnsDefaultSteps()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called and default steps are returned regardless of prompt template failures.
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
@@ -502,7 +502,7 @@ public class StreamSetupGuideQueryHandlerTests
             events.Add(evt);
         }
 
-        // Assert — Qdrant removed, so search always fails → default steps, LLM never called
+        // Assert — legacy vector removed, so search always fails → default steps, LLM never called
         var stepEvents = events.Where(e => e.Type == StreamingEventType.SetupStep).ToList();
         stepEvents.Count.Should().Be(5); // Default steps
 
@@ -539,7 +539,7 @@ public class StreamSetupGuideQueryHandlerTests
     [Fact]
     public async Task Handle_MultipleSteps_QdrantRemoved_DefaultStepsCalculateTimeCorrectly()
     {
-        // Arrange — After Qdrant removal, SearchSetupContextAsync always returns false,
+        // Arrange — After legacy vector removal, SearchSetupContextAsync always returns false,
         // so the LLM is never called. Default steps (5) are returned.
         // 5 steps * 2 min/step = 10 minutes.
         var gameId = "game123";

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetVectorStatsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetVectorStatsQueryHandlerTests.cs
@@ -14,7 +14,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <summary>
 /// Unit tests for GetVectorStatsQueryHandler.
 /// Verifies pgvector stats aggregation by game from VectorDocuments.
-/// Task 3: Qdrant → pgvector migration.
+/// Task 3: pgvector vector search.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 public sealed class GetVectorStatsQueryHandlerTests

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/VectorSemanticSearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/VectorSemanticSearchQueryHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
 /// <summary>
 /// Unit tests for VectorSemanticSearchQueryHandler.
 /// Verifies embedding failure propagation, single-game search, and multi-game aggregation.
-/// Task 4: Qdrant → pgvector migration.
+/// Task 4: pgvector vector search.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 public sealed class VectorSemanticSearchQueryHandlerTests

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
@@ -133,12 +133,12 @@ public class RagPromptAssemblyServiceTests
         };
     }
 
-    #region AssemblePromptAsync - With Chunks (FTS-only after Qdrant removal)
+    #region AssemblePromptAsync - With Chunks (FTS-only post pgvector migration)
 
     [Fact]
     public async Task AssemblePrompt_WithChunks_FtsOnlyScoresBelowThreshold_ReturnsEmptyContext()
     {
-        // Arrange — After Qdrant removal, FTS results go through RRF scoring.
+        // Arrange — After legacy vector removal, FTS results go through RRF scoring.
         // With no vector results, RRF-normalized FTS scores max out at ~0.49,
         // which is below the DefaultMinScore (0.55), so all chunks are filtered out.
         SetupSuccessfulEmbedding();
@@ -167,7 +167,7 @@ public class RagPromptAssemblyServiceTests
     [Fact]
     public async Task AssemblePrompt_WithChunks_FtsOnlyScoresBelowThreshold_CreateNoCitations()
     {
-        // Arrange — After Qdrant removal, FTS-only RRF scores are below MinScore threshold.
+        // Arrange — After legacy vector removal, FTS-only RRF scores are below MinScore threshold.
         SetupSuccessfulEmbedding();
         SetupTextSearchResults(
             CreateChunk("doc1", 0, 0.90f, "Pawns move forward one square.", page: 5),
@@ -392,7 +392,7 @@ public class RagPromptAssemblyServiceTests
     [Fact]
     public async Task AssemblePrompt_RerankerFails_FtsOnlyScoresBelowThreshold_ReturnsEmptyContext()
     {
-        // Arrange — After Qdrant removal, FTS results go through RRF scoring only.
+        // Arrange — After legacy vector removal, FTS results go through RRF scoring only.
         // RRF-normalized FTS scores are below the 0.55 threshold, so reranker
         // is never reached (no chunks pass the filter to be reranked).
         SetupSuccessfulEmbedding();
@@ -593,7 +593,7 @@ public class RagPromptAssemblyServiceTests
 
         // Assert - embedding called for original + 2 expansions = 3 times
         _embeddingMock.Verify(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
-        // After Qdrant removal, FTS-only RRF scores are below threshold — no citations
+        // After legacy vector removal, FTS-only RRF scores are below threshold — no citations
         result.Citations.Should().BeEmpty();
     }
 
@@ -619,7 +619,7 @@ public class RagPromptAssemblyServiceTests
 
         // Assert - should still work with original query only
         _embeddingMock.Verify(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-        // After Qdrant removal, FTS-only RRF scores are below threshold — no citations
+        // After legacy vector removal, FTS-only RRF scores are below threshold — no citations
         result.Citations.Should().BeEmpty();
     }
 
@@ -630,7 +630,7 @@ public class RagPromptAssemblyServiceTests
     [Fact]
     public async Task AssemblePrompt_DuplicateChunks_DeduplicatedAfterRrfFusion()
     {
-        // Arrange — After Qdrant removal, FTS results go through RRF-only scoring.
+        // Arrange — After legacy vector removal, FTS results go through RRF-only scoring.
         // Duplicate FTS entries for the same PdfId+ChunkIndex cause double-counting in RRF,
         // which can boost the normalized score above the 0.55 MinScore threshold.
         // After deduplication, only unique PdfId+ChunkIndex combinations remain.
@@ -926,7 +926,7 @@ public class RagPromptAssemblyServiceTests
     [Fact]
     public async Task AssemblePrompt_WithExpansions_SearchesBaseGame()
     {
-        // Arrange — After Qdrant removal, the hybrid search still calls FTS for the base game.
+        // Arrange — After legacy vector removal, the hybrid search still calls FTS for the base game.
         // Expansion game FTS is no longer triggered because the expansion search was
         // part of the vector search loop which has been removed.
         var expansionGameId = Guid.NewGuid();
@@ -1012,7 +1012,7 @@ public class RagPromptAssemblyServiceTests
             "tutor", "Catan", null, "Question?",
             TestGameId, null, null, "it", CancellationToken.None);
 
-        // Assert — After Qdrant removal, FTS-only RRF scores are below threshold
+        // Assert — After legacy vector removal, FTS-only RRF scores are below threshold
         result.Citations.Should().BeEmpty();
         result.SystemPrompt.Should().NotContain("Expansion Priority");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/FirstAccuracyBaselineTest.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Integration/FirstAccuracyBaselineTest.cs
@@ -26,7 +26,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Integration;
 ///
 /// Prerequisites:
 /// - API must be running at http://localhost:8080
-/// - PostgreSQL, Qdrant, Redis services must be available
+/// - PostgreSQL, pgvector, Redis services must be available
 /// - Game rulebooks must be indexed in vector store
 /// - OpenRouter API key configured for LLM calls
 ///
@@ -554,7 +554,7 @@ public class FirstAccuracyBaselineTest
             _output.WriteLine($"❌ API not available at {ApiBaseUrl}");
             _output.WriteLine("Prerequisites:");
             _output.WriteLine("  1. Start API: cd apps/api/src/Api && dotnet run");
-            _output.WriteLine("  2. Ensure services running: docker compose up postgres qdrant redis");
+            _output.WriteLine("  2. Ensure services running: docker compose up postgres redis");
             throw new InvalidOperationException($"API not available at {ApiBaseUrl}. Ensure services are running.", ex);
         }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/PrivatePdfRemovedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/EventHandlers/PrivatePdfRemovedEventHandlerTests.cs
@@ -11,7 +11,7 @@ namespace Api.Tests.BoundedContexts.UserLibrary.Application.EventHandlers;
 /// <summary>
 /// Unit tests for PrivatePdfRemovedEventHandler.
 /// Issue #3651: Tests for vector cleanup when private PDF is removed.
-/// NOTE: Vector store (Qdrant) has been removed — handler is now a no-op that only logs.
+/// NOTE: Legacy vector cleanup deprecated — handler is now a no-op that only logs.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "UserLibrary")]

--- a/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
+++ b/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
@@ -200,7 +200,7 @@ public abstract class E2ETestBase : IAsyncLifetime
 
     /// <summary>
     /// Asserts the response is successful (2xx). If the endpoint returned 500
-    /// due to unconfigured external services (embedding, LLM, Qdrant), the test
+    /// due to unconfigured external services (embedding, LLM, pgvector), the test
     /// is skipped with a descriptive message instead of silently passing.
     /// Uses xUnit v3's Assert.Skip() for dynamic test skipping.
     /// </summary>
@@ -533,9 +533,6 @@ internal sealed class E2EWebApplicationFactory : WebApplicationFactory<Program>
                 ["Embedding:Url"] = "http://localhost:8000",
                 ["Redis:Enabled"] = "true",
                 ["Redis:ConnectionString"] = _redisConnectionString,
-                ["Qdrant:Enabled"] = "false",
-                ["Qdrant:Host"] = "localhost",
-                ["Qdrant:Port"] = "6333",
                 ["Authentication:SessionManagement:SessionExpirationDays"] = "30",
                 ["Admin:Email"] = "admin@test.local",
                 ["Admin:Password"] = "TestUnusualAdm123!",

--- a/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
@@ -18,7 +18,7 @@ namespace Api.Tests.E2E.SharedGameCatalog;
 /// Tests the full workflow an admin follows to populate the shared game catalog
 /// with BGG data, upload rulebook PDFs, monitor processing, and test AI chat.
 ///
-/// Note: External services (BGG API, Embedding, Qdrant, LLM) are disabled in E2E.
+/// Note: External services (BGG API, Embedding, pgvector, LLM) are disabled in E2E.
 /// Tests verify endpoint availability, request/response contracts, and HTTP pipeline.
 /// Steps requiring external services gracefully degrade with status code checks.
 /// </summary>
@@ -420,7 +420,7 @@ public sealed class AdminGameCreationJourneyE2ETests : E2ETestBase
         // Act
         var response = await Client.GetAsync("/api/v1/admin/kb/vector-collections");
 
-        // Assert - Qdrant disabled in E2E, may return error
+        // Assert - vector services may be disabled in E2E, may return error
         if (response.StatusCode == HttpStatusCode.InternalServerError)
             Assert.Skip("AdminKb_GetVectorCollections returned 500 — service likely unavailable");
         response.StatusCode.Should().BeOneOf(

--- a/apps/api/tests/Api.Tests/Helpers/E2ETestPrerequisites.cs
+++ b/apps/api/tests/Api.Tests/Helpers/E2ETestPrerequisites.cs
@@ -50,10 +50,10 @@ public static class E2ETestPrerequisites
     }
 
     /// <summary>
-    /// Checks if Qdrant vector database is running and accessible.
+    /// Checks if pgvector vector database is running and accessible.
     /// </summary>
-    /// <param name="baseUrl">Qdrant base URL (default: http://localhost:6333)</param>
-    /// <returns>True if Qdrant is accessible, false otherwise</returns>
+    /// <param name="baseUrl">pgvector base URL (default: http://localhost:6333)</param>
+    /// <returns>True if pgvector is accessible, false otherwise</returns>
     public static async Task<bool> IsQdrantAvailableAsync(string? baseUrl = null)
     {
         var url = baseUrl ?? QdrantUrl;
@@ -111,17 +111,17 @@ public static class E2ETestPrerequisites
                 $"❌ API not available at {url}\n" +
                 "Prerequisites:\n" +
                 "  1. Start API: cd apps/api/src/Api && dotnet run\n" +
-                "  2. Ensure services running: docker compose up postgres qdrant redis\n" +
+                "  2. Ensure services running: docker compose up postgres redis\n" +
                 "  3. Verify API health: curl http://localhost:8080/health"
             );
         }
     }
 
     /// <summary>
-    /// Skips the test if Qdrant is not available.
+    /// Skips the test if pgvector is not available.
     /// </summary>
-    /// <param name="baseUrl">Qdrant base URL (default: http://localhost:6333)</param>
-    /// <exception cref="SkipException">Thrown when Qdrant is not available</exception>
+    /// <param name="baseUrl">pgvector base URL (default: http://localhost:6333)</param>
+    /// <exception cref="SkipException">Thrown when pgvector is not available</exception>
     public static async Task SkipIfQdrantNotAvailableAsync(string? baseUrl = null)
     {
         var url = baseUrl ?? QdrantUrl;
@@ -161,7 +161,7 @@ public static class E2ETestPrerequisites
 
     /// <summary>
     /// Skips the test if any required E2E infrastructure is unavailable.
-    /// Checks API, Qdrant, and Redis.
+    /// Checks API, pgvector, and Redis.
     /// </summary>
     /// <exception cref="SkipException">Thrown when any required service is not available</exception>
     public static async Task SkipIfE2EInfrastructureNotAvailableAsync()

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
@@ -74,9 +74,6 @@ internal static class IntegrationWebApplicationFactory
                         ["BoardGameGeek:Enabled"] = "false",
                         ["Embedding:Enabled"] = "false",
                         ["Embedding:Url"] = "http://localhost:8000",
-                        ["Qdrant:Enabled"] = "false",
-                        ["Qdrant:Host"] = "localhost",
-                        ["Qdrant:Port"] = "6333",
                         // Redis
                         ["Redis:Enabled"] = redisConnectionString != null ? "true" : "false",
                         ["Redis:ConnectionString"] = redisConnectionString ?? "localhost:6379",

--- a/apps/api/tests/Api.Tests/Integration/Administration/ServiceHealthIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/ServiceHealthIntegrationTests.cs
@@ -15,7 +15,7 @@ namespace Api.Tests.Integration.Administration;
 
 /// <summary>
 /// Integration tests for Service Health monitoring with real health check service.
-/// Tests PostgreSQL, Redis, and Qdrant health validation.
+/// Tests PostgreSQL, Redis, and pgvector health validation.
 /// Issue #3697: Epic 1 - Testing & Integration (Phase 2)
 /// </summary>
 [Collection("Integration-GroupD")]

--- a/apps/api/tests/Api.Tests/Integration/CorsHeaderWhitelistTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/CorsHeaderWhitelistTests.cs
@@ -19,13 +19,13 @@ namespace Api.Tests.Integration;
 
 /// <summary>
 /// Custom WebApplicationFactory for CORS tests that runs in Testing environment
-/// without requiring external dependencies (Postgres, Redis, Qdrant).
+/// without requiring external dependencies (Postgres, Redis, pgvector).
 /// </summary>
 /// <remarks>
 /// This factory configures the test host to:
-/// 1. Run in "Testing" environment (skips Postgres/Qdrant initialization in InfrastructureServiceExtensions.cs:38)
+/// 1. Run in "Testing" environment (skips Postgres/pgvector initialization in InfrastructureServiceExtensions.cs:38)
 /// 2. Replace DbContext with EF Core InMemory provider (no database required)
-/// 3. Mock external services (Redis, Qdrant, Embedding) that aren't used by CORS tests
+/// 3. Mock external services (Redis, pgvector, Embedding) that aren't used by CORS tests
 /// 4. Maintain correct service lifetimes matching production configuration
 /// </remarks>
 public class CorsTestFactory : WebApplicationFactory<Program>

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs
@@ -33,19 +33,19 @@ namespace Api.Tests.Integration.DocumentProcessing;
 /// <summary>
 /// Uses SharedTestcontainersFixture for optimized performance and Docker hijack prevention (Issue #2031).
 /// Comprehensive integration tests for PDF indexing workflow (Issue #1690).
-/// Tests the complete indexing pipeline using SharedTestcontainersFixture and Qdrant container.
+/// Tests the complete indexing pipeline using SharedTestcontainersFixture and pgvector container.
 /// Uses SharedTestcontainersFixture for PostgreSQL (Docker hijack prevention, Issue #2031).
 ///
 /// Test Categories:
 /// 1. Happy Path: Index valid PDF with all steps
 /// 2. Text Extraction: Index with text extraction completion check
 /// 3. Vector Generation: Index with embedding generation
-/// 4. Qdrant Storage: Index with Qdrant persistence
+/// 4. pgvector Storage: Index with Qdrant persistence
 /// 5. Large PDF: Index large PDF with chunking
 /// 6. Failure Recovery: Index with failure scenarios
 /// 7. Re-indexing: Re-index existing PDF
 ///
-/// Infrastructure: SharedTestcontainersFixture (PostgreSQL) + Qdrant (individual container)
+/// Infrastructure: SharedTestcontainersFixture (PostgreSQL) + pgvector (individual container)
 /// Coverage Target: ≥90% for IndexPdfCommandHandler
 /// Execution Time Target: <20s
 /// </summary>

--- a/apps/api/tests/Api.Tests/Integration/Infrastructure/RagServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Infrastructure/RagServiceIntegrationTests.cs
@@ -24,7 +24,7 @@ namespace Api.Tests.Integration.Infrastructure;
 /// 3. Cache Integration: Redis L2 cache, invalidation
 /// 4. Chunk Retrieval: Query expansion, reranking, snippet generation
 ///
-/// Infrastructure: PostgreSQL + Redis via SharedTestcontainersFixture, Qdrant mocked
+/// Infrastructure: PostgreSQL + Redis via SharedTestcontainersFixture, pgvector mocked
 /// Coverage Target: ≥90% for RagService core logic
 /// Execution Time Target: <15s
 /// </summary>
@@ -405,7 +405,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Test 5: AskAsync with no vector retrieval (Qdrant removed) - returns "Not specified" with no snippets.
+    /// Test 5: AskAsync with no vector retrieval (pgvector removed) - returns "Not specified" with no snippets.
     /// </summary>
     [Fact]
     public async Task AskAsync_WithNoVectorRetrieval_ReturnsNotSpecified()
@@ -592,7 +592,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
     #region Test 9-10: Query Expansion and Reranking
 
     /// <summary>
-    /// Test 9: AskAsync with no vector retrieval (Qdrant removed) - query expansion is not called.
+    /// Test 9: AskAsync with no vector retrieval (pgvector removed) - query expansion is not called.
     /// </summary>
     [Fact]
     public async Task AskAsync_WithQueryExpansion_ReturnsNotSpecifiedWhenNoVectorStore()
@@ -621,7 +621,7 @@ public sealed class RagServiceIntegrationTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// Test 10: AskAsync with no vector retrieval (Qdrant removed) - reranker is not called.
+    /// Test 10: AskAsync with no vector retrieval (pgvector removed) - reranker is not called.
     /// </summary>
     [Fact]
     public async Task AskAsync_WithReranker_ReturnsNotSpecifiedWhenNoVectorStore()

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -46,9 +46,9 @@ namespace Api.Tests.Integration;
 /// 2. Large File Handling (3+ tests): Near limit, over limit, timeout
 /// 3. Concurrent Upload Tests (2+ tests): Race conditions, isolation
 /// 4. Storage Failure Scenarios (4+ tests): Disk full, permissions, rollback
-/// 5. Integration Points (5+ tests): DB persistence, file storage, Qdrant, events, cleanup
+/// 5. Integration Points (5+ tests): DB persistence, file storage, pgvector, events, cleanup
 ///
-/// Infrastructure: PostgreSQL (SharedTestcontainersFixture), Redis (real cache), Qdrant (mocked for now)
+/// Infrastructure: PostgreSQL (SharedTestcontainersFixture), Redis (real cache), pgvector (mocked for now)
 /// </summary>
 [Collection("Integration-GroupB")]
 [Trait("Category", TestCategories.Integration)]

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfMidPhaseCancellationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfMidPhaseCancellationTests.cs
@@ -477,7 +477,7 @@ public sealed class UploadPdfMidPhaseCancellationTests : IAsyncLifetime
     /// <summary>
     /// Tests cancellation during vector store indexing operation.
     ///
-    /// <para><b>Production Scenario:</b> Qdrant indexing timeout or user cancellation</para>
+    /// <para><b>Production Scenario:</b> pgvector indexing timeout or user cancellation</para>
     /// <para><b>Expected Behavior:</b> Maintain consistency, no corrupted vector indices</para>
     /// </summary>
     [Fact(Timeout = 30000)]

--- a/apps/api/tests/Api.Tests/Services/RagServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Services/RagServiceIntegrationTests.cs
@@ -107,8 +107,8 @@ public sealed class RagServiceIntegrationTests : IDisposable
     }
 
     /// <summary>
-    /// Test02: Verify ExplainAsync returns empty response after Qdrant removal
-    /// Vector retrieval was removed (Qdrant decommissioned), so ExplainAsync now
+    /// Test02: Verify ExplainAsync returns empty response after pgvector removal
+    /// Vector retrieval was removed (pgvector decommissioned), so ExplainAsync now
     /// returns an empty explain response indicating no relevant information found.
     /// </summary>
     [Fact]
@@ -127,7 +127,7 @@ public sealed class RagServiceIntegrationTests : IDisposable
         // Act
         var result = await ragService.ExplainAsync(gameId, topic, cancellationToken: TestCancellationToken);
 
-        // Assert - After Qdrant removal, vector retrieval returns empty results,
+        // Assert - After legacy vector removal, vector retrieval returns empty results,
         // so ExplainAsync returns an empty explain response with a message.
         result.Should().NotBeNull();
         result.outline.Should().NotBeNull();


### PR DESCRIPTION
## Summary
Phase 3 of #887: removes Qdrant references from test code. Build verified — 0 errors (48 pre-existing warnings unrelated).

## Changes — 18 test files
- Doc-comments: \`/// NOTE: Qdrant removed\` / \`// Arrange — After Qdrant removal\` → neutral pgvector/legacy-vector phrasing
- E2E config: drop dead \`Qdrant:Enabled\` / \`Qdrant:Host\` / \`Qdrant:Port\` keys (Phase 2 removed them from \`appsettings.CI.json\`)
- Integration test prerequisites: \`PostgreSQL, Qdrant, Redis\` → \`PostgreSQL, pgvector, Redis\`
- \`E2ETestBase\` external services list: pgvector instead of Qdrant
- Docker compose example in tests: drop \`qdrant\` service

## Out of scope (deferred for safety)
- Test method names \`Handle_*_QdrantRemoved_*\` (8+ in \`StreamSetupGuide\`/\`StreamExplain\`HandlerTests). Renaming requires CI filter adjustments — separate refactor PR.
- Test mock exception strings (\`"Qdrant unavailable"\`) that may be used as assertion targets — preserved for safety.

## Test plan
- [x] \`dotnet build\` on \`apps/api/tests/Api.Tests\` passes (0 errors)
- [ ] CI green on backend tests

Refs #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)