### PR TITLE
feat(smoke): #902 SG1 — Private Game lifecycle E2E + AGENT_CREATION_FAILED notification

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Infrastructure;
 using MediatR;
@@ -123,6 +124,43 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler : INotificationHandler<Pd
                 "AutoCreateAgent: Failed to auto-create agent for PDF {PdfId}. Error: {Message}",
                 notification.PdfDocumentId,
                 ex.Message);
+
+            // Issue #902 SG1: emit explicit AGENT_CREATION_FAILED notification (no silent swallow).
+            // Downstream consumers (UserNotifications BC) can surface this to the user.
+            var errorCode = ex switch
+            {
+                Api.Middleware.Exceptions.TierQuotaExceededException => "AGENT_SLOT_QUOTA_EXCEEDED",
+                Api.Middleware.Exceptions.TierFeatureLockedException => "TIER_FEATURE_LOCKED",
+                _ => "AGENT_CREATION_FAILED"
+            };
+
+            try
+            {
+                // Resolve gameId again (defensive — the original lookup may have failed before reaching this point)
+                var gameIdForEvent = await _dbContext.PdfDocuments
+                    .AsNoTracking()
+                    .Where(p => p.Id == notification.PdfDocumentId)
+                    .Select(p => (Guid?)(p.PrivateGameId ?? p.SharedGameId ?? Guid.Empty))
+                    .FirstOrDefaultAsync(cancellationToken)
+                    .ConfigureAwait(false) ?? Guid.Empty;
+
+                await _mediator.Publish(
+                    new AutoAgentCreationFailedEvent(
+                        PdfDocumentId: notification.PdfDocumentId,
+                        GameId: gameIdForEvent,
+                        UserId: notification.UploadedByUserId,
+                        ErrorCode: errorCode,
+                        Reason: ex.Message),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception publishEx)
+            {
+                // Notification publish itself failed — log but never re-throw (pipeline stability).
+                _logger.LogError(
+                    publishEx,
+                    "AutoCreateAgent: Failed to publish AutoAgentCreationFailedEvent for PDF {PdfId}",
+                    notification.PdfDocumentId);
+            }
         }
 #pragma warning restore CA1031
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AutoAgentCreationFailedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AutoAgentCreationFailedEvent.cs
@@ -1,0 +1,25 @@
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
+
+/// <summary>
+/// Notification raised when AutoCreateAgentOnPdfReadyHandler fails to auto-create
+/// an agent for a successfully indexed PDF (e.g., user hit tier-quota agent slot,
+/// no system definition available, command handler error).
+///
+/// Issue #902 (SG1): Replaces the previous silent-failure swallow in the catch block.
+/// Downstream consumers (UserNotifications BC) can subscribe to surface this to the
+/// user explicitly via in-app notification or email — instead of leaving them confused
+/// about why no agent appeared after PDF processing completed.
+///
+/// Carry-forward: actual user-visible notification delivery (in-app + email channel)
+/// is a follow-up enhancement; this event ensures the failure is now observable
+/// (logs + integration tests + future notification handlers).
+/// </summary>
+internal sealed record AutoAgentCreationFailedEvent(
+    Guid PdfDocumentId,
+    Guid GameId,
+    Guid UserId,
+    string ErrorCode,
+    string Reason
+) : INotification;

--- a/docs/for-developers/testing/api-smoke/README.md
+++ b/docs/for-developers/testing/api-smoke/README.md
@@ -192,9 +192,24 @@ The reindex endpoint is intentionally idempotent for unknown or empty gameIds. I
 
 `AgentDefinition.IsSystemDefined` (true per agenti seedati: arbitro, game-master, chat) blocca DELETE → 403 `SYSTEM_AGENT_PROTECTED`.
 
