### PR TITLE
fix(e2e): #938 set SEED IDs from snapshot DB (Catan + catan_en_rulebook)

### DIFF
--- a/apps/web/e2e/smoke/_helpers.fixtures.ts
+++ b/apps/web/e2e/smoke/_helpers.fixtures.ts
@@ -21,7 +21,13 @@ export const SMOKE_USER = {
   password: 'SmokeAaron1!!',
 } as const;
 
-// Placeholder UUIDs — sostituire dopo aver eseguito Step 0.4 del plan.
-// Format atteso: UUID v4 (es. 'a1b2c3d4-e5f6-4789-90ab-cdef12345678')
-export const SEED_GAME_ID = '__REPLACE_ME_FROM_STEP_0_4__';
-export const SEED_DOCUMENT_ID = '__REPLACE_ME_FROM_STEP_0_4__';
+// SEED IDs identificati dallo snapshot DB (DB: meepleai_staging, 2026-05-10).
+// Estratti via:
+//   docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -tAc \
+//     "SELECT id, title FROM shared_games WHERE id IN \
+//      (SELECT \"SharedGameId\" FROM pdf_documents WHERE processing_state='Ready');"
+//
+// Game: Catan — è l'UNICO con un PDF processing_state='Ready' nel snapshot corrente.
+// Se lo snapshot viene rigenerato e il PDF Ready cambia, sostituire i 2 UUID sotto.
+export const SEED_GAME_ID = '3d54901d-fe9d-4d00-a7ae-e9865bb764f7'; // Catan
+export const SEED_DOCUMENT_ID = '47725c26-20b9-41e9-ad80-c00bc1a799d0'; // catan_en_rulebook.pdf


### PR DESCRIPTION
Sostituisce placeholder `__REPLACE_ME__` con UUID reali estratti dallo snapshot DB.

- SEED_GAME_ID: `3d54901d-fe9d-4d00-a7ae-e9865bb764f7` (Catan)
- SEED_DOCUMENT_ID: `47725c26-20b9-41e9-ad80-c00bc1a799d0` (catan_en_rulebook.pdf)

Catan è l'unico shared-game con PDF `processing_state='Ready'` nello snapshot corrente.

Refs: #938 follow-up