### PR TITLE
fix(library): probe PrivateGame as third source — Nanolith default state (closes #1068)

### DIFF
--- a/apps/web/src/hooks/queries/__tests__/useLibrary.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useLibrary.test.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { useLibrary, useLibraryStats, libraryKeys } from '../useLibrary';
+import { useLibrary, useLibraryStats, useLibraryGameDetail, libraryKeys } from '../useLibrary';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -16,6 +16,11 @@ vi.mock('@/lib/api', () => ({
     library: {
       getLibrary: vi.fn(),
       getStats: vi.fn(),
+      getGameDetail: vi.fn(),
+      getPrivateGame: vi.fn(),
+    },
+    sharedGames: {
+      getById: vi.fn(),
     },
   },
 }));
@@ -28,6 +33,9 @@ import { api } from '@/lib/api';
 
 const mockGetLibrary = api.library.getLibrary as ReturnType<typeof vi.fn>;
 const mockGetStats = api.library.getStats as ReturnType<typeof vi.fn>;
+const mockGetGameDetail = api.library.getGameDetail as ReturnType<typeof vi.fn>;
+const mockGetPrivateGame = api.library.getPrivateGame as ReturnType<typeof vi.fn>;
+const mockGetSharedGameById = api.sharedGames.getById as ReturnType<typeof vi.fn>;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -129,5 +137,62 @@ describe('useLibraryStats', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(mockGetStats).not.toHaveBeenCalled();
+  });
+});
+
+describe('useLibraryGameDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Issue #1068 (WS-B Mockup Conformity): the unified `/library/[gameId]` route after
+  // PR #1037 IA consolidation must serve PrivateGame entries (e.g. Nanolith dogfood
+  // game) the same way it serves SharedGame entries — neither getGameDetail (library
+  // shared entry) nor sharedGames.getById (catalog) returns data for a private game
+  // UUID, so the hook MUST also probe getPrivateGame and map its DTO to
+  // LibraryGameDetail. Without this fallback, page.tsx:76 collapses `!gameDetail`
+  // into a misleading "Gioco non trovato" state for a game Aaron actually owns.
+  it('returns mapped LibraryGameDetail when only getPrivateGame resolves (private game fallback)', async () => {
+    const privateGameId = '11111111-1111-4111-8111-111111111111';
+    const privateGame = {
+      id: privateGameId,
+      ownerId: '22222222-2222-4222-8222-222222222222',
+      source: 'Manual' as const,
+      bggId: 462362,
+      title: 'Nanolith',
+      minPlayers: 1,
+      maxPlayers: 4,
+      yearPublished: 2025,
+      description: 'A libro game adventure',
+      playingTimeMinutes: 60,
+      minAge: 12,
+      complexityRating: 3.5,
+      imageUrl: 'https://example.com/nanolith.png',
+      thumbnailUrl: 'https://example.com/nanolith-thumb.png',
+      createdAt: '2026-01-15T10:30:00Z',
+      updatedAt: null,
+      bggSyncedAt: null,
+    };
+
+    mockGetGameDetail.mockResolvedValue(null);
+    mockGetSharedGameById.mockResolvedValue(null);
+    mockGetPrivateGame.mockResolvedValue(privateGame);
+
+    const { result } = renderHook(() => useLibraryGameDetail(privateGameId), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.gameId).toBe(privateGameId);
+    expect(result.current.data?.gameTitle).toBe('Nanolith');
+    expect(result.current.data?.libraryEntryId).toBe('');
+    expect(result.current.data?.minPlayers).toBe(1);
+    expect(result.current.data?.maxPlayers).toBe(4);
+    expect(result.current.data?.gameImageUrl).toBe('https://example.com/nanolith.png');
+    expect(result.current.data?.bggId).toBe(462362);
+    expect(result.current.data?.playingTimeMinutes).toBe(60);
+    expect(result.current.data?.complexityRating).toBe(3.5);
   });
 });