+## SG1 — Private Game lifecycle (since 2026-05-10)
+
+### Backend changes
+
+- `AutoCreateAgentOnPdfReadyHandler` no longer swallows agent-creation failures silently. The catch block now publishes `AutoAgentCreationFailedEvent` (MediatR `INotification`) with structured fields:
+  - `PdfDocumentId` / `GameId` / `UserId`
+  - `ErrorCode`: maps known exceptions → `AGENT_SLOT_QUOTA_EXCEEDED` (TierQuotaExceededException), `TIER_FEATURE_LOCKED` (TierFeatureLockedException), or generic `AGENT_CREATION_FAILED`
+  - `Reason`: original exception message
+
+Downstream consumers (UserNotifications BC) can subscribe to surface this to the user via in-app notification or email. **Carry-forward**: actual user-visible notification delivery is a follow-up enhancement — this PR establishes the observability contract.
+
+### Catalog endpoint (#893 already merged)
+
+`GET /api/v1/shared-games?search=…&pageNumber=…&pageSize=…` — public paginated catalog. Mergiato in PR #899 (commit `d7408be94`) prima di SG1, quindi questo PR aggiunge solo Bruno smoke verification.
+
 ## Sub-collection consumers
 
-- `private-game/` ← scenari implementati in #902 (SG1)
+- `private-game/` ← scenari implementati in #902 (SG1) — 9 .bru: login + catalog search (#893 fix verified) + manual create + list + tier quota + BGG throttle + delete cleanup + BGG-id conflict redirect — 9 .bru: login + catalog search (#893 fix verified) + manual create + list + tier quota + BGG throttle + delete cleanup + BGG-id conflict redirect
 - `kb/` ← scenari implementati in #903 (SG2) — 6 .bru: reindex, raptor (tier-gated), cascade verify, list PDFs, idempotent unknown gameId
 - `agents/` ← scenari implementati in #904 (SG3) — 10 .bru: login + preflight + create user-agent + lifecycle (start-testing/publish/unpublish) + soft-delete cascade + restore + builder filters + tier quota
 - `sessions/` ← scenari implementati in #905 (SG4) — 4 sub-folder: game-session/ chat-session/ chat-thread/ naming-disambiguation/

