### PR TITLE
fix(test): CI batch D2 — PdfSeeder assertion expects SharedGameId

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
@@ -115,8 +115,12 @@ public sealed class SeedCatalogBlobIntegrationTests
         savedPdfs.Should().ContainSingle();
 
         var pdf = savedPdfs[0];
-        pdf.SharedGameId.Should().Be(gameEntityId,
-            "PdfSeeder links the PDF to the shared game catalog entry");
+        // PdfDocumentEntity.SharedGameId resolves to the SharedGameEntity.Id
+        // (not GameEntity.Id) — PdfSeeder reads gameIdToSharedId[gameId] from
+        // Games.SharedGameId. Post-2026-04-19 migration this is the canonical
+        // foreign key on pdf_documents.
+        pdf.SharedGameId.Should().Be(sharedGameId,
+            "PdfSeeder links the PDF to the SharedGameEntity catalog entry");
         pdf.FileName.Should().Be("mage-knight_rulebook.pdf");
         pdf.ContentHash.Should().Be("sha256-deadbeef-integration-test");
         pdf.Language.Should().Be("en");


### PR DESCRIPTION
## Summary

Follow-up to **#1038**. The previous PR added `SharedGameEntity` seeding so `PdfSeeder` could resolve `gameId → sharedGameId`, but the test then failed at the assertion stage:

```
Expected pdf.SharedGameId to be {fdd28091...} (gameEntityId),
                  but found {06499f30...} (sharedGameId)
```

## Root cause

`PdfSeeder` reads `gameIdToSharedId[gameId]` from `Games.SharedGameId` to populate `PdfDocumentEntity.SharedGameId`. Post-2026-04-19 migration that field is the canonical FK on `pdf_documents` pointing to `shared_games.Id`, **not** `games.Id`. The assertion was still comparing against `gameEntityId`.

## Fix

One-liner change in `PdfSeeder_EndToEndSingleGame_CreatesPdfDocumentLinkedToGameEntity`:
- `pdf.SharedGameId.Should().Be(sharedGameId, ...)` (was `gameEntityId`)
- Added a comment explaining the mapping for future readers.

The multi-game and reseed tests assert by `FileName` only, so they're unaffected.

## Test plan

- [ ] CI: `Backend - Integration (Core)` green for `PdfSeeder_EndToEndSingleGame_CreatesPdfDocumentLinkedToGameEntity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)