### PR TITLE
chore(smoke): #1004 network logging in mockHasIndexedDocument

### DIFF
--- a/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
+++ b/apps/web/e2e/smoke-real-backend/_helpers/game-chat.ts
@@ -150,11 +150,38 @@ export async function mockHasIndexedDocument(page: Page, gameId: string): Promis
     category: 'Rulebook',
     versionLabel: null,
   };
-  await page.route(`**/api/v1/knowledge-base/${gameId}/documents`, async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([doc]),
-    });
+
+  // #1004 debug instrumentation: log when mock fires + when un-mocked
+  // /documents request slips through. CI artifact will surface this in
+  // test stdout (visible in HTML report). Remove after root cause identified.
+  await page.route('**/api/v1/knowledge-base/**/documents', async (route: Route) => {
+    const url = route.request().url();
+    if (url.includes(gameId)) {
+      console.log(`[mockHasIndexedDocument] HIT ${url}`);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([doc]),
+      });
+    } else {
+      console.log(`[mockHasIndexedDocument] PASS (other gameId): ${url}`);
+      await route.continue();
+    }
+  });
+
+  // Capture all /knowledge-base/*/documents requests at network level too —
+  // page.route handler runs only if the URL matches its glob; this listener
+  // shows the actual URL shape regardless of pattern match.
+  page.on('request', req => {
+    if (req.url().includes('/api/v1/knowledge-base/') && req.url().includes('/documents')) {
+      console.log(`[network REQ] ${req.method()} ${req.url()}`);
+    }
+  });
+  page.on('response', async resp => {
+    const url = resp.url();
+    if (url.includes('/api/v1/knowledge-base/') && url.includes('/documents')) {
+      const body = (await resp.text().catch(() => '')).slice(0, 150);
+      console.log(`[network RES] ${resp.status()} ${url} → ${body}`);
+    }
   });
 }


### PR DESCRIPTION
## Summary
Instrument \`mockHasIndexedDocument\` helper to log:
1. **mock route handler**: every HIT/PASS with matched URL
2. **page network listener**: every REQ/RES to \`/api/v1/knowledge-base/*/documents\` regardless of mock pattern

Goal: identify why mock doesn't intercept in CI. Hypotheses to test:
- **H4**: URL has query params/trailing slash not matched by glob
- **H5**: Fetch fires before \`page.route\` registered (timing race)
- **H6**: Different transport bypasses page.route in CI chromium

Output surfaces in CI artifact (playwright-report-smoke + html reporter from #1010).

## Test plan
- [ ] After merge, manually dispatch smoke run on main-dev
- [ ] Download playwright-report-smoke
- [ ] Inspect console logs → identify which hypothesis matches
- [ ] Filing fix in subsequent PR
- [ ] Remove this instrumentation when root cause resolved

Refs: #1004