--- a/apps/web/src/hooks/queries/useLibrary.ts
+++ b/apps/web/src/hooks/queries/useLibrary.ts
@@ -800,6 +800,51 @@ export interface LibraryGameDetail {
 }
 
 /**
+ * Map a PrivateGameDto into the LibraryGameDetail shape so the unified
+ * `/library/[gameId]` route can render private-game ownership (Issue #1068).
+ *
+ * Private games are user-owned game records not present in the shared catalog —
+ * typically dogfood titles (Nanolith) or manually-added entries. They expose a
+ * narrower schema than GameDetailDto (no play stats, no shared metadata), so
+ * the mapper substitutes sentinel/null values for fields the source cannot
+ * provide. `libraryEntryId === ''` is the same sentinel used by the catalog
+ * fallback to signal `heroVariant === 'community'` downstream.
+ */
+function mapPrivateGameToLibraryGameDetail(privateGame: PrivateGameDto): LibraryGameDetail {
+  return {
+    libraryEntryId: '',
+    userId: privateGame.ownerId,
+    gameId: privateGame.id,
+    addedAt: privateGame.createdAt,
+    notes: null,
+    isFavorite: false,
+    currentState: 'Nuovo',
+    stateChangedAt: null,
+    stateNotes: null,
+    isAvailableForPlay: true,
+    hasCustomPdf: false,
+    hasRagAccess: false,
+    gameTitle: privateGame.title,
+    gamePublisher: null,
+    gameYearPublished: privateGame.yearPublished ?? null,
+    gameIconUrl: privateGame.thumbnailUrl ?? null,
+    gameImageUrl: privateGame.imageUrl ?? null,
+    description: privateGame.description ?? null,
+    minPlayers: privateGame.minPlayers,
+    maxPlayers: privateGame.maxPlayers,
+    playingTimeMinutes: privateGame.playingTimeMinutes ?? null,
+    minAge: privateGame.minAge ?? undefined,
+    complexityRating: privateGame.complexityRating ?? null,
+    averageRating: null,
+    timesPlayed: 0,
+    lastPlayed: null,
+    winRate: null,
+    avgDuration: null,
+    bggId: privateGame.bggId ?? null,
+  };
+}
+
+/**
  * Hook to fetch library game detail for Game Detail page (Issue #3513)
  *
  * Uses the efficient GET /library/{gameId} endpoint that returns
@@ -807,7 +852,11 @@ export interface LibraryGameDetail {
  *
  * For extended data (categories, mechanics, designers), fetches SharedGame in parallel.
  *
- * @param gameId - Game UUID (same as SharedGame.id)
+ * Issue #1068: also probes PrivateGame as third source so private-game ownership
+ * (Nanolith dogfood) renders correctly on the unified `/library/[gameId]` route
+ * introduced by PR #1037 IA consolidation.
+ *
+ * @param gameId - Game UUID (SharedGame.id, PrivateGame.id, or library entry UUID)
  * @param enabled - Whether to run the query (default: true)
  * @returns UseQueryResult with combined library game detail
  */
