### PR TITLE
fix(smoke): SharedGame fixture status=Published (#960 Cat B)

### DIFF
--- a/tests/fixtures/smoke-test-games.sql
+++ b/tests/fixtures/smoke-test-games.sql
@@ -51,8 +51,8 @@ SELECT
     8,
     '',
     '',
-    1,  -- 1 = Published
-    5,  -- 5 = Complete
+    2,  -- GameStatus enum: 0=Draft, 1=PendingApproval, 2=Published, 3=Archived
+    5,  -- GameDataStatus enum: 5 = Complete
     false,
     u."Id",
     NOW(),


### PR DESCRIPTION
## Real Cat B root cause (after local repro)

Mio fixture aveva `status=1` con commento errato "1=Published". Vero enum: `PendingApproval=1`, **Published=2**. Catalog endpoint `GET /api/v1/shared-games/{id}` ritorna 404 per non-Published → useLibraryGameDetail null → page mostra 'Gioco non trovato' → message-input mai renderizzato → 30s timeout.

## Repro locale

- DB row presente con status=1 → curl 404
- DB UPDATE status=2 + API restart → curl 200 OK con `status:"Published"` body completo

## Diagnostic chain (4 PR)

- #980 Set-Cookie: OK ✅
- #998 kb-documents probe: HTTP 200 [] ✅
- #998 chat-threads probe: HTTP 200 {threads:[]} ✅
- shared-games/{id}: HTTP 404 ❌ ← bug
- DB UPDATE → HTTP 200 ✅

## Fix

`tests/fixtures/smoke-test-games.sql`: status 1 → 2 + commento aggiornato con tutti i 4 valori enum.

## Verification

- [x] Local repro HTTP 200 post-fix
- [ ] Trigger workflow_dispatch post-merge → atteso 19+ passed (vs 16 attuali)

Closes #960 Cat B