### PR TITLE
fix(smoke): cookie cross-port via domain binding (closes #960 H4)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
@@ -33,11 +33,18 @@ export async function applySessionToPage(page: Page, cookieHeader: string): Prom
   const eq = cookieHeader.indexOf('=');
   const name = cookieHeader.slice(0, eq);
   const value = cookieHeader.slice(eq + 1);
+  // Cookie cross-port (#960 H4): tests run frontend on :3000 + backend on :8080.
+  // Using `url: API_BASE` binds the cookie to :8080 only — browser does NOT send
+  // it during hydration fetches initiated by pages loaded from :3000. Switching
+  // to `domain: 'localhost'` makes the cookie shared across all ports of the
+  // host, matching how a real browser receives Set-Cookie from the backend
+  // (where domain is the eTLD+1).
   await page.context().addCookies([
     {
       name,
       value,
-      url: API_BASE,
+      domain: 'localhost',
+      path: '/',
       httpOnly: true,
       secure: false,
       sameSite: 'Lax',


### PR DESCRIPTION
## Summary

H4 root cause + fix per le 11 spec smoke che timeout su `page.waitForSelector` (selector mai renderizzato).

### Root cause

`applySessionToPage()` attaccava il cookie a `url: 'http://localhost:8080'` (backend). Il browser carica le pagine da `http://localhost:3000` (frontend) e non includeva il cookie nelle fetch cross-port iniziate durante l'hydration. Hooks come `useLibraryGameDetail` ricevevano 401, page mostrava not-found state, selectors mai renderizzati.

### Fix (5 righe)

`url: API_BASE` → `domain: 'localhost'` + `path: '/'`. Cookie ora condiviso cross-port, matching real Set-Cookie behavior del backend.

### Evidence chain

- ✅ Diagnostic step (PR #964): web UP, Next.js Ready, HTTP 200 OK su / e /library
- ✅ API probe (PR #970): login + library detail HTTP 200 con cookie
- ✅ Runtime bisect last-green c418365e45: 9 specs passed in 9.7s — i 11 falliti oggi non esistevano 6 giorni fa
- ✅ Code-bisect range: ZERO cambi a CORS/auth/cookie/httpClient

### Test plan

- [ ] Trigger workflow_dispatch post-merge → atteso ≥14 passed (vs 11 attuali)
- [ ] Se ancora fail su altri spec → root cause separato, NUOVO issue (#960 può chiudersi se i 9 specifici passano)

### Refs

- Issue #960
- Diagnostic step + auto-issue dedup: PR #964
- API probe: PR #970
- F1 SQL fixture (sblocca le 3 game-night-* spec): PR #961

Closes #960 (assuming nightly green post-merge)