### PR TITLE
fix(test): CI batch C2 — seed SharedGameEntity in KB+DocCollection FK tests

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DocumentCollectionRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DocumentCollectionRepositoryIntegrationTests.cs
@@ -312,6 +312,12 @@ public sealed class DocumentCollectionRepositoryIntegrationTests : IAsyncLifetim
         await _dbContext.SaveChangesAsync(TestCancellationToken);
 
         var game1Id = Guid.NewGuid();
+        // DocumentCollection.SharedGameId FKs to shared_games (see SeedTestDataAsync).
+        _dbContext.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = game1Id,
+            Title = "Test Game 1 for Ordering",
+        });
         var game1 = new GameEntity { Id = game1Id, Name = "Test Game 1 for Ordering" };
         _dbContext.Games.Add(game1);
         await _dbContext.SaveChangesAsync(TestCancellationToken);
@@ -328,6 +334,11 @@ public sealed class DocumentCollectionRepositoryIntegrationTests : IAsyncLifetim
         await Task.Delay(TimeSpan.FromMilliseconds(100), TestCancellationToken); // Ensure different timestamps
 
         var game2Id = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = game2Id,
+            Title = "Test Game 2 for Ordering",
+        });
         var game2 = new GameEntity { Id = game2Id, Name = "Test Game 2 for Ordering" };
         _dbContext!.Games.Add(game2);
         await _dbContext.SaveChangesAsync(TestCancellationToken);
@@ -554,7 +565,20 @@ public sealed class DocumentCollectionRepositoryIntegrationTests : IAsyncLifetim
         };
         _dbContext!.Users.Add(testUser);
 
-        // Create test games
+        // Create test games.
+        // DocumentCollection.SharedGameId FKs to shared_games (not games), so
+        // seed a SharedGameEntity with the same GUID — this satisfies the FK
+        // without changing existing test fixture IDs.
+        _dbContext.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = TestGameId1,
+            Title = "Test Game 1",
+        });
+        _dbContext.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity
+        {
+            Id = TestGameId2,
+            Title = "Test Game 2",
+        });
         var game1 = new GameEntity
         {
             Id = TestGameId1,

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ChatThreadCollectionForeignKeyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ChatThreadCollectionForeignKeyTests.cs
@@ -47,9 +47,14 @@ public class ChatThreadCollectionForeignKeyTests : IAsyncLifetime
         var userId = Guid.NewGuid();
         var user = new UserEntity { Id = userId, Email = "user@test.com", DisplayName = "User", Role = "User" };
         var gameId = Guid.NewGuid();
+        // DocumentCollection.SharedGameId FKs to shared_games — same GUID
+        // doubles as PK on both rows so the existing ChatThread.GameId references
+        // to `games` keep working alongside the FK on shared_games.
+        var sharedGame = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = gameId, Title = "Gloomhaven" };
         var game = new GameEntity { Id = gameId, Name = "Gloomhaven" };
 
         _dbContext!.Users.Add(user);
+        _dbContext.SharedGames.Add(sharedGame);
         _dbContext.Games.Add(game);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -107,9 +112,11 @@ public class ChatThreadCollectionForeignKeyTests : IAsyncLifetime
         var userId = Guid.NewGuid();
         var user = new UserEntity { Id = userId, Email = "user@test.com", DisplayName = "User", Role = "User" };
         var gameId = Guid.NewGuid();
+        var sharedGame = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = gameId, Title = "Wingspan" };
         var game = new GameEntity { Id = gameId, Name = "Wingspan" };
 
         _dbContext!.Users.Add(user);
+        _dbContext.SharedGames.Add(sharedGame);
         _dbContext.Games.Add(game);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -163,13 +170,18 @@ public class ChatThreadCollectionForeignKeyTests : IAsyncLifetime
     [Fact]
     public async Task DeleteGame_WithCompleteChain_CascadesCorrectly()
     {
-        // Arrange - Complex cascade: Game → Collection → Junction (ChatThread remains)
+        // Arrange - Complex cascade: SharedGame → Collection → Junction (ChatThread remains).
+        // DocumentCollection.SharedGameId FKs to shared_games with CASCADE (see
+        // DocumentCollectionEntityConfiguration), so removing the SharedGame
+        // triggers the chain. The GameEntity row is incidental here.
         var userId = Guid.NewGuid();
         var user = new UserEntity { Id = userId, Email = "user@test.com", DisplayName = "User", Role = "User" };
         var gameId = Guid.NewGuid();
+        var sharedGame = new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = gameId, Title = "Azul" };
         var game = new GameEntity { Id = gameId, Name = "Azul" };
 
         _dbContext!.Users.Add(user);
+        _dbContext.SharedGames.Add(sharedGame);
         _dbContext.Games.Add(game);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -187,8 +199,10 @@ public class ChatThreadCollectionForeignKeyTests : IAsyncLifetime
         _dbContext.ChatThreadCollections.Add(junction);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Act - Delete game (Game → Collection → Junction cascade)
-        _dbContext.Games.Remove(game);
+        // Act - Delete SharedGame (SharedGame → Collection → Junction cascade).
+        // Note: GameEntity is left intact; ChatThread.GameId references `games`
+        // and is NOT part of the cascade chain (deliberately decoupled).
+        _dbContext.SharedGames.Remove(sharedGame);
         await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Assert - Collection and junction deleted, thread remains


### PR DESCRIPTION
## Summary

Follow-up to **#1036**. The previous PR fixed the same FK violation in `DocumentCollectionUserRestrictionTests` + `CertificationThresholdsConfig*`, but the [latest CI run](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25693769790) revealed **11+ more tests** in `ChatThreadCollectionForeignKeyTests` and `DocumentCollectionRepositoryIntegrationTests` failing with the same exception:

```
Npgsql.PostgresException : 23503: insert or update on table "document_collections"
violates foreign key constraint "FK_document_collections_shared_games_SharedGameId"
```

These were hidden by the timeout in the previous run.

## Root cause (same as #1036)

`DocumentCollection.SharedGameId` FKs to `shared_games` (see `DocumentCollectionEntityConfiguration.cs:29-32`), but the tests seeded only `GameEntity` rows in the `games` table.

## Fix

### 1. `ChatThreadCollectionForeignKeyTests` (3 tests)
Each test now seeds a `SharedGameEntity` with the same GUID as `GameEntity` so the FK resolves while keeping `ChatThread.GameId` references intact:
- `DeleteChatThread_WithCollectionJunction_CascadesDelete`
- `DeleteDocumentCollection_WithChatThreadJunction_CascadesDelete`
- `DeleteGame_WithCompleteChain_CascadesCorrectly` — **semantic fix**: the cascade chain is SharedGame → Collection → Junction, not Game → Collection. The test now removes the SharedGameEntity, leaving GameEntity intact (decoupled from this cascade chain).

### 2. `DocumentCollectionRepositoryIntegrationTests` (8+ tests)
Added `SharedGameEntity` seeding in:
- `SeedTestDataAsync` (singleton helper, fixes 6+ tests reusing `TestGameId1` / `TestGameId2`)
- `FindByUserIdAsync_OrderByCreatedAtDescending` (inline game1/game2 seed)

## Test plan

- [x] `dotnet build apps/api/tests/Api.Tests` — 0 errors
- [ ] CI: `Backend - Integration (KnowledgeBase)` green for all `ChatThreadCollectionFKTests` + `DocumentCollectionRepositoryIntegrationTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)