### PR TITLE
fix(ci): #938 disable auto-trigger E2E smoke + fix pnpm version

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,14 +1,10 @@
 name: E2E Smoke G1-G5
 
+# NB: trigger automatico DISABILITATO temporaneamente — workflow richiede env files
+# setup completo (pattern `e2e-smoke-real-backend.yml` riga 27-65) per essere robusto in CI.
+# Run manuale via workflow_dispatch finché l'integrazione completa non è plan-pickata.
+# Vedi follow-up: integrare 4 spec smoke/game-night-*.spec.ts in smoke-real-backend/ structure.
 on:
-  push:
-    branches: [main-dev, main]
-    paths:
-      - 'apps/web/src/components/v2/game-chat/**'
-      - 'apps/web/src/hooks/queries/useGameChat.ts'
-      - 'apps/web/e2e/smoke/**'
-      - 'apps/api/src/Api/BoundedContexts/KnowledgeBase/**'
-      - '.github/workflows/e2e-smoke.yml'
   workflow_dispatch:
 
 jobs:
@@ -21,6 +17,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
+        with:
+          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fixes immediati workflow E2E smoke (3 run failed in main-dev):

1. **Disabilitato auto-trigger push** → solo `workflow_dispatch` manuale (no spam fail su CI)
2. **pnpm version: 9 esplicito** (fix `ENOENT package.json` error)

## Motivazione

Workflow attuale richiede env files setup completo (`web.env.dev`, `api.env.dev`, `n8n.env.dev`) per funzionare in CI — pattern già implementato in `e2e-smoke-real-backend.yml` (nightly).

Strategie possibili (follow-up):
- (a) Estendere `e2e-smoke.yml` replicando setup completo
- (b) **Consigliato**: integrare i 4 spec `smoke/game-night-*.spec.ts` nella struttura esistente `apps/web/e2e/smoke-real-backend/` e riusare workflow nightly

I 4 spec restano comunque eseguibili manualmente:
- `pnpm exec playwright test e2e/smoke/` con stack locale up

Refs: #938 follow-up