### PR TITLE
chore(ci): allow dependabot/* branches in main-dev source policy

### DIFF
--- a/.github/workflows/auto-branch-policy.yml
+++ b/.github/workflows/auto-branch-policy.yml
@@ -62,8 +62,9 @@ jobs:
           # - hotfix/* branches (urgent security/bug fixes; still flow
           #   through main-dev → main-staging → main, no direct-to-main)
           # - fix/*, docs/*, refactor/*, chore/* branches
+          # - dependabot/* branches (automated dependency updates)
           if [[ "$BASE_BRANCH" == "main-dev" ]]; then
-            ALLOWED_PATTERNS="^(feature/|fix/|hotfix/|docs/|test/|refactor/|chore/|release/|merge/)"
+            ALLOWED_PATTERNS="^(feature/|fix/|hotfix/|docs/|test/|refactor/|chore/|release/|merge/|dependabot/)"
 
             if ! echo "$SOURCE_BRANCH" | grep -qE "$ALLOWED_PATTERNS"; then
               echo "::error::Branch 'main-dev' can only be updated from allowed branches"
@@ -79,6 +80,7 @@ jobs:
               echo "  - chore/*"
               echo "  - release/*"
               echo "  - merge/*"
+              echo "  - dependabot/*"
               exit 1
             fi
             echo "✅ Valid: $SOURCE_BRANCH -> main-dev"


### PR DESCRIPTION
## Summary

Sblocca **8 Dependabot PR** che sono attualmente bloccate dal workflow \`validate-source-branch\` perché \`dependabot/\` non è nell'allowlist dei branch ammessi a mergeare in \`main-dev\`.

## Root cause

\`.github/workflows/auto-branch-policy.yml\` contiene un regex allowlist:

\`\`\`bash
ALLOWED_PATTERNS="^(feature/|fix/|hotfix/|docs/|test/|refactor/|chore/|release/|merge/)"
\`\`\`

Dependabot crea branch con prefix \`dependabot/...\` (es. \`dependabot/github_actions/main-dev/github/codeql-action-4\`), che fallisce il match → `validate-source-branch` step error → CI Success fail → blocco merge.

## Fix

Aggiunto \`dependabot/\` al pattern.

## PR sbloccate

- #763 — codeql-action 3 → 4
- #764 — codecov-action 5.5.4 → 6.0.0
- #771 — react-joyride 2.9.3 → 3.1.0
- #772 — diff 8.0.3 → 9.0.0
- #774 — @xstate/react 4.1.3 → 6.1.0
- #775 — react-virtualized-auto-sizer 1.0.26 → 2.0.3
- #776 — pytest 8.3.3 → 9.0.3
- #859 — minor-and-patch group (53 updates)

## Test plan

- [x] Workflow YAML lint (gh actions)
- [ ] Dependabot PR #763 ricomputa CI dopo merge → validate-source-branch dovrebbe passare

🤖 Generated with [Claude Code](https://claude.com/claude-code)