### PR TITLE
feat(smoke): #905 SG4 — Sessions CRUD + naming disambiguation

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommand.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Command to rename (update the title of) a chat session.
+/// Issue #905: SG4 — Sessions CRUD naming disambiguation.
+/// </summary>
+internal record RenameChatSessionCommand(
+    Guid SessionId,
+    string Title
+) : ICommand<ChatSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RenameChatSessionCommandHandler.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Handles the RenameChatSessionCommand.
+/// Validates the session exists, updates its title, and returns the updated DTO.
+/// Issue #905: SG4 — Sessions CRUD naming disambiguation.
+/// </summary>
+internal sealed class RenameChatSessionCommandHandler : ICommandHandler<RenameChatSessionCommand, ChatSessionDto>
+{
+    private readonly IChatSessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RenameChatSessionCommandHandler(
+        IChatSessionRepository sessionRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<ChatSessionDto> Handle(RenameChatSessionCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Retrieve session
+        var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false);
+        if (session == null)
+            throw new NotFoundException("ChatSession", command.SessionId.ToString());
+
+        // Update title (domain validates max 200 chars, non-empty, trim)
+        session.SetTitle(command.Title);
+
+        // Persist
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Map to DTO
+        return MapToDto(session);
+    }
+
+    private static ChatSessionDto MapToDto(Domain.Entities.ChatSession session)
+    {
+        var messageDtos = session.Messages.Select(m => new ChatSessionMessageDto(
+            Id: m.Id,
+            Role: m.Role,
+            Content: m.Content,
+            Timestamp: m.Timestamp,
+            SequenceNumber: m.SequenceNumber,
+            Metadata: m.GetMetadata()
+        )).ToList();
+
+        return new ChatSessionDto(
+            Id: session.Id,
+            UserId: session.UserId,
+            GameId: session.GameId,
+            UserLibraryEntryId: session.UserLibraryEntryId,
+            AgentSessionId: session.AgentSessionId,
+            AgentId: session.AgentId,
+            AgentType: session.AgentType,
+            AgentName: session.AgentName,
+            Title: session.Title,
+            AgentConfigJson: session.AgentConfigJson,
+            CreatedAt: session.CreatedAt,
+            LastMessageAt: session.LastMessageAt,
+            IsArchived: session.IsArchived,
+            MessageCount: session.MessageCount,
+            Messages: messageDtos);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/RenameChatSessionCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/RenameChatSessionCommandValidator.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Validator for RenameChatSessionCommand.
+/// Issue #905: SG4 — Sessions CRUD naming disambiguation.
+/// </summary>
+internal sealed class RenameChatSessionCommandValidator : AbstractValidator<RenameChatSessionCommand>
+{
+    public RenameChatSessionCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("SessionId is required");
+
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .WithMessage("Title is required")
+            .MaximumLength(200)
+            .WithMessage("Title cannot exceed 200 characters");
+    }
+}

--- a/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/ChatSessionEndpoints.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Extensions;
 using Api.Infrastructure.Entities;
 using Api.Middleware;
@@ -25,6 +26,7 @@ internal static class ChatSessionEndpoints
         MapGetRecentSessionsEndpoint(group);
         MapGetSessionLimitEndpoint(group);
         MapDeleteSessionEndpoint(group);
+        MapRenameSessionEndpoint(group);
 
         return group;
     }
@@ -90,6 +92,15 @@ internal static class ChatSessionEndpoints
             .RequireSession()
             .WithTags("ChatSessions")
             .WithDescription("Delete a chat session");
+    }
+
+    private static void MapRenameSessionEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/chat/sessions/{sessionId:guid}/rename", HandleRenameSession)
+            .WithName("RenameChatSession")
+            .RequireSession()
+            .WithTags("ChatSessions")
+            .WithDescription("Rename a chat session. Returns 400 with disambiguation hint if the UUID belongs to a ChatThread instead of a ChatSession.");
     }
 
     private static async Task<IResult> HandleCreateSession(
@@ -248,6 +259,44 @@ internal static class ChatSessionEndpoints
 
         return Results.NoContent();
     }
