### PR TITLE
fix(smoke): apply all meepleai_* cookies (#960 H4 step 2)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/auth.ts
@@ -16,7 +16,9 @@ const API_BASE = process.env.SMOKE_API_BASE ?? 'http://localhost:8080';
 const SEED_EMAIL = process.env.SMOKE_USER_EMAIL ?? 'smoke-user@meepleai.test';
 const SEED_PASSWORD = process.env.SMOKE_USER_PASSWORD ?? 'SmokeUser1!!';
 
-export async function smokeLogin(request: APIRequestContext): Promise<{ cookieHeader: string }> {
+export async function smokeLogin(
+  request: APIRequestContext
+): Promise<{ cookieHeader: string; cookieHeaders: string[] }> {
   const res = await request.post(`${API_BASE}/api/v1/auth/login`, {
     data: { email: SEED_EMAIL, password: SEED_PASSWORD },
   });
@@ -24,30 +26,46 @@ export async function smokeLogin(request: APIRequestContext): Promise<{ cookieHe
     throw new Error(`smokeLogin failed ${res.status()} for ${SEED_EMAIL}`);
   }
   const cookies = res.headersArray().filter(h => h.name.toLowerCase() === 'set-cookie');
-  const session = cookies.find(c => c.value.startsWith('meepleai_session='));
+  // #960 H4 step 2: backend sets MULTIPLE meepleai_* cookies (session + user_role_v2).
+  // Earlier code returned only meepleai_session, but the role cookie is also required
+  // for downstream authorization on hydration fetches. Capture every meepleai_* cookie
+  // in declaration order; cookieHeader (single) kept for backward compat with callers
+  // that pass a string to applySessionToPage.
+  const meepleCookies = cookies
+    .map(c => c.value.split(';')[0])
+    .filter(v => v.startsWith('meepleai_') && !v.endsWith('='));
+  const session = meepleCookies.find(v => v.startsWith('meepleai_session='));
   if (!session) throw new Error('No meepleai_session cookie returned');
-  return { cookieHeader: session.value.split(';')[0] };
+  return { cookieHeader: session, cookieHeaders: meepleCookies };
 }
 
-export async function applySessionToPage(page: Page, cookieHeader: string): Promise<void> {
-  const eq = cookieHeader.indexOf('=');
-  const name = cookieHeader.slice(0, eq);
-  const value = cookieHeader.slice(eq + 1);
+export async function applySessionToPage(
+  page: Page,
+  cookieHeaderOrHeaders: string | readonly string[]
+): Promise<void> {
+  // Accept either a single header string (legacy) or the array form returned by
+  // the updated smokeLogin. Convert to array for uniform processing.
+  const headers = typeof cookieHeaderOrHeaders === 'string'
+    ? [cookieHeaderOrHeaders]
+    : cookieHeaderOrHeaders;
+
   // Cookie cross-port (#960 H4): tests run frontend on :3000 + backend on :8080.
   // Using `url: API_BASE` binds the cookie to :8080 only — browser does NOT send
   // it during hydration fetches initiated by pages loaded from :3000. Switching
   // to `domain: 'localhost'` makes the cookie shared across all ports of the
   // host, matching how a real browser receives Set-Cookie from the backend
   // (where domain is the eTLD+1).
-  await page.context().addCookies([
-    {
-      name,
-      value,
+  const cookieEntries = headers.map(header => {
+    const eq = header.indexOf('=');
+    return {
+      name: header.slice(0, eq),
+      value: header.slice(eq + 1),
       domain: 'localhost',
       path: '/',
       httpOnly: true,
       secure: false,
-      sameSite: 'Lax',
-    },
-  ]);
+      sameSite: 'Lax' as const,
+    };
+  });
+  await page.context().addCookies(cookieEntries);
 }


### PR DESCRIPTION
Step 2 fix per H4. PR #982 (Secure=false) era necessario ma non sufficient: backend setta DUE cookies (session + user_role_v2), smokeLogin ne restituiva uno solo.

Browser context riceveva 1 cookie → fetch hydration con session ma senza role → backend role auth rifiuta.

Direct curl probe HTTP 200 perché cookie jar ha entrambi (curl -c salva tutti i Set-Cookie).

## Fix

`smokeLogin` ora ritorna `cookieHeaders[]` (tutti meepleai_*). `applySessionToPage` accepta single string (legacy) o array, applica ognuno al context.

## Verification

- [x] tsc clean
- [ ] Trigger workflow_dispatch → atteso ≥18 passed

Refs: #960