### PR TITLE
fix(infra): HealthMonitor per-iteration save + granular logging (#896)

### DIFF
--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
@@ -260,6 +260,13 @@ internal sealed class InfrastructureHealthMonitorService : BackgroundService
                     ex,
                     "[HealthMonitor] {Service}: persist failed (status={Status}); in-memory cache updated, DB out of sync until next successful save",
                     serviceName, newState.CurrentStatus);
+
+                // EF Core guidance: after SaveChanges throws, the change tracker may
+                // hold the failed entity in Modified/Added state. Without a clear, the
+                // NEXT iteration's UpsertStateAsync would re-attempt persisting that
+                // entity alongside the new one, cascading the failure across services
+                // and defeating the per-iteration isolation we want here.
+                db.ChangeTracker.Clear();
             }
 #pragma warning restore CA1031
         }

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs
@@ -239,11 +239,30 @@ internal sealed class InfrastructureHealthMonitorService : BackgroundService
             // Update in-memory cache
             _states[serviceName] = newState;
 
-            // Persist to database (upsert by ServiceName)
-            await UpsertStateAsync(db, newState, tags, cancellationToken).ConfigureAwait(false);
+            // Persist to database — issue #896: commit per service so a single-row
+            // failure (concurrency conflict, transient connection, constraint) does
+            // NOT roll back the other services in this poll cycle. Previously the
+            // batched SaveChangesAsync at the end of the foreach meant one bad
+            // upsert silently kept every service stuck at its DB-hydrated status
+            // (memory said Unhealthy, DB stayed Degraded — see #896 evidence).
+#pragma warning disable CA1031 // Per-service catch — must not abort the poll loop
+            try
+            {
+                await UpsertStateAsync(db, newState, tags, cancellationToken).ConfigureAwait(false);
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug(
+                    "[HealthMonitor] {Service}: persisted {Status} (failures={Failures}, successes={Successes})",
+                    serviceName, newState.CurrentStatus, newState.ConsecutiveFailures, newState.ConsecutiveSuccesses);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(
+                    ex,
+                    "[HealthMonitor] {Service}: persist failed (status={Status}); in-memory cache updated, DB out of sync until next successful save",
+                    serviceName, newState.CurrentStatus);
+            }
+#pragma warning restore CA1031
         }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task UpsertStateAsync(


### PR DESCRIPTION
## Summary

Closes #896.

\`InfrastructureHealthMonitorService.PollHealthChecksAsync\` previously batched every per-service \`UpsertStateAsync\` into a single trailing \`SaveChangesAsync\`. When ONE service triggers an EF Core failure (concurrency conflict, transient connection issue, constraint violation), the whole transaction is rolled back — NONE of the N services are persisted. The in-memory \`_states\` cache is already updated before \`SaveChanges\`, so subsequent polls log \`Unhealthy\` from memory while the DB stays frozen on whatever the hydration step loaded at startup — the exact divergence described in #896 (\"Reminder — still Unhealthy\" logs vs. \`Degraded\` persisted state for unstructured/smoldocling/ollama).

## Changes

\`apps/api/src/Api/Infrastructure/BackgroundServices/InfrastructureHealthMonitorService.cs\` only — +23/-4.

- Move \`db.SaveChangesAsync\` inside the \`foreach\` loop (per-service commit).
- Wrap \`UpsertStateAsync\` + \`SaveChangesAsync\` in a per-service \`try/catch\` so a failure on service A no longer rolls back queued upserts for services B/C/D.
- Add a \`LogDebug\` on the happy path that includes \`{Service}\`, \`{Status}\`, \`failures=\` and \`successes=\` counters.
- Add a \`LogError\` on failure that names the offending service and clarifies that the in-memory cache stays updated until the next successful save (matches the observed staging behavior).
- \`#pragma\` to silence CA1031 with an inline justification (per-service catch is intentional, must not abort the poll loop).

Trade-off: N round-trips to PostgreSQL per poll instead of 1. With N≈10 services and a polling interval of seconds, the overhead is negligible.

## Verification

- \`dotnet build\` → 0 warnings, 0 errors.
- \`dotnet test --filter \"HealthMonitor|HealthState\"\` → 37/37 passed.
- Existing \`HealthMonitorStateMachineTests\` + \`HealthStateOrphanCleanupTests\` cover the pure FSM + cleanup helper, both untouched.

## Follow-up

The underlying root cause of the SaveChanges failure (concurrency token? constraint? transient transport?) requires staging-log evidence. The new \`{Service}: persist failed (status={Status})\` log line surfaces actionable information — closing #896 once that log appears in staging after deploy.

## Test plan

- [x] Backend build (\`dotnet build\`) passes
- [x] Existing HealthMonitor tests pass (37/37)
- [ ] After deploy: confirm new debug log line is emitted in staging
- [ ] After deploy: monitor for \`{Service}: persist failed\` errors and triage with concrete service name

🤖 Generated with [Claude Code](https://claude.com/claude-code)