### PR TITLE
fix(test): use vi.stubGlobal for XMLHttpRequest mock (#979)

### DIFF
--- a/apps/web/src/__tests__/components/admin/shared-games/PdfUploadSection.test.tsx
+++ b/apps/web/src/__tests__/components/admin/shared-games/PdfUploadSection.test.tsx
@@ -57,7 +57,13 @@ const mockXHR = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  global.XMLHttpRequest = vi.fn(() => mockXHR) as unknown as typeof XMLHttpRequest;
+  // Vitest 2+/Node 24 made `global.XMLHttpRequest` read-only via property
+  // descriptor → direct assignment throws. Use vi.stubGlobal() which handles
+  // the assignment via the proper API.
+  vi.stubGlobal(
+    'XMLHttpRequest',
+    vi.fn(() => mockXHR)
+  );
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
Vitest 2+ / Node 24 (post-#994 docker/setup-buildx-action major bump cascade) made \`global.XMLHttpRequest\` a read-only property descriptor. Direct assignment \`global.XMLHttpRequest = vi.fn(() => mockXHR)\` throws \`TypeError: Cannot assign to read only property 'XMLHttpRequest'\`, breaking all 16 PdfUploadSection tests in CI.

## Fix
Switch to \`vi.stubGlobal('XMLHttpRequest', vi.fn(() => mockXHR))\` — proper API that uses \`Object.defineProperty\` under the hood and is auto-cleaned by \`vi.restoreAllMocks()\` in afterEach.

## Validation
- Local: \`pnpm exec vitest run src/__tests__/components/admin/shared-games/PdfUploadSection.test.tsx\` → **16/16 pass**

## Resolves
"Frontend - Build & Test" hard fail on PR #979 (release main-dev → main-staging).