### PR TITLE
fix(smoke): KB FK chain fixture for game-night specs (closes #960 Cat B)

### DIFF
--- a/tests/fixtures/smoke-test-games.sql
+++ b/tests/fixtures/smoke-test-games.sql
@@ -88,3 +88,113 @@ SELECT
 FROM users u
 WHERE u."Email" = 'smoke-user@meepleai.test'
 ON CONFLICT ("Id") DO NOTHING;
+
+-- ============================================================================
+-- KB FK chain (#960 Cat B): unblock GameAiChatTab Stato 3 → GameChatTabV2
+-- ============================================================================
+-- GameAiChatTab gates rendering of <GameChatTabV2/> on
+-- `kbDocs.some(d => d.status === 'indexed' || 'processing')`. Without indexed
+-- docs the tab shows the "Carica un PDF" placeholder and ChatInputBar never
+-- mounts (data-testid=message-input invisible → smoke specs timeout 30s).
+--
+-- Backend handler GetGameDocumentsHandler (KnowledgeBase BC) joins:
+--   vector_documents vd JOIN pdf_documents pdf ON vd.PdfDocumentId = pdf.Id
+--   WHERE vd.GameId == query.GameId
+--
+-- vector_documents.GameId FK → games.Id (NOT shared_games — schema reality).
+-- The smoke endpoint is called with the URL gameId, which we use as both
+-- shared_games.id and games.Id (same UUID for fixture symmetry).
+
+-- 1) Game row mirroring SharedGame (FK target for vector_documents.GameId).
+--    games.Name has UNIQUE constraint — suffix avoids collisions if rerun.
+INSERT INTO games (
+    "Id",
+    "Name",
+    "CreatedAt",
+    "SharedGameId",
+    "MinPlayers",
+    "MaxPlayers",
+    approval_status
+)
+VALUES (
+    '00000000-0000-4000-8000-000000053e1d'::uuid,  -- same as SharedGame.id
+    'Smoke Chat Fixture Game (smoke)',
+    NOW(),
+    '00000000-0000-4000-8000-000000053e1d'::uuid,
+    2,
+    4,
+    2  -- Approved (mirrors SharedGameStatus.Published)
+)
+ON CONFLICT ("Id") DO NOTHING;
+
+-- 2) PdfDocument with all NOT NULL columns + processing_state='Ready' so the
+--    backend treats it as indexed-source. UploadedByUserId resolves to
+--    smoke-user (admin) via subquery. Path/file are placeholders — not
+--    served by any real PDF endpoint in smoke flow.
+INSERT INTO pdf_documents (
+    "Id",
+    "FileName",
+    "FilePath",
+    "FileSizeBytes",
+    "ContentType",
+    "UploadedByUserId",
+    "UploadedAt",
+    processing_state,
+    "PageCount",
+    "Language",
+    "DocumentType",
+    "SortOrder",
+    "IsPublic",
+    document_category,
+    is_active_for_rag,
+    license_type,
+    processing_priority
+)
+SELECT
+    '00000000-0000-4000-8000-000000053edd'::uuid,
+    'smoke-fixture-rulebook.pdf',
+    '/tmp/smoke-fixture-rulebook.pdf',
+    1024,
+    'application/pdf',
+    u."Id",
+    NOW(),
+    'Ready',
+    1,
+    'it',
+    'base',
+    0,
+    false,
+    'Rulebook',
+    true,
+    0,
+    'Normal'
+FROM users u
+WHERE u."Email" = 'smoke-user@meepleai.test'
+ON CONFLICT ("Id") DO NOTHING;
+
+-- 3) VectorDocument linking PDF + Game with IndexingStatus='completed'
+--    (handler MapIndexingStatus maps 'completed' → 'indexed' = the value
+--    GameAiChatTab checks). Embedding fields are placeholders.
+INSERT INTO vector_documents (
+    "Id",
+    "GameId",
+    "PdfDocumentId",
+    "ChunkCount",
+    "TotalCharacters",
+    "IndexingStatus",
+    "IndexedAt",
+    "EmbeddingModel",
+    "EmbeddingDimensions"
+)
+VALUES (
+    '00000000-0000-4000-8000-000000053ede'::uuid,
+    '00000000-0000-4000-8000-000000053e1d'::uuid,
+    '00000000-0000-4000-8000-000000053edd'::uuid,
+    1,
+    100,
+    'completed',
+    NOW(),
+    'intfloat/multilingual-e5-base',
+    768
+)
+ON CONFLICT ("Id") DO NOTHING;


### PR DESCRIPTION
## Real Cat B fix (after RSC discovery)

CI trace (PR #1011 html reporter) ha rivelato: browser NON fa fetch a `knowledge-base/{id}/documents` durante page.goto — dati pre-fetched server-side da Next.js 16 RSC. Mock route Playwright **inefficace** in produzione build.

Fix: dati REALI in DB via extended fixture SQL.

## FK chain seeded

```
shared_games (053e1d, status=Published)  ← already
   ↓ SharedGameId
games (053e1d, approval_status=2)        ← NEW
   ↓ GameId
vector_documents (053ede, IndexingStatus='completed')  ← NEW
   ↓ PdfDocumentId
pdf_documents (053edd, processing_state='Ready')        ← NEW
```

Tutti idempotent (`ON CONFLICT DO NOTHING`).

## Verifica locale

- `GET /api/v1/knowledge-base/053e1d/documents` → `200 + [{status:'indexed',...}]` (era `[]`)
- `pnpm playwright test game-night-low-confidence.smoke` → ✅ **1 passed (12s)**

## Aspettativa CI

Smoke health 16/20 → **20/20** (3 game-night-* sbloccati + player-detail :50 da PR #1017).

Closes #960 Cat B