### PR TITLE
chore(admin): factory interfaces + service unit tests (closes #972)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ProviderProbeService.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ProviderProbeService.cs
@@ -8,10 +8,10 @@ namespace Api.BoundedContexts.Administration.Infrastructure.Services;
 
 internal sealed class ProviderProbeService : IProviderProbeService
 {
-    private readonly ProviderProbeExecutorFactory _factory;
+    private readonly IProviderProbeExecutorFactory _factory;
     private readonly IProviderProbeAuditRepository _auditRepo;
 
-    public ProviderProbeService(ProviderProbeExecutorFactory factory, IProviderProbeAuditRepository auditRepo)
+    public ProviderProbeService(IProviderProbeExecutorFactory factory, IProviderProbeAuditRepository auditRepo)
     {
         _factory = factory;
         _auditRepo = auditRepo;

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaService.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaService.cs
@@ -14,10 +14,10 @@ internal sealed class ProviderQuotaService : IProviderQuotaService
     private const int CacheTtlSeconds = 300; // 5 minutes
     private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(CacheTtlSeconds);
 
-    private readonly ProviderQuotaProviderFactory _factory;
+    private readonly IProviderQuotaProviderFactory _factory;
     private readonly IHybridCacheService _cache;
 
-    public ProviderQuotaService(ProviderQuotaProviderFactory factory, IHybridCacheService cache)
+    public ProviderQuotaService(IProviderQuotaProviderFactory factory, IHybridCacheService cache)
     {
         _factory = factory;
         _cache = cache;

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -76,14 +76,14 @@ internal static class InfrastructureServiceExtensions
                 ?? OllamaLocalDefaultBaseUrl,
             apiKeyEnvVar: null));
 
-        services.AddSingleton<ProviderProbeExecutorFactory>();
+        services.AddSingleton<IProviderProbeExecutorFactory, ProviderProbeExecutorFactory>();
         services.AddScoped<IProviderProbeAuditRepository, ProviderProbeAuditRepository>();
         services.AddScoped<IProviderProbeService, ProviderProbeService>();
 
         // Issue #936 (G2): Provider quota providers — OpenRouter + DeepSeek only.
         services.AddSingleton<IProviderQuotaProvider, OpenRouterQuotaProvider>();
         services.AddSingleton<IProviderQuotaProvider, DeepSeekQuotaProvider>();
-        services.AddSingleton<ProviderQuotaProviderFactory>();
+        services.AddSingleton<IProviderQuotaProviderFactory, ProviderQuotaProviderFactory>();
         services.AddScoped<IProviderQuotaService, ProviderQuotaService>();
 
         return services;

--- a/apps/api/src/Api/Services/Providers/Probe/IProviderProbeExecutorFactory.cs
+++ b/apps/api/src/Api/Services/Providers/Probe/IProviderProbeExecutorFactory.cs
@@ -1,0 +1,11 @@
+namespace Api.Services.Providers.Probe;
+
+/// <summary>
+/// Resolves an <see cref="IProviderProbeExecutor"/> by provider name. Issue #972.
+/// </summary>
+internal interface IProviderProbeExecutorFactory
+{
+    IProviderProbeExecutor? GetExecutor(string providerName);
+
+    IReadOnlyCollection<string> KnownProviderNames { get; }
+}

--- a/apps/api/src/Api/Services/Providers/Probe/ProviderProbeExecutorFactory.cs
+++ b/apps/api/src/Api/Services/Providers/Probe/ProviderProbeExecutorFactory.cs
@@ -3,7 +3,7 @@ namespace Api.Services.Providers.Probe;
 /// <summary>
 /// Resolves an <see cref="IProviderProbeExecutor"/> by provider name (case-insensitive).
 /// </summary>
-internal sealed class ProviderProbeExecutorFactory
+internal sealed class ProviderProbeExecutorFactory : IProviderProbeExecutorFactory
 {
     private readonly Dictionary<string, IProviderProbeExecutor> _executors;
     private readonly IReadOnlyCollection<string> _knownProviderNames;

--- a/apps/api/src/Api/Services/Providers/Quota/IProviderQuotaProviderFactory.cs
+++ b/apps/api/src/Api/Services/Providers/Quota/IProviderQuotaProviderFactory.cs
@@ -1,0 +1,11 @@
+namespace Api.Services.Providers.Quota;
+
+/// <summary>
+/// Resolves an <see cref="IProviderQuotaProvider"/> by provider name. Issue #972.
+/// </summary>
+internal interface IProviderQuotaProviderFactory
+{
+    IProviderQuotaProvider? GetProvider(string providerName);
+
+    IReadOnlyCollection<string> SupportedProviderNames { get; }
+}

--- a/apps/api/src/Api/Services/Providers/Quota/ProviderQuotaProviderFactory.cs
+++ b/apps/api/src/Api/Services/Providers/Quota/ProviderQuotaProviderFactory.cs
@@ -4,7 +4,7 @@ namespace Api.Services.Providers.Quota;
 /// Resolves an <see cref="IProviderQuotaProvider"/> by provider name (case-insensitive).
 /// Issue #936 (G2).
 /// </summary>
-internal sealed class ProviderQuotaProviderFactory
+internal sealed class ProviderQuotaProviderFactory : IProviderQuotaProviderFactory
 {
     private readonly Dictionary<string, IProviderQuotaProvider> _providers;
     private readonly IReadOnlyCollection<string> _supportedProviderNames;

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderProbeServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderProbeServiceTests.cs
@@ -1,0 +1,119 @@
+using Api.BoundedContexts.Administration.Domain.Aggregates.ProviderProbeAudit;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.BoundedContexts.Administration.Infrastructure.Services;
+using Api.Services.Providers.Probe;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Infrastructure.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Administration")]
+[Trait("Issue", "972")]
+public sealed class ProviderProbeServiceTests
+{
+    private static (ProviderProbeService svc, Mock<IProviderProbeAuditRepository> repo, Mock<IProviderProbeExecutorFactory> factory)
+        BuildSubject(IProviderProbeExecutor? executor = null, string providerName = "openrouter", string? envVar = "TEST_API_KEY")
+    {
+        var repo = new Mock<IProviderProbeAuditRepository>();
+        var factory = new Mock<IProviderProbeExecutorFactory>();
+
+        if (executor is null)
+        {
+            var execMock = new Mock<IProviderProbeExecutor>();
+            execMock.SetupGet(e => e.ProviderName).Returns(providerName);
+            execMock.SetupGet(e => e.ApiKeyEnvVar).Returns(envVar);
+            executor = execMock.Object;
+        }
+
+        factory.Setup(f => f.GetExecutor(providerName)).Returns(executor);
+        factory.Setup(f => f.GetExecutor(It.Is<string>(n => n != providerName))).Returns((IProviderProbeExecutor?)null);
+
+        var svc = new ProviderProbeService(factory.Object, repo.Object);
+        return (svc, repo, factory);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_UnknownProvider_ThrowsUnknownProviderException()
+    {
+        var (svc, _, _) = BuildSubject();
+
+        var act = async () => await svc.ProbeAsync("cohere", Guid.NewGuid(), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnknownProviderException>();
+    }
+
+    [Fact]
+    public async Task ProbeAsync_NotConfigured_WritesAuditAndReturnsNotConfigured()
+    {
+        var execMock = new Mock<IProviderProbeExecutor>();
+        execMock.SetupGet(e => e.ProviderName).Returns("openrouter");
+        execMock.SetupGet(e => e.ApiKeyEnvVar).Returns("__ABSENT_TEST_VAR_972__");
+        // Ensure env var is not set
+        Environment.SetEnvironmentVariable("__ABSENT_TEST_VAR_972__", null);
+
+        var (svc, repo, _) = BuildSubject(execMock.Object);
+        var actorId = Guid.NewGuid();
+
+        var result = await svc.ProbeAsync("openrouter", actorId, null, CancellationToken.None);
+
+        result.TokenConfigured.Should().BeFalse();
+        result.TokenAuthenticated.Should().BeFalse();
+        result.ErrorCode.Should().Be("not_configured");
+        result.ModelAvailable.Should().BeNull();
+
+        repo.Verify(r => r.AddAsync(
+                It.Is<ProviderProbeAuditEntry>(e =>
+                    e.ProviderName == "openrouter" &&
+                    e.Outcome == ProbeOutcome.NotConfigured &&
+                    e.ActorId == actorId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        execMock.Verify(e => e.ExecuteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_OllamaNoAuthRequired_ProceedsWithoutKey()
+    {
+        var execMock = new Mock<IProviderProbeExecutor>();
+        execMock.SetupGet(e => e.ProviderName).Returns("ollama-local");
+        execMock.SetupGet(e => e.ApiKeyEnvVar).Returns((string?)null);
+        execMock.Setup(e => e.ExecuteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProbeExecutionResult(ProbeOutcome.Success, null, null, 42, null));
+
+        var (svc, repo, _) = BuildSubject(execMock.Object, providerName: "ollama-local", envVar: null);
+
+        var result = await svc.ProbeAsync("ollama-local", Guid.NewGuid(), null, CancellationToken.None);
+
+        result.TokenConfigured.Should().BeTrue();
+        result.TokenAuthenticated.Should().BeTrue();
+        result.LatencyMs.Should().Be(42);
+        result.TokenFingerprint.Should().BeNull();
+
+        execMock.Verify(e => e.ExecuteAsync(string.Empty, null, It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.AddAsync(
+                It.Is<ProviderProbeAuditEntry>(e => e.Outcome == ProbeOutcome.Success),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_PropagatesExpectedModel_ToExecutor()
+    {
+        var execMock = new Mock<IProviderProbeExecutor>();
+        execMock.SetupGet(e => e.ProviderName).Returns("ollama-local");
+        execMock.SetupGet(e => e.ApiKeyEnvVar).Returns((string?)null);
+        execMock.Setup(e => e.ExecuteAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProbeExecutionResult(ProbeOutcome.Success, null, null, 100, false));
+
+        var (svc, _, _) = BuildSubject(execMock.Object, providerName: "ollama-local", envVar: null);
+
+        var result = await svc.ProbeAsync("ollama-local", Guid.NewGuid(), "fake-model", CancellationToken.None);
+
+        result.ExpectedModel.Should().Be("fake-model");
+        result.ModelAvailable.Should().BeFalse();
+        execMock.Verify(e => e.ExecuteAsync(string.Empty, "fake-model", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/Services/ProviderQuotaServiceTests.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.Administration.Infrastructure.Services;
+using Api.Services;
+using Api.Services.Providers.Quota;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Infrastructure.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Administration")]
+[Trait("Issue", "972")]
+public sealed class ProviderQuotaServiceTests
+{
+    private sealed class PassThroughCache : IHybridCacheService
+    {
+        public Task<T> GetOrCreateAsync<T>(
+            string cacheKey,
+            Func<CancellationToken, Task<T>> factory,
+            string[]? tags = null,
+            TimeSpan? expiration = null,
+            CancellationToken ct = default) where T : class
+            => factory(ct);
+
+        public Task RemoveAsync(string cacheKey, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int> RemoveByTagAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> RemoveByTagsAsync(string[] tags, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default) => Task.FromResult(new HybridCacheStats());
+    }
+
+    private static ProviderQuotaService BuildSubject(IProviderQuotaProvider? provider, string providerName = "openrouter")
+    {
+        var factory = new Mock<IProviderQuotaProviderFactory>();
+        factory.Setup(f => f.GetProvider(providerName)).Returns(provider);
+        factory.Setup(f => f.GetProvider(It.Is<string>(n => n != providerName))).Returns((IProviderQuotaProvider?)null);
+        return new ProviderQuotaService(factory.Object, new PassThroughCache());
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_UnknownProvider_ReturnsQuotaNotSupported()
+    {
+        var svc = BuildSubject(provider: null);
+
+        var result = await svc.GetQuotaAsync("cohere", CancellationToken.None);
+
+        result.QuotaSupported.Should().BeFalse();
+        result.TokenConfigured.Should().BeFalse();
+        result.ErrorCode.Should().Be("quota_not_supported");
+        result.RemainingUsd.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_NotConfigured_ReturnsTokenConfiguredFalse()
+    {
+        var providerMock = new Mock<IProviderQuotaProvider>();
+        providerMock.SetupGet(p => p.ProviderName).Returns("openrouter");
+        providerMock.SetupGet(p => p.ApiKeyEnvVar).Returns("__ABSENT_QUOTA_VAR_972__");
+        Environment.SetEnvironmentVariable("__ABSENT_QUOTA_VAR_972__", null);
+
+        var svc = BuildSubject(providerMock.Object);
+
+        var result = await svc.GetQuotaAsync("openrouter", CancellationToken.None);
+
+        result.QuotaSupported.Should().BeTrue();
+        result.TokenConfigured.Should().BeFalse();
+        result.ErrorCode.Should().Be("not_configured");
+        providerMock.Verify(p => p.FetchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_HappyPath_ReturnsRemainingUsd()
+    {
+        const string envVar = "__OPENROUTER_QUOTA_TEST_972__";
+        Environment.SetEnvironmentVariable(envVar, "test-key-secret");
+
+        var providerMock = new Mock<IProviderQuotaProvider>();
+        providerMock.SetupGet(p => p.ProviderName).Returns("openrouter");
+        providerMock.SetupGet(p => p.ApiKeyEnvVar).Returns(envVar);
+        providerMock.Setup(p => p.FetchAsync("test-key-secret", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QuotaFetchResult(true, 12.5m, 50.0m, 37.5m, null, null, null));
+
+        try
+        {
+            var svc = BuildSubject(providerMock.Object);
+
+            var result = await svc.GetQuotaAsync("openrouter", CancellationToken.None);
+
+            result.QuotaSupported.Should().BeTrue();
+            result.TokenConfigured.Should().BeTrue();
+            result.UsedUsd.Should().Be(12.5m);
+            result.LimitUsd.Should().Be(50.0m);
+            result.RemainingUsd.Should().Be(37.5m);
+            result.CacheTtlSeconds.Should().Be(300);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVar, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Followup from PR #957 code review (I1).

- Extract \`IProviderProbeExecutorFactory\` + \`IProviderQuotaProviderFactory\` interfaces
- Services depend on interfaces (Mock-friendly)
- DI registration: interface→impl mapping
- 7 new unit tests covering ProviderProbeService + ProviderQuotaService

## Tests added

\`ProviderProbeServiceTests\`:
- \`UnknownProvider\` → throws \`UnknownProviderException\`
- \`NotConfigured\` → audit + DTO (no upstream call)
- \`Ollama\` no-auth → proceeds without env var
- \`ExpectedModel\` propagated to executor

\`ProviderQuotaServiceTests\` (with PassThroughCache):
- Unknown provider → \`quota_not_supported\`
- NotConfigured → \`tokenConfigured: false\`
- Happy path → \`remainingUsd: 37.5\`

## Closes

Closes #972

## Test plan

- [x] 7 unit tests pass (4 probe + 3 quota)
- [x] Build clean (0 errors)
- [x] No behavior change — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)