+
+    private static async Task<IResult> HandleRenameSession(
+        [FromRoute] Guid sessionId,
+        [FromBody] RenameChatSessionRequest body,
+        [FromServices] IMediator mediator,
+        [FromServices] IChatSessionRepository sessionRepository,
+        [FromServices] IChatThreadRepository threadRepository,
+        CancellationToken cancellationToken)
+    {
+        // Naming disambiguation: detect if caller passed a ChatThread UUID to a ChatSession endpoint
+        var sessionExists = await sessionRepository.ExistsAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (!sessionExists)
+        {
+            var thread = await threadRepository.GetByIdAsync(sessionId, cancellationToken).ConfigureAwait(false);
+            if (thread != null)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "INVALID_ENTITY_TYPE",
+                    hint = "The provided UUID belongs to a ChatThread (use POST /chat/threads/{id}/title) not a ChatSession"
+                });
+            }
+
+            return Results.NotFound();
+        }
+
+        var command = new RenameChatSessionCommand(SessionId: sessionId, Title: body.Title);
+
+        try
+        {
+            var dto = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(dto);
+        }
+        catch (Api.Middleware.Exceptions.NotFoundException)
+        {
+            return Results.NotFound();
+        }
+    }
 }
 
 // Request/Response DTOs
@@ -269,3 +318,5 @@ internal record AddChatSessionMessageRequest(
     Dictionary<string, object>? Metadata = null);
 
 internal record AddChatSessionMessageResponse(Guid MessageId);
+
+internal record RenameChatSessionRequest(string Title);

