### PR TITLE
feat(design-system): finalize token canonicalization — lint→error (DS-15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,16 +272,26 @@ Stage 2 codemod (atomic rename + import fix) is the unblocker. Exceptions requir
 
 > **Historical**: SP6 v2 expansion FREEZE (issued 2026-05-06 per [#808](https://github.com/meepleAi-app/meepleai-monorepo/issues/808), tied to A11y audit [#807](https://github.com/meepleAi-app/meepleai-monorepo/issues/807)) was **lifted on 2026-05-10** by PR #876 (token redesign — AA-compliant CSS vars + entity Tailwind utilities). Issues #807 and #808 are both CLOSED. Restore A11y CI job (`Frontend - A11y E2E`) to blocking (`continue-on-error: false`) when verified green on `main-dev`.
 
-**Token Canonicalization in progress** (DS-1 #1044 landed 2026-05-12, spec [`2026-05-12-token-canonicalization.md`](./docs/for-developers/specs/2026-05-12-token-canonicalization.md))
+**Token Canonicalization** — Tier 1+2+3+4 complete, 0 project-wide violations (2026-05-12, spec [`2026-05-12-token-canonicalization.md`](./docs/for-developers/specs/2026-05-12-token-canonicalization.md)).
 
-The runtime now imports `admin-mockups/design_files/tokens.css` as `apps/web/src/styles/design-tokens-canonical.css` and bridges legacy v1 names via `token-bridge.css`. Theming uses `[data-theme="light|dark"]` (next-themes applies both `class="dark"` AND `data-theme="dark"`). **Default theme is light** (mockup cream `#f7f3ee`), with dark accessible via user toggle.
+The runtime imports `admin-mockups/design_files/tokens.css` as `apps/web/src/styles/design-tokens-canonical.css`. Legacy v1 names (`--bg-base`, `--gaming-bg-*`, `--nh-bg-*`, `--e-*`) are still aliased via `token-bridge.css` because ~120 CSS-side consumers reference them directly via `var(--*)` literals. The bridge will be removed in **DS-16** (CSS variable migration codemod), separate from this token-class migration.
+
+Theming uses `[data-theme="light|dark"]` (next-themes applies both `class="dark"` AND `data-theme="dark"`). **Default theme is light** (mockup cream `#f7f3ee`), dark accessible via user toggle.
 
 When writing new components:
 - ✅ Use semantic tokens: `bg-background`, `bg-card`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `border-border`, `border-border-strong`.
 - ✅ Use entity utilities: `bg-entity-game`, `text-entity-session`, `ring-entity-event/30`, etc.
-- ❌ Avoid hardcoded neutrals: `bg-white`, `bg-slate-*`, `text-gray-*`, `border-zinc-*`, etc. ESLint rule `local/no-hardcoded-color-utility` flags these (warn mode during DS-3..DS-11, error in DS-12).
+- ❌ Forbidden by ESLint rule `local/no-hardcoded-color-utility` (mode: **error** since DS-15): `bg-white`, `bg-slate-*`, `text-gray-*`, `border-zinc-*`, etc. (full neutral palette).
 
-Run `pnpm lint:tokens` to regenerate the violation inventory in `audits/2026-05-12-token-violations.md`. Bridge layer removed in DS-12.
+Exemption: `text-white` / `border-white` / `ring-white` ARE allowed when the same className declares a colored bg (entity utility, gradient, arbitrary `bg-[hsl(…)]`, hue palette, semantic `bg-primary/secondary/accent`). This is the mockup `.e-bg` pattern.
+
+Run `pnpm lint:tokens` to regenerate the inventory in `audits/2026-05-12-token-violations.md`.
+
+**Deferred decisions** (planned for DS-16):
+- `--admin-*` token family (admin inline gradients still file-level eslint-disable).
+- `--mc-*` MeepleCard palette consolidation.
+- CSS variable migration (`var(--bg-base)` → `var(--bg)`) — bridge removal.
+- Audit of file-level `eslint-disable local/no-hardcoded-color-utility` directives; convert to line-level or refactor via primitives where feasible.
 
 ### DDD Rules
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -604,20 +604,22 @@ export default [
       "@next/next/no-img-element": "off",
     },
   },
-  // DS-2 (token canonicalization, 2026-05-12):
+  // DS-15 (token canonicalization finalization, 2026-05-12):
   // Forbid hardcoded Tailwind neutral-greyscale utilities (bg-white, bg-slate-*,
   // text-gray-*, …) in src/. Components must consume semantic tokens from the
   // canonical design system (bg-background, bg-card, text-muted-foreground, …)
   // so the mockup palette flows through every surface uniformly.
   //
-  // Mode: `warn` during DS-3 inventory + DS-4..DS-11 cluster migrations.
-  // Switched to `error` in DS-12 once `pnpm lint:tokens --max-warnings 0` is green.
+  // Mode: `error` — enforced after DS-4..DS-14 migrated all 5710 violations.
+  // File-level eslint-disable comments are allowed only for the documented
+  // mockup `.e-bg` pattern (white text on style-prop colored backgrounds);
+  // surgical line-level suppressions preferred where feasible.
   //
   // Spec: docs/for-developers/specs/2026-05-12-token-canonicalization.md
   {
     files: ["src/**/*.{ts,tsx}"],
     rules: {
-      "local/no-hardcoded-color-utility": "warn",
+      "local/no-hardcoded-color-utility": "error",
     },
   },
 ];


### PR DESCRIPTION
## Summary

**DS-15 finalization** — flips `local/no-hardcoded-color-utility` from `warn` to **error** mode and updates the project docs. **2 files changed** (eslint config + CLAUDE.md), no consumer code touched.

**Spec**: [`2026-05-12-token-canonicalization.md`](docs/for-developers/specs/2026-05-12-token-canonicalization.md) (DS-15)
**Templates**: #1048–#1063 (all merged)

## Bridge layer remains (deferred to DS-16) — IMPORTANT

The original DS-12 plan was to remove `token-bridge.css` here, but a project-wide scan reveals **~120 CSS-side consumers** still reference the deprecated names via `var(--*)` literals in inline `style` props and CSS files. Removing the bridge now would break the runtime.

**DS-16 will**:
1. Codemod the ~120 consumers (`var(--bg-base)` → `var(--bg)`, `var(--e-game)` → `var(--c-game)`, etc.)
2. Remove `token-bridge.css`
3. Remove `premium-gaming.css`
4. Audit `--admin-*` family decision
5. Audit `--mc-*` MeepleCard palette decision
6. Convert file-level `eslint-disable` directives → line-level or refactor via primitives

## Final inventory milestone 🎉

| Stage | Violations | Reduction |
|-------|-----------:|----------:|
| Baseline (DS-2 inventory) | 5710 | — |
| Post Tier 1 (DS-4..DS-11) | 4141 | -1569 |
| Post Tier 2 (DS-12) | 3491 | -2219 |
| Post Tier 3 (DS-13a..d) | 3236 | -2474 |
| Post Tier 4 (DS-14) | 0 | -5710 |
| **DS-15 lint→error** | **0** | enforced ✅ |

## Test plan

- [x] `pnpm lint` — 0 errors, 35 unrelated pre-existing warnings (non-null-assertion etc.)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint:tokens` — 0 violations

## Outcome

Token-class canonicalization **phase 1** (Tailwind class layer) **CLOSED** with lint enforcement.
Phase 2 (CSS variable layer) → **DS-16**.

🟢 Minimal change PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)