### PR TITLE
fix(chat): /chat/new no longer deadlocks on 'Preparazione...' (#923)

### DIFF
--- a/apps/web/src/components/chat/entry/ChatEntryOrchestrator.tsx
+++ b/apps/web/src/components/chat/entry/ChatEntryOrchestrator.tsx
@@ -209,12 +209,27 @@ export function ChatEntryOrchestrator({ className }: ChatEntryOrchestratorProps)
     hasAgentAvailable && (selectedAgentType !== null || selectedCustomAgentId !== null);
 
   // Direct game mode: loading spinner while resolving agents
+  // Issue #923: AgentSelector must be mounted (offscreen) so its useEffect
+  // fires the API call and resolves `isLoadingCustomAgents` via the
+  // onCustomAgentsResolved callback. Otherwise the page deadlocks on
+  // "Preparazione..." because the callback never runs.
   if (
     isDirectGameMode &&
     (isLoadingCustomAgents || isCreating || (customAgents.length === 1 && !error))
   ) {
     return (
       <div className="min-h-dvh bg-background flex items-center justify-center">
+        {/* Headless agent resolver — drives onCustomAgentsResolved while spinner is visible */}
+        <div aria-hidden="true" className="sr-only">
+          <AgentSelector
+            gameId={selectedGameId}
+            onSelectSystemAgent={handleSystemAgentSelect}
+            onSelectCustomAgent={handleCustomAgentSelect}
+            selectedAgentType={selectedAgentType}
+            selectedCustomAgentId={selectedCustomAgentId}
+            onCustomAgentsResolved={handleCustomAgentsResolved}
+          />
+        </div>
         <div className="text-center">
           <div className="h-8 w-8 border-3 border-amber-500/30 border-t-amber-500 rounded-full animate-spin mx-auto mb-4" />
           <p className="text-muted-foreground font-nunito">


### PR DESCRIPTION
## Summary
Fixes the infinite "Preparazione..." spinner on \`/chat/new?game={id}\` that blocked the canonical RAG demo flow on local + staging + real device.

## Root cause
\`ChatEntryOrchestrator\` returns the spinner branch early when \`isLoadingCustomAgents\` is true. But \`AgentSelector\` is the only component that fires \`api.agents.getUserAgentsForGame()\` and calls \`onCustomAgentsResolved\` (which clears \`isLoadingCustomAgents\`). Because the early-return prevents \`AgentSelector\` from ever mounting in direct-game mode, the callback never runs and the spinner state never resolves — classic React deadlock.

## Fix
Mount \`AgentSelector\` as a hidden \`sr-only\` child inside the spinner branch so its \`useEffect\` fires and the resolution callback runs. Visible spinner UI unchanged. Once \`isLoadingCustomAgents\` flips to \`false\` and the auto-start \`useEffect\` in the parent runs (line 95+), the page either:
- Auto-creates a thread (if exactly 1 custom agent) → redirects to \`/chat/{threadId}\`
- Falls through to render the agent picker (Auto / Tutor / Arbitro / Stratega / Narratore) + Quick Start

## Verification
End-to-end via cloudflared tunnel + Playwright (Pixel 5, 390×844):

| Before | After |
|--------|-------|
| Spinner forever on "Preparazione..." | Agent picker rendered in ~5s |

Console silent (no errors), API calls 200 across the board.

## Test plan
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm build\` succeeds
- [x] Manual repro on tunnel: \`/chat/new?game={catanGameId}\` resolves to agent picker
- [ ] CI tests on this PR
- [ ] Vitest snapshot of ChatEntryOrchestrator (if tests exist) — to be added if regression risk

## Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)