### PR TITLE
fix(test): batch 3 fixes — XHR mock + Stage 2 rename + admin redirect

### DIFF
--- a/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/login/__tests__/_content.test.tsx
@@ -232,7 +232,10 @@ describe('LoginPageContent (v2 AuthCard)', () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
-  it('redirects admins to /admin after successful login', async () => {
+  it('redirects admins to /library (user app) after successful login', async () => {
+    // Issue #893 demo follow-up: admins/superadmins land on the user app by
+    // default (consistent with role experience). Admin pages remain accessible
+    // via the navigation menu. See _content.tsx:56-69.
     loginMock.mockResolvedValueOnce({
       user: { id: 'u2', email: 'a@e.com', role: 'Admin' },
       requiresTwoFactor: false,
@@ -249,7 +252,7 @@ describe('LoginPageContent (v2 AuthCard)', () => {
     fireEvent.submit(screen.getByTestId('login-form'));
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith('/admin');
+      expect(pushMock).toHaveBeenCalledWith('/library');
     });
   });
 });

--- a/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
@@ -61,7 +61,11 @@ beforeEach(() => {
     responseText: JSON.stringify({ documentId: 'doc-123', fileName: 'rules.pdf' }),
   };
   vi.clearAllMocks();
-  global.XMLHttpRequest = vi.fn(() => mockXHR) as unknown as typeof XMLHttpRequest;
+  // Vitest 2+/Node 24 made global.XMLHttpRequest read-only — mirror fix #1031.
+  vi.stubGlobal(
+    'XMLHttpRequest',
+    vi.fn(() => mockXHR)
+  );
 });
 
 afterEach(() => {

--- a/apps/web/src/components/features/game-chat/__tests__/GameChatTabV2.test.tsx
+++ b/apps/web/src/components/features/game-chat/__tests__/GameChatTabV2.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/lib/api', () => ({
 
 import { qaStream } from '@/lib/api/clients/chatClient';
 import { api } from '@/lib/api';
-import { GameChatTabV2 } from '../GameChatTabV2';
+import { GameChatTabV2 } from '../GameChatTab';
 
 async function* mockStream(events: Array<{ type: number; data: unknown }>) {
   for (const e of events) yield e;
@@ -43,7 +43,13 @@ const happyEvents = [
 
 const lowConfEvents = [
   { type: 7, data: 'Non sono certo, probabilmente si rimescolano gli scarti.' },
-  { type: 4, data: { confidence: 0.42, Citations: [{ ...sampleCitation, pageNumber: 6, snippet: 'fine mazzo', documentId: 'd2' }] } },
+  {
+    type: 4,
+    data: {
+      confidence: 0.42,
+      Citations: [{ ...sampleCitation, pageNumber: 6, snippet: 'fine mazzo', documentId: 'd2' }],
+    },
+  },
 ];
 
 const oocEvents = [
@@ -88,7 +94,9 @@ describe('GameChatTabV2', () => {
     render(<GameChatTabV2 gameId="wingspan" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'tg?' } });
     fireEvent.click(screen.getByRole('button', { name: /invia/i }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /cambia gioco/i })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /cambia gioco/i })).toBeInTheDocument()
+    );
     expect(screen.getByRole('button', { name: /cerca un agente/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /resta/i })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
3 unrelated test failures surfaced on PR #979 CI post-Stage 2 de-versioning merge (#1025):

1. **PdfUploadSection.priority.test.tsx** — mirror #1031 XHR mock fix (\`vi.stubGlobal\`). Same Vitest 2+/Node 24 readonly-property issue.

2. **features/game-chat/__tests__/GameChatTabV2.test.tsx** — fix import path after Stage 2 rename: \`../GameChatTabV2\` → \`../GameChatTab\` (source file renamed in #1025, exports still \`GameChatTabV2\` for API stability).

3. **(auth)/login/__tests__/_content.test.tsx** — update stale expectation: "admins redirect to /admin" → "admins redirect to /library". Per \`_content.tsx:56-69\` (Issue #893 demo follow-up): admins/superadmins land on user app by default. Test was lagging the code change.

## Validation
Local: 5+8+13 = **26 tests pass**.

## Resolves
Remaining "Frontend - Build & Test" hard fails on PR #979 release.