### PR TITLE
fix(e2e): smoke specs route to canonical /library/[gameId] (#992)

### DIFF
--- a/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-low-confidence.smoke.spec.ts
@@ -46,7 +46,7 @@ test.describe('SMOKE — game-chat low confidence (G5)', () => {
       confidence: 0.42,
     });
 
-    await page.goto(`/library/games/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`/library/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('[data-testid="message-input"]', { timeout: 30_000 });
 
     const input = page.locator('[data-testid="message-input"]');

--- a/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-out-of-context.smoke.spec.ts
@@ -36,7 +36,7 @@ test.describe('SMOKE — game-chat out of context', () => {
       confidence: 0.0,
     });
 
-    await page.goto(`/library/games/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`/library/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('[data-testid="message-input"]', { timeout: 30_000 });
 
     const input = page.locator('[data-testid="message-input"]');

--- a/apps/web/e2e/smoke-real-backend/game-night-pdf-non-owner.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/game-night-pdf-non-owner.smoke.spec.ts
@@ -47,7 +47,7 @@ test.describe('SMOKE — game-chat PDF non-owner upsell (G4)', () => {
       confidence: 0.9,
     });
 
-    await page.goto(`/library/games/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`/library/${gameId}?tab=aiChat`, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('[data-testid="message-input"]', { timeout: 30_000 });
 
     const input = page.locator('[data-testid="message-input"]');

--- a/apps/web/e2e/smoke-real-llm/game-night-happy-path.spec.ts
+++ b/apps/web/e2e/smoke-real-llm/game-night-happy-path.spec.ts
@@ -36,7 +36,7 @@ test.describe('SMOKE-REAL-LLM — game-night happy path (free tier)', () => {
     const { cookieHeader } = await smokeLogin(request);
     await applySessionToPage(page, cookieHeader);
 
-    await page.goto(`/library/games/${SEED_GAME_ID}?tab=aiChat`, {
+    await page.goto(`/library/${SEED_GAME_ID}?tab=aiChat`, {
       waitUntil: 'domcontentloaded',
     });
     await page.waitForSelector('[data-testid="message-input"]', { timeout: 30_000 });


### PR DESCRIPTION
## Summary

Closes #992. Resolves the 3 failing nightly smoke specs whose root cause was traced to a deprecated URL path.

### Root cause

PR #1009 (closes #1004) removed the catch-all redirect \`/library/games/:id → /library/:id\`. Four smoke specs still navigate to \`/library/games/\${gameId}?tab=aiChat\`, which now matches no route and serves the global \`not-found.tsx\`. \`NotFoundContent\` calls \`useTranslation()\`, but \`IntlProvider\` is client-only (documented in CLAUDE.md \"Token Canonicalization\"), so SSR HTML contains raw message-id keys (\`pages.errors.notFound.title\`) while the client renders translated text — producing **React error #418** and the observed Chromium SEGV.

### Changes

- 3 spec files in \`apps/web/e2e/smoke-real-backend/\` switched to canonical 2-segment path
- 1 spec file in \`apps/web/e2e/smoke-real-llm/\` switched to canonical path
- Gamebook specs (\`/library/games/:id/play/**\`) untouched — those sub-routes still have explicit redirects in \`next.config.js:196-209\`

### Out of scope

The underlying \`NotFoundContent\` SSR/CSR mismatch is tracked in #1076 (option 1: replace \`useTranslation()\` with a static \`it.json\` import). Fixing it would harden every 404 page, not just these smoke flows.

## Test plan

- [x] \`pnpm typecheck\` passes (verified via pre-commit hook)
- [x] \`pnpm lint\` passes (verified via lint-staged on staged files)
- [ ] Wait 1 nightly smoke run on main-dev to confirm the 3 specs go green
- [ ] DoD per #992: 5 consecutive nightly green runs to close definitively

🤖 Generated with [Claude Code](https://claude.com/claude-code)