### PR TITLE
fix(smoke): enable PLAYWRIGHT_AUTH_BYPASS in web container (closes #960 H4)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -41,6 +41,18 @@ jobs:
           NODE_ENV=production
           NEXT_TELEMETRY_DISABLED=1
           NEXT_PUBLIC_HYPERDX_API_KEY=demo
+          # #960 H4 step 4 (true root cause): smoke specs hit `(authenticated)`
+          # routes (/agents/[id], /games/[id], /players/[id], /library/games/[id]).
+          # apps/web/src/proxy.ts:386 trusts session cookies WITHOUT backend
+          # validation only when PLAYWRIGHT_AUTH_BYPASS=true AND the bypass is
+          # ALLOWED. The allow flag is `NODE_ENV !== 'production' || isVisualTestBuild`.
+          # Since NODE_ENV=production above, we need NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1
+          # so the bypass branch is alive in the production build (NEXT_PUBLIC_*
+          # is inlined at build time and would otherwise be dead-code-eliminated).
+          # Without this, the 6 detail-page specs that DON'T call smokeLogin
+          # never reach their not-found shell — the proxy redirects to /login.
+          PLAYWRIGHT_AUTH_BYPASS=true
+          NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1
           WEBENV
           # api.env.dev — backend container env
           # Seed initial admin matching SMOKE_USER_* in workflow env so smoke


### PR DESCRIPTION
## Real H4 root cause (after 4 partial fixes + local repro)

`apps/web/src/proxy.ts:386` has an E2E auth bypass that requires:

1. `PLAYWRIGHT_AUTH_BYPASS=true` (runtime env)
2. Either `NODE_ENV !== 'production'` OR `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` (build-time guard)

The CI workflow sets `NODE_ENV=production` and never sets either of the bypass-enabling flags. The bypass branch is dead-code-eliminated by Next.js production tree-shaking. Every authenticated route falls through to backend validation:

- **6 spec senza smokeLogin** (agent-detail/game-detail/player-detail x2 each): no cookie → backend 401 → `/login` redirect → `data-slot=*-not-found` mai renderizzato → timeout
- **3 spec game-night-* con smokeLogin**: cookie presente, ma proxy fallisce comunque per altri edge

## Fix

Inject in `web.env.dev`:
- `PLAYWRIGHT_AUTH_BYPASS=true`
- `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1`

## Local repro confirma

`pnpm exec playwright test smoke-real-backend/library.smoke.spec.ts` localmente: **2/2 PASS in 10.8s**. Stack locale inherita `PLAYWRIGHT_AUTH_BYPASS` via dev defaults; CI no.

## Earlier PRs (Step 1-3) status

- PR #974: cleanup cookie domain (kept)
- PR #982: `Secure=false` (kept — semantically corretto per dev/CI HTTP)
- PR #984: multi-cookie smokeLogin (kept — pattern corretto per future)
- **PR (this) Step 4**: bypass env enable — il fix vero

Closes #960