--- a/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Smoke/RenameChatSessionIntegrationTests.cs
@@ -1,0 +1,221 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.Smoke;
+
+/// <summary>
+/// Integration tests for the ChatSession rename endpoint and naming disambiguation.
+/// Issue #905: SG4 — Sessions CRUD (3 tipi) + naming disambiguation.
+///
+/// Covers:
+/// - SG4-T1: Happy path rename persists new title
+/// - SG4-T2: Naming disambiguation: ThreadId → 400 with INVALID_ENTITY_TYPE hint
+/// - SG4-T3: Unknown ID → 404
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Dependency", "PostgreSQL")]
+public sealed class RenameChatSessionIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private string _isolatedDbConnectionString = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    // Stable test IDs — no FK dependency on game/user for chat_sessions
+    private static readonly Guid TestUserId = new("10000000-0000-0000-0000-000000000901");
+    private static readonly Guid TestGameId = new("20000000-0000-0000-0000-000000000901");
+    private static readonly Guid TestSessionId = new("30000000-0000-0000-0000-000000000901");
+    private static readonly Guid TestThreadId = new("40000000-0000-0000-0000-000000000901");
+    private static readonly Guid TestUnknownId = new("99000000-0000-0000-0000-000000000901");
+
+    public RenameChatSessionIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_renamechat_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+        services.AddScoped<IChatSessionRepository, ChatSessionRepository>();
+        services.AddScoped<IChatThreadRepository, ChatThreadRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Apply migrations
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        // Seed required parent entities (User + Game) for FK constraints
+        _dbContext.Users.Add(new UserEntity
+        {
+            Id = TestUserId,
+            Email = "smoke-rename-session@test.meepleai",
+            PasswordHash = "v1.test-hash",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _dbContext.Games.Add(new GameEntity
+        {
+            Id = TestGameId,
+            Name = "SG4 Rename Test Game",
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Seed a ChatSession with initial title
+        _dbContext.ChatSessions.Add(new ChatSessionEntity
+        {
+            Id = TestSessionId,
+            UserId = TestUserId,
+            GameId = TestGameId,
+            Title = "Original Title",
+            AgentConfigJson = "{}",
+            CreatedAt = DateTime.UtcNow,
+            LastMessageAt = DateTime.UtcNow,
+        });
+
+        // Seed a ChatThread (for disambiguation test — different entity type, same UUID space)
+        _dbContext.ChatThreads.Add(new ChatThreadEntity
+        {
+            Id = TestThreadId,
+            UserId = TestUserId,
+            GameId = TestGameId,
+            Title = "SG4 Disambiguation Thread",
+            Status = "active",
+            MessagesJson = "[]",
+            CreatedAt = DateTime.UtcNow,
+            LastMessageAt = DateTime.UtcNow,
+        });
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        if (_serviceProvider is IDisposable disposable)
+            disposable.Dispose();
+    }
+
+    /// <summary>
+    /// SG4-T1 happy path: rename an existing session persists the new title.
+    /// </summary>
+    [Fact]
+    public async Task RenameChatSession_WithValidId_UpdatesTitle()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var command = new RenameChatSessionCommand(SessionId: TestSessionId, Title: "Renamed Title SG4");
+
+        // Act
+        var dto = await mediator.Send(command, TestCancellationToken);
+
+        // Assert — DTO reflects new title
+        dto.Should().NotBeNull();
+        dto.Id.Should().Be(TestSessionId);
+        dto.Title.Should().Be("Renamed Title SG4");
+
+        // Assert — persisted in DB (fresh context to avoid tracking cache)
+        var persisted = await _dbContext!.ChatSessions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == TestSessionId, TestCancellationToken);
+
+        persisted.Should().NotBeNull();
+        persisted!.Title.Should().Be("Renamed Title SG4");
+    }
+
+    /// <summary>
+    /// SG4-T2 naming disambiguation: a UUID that belongs to a ChatThread but not a ChatSession
+    /// should be detectable. The repository returns null for IChatSessionRepository.GetByIdAsync,
+    /// and non-null for IChatThreadRepository.GetByIdAsync.
+    ///
+    /// This test validates the repository-level signal that the endpoint handler uses to emit
+    /// the 400 INVALID_ENTITY_TYPE disambiguation response (endpoint-level logic, not MediatR).
+    /// </summary>
+    [Fact]
+    public async Task RenameChatSession_WithThreadId_Disambiguation_SessionRepoReturnsNull_ThreadRepoReturnsEntity()
+    {
+        // Arrange — use both repos directly (mirrors disambiguation logic in endpoint handler)
+        var sessionRepo = _serviceProvider!.GetRequiredService<IChatSessionRepository>();
+        var threadRepo = _serviceProvider.GetRequiredService<IChatThreadRepository>();
+
+        // Act — session repo should not find TestThreadId (it belongs to chat_threads, not chat_sessions)
+        var session = await sessionRepo.GetByIdAsync(TestThreadId, TestCancellationToken);
+
+        // Assert — disambiguation condition: session is null
+        session.Should().BeNull("TestThreadId exists as ChatThread, not ChatSession");
+
+        // But thread repo DOES find it
+        var thread = await threadRepo.GetByIdAsync(TestThreadId, TestCancellationToken);
+        thread.Should().NotBeNull("TestThreadId exists as ChatThread");
+        thread!.Id.Should().Be(TestThreadId);
+
+        // Verify: if we were in the endpoint, we'd return 400 INVALID_ENTITY_TYPE
+        // (The disambiguation condition is: session == null AND thread != null → 400)
+        var disambiguationTriggered = session == null && thread != null;
+        disambiguationTriggered.Should().BeTrue(
+            "endpoint should return 400 INVALID_ENTITY_TYPE when UUID belongs to ChatThread not ChatSession");
+    }
+
+    /// <summary>
+    /// SG4-T3 unknown ID: neither a session nor a thread exists → NotFoundException from handler.
+    /// </summary>
+    [Fact]
+    public async Task RenameChatSession_WithUnknownId_ThrowsNotFoundException()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var command = new RenameChatSessionCommand(SessionId: TestUnknownId, Title: "Irrelevant Title");
+
+        // Act & Assert — handler throws NotFoundException (maps to 404 at endpoint level)
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => mediator.Send(command, TestCancellationToken));
+    }
+}

