### PR TITLE
ci(smoke): remove path-trigger on push, cron + dispatch only

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -3,13 +3,6 @@ name: E2E Smoke Real Backend (nightly)
 on:
   schedule:
     - cron: '0 3 * * *'
-  push:
-    branches: [main-dev]
-    paths:
-      - 'apps/web/src/components/v2/game-chat/**'
-      - 'apps/web/src/hooks/queries/useGameChat.ts'
-      - 'apps/web/e2e/smoke-real-backend/**'
-      - '.github/workflows/e2e-smoke-real-backend.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Rimuove il path-trigger introdotto da PR #964.

## Motivo

In pratica ha causato:
- Concurrency cancellation con cron 03:00 (es. run #25635594738 cancelled)
- ~25min run su ogni merge che tocca chat-night o smoke-real-backend
- Trigger ricorsivo: ogni PR di fix al workflow stesso lo ri-triggerava

## Fix

Solo `cron + workflow_dispatch`, pattern degli altri smoke workflow.

Refs: #964 (introdotto), #960 (durante investigation)