### PR TITLE
fix(a11y): CI batch B — dark-mode entity color contrast

### DIFF
--- a/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
+++ b/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
@@ -116,7 +116,7 @@ export function ActionLogTimeline({
               {/* Timestamp */}
               <time
                 dateTime={entry.timestamp}
-                className="shrink-0 tabular-nums text-xs text-slate-600"
+                className="shrink-0 tabular-nums text-xs text-muted-foreground"
               >
                 {formatTime(entry.timestamp)}
               </time>

--- a/apps/web/src/components/features/session-live/DesktopBody.tsx
+++ b/apps/web/src/components/features/session-live/DesktopBody.tsx
@@ -58,7 +58,7 @@ export function DesktopBody({
             className="flex h-full items-center justify-center p-4"
           >
             {/* RightColumnTabs (tools/chat/notes) added in Interactions sub-PR */}
-            <div className="text-center text-xs text-slate-600">Tools, Chat &amp; Notes</div>
+            <div className="text-center text-xs text-muted-foreground">Tools, Chat &amp; Notes</div>
           </div>
         )}
       </aside>

--- a/apps/web/src/components/features/sessions/SessionsHero.tsx
+++ b/apps/web/src/components/features/sessions/SessionsHero.tsx
@@ -45,7 +45,7 @@ export function SessionsHero({ onNewSession, labels, className }: SessionsHeroPr
           <h1 className="text-2xl font-bold tracking-tight text-entity-session sm:text-3xl">
             {labels.title}
           </h1>
-          <p className="text-sm text-slate-600">{labels.subtitle}</p>
+          <p className="text-sm text-muted-foreground">{labels.subtitle}</p>
         </div>
 
         {/* CTA */}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -677,6 +677,21 @@
   --color-neutral-400: hsl(0 0% 34%);
   --color-neutral-600: hsl(0 0% 46%);
 
+  /* Entity color utilities — dark mode overrides.
+     Lighter HSLs to maintain WCAG AA contrast on dark bg (#0f0a1a).
+     Mirrors --c-* tokens in design-tokens.css .dark block.
+     Issue #807 follow-up: A11y dark theme contrast fix (sessions-index, gamebook,
+     session-live, session-summary specs). */
+  --e-game: 28 95% 58%;
+  --e-player: 262 75% 70%;
+  --e-session: 235 70% 70%;
+  --e-agent: 38 92% 62%;
+  --e-document: 174 60% 55%;
+  --e-chat: 218 80% 68%;
+  --e-event: 350 85% 70%;
+  --e-toolkit: 142 60% 58%;
+  --e-tool: 195 75% 62%;
+
   /* NOTE: --bg-base, --bg-elevated, --text-primary, --text-secondary, --text-tertiary
      are unified tokens from design-tokens.css. Do NOT redefine here. */
   --bg-primary: var(--bg-base);


### PR DESCRIPTION
## Summary

CI batch B: addresses **26 axe-core color-contrast violations** on dark theme reported by the Frontend A11y E2E job in the [latest CI run](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25685223108).

Affected specs:
- `sessions-index.spec.ts` (2 tests)
- `session-live.spec.ts` (4 tests)
- `session-summary.spec.ts` (7 tests)
- `gamebook-index.spec.ts` (6 tests)
- `gamebook-upload.spec.ts` (6 tests + 1 placeholder)

## Root cause

The `--e-*` entity tokens in `globals.css :root` use dark HSL lightness (35–45%) tuned for **light-mode** AA contrast on the beige bg. The `.dark` block was missing overrides for these tokens entirely, so on dark bg (#0f0a1a) `text-entity-session` resolved to **#24248f → 1.59:1** contrast (large text needs 3:1).

The companion `--c-*` tokens in `design-tokens.css` already had proper dark overrides (lightness 55-70%) — `globals.css` just had to mirror them for the `text-entity-*` Tailwind utility consumers.

A secondary issue: hard-coded `text-slate-600` (#475569) in three components has no dark-mode counterpart and fails 4.5:1 against dark bg.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/styles/globals.css` | Add `--e-*` overrides in `.dark` block for all 9 entities |
| `apps/web/src/components/features/sessions/SessionsHero.tsx` | `text-slate-600` → `text-muted-foreground` |
| `apps/web/src/components/features/session-live/ActionLogTimeline.tsx` | `text-slate-600` → `text-muted-foreground` |
| `apps/web/src/components/features/session-live/DesktopBody.tsx` | `text-slate-600` → `text-muted-foreground` |

## Out of scope (follow-up)

Many other components hard-code `text-slate-700/600/500` in feature dirs (especially `gamebook/*`). These weren't called out in the failing test error contexts I inspected, so leaving them for a dedicated A11y audit follow-up. If CI still has color-contrast failures after this PR merges, we'll widen the scope.

When this PR lands and CI is green on `main-dev`, the **`Frontend - A11y E2E` job can be moved back to blocking** (`continue-on-error: false`) per the CLAUDE.md note about #807/#876.

## Context

Batch B of a 4-PR CI cleanup series. Batch A (#1034) is open; C and D follow.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] Existing `entity-theme-tokens.test.ts` still passes (uses `toContain`, tolerant of duplicates)
- [ ] CI: `Frontend - A11y E2E` green for the 26 failing tests
- [ ] Manual: visual check that dark-mode entity colors still match design intent (lighter on dark bg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)