### PR TITLE
ci(smoke): add html reporter for Cat B residual debug (#1004)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -223,7 +223,11 @@ jobs:
           # docker compose already provides web on :3000 (see infra/compose.dev.yml:72)
           # — skip Playwright's own webServer to avoid port collision
           PLAYWRIGHT_SKIP_WEB_SERVER: '1'
-        run: pnpm playwright test smoke-real-backend/ --project=desktop-chrome
+        # #1004 investigation: html reporter captures screenshot + error-context.md
+        # per failed test. Required to debug Cat B residual without local repro
+        # (artifact upload uses apps/web/playwright-report dir which dot reporter
+        # doesn't create).
+        run: pnpm playwright test smoke-real-backend/ --project=desktop-chrome --reporter=html,list
 
       - name: Upload report on failure
         if: failure()


### PR DESCRIPTION
Diagnostic-only PR. dot reporter no playwright-report dir → no artifact. Switch to html+list combo.

Refs: #1004 #960