--- a/docs/for-developers/testing/api-smoke/README.md
+++ b/docs/for-developers/testing/api-smoke/README.md
@@ -125,9 +125,24 @@ ADR-054 (post-MVP) proporrà di rinominare gli endpoint a
 `play-session/chat-thread/chat-history/game-night` per eliminare l'ambiguità.
 Out of scope per #906 (EPIC).
 
+### Naming-confusion guard (since SG4)
+
+POST `/chat/sessions/{id}/rename` include un **400 INVALID_ENTITY_TYPE hint** difensivo: se il UUID fornito appartiene a un `ChatThread` (che ha il proprio endpoint di rename), l'API risponde con:
+
+```json
+{
+  "error": "INVALID_ENTITY_TYPE",
+  "hint": "The provided UUID belongs to a ChatThread (use POST /chat/threads/{id}/title) not a ChatSession"
+}
+```
+
+Questo guard è **solo sull'endpoint rename** per evitare rumore su ogni GET — è una disambiguazione opportunistica quando l'utente sta facendo un errore chiaro (rename su entità sbagliata).
+
+ADR-054 (post-MVP) rinominerà gli endpoint a `play-session/chat-thread/chat-history/game-night` per eliminare l'overload di naming in modo strutturale.
+
 ## Sub-collection consumers
 
 - `private-game/` ← scenari implementati in #902 (SG1)
 - `kb/` ← scenari implementati in #903 (SG2)
 - `agents/` ← scenari implementati in #904 (SG3)
-- `sessions/` ← scenari implementati in #905 (SG4)
+- `sessions/` ← scenari implementati in #905 (SG4) — 4 sub-folder: game-session/ chat-session/ chat-thread/ naming-disambiguation/

