### PR TITLE
fix(routes): remove /library/games/:id catch-all redirect (closes #1004, unblocks #960 Cat B)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -188,7 +188,16 @@ const nextConfig = {
         destination: '/library/:id?tab=strategies',
         permanent: true,
       },
-      { source: '/library/games/:id', destination: '/library/:id', permanent: true },
+      // Issue #1004: removed `/library/games/:id` → `/library/:id` redirect.
+      // The legacy `/library/[gameId]/layout.tsx` only knows 4 tabs
+      // (Dettagli/Agente/Toolkit/FAQ) and silently falls back to a CTA when an
+      // unknown `?tab=aiChat` arrives. The S4 GameDetailDesktop on the new path
+      // `/library/games/[gameId]/page.tsx` is the canonical surface for the
+      // 5-tab game detail (incl. aiChat). Keep sub-route redirects above (they
+      // map specific tab paths) but stop the catch-all that rerouted aiChat
+      // traffic into the placeholder layout. Issue #5039 (consolidation)
+      // remains tracked separately — to be revisited by extending the legacy
+      // layout to mount the v2 tabs OR by deprecating `/library/[id]` entirely.
       { source: '/library/wishlist', destination: '/library?tab=wishlist', permanent: true },
       { source: '/library/private', destination: '/library?tab=private', permanent: true },
       { source: '/library/proposals', destination: '/discover?tab=proposals', permanent: true },


### PR DESCRIPTION
## Real root cause via local DOM dump

Smoke spec naviga a `/library/games/{id}?tab=aiChat`. `next.config.js:191` redirect 308 → `/library/:id?tab=aiChat`. Destination è layout legacy con SOLO 4 tabs (Dettagli/Agente/Toolkit/FAQ). `tab=aiChat` non riconosciuto → CTA fallback ('AI Chat' h3 + 'Chatta con AI' button + 'Apri chat completa' link) invece di mounting GameAiChatTab.

I 3 game-night-* smoke specs facevano test della CTA invece del v2 chat → 30s timeout su `message-input`.

## Fix

Rimosso catch-all redirect. Sub-route redirects specifici (`/agent`, `/toolkit`, ecc.) RESTANO funzionanti. Path `/library/games/[gameId]/page.tsx` ora canonical per GameDetailDesktop (5 tabs).

## Verification

- [x] Local repro: DOM dump da error-context.md mostra layout legacy
- [x] next.config.js syntax valid
- [ ] Trigger workflow_dispatch post-merge → atteso 19/20 (3 Cat B sbloccati)

## Out of scope

Issue #5039 (route consolidation /library/[id] → /library/games/[id]) NON risolto. Legacy layout sopravvive. Tracked separatamente.

Closes #1004
Refs #960 Cat B