### PR TITLE
fix(test): CI batch A — align stale routing/exception assertions

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/Administration/AdminUserEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/AdminUserEndpointsIntegrationTests.cs
@@ -111,17 +111,17 @@ public sealed class AdminUserEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact(Timeout = 30000)]
-    public async Task GetAllUsers_WithSearchTerm_ThrowsQueryTranslationError()
+    public async Task GetAllUsers_WithSearchTerm_ReturnsMatchingUsers()
     {
-        // Arrange - Handler uses string.Contains with StringComparison.InvariantCultureIgnoreCase
-        // which cannot be translated to PostgreSQL SQL. This test documents the known issue.
-        // Fix: Handler should use EF.Functions.ILike() for PostgreSQL case-insensitive search.
+        // Handler uses EF.Functions.ILike() in UserProfileRepository for PostgreSQL
+        // case-insensitive search — the previous translation-error issue is fixed.
         await SeedSpecificUserAsync("searchable_unique@example.com", "Searchable User");
         var query = new GetAllUsersQuery(SearchTerm: "searchable_unique", Page: 1, Limit: 20);
 
-        // Act & Assert - documents known query translation issue
-        var act = async () => await _mediator!.Send(query, TestCancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        var result = await _mediator!.Send(query, TestCancellationToken);
+
+        result.Should().NotBeNull();
+        result.Items.Should().Contain(u => u.Email == "searchable_unique@example.com");
     }
 
     [Fact(Timeout = 30000)]

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/ResolveRuleCommentIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/ResolveRuleCommentIntegrationTests.cs
@@ -387,7 +387,7 @@ public sealed class ResolveRuleCommentIntegrationTests : IAsyncLifetime
         result.IsResolved.Should().BeTrue();
     }
     [Fact]
-    public async Task ResolveNonExistentComment_ThrowsInvalidOperation()
+    public async Task ResolveNonExistentComment_ThrowsNotFoundException()
     {
         // Arrange
         await ResetDatabaseAsync();
@@ -403,8 +403,8 @@ public sealed class ResolveRuleCommentIntegrationTests : IAsyncLifetime
         // Act
         Func<Task> act = async () => await handler.Handle(command, TestCancellationToken);
 
-        // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not found*");
+        // Assert — see CLAUDE.md #2568: exceptions are NotFoundException (404), never InvalidOperationException (500)
+        await act.Should().ThrowAsync<Api.Middleware.Exceptions.NotFoundException>()
+            .WithMessage("*RuleComment*not found*");
     }
 }

--- a/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/EndpointContractTests.cs
@@ -103,6 +103,10 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         // Agent Slots (Issue #417)
         yield return ["GET", "/api/v1/user/agent-slots"];
 
+        // Agents (Issues #654, #655 — handlers implemented in Wave B.2 / β.3)
+        yield return ["POST", "/api/v1/agents/user"];
+        yield return ["POST", "/api/v1/agents/create-with-setup"];
+
         // Contact (public, no auth)
         yield return ["POST", "/api/v1/contact"];
     }
@@ -120,9 +124,9 @@ public sealed class EndpointContractTests : IClassFixture<RouteContractTestFacto
         yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/status",                   "agent status"];
         yield return ["GET",  "/api/v1/agent-typologies",                                                     "typology listing"];
         yield return ["GET",  "/api/v1/agents/recent?limit=10",                                               "recent agents"];
-        yield return ["POST", "/api/v1/agents/user",                                                          "create user agent"];
+        // agents/user: moved to KnownRoutes (Issue #654 — Wave B.2 handler implemented)
         // agent-slots: moved to KnownRoutes (Issue #417 — handler implemented)
-        yield return ["POST", "/api/v1/agents/create-with-setup",                                             "create with setup"];
+        // agents/create-with-setup: moved to KnownRoutes (Issue #655 — Phase β.3 handler implemented)
         yield return ["POST", "/api/v1/agents/quick-create",                                                  "quick create tutor"];
         yield return ["PUT",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configure",                "configure agent"];
         yield return ["GET",  "/api/v1/agents/00000000-0000-0000-0000-000000000001/configuration",            "get agent config"];


### PR DESCRIPTION
## Summary

CI batch A: fixes the 4 stale-assertion test failures on the latest `main-dev` CI run (PR #979).

- **EndpointContractTests** (2): move `POST /api/v1/agents/user` (#654) and `POST /api/v1/agents/create-with-setup` (#655) from `PendingBackendRoutes` to `KnownRoutes`. Handlers landed during Wave B.2 / β.3 — endpoints now return 401, tripping the "implementation detected" guard.
- **ResolveRuleCommentIntegrationTests** (1): rename `ResolveNonExistentComment_ThrowsInvalidOperation` → `ThrowsNotFoundException`. Handler migrated to the CQRS exception model (CLAUDE.md #2568: `NotFoundException` for 404, never `InvalidOperationException`).
- **AdminUserEndpointsIntegrationTests** (1): rename `GetAllUsers_WithSearchTerm_ThrowsQueryTranslationError` → `ReturnsMatchingUsers`. `UserProfileRepository` already uses `EF.Functions.ILike()` (PostgreSQL ILIKE) — translation error no longer occurs.

No production-code changes — tests only.

## Context

Part of a 4-PR CI cleanup series (A → D) addressing failures on the [latest CI run](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25685223108).

| Batch | Scope | Test count |
|-------|-------|------------|
| **A (this PR)** | Stale assertions | 4 |
| B | A11y dark-theme contrast | 26 |
| C | FK violations in integration seed | 3 |
| D | Runtime bugs (SearchChunks 500, BulkImport 1%, EF query, PDF seed) | ~5 |

## Test plan

- [x] `dotnet build apps/api/tests/Api.Tests` — 0 errors, 52 pre-existing warnings (Sonar S927 + analyzer crashes, unrelated)
- [ ] CI: `Backend - Integration (Core)` green for `EndpointContractTests`
- [ ] CI: `Backend - Integration (Games)` green for `ResolveNonExistentComment_*` and `GetAllUsers_WithSearchTerm_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)