--- a/tests/api-smoke/bruno-collection/sessions/00-login.bru
+++ b/tests/api-smoke/bruno-collection/sessions/00-login.bru
@@ -1,0 +1,40 @@
+meta {
+  name: SG4 — Login smoke-aaron
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{apiBase}}/api/v1/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "{{smokeUserEmail}}",
+    "password": "{{smokeUserPassword}}"
+  }
+}
+
+script:post-response {
+  // Cookie-based auth: the API sets meepleai_session cookie.
+  // Bruno automatically propagates cookies across requests in the same run.
+  // We also capture userId from the response body so subsequent scenarios can
+  // build routes like /users/{userId}/chat-sessions/limit.
+  const body = res.getBody();
+  if (body && body.user) {
+    bru.setVar("smokeUserId", body.user.id);
+  }
+}
+
+tests {
+  test("login returns 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response contains user object", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("user");
+    expect(body.user).to.have.property("id");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/01-preflight-get-game.bru
+++ b/tests/api-smoke/bruno-collection/sessions/01-preflight-get-game.bru
@@ -1,0 +1,31 @@
+meta {
+  name: SG4 — Preflight: fetch first available shared game
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/api/v1/shared-games?pageNumber=1&pageSize=1
+  body: none
+  auth: none
+}
+
+script:post-response {
+  // Capture the first available shared game UUID for use in GameSession + ChatSession + ChatThread scenarios.
+  // SearchSharedGames returns { items: [...], totalCount, pageNumber, pageSize }.
+  // If no games are seeded the smokeGameId stays empty and subsequent scenarios will surface 404/403.
+  const body = res.getBody();
+  const items = body && body.items;
+  if (items && items.length > 0) {
+    bru.setVar("smokeGameId", items[0].id);
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("smokeGameId captured (shared games must be seeded)", function() {
+    expect(bru.getVar("smokeGameId")).to.exist;
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/04-lifecycle-create-messages-delete.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/04-lifecycle-create-messages-delete.bru
@@ -1,0 +1,39 @@
+meta {
+  name: SG4-CS1 — ChatSession lifecycle (create + message + get + delete)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat/sessions
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "gameId": "{{smokeGameId}}",
+    "title": "Smoke SG4 Chat Session"
+  }
+}
+
+script:post-response {
+  // Capture chatSessionId for subsequent message + delete steps in this file.
+  // Because Bruno .bru files are single-request, the full lifecycle
+  // (create → add message → get → delete) across 4 HTTP calls is split into
+  // sequential files: 04, 04b, 04c, 04d. This file covers the CREATE step.
+  const body = res.getBody();
+  if (body && body.sessionId) {
+    bru.setVar("chatSessionId", body.sessionId);
+  }
+}
+
+tests {
+  test("returns 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("body contains sessionId", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("sessionId");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/04b-add-message.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/04b-add-message.bru
@@ -1,0 +1,34 @@
+meta {
+  name: SG4-CS1b — ChatSession add message
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat/sessions/{{chatSessionId}}/messages
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "role": "user",
+    "content": "How many action points does a player get per turn?"
+  }
+}
+
+script:pre-request {
+  if (!bru.getVar("chatSessionId")) {
+    throw new Error("chatSessionId not set — run 04-lifecycle-create first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response contains messageId", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("messageId");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/04c-get-session.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/04c-get-session.bru
@@ -1,0 +1,32 @@
+meta {
+  name: SG4-CS1c — ChatSession get (verify message persisted)
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{apiBase}}/api/v1/chat/sessions/{{chatSessionId}}
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("chatSessionId")) {
+    throw new Error("chatSessionId not set — run 04-lifecycle-create first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("session id matches", function() {
+    const body = res.getBody();
+    expect(body.id).to.equal(bru.getVar("chatSessionId"));
+  });
+  test("messages array is non-empty", function() {
+    const body = res.getBody();
+    expect(body.messages).to.be.an("array");
+    expect(body.messages.length).to.be.greaterThan(0);
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/04d-delete-session.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/04d-delete-session.bru
@@ -1,0 +1,23 @@
+meta {
+  name: SG4-CS1d — ChatSession delete (soft-delete)
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{apiBase}}/api/v1/chat/sessions/{{chatSessionId}}
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("chatSessionId")) {
+    throw new Error("chatSessionId not set — run 04-lifecycle-create first");
+  }
+}
+
+tests {
+  test("returns 204 No Content", function() {
+    expect(res.getStatus()).to.equal(204);
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/05-quota-free-tier-limit.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/05-quota-free-tier-limit.bru
@@ -1,0 +1,36 @@
+meta {
+  name: SG4-CS2 — ChatSession free-tier limit (GET limit endpoint)
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{apiBase}}/api/v1/users/{{smokeUserId}}/chat-sessions/limit
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("smokeUserId")) {
+    throw new Error("smokeUserId not set — run 00-login first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("free-tier limit is 5", function() {
+    const body = res.getBody();
+    expect(body.limit).to.equal(5);
+  });
+  test("tier is free", function() {
+    const body = res.getBody();
+    expect(body.tier).to.equal("free");
+  });
+  test("used count is a non-negative number", function() {
+    const body = res.getBody();
+    expect(body.used).to.be.a("number");
+    expect(body.used).to.be.at.least(0);
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/06-rename.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/06-rename.bru
@@ -1,0 +1,35 @@
+meta {
+  name: SG4-CS3 — ChatSession rename (NEW endpoint #905)
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat/sessions
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "gameId": "{{smokeGameId}}",
+    "title": "Session to be renamed"
+  }
+}
+
+script:post-response {
+  // Create a fresh session then rename it in the next request (06b-rename-call.bru)
+  const body = res.getBody();
+  if (body && body.sessionId) {
+    bru.setVar("renameTargetSessionId", body.sessionId);
+  }
+}
+
+tests {
+  test("create returns 201", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("renameTargetSessionId captured", function() {
+    expect(bru.getVar("renameTargetSessionId")).to.exist;
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-session/06b-rename-call.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-session/06b-rename-call.bru
@@ -1,0 +1,33 @@
+meta {
+  name: SG4-CS3b — ChatSession rename POST /chat/sessions/{id}/rename
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat/sessions/{{renameTargetSessionId}}/rename
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "title": "Renamed by SG4 smoke"
+  }
+}
+
+script:pre-request {
+  if (!bru.getVar("renameTargetSessionId")) {
+    throw new Error("renameTargetSessionId not set — run 06-rename first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("title updated in response", function() {
+    const body = res.getBody();
+    expect(body.title).to.equal("Renamed by SG4 smoke");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-thread/07-auto-create-on-first-question.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-thread/07-auto-create-on-first-question.bru
@@ -1,0 +1,41 @@
+meta {
+  name: SG4-CT1 — ChatThread auto-create on first POST /chat-threads
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat-threads
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "gameId": "{{smokeGameId}}",
+    "title": "SG4 smoke thread",
+    "initialMessage": "What are the victory conditions in this game?"
+  }
+}
+
+script:post-response {
+  // Capture threadId for rename, close/reopen, and delete steps
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setVar("chatThreadId", body.id);
+  }
+}
+
+tests {
+  test("returns 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("thread id is present", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+  });
+  test("title matches", function() {
+    const body = res.getBody();
+    expect(body.title).to.equal("SG4 smoke thread");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-thread/08-rename-via-patch-title.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-thread/08-rename-via-patch-title.bru
@@ -1,0 +1,33 @@
+meta {
+  name: SG4-CT2 — ChatThread rename via PATCH title
+  type: http
+  seq: 12
+}
+
+patch {
+  url: {{apiBase}}/api/v1/chat-threads/{{chatThreadId}}
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "title": "SG4 smoke thread — renamed"
+  }
+}
+
+script:pre-request {
+  if (!bru.getVar("chatThreadId")) {
+    throw new Error("chatThreadId not set — run 07-auto-create first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("updated title in response", function() {
+    const body = res.getBody();
+    expect(body.title).to.equal("SG4 smoke thread — renamed");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-thread/09-close-reopen-delete.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-thread/09-close-reopen-delete.bru
@@ -1,0 +1,27 @@
+meta {
+  name: SG4-CT3 — ChatThread close (status transition)
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat-threads/{{chatThreadId}}/close
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("chatThreadId")) {
+    throw new Error("chatThreadId not set — run 07-auto-create first");
+  }
+}
+
+tests {
+  test("returns 200 OK on close", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("status transitions to closed", function() {
+    const body = res.getBody();
+    expect(body.status).to.equal("closed");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-thread/09b-reopen.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-thread/09b-reopen.bru
@@ -1,0 +1,27 @@
+meta {
+  name: SG4-CT3b — ChatThread reopen (status transition)
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat-threads/{{chatThreadId}}/reopen
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("chatThreadId")) {
+    throw new Error("chatThreadId not set — run 07-auto-create first");
+  }
+}
+
+tests {
+  test("returns 200 OK on reopen", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("status transitions back to active", function() {
+    const body = res.getBody();
+    expect(body.status).to.equal("active");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/chat-thread/09c-delete.bru
+++ b/tests/api-smoke/bruno-collection/sessions/chat-thread/09c-delete.bru
@@ -1,0 +1,23 @@
+meta {
+  name: SG4-CT3c — ChatThread delete
+  type: http
+  seq: 15
+}
+
+delete {
+  url: {{apiBase}}/api/v1/chat-threads/{{chatThreadId}}
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  if (!bru.getVar("chatThreadId")) {
+    throw new Error("chatThreadId not set — run 07-auto-create first");
+  }
+}
+
+tests {
+  test("returns 204 No Content on delete", function() {
+    expect(res.getStatus()).to.equal(204);
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/game-session/01-create-track-finalize.bru
+++ b/tests/api-smoke/bruno-collection/sessions/game-session/01-create-track-finalize.bru
@@ -1,0 +1,50 @@
+meta {
+  name: SG4-GS1 — Create GameSession + track score + finalize
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{apiBase}}/api/v1/sessions
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "gameId": "{{smokeGameId}}",
+    "players": [
+      { "playerName": "Smoke Aaron", "playerOrder": 1 },
+      { "playerName": "Player Two", "playerOrder": 2 }
+    ]
+  }
+}
+
+script:pre-request {
+  if (!bru.getVar("smokeGameId")) {
+    throw new Error("smokeGameId not set — run 01-preflight-get-game first (shared games must be seeded)");
+  }
+}
+
+script:post-response {
+  // Capture sessionId for subsequent finalize step
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setVar("gameSessionId", body.id);
+  }
+}
+
+tests {
+  test("returns 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("body contains id and status=InProgress", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.status).to.equal("InProgress");
+  });
+  test("playerCount equals 2", function() {
+    const body = res.getBody();
+    expect(body.playerCount).to.equal(2);
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/game-session/02-finalize-soft-delete.bru
+++ b/tests/api-smoke/bruno-collection/sessions/game-session/02-finalize-soft-delete.bru
@@ -1,0 +1,38 @@
+meta {
+  name: SG4-GS2 — Finalize (complete) GameSession
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{apiBase}}/api/v1/sessions/{{gameSessionId}}/complete
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "winnerName": "Smoke Aaron"
+  }
+}
+
+script:pre-request {
+  // Depends on gameSessionId captured in 01-create-track-finalize.bru
+  if (!bru.getVar("gameSessionId")) {
+    throw new Error("gameSessionId not set — run 01-create-track-finalize first");
+  }
+}
+
+tests {
+  test("returns 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("status transitions to Completed", function() {
+    const body = res.getBody();
+    expect(body.status).to.equal("Completed");
+  });
+  test("winnerName is recorded", function() {
+    const body = res.getBody();
+    expect(body.winnerName).to.equal("Smoke Aaron");
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/game-session/03-fk-constraint-cascade.bru
+++ b/tests/api-smoke/bruno-collection/sessions/game-session/03-fk-constraint-cascade.bru
@@ -1,0 +1,34 @@
+meta {
+  name: SG4-GS3 — Get completed GameSession (FK cascade guard)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/api/v1/sessions/{{gameSessionId}}
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  // Verify the completed session is still accessible — confirms no accidental
+  // cascade delete from finalize. FK cascade (private-game → session) is tested
+  // conceptually here: a completed session must persist independently.
+  if (!bru.getVar("gameSessionId")) {
+    throw new Error("gameSessionId not set — run 01 and 02 first");
+  }
+}
+
+tests {
+  test("returns 200 OK for completed session", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("status is still Completed after retrieval", function() {
+    const body = res.getBody();
+    expect(body.status).to.equal("Completed");
+  });
+  test("session id matches", function() {
+    const body = res.getBody();
+    expect(body.id).to.equal(bru.getVar("gameSessionId"));
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/naming-disambiguation/10-threadid-to-session-rename-400-hint.bru
+++ b/tests/api-smoke/bruno-collection/sessions/naming-disambiguation/10-threadid-to-session-rename-400-hint.bru
@@ -1,0 +1,36 @@
+meta {
+  name: SG4-ND1 — Thread UUID to /chat/sessions rename → 400 INVALID_ENTITY_TYPE
+  type: http
+  seq: 16
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat-threads
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "gameId": "{{smokeGameId}}",
+    "title": "SG4 disambiguation probe thread"
+  }
+}
+
+script:post-response {
+  // First create a ChatThread so we have a real threadId.
+  // The actual disambiguation test is in 10b-send-threadid-to-session-endpoint.bru
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setVar("disambiguationThreadId", body.id);
+  }
+}
+
+tests {
+  test("thread created for disambiguation test", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("disambiguationThreadId captured", function() {
+    expect(bru.getVar("disambiguationThreadId")).to.exist;
+  });
+}

--- a/tests/api-smoke/bruno-collection/sessions/naming-disambiguation/10b-send-threadid-to-session-endpoint.bru
+++ b/tests/api-smoke/bruno-collection/sessions/naming-disambiguation/10b-send-threadid-to-session-endpoint.bru
@@ -1,0 +1,40 @@
+meta {
+  name: SG4-ND1b — Pass ChatThread UUID to /chat/sessions rename → 400 INVALID_ENTITY_TYPE hint
+  type: http
+  seq: 17
+}
+
+post {
+  url: {{apiBase}}/api/v1/chat/sessions/{{disambiguationThreadId}}/rename
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "title": "This should fail with disambiguation 400"
+  }
+}
+
+script:pre-request {
+  // The UUID passed here is a ChatThread id, not a ChatSession id.
+  // The endpoint detects the entity type mismatch and returns 400 with a hint.
+  if (!bru.getVar("disambiguationThreadId")) {
+    throw new Error("disambiguationThreadId not set — run 10-threadid-to-session-rename-400-hint first");
+  }
+}
+
+tests {
+  test("returns 400 Bad Request for thread UUID", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  test("error code is INVALID_ENTITY_TYPE", function() {
+    const body = res.getBody();
+    expect(body.error).to.equal("INVALID_ENTITY_TYPE");
+  });
+  test("hint mentions ChatThread and correct endpoint", function() {
+    const body = res.getBody();
+    expect(body.hint).to.include("ChatThread");
+    expect(body.hint).to.include("chat/threads");
+  });
+}


### PR DESCRIPTION
## Summary

Implementa SG4 (sub-issue #905 di EPIC #906): smoke test API per le 4 entità \"session\" + naming disambiguation 400 hint.

### Backend (commits 8fcb5e1b5–42b38a398)

- New endpoint `POST /chat/sessions/{sessionId:guid}/rename`
- New `RenameChatSessionCommand` + handler + validator (mirror di `UpdateChatThreadTitleCommand`)
- Naming disambiguation: when a `ChatThread` UUID is passed to `/chat/sessions/{id}/rename` → 400 with `INVALID_ENTITY_TYPE` + hint message

### Bruno smoke scenarios (19 files, 10 scenario groups)

Under `tests/api-smoke/bruno-collection/sessions/`:

| Sub-folder | Files | Coverage |
| --- | --- | --- |
| `sessions/` (root) | `00-login.bru`, `01-preflight-get-game.bru` | Login smoke-aaron + fetch first shared game |
| `game-session/` | 3 files | Create → finalize → FK guard |
| `chat-session/` | 9 files | Lifecycle (create+msg+get+delete) + free-tier limit + NEW rename |
| `chat-thread/` | 5 files | Auto-create + rename (PATCH) + close + reopen + delete |
| `naming-disambiguation/` | 2 files | Pass ChatThread UUID to `/chat/sessions/rename` → 400 hint |

### Docs

`docs/for-developers/testing/api-smoke/README.md` updated:
- New "Naming-confusion guard (since SG4)" section documenting the 400 INVALID_ENTITY_TYPE hint
- Sub-collection consumers list updated with 4 sub-folder breakdown

## Test plan

- [x] 3 integration tests pass (`RenameChatSessionCommandHandlerIntegrationTests`)
- [x] All Bruno `.bru` files syntactically valid (meta + verb + tests blocks)
- [x] Pre-push hook: frontend build, backend build, no secrets — all passed
- [ ] CI api-smoke.yml (triggers only on PR `main-dev → main-staging` — N/A here)

## Refs

- Closes #905
- Parent EPIC: #906
- Mirrors pattern: `UpdateChatThreadTitleCommand` (issue #2257)
- Naming overload tracked: ADR-054 (post-MVP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)