### PR TITLE
fix(deps): override Snappier 1.3.0 → 1.3.1 to patch GHSA-pggp-6c3x-2xmx (HIGH)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -53,6 +53,10 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.14.0-beta.2" />
     <PackageReference Include="Otp.NET" Version="1.4.1" />
     <PackageReference Include="Parquet.Net" Version="5.5.0" />
+    <!-- GHSA-pggp-6c3x-2xmx: Parquet.Net 5.5.0 pulls Snappier 1.3.0 (vulnerable).
+         Override to 1.3.1 patched. Bumping Parquet.Net to 6.x is a breaking
+         change (ParquetSerializer.DeserializeAllAsync removed) — tracked separately. -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
     <PackageReference Include="Quartz" Version="3.13.1" />

--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -83,6 +83,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- GHSA-pggp-6c3x-2xmx: mirror Snappier override from Api.csproj for the
+         test project. ProjectReference doesn't propagate package overrides. -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Api\Api.csproj" />


### PR DESCRIPTION
## Summary
Snappier 1.3.0 is a transitive dependency of Parquet.Net 5.5.0 and flagged HIGH severity (GHSA-pggp-6c3x-2xmx). Patched in 1.3.1.

## Why not bump Parquet.Net
Parquet.Net 5.5.0 → 6.0.2 was attempted first but introduces a breaking API change: \`ParquetSerializer.DeserializeAllAsync\` was removed. Two consumer call sites in \`apps/api/src/Api/BoundedContexts/Administration/Application/Services/RagParquetSerializer.cs\` would need refactoring. Tracked separately as P3 cleanup.

## Fix
Direct \`PackageReference\` override on Snappier 1.3.1 in **both** \`Api.csproj\` and \`Api.Tests.csproj\` (transitive refs don't propagate across ProjectReference).

## Validation
- \`dotnet list package --vulnerable\` on \`Api\` → only \`OpenTelemetry.Api Moderate\` remains (below HIGH/CRITICAL CI gate)
- \`dotnet list package --vulnerable\` on \`Api.Tests\` → "non contiene pacchetti vulnerabili"
- \`dotnet build\` → 0 errors, 0 warnings

## Release blocker resolution
Resolves "Dependency Vulnerabilities" failure on PR #979 (release main-dev → main-staging).