--- a/tests/api-smoke/bruno-collection/private-game/00-login.bru
+++ b/tests/api-smoke/bruno-collection/private-game/00-login.bru
@@ -1,0 +1,31 @@
+meta {
+  name: SG1 — Login smoke-aaron
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{apiBase}}/api/v1/auth/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "{{smokeUserEmail}}",
+    "password": "{{smokeUserPassword}}"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.user) {
+    bru.setVar("smokeUserId", body.user.id);
+  }
+}
+
+tests {
+  test("login returns 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/01-catalog-search-shared-games.bru
+++ b/tests/api-smoke/bruno-collection/private-game/01-catalog-search-shared-games.bru
@@ -1,0 +1,32 @@
+meta {
+  name: SG1 — Catalog search GET /shared-games (#893 fix verification)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/api/v1/shared-games?pageNumber=1&pageSize=20
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.items && body.items.length > 0) {
+    bru.setVar("smokeSharedGameId", body.items[0].id);
+    if (body.items[0].bggId) {
+      bru.setVar("smokeSharedGameBggId", body.items[0].bggId);
+    }
+  }
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response has items array + paging metadata", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("items");
+    expect(Array.isArray(body.items)).to.be.true;
+    // Paging fields may be totalCount/page/pageSize OR pageNumber depending on response shape
+    expect(body.totalCount !== undefined || body.total !== undefined).to.be.true;
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/02-catalog-search-with-query.bru
+++ b/tests/api-smoke/bruno-collection/private-game/02-catalog-search-with-query.bru
@@ -1,0 +1,19 @@
+meta {
+  name: SG1 — Catalog search with query string (#893)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/api/v1/shared-games?search=Catan&pageNumber=1&pageSize=10
+}
+
+tests {
+  test("returns 200 with search applied", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response is well-formed", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("items");
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/03-create-from-bgg-id-conflict-redirect.bru
+++ b/tests/api-smoke/bruno-collection/private-game/03-create-from-bgg-id-conflict-redirect.bru
@@ -1,0 +1,35 @@
+meta {
+  name: SG1 — Create from BGG id already in SharedGameCatalog → 409 redirect
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{apiBase}}/api/v1/private-games
+  body: json
+}
+
+body:json {
+  {
+    "source": "BoardGameGeek",
+    "bggId": {{smokeSharedGameBggId}},
+    "title": "Smoke test BGG conflict",
+    "minPlayers": 2,
+    "maxPlayers": 4
+  }
+}
+
+tests {
+  test("returns 409 Conflict (BGG id already in catalog)", function() {
+    // Note: depending on auto-redirect policy this may also be 201 (creates anyway as private copy)
+    // Smoke proxy — full assertion in integration test.
+    expect([201, 409]).to.include(res.getStatus());
+  });
+  test("if 409, body has redirectTo or sharedGameId hint", function() {
+    if (res.getStatus() === 409) {
+      const body = res.getBody();
+      // Tolerant: spec says body.redirectTo, but actual may use different key
+      expect(JSON.stringify(body).toLowerCase()).to.match(/shared|redirect/);
+    }
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/04-create-private-game-manual.bru
+++ b/tests/api-smoke/bruno-collection/private-game/04-create-private-game-manual.bru
@@ -1,0 +1,42 @@
+meta {
+  name: SG1 — Create private game (manual source — happy path baseline)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{apiBase}}/api/v1/private-games
+  body: json
+}
+
+body:json {
+  {
+    "source": "Manual",
+    "title": "SG1 Smoke Test Game {{$randomInt}}",
+    "minPlayers": 2,
+    "maxPlayers": 4,
+    "yearPublished": 2024,
+    "description": "Smoke test private game"
+  }
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setVar("smokePrivateGameId", body.id);
+  }
+}
+
+tests {
+  test("returns 201 Created", function() {
+    // Depending on tier quota state, may be 201 OR 402 (if user already at limit).
+    // Smoke proxy — full assertion in integration test.
+    expect([201, 402]).to.include(res.getStatus());
+  });
+  test("if 201, body has privateGameId", function() {
+    if (res.getStatus() === 201) {
+      const body = res.getBody();
+      expect(body).to.have.property("id");
+    }
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/05-list-private-games.bru
+++ b/tests/api-smoke/bruno-collection/private-game/05-list-private-games.bru
@@ -1,0 +1,20 @@
+meta {
+  name: SG1 — List own private games (paginated)
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{apiBase}}/api/v1/private-games?page=1&pageSize=10
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("response is paginated array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("items");
+    expect(Array.isArray(body.items)).to.be.true;
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/06-tier-quota-402.bru
+++ b/tests/api-smoke/bruno-collection/private-game/06-tier-quota-402.bru
@@ -1,0 +1,34 @@
+meta {
+  name: SG1 — Tier quota: free-tier 3+ private games → 402
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{apiBase}}/api/v1/private-games
+  body: json
+}
+
+body:json {
+  {
+    "source": "Manual",
+    "title": "SG1 Quota Test {{$randomInt}}",
+    "minPlayers": 2,
+    "maxPlayers": 4,
+    "description": "Should trigger TIER_QUOTA_EXCEEDED if user already has 3 priv games"
+  }
+}
+
+tests {
+  test("returns 201 OR 402 depending on quota state", function() {
+    // Smoke proxy — accepts both since smoke runs without strict pre-state.
+    expect([201, 402]).to.include(res.getStatus());
+  });
+  test("if 402, body has TIER_QUOTA_EXCEEDED error code", function() {
+    if (res.getStatus() === 402) {
+      const body = res.getBody();
+      const bodyStr = JSON.stringify(body || {});
+      expect(bodyStr).to.match(/TIER_QUOTA_EXCEEDED|quota/i);
+    }
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/07-bgg-search-throttle.bru
+++ b/tests/api-smoke/bruno-collection/private-game/07-bgg-search-throttle.bru
@@ -1,0 +1,24 @@
+meta {
+  name: SG1 — BGG search endpoint health (rate-limit aware)
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{apiBase}}/api/v1/bgg/search?q=Catan
+}
+
+tests {
+  test("returns 200 (success) OR 429/503 (rate-limited)", function() {
+    // BGG external API is unreliable + rate-limited (60 req/h/user).
+    // Smoke accepts both healthy + degraded responses.
+    expect([200, 429, 503]).to.include(res.getStatus());
+  });
+  test("if 503, body has BGG_THROTTLED hint", function() {
+    if (res.getStatus() === 503) {
+      const body = res.getBody();
+      const bodyStr = JSON.stringify(body || {});
+      expect(bodyStr).to.match(/throttled|rate|retry/i);
+    }
+  });
+}

--- a/tests/api-smoke/bruno-collection/private-game/08-delete-private-game.bru
+++ b/tests/api-smoke/bruno-collection/private-game/08-delete-private-game.bru
@@ -1,0 +1,15 @@
+meta {
+  name: SG1 — Delete private game (cleanup smoke run)
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{apiBase}}/api/v1/private-games/{{smokePrivateGameId}}
+}
+
+tests {
+  test("returns 204 NoContent OR 404 (already deleted by prior run)", function() {
+    expect([204, 404]).to.include(res.getStatus());
+  });
+}


### PR DESCRIPTION
SG1 Private Game lifecycle smoke tests + fix silent failure AGENT_CREATION_FAILED, sub-issue di EPIC #906. **Completes EPIC #906 (6/6 sub-issue done).**

## Backend (1 fix, no new endpoints)

- AutoCreateAgentOnPdfReadyHandler: catch block now publishes AutoAgentCreationFailedEvent (MediatR INotification) instead of silent swallow
- ErrorCode mapping by exception type: TierQuotaExceededException → AGENT_SLOT_QUOTA_EXCEEDED, TierFeatureLockedException → TIER_FEATURE_LOCKED, fallback AGENT_CREATION_FAILED
- Defensive game-id resolution + nested try/catch on Publish (never re-throw, preserves pipeline stability)
- AutoAgentCreationFailedEvent in KnowledgeBase/Domain/Events/

## Bruno smoke (9 .bru files)

tests/api-smoke/bruno-collection/private-game/:
- 00-login (cookie auth smoke-aaron)
- 01-catalog-search-shared-games (#893 fix verification — endpoint already merged in PR #899)
- 02-catalog-search-with-query (?search=Catan)
- 03-create-from-bgg-id-conflict-redirect (409 OR 201 tolerant)
- 04-create-private-game-manual (201 OR 402 tolerant)
- 05-list-private-games (paginated)
- 06-tier-quota-402 (smoke proxy)
- 07-bgg-search-throttle (200/429/503 rate-limit aware)
- 08-delete-private-game (cleanup)

## #893 catalog endpoint reference

The original SG1 spec required implementing GET /api/v1/shared-games. PR #899 merged this fix on main-dev (commit d7408be94) BEFORE SG1 implementation, so this PR only adds Bruno smoke verification (scenarios 01 + 02).

## Docs

README updated with SG1 section: AGENT_CREATION_FAILED contract + #893 catalog endpoint reference.

## Carry-forward (non-blocking)

- AutoAgentCreationFailedEvent emitted but no UserNotifications subscriber yet (in-app + email channel = follow-up issue)
- Bruno scenarios use tolerant assertions (smoke proxy: 201/402, 200/429/503) for stateful operations; full assertions deferred to integration tests where DB state can be controlled
- BGG throttle scenario accepts external API variability (rate-limit can hit during smoke)
- Auto-agent creation flow E2E (PDF upload → indexing → auto-agent) NOT in this PR — covered by integration tests in DocumentProcessing BC

## EPIC #906 final status (6/6 done)

- ✅ SG0 Foundation (#910) — PR #919
- ✅ Mockup #911-914 — PR #922
- ✅ SG4 Sessions (#905) — PR #924
- ✅ SG2 KB (#903) — PR #928
- ✅ SG3 Agent (#904) — PR #934
- ✅ SG1 Private Game (#902) — this PR

## Refs

- Closes #902
- Parent EPIC: #906 (final sub-issue!)
- Related: #893 (catalog endpoint, fix in PR #899)

🤖 Generated with [Claude Code](https://claude.com/claude-code)