### PR TITLE
fix(test): allow null BggId for libro games in catalog manifest test

### DIFF
--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederTests.cs
@@ -36,10 +36,20 @@ public sealed class CatalogSeederTests
     {
         var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev);
 
+        // BggId is nullable: libro games (e.g. Nanolith, PR #971) are not catalogued
+        // on BoardGameGeek by design. Standard published board games MUST have a
+        // positive BggId; libro/narrative games may have null.
         manifest.Catalog.Games.Should().AllSatisfy(g =>
         {
-            g.BggId.Should().BeGreaterThan(0, $"game '{g.Title}' should have a valid BggId");
             g.Title.Should().NotBeNullOrWhiteSpace();
+            var isGamebook = g.Categories?.Contains("Gamebook") ?? false;
+            if (isGamebook)
+            {
+                // Libro game: BggId may be null. No assertion on BggId value.
+                return;
+            }
+            g.BggId.Should().BeGreaterThan(0,
+                $"non-gamebook game '{g.Title}' should have a valid BggId");
         });
     }
 


### PR DESCRIPTION
## Summary
PR #971 added Nanolith (libro game, BggId=null by design — not on BoardGameGeek) to dev.yml manifest, breaking \`LoadManifest_DevProfile_GamesHaveValidBggIds\` which asserted ALL games have BggId > 0.

Updates test premise: standard published board games MUST have a positive BggId, but libro/gamebook entries legitimately have null. Detects libro games via Categories field containing \"Gamebook\" and skips BggId assertion for those.

\`SeedManifest.Validate()\` (apps/api/src/Api/Infrastructure/Seeders/SeedManifest.cs:35) already allows null BggId and only errors on \`<= 0\` — this aligns the test with production model semantics.

## Validation
- ✅ Local: \`dotnet test --filter \"FullyQualifiedName~LoadManifest_DevProfile_GamesHaveValidBggIds\"\` → **1 passed** in 373ms.

## Release blocker resolution
Resolves \"Backend - Unit Tests\" failure on PR #979 (release main-dev → main-staging). One of 7 residual failures after #1002/#1006 GG fixes.

## Test plan
- [ ] CI Backend Unit Tests passes on this PR
- [ ] After merge, #979 re-run shows Backend Unit ✅