### PR TITLE
fix(test): CI batch C — seed FK targets for document_collections + certification_thresholds_config

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/CertificationThresholdsConfigRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/CertificationThresholdsConfigRepositoryIntegrationTests.cs
@@ -79,9 +79,10 @@ public sealed class CertificationThresholdsConfigRepositoryIntegrationTests : IA
     [Fact]
     public async Task UpdateAsync_PersistsNewThresholdsAndAuditFields()
     {
-        // Arrange
+        // Arrange: migration M2_0 declares updated_by_user_id REFERENCES users(Id) ON DELETE SET NULL,
+        // so the actor user must exist before SaveChanges runs.
+        var actor = await SeedUserAsync(_dbContext);
         var loaded = await _repository.GetAsync();
-        var actor = Guid.NewGuid();
         var newThresholds = CertificationThresholds.Create(
             minCoveragePct: 85m,
             maxPageTolerance: 5,
@@ -136,6 +137,9 @@ public sealed class CertificationThresholdsConfigRepositoryIntegrationTests : IA
     public async Task ConcurrentUpdate_ThrowsDbUpdateConcurrencyException()
     {
         // Arrange: open two parallel contexts against the same row.
+        // FK updated_by_user_id REFERENCES users(Id) — seed a real user shared by both writes.
+        var actorId = await SeedUserAsync(_dbContext);
+
         await using var ctxA = _fixture.CreateDbContext(_connectionString);
         await using var ctxB = _fixture.CreateDbContext(_connectionString);
 
@@ -150,8 +154,8 @@ public sealed class CertificationThresholdsConfigRepositoryIntegrationTests : IA
         var copyA = await repoA.GetAsync();
         var copyB = await repoB.GetAsync();
 
-        copyA.Update(CertificationThresholds.Create(75m, 8, 82m, 65m), Guid.NewGuid());
-        copyB.Update(CertificationThresholds.Create(88m, 3, 92m, 78m), Guid.NewGuid());
+        copyA.Update(CertificationThresholds.Create(75m, 8, 82m, 65m), actorId);
+        copyB.Update(CertificationThresholds.Create(88m, 3, 92m, 78m), actorId);
 
         // Act: first write wins — xmin advances; second write sees stale xmin.
         await repoA.UpdateAsync(copyA);
@@ -162,5 +166,17 @@ public sealed class CertificationThresholdsConfigRepositoryIntegrationTests : IA
 
         // Assert
         await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext ctx)
+    {
+        var userId = Guid.NewGuid();
+        ctx.Users.Add(new Api.Infrastructure.Entities.UserEntity
+        {
+            Id = userId,
+            Email = $"actor-{userId:N}@test.local",
+        });
+        await ctx.SaveChangesAsync();
+        return userId;
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DocumentCollectionUserRestrictionTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DocumentCollectionUserRestrictionTests.cs
@@ -158,10 +158,15 @@ public class DocumentCollectionUserRestrictionTests : IAsyncLifetime
         var userId = Guid.NewGuid();
         var user = new UserEntity { Id = userId, Email = "cleanup@test.com", DisplayName = "Cleanup", Role = "User" };
         var gameId = Guid.NewGuid();
-        var game = new GameEntity { Id = gameId, Name = "Pandemic" };
+        // DocumentCollection.SharedGameId FKs to shared_games (not games), so seed a SharedGameEntity.
+        var sharedGame = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Pandemic",
+        };
 
         _dbContext!.Users.Add(user);
-        _dbContext.Games.Add(game);
+        _dbContext.SharedGames.Add(sharedGame);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var collectionId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

CI batch C: addresses **3 FK constraint violations** in integration tests on the [latest CI run](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25685223108). Both root causes are migration-level SQL FKs that are invisible to the EF entity configurations.

### 1. `DocumentCollectionUserRestrictionTests.DeleteDocumentCollection_ThenDeleteUser_Succeeds`

The test seeded a `GameEntity` (`games` table), but `DocumentCollection.SharedGameId` FKs to **`shared_games`** (per `DocumentCollectionEntityConfiguration`). So the collection insert blew up on `FK_document_collections_shared_games_SharedGameId`.

Fix: seed a `SharedGameEntity` instead of `GameEntity`.

The earlier `DeleteUser_With*` tests in the same file have the same wrong seed but happen to pass because they catch *any* exception expecting an FK-restrict outcome. Left them alone to keep this PR minimal.

### 2. `CertificationThresholdsConfigRepositoryIntegrationTests` (2 tests)

Both tests passed `Guid.NewGuid()` as the audit actor. The EF entity config has **no FK declared** (and its comment claims "No FKs"), but migration `M2_0_MechanicGoldenAndValidation` adds via raw SQL:

```sql
updated_by_user_id uuid NULL REFERENCES users("Id") ON DELETE SET NULL
```

So a random Guid fails `certification_thresholds_config_updated_by_user_id_fkey` at save time.

Fix: small `SeedUserAsync` helper, use the real user id as the actor.

## Out of scope

The EF config/migration mismatch is a design smell (the EF model says "no FK" but the DB has one). Fixing that properly would require either:
- adding `HasOne<UserEntity>().WithMany().HasForeignKey(c => c.UpdatedByUserId).OnDelete(DeleteBehavior.SetNull);` to the EF config, **and** the EF migration scaffolder generating a compatible new migration, or
- dropping the SQL FK via a new migration.

Both are wider than this CI fix. Per CLAUDE.md #2620: "FK constraints: seed dependent entities first" — that's what this PR does.

## Context

Batch C of a 4-PR CI cleanup series. Batches A (#1034) and B (#1035) are open; D is next.

## Test plan

- [x] `dotnet build apps/api/tests/Api.Tests` — 0 errors, 52 pre-existing warnings
- [ ] CI: `Backend - Integration (KnowledgeBase)` green for `DeleteDocumentCollection_ThenDeleteUser_Succeeds`
- [ ] CI: `Backend - Integration (Games)` green for the two `CertificationThresholdsConfig*` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)