@@ -818,13 +867,25 @@ export function useLibraryGameDetail(
   return useQuery({
     queryKey: libraryKeys.gameDetail(gameId),
     queryFn: async (): Promise<LibraryGameDetail | null> => {
-      // Fetch game detail (efficient single endpoint) and shared game (for extended data) in parallel
-      const [gameDetail, sharedGame] = await Promise.all([
+      // Issue #1068 (WS-B Mockup Conformity): probe three sources in parallel.
+      // After PR #1037 IA consolidation collapsed `/library/games/[id]` →
+      // `/library/[id]`, the same URL must serve shared-library entries,
+      // shared-catalog browse, AND private-game ownership (e.g. Nanolith
+      // dogfood). Without the PrivateGame fallback, page.tsx:76 collapses
+      // owned private games into a misleading "Gioco non trovato" state.
+      const [gameDetail, sharedGame, privateGame] = await Promise.all([
         api.library.getGameDetail(gameId).catch(() => null),
         api.sharedGames.getById(gameId).catch(() => null),
+        api.library.getPrivateGame(gameId).catch(() => null),
       ]);
 
       if (!gameDetail) {
+        // PrivateGame ownership takes priority over catalog fallback: an owned
+        // private game is more specific than a community-only entry, and
+        // typically a private-game UUID will NOT match shared_games anyway.
+        if (privateGame) {
+          return mapPrivateGameToLibraryGameDetail(privateGame);
+        }
         // Game not in user's library → fall back to catalog-only view (G1).
         // The detail page must render for ANY shared_game so the user can
         // see metadata and click "Aggiungi alla libreria". The sentinel

--- a/docs/for-developers/frontend/game-id-taxonomy.md
+++ b/docs/for-developers/frontend/game-id-taxonomy.md
@@ -1,0 +1,70 @@
+# Game ID taxonomy
+
+| Field | Value |
+|---|---|
+| **Status** | reference |
+| **Date** | 2026-05-12 |
+| **Author** | WS-B (Issue #1068) Mockup Conformity Nanolith bugfix |
+| **Scope** | Frontend ID resolution across game-related routes |
+
+## Overview
+
+The MeepleAI frontend resolves game-related routes against three distinct ID schemas. Confusion between them is the root cause of **Issue #1068**: the unified `/library/[gameId]` route introduced by PR #1037 (IA consolidation) initially served only `SharedGame` lookups, collapsing private-game ownership (e.g. Nanolith dogfood) into a misleading "Gioco non trovato" state.
+
+## ID types
+
+| ID type | Format | Source | Backend table | Endpoint base |
+|---|---|---|---|---|
+| **BGG ID** | int positive | BoardGameGeek external | (FK only) | `/api/v1/bgg/{id}` |
+| **SharedGame.id** | UUID v4 | Community shared catalog | `shared_games` | `/api/v1/shared-games/{id}` |
+| **PrivateGame.id** | UUID v4 | User-owned, often dogfood | `private_games` | `/api/v1/private-games/{id}` |
+| **UserLibraryEntry.id** | UUID v4 | Join row library ↔ game | `user_library_entries` | (internal) |
+| **UserLibraryEntry.gameId** | UUID v4 (FK) | Refers to `SharedGame.id` OR `PrivateGame.id` | (FK) | (internal) |
+
+## Route → ID mapping
+
+| Route | Expected ID type | Hook |
+|---|---|---|
+| `/library/[gameId]` | `SharedGame.id` OR `PrivateGame.id` | `useLibraryGameDetail(gameId)` — probes three sources |
+| `/library/private/[privateGameId]` | `PrivateGame.id` only | `usePrivateGame(privateGameId)` |
+| `/shared-games/[id]` (TBD public) | `SharedGame.id` only | `useSharedGame(id)` |
+
+After **PR #1037** IA consolidation collapsed `/library/games/[id]` → `/library/[id]`, the unified path must serve both shared and private games. The `useLibraryGameDetail` hook (Issue #1068) probes three sources in parallel and resolves with priority:
+
+1. **`api.library.getGameDetail(gameId)`** — library entry with shared game join (returns `GameDetailDto`, fastest path for library members with stats + recent sessions).
+2. **`api.library.getPrivateGame(gameId)`** — private game ownership (returns `PrivateGameDto`, covers user-owned non-catalog games like Nanolith).
+3. **`api.sharedGames.getById(gameId)`** — catalog-only fallback (returns `SharedGame`, powers community browse flow and "Aggiungi alla libreria" CTA).
+
+The mapper `mapPrivateGameToLibraryGameDetail` (in `apps/web/src/hooks/queries/useLibrary.ts`) normalizes `PrivateGameDto` into the same `LibraryGameDetail` shape consumed by the page, using sentinel values for fields the source cannot provide:
+
+- `libraryEntryId === ''` — same sentinel used by catalog fallback, signals `heroVariant === 'community'` downstream
+- `currentState === 'Nuovo'` — default state for owned-but-not-yet-classified games
+- `timesPlayed === 0` — no play stats available without library entry
+- `gamePublisher === null`, `averageRating === null`, etc. — fields not on `PrivateGameDto` schema
+
+## Resolution priority
+
+```
+gameDetail > privateGame > sharedGame fallback > null
+```
+
+The first non-null source wins. A genuine `not-found` returns `null` only when all three sources return null (URL points to a non-existent UUID across all three tables).
+
+## Failure modes
+
+| Failure mode | Symptom | Fix / Status |
+|---|---|---|
+| URL contains BGG id instead of UUID | All three sources null → not-found | Resolve BGG id to `SharedGame.id` upstream (e.g. `/api/v1/shared-games/by-bgg/{bggId}` lookup) |
+| Private game UUID, hook lacks third probe | Not-found shown for owned game | **Issue #1068 — fixed** by adding `getPrivateGame` probe |
+| 5xx network error treated as not-found | Misleading "Gioco non trovato" hides backend outage | **WS-B AC-B.2 deferred** — error vs not-found distinction. `.catch(() => null)` silently swallows all failures; future work re-throws non-404 errors so React Query enters `isError` state |
+| Soft-deleted SharedGame still resolved | Stale data returned for deleted catalog entry | Backend `HasQueryFilter(e => !e.IsDeleted)` handles this (see CLAUDE.md "Soft Delete" pattern) |
+
+## References
+
+- **Issue #1068** — WS-B Mockup Conformity Nanolith bugfix
+- **PR #1037** — `f3702921d` IA consolidation (`/library/games/[id]` → `/library/[id]`)
+- `apps/web/src/hooks/queries/useLibrary.ts` — `useLibraryGameDetail` hook (~line 814) + `mapPrivateGameToLibraryGameDetail` mapper (~line 802)
+- `apps/web/src/app/(authenticated)/library/[gameId]/page.tsx` — consumer (collapses `!gameDetail` → not-found at line 76)
+- `apps/web/src/app/(authenticated)/library/private/[privateGameId]/page.tsx` — alternate dedicated route for private games
+- `apps/web/src/lib/api/schemas/private-games.schemas.ts` — `PrivateGameDto` Zod schema
+- Umbrella **#1066** — Mockup Conformity Roadmap


### PR DESCRIPTION
## Summary

Fix `/library/[gameId]` not-found regression for private-game ownership (Nanolith dogfood) introduced by PR #1037 IA consolidation. The unified route now serves `SharedGame`, `PrivateGame`, and catalog-only fallback via a three-source probe in `useLibraryGameDetail`.

## Root cause

Before #1037, `/library/games/[id]/page.tsx` was implicitly the "shared catalog member" path. The consolidation collapsed `/library/games/[id]` → `/library/[id]` without updating the resolver to probe PrivateGame entries. Aaron (badsworm@gmail.com) has Nanolith in collection as a PrivateGame → listing shows it correctly → detail page collapses `!gameDetail` (`page.tsx:76`) into "Gioco non trovato".

Evidence:
- `MeepleLibraryGameCard.tsx:274` → `navigateWithTransition(/library/${game.gameId})` for all entries regardless of private/shared
- `useLibrary.ts:822-825` (pre-fix) → probed only `getGameDetail` + `sharedGames.getById`
- `getPrivateGame` endpoint already exists (`/api/v1/private-games/{id}`) but was never consulted by the unified hook

## Changes

- `apps/web/src/hooks/queries/useLibrary.ts`: third parallel fetch `api.library.getPrivateGame(gameId)` + new `mapPrivateGameToLibraryGameDetail` helper. Priority order: `gameDetail > privateGame > sharedGame fallback > null`.
- `apps/web/src/hooks/queries/__tests__/useLibrary.test.tsx`: unit test scenario "returns mapped LibraryGameDetail when only getPrivateGame resolves". Followed RED → GREEN via TDD.
- `docs/for-developers/frontend/game-id-taxonomy.md` (NEW): reference doc covering the four ID schemas (BGG, SharedGame, PrivateGame, UserLibraryEntry) and the resolution priority used by `useLibraryGameDetail`.

## DoD status (per Issue #1068 ACs)

- [x] **AC-B.1** — Aaron + `/library/{nanolithPrivateGameId}` renders default state (verified via unit test fixture)
- [ ] **AC-B.2** — error vs not-found distinction → deferred to follow-up PR; rationale in `game-id-taxonomy.md` § Failure modes (touches `.catch(() => null)` swallowing 5xx vs 404)
- [ ] **AC-B.3** — E2E with Aaron fixture → deferred; requires backend seed setup (Aaron persona + Nanolith private game seed)
- [x] **AC-B.4** — game-id taxonomy doc cross-linking BGG/Shared/Private/Library schemas

Deferred items (AC-B.2 + AC-B.3) intentionally split to keep this PR focused on the user-facing bug (AC-B.1) per CLAUDE.md scope discipline.

## Test plan

- [x] `pnpm vitest run src/hooks/queries/__tests__/useLibrary.test.tsx` → 9/9 passed
- [x] `pnpm vitest run src/hooks/queries/__tests__/` → 21 files, 170/170 passed (no regression)
- [x] `pnpm typecheck` → clean (post `.next` rebuild to flush stale type validator referencing pre-#1037 paths)
- [x] `pnpm lint` on touched files → 0 errors
- [ ] Manual smoke: Aaron persona + Nanolith → default state visible (requires local FE + backend with Aaron seed)

## Refs

- Closes #1068
- Umbrella #1066 — Mockup Conformity Roadmap
- Spec: `docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md` § WS-B
- Trigger commit: `f3702921d` (PR #1037 IA consolidation)

Generated with [Claude Code](https://claude.com/claude-code)