### PR TITLE
ci(smoke): probe shared-games/{id} for Cat B residual (#960)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -178,6 +178,10 @@ jobs:
             -b /tmp/cookies.txt -o /tmp/detail.json -w "library detail HTTP %{http_code}\n" || true
           head -c 800 /tmp/detail.json 2>/dev/null
           echo ""
+          curl -sS -X GET http://localhost:8080/api/v1/shared-games/00000000-0000-4000-8000-000000053e1d \
+            -b /tmp/cookies.txt -o /tmp/sg-detail.json -w "shared-games detail HTTP %{http_code}\n" || true
+          head -c 600 /tmp/sg-detail.json 2>/dev/null
+          echo ""
           echo "--- Set-Cookie response headers (login) ---"
           curl -sS -D - -X POST http://localhost:8080/api/v1/auth/login \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
Diagnostic-only. useLibraryGameDetail fa Promise.all([library.getGameDetail, sharedGames.getById]). Library probe HTTP 200 OK. Manca verify del secondo endpoint.

Refs: #960 Cat B