### PR TITLE
fix(smoke): mock indexed PDF for game-night specs (closes #960 Cat B)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
@@ -120,3 +120,39 @@ export async function mockNoDocuments(page: Page, gameId: string): Promise<void>
     await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
   });
 }
+
+/**
+ * Mock getGameDocuments with at least one indexed document.
+ *
+ * Required for game-night specs that need ChatInputBar to mount: GameAiChatTab
+ * gates rendering of GameChatTabV2 on `kbDocs.some(d => d.status === 'indexed' || 'processing')`.
+ * If kbDocs is empty (real backend with no PDFs uploaded for the seed game),
+ * the tab renders the "Carica un PDF" placeholder and message-input never appears,
+ * causing waitForSelector to time out (#960 Cat B real root cause).
+ *
+ * The doc shape mirrors what /api/v1/knowledge-base/{gameId}/documents returns
+ * in production. Only `id` and `status` are consumed by GameAiChatTab; other
+ * fields are present for type safety against PdfDocumentResponseSchema.
+ */
+export async function mockHasIndexedDocument(page: Page, gameId: string): Promise<void> {
+  const doc = {
+    id: '00000000-0000-4000-8000-000000053edd',
+    fileName: 'smoke-fixture-rulebook.pdf',
+    fileSizeBytes: 1024,
+    contentType: 'application/pdf',
+    pageCount: 1,
+    uploadedAt: new Date().toISOString(),
+    uploadedByUserId: '00000000-0000-4000-8000-000000000001',
+    processingStatus: 'Ready',
+    status: 'indexed',
+    chunkCount: 1,
+    isPublic: false,
+  };
+  await page.route(`**/api/v1/knowledge-base/${gameId}/documents`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([doc]),
+    });
+  });
+}

--- a/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
@@ -12,7 +12,12 @@
 import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
-import { mockNoChatHistory, mockQaStreamV2, seedGameForChat } from './_helpers/game-chat';
+import {
+  mockHasIndexedDocument,
+  mockNoChatHistory,
+  mockQaStreamV2,
+  seedGameForChat,
+} from './_helpers/game-chat';
 
 test.describe('SMOKE — game-chat low confidence (G5)', () => {
   test('shows LowConfidenceDisclaimer + bassa badge when confidence < 0.50', async ({
@@ -22,6 +27,10 @@ test.describe('SMOKE — game-chat low confidence (G5)', () => {
     const { cookieHeader } = await smokeLogin(request);
     await applySessionToPage(page, cookieHeader);
     const gameId = await seedGameForChat(request, cookieHeader);
+    // Mock at least 1 indexed PDF so GameAiChatTab renders GameChatTabV2
+    // (and therefore ChatInputBar with data-testid=message-input). Without
+    // this the tab shows the "Carica un PDF" placeholder instead.
+    await mockHasIndexedDocument(page, gameId);
     await mockNoChatHistory(page, gameId);
     await mockQaStreamV2(page, {
       tokens: ['Non sono certo: ', 'questa è una risposta a confidenza bassa.'],

--- a/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
@@ -12,7 +12,12 @@
 import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
-import { mockNoChatHistory, mockQaStreamV2, seedGameForChat } from './_helpers/game-chat';
+import {
+  mockHasIndexedDocument,
+  mockNoChatHistory,
+  mockQaStreamV2,
+  seedGameForChat,
+} from './_helpers/game-chat';
 
 test.describe('SMOKE — game-chat out of context', () => {
   test('shows OutOfContextActions when confidence=0 and no citations', async ({
@@ -22,6 +27,8 @@ test.describe('SMOKE — game-chat out of context', () => {
     const { cookieHeader } = await smokeLogin(request);
     await applySessionToPage(page, cookieHeader);
     const gameId = await seedGameForChat(request, cookieHeader);
+    // Mock at least 1 indexed PDF so GameAiChatTab renders GameChatTabV2.
+    await mockHasIndexedDocument(page, gameId);
     await mockNoChatHistory(page, gameId);
     await mockQaStreamV2(page, {
       tokens: ['Non ho informazioni su questo argomento.'],

--- a/apps/web/e2e/smoke-real-backend/game-night-pdf-non-owner.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-pdf-non-owner.smoke.spec.ts
@@ -13,8 +13,8 @@ import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
 import {
+  mockHasIndexedDocument,
   mockNoChatHistory,
-  mockNoDocuments,
   mockQaStreamV2,
   seedGameForChat,
 } from './_helpers/game-chat';
@@ -28,7 +28,11 @@ test.describe('SMOKE — game-chat PDF non-owner upsell (G4)', () => {
     await applySessionToPage(page, cookieHeader);
     const gameId = await seedGameForChat(request, cookieHeader);
     await mockNoChatHistory(page, gameId);
-    await mockNoDocuments(page, gameId);
+    // Mock 1 indexed doc with id 053edd. The citation below uses id 0001
+    // (different) → useCanViewPdf cerca doc 0001 nei kbDocs returned (053edd)
+    // → not found → canView=false → CitationOwnershipUpsell mostrato.
+    // Same single mock satisfies both: GameAiChatTab gate (kbDocs > 0) + non-owner state.
+    await mockHasIndexedDocument(page, gameId);
     await mockQaStreamV2(page, {
       tokens: ['Risposta con citazione.'],
       citations: [


### PR DESCRIPTION
## Real Cat B root cause (after diagnostic + GameAiChatTab.tsx code-walk)

`GameAiChatTab` ha 3 stati condizionali. Stato 2 (no KB indexed/processing) mostra placeholder "Carica un PDF" invece di montare `GameChatTabV2` con `ChatInputBar`. Senza ChatInputBar → no `data-testid='message-input'` → 30s timeout.

PR #1000 (status=2) era necessario ma non sufficient: anche con SharedGame Published + library entry, i game-night spec non mockavano `getGameDocuments` con almeno 1 doc indexed, quindi la chat non si montava.

## Backend confermato OK

5 endpoint probati via diagnostic step (PR #998 + #1003):
- `shared-games/{id}` HTTP 200 ✅
- `library/games/{id}` HTTP 200 ✅
- `knowledge-base/{id}/documents` HTTP 200 [] ✅ (correct, no real docs)
- `chat-threads` HTTP 200 ✅
- `auth/login` HTTP 200 ✅

## Fix

Nuovo helper `mockHasIndexedDocument(page, gameId)` che intercetta `GET /knowledge-base/{id}/documents` e ritorna 1 doc indexed (id `053edd`).

Wire nei 3 spec:
- low-confidence + out-of-context: solo per attivare ChatInputBar
- pdf-non-owner: sostituisce `mockNoDocuments`. Stesso mock soddisfa ENTRAMBI:
  - GameAiChatTab gate (kbDocs.length > 0)
  - useCanViewPdf non-owner state (citation usa id 0001 ≠ doc 053edd → not found → upsell)

## Verification

- [x] tsc + eslint clean
- [ ] Trigger workflow_dispatch post-merge → atteso 19/20 (+3 Cat B)

Closes #960 Cat B (player-detail :50 residuo separato — Cat A residual)