### PR TITLE
feat(design-system): import mockup tokens + bridge alias (DS-1)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,6 +13,13 @@ import { Quicksand, Nunito } from 'next/font/google';
 import { AppProviders } from './providers';
 
 import type { Metadata, Viewport } from 'next';
+// Token system load order (DS-1, 2026-05-12-token-canonicalization.md):
+//   1. design-tokens-canonical.css — single source of truth (mockup-faithful)
+//   2. token-bridge.css            — v1 → canonical aliases (removed in DS-12)
+//   3. globals.css                 — Tailwind layer + component utilities
+//   4. domain-specific stylesheets
+import '../styles/design-tokens-canonical.css';
+import '../styles/token-bridge.css';
 import '../styles/globals.css';
 import '../styles/diff-viewer.css';
 import '../styles/agent-theme.css';
@@ -64,8 +71,11 @@ export const viewport: Viewport = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // SSR theme hint (DS-1): `data-theme="light"` matches the mockup default.
+  // next-themes will rewrite this attribute client-side based on user
+  // preference / localStorage. The hint prevents FOUC on first paint.
   return (
-    <html lang="it" suppressHydrationWarning>
+    <html lang="it" data-theme="light" suppressHydrationWarning>
       <body className={`${quicksand.variable} ${nunito.variable}`} suppressHydrationWarning>
         <AppProviders>{children}</AppProviders>
       </body>

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -21,8 +21,18 @@ export type ThemeProviderProps = NextThemesProviderProps;
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
     <NextThemesProvider
-      attribute="class"
-      defaultTheme="dark"
+      // DS-1 (2026-05-12 token canonicalization):
+      // - attribute={['class', 'data-theme']} applies BOTH `class="dark"` and
+      //   `data-theme="dark"` on <html>. This keeps backwards compatibility
+      //   with the ~80 legacy `.dark .foo` selectors in globals.css /
+      //   design-tokens.css while enabling the canonical mockup convention
+      //   (admin-mockups/design_files/tokens.css uses [data-theme="light|dark"]).
+      //   Bridge removed in DS-12 once all legacy `.dark` selectors migrate.
+      // - defaultTheme="light" — mockup default warm cream (#f7f3ee).
+      //   Previously dark-first via legacy gaming palette; now the canonical
+      //   light theme is authoritative.
+      attribute={['class', 'data-theme']}
+      defaultTheme="light"
       enableSystem
       disableTransitionOnChange={false}
       {...props}

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -1,0 +1,193 @@
+/* ============================================================================
+ * MeepleAI Design Tokens — CANONICAL (mockup-faithful)
+ *
+ * Single source of truth: admin-mockups/design_files/tokens.css
+ * Date imported: 2026-05-12 (DS-1, spec: 2026-05-12-token-canonicalization.md)
+ *
+ * IMPORTANT — DS-1 transitional state:
+ *   This file is the authoritative token source. Legacy tokens in
+ *   `globals.css` / `design-tokens.css` / `premium-gaming.css` are now
+ *   bridged aliases pointing here (see token-bridge.css).
+ *   Bridge layer will be removed in DS-12 once all clusters are migrated.
+ *
+ * Theming mechanism: [data-theme="light|dark"] attribute on <html>
+ * (set by next-themes; SSR default = "light" — mockup convention).
+ *
+ * Reset / typography base rules from the mockup are OMITTED here to avoid
+ * conflicts with globals.css base layer. Only token declarations are kept.
+ * ============================================================================ */
+
+:root {
+  /* ─── Entity Colors (HSL triplets for alpha composability) ─── */
+  --c-game:    25 95% 45%;
+  --c-player:  262 83% 58%;
+  --c-session: 240 60% 55%;
+  --c-agent:   38 92% 50%;
+  --c-kb:      174 60% 40%;
+  --c-chat:    220 80% 55%;
+  --c-event:   350 89% 60%;
+  --c-toolkit: 142 70% 45%;
+  --c-tool:    195 80% 50%;
+
+  /* ─── Semantic Colors ─── */
+  --c-success: 142 70% 45%;
+  --c-warning: 38 92% 50%;
+  --c-danger:  350 89% 60%;
+  --c-info:    220 80% 55%;
+
+  /* ─── Brand ─── */
+  --brand: var(--c-game);
+  --brand-fg: hsl(var(--c-game));
+
+  /* ─── Typography ─── */
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body:    'Nunito', system-ui, sans-serif;
+  --f-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --fs-xs:   11px;
+  --fs-sm:   12px;
+  --fs-base: 14px;
+  --fs-md:   15px;
+  --fs-lg:   17px;
+  --fs-xl:   20px;
+  --fs-2xl:  24px;
+  --fs-3xl:  32px;
+  --fs-4xl:  40px;
+
+  --fw-reg:  400;
+  --fw-med:  500;
+  --fw-semi: 600;
+  --fw-bold: 700;
+  --fw-ext:  800;
+
+  --lh-tight: 1.2;
+  --lh-snug:  1.35;
+  --lh-body:  1.5;
+  --lh-relax: 1.65;
+
+  /* ─── Spacing (4px grid) ─── */
+  --s-0: 0;
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-7: 32px;
+  --s-8: 40px;
+  --s-9: 48px;
+  --s-10: 64px;
+
+  /* ─── Radius ─── */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 18px;
+  --r-2xl: 24px;
+  --r-pill: 9999px;
+
+  /* ─── Motion ─── */
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+  --ease-in-out: cubic-bezier(.65, 0, .35, 1);
+  --ease-spring: cubic-bezier(.34, 1.56, .64, 1);
+  --dur-xs: 120ms;
+  --dur-sm: 180ms;
+  --dur-md: 280ms;
+  --dur-lg: 400ms;
+  --dur-xl: 600ms;
+
+  /* ─── Z-index ─── */
+  --z-base: 0;
+  --z-sticky: 10;
+  --z-nav: 20;
+  --z-overlay: 50;
+  --z-drawer: 51;
+  --z-modal: 60;
+  --z-toast: 70;
+  --z-tooltip: 80;
+}
+
+/* ─── LIGHT THEME (default) ─── */
+:root,
+:root[data-theme="light"] {
+  --bg:        #f7f3ee;
+  --bg-card:   #ffffff;
+  --bg-muted:  #efe6d9;
+  --bg-sunken: #ede2d0;
+  --bg-hover:  rgba(180, 130, 80, 0.06);
+
+  --text:       #2b1f12;
+  --text-sec:   #5a4a38;
+  --text-muted: #9a8870;
+
+  --border:       rgba(180, 130, 80, 0.18);
+  --border-light: rgba(180, 130, 80, 0.1);
+  --border-strong: rgba(180, 130, 80, 0.32);
+
+  --shadow-xs: 0 1px 2px rgba(90, 60, 20, 0.06);
+  --shadow-sm: 0 2px 8px rgba(90, 60, 20, 0.08);
+  --shadow-md: 0 4px 16px rgba(90, 60, 20, 0.1);
+  --shadow-lg: 0 12px 36px rgba(90, 60, 20, 0.14);
+  --shadow-drawer: 0 -8px 32px rgba(90, 60, 20, 0.12);
+
+  --glass-bg: rgba(255, 255, 255, 0.88);
+  --glass-border: rgba(255, 255, 255, 0.6);
+
+  color-scheme: light;
+}
+
+/* ─── DARK THEME ─── */
+:root[data-theme="dark"] {
+  --bg:        #14100a;
+  --bg-card:   #1e1710;
+  --bg-muted:  #241c13;
+  --bg-sunken: #0f0c08;
+  --bg-hover:  rgba(255, 200, 130, 0.05);
+
+  --text:       #f0e4d2;
+  --text-sec:   #c8b896;
+  --text-muted: #8a7860;
+
+  --border:       rgba(224, 180, 110, 0.14);
+  --border-light: rgba(224, 180, 110, 0.08);
+  --border-strong: rgba(224, 180, 110, 0.28);
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6);
+  --shadow-drawer: 0 -8px 32px rgba(0, 0, 0, 0.5);
+
+  --glass-bg: rgba(30, 22, 14, 0.85);
+  --glass-border: rgba(224, 180, 110, 0.14);
+
+  /* lighter entity colors for dark bg contrast */
+  --c-game:    28 95% 58%;
+  --c-player:  262 75% 70%;
+  --c-session: 235 70% 70%;
+  --c-agent:   38 92% 62%;
+  --c-kb:      174 60% 55%;
+  --c-chat:    218 80% 68%;
+  --c-event:   350 85% 70%;
+  --c-toolkit: 142 60% 58%;
+  --c-tool:    195 75% 62%;
+
+  color-scheme: dark;
+}
+
+/* ─── Entity utility classes (mockup) ─── */
+.e-game    { --e: var(--c-game); }
+.e-player  { --e: var(--c-player); }
+.e-session { --e: var(--c-session); }
+.e-agent   { --e: var(--c-agent); }
+.e-kb      { --e: var(--c-kb); }
+.e-chat    { --e: var(--c-chat); }
+.e-event   { --e: var(--c-event); }
+.e-toolkit { --e: var(--c-toolkit); }
+.e-tool    { --e: var(--c-tool); }
+
+.e-fg   { color: hsl(var(--e)); }
+.e-bg   { background: hsl(var(--e)); color: #fff; }
+.e-tint { background: hsl(var(--e) / 0.1); color: hsl(var(--e)); }
+.e-ring { box-shadow: 0 0 0 2px hsl(var(--e) / 0.35); }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -6,7 +6,10 @@
 @import "./design-tokens.css";
 @import "./premium-gaming.css";
 
-@custom-variant dark (&:is(.dark *));
+/* DS-1 (2026-05-12 token canonicalization): dark variant honours both
+ * the legacy `.dark` class (compat) and the canonical `[data-theme="dark"]`
+ * attribute (now set by next-themes — see ThemeProvider.tsx). */
+@custom-variant dark (&:is(.dark *, [data-theme="dark"] *));
 
 @theme {
   /* Remove all brand color shade references - migrating to semantic tokens */
@@ -622,7 +625,9 @@
   --font-weight-bold: var(--font-bold);
 }
 
-.dark {
+/* DS-1: dual selector — `.dark` (legacy class) OR `[data-theme="dark"]`
+ * (canonical attribute set by next-themes per ThemeProvider.tsx). */
+:is(.dark, [data-theme="dark"]) {
   /* Base theme tokens - Dark Professional (Issue #2965) */
   --background: 0 0% 10%;           /* #1a1a1a - Neutral dark gray */
   --foreground: 30 25% 90%;         /* #e8e4d8 - Warm beige text */

--- a/apps/web/src/styles/token-bridge.css
+++ b/apps/web/src/styles/token-bridge.css
@@ -1,0 +1,106 @@
+/* ============================================================================
+ * Token Bridge Layer — v1 → canonical
+ *
+ * Date: 2026-05-12 (DS-1, spec: 2026-05-12-token-canonicalization.md)
+ *
+ * PURPOSE
+ *   Maps legacy CSS custom property names (used across the existing component
+ *   base) to the canonical tokens declared in `design-tokens-canonical.css`.
+ *   This allows consumer-by-consumer migration without a big-bang refactor.
+ *
+ * REMOVAL
+ *   This file will be deleted in DS-12 once all cluster migrations land and
+ *   `pnpm lint:tokens` reports 0 violations across `apps/web/src/`.
+ *
+ * NAMING RULE
+ *   Each alias points to a canonical token. If a runtime token has no
+ *   direct mapping, it stays declared in its original file
+ *   (`globals.css`/`design-tokens.css`) until its cluster is migrated.
+ *
+ * THEMING
+ *   Aliases are :root-scoped (light-default). Dark overrides cascade
+ *   automatically via the canonical tokens themselves (already keyed on
+ *   `[data-theme="dark"]`).
+ *
+ * See: `docs/for-developers/frontend/token-bridge-map.md` for full mapping
+ * and migration status per consumer.
+ * ============================================================================ */
+
+:root {
+  /* ─── Background (v1 runtime → canonical) ─── */
+  --bg-base: var(--bg);
+  --bg-elevated: var(--bg-card);
+  --bg-surface: var(--bg-card);
+  --bg-sunken-runtime: var(--bg-sunken);     /* hyphen avoids collision with canonical */
+
+  /* shadcn-style semantics — keep names for component compat */
+  --background: var(--bg);
+  --foreground: var(--text);
+  --card: var(--bg-card);
+  --card-foreground: var(--text);
+  --popover: var(--bg-card);
+  --popover-foreground: var(--text);
+  --muted: var(--bg-muted);
+  --muted-foreground: var(--text-muted);
+
+  /* ─── Text (v1 runtime → canonical) ─── */
+  --text-primary: var(--text);
+  --text-secondary: var(--text-sec);
+  --text-tertiary: var(--text-muted);
+
+  /* ─── nh-* warm palette aliases ─── */
+  --nh-bg-base: var(--bg);
+  --nh-bg-surface: var(--bg-card);
+  --nh-bg-surface-end: var(--bg-muted);
+  --nh-bg-elevated: var(--bg-card);
+  --nh-text-primary: var(--text);
+  --nh-text-secondary: var(--text-sec);
+  --nh-text-muted: var(--text-muted);
+  --nh-border-default: var(--border);
+
+  /* ─── premium-gaming aliases (legacy "gaming" palette) ─── */
+  --gaming-bg-base: var(--bg);
+  --gaming-bg-elevated: var(--bg-card);
+  --gaming-bg-glass: var(--glass-bg);
+  --gaming-text-primary: var(--text);
+  --gaming-text-secondary: var(--text-sec);
+  --gaming-text-tertiary: var(--text-muted);
+  --gaming-text-accent: var(--brand-fg);
+  --gaming-border-glass: var(--glass-border);
+
+  /* ─── Glass effects ─── */
+  --bg-glass: var(--glass-bg);
+  --border-glass: var(--glass-border);
+
+  /* ─── Border ─── */
+  --border-primary: var(--border);
+  --border-secondary: var(--border-strong);
+
+  /* ─── Entity color compat (--e-* → --c-*)
+     Existing runtime uses --e-*; mockup uses --c-*. We keep both names
+     pointing at the same canonical HSL triplet so consumer-side code
+     using either spelling continues to work.
+     The dark override is handled by the canonical tokens themselves. */
+  --e-game: var(--c-game);
+  --e-player: var(--c-player);
+  --e-session: var(--c-session);
+  --e-agent: var(--c-agent);
+  --e-document: var(--c-kb);
+  --e-chat: var(--c-chat);
+  --e-event: var(--c-event);
+  --e-toolkit: var(--c-toolkit);
+  --e-tool: var(--c-tool);
+
+  /* ─── Radius (Tailwind --radius shadcn variable) ─── */
+  --radius: var(--r-md);                /* shadcn default → 10px */
+  --radius-card: var(--r-xl);           /* 18px */
+  --radius-btn: var(--r-md);            /* 10px */
+  --radius-pill: var(--r-pill);         /* 9999px */
+  --radius-sheet: var(--r-2xl);         /* 24px */
+
+  /* ─── Font family (legacy aliases) ─── */
+  --font-heading: var(--f-display);
+  --font-body: var(--f-body);
+  --font-display: var(--f-display);
+  --font-sans: var(--f-body);
+}

--- a/docs/for-developers/frontend/token-bridge-map.md
+++ b/docs/for-developers/frontend/token-bridge-map.md
@@ -1,0 +1,150 @@
+# Token Bridge Map — v1 → canonical
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-05-12 (DS-1) |
+| **Spec** | [`2026-05-12-token-canonicalization.md`](../specs/2026-05-12-token-canonicalization.md) |
+| **Bridge file** | [`apps/web/src/styles/token-bridge.css`](../../../apps/web/src/styles/token-bridge.css) |
+| **Canonical source** | [`apps/web/src/styles/design-tokens-canonical.css`](../../../apps/web/src/styles/design-tokens-canonical.css) (mirror of [`admin-mockups/design_files/tokens.css`](../../../admin-mockups/design_files/tokens.css)) |
+| **Removal target** | DS-12 (when 0 consumers reference legacy names) |
+
+## Purpose
+
+Map legacy custom property names (used across ~167 v2 components + ~36 legacy non-prefixed components) to the canonical token vocabulary from the mockup. Each alias is a one-way redirect: consumer code keeps its current spelling while the cascade resolves to a single source of truth.
+
+## Theming mechanism
+
+- next-themes is configured with `attribute={['class', 'data-theme']}` (see [`ThemeProvider.tsx`](../../../apps/web/src/components/providers/ThemeProvider.tsx)). When the user picks dark mode, both `class="dark"` AND `data-theme="dark"` land on `<html>`.
+- Canonical tokens use `:root[data-theme="dark"]` selectors.
+- Legacy tokens (e.g. `globals.css :is(.dark, [data-theme="dark"]) { … }`) use a dual selector so they fire under both schemes during the transition.
+- SSR hint: `<html lang="it" data-theme="light">` in [`layout.tsx`](../../../apps/web/src/app/layout.tsx) — eliminates dark→light FOUC on first paint.
+
+## Alias table
+
+### Backgrounds
+
+| Legacy name (v1) | Canonical | Notes |
+|---|---|---|
+| `--bg-base` | `--bg` | Base page background |
+| `--bg-elevated` | `--bg-card` | Cards, sheets |
+| `--bg-surface` | `--bg-card` | Alias of card |
+| `--background` (shadcn) | `--bg` | Tailwind `bg-background` resolves here |
+| `--card` (shadcn) | `--bg-card` | Tailwind `bg-card` |
+| `--card-foreground` | `--text` | Card text |
+| `--popover` | `--bg-card` | Popovers, dropdowns |
+| `--popover-foreground` | `--text` | |
+| `--muted` | `--bg-muted` | Muted background |
+| `--muted-foreground` | `--text-muted` | Muted text |
+| `--nh-bg-base` | `--bg` | Warm-modern palette (deprecated) |
+| `--nh-bg-surface` | `--bg-card` | |
+| `--nh-bg-surface-end` | `--bg-muted` | |
+| `--nh-bg-elevated` | `--bg-card` | |
+| `--gaming-bg-base` | `--bg` | Legacy "premium gaming" (deprecated, file slated for removal in DS-12) |
+| `--gaming-bg-elevated` | `--bg-card` | |
+| `--gaming-bg-glass` | `--glass-bg` | |
+| `--bg-glass` | `--glass-bg` | |
+
+### Text
+
+| Legacy name | Canonical | Notes |
+|---|---|---|
+| `--foreground` (shadcn) | `--text` | Tailwind `text-foreground` |
+| `--text-primary` | `--text` | |
+| `--text-secondary` | `--text-sec` | |
+| `--text-tertiary` | `--text-muted` | |
+| `--nh-text-primary` | `--text` | |
+| `--nh-text-secondary` | `--text-sec` | |
+| `--nh-text-muted` | `--text-muted` | |
+| `--gaming-text-primary` | `--text` | |
+| `--gaming-text-secondary` | `--text-sec` | |
+| `--gaming-text-tertiary` | `--text-muted` | |
+| `--gaming-text-accent` | `--brand-fg` | |
+
+### Borders
+
+| Legacy name | Canonical | Notes |
+|---|---|---|
+| `--border-primary` | `--border` | |
+| `--border-secondary` | `--border-strong` | |
+| `--nh-border-default` | `--border` | |
+| `--gaming-border-glass` | `--glass-border` | |
+
+### Entity colors
+
+| Legacy name (`--e-*`) | Canonical (`--c-*`) | Notes |
+|---|---|---|
+| `--e-game` | `--c-game` | |
+| `--e-player` | `--c-player` | |
+| `--e-session` | `--c-session` | |
+| `--e-agent` | `--c-agent` | |
+| `--e-document` | `--c-kb` | KB entity uses `--c-kb` in canonical |
+| `--e-chat` | `--c-chat` | |
+| `--e-event` | `--c-event` | |
+| `--e-toolkit` | `--c-toolkit` | |
+| `--e-tool` | `--c-tool` | |
+
+Dark overrides cascade through the canonical block; both `--e-*` and `--c-*` names resolve to the lighter HSL values automatically.
+
+### Radius
+
+| Legacy name | Canonical | Notes |
+|---|---|---|
+| `--radius` (shadcn) | `--r-md` | 10px |
+| `--radius-card` | `--r-xl` | 18px |
+| `--radius-btn` | `--r-md` | 10px |
+| `--radius-pill` | `--r-pill` | 9999px |
+| `--radius-sheet` | `--r-2xl` | 24px |
+
+### Typography
+
+| Legacy name | Canonical | Notes |
+|---|---|---|
+| `--font-display` | `--f-display` | Quicksand |
+| `--font-heading` | `--f-display` | |
+| `--font-body` | `--f-body` | Nunito |
+| `--font-sans` | `--f-body` | |
+
+## What is **NOT** aliased (still legacy)
+
+The bridge intentionally does not alias:
+
+- `--mc-*` (MeepleCard v2 internal palette) — clusters using `MeepleCard` migrate component-side in DS-7/DS-8.
+- `--chart-{1..5}` — chart-specific, no mockup equivalent yet.
+- `--sidebar-*` — UI shell tokens, awaiting dedicated cluster.
+- Tailwind shadcn semantic tokens fully redeclared in `globals.css` (`--primary`, `--secondary`, `--accent`, `--destructive`, `--ring`, `--input`) — these stay until DS-7+ when individual clusters migrate.
+- `--text-xs..3xl` Tailwind sizes — bridge to `--fs-*` happens at Tailwind `@theme` level (DS-4+).
+- `--s-*` spacing tokens — Tailwind already provides 4-based scale; clusters migrate inline `style={{ padding: ... }}` consumers individually.
+
+## Migration status
+
+| Cluster | Status | Stage | Tracking PR |
+|---|---|---|---|
+| `app/(authenticated)/dashboard/*` | pending | DS-4 | — |
+| `components/features/sessions/*` | pending | DS-5 | — |
+| `components/features/session-live/*` | pending | DS-6 | — |
+| `components/features/session-summary/*` | pending | DS-6 | — |
+| `components/features/games/*` | pending | DS-7 | — |
+| `components/features/game-detail/*` | pending | DS-7 | — |
+| `components/features/agents/*` | pending | DS-8 | — |
+| `components/features/agent-detail/*` | pending | DS-8 | — |
+| `components/features/players/*` | pending | DS-9 | — |
+| `components/features/player-detail/*` | pending | DS-9 | — |
+| `components/features/gamebook/*` | pending | DS-10 | — |
+| `components/features/game-chat/*` | pending | DS-10 | — |
+| `components/features/library/*` | pending | DS-11 | — |
+| `app/(authenticated)/library/*` | pending | DS-11 | — |
+
+## Removal procedure (DS-12)
+
+1. Verify `pnpm lint:tokens` reports 0 violations (no consumer uses legacy names).
+2. Delete `apps/web/src/styles/token-bridge.css`.
+3. Delete `apps/web/src/styles/premium-gaming.css` (legacy palette).
+4. Reduce `apps/web/src/styles/globals.css` to Tailwind `@theme` + components + base-layer rules only (no `:root` token declarations).
+5. Reduce `apps/web/src/styles/design-tokens.css` to consumer-facing utility classes only.
+6. Update `layout.tsx` to import only `design-tokens-canonical.css` + `globals.css`.
+
+## See also
+
+- Spec: [`docs/for-developers/specs/2026-05-12-token-canonicalization.md`](../specs/2026-05-12-token-canonicalization.md)
+- Parent spec: [`docs/for-developers/specs/2026-05-11-design-system-deversioning.md`](../specs/2026-05-11-design-system-deversioning.md)
+- Mockup audit (Stage 1): [`docs/for-developers/audits/2026-05-11-mockup-conformity.md`](../audits/2026-05-11-mockup-conformity.md)

--- a/docs/for-developers/specs/2026-05-12-token-canonicalization.md
+++ b/docs/for-developers/specs/2026-05-12-token-canonicalization.md
@@ -1,0 +1,242 @@
+# Design Token Canonicalization — Mockup Authority Convergence
+
+| Field | Value |
+|---|---|
+| **Status** | draft |
+| **Date** | 2026-05-12 |
+| **Author** | spec-panel (Fowler/Wiegers/Nygard/Adzic/Doumont) |
+| **Extends** | [`2026-05-11-design-system-deversioning.md`](./2026-05-11-design-system-deversioning.md) §8 (out-of-scope) — questa spec lo riapre |
+| **Mockup source of truth** | [`admin-mockups/design_files/tokens.css`](../../../admin-mockups/design_files/tokens.css), [`components.css`](../../../admin-mockups/design_files/components.css) |
+| **Branch convention** | `feature/token-canonicalization-{stage}` per PR stage |
+
+## 1. Problem statement
+
+Il runtime frontend ospita **due token system paralleli**:
+
+- **Runtime v1**: `apps/web/src/styles/{globals,design-tokens,premium-gaming}.css` — usa `--bg-base`, `--gaming-bg-*`, `--nh-bg-*`, `--background` (shadcn), `.dark` class via `next-themes`.
+- **Mockup canonical**: `admin-mockups/design_files/tokens.css` — usa `--bg`, `--bg-card`, `--bg-muted`, `--bg-sunken`, `[data-theme]` attribute, scale typography/spacing/radius/motion proprie.
+
+I 9 layer (color, typography, spacing, radius, motion, glass, shadow, z-index, theming-mechanism) hanno delta significativi tra runtime e mockup. Gli sviluppatori non hanno una source of truth univoca; alcune pagine consumano `bg-white`/`bg-slate-*` hardcoded di Tailwind, altre usano i tokens semantici v1 (`--bg-base`), altre ancora hanno migrato parzialmente.
+
+**Risultato visivo osservato (utente, 2026-05-12)**: "vedo ancora sfondi legacy" su pagine in produzione, indice di drift tra cluster.
+
+## 2. Goals & Non-goals
+
+### Goals
+
+- G1: **Single source of truth** = `admin-mockups/design_files/tokens.css`. Tutti i layer (color, typography, spacing, radius, motion, glass, shadow) consumati esclusivamente da quel file (importato in runtime).
+- G2: **Theming mechanism** unificato: `[data-theme="light|dark"]` attribute su `<html>` (mockup convention), `.dark` class deprecato.
+- G3: **Light theme default** (mockup): `--bg: #f7f3ee` warm cream. Dark theme via `[data-theme="dark"]` override.
+- G4: **Lint enforcement**: regole custom che proibiscono `bg-white|bg-slate-*|text-slate-*|bg-gray-*` hardcoded e CSS custom properties non listate in `tokens.css`. Mode `warning` fase 1 → `error` fase finale.
+- G5: **Visual conformity** ≤ 2% pixel diff vs mockup HTML per ogni route migrata.
+- G6: **A11y AA** mantenuto: 0 axe violations su WCAG 2.1 AA tags durante l'intera transizione.
+- G7: **Bridge layer temporaneo**: alias `--bg-base → var(--bg)` etc. permettono migrazione consumer-by-consumer senza big-bang.
+
+### Non-goals
+
+- NG1: Refactor logico di Server Action / data hooks (separato).
+- NG2: Routing/IA changes — separato in [`2026-05-11-design-system-deversioning.md`](./2026-05-11-design-system-deversioning.md) §6.
+- NG3: Mobile React Native app.
+- NG4: Storybook catalog rebuild (separato post-migration).
+- NG5: Backend API renames (frontend-only).
+
+## 3. Stage plan (12 PR sequenziali, parallelizzabili dopo DS-3)
+
+### Stage DS-1 — Token import + bridge layer + theming mechanism
+
+**PR title**: `feat(design-system): import mockup tokens + bridge alias (DS-1)`
+
+**Branch**: `feature/token-canonicalization-ds-1`
+
+**Deliverable**:
+1. Copia `admin-mockups/design_files/tokens.css` → `apps/web/src/styles/design-tokens-canonical.css` (file canonico runtime).
+2. Aggiorna `apps/web/src/app/layout.tsx`:
+   - Import `design-tokens-canonical.css` come **primo** stylesheet (prima di `globals.css`).
+3. Aggiorna `apps/web/src/styles/globals.css`:
+   - Rimuovi `:root` redeclarations dei token canonici (color, typography, spacing, radius).
+   - Mantieni **solo** bridge alias `v1 → canonical`:
+     ```css
+     :root {
+       --bg-base: var(--bg);
+       --background: var(--bg);
+       --foreground: var(--text);
+       --text-primary: var(--text);
+       --text-secondary: var(--text-sec);
+       --text-tertiary: var(--text-muted);
+       /* ... 30+ alias documentati */
+     }
+     ```
+4. Aggiorna `apps/web/src/components/providers/ThemeProvider.tsx`:
+   - `next-themes` config: `attribute="class"` → `attribute="data-theme"`.
+   - `defaultTheme="dark"` → `defaultTheme="light"` (mockup default).
+   - `enableSystem` mantenuto.
+5. Aggiorna `apps/web/tailwind.config.ts` o `@theme` in `globals.css`:
+   - `--color-background: var(--bg)` (Tailwind utility `bg-background` ora risolve al canonico).
+   - Stesso pattern per `text`, `border`, `muted`, `card`, etc.
+   - Typography scale: `--text-xs..3xl` mappati a `--fs-xs..3xl` (mockup).
+6. Documento `docs/for-developers/frontend/token-bridge-map.md`: tabella `v1-name → canonical-name` per ogni alias.
+
+**Acceptance criteria**:
+
+- AC1.1: `pnpm typecheck && pnpm lint && pnpm test && pnpm build` verdi.
+- AC1.2: Visual regression run — snapshot baseline rebake (diff atteso significativo, validato manualmente sui 5-6 routes principali).
+- AC1.3: A11y E2E suite passa (con `colorScheme: 'dark'` rimosso, ora redundant — light default).
+- AC1.4: Bundle size delta ≤ 3% (più tokens, ma meno duplicazione).
+- AC1.5: `<html data-theme="light">` SSR-rendered al primo paint (no FOUC dark→light).
+
+**Rollback**: revert PR. Tutti i consumer puntano ancora ai nomi v1 (alias attivi), zero breakage.
+
+### Stage DS-2 — Lint rules (token vocabulary enforcement)
+
+**PR title**: `feat(eslint): forbid hardcoded Tailwind colors + non-canonical tokens (DS-2)`
+
+**Branch**: `feature/token-canonicalization-ds-2`
+
+**Deliverable**:
+1. Custom ESLint plugin `eslint-plugin-meepleai-tokens` (o estensione del plugin esistente) con 2 regole:
+   - `meepleai-tokens/no-hardcoded-color-utility`: vieta classi Tailwind di colore hardcoded:
+     - `bg-white`, `bg-black`
+     - `bg-slate-*`, `bg-gray-*`, `bg-zinc-*`, `bg-neutral-*`, `bg-stone-*`
+     - `text-slate-*`, `text-gray-*`, etc.
+     - `border-slate-*`, etc.
+     - Eccezione: i 9 entity colors (`bg-entity-game`, `text-entity-session`, etc.).
+   - `meepleai-tokens/no-non-canonical-custom-property`: vieta CSS custom properties non listate in `tokens.css` whitelist (es. `var(--my-custom-thing)`).
+2. Modalità inizio: `warn` (fase 1).
+3. Output: report aggregato `audit/2026-05-12-token-violations.json` con count per file.
+4. CI workflow: `pnpm lint:tokens` step separato, non-blocking in fase 1.
+
+**Acceptance criteria**:
+
+- AC2.1: Lint rules eseguibili su tutto il monorepo `apps/web/src/**/*.{ts,tsx}` in < 30s.
+- AC2.2: Report violations totali ≥ 1 (deve trovare violazioni esistenti).
+- AC2.3: Eccezioni documentate (entity colors) effettivamente whitelistate.
+
+**Rollback**: revert PR. Lint rule disabilitata, zero breakage.
+
+### Stage DS-3 — Inventory & cluster prioritization
+
+**PR title**: `docs(audit): token violation inventory + cluster priority (DS-3)`
+
+**Branch**: `feature/token-canonicalization-ds-3`
+
+**Deliverable**:
+1. Run `pnpm lint:tokens` → `audit/2026-05-12-token-violations.json`.
+2. Aggregazione per cluster (es. `features/sessions/*`, `features/gamebook/*`, etc.).
+3. Documento `docs/for-developers/audits/2026-05-12-token-canonicalization-inventory.md`:
+   - Tabella cluster × violations count × suggested order.
+   - Note su orphan files (no cluster assignment).
+4. Aggiornamento `v2-migration-matrix.md`: nuova colonna `Token compliance: pending|partial|done`.
+
+**Acceptance criteria**:
+
+- AC3.1: 100% file con violations classificati per cluster.
+- AC3.2: Priority order proposta basata su (a) traffico utente, (b) violations count, (c) test coverage esistente.
+
+**Rollback**: revert PR (doc only).
+
+### Stage DS-4..DS-11 — Cluster migration (8 PR cluster-by-cluster, parallelizzabili)
+
+**PR title pattern**: `feat(<cluster>): migrate to canonical tokens (DS-<N>)`
+
+**Branch pattern**: `feature/token-canonicalization-ds-<N>-<cluster>`
+
+**Proposed cluster order** (rivedibile post DS-3):
+
+| Stage | Cluster | Priority rationale |
+|-------|---------|--------------------|
+| DS-4 | `app/(authenticated)/dashboard` | Landing page utente — alta visibilità |
+| DS-5 | `features/sessions/*` | 5 component, già toccati in batch B2 |
+| DS-6 | `features/session-live/*` + `features/session-summary/*` | A11y critical |
+| DS-7 | `features/games/*` + `app/.../games/*` | Catalogo utente |
+| DS-8 | `features/agents/*` + `features/agent-detail/*` | Wave B.2 / γ |
+| DS-9 | `features/players/*` + `features/player-detail/*` | Wave 3 pending |
+| DS-10 | `features/gamebook/*` + `features/game-chat/*` | SP6 |
+| DS-11 | `features/library/*` + `app/(authenticated)/library/*` | Multi-tab UI |
+
+**Procedura per cluster**:
+1. Rimuovi `bg-white|bg-slate-*|text-slate-*` hardcoded → `bg-background`, `text-muted-foreground`, etc. (token semantici).
+2. Rimuovi qualsiasi `var(--bg-base)` etc. → `var(--bg)`.
+3. Migra inline styles con valori non-token → tokens.
+4. Aggiorna snapshot Playwright + Vitest.
+5. Visual diff vs mockup HTML corrispondente (≤ 2%).
+6. axe-core AA pass.
+7. ESLint `lint:tokens` per il cluster → 0 violations (passa da `warn` → `error` solo per file del cluster).
+
+**Acceptance criteria per cluster**:
+
+- AC-N.1: 0 lint violations nel cluster.
+- AC-N.2: Visual diff ≤ 2% vs mockup HTML.
+- AC-N.3: A11y axe AA pass (0 violations).
+- AC-N.4: Test suite passa per il cluster (unit + E2E).
+- AC-N.5: Snapshot baseline rebake committato.
+
+**Rollback**: per-cluster — revert del PR specifico, alias bridge ancora attivi, zero breakage cross-cluster.
+
+### Stage DS-12 — Bridge removal + lint→error
+
+**PR title**: `chore(design-system): remove bridge aliases, enforce token vocabulary (DS-12)`
+
+**Branch**: `feature/token-canonicalization-ds-12`
+
+**Pre-conditions**: stage DS-4..DS-11 mergiati. Zero violations cluster-wide.
+
+**Deliverable**:
+1. Rimuovi bridge alias da `globals.css`.
+2. Elimina `premium-gaming.css` (nessun consumer post-migration).
+3. Elimina `design-tokens.css` se ridondante.
+4. Lint rules `meepleai-tokens/*` → mode `error` globale.
+5. CI workflow: `pnpm lint:tokens` blocking.
+
+**Acceptance criteria**:
+
+- AC12.1: `grep -rE "bg-(white|slate-|gray-|zinc-)|--bg-base|--gaming-bg-" apps/web/src` → 0 matches (esclusi commenti e file di test).
+- AC12.2: CI `pnpm lint:tokens` blocking ed verde su `main-dev`.
+- AC12.3: Bundle size: -10 a -20% sul foglio di stile (eliminazione duplicazioni).
+
+**Rollback**: revert PR. Bridge layer ripristinato per emergenza.
+
+## 4. Failure matrix
+
+| Stage | Failure mode | Detection | Mitigation |
+|-------|--------------|-----------|------------|
+| DS-1 | FOUC dark→light al primo paint | Manual review + Playwright trace inspection | `<html data-theme="light">` SSR hint hardcoded in layout.tsx |
+| DS-1 | Snapshot regression mass | Visual regression test fail | Baseline rebake committato in stesso PR + screenshot review umano |
+| DS-1 | A11y AA regression (es. contrast su light theme) | axe-core E2E | Block merge, fix tokens prima del merge |
+| DS-2 | Lint rule false positive (entity colors esclusi male) | Test su un file pulito | Whitelist tuning |
+| DS-3 | Cluster orphans (file non assegnabili) | Inventory review | Manual cluster assignment in DS-3 PR review |
+| DS-4..DS-11 | Visual diff > 2% per cluster | Playwright pixelmatch | Block merge, investigate (può essere bug nel mockup) |
+| DS-4..DS-11 | Cluster cross-import inconsistency | TypeScript build fail | Per-cluster atomic — rivedi import boundaries |
+| DS-12 | Hidden consumer non migrato | Lint `pnpm lint:tokens --max-warnings 0` fail | Block PR, identifica consumer, riassegna cluster |
+
+## 5. Sequencing & estimated effort
+
+| Stage | PR count | Estimated effort | Parallelizzabile? |
+|-------|----------|------------------|-------------------|
+| DS-1 | 1 | 1g (incluso baseline rebake) | NO — fondazione |
+| DS-2 | 1 | 0.5g | NO |
+| DS-3 | 1 | 0.5g (doc) | NO |
+| DS-4..DS-11 | 8 | 1-2g/cluster | SÌ post DS-3 |
+| DS-12 | 1 | 0.5g + verifica | NO |
+
+**Total**: ~14g con 1 dev FTE; ~7-8g con 2 dev paralleli sui cluster.
+
+## 6. Open questions
+
+- Q1: Esiste già un ESLint plugin custom in cui appendere le 2 nuove regole, o crearne uno nuovo? → Verificare in DS-2 kickoff.
+- Q2: `[data-theme]` su `<html>` o su `<body>`? Mockup esempi mostrano `<html data-theme="light">`. Confermare in DS-1.
+- Q3: Cosa fare di `--nh-bg-*` (warm-modern palette)? Consolidare in alias del canonico o ridichiarare in cluster-specific layer? → Risolto in DS-1 design.
+
+## 7. References
+
+- Mockup source: [`admin-mockups/design_files/`](../../../admin-mockups/design_files/)
+- De-versioning spec (parent): [`2026-05-11-design-system-deversioning.md`](./2026-05-11-design-system-deversioning.md)
+- Existing audit: [`2026-05-11-mockup-conformity.md`](../audits/2026-05-11-mockup-conformity.md)
+- Token system v1 audit: [`v2-a11y-token-audit.md`](../frontend/v2-a11y-token-audit.md)
+- next-themes attribute config: https://github.com/pacocoursey/next-themes#with-attribute
+
+---
+
+**Sign-off required from**:
+- [x] Project owner — Strategy X confirmed 2026-05-12 (chat)
+- [ ] Frontend architecture review — DS-1 PR review
+- [ ] A11y review — DS-1 visual diff + axe baseline


### PR DESCRIPTION
## Summary

**Foundation PR** of the token canonicalization initiative. Establishes the mockup-faithful token vocabulary as the single source of truth in the runtime, with a bridge layer that maps legacy v1 names so consumer code keeps working unchanged.

**Spec**: [`docs/for-developers/specs/2026-05-12-token-canonicalization.md`](docs/for-developers/specs/2026-05-12-token-canonicalization.md) — strategy X (bridge layer) confirmed with user 2026-05-12.

## What changes

| File | Type | Description |
|------|------|-------------|
| `apps/web/src/styles/design-tokens-canonical.css` | **new** | Mirror of [`admin-mockups/design_files/tokens.css`](admin-mockups/design_files/tokens.css). Authoritative source for color, typography, spacing, radius, motion, glass, shadow, z-index. Keyed on `[data-theme="light\|dark"]` attribute. |
| `apps/web/src/styles/token-bridge.css` | **new** | One-way aliases: `--bg-base → var(--bg)`, `--gaming-bg-* → var(--bg)`, `--nh-bg-* → var(--bg)`, `--text-primary → var(--text)`, `--e-* → var(--c-*)`, etc. Allows consumer-by-consumer migration without big-bang. |
| `app/layout.tsx` | modified | Import order: canonical → bridge → globals. SSR hint `<html data-theme="light">` eliminates dark→light FOUC. |
| `components/providers/ThemeProvider.tsx` | modified | `attribute={['class', 'data-theme']}` (BOTH) + `defaultTheme="light"`. Backwards-compat with the 80+ legacy `.dark .foo` selectors. |
| `styles/globals.css` | modified | `@custom-variant dark` widened to match `.dark *` OR `[data-theme="dark"] *`. `.dark { … }` token override block widened to `:is(.dark, [data-theme="dark"]) { … }`. |
| `docs/for-developers/specs/2026-05-12-token-canonicalization.md` | **new** | 12-stage plan, failure matrix, sequencing. |
| `docs/for-developers/frontend/token-bridge-map.md` | **new** | Full alias table v1 → canonical + per-cluster migration status. |

## What does NOT change

- **No consumer code modified** — components keep their existing token references.
- No Tailwind config changes.
- No removal of `premium-gaming.css` or `design-tokens.css` (deferred to DS-12).

## Theming mechanism

```
<html lang="it" data-theme="light">   ← SSR default (mockup)
        ↓ (next-themes hydrates)
<html class="dark" data-theme="dark"> ← user picks dark
```

Both `.dark` legacy selectors AND canonical `[data-theme="dark"]` block fire under both schemes during the transition.

## Sequencing

DS-1 (this PR) → DS-2 (lint rules) → DS-3 (inventory) → DS-4..DS-11 (cluster migration, parallel) → DS-12 (bridge removal).

## Test plan

- [x] `pnpm typecheck` — green (post `.next` clean — confirms type-level coherence)
- [ ] Visual smoke on `main-dev` after merge — manual review on 5-6 routes (dashboard, games, sessions, gamebook, agent-detail). Expectation: **light cream bg** by default instead of dark gaming bg, but content/structure unchanged.
- [ ] CI: Frontend Build & Test, Frontend A11y E2E green.

## Risk & rollback

🟢 **Low risk**: pure CSS additions + theme attribute extension. No consumer code touched.

**Rollback**: revert PR. All token references continue resolving through bridge aliases — no consumer breaks. Default theme switches back to dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)