### PR TITLE
fix(ci): #938 use OPENROUTER_API_KEY for E2E smoke (not Anthropic)

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -37,6 +37,18 @@ jobs:
         working-directory: apps/web
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Setup secret files (LLM provider for backend)
+        working-directory: infra
+        run: |
+          # Bootstrap placeholder secret files from .example templates
+          make secrets-setup
+          # Override OpenRouter secret with real CI key (backend uses OPENROUTER_API_KEY,
+          # NOT Anthropic — see apps/api/src/Api/.../OpenRouterService.cs)
+          cat > secrets/openrouter.secret <<EOF
+          OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY_SMOKE }}
+          OPENROUTER_DEFAULT_MODEL=${{ vars.OPENROUTER_DEFAULT_MODEL || 'meta-llama/llama-3.3-70b-instruct:free' }}
+          EOF
+
       - name: Start full stack with snapshot DB
         working-directory: infra
         run: make dev-from-snapshot
@@ -63,7 +75,6 @@ jobs:
         working-directory: apps/web
         env:
           BASE_URL: http://localhost:3000
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_SMOKE }}
         run: pnpm exec playwright test e2e/smoke/
 
       - name: Upload Playwright report on fail


### PR DESCRIPTION
## Summary
Bug correction in PR #944 E2E smoke workflow:
- Backend uses **OpenRouter + DeepSeek**, not Anthropic Claude
- Workflow setava \`ANTHROPIC_API_KEY\` env var sul Playwright job → inutile
- Backend Docker legge \`OPENROUTER_API_KEY\` da \`./secrets/openrouter.secret\` (env_file)

## Fix
- Aggiunto step "Setup secret files" che bootstrap secrets dai .example template + override openrouter.secret con CI secret
- Rimosso ANTHROPIC_API_KEY env dal job Playwright (irrilevante)

## Action richiesta admin GitHub repo
- RINOMINARE secret \`ANTHROPIC_API_KEY_SMOKE\` → \`OPENROUTER_API_KEY_SMOKE\`
- Valore: OpenRouter API key (formato \`sk-or-v1-...\`)
- Modello free disponibile: \`meta-llama/llama-3.3-70b-instruct:free\`

## Refs
- #938 follow-up
- Backend: \`apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/OpenRouterService.cs\`
- Compose: \`infra/compose.dev.yml\` api service env_file list