### PR TITLE
fix(smoke): smokeLogin in detail specs (closes #969)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/agent-detail.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/agent-detail.smoke.spec.ts
@@ -10,9 +10,11 @@
  *   - If `SMOKE_AGENT_ID` env var is set (seeded staging agent), navigate
  *     to that real id and assert the default render shell appears.
  *
- * Auth: the `(authenticated)` layout does NOT gate server-side; `PLAYWRIGHT_AUTH_BYPASS=true`
- * (set in `playwright.config.ts` webServer env) allows Playwright to access the
- * route. No seedAuthSession needed for the shell render assertion.
+ * Auth (#960 → Smoke RCA-2): the `(authenticated)` layout requires a session
+ * cookie. Even with `PLAYWRIGHT_AUTH_BYPASS=true` the `proxy.ts:386` bypass
+ * branch is only taken when `sessionCookieValue` is present. So we MUST
+ * `smokeLogin` + `applySessionToPage` before navigation, even for not-found
+ * shell tests.
  *
  * data-slot selectors match committed Task 3 orchestrator shells:
  *   - default:   `[data-slot="agent-detail-view"]`
@@ -22,6 +24,8 @@
  *   `gh workflow run smoke.yml --ref main-dev -f SMOKE_AGENT_ID=<uuid>`
  */
 import { test, expect } from '@playwright/test';
+
+import { applySessionToPage, smokeLogin } from './_helpers/auth';
 
 /**
  * Deterministic UUID that NEVER exists in any environment — drives the
@@ -34,6 +38,11 @@ import { test, expect } from '@playwright/test';
 const NEVER_EXISTS_ID = '00000000-0000-4000-8000-000000000581' as const;
 
 test.describe('SMOKE — /agents/[id] real backend', () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { cookieHeaders } = await smokeLogin(request);
+    await applySessionToPage(page, cookieHeaders);
+  });
+
   test('frontend /agents/{id} renders not-found shell for deterministic UUID', async ({ page }) => {
     // NEVER_EXISTS_ID ensures the backend returns 404 → frontend renders not-found shell.
     // Validates the FSM Cell 4 path (detail success(null)) against real backend.

--- a/apps/web/e2e/smoke-real-backend/game-detail.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-detail.smoke.spec.ts
@@ -10,9 +10,10 @@
  *   - If `SMOKE_GAME_DETAIL_ID` env var is set (seeded staging game), navigate
  *     to that real id and assert the default render shell appears.
  *
- * Auth: the `(authenticated)` layout does NOT gate server-side; `PLAYWRIGHT_AUTH_BYPASS=true`
- * (set in `playwright.config.ts` webServer env) allows Playwright to access the
- * route. No seedAuthSession needed for the shell render assertion.
+ * Auth (#960 → Smoke RCA-2): the `(authenticated)` layout requires a session
+ * cookie. Even with `PLAYWRIGHT_AUTH_BYPASS=true` the `proxy.ts:386` bypass
+ * branch is only taken when `sessionCookieValue` is present. We MUST
+ * `smokeLogin` + `applySessionToPage` before navigation.
  *
  * data-slot selectors match committed Task 3 orchestrator shells:
  *   - default: `[data-slot="game-detail-view"]`
@@ -23,6 +24,8 @@
  */
 import { test, expect } from '@playwright/test';
 
+import { applySessionToPage, smokeLogin } from './_helpers/auth';
+
 /**
  * Deterministic UUID that NEVER exists in any environment — drives the
  * frontend not-found shell without needing a seeded game.
@@ -32,6 +35,11 @@ import { test, expect } from '@playwright/test';
 const NEVER_EXISTS_ID = '00000000-0000-4000-8000-000000000581' as const;
 
 test.describe('SMOKE — /games/[id] real backend', () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { cookieHeaders } = await smokeLogin(request);
+    await applySessionToPage(page, cookieHeaders);
+  });
+
   test('frontend /games/{id} renders not-found shell for deterministic UUID', async ({ page }) => {
     // NEVER_EXISTS_ID ensures the backend returns 404 → frontend renders not-found shell.
     // Validates the FSM Cell 4 path (detail success(null)) against real backend.

--- a/apps/web/e2e/smoke-real-backend/player-detail.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/player-detail.smoke.spec.ts
@@ -17,9 +17,10 @@
  *   For smoke purposes we assert that EITHER the populated hero (data present) OR
  *   the not-found shell renders — both confirm graceful frontend rendering.
  *
- * Auth: the `(authenticated)` layout does NOT gate server-side; `PLAYWRIGHT_AUTH_BYPASS=true`
- * (set in `playwright.config.ts` webServer env) allows Playwright to access the
- * route. No seedAuthSession needed for the shell render assertion.
+ * Auth (#960 → Smoke RCA-2): the `(authenticated)` layout requires a session
+ * cookie. Even with `PLAYWRIGHT_AUTH_BYPASS=true` the `proxy.ts:386` bypass
+ * branch is only taken when `sessionCookieValue` is present. We MUST
+ * `smokeLogin` + `applySessionToPage` before navigation.
  *
  * data-slot selectors match committed Task 3 orchestrator shells:
  *   - default:   `[data-slot="player-detail-view"]`
@@ -30,6 +31,8 @@
  */
 import { test, expect } from '@playwright/test';
 
+import { applySessionToPage, smokeLogin } from './_helpers/auth';
+
 /**
  * Deterministic slug that NEVER maps to a real player in any environment.
  * Drives the frontend not-found shell without needing a seeded player.
@@ -39,6 +42,11 @@ import { test, expect } from '@playwright/test';
 const NEVER_EXISTS_ID = 'never-exists-player-id-smoke-test' as const;
 
 test.describe('SMOKE — /players/[id] real backend', () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { cookieHeaders } = await smokeLogin(request);
+    await applySessionToPage(page, cookieHeaders);
+  });
+
   test('frontend /players/{id} renders not-found shell for deterministic slug', async ({
     page,
   }) => {


### PR DESCRIPTION
## Root cause (Smoke RCA-2)

Post PR #988 ha fissato l'env \`PLAYWRIGHT_AUTH_BYPASS=true\` + \`NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1\`, ma 3 spec smoke fallivano ancora con \`TimeoutError: page.waitForSelector\` su \`[data-slot=\"agent-detail-not-found\"]\` (30s timeout).

\`apps/web/src/proxy.ts:386\` ha questa logica:

\`\`\`typescript
const isVisualTestBuild = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1';
const isAuthBypassAllowed = process.env.NODE_ENV !== 'production' || isVisualTestBuild;
if (isAuthBypassAllowed && process.env.PLAYWRIGHT_AUTH_BYPASS === 'true' && sessionCookieValue) {
  isAuthenticated = true;
}
\`\`\`

Il bypass si attiva **solo se \`sessionCookieValue\` è presente**. Le 3 spec navigavano a \`(authenticated)\` route SENZA seedare cookie → bypass non attivato → redirect /login → not-found shell mai renderizzato.

## Fix

Aggiunto \`test.beforeEach\` con \`smokeLogin\` + \`applySessionToPage\` in:
- \`apps/web/e2e/smoke-real-backend/agent-detail.smoke.spec.ts\`
- \`apps/web/e2e/smoke-real-backend/game-detail.smoke.spec.ts\`
- \`apps/web/e2e/smoke-real-backend/player-detail.smoke.spec.ts\`

Stesso pattern di \`library.smoke.spec.ts\` e \`game-night-*.smoke.spec.ts\` (già verdi).

## Out of scope

- \`shared-game-detail.smoke.spec.ts\`: route \`(public)\`, no auth needed
- \`gamebook-upload\` / \`session-live\`: skip-by-default in CI

## Closes

Closes #969 (umbrella RCA-2)
Refs #963, #962, #959, #958, #932, #884, #877 (gli smoke fail nightly recenti causati da questo specifico timeout)

## Test plan

- [x] Typecheck clean
- [ ] Nightly smoke run post-merge → atteso green su agent-detail/game-detail/player-detail specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)