### PR TITLE
fix(smoke): SharedGame BC mismatch + weekly snapshot drift (#938)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -86,6 +86,11 @@ jobs:
             sleep 5
           done
 
+      - name: Apply smoke chat fixture (SharedGame + UserLibraryEntry for game-night specs)
+        run: |
+          docker exec -i meepleai-postgres psql -U meepleai -d meepleai \
+            < tests/fixtures/smoke-test-games.sql
+
       - name: Dump API logs on stack-up failure
         if: failure()
         working-directory: infra

--- a/.github/workflows/e2e-smoke-real-llm-weekly.yml
+++ b/.github/workflows/e2e-smoke-real-llm-weekly.yml
@@ -1,15 +1,24 @@
-name: E2E Smoke Real LLM Weekly (free tier)
+name: E2E Smoke Real LLM (free tier, on-demand)
 
-# Weekly canary against real LLM (free OpenRouter tier) on snapshot DB.
+# On-demand canary against real LLM (free OpenRouter tier) on snapshot DB.
 # Mitigation Crispin: retries: 3 + timeout 180s + tag @flaky-by-design (legitimate flake).
 # Mitigation Nygard: free-model availability check + fallback chain (deprecation guard).
 # NO auto-issue creation — free tier flake non deve spammare bug tracker.
 #
+# ⚠️ Cron schedule DISABILITATO: il workflow dipende da `make dev-from-snapshot`
+# che ha un compat-gate fail-stop quando le migration HEAD del working tree non
+# matchano lo snapshot DB cached. Quando arriva una migration nuova, lo snapshot
+# va rigenerato manualmente via `make seed-index` (~20 min, richiede ambiente con
+# tutti i PDF + LLM). Eseguire questo workflow on-demand pre-staging deploy.
+#
+# Pre-requisito ogni run:
+#   1. Verificare che lo snapshot sia allineato (`make dev-from-snapshot` localmente)
+#   2. Se compat-gate fail → `make seed-index` per rigenerare → push del nuovo snapshot
+#   3. Trigger manuale di questo workflow
+#
 # Spec: docs/superpowers/specs/2026-05-10-e2e-smoke-game-night-integration-design.md §4.3 + §5.2
 
 on:
-  schedule:
-    - cron: '0 4 * * 0'  # Domenica 04:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
@@ -32,81 +32,24 @@ interface MockQaV2Options {
 }
 
 /**
- * Idempotent inline game seeding for chat smoke specs.
+ * Deterministic SharedGame ID seeded via SQL fixture (tests/fixtures/smoke-test-games.sql).
  *
- * Creates a game with a run-id-suffixed title (unique per CI run), then adds
- * it to the admin's library so /library/games/{id} route renders. Returns the
- * gameId. The smoke-user is admin (INITIAL_ADMIN_* env in CI workflow), so
- * has authority to create games.
+ * Inline runtime seeding via API was attempted (PR #956) but failed because
+ * POST /api/v1/games creates a Game (GameManagement BC), while the library
+ * route requires a SharedGame (SharedGameCatalog BC) — different aggregates,
+ * no public admin endpoint for SharedGame creation. SQL fixture is applied
+ * by the workflow before specs run.
  *
- * Throws on any non-2xx status (except 409 conflict on create, which is
- * tolerated — but we still need the id, so re-fetch via list query).
+ * The `request` and `cookieHeader` parameters are unused but kept for API
+ * stability across spec call sites — future migrations may need real seeding.
+ *
+ * @returns deterministic UUID matching tests/fixtures/smoke-test-games.sql
  */
-export async function seedGameForChat(
-  request: APIRequestContext,
-  cookieHeader: string
+export function seedGameForChat(
+  _request: APIRequestContext,
+  _cookieHeader: string
 ): Promise<string> {
-  const runId = process.env.GITHUB_RUN_ID ?? 'local';
-  const title = `Smoke Chat Game ${runId}`;
-
-  const createRes = await request.post(`${API_BASE}/api/v1/games`, {
-    headers: { Cookie: cookieHeader },
-    data: {
-      title,
-      publisher: 'smoke',
-      minPlayers: 2,
-      maxPlayers: 4,
-    },
-  });
-
-  let gameId: string;
-
-  if (createRes.status() === 201 || createRes.status() === 200) {
-    const body = (await createRes.json()) as { id: string };
-    if (!body.id) {
-      throw new Error(`seedGameForChat: create returned no id (status=${createRes.status()})`);
-    }
-    gameId = body.id;
-  } else if (createRes.status() === 409) {
-    // Conflict — game with this title already exists from a prior run on
-    // the same GITHUB_RUN_ID. Re-fetch to recover the id.
-    const listRes = await request.get(
-      `${API_BASE}/api/v1/games?title=${encodeURIComponent(title)}`,
-      { headers: { Cookie: cookieHeader } }
-    );
-    if (!listRes.ok()) {
-      throw new Error(
-        `seedGameForChat: create=409 but list re-fetch failed ${listRes.status()}`
-      );
-    }
-    const listBody = (await listRes.json()) as { id: string; title: string }[] | { items: { id: string; title: string }[] };
-    const items = Array.isArray(listBody) ? listBody : listBody.items;
-    const found = items.find(g => g.title === title);
-    if (!found) {
-      throw new Error(`seedGameForChat: create=409 but no game with title="${title}" in list`);
-    }
-    gameId = found.id;
-  } else {
-    const errBody = await createRes.text();
-    throw new Error(
-      `seedGameForChat: create failed status=${createRes.status()} body=${errBody}`
-    );
-  }
-
-  // Add to library so /library/games/{id} renders. Idempotent on backend (or
-  // tolerate 409 if already present).
-  const libRes = await request.post(
-    `${API_BASE}/api/v1/library/games/${gameId}`,
-    { headers: { Cookie: cookieHeader } }
-  );
-  if (!libRes.ok() && libRes.status() !== 409) {
-    const errBody = await libRes.text();
-    throw new Error(
-      `seedGameForChat: library add failed status=${libRes.status()} body=${errBody}`
-    );
-  }
-
-  return gameId;
+  return Promise.resolve('00000000-0000-4000-8000-000000053e1d');
 }
 
 /**

--- a/tests/fixtures/smoke-test-games.sql
+++ b/tests/fixtures/smoke-test-games.sql
@@ -1,0 +1,90 @@
+-- Smoke test SharedGame + UserLibraryEntry fixture — applied AFTER EF Core migrations.
+--
+-- Purpose: provide a deterministic SharedGame ID + library entry for smoke-user
+-- (admin) so that nightly E2E specs in apps/web/e2e/smoke-real-backend/game-night-*.smoke.spec.ts
+-- can navigate to /library/games/{id}?tab=aiChat without runtime seeding (which
+-- requires admin SharedGame creation endpoint we don't have).
+--
+-- Used by:
+--   apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
+--   apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
+--   apps/web/e2e/smoke-real-backend/game-night-pdf-non-owner.smoke.spec.ts
+--
+-- All chat UI behavior is mocked at SSE level (mockQaStreamV2) — SharedGame doesn't
+-- need a real KB / PDF / vector index. Only the route /library/games/{id} must resolve.
+--
+-- ⚠️  Apply AFTER tests/fixtures/smoke-test-users.sql (smoke-user already exists as INITIAL_ADMIN).
+-- Idempotent: ON CONFLICT DO NOTHING for both inserts.
+
+-- Deterministic SharedGame UUID (v4, not in any real catalog)
+-- Last segment "53e1d" encodes "seedi" = "seeded" shorthand
+INSERT INTO shared_games (
+    id,
+    bgg_id,
+    title,
+    year_published,
+    description,
+    min_players,
+    max_players,
+    playing_time_minutes,
+    min_age,
+    image_url,
+    thumbnail_url,
+    status,
+    "GameDataStatus",
+    "HasUploadedPdf",
+    created_by,
+    created_at,
+    is_deleted,
+    is_rag_public,
+    has_knowledge_base
+)
+SELECT
+    '00000000-0000-4000-8000-000000053e1d'::uuid,
+    NULL,
+    'Smoke Chat Fixture Game',
+    0,
+    'Deterministic smoke test fixture — DO NOT delete. See tests/fixtures/smoke-test-games.sql',
+    2,
+    4,
+    30,
+    8,
+    '',
+    '',
+    1,  -- 1 = Published
+    5,  -- 5 = Complete
+    false,
+    u."Id",
+    NOW(),
+    false,
+    false,
+    false
+FROM users u
+WHERE u."Email" = 'smoke-user@meepleai.test'
+ON CONFLICT (id) DO NOTHING;
+
+-- UserLibraryEntry: smoke-user owns the smoke fixture game
+INSERT INTO user_library_entries (
+    "Id",
+    "UserId",
+    shared_game_id,
+    "AddedAt",
+    "OwnershipDeclaredAt",
+    "CurrentState",
+    "TimesPlayed",
+    "CompetitiveSessions",
+    "IsFavorite"
+)
+SELECT
+    '00000000-0000-4000-8000-000000053e1e'::uuid,
+    u."Id",
+    '00000000-0000-4000-8000-000000053e1d'::uuid,
+    NOW(),
+    NOW(),
+    0,
+    0,
+    0,
+    false
+FROM users u
+WHERE u."Email" = 'smoke-user@meepleai.test'
+ON CONFLICT ("Id") DO NOTHING;


### PR DESCRIPTION
## Summary

Fix 2 bug emersi dal validation trigger di PR #956:

### F1: SharedGame BC mismatch (mio bug PR #956)
\`POST /api/v1/games\` crea Game (GameManagement BC), ma \`POST /api/v1/library/games/{id}\` aspetta SharedGameId (SharedGameCatalog BC). Due aggregati diversi, no public admin endpoint per SharedGame creation.
**Fix**: SQL fixture \`tests/fixtures/smoke-test-games.sql\` con SharedGame + UserLibraryEntry deterministici, applicato dal workflow nightly post-stack-up. \`seedGameForChat()\` ora returna const ID.

### F2: Weekly snapshot drift
Cron weekly falliva immediatamente con \`snapshot disallineato con le migrations del working tree\`. Ogni nuova migration backend rompe il workflow finché lo snapshot non viene rigenerato manualmente (\`make seed-index\`).
**Fix**: disabilita schedule cron, lascia solo \`workflow_dispatch\`. Documentato pre-requisito manuale nel header del workflow.

### F3 (separato): nightly broken pre-existing
Discovery: 9 spec esistenti del nightly falliscono con timeout su \`data-slot\` selectors da almeno 2026-05-09 (prima del merge PR #956). NON regressione mia. Issue dedicato: #960

## Verification post-merge

- [ ] Trigger manual \`e2e-smoke-real-backend\`: i 3 spec game-night-* devono ora seedGameForChat OK
- [ ] Trigger manual \`e2e-smoke-real-llm\`: snapshot drift compat-gate ancora fail-stop, ma intenzionalmente (richiede \`make seed-index\` manuale prima)

## Refs

- Bug F1 root cause: log run [25627584147](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25627584147) — \`seedGameForChat: library add failed status=400\`
- Bug F2 root cause: log run [25627584556](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25627584556) — compat-gate
- F3 issue: #960
- Spec/plan PR #956: \`docs/superpowers/specs/2026-05-10-e2e-smoke-game-night-integration-design.md\`