### PR TITLE
test(smoke): mock /knowledge-base documents to unblock chat State-3 (#992)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
@@ -120,3 +120,39 @@ export async function mockNoDocuments(page: Page, gameId: string): Promise<void>
     await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
   });
 }
+
+/**
+ * Mock indexed getGameDocuments (forces State-3 KB-ready chat in GameAiChatTab).
+ *
+ * Issue #992: senza questo mock, GameAiChatTab.tsx:60 vede indexedCount=0 e
+ * renderizza lo State-2 "Carica un PDF delle regole per abilitare la chat AI"
+ * invece della chat UI → message-input mai presente → timeout 30s. La SQL fixture
+ * smoke-test-games.sql crea una SharedGame senza PDF reale (per design — niente
+ * KB / vector index nel nightly stack), quindi il test DEVE mockare l'endpoint.
+ *
+ * Pre-PR #988 il fallimento si manifestava come React #418 hydration mismatch
+ * minified in produzione (SSR vs client state divergence sul KB list); locale
+ * dev build mostra solo l'empty State-2 silent. Root cause identica.
+ */
+export async function mockReadyKbDocuments(page: Page, gameId: string): Promise<void> {
+  // Shape matches GameDocumentSchema (apps/web/src/lib/api/schemas/game-documents.schemas.ts).
+  // Zod strict parse: any extra/missing field → null → State-2 empty regression.
+  const docs = [
+    {
+      id: '00000000-0000-4000-8000-000000000001',
+      title: 'smoke-rules.pdf',
+      status: 'indexed',
+      pageCount: 10,
+      createdAt: new Date().toISOString(),
+      category: 'Rulebook',
+      versionLabel: null,
+    },
+  ];
+  await page.route(`**/api/v1/knowledge-base/${gameId}/documents`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(docs),
+    });
+  });
+}

--- a/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
@@ -12,7 +12,12 @@
 import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
-import { mockNoChatHistory, mockQaStreamV2, seedGameForChat } from './_helpers/game-chat';
+import {
+  mockNoChatHistory,
+  mockQaStreamV2,
+  mockReadyKbDocuments,
+  seedGameForChat,
+} from './_helpers/game-chat';
 
 test.describe('SMOKE — game-chat low confidence (G5)', () => {
   test('shows LowConfidenceDisclaimer + bassa badge when confidence < 0.50', async ({
@@ -23,6 +28,7 @@ test.describe('SMOKE — game-chat low confidence (G5)', () => {
     await applySessionToPage(page, cookieHeader);
     const gameId = await seedGameForChat(request, cookieHeader);
     await mockNoChatHistory(page, gameId);
+    await mockReadyKbDocuments(page, gameId);
     await mockQaStreamV2(page, {
       tokens: ['Non sono certo: ', 'questa è una risposta a confidenza bassa.'],
       citations: [

--- a/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
@@ -12,7 +12,12 @@
 import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
-import { mockNoChatHistory, mockQaStreamV2, seedGameForChat } from './_helpers/game-chat';
+import {
+  mockNoChatHistory,
+  mockQaStreamV2,
+  mockReadyKbDocuments,
+  seedGameForChat,
+} from './_helpers/game-chat';
 
 test.describe('SMOKE — game-chat out of context', () => {
   test('shows OutOfContextActions when confidence=0 and no citations', async ({
@@ -23,6 +28,7 @@ test.describe('SMOKE — game-chat out of context', () => {
     await applySessionToPage(page, cookieHeader);
     const gameId = await seedGameForChat(request, cookieHeader);
     await mockNoChatHistory(page, gameId);
+    await mockReadyKbDocuments(page, gameId);
     await mockQaStreamV2(page, {
       tokens: ['Non ho informazioni su questo argomento.'],
       citations: [],


### PR DESCRIPTION
## Summary
- Add `mockReadyKbDocuments(page, gameId)` helper in `_helpers/game-chat.ts` matching `GameDocumentSchema` shape (id/title/status/pageCount/createdAt/category/versionLabel)
- Invoke it in `game-night-low-confidence` + `game-night-out-of-context` smoke specs alongside existing `mockNoChatHistory` + `mockQaStreamV2`
- Leave `mockNoDocuments` untouched — `game-night-pdf-non-owner` intentionally tests the non-owner empty-docs path

## Root cause
`GameAiChatTab.tsx:60` gates State-3 inline chat on `indexedCount > 0 || processingCount > 0`. The SQL fixture `tests/fixtures/smoke-test-games.sql` seeds a `SharedGame` with `has_knowledge_base=false` (per design — no real PDF / vector index in the nightly stack), so the real backend returns `documents=[]` → State-2 empty "Carica un PDF" → `[data-testid="message-input"]` never appears → 30s timeout.

In CI the failure surfaces as the minified React error #418 (SSR prerender vs client document fetch hydration mismatch). Locally with dev build it shows the silent State-2 fallback. **Same root cause.**

## Local repro
1. `make dev` (Postgres + API + Web)
2. Apply `tests/fixtures/smoke-test-games.sql` + seed `smoke-user@meepleai.test` (mirrors CI workflow `INITIAL_ADMIN_*`)
3. `pnpm exec playwright test smoke-real-backend/game-night-low-confidence.smoke.spec.ts --project=desktop-chrome`
4. Pre-fix: timeout. Post-fix: State-3 reached (separate local repro shows possible stale prod build cache rendering different State-3 fallback CTA — CI uses fresh build so unaffected).

## Test plan
- [ ] Wait for `e2e-smoke-real-backend.yml` workflow on this PR to confirm both `game-night-low-confidence` and `game-night-out-of-context` pass
- [ ] Verify `game-night-pdf-non-owner` still passes (mockNoDocuments untouched)

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)