### PR TITLE
docs(mockups): follow-up cleanup post PR #1056 code-review

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -114,7 +114,10 @@
 | `nanolith-nav-bottom-mobile.html` | component-mock | Mobile bottom-nav primitive (global) |
 | `nanolith-nav-chat-panel.html` | component-mock | Chat slide-over panel (used globally via `useChatPanel`) |
 | `nanolith-nav-topbar.html` | component-mock | Top-bar primitive (global) |
+| `nanolith-runthrough-encounter-cheatsheet.html` | page-mock | `/library/[gameId]/play/[campaignId]/encounter` (gap-coverage 2026-05-12, PR #1056) |
+| `nanolith-runthrough-error-states.html` | component-mock | Trasversale: chat (N1/N2) · translate (N3) · encounter — stream-timeout / OCR-fail / LLM-503 / segmentation-fail (PR #1056) |
 | `nanolith-runthrough-game-detail.html` | page-mock | `/library/[gameId]` (libro variant, PR #1037) |
+| `nanolith-runthrough-game-onboarding.html` | page-mock | `/library/[gameId]` (libro variant — prereq gate, gap-coverage 2026-05-12, PR #1056) |
 | `nanolith-runthrough-glossary-editor.html` | component-mock | Glossary editor (mirror of sp6 jsx) |
 | `nanolith-runthrough-library-search.html` | component-mock | In-library search overlay (not page-level) |
 | `nanolith-runthrough-play-session.html` | page-mock | `/library/[gameId]/play/[campaignId]` |
@@ -129,10 +132,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 44 |
-| component-mock | 14 |
+| page-mock | 46 |
+| component-mock | 15 |
 | dev-fixture | 10 |
-| **Total** | **68** |
+| **Total** | **71** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -11,8 +11,9 @@
 > Pre-requisite for Phase 1+2 of the v2 design migration ([spec](../specs/2026-04-26-v2-design-migration.md), section 3.3).
 > **Tier classification added 2026-05-04** post spec-panel critique Wave C.1 fail RCA — see [Tier classification](#tier-classification) section.
 
-This matrix is the **single source of truth** for the ~80 v2 feature components that the
-SP4 wave 1 + 2 + 3 + 4 mockups introduced and that do not yet exist in the codebase. Each
+This matrix is the **single source of truth** for the ~83 v2 feature components that the
+SP4 wave 1 + 2 + 3 + 4 mockups + SP6 Nanolith gap-coverage introduced and that do not yet
+exist in the codebase. Each
 row binds a mockup definition to a target component path, route, and acceptance criteria
 so that downstream PRs can pick up an entry and turn it from `pending` → `done` without
 ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch strategy.
@@ -32,22 +33,29 @@ ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch st
 > · G2 game-night-detail) and SP5 admin batch tracked separately — pending Claude Design
 > production resumption (post 2026-05-10).
 
-> **Updated 2026-05-12** (Nanolith gap-coverage mockups post-storyboard audit): added
+> **Updated 2026-05-12** (Nanolith gap-coverage mockups post-storyboard audit, PR #1056): added
 > 3 new components across 1 new route + 1 existing route extension + 1 cross-cutting —
-> `EncounterCheatsheetView` (new route `/library/[gameId]/play/[campaignId]/encounter`,
-> Tier S, BLOCKER §9.1), `LibroGameOnboardingPanel` (existing route `/library/[gameId]`
-> libro variant prereq gate), `GamebookErrorBanner` (cross-cutting chat/translate/encounter).
+> `EncounterCheatsheetView` (Tier S, new route `/library/[gameId]/play/[campaignId]/encounter`,
+> BLOCKER §9.1), `LibroGameOnboardingPanel` (**Tier L**, existing route `/library/[gameId]`
+> libro variant prereq gate — Phase 0.5 sub-hook contract OBBLIGATORIA, 3 hook indipendenti),
+> `GamebookErrorBanner` (Tier S primitive-like, cross-cutting chat/translate/encounter).
 > Total grew 80 → 83. All `pending` — gated by Design System De-versioning FREEZE
 > (umbrella #1023) until Stage 2 path-migration lands. Target path
 > `apps/web/src/components/features/gamebook/` (NON `components/v2/gamebook/` per nuove
 > implementazioni post-PR #1025). Storyboard iframe references added to
 > `nanolith-game-night-storyboard.html` (step 00 + step 11a + step E4).
 
+> **Updated 2026-05-12 (follow-up cleanup)** post code-review PR #1056: aggiornati
+> count references `~80 → ~83` (intro paragraph L14) e `In scope: 80 → 83` (Scope L48-50)
+> per allineare con totale post gap-coverage. Reclassificato `LibroGameOnboardingPanel`
+> da Tier S blanket erroneo a Tier L (3 hook indipendenti). `MOCKUPS_INDEX.md` synced
+> (page-mock 44→46, component-mock 14→15, Total 68→71).
+
 ## Scope and ground rules
 
-- **In scope**: 80 feature components extracted from `admin-mockups/design_files/sp4-*.jsx`
-  wave 1 + 2 + 3 + 4 partial (16 mockups). Stubs live under
-  `apps/web/src/components/features/<feature>/`.
+- **In scope**: 83 feature components extracted from `admin-mockups/design_files/sp4-*.jsx`
+  wave 1 + 2 + 3 + 4 partial (16 mockups) + SP6 Nanolith gap-coverage (3 mockups).
+  Stubs live under `apps/web/src/components/features/<feature>/`.
 - **Out of scope**: existing v2 primitives at `apps/web/src/components/ui/` (auth-card,
   btn, divider, drawer, entity-card, entity-chip, entity-pip, faq, hero-gradient,
   input-field, invites, join, notification-card, oauth-buttons, pricing-card, pwd-input,
@@ -372,19 +380,24 @@ the PR review.
 > precedenti che puntano a `components/v2/gamebook/` (LibroGameDetailView,
 > CampaignSetupDrawer) rimangono in quel path perché pre-FREEZE shipped.
 
-### Libro-game gap-coverage — 3 components — **Tier S**
+### Libro-game gap-coverage — 3 components — **Mixed Tier (S + L + S-primitive)**
 
-| Mockup | Component | Path | Route | Status | PR | AC |
-|--------|-----------|------|-------|--------|----|----|
-| `nanolith-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | pending | — | T A M V |
-| `nanolith-runthrough-game-onboarding.html` | `LibroGameOnboardingPanel` | `apps/web/src/components/features/gamebook/LibroGameOnboardingPanel.tsx` | `/library/[gameId]` (libro variant — prereq gate) | pending | — | T A M V |
-| `nanolith-runthrough-error-states.html` | `GamebookErrorBanner` | `apps/web/src/components/features/gamebook/GamebookErrorBanner.tsx` | cross-cutting (chat, translate, encounter) | pending | — | T A V |
+> **Tier note** (refined post code-review PR #1056): originale section header "Tier S" era
+> blanket-incorrect. `LibroGameOnboardingPanel` ha 3 hook indipendenti
+> (`useGamePrerequisites` + `usePdfUpload` + `useKbIndexing`) → per la Tier table del documento
+> richiede **Tier L** + Phase 0.5 sub-hook contract OBBLIGATORIA (vedi linea 83). Reclassificato.
+
+| Mockup | Component | Tier | Path | Route | Status | PR | AC |
+|--------|-----------|------|------|-------|--------|----|----|
+| `nanolith-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | **S** | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | pending | — | T A M V |
+| `nanolith-runthrough-game-onboarding.html` | `LibroGameOnboardingPanel` | **L** ⚠️ | `apps/web/src/components/features/gamebook/LibroGameOnboardingPanel.tsx` | `/library/[gameId]` (libro variant — prereq gate) | pending | — | T A M V |
+| `nanolith-runthrough-error-states.html` | `GamebookErrorBanner` | **S** (primitive-like) | `apps/web/src/components/features/gamebook/GamebookErrorBanner.tsx` | cross-cutting (chat, translate, encounter) | pending | — | T A V |
 
 **Stato di copertura** (4 stati ciascuno, mobile + desktop parity):
 
-- **`EncounterCheatsheetView`** (BLOCKER): entry-from-story / photo-segmenting / cheatsheet-rendered / resolved-back. Ephemeral card (no long-term cache, §9.1 spec). Single hook `useEncounterParse({photoId, paragraphRef})` + linear FSM 5-state.
-- **`LibroGameOnboardingPanel`** (NICE-TO-HAVE): prereq-missing / pdf-uploading / kb-indexing / ready. Replace della CTA "Avvia libro game" quando prerequisiti non soddisfatti. Composition: drop-zone + upload-row + index-detail + step-list primitives. Multi-hook (`useGamePrerequisites` + `usePdfUpload` + `useKbIndexing`).
-- **`GamebookErrorBanner`** (NICE-TO-HAVE): stream-timeout / ocr-fail / llm-503 / segmentation-fail. Trasversale alle 3 route gamebook (chat, translate, encounter). Cost-note "non addebitato" + ≥2 azioni di recupero + telemetry dogfood. Componente "primitive-like" candidato a `components/ui/error-banner/` se generalizzato post-Iter-1.
+- **`EncounterCheatsheetView`** (BLOCKER · Tier S): entry-from-story / photo-segmenting / cheatsheet-rendered / resolved-back. Ephemeral card (no long-term cache, §9.1 spec). Single hook `useEncounterParse({photoId, paragraphRef})` + linear FSM 5-state. Bundle budget < +50 KB.
+- **`LibroGameOnboardingPanel`** (NICE-TO-HAVE · Tier L): prereq-missing / pdf-uploading / kb-indexing / ready. Replace della CTA "Avvia libro game" quando prerequisiti non soddisfatti. Composition: drop-zone + upload-row + index-detail + step-list primitives. Multi-hook ≥3 (`useGamePrerequisites` + `usePdfUpload` + `useKbIndexing`) → Phase 0.5 sub-hook contract OBBLIGATORIA prima di implementation (vedi `contracts/library-id-onboarding-hooks.md` TBD). Bundle budget < +120 KB.
+- **`GamebookErrorBanner`** (NICE-TO-HAVE · Tier S primitive-like): stream-timeout / ocr-fail / llm-503 / segmentation-fail. Trasversale alle 3 route gamebook (chat, translate, encounter). Cost-note "non addebitato" + ≥2 azioni di recupero + telemetry dogfood. Componente "primitive-like" candidato a `components/ui/error-banner/` se generalizzato post-Iter-1.
 
 ## Stub format (informational)
 


### PR DESCRIPTION
## Summary

Addresses 4 low-confidence (score 75) findings from PR #1056 code review. All doc-only fixes, no shipped code touched.

## Fixes

### 1. `MOCKUPS_INDEX.md` sync (precedent: PR #1043 follow-up)

Added 3 missing Nanolith gap-coverage entries:
- `nanolith-runthrough-encounter-cheatsheet.html` (page-mock, `/library/[gameId]/play/[campaignId]/encounter`)
- `nanolith-runthrough-game-onboarding.html` (page-mock, libro variant prereq gate)
- `nanolith-runthrough-error-states.html` (component-mock, trasversale)

Summary counts updated: `page-mock 44→46`, `component-mock 14→15`, `Total 68→71`.

### 2. `v2-migration-matrix.md` internal-consistency

Fixed stale `80` hardcoded references:
- L14 intro: `~80 v2 feature components` → `~83 v2 feature components + SP6 Nanolith gap-coverage`
- L48-50 Scope: `In scope: 80` → `In scope: 83 (16 SP4 mockups + 3 SP6 gap-coverage)`

Aligned with existing `Total grew 80 → 83` update note (was inconsistent within same file).

### 3. `v2-migration-matrix.md` Tier reclassification

Section header `Libro-game gap-coverage — 3 components — Tier S` was **blanket-incorrect** for `LibroGameOnboardingPanel`, which uses 3 independent hooks (`useGamePrerequisites + usePdfUpload + useKbIndexing`). Per matrix's own Tier classification table:
- **S**: 1 hook
- **M**: 2 hook indipendenti
- **L**: ≥3 hook indipendenti / cross-resource — **Phase 0.5 sub-hook contract OBBLIGATORIA**

Changes:
- Section header → "Mixed Tier (S + L + S-primitive)"
- New per-component **Tier column** in gap-coverage table:
  - `EncounterCheatsheetView` → Tier S
  - `LibroGameOnboardingPanel` → Tier L ⚠️
  - `GamebookErrorBanner` → Tier S (primitive-like)
- Bundle budgets noted: <50KB (S), <120KB (L)
- Phase 0.5 contract file path noted as TBD: `contracts/library-id-onboarding-hooks.md`
- Update note (L36-44) also corrected (was "Tier S" blanket)

Added second update note 2026-05-12 (follow-up cleanup) for traceability.

## Test plan

- [ ] Render `MOCKUPS_INDEX.md` in GitHub preview — verify Summary table shows 46/15/10/71
- [ ] Render `v2-migration-matrix.md` — verify intro/Scope show ~83 / 83
- [ ] Verify SP6 gap-coverage section header reads "Mixed Tier (S + L + S-primitive)" and new Tier column renders correctly
- [ ] Verify both update notes (2026-05-12 main + 2026-05-12 follow-up cleanup) appear in chronological order

## Note operative

- PR target: `main-dev` (parent branch tracked via `git config branch.feature/...parent`)
- No code/typecheck/test impact — pure documentation
- No new mockup files (FREEZE umbrella #1023 still active on `components/v2/**` + `components/features/**`)
- Closes the cleanup loop opened by PR #1056 code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)