### PR TITLE
fix(ci): honor frontend-a11y continue-on-error in ci-success aggregator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,10 +697,16 @@ jobs:
       - name: Check Status
         run: |
           # Required jobs (block CI)
-          for job in frontend frontend-a11y frontend-bundle-size backend-unit python-tests e2e; do
+          # NOTE: frontend-a11y has continue-on-error: true at job level (line 600,
+          # rationale: #807 token redesign light/dark base AA OK but dark-mode
+          # legacy surfaces still violate, baseline-diff policy pending #1015).
+          # Job-level continue-on-error does NOT propagate to `needs.X.result` —
+          # axe failures still surface as `result=failure` here. Move to advisory
+          # group to honor the continue-on-error intent until #1015 lands a
+          # proper baseline-diff gate.
+          for job in frontend frontend-bundle-size backend-unit python-tests e2e; do
             result="${{ needs.frontend.result }}"
             case "$job" in
-              frontend-a11y) result="${{ needs.frontend-a11y.result }}" ;;
               frontend-bundle-size) result="${{ needs.frontend-bundle-size.result }}" ;;
               backend-unit) result="${{ needs.backend-unit.result }}" ;;
               python-tests) result="${{ needs.python-tests.result }}" ;;
@@ -712,10 +718,15 @@ jobs:
             fi
           done
 
-          # Advisory jobs (warn but don't block — integration tests depend on CI service containers)
+          # Advisory jobs (warn but don't block — integration tests depend on CI service containers,
+          # a11y has continue-on-error and known dark-mode debt tracked in #1015).
           integration_result="${{ needs.backend-integration.result }}"
           if [ "$integration_result" == "failure" ]; then
             echo "⚠️ CI Warning: backend-integration=$integration_result (non-blocking, may be infrastructure)"
+          fi
+          a11y_result="${{ needs.frontend-a11y.result }}"
+          if [ "$a11y_result" == "failure" ]; then
+            echo "⚠️ CI Warning: frontend-a11y=$a11y_result (non-blocking; #1015 baseline-diff pending)"
           fi
 
           echo "✅ CI Passed"


### PR DESCRIPTION
## Summary
\`ci-success\` aggregator (\`.github/workflows/ci.yml:700\`) listed \`frontend-a11y\` in the **blocking** required-jobs loop and exited on failure. This contradicted the job-level \`continue-on-error: true\` on \`frontend-a11y\` (line 600), which documents intent:

> #807: token redesign light/dark base AA OK, but legacy dark-mode surfaces (#2e2e2e, alpha-blended bg-entity-*/15) + slate-700 fg combos still violate. Re-block gate via dedicated PR after dark-surface audit follow-up.

GitHub Actions: job-level \`continue-on-error\` does NOT propagate to \`needs.X.result\` — axe failures still surface as \`result=failure\` in the aggregator. Move \`frontend-a11y\` to the **advisory** group (warn + log, don't exit 1).

## Impact
- ✅ Resolves \"CI Success: fail\" on PR #979 (release main-dev → main-staging) caused by 96 known color-contrast violations
- ✅ Other a11y warnings still surface in workflow output for visibility
- 🟡 Re-blocking deferred to **#1015** (baseline-diff policy: fail only on NEW violations, not preexisting)

## Test plan
- [ ] This PR's CI: ci-success should now pass even if a11y axe reports violations
- [ ] After merge, #979 ci-success should green out (assuming other gates clear)