### PR TITLE
fix(ci): force web image rebuild on smoke run (closes #1004)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -84,9 +84,14 @@ jobs:
           N8NENV
           ls -la
 
-      - name: Boot dev stack (postgres + redis + api)
+      - name: Boot dev stack (postgres + redis + api + web — fresh build)
         working-directory: infra
         run: |
+          # #1004 root cause: docker compose up with cached web image rendered
+          # stale GameAiChatTab (pre-#918) → State-3 CTA fallback instead of inline
+          # GameChatTabV2 → message-input never appears → 30s timeout. Force rebuild
+          # every smoke run so the image matches HEAD source.
+          docker compose -f docker-compose.yml -f compose.dev.yml build web
           make dev-core
           for i in {1..40}; do
             if curl -fs http://localhost:8080/health 2>/dev/null; then
@@ -223,7 +228,10 @@ jobs:
           # docker compose already provides web on :3000 (see infra/compose.dev.yml:72)
           # — skip Playwright's own webServer to avoid port collision
           PLAYWRIGHT_SKIP_WEB_SERVER: '1'
-        run: pnpm playwright test smoke-real-backend/ --project=desktop-chrome
+        # Force html reporter so apps/web/playwright-report/ exists for the
+        # always-run upload step (#1004 debug: dot-only reporter was producing
+        # 0 artifacts → couldn't inspect error-context.md remotely).
+        run: pnpm playwright test smoke-real-backend/ --project=desktop-chrome --reporter=html
 
       - name: Upload report on failure
         if: failure()


### PR DESCRIPTION
## Summary
Adds an explicit \`docker compose build web\` step before \`make dev-core\` in the smoke workflow so the web container image always matches HEAD source. Without this, GitHub Actions reused a cached web image (predating PR #918's GameChatTabV2 inline render) → State-3 fell back to a CTA layout → \`[data-testid="message-input"]\` never appeared → 30s timeout on 3 game-night smoke specs.

## Root cause walkthrough
Investigation steps (full thread in #1004 comments):
1. PR #999 + PR #1005 both added \`mockHasIndexedDocument\` helpers — necessary to satisfy GameAiChatTab.tsx:60 gate (\`indexedCount > 0\`) but **not sufficient** when image is stale.
2. Local repro on \`pnpm dev\` (NODE_ENV=development) → State-3 renders \`<GameChatTabV2/>\` inline → \`message-input\` present → ✅ test passes.
3. Same code on the docker compose web container (cached image, NODE_ENV=production) → State-3 renders a CTA fallback ("Knowledge Base pronta + Chatta con AI + Apri chat completa") → ❌ \`message-input\` absent → timeout.
4. \`docker compose build web\` (force rebuild) → State-3 renders \`<GameChatTabV2/>\` correctly → all 3 specs pass in 13s on the freshly rebuilt prod image.

The cached image's bundled \`GameAiChatTab.tsx\` predates the inline-chat refactor; even with the right backend data, the old code path renders the older UI.

## Fix
\`\`\`yaml
- name: Boot dev stack (postgres + redis + api + web — fresh build)
  working-directory: infra
  run: |
    docker compose -f docker-compose.yml -f compose.dev.yml build web
    make dev-core
\`\`\`

Adds ~1-2 min to nightly smoke runtime — acceptable for the reliability gain.

## Validation
- ✅ Local: \`docker compose build web && make dev-core\` then \`pnpm exec playwright test smoke-real-backend/game-night-*.smoke.spec.ts\` → **3 passed** in 13s.
- [ ] CI: this PR's smoke run (will be auto-triggered? confirm in checks tab — if not, manual \`gh workflow run\`)

## Followup
Migrate to BuildKit cache mounts so the rebuild is layer-incremental rather than a full build every time. Not blocking; current fix is reliable.

Closes #1004
Refs #999 #1005