### PR TITLE
chore(release): cherry-pick #971 badsworm seed → main-staging

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormPersonaCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormPersonaCommand.cs
@@ -1,0 +1,15 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Commands;
+
+/// <summary>
+/// Command to seed the badsworm@gmail.com persona dogfood data:
+/// 10 library entries (incl. Nanolith libro game) with mixed KB processing
+/// states for UI dashboard validation. Idempotent. Runs after the Catalog
+/// seed layer (Dev + Staging profiles only) so the SharedGames it references
+/// are guaranteed to exist.
+///
+/// Reference: docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md
+/// (Aaron persona dogfood) + acceptance spec defined in chat 2026-05-10.
+/// </summary>
+public sealed record SeedBadswormPersonaCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormPersonaCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SeedBadswormPersonaCommandHandler.cs
@@ -1,0 +1,208 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.UserLibrary;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.Commands;
+
+/// <summary>
+/// Handler for SeedBadswormPersonaCommand.
+///
+/// Populates 10 library entries for badsworm@gmail.com (project owner, persona used
+/// for the Nanolith libro-game dogfood demo) plus mocked PdfDocument rows with
+/// distinct ProcessingState values so the UI can render every KB lifecycle state.
+///
+/// Library composition:
+///   1. Nanolith            — KB Ready  (libro game, hero use case)
+///   2. Catan               — KB Ready
+///   3. Root                — KB Ready
+///   4. Wingspan            — KB Ready
+///   5. Pandemic            — KB Ready
+///   6. Ark Nova            — KB Ready
+///   7. 7 Wonders           — KB Embedding (processing)
+///   8. Spirit Island       — KB Pending   (uploaded, not started)
+///   9. Terraforming Mars   — no KB
+///  10. Brass: Birmingham   — no KB
+///
+/// Idempotency:
+///   - skip if badsworm user not found
+///   - skip if badsworm already has ≥10 library entries
+///   - per-game: insert library entry only if missing (lookup by (UserId, SharedGameId))
+///   - per-pdf:  insert mock document only if missing (lookup by (UploadedByUserId, SharedGameId))
+///
+/// The PdfDocument rows are mock placeholders (no real file blob). They drive the
+/// dashboard "GIOCHI" section count and the KB-state visual cues; full RAG queries
+/// against these games will return empty results until the embedding pipeline runs.
+/// </summary>
+internal sealed class SeedBadswormPersonaCommandHandler : ICommandHandler<SeedBadswormPersonaCommand>
+{
+    private const string BadswormEmail = "badsworm@gmail.com";
+    private const int OwnedStateInt = 3; // GameStateType.Owned
+    private const int ExpectedLibrarySize = 10;
+
+    private static readonly LibraryGameSpec[] LibrarySpec =
+    {
+        new("Nanolith",            "Ready",     "it"),
+        new("Catan",               "Ready",     "en"),
+        new("Root",                "Ready",     "en"),
+        new("Wingspan",            "Ready",     "en"),
+        new("Pandemic",            "Ready",     "en"),
+        new("Ark Nova",            "Ready",     "en"),
+        new("7 Wonders",           "Embedding", "en"),
+        new("Spirit Island",       "Pending",   "en"),
+        new("Terraforming Mars",   null,        "en"),
+        new("Brass: Birmingham",   null,        "en"),
+    };
+
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<SeedBadswormPersonaCommandHandler> _logger;
+
+    public SeedBadswormPersonaCommandHandler(
+        MeepleAiDbContext db,
+        ILogger<SeedBadswormPersonaCommandHandler> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SeedBadswormPersonaCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var badsworm = await _db.Users
+            .FirstOrDefaultAsync(u => u.Email == BadswormEmail, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (badsworm == null)
+        {
+            _logger.LogInformation(
+                "Badsworm user not found — skipping persona seed (run SeedBadswormUser first)");
+            return;
+        }
+
+        var existingCount = await _db.UserLibraryEntries
+            .CountAsync(e => e.UserId == badsworm.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existingCount >= ExpectedLibrarySize)
+        {
+            _logger.LogInformation(
+                "Badsworm persona already has {Count} library entries — skipping",
+                existingCount);
+            return;
+        }
+
+        var libraryAdded = 0;
+        var pdfsAdded = 0;
+        var missingGames = new List<string>();
+
+        foreach (var spec in LibrarySpec)
+        {
+            var sharedGame = await _db.SharedGames
+                .Where(g => !g.IsDeleted && g.Title == spec.Title)
+                .Select(g => new { g.Id, g.Title })
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (sharedGame == null)
+            {
+                missingGames.Add(spec.Title);
+                continue;
+            }
+
+            var entryExists = await _db.UserLibraryEntries
+                .AnyAsync(
+                    e => e.UserId == badsworm.Id && e.SharedGameId == sharedGame.Id,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!entryExists)
+            {
+                _db.UserLibraryEntries.Add(new UserLibraryEntryEntity
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = badsworm.Id,
+                    SharedGameId = sharedGame.Id,
+                    AddedAt = DateTime.UtcNow,
+                    CurrentState = OwnedStateInt,
+                    StateChangedAt = DateTime.UtcNow,
+                    OwnershipDeclaredAt = DateTime.UtcNow,
+                });
+                libraryAdded++;
+            }
+
+            if (spec.PdfState is null)
+            {
+                continue;
+            }
+
+            var pdfExists = await _db.PdfDocuments
+                .AnyAsync(
+                    p => p.UploadedByUserId == badsworm.Id && p.SharedGameId == sharedGame.Id,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (pdfExists)
+            {
+                continue;
+            }
+
+            var isReady = string.Equals(spec.PdfState, "Ready", StringComparison.Ordinal);
+            _db.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                FileName = $"rulebook-{Slugify(spec.Title)}.pdf",
+                FilePath = $"seed/badsworm/{Slugify(spec.Title)}/rulebook.pdf",
+                FileSizeBytes = 250_000,
+                ContentType = "application/pdf",
+                UploadedByUserId = badsworm.Id,
+                UploadedAt = DateTime.UtcNow,
+                SharedGameId = sharedGame.Id,
+                ProcessingState = spec.PdfState,
+                ProcessedAt = isReady ? DateTime.UtcNow : null,
+                IsActiveForRag = isReady,
+                Language = spec.Language,
+                IsPublic = false,
+                DocumentCategory = "Rulebook",
+                LicenseType = 0,
+                ProcessingPriority = "Normal",
+            });
+            pdfsAdded++;
+        }
+
+        if (libraryAdded == 0 && pdfsAdded == 0)
+        {
+            _logger.LogInformation(
+                "Badsworm persona seed: no changes (library entries={Count}, pdfs already present)",
+                existingCount);
+        }
+        else
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Badsworm persona seeded: +{Library} library entries, +{Pdfs} pdf documents",
+                libraryAdded, pdfsAdded);
+        }
+
+        if (missingGames.Count > 0)
+        {
+            _logger.LogWarning(
+                "Badsworm persona seed: {Count} games missing from catalog (run CatalogSeeder first): {Titles}",
+                missingGames.Count,
+                string.Join(", ", missingGames));
+        }
+    }
+
+    private static string Slugify(string title)
+    {
+        return title
+            .Replace(' ', '-')
+            .Replace(':', '-')
+            .Replace("--", "-")
+            .ToLowerInvariant();
+    }
+
+    private sealed record LibraryGameSpec(string Title, string? PdfState, string Language);
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -1,6 +1,8 @@
+using Api.BoundedContexts.Administration.Application.Commands;
 using Api.Infrastructure.Seeders.Catalog.SeedBlob;
 using Api.Services;
 using Api.Services.Pdf;
