### PR TITLE
fix(auth): SessionCookie.Secure=false in smoke CI (closes #960 H4)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -62,6 +62,11 @@ jobs:
           INITIAL_ADMIN_EMAIL=smoke-user@meepleai.test
           INITIAL_ADMIN_PASSWORD=SmokeUser1!!
           INITIAL_ADMIN_DISPLAY_NAME=Smoke User
+          # #960 H4: SessionCookie.Secure=false because CI runs frontend+backend
+          # on http://localhost:* — browsers refuse to attach cookies marked
+          # secure to non-HTTPS origins, blocking authenticated smoke specs.
+          # Production / Staging keep the default Secure=true (HTTPS enforced).
+          Authentication__SessionCookie__Secure=false
           APIENV
           # n8n.env.dev — minimal (n8n unused by smoke specs but referenced by compose)
           cat > n8n.env.dev <<'N8NENV'


### PR DESCRIPTION
Root cause definitivo per smoke nightly H4 (9 spec timeout su data-slot).

## Trovato via CORS+Origin probe (PR #980)

`Set-Cookie` da `POST /api/v1/auth/login` include flag `secure`. Browser su `http://localhost:3000` (non HTTPS) **rifiuta di inviare cookie secure**. Backend riceve request senza cookie → 401 → frontend not-found state → test timeout.

curl bypassava il flag (motivo per cui le probe direct ritornavano HTTP 200) — ha mascherato la causa per diversi cicli di investigation.

## Fix

Inject `Authentication__SessionCookie__Secure=false` nel `api.env.dev` generato dal workflow. ASP.NET Core legge `__` come nesting separator → override `Authentication.SessionCookie.Secure` da appsettings.json.

Production / Staging mantengono `Secure=true` via i loro appsettings dedicati.

## Verification

- [x] YAML syntax valida
- [ ] Trigger workflow_dispatch post-merge → atteso ≥18 passed (vs 11 attuali)

## Fallback se non risolve

Se il fix non funziona, hypothesis residue:
1. Browser SSR fetch lato Next.js server-side dove cookie non è disponibile
2. Backend HybridCache TTL 5min cacha 401 → repeat fetch dalla cache

Closes #960