### PR TITLE
fix(repos): explicit AsTracking() on UpdateAsync (closes #930)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentGameStateSnapshotRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentGameStateSnapshotRepository.cs
@@ -76,7 +76,10 @@ internal class AgentGameStateSnapshotRepository : RepositoryBase, IAgentGameStat
 
     public async Task UpdateAsync(AgentGameStateSnapshot snapshot, CancellationToken cancellationToken = default)
     {
+        // #930: explicit AsTracking() — DbContext default is NoTracking (PERF-06),
+        // without this the property mutations below would not be persisted.
         var entity = await DbContext.Set<AgentGameStateSnapshotEntity>()
+            .AsTracking()
             .FirstOrDefaultAsync(s => s.Id == snapshot.Id, cancellationToken).ConfigureAwait(false);
 
         if (entity is null) return;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentSessionRepository.cs
@@ -61,7 +61,10 @@ internal class AgentSessionRepository : RepositoryBase, IAgentSessionRepository
 
     public async Task UpdateAsync(AgentSession agentSession, CancellationToken cancellationToken = default)
     {
+        // #930: explicit AsTracking() — DbContext default is NoTracking (PERF-06),
+        // without this the property mutations below would not be persisted.
         var entity = await DbContext.Set<AgentSessionEntity>()
+            .AsTracking()
             .FirstOrDefaultAsync(a => a.Id == agentSession.Id, cancellationToken).ConfigureAwait(false);
 
         if (entity == null)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/CustomRagPipelineRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/CustomRagPipelineRepository.cs
@@ -79,7 +79,10 @@ internal sealed class CustomRagPipelineRepository : RepositoryBase, ICustomRagPi
         string[] tags,
         CancellationToken cancellationToken = default)
     {
+        // #930: explicit AsTracking() — DbContext default is NoTracking (PERF-06),
+        // without this the property mutations below would not be persisted.
         var entity = await DbContext.Set<CustomRagPipelineEntity>()
+            .AsTracking()
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/ScoreEntryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/ScoreEntryRepository.cs
@@ -68,8 +68,11 @@ public class ScoreEntryRepository : RepositoryBase, IScoreEntryRepository
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        // Retrieve existing entity to preserve EF Core tracking
+        // Retrieve existing entity to preserve EF Core tracking.
+        // #930: explicit AsTracking() — DbContext default is NoTracking (PERF-06),
+        // without this the property mutations below would not be persisted.
         var existing = await DbContext.SessionTrackingScoreEntries
+            .AsTracking()
             .FirstOrDefaultAsync(e => e.Id == entry.Id, ct)
             .ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary

Audit completato per issue #930 (NoTracking-default silent-discard bug). Initial triage diceva 10+ repos affetti — verifica chirurgica conferma **solo 4** sono vulnerabili.

### Audit findings

| Repo | Pattern | Vulnerable? |
|---|---|---|
| AlertConfiguration / AlertRule / AccessRequest / InvitationToken / ShareLink / WaitlistEntry | `FindAsync()` | ❌ NO (FindAsync attaches regardless of NoTracking default — per EF docs) |
| AgentGameStateSnapshot / AgentSession / CustomRagPipeline / ScoreEntry | `FirstOrDefaultAsync` no AsTracking | ✅ YES — fixed |

ScoreEntry aveva commento `// Retrieve existing entity to preserve EF Core tracking` — l'intento era preservare tracking ma il default NoTracking lo rendeva no-op.

### Fix

`.AsTracking()` aggiunto prima di `.FirstOrDefaultAsync` nei 4 repos affetti. Comment esplicito `#930` + PERF-06 in ognuno per future readers.

### Test

- ✅ `dotnet build` clean (0 warnings, 0 errors)
- ⏭️ Test integration: la natura del bug è silent-discard, esiste già copertura via #888 fix per UserRepository (stesso pattern). Test dedicato per i 4 nuovi non aggiunto in scope hotfix.

### Out of scope (follow-up suggerito)

Opzione B dell'issue (`RepositoryBase.LoadForUpdateAsync` helper + failing test asserting `SaveChangesAsync > 0`) prevent regression future. Aprire issue dedicato se recurrence.

Closes #930