### PR TITLE
fix(test): CI batch D — EF string.Equals translation + PdfSeeder SharedGame link

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicGoldenBggTagRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicGoldenBggTagRepositoryIntegrationTests.cs
@@ -147,9 +147,10 @@ public sealed class MechanicGoldenBggTagRepositoryIntegrationTests : IAsyncLifet
         await _dbContext.SaveChangesAsync();
         _dbContext.ChangeTracker.Clear();
 
+        // EF/Npgsql cannot translate string.Equals(..., StringComparison.Ordinal).
+        // Use the operator overload — PostgreSQL `=` is ordinal/case-sensitive for text.
         var target = await _dbContext.MechanicGoldenBggTags.AsNoTracking()
-            .FirstAsync(t => t.SharedGameId == sharedGameId
-                && string.Equals(t.Name, "Fantasy", StringComparison.Ordinal));
+            .FirstAsync(t => t.SharedGameId == sharedGameId && t.Name == "Fantasy");
 
         // Act
         await _repository.DeleteAsync(target.Id);

--- a/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
@@ -36,14 +36,25 @@ public sealed class SeedCatalogBlobIntegrationTests
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
 
         var gameEntityId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
         const int bggId = 96848;
 
+        // PdfSeeder filters Games by `SharedGameId != null` (see Catalog/PdfSeeder.cs#L72),
+        // so the test must mirror what GameSeeder produces in prod: a SharedGameEntity
+        // row linked from GameEntity.SharedGameId. Without it, gameIdToSharedId is empty
+        // and every manifest entry gets skipped → 0 PdfDocumentEntity rows created.
+        db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = "Mage Knight Board Game",
+        });
         db.Games.Add(new GameEntity
         {
             Id = gameEntityId,
             Name = "Mage Knight Board Game",
             CreatedAt = DateTime.UtcNow,
             BggId = bggId,
+            SharedGameId = sharedGameId,
         });
         await db.SaveChangesAsync();
 
@@ -132,10 +143,16 @@ public sealed class SeedCatalogBlobIntegrationTests
 
         var bcGameId = Guid.NewGuid();
         var mkGameId = Guid.NewGuid();
+        var bcSharedId = Guid.NewGuid();
+        var mkSharedId = Guid.NewGuid();
 
+        // PdfSeeder requires Game.SharedGameId to be populated — see EndToEndSingleGame test for rationale.
+        db.SharedGames.AddRange(
+            new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = bcSharedId, Title = "Barrage" },
+            new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = mkSharedId, Title = "Mage Knight Board Game" });
         db.Games.AddRange(
-            new GameEntity { Id = bcGameId, Name = "Barrage", CreatedAt = DateTime.UtcNow, BggId = 251247 },
-            new GameEntity { Id = mkGameId, Name = "Mage Knight Board Game", CreatedAt = DateTime.UtcNow, BggId = 96848 });
+            new GameEntity { Id = bcGameId, Name = "Barrage", CreatedAt = DateTime.UtcNow, BggId = 251247, SharedGameId = bcSharedId },
+            new GameEntity { Id = mkGameId, Name = "Mage Knight Board Game", CreatedAt = DateTime.UtcNow, BggId = 96848, SharedGameId = mkSharedId });
         await db.SaveChangesAsync();
 
         var manifest = new SeedManifest
@@ -207,12 +224,20 @@ public sealed class SeedCatalogBlobIntegrationTests
         using var db = TestDbContextFactory.CreateInMemoryDbContext();
 
         var gameEntityId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        // PdfSeeder requires Game.SharedGameId to be populated — see EndToEndSingleGame test for rationale.
+        db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = "Barrage",
+        });
         db.Games.Add(new GameEntity
         {
             Id = gameEntityId,
             Name = "Barrage",
             CreatedAt = DateTime.UtcNow,
             BggId = 251247,
+            SharedGameId = sharedGameId,
         });
         await db.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary

CI batch D (**partial — 2 of 4 issues**, see Out of scope) on the [latest CI run](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25685223108).

### 1. `MechanicGoldenBggTagRepositoryIntegrationTests.DeleteAsync_RemovesSingleTag`

The test crashed with:

> Translation of the 'string.Equals' overload with a 'StringComparison' parameter is not supported

EF/Npgsql cannot translate `string.Equals(., StringComparison.Ordinal)`. PostgreSQL `=` on text is already ordinal/case-sensitive, so the operator overload works without explicit comparison. The post-query in-memory equality check is unchanged (runs client-side over a `List<T>`).

### 2. `SeedCatalogBlobIntegrationTests` (3 tests)

- `PdfSeeder_EndToEndSingleGame_CreatesPdfDocumentLinkedToGameEntity`
- `PdfSeeder_EndToEndMultipleGames_ProcessesAllAndSkipsMissingBggId`
- `PdfSeeder_Reseed_IsIdempotentAndDoesNotCreateDuplicates`

All three failed with `Expected pdfs to contain N item(s), but found 0`. Root cause: `PdfSeeder` filters `Games` by `SharedGameId != null` to build the `gameId → sharedGameId` lookup ([`Catalog/PdfSeeder.cs#L72-77`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs#L72-L77)). The tests seeded `GameEntity` rows without setting `SharedGameId`, so the lookup was empty and every manifest entry got skipped before insertion.

Fix: seed a `SharedGameEntity` row in each test and link `GameEntity.SharedGameId`. Mirrors what `GameSeeder` produces in prod.

## Out of scope (deferred follow-ups)

Two runtime bugs from the failure list need deeper investigation and are intentionally left for dedicated PRs:

| Test | Symptom | Why deferred |
|------|---------|--------------|
| `KbChunkEndpointsIntegrationTests.SearchChunks_*` (3 tests) | 500 Internal Server Error | Likely a seed-side `search_vector` population issue or a Postgres FTS function availability gap on the CI image. Speculative fix could regress prod — needs actual server logs. |
| `BulkUserOperationsE2ETests.E2E_BulkImport_With100Users` | 1/100 success rate | Per-record failure path (likely `PasswordHash.Create` or `UserRepository.AddAsync` domain-event collection). Can't reproduce without the full integration suite running. Needs a focused repro PR with added logging. |

## Context

Batch D of a 4-PR CI cleanup series. Earlier batches: #1034 (A), #1035 (B), #1036 (C).

## Test plan

- [x] `dotnet build apps/api/tests/Api.Tests` — 0 errors, 52 pre-existing warnings
- [ ] CI: `Backend - Integration (Games)` green for `DeleteAsync_RemovesSingleTag`
- [ ] CI: `Backend - Integration (Core)` green for the 3 `PdfSeeder_*` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)