### PR TITLE
fix(ci): GG ignore audits/ dir — pwd-input false positive (#979)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -13,6 +13,9 @@ ignore-paths:
   # demo persona on staging), not production secrets. Same rationale as src test files.
   - apps/web/e2e/
   - infra/scripts/demo-smoke-*.sh
+  # Audit reports list UI component paths (e.g. `pwd-input/pwd-input.tsx`)
+  # that GG generic-password detector flags as false positives.
+  - docs/for-developers/audits/
   - infra/secrets/*.secret.example
   # I7 (auth security fixes): blocklist of common passwords used to REJECT
   # weak choices at registration. The literals are the very strings users

--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -10,5 +10,8 @@ paths-ignore:
   # NOT production secrets — see .gitguardian.yaml ignore-paths comment.
   - "apps/web/e2e/**"
   - "infra/scripts/demo-smoke-*.sh"
+  # Audit reports list UI component paths (e.g. pwd-input) flagged as false
+  # positives by GG generic-password detector.
+  - "docs/for-developers/audits/**"
   # I7: common-password blocklist (rejection list, not credential leak)
   - "**/CommonPasswords.txt"


### PR DESCRIPTION
## Summary
PR #1024 (design-system de-versioning Stage 1 audit) introduced \`docs/for-developers/audits/2026-05-11-mockup-conformity.json\` listing UI component paths. GitGuardian generic-password detector flags \`pwd-input/\` component name (line 181) as a generic secret. **False positive.**

Same pattern as #1002/#1006 (test fixtures, demo scripts): audit reports describe codebase structure, not credentials.

## Changes
Extend ignore-paths in both \`.gitguardian.yaml\` + \`.gitguardian.yml\`:
- \`docs/for-developers/audits/\` / \`docs/for-developers/audits/**\`

(#1007 tracks consolidation of the two GG config files.)

## Resolves
"1 secret uncovered!" GG fail on PR #979 release.

After merge: dashboard incident may still need manual False Positive ack (same as previous round — see #1004 commentary).