+using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -57,5 +59,18 @@ internal sealed class CatalogSeedLayer : ISeedLayer
             embeddingService,
             config,
             manifestNameOverride: manifestOverride).ConfigureAwait(false);
+
+        // Badsworm dogfood persona: 10 library entries (incl. Nanolith) + mock KB
+        // documents for dashboard validation. Runs after CatalogSeeder so the
+        // SharedGames it references are guaranteed to exist. Idempotent.
+        try
+        {
+            var mediator = context.Services.GetRequiredService<IMediator>();
+            await mediator.Send(new SeedBadswormPersonaCommand(), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            context.Logger.LogError(ex, "[Catalog] Badsworm persona seed failed — continuing");
+        }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -12165,6 +12165,34 @@ catalog:
     pdfVersion: '1.0'
     fallbackImageUrl: https://placehold.co/400x300?text=Disney%20Villainous
     fallbackThumbnailUrl: https://placehold.co/150x150?text=Disney%20Villainous
+  - title: Nanolith
+    bggId: null
+    language: it
+    seedAgent: true
+    yearPublished: 2026
+    minPlayers: 1
+    maxPlayers: 1
+    playingTime: 120
+    minAge: 12
+    averageRating: 8.0
+    description: Nanolith è un libro game narrativo con paragrafi numerati e glossario fotografabile.
+      Il giocatore esplora una storia ramificata, registra scelte e oggetti tramite l'AI assistant
+      di MeepleAI. Pensato come dogfood demo della modalità Libro Game (campagne, photo-translate,
+      glossary editor, resume picker).
+    categories:
+    - Gamebook
+    - Adventure
+    - Narrative Choice / Paragraph
+    mechanics:
+    - Solo / Single-Player
+    - Storytelling
+    - Variable Set-up
+    designers:
+    - MeepleAI Studio
+    publishers:
+    - MeepleAI
+    fallbackImageUrl: https://placehold.co/400x300?text=Nanolith
+    fallbackThumbnailUrl: https://placehold.co/150x150?text=Nanolith
   defaultAgent:
     name: MeepleAssistant POC
     model: anthropic/claude-3-haiku

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -48,6 +48,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
+      SECRETS_DIRECTORY: /app/infra/secrets
       POSTGRES_HOST: postgres
       REDIS_HOST: redis
       OLLAMA_URL: http://ollama:11434

--- a/infra/env/api.env.dev
+++ b/infra/env/api.env.dev
@@ -1,0 +1,97 @@
+# MeepleAI API Backend Configuration
+# Development Environment (.NET 9 ASP.NET Core)
+
+# ASP.NET Core
+ASPNETCORE_ENVIRONMENT=Development
+ASPNETCORE_URLS=http://+:8080
+ASPNETCORE_DETAILEDERRORS=true
+
+# Database Configuration (PostgreSQL)
+# Connection strings use __ for nested config (ASP.NET Core convention)
+# Note: Passwords are loaded from secrets via load-secrets-env.sh
+# The placeholder values will be replaced at runtime
+# Don't set ConnectionStrings here - they will be built from POSTGRES_* and REDIS_* env vars
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Vector Database (Qdrant)
+Qdrant__Url=http://qdrant:6333
+Qdrant__ApiKey=
+
+# AI/ML Services
+Ollama__Url=http://ollama:11434
+Embedding__Provider=HuggingFaceBgeM3
+Embedding__Dimensions=1024
+Embedding__LocalServiceUrl=http://embedding-service:8000
+Embedding__FallbackEnabled=false
+
+# Reranker Service (ADR-016 Phase 4)
+Reranker__ServiceUrl=http://reranker-service:8003
+Reranker__Enabled=true
+
+# BoardGameGeek API (optional)
+Bgg__ApiToken=
+
+# LLM Provider (OpenRouter)
+# OPENROUTER_API_KEY loaded from secret via load-secrets-env.sh
+
+# JWT Configuration
+Jwt__Issuer=http://localhost:8080
+Jwt__Audience=http://localhost:3000
+Jwt__ExpirationMinutes=60
+
+# CORS
+Cors__AllowedOrigins=http://localhost:3000
+Cors__AllowCredentials=true
+
+# Email Configuration (Mailpit for dev)
+Email__SmtpHost=mailpit
+Email__SmtpPort=1025
+Email__EnableSsl=false
+Email__SmtpUsername=
+Email__SmtpPassword=
+Email__FromAddress=noreply@meepleai.dev
+Email__FromName=MeepleAI Dev
+
+# Bootstrap Initial Admin
+# Note: ALL admin bootstrap values loaded from infra/secrets/admin.secret
+# (INITIAL_ADMIN_EMAIL, INITIAL_ADMIN_DISPLAY_NAME, INITIAL_ADMIN_PASSWORD/ADMIN_PASSWORD).
+# Do not hardcode INITIAL_ADMIN_* here — env_file overrides the synced secret
+# values and breaks parity with staging.
+
+# OAuth Providers (secrets loaded via load-secrets-env.sh)
+# Google OAuth: GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET
+# Discord OAuth: DISCORD_OAUTH_CLIENT_ID, DISCORD_OAUTH_CLIENT_SECRET
+# GitHub OAuth: GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET
+
+# Logging
+Logging__LogLevel__Default=Debug
+Logging__LogLevel__Microsoft=Information
+Logging__LogLevel__Microsoft.AspNetCore=Warning
+Logging__LogLevel__Microsoft.EntityFrameworkCore=Information
+
+# OpenTelemetry (HyperDX)
+OpenTelemetry__Enabled=true
+OpenTelemetry__ServiceName=meepleai-api
+OpenTelemetry__ServiceVersion=1.0.0
+
+# Feature Flags
+Features__PromptDatabase=true
+Features__StreamingResponses=true
+Features__SetupGuideGeneration=true
+Features__ChatExport=true
+Features__MessageEditDelete=true
+Features__PdfUpload=true
+
+# Performance
+Cache__Optimization__Enabled=false
+Cache__Warming__Enabled=false
+FollowupQuestions__Enabled=true
+FollowupQuestions__MaxPerResponse=3
+FollowupQuestions__TimeoutMs=5000
+
+# Quality Evaluation (disabled in dev)
+Quality__EvaluationEnabled=false
+Rag__EvaluationEnabled=false


### PR DESCRIPTION
## Summary

Surgical cherry-pick of PR #971 (badsworm dogfood persona) onto `main-staging`, bypassing the larger promotion PR #979 which is currently stuck on a 84-commit moving target with continuous main-dev pushes.

## Why surgical

PR #979 (full main-dev → main-staging promotion) accumulated 11+ new commits during the wait, re-triggering CI repeatedly. Backend - Unit Tests has now regressed on HEAD, and stabilization timeline is unbounded while main-dev keeps receiving pushes.

This branch contains exactly **one commit** (`ecffaf33b`, the squashed merge of PR #971) cherry-picked clean onto `main-staging`. No other commits hitchhike. Auto-merge resolved one trivial conflict in `infra/compose.dev.yml` (no functional change).

## What lands on staging

- `SeedBadswormPersonaCommand` + idempotent handler — populates badsworm@gmail.com with 10 library entries (incl. Nanolith libro game) + 8 mock PdfDocument rows covering KB processing states (6 Ready / 1 Embedding / 1 Pending / 2 no-KB)
- `INITIAL_ADMIN_EMAIL` flows from `infra/secrets/admin.secret` only (`api.env.dev` override removed). Staging already uses `.app` so behavior unchanged there.
- Nanolith added to `dev.yml` manifest (synthetic BGG, language=it, category=Gamebook, seedAgent=true)
- `compose.dev.yml`: `SECRETS_DIRECTORY=/app/infra/secrets` env override (dev-only convenience; staging compose uses different paths)

## What does NOT land

- Provider probe endpoint (#957)
- Game-night G3 recents rail (#907)
- ALPHA_MODE removal (#949)
- Smoke fixes (#961, #964, #965, #970, #974)
- KB search_vector migration (#976)

These remain on `main-dev`. They'll ride the next full promotion PR once main-dev stabilizes.

## Test plan

Tracked in #977 — full ACs:
- [ ] CI green (this PR — minimal scope, expect faster signal than #979)
- [ ] Merge to main-staging
- [ ] Auto-deploy "Deploy to Staging" workflow succeeds
- [ ] https://meepleai.app/login with `badsworm@gmail.com` (password from staging secret) → /dashboard
- [ ] Dashboard binary check: h1 "Badsworm" + GIOCHI=10 + Nanolith card visible
- [ ] No regression on `admin@meepleai.app` login

## Idempotency

The seed handler skips if badsworm already has ≥10 library entries. Safe to redeploy.

## Rollback

If staging breaks:
```bash
git checkout main-staging
git revert <this-merge-sha>
git push origin main-staging
```

Or SQL-only rollback for badsworm persona data:
```sql
DELETE FROM pdf_documents
WHERE uploaded_by_user_id = (SELECT id FROM users WHERE email='badsworm@gmail.com')
  AND file_path LIKE 'seed/badsworm/%';

DELETE FROM user_library_entries
WHERE user_id = (SELECT id FROM users WHERE email='badsworm@gmail.com');
```

## Refs

- Original PR: #971 (merged on main-dev 2026-05-10 15:30 UTC)
- Tracking issue: #977
- Stalled promotion: #979 (will eventually subsume this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)