### PR TITLE
chore(ci): refresh frontend-a11y blocker reference to #752

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,17 +606,29 @@ jobs:
 
   # Frontend Accessibility Gate (Issue #601)
   # Runs Playwright + axe-core against public routes for WCAG 2.1 AA compliance.
-  # BLOCKING (post P2 #807 token redesign — entity tokens now AA-compliant on bg-card).
-  # Pre-P2: pattern hsl(*, 89%, 48%) on hsla(0.10) bg in SP6 v2 design tokens triggers
-  # axe-core color-contrast violations. Resolved by P2 #807 — see:
-  #   - https://github.com/meepleAi-app/meepleai-monorepo/issues/807 (closed)
-  #   - https://github.com/meepleAi-app/meepleai-monorepo/issues/808 (freeze lifted)
+  # STATUS: non-blocking. Re-enabling requires resolving the residual dark-mode
+  # contrast violations tracked in #752 (text-slate-500 on dark surfaces — fails
+  # WCAG AA 4.5:1, ~20-36 nodes per state).
+  #
+  # History:
+  #   - #807 (closed 2026-05-09): SP6 v2 token redesign — entity tokens AA on light;
+  #     base text/bg pairs AA on both themes.
+  #   - #808 (closed): SP6 freeze lifted post-#807.
+  #   - #752 (OPEN — blocker for restoring this gate to blocking): D.2 Foundation
+  #     dark-mode contrast — text-slate-500 on dark backgrounds fails 4.5:1.
+  #     Fix path: migrate text-slate-500 → text-muted-foreground (DS-15 semantic
+  #     token) on dark-mode surfaces.
+  #
+  # Dashboard restyle (PR #1079) and follow-ups (#1081 token cleanup, #1082
+  # gradient mark) verified locally with jest-axe → 0 violations on the new
+  # dashboard surfaces in both themes. The continue-on-error stays until #752
+  # closes.
   frontend-a11y:
     name: Frontend - A11y E2E
     runs-on: ${{ needs.changes.outputs.runner }}
     timeout-minutes: 15
     needs: changes
-    continue-on-error: true # #807: token redesign light/dark base AA OK, but legacy dark-mode surfaces (#2e2e2e, alpha-blended bg-entity-*/15) + slate-700 fg combos still violate. Re-block gate via dedicated PR after dark-surface audit follow-up.
+    continue-on-error: true # Blocker: #752 (text-slate-500 on dark fails AA). See comment block above for re-enable path.
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     defaults:
       run:


### PR DESCRIPTION
Comment refresh in .github/workflows/ci.yml: the frontend-a11y job referenced #807 (CLOSED 2026-05-09) as blocker for restoring continue-on-error: false. The actual remaining blocker is #752 (OPEN — text-slate-500 on dark surfaces fails WCAG AA 4.5:1, ~20-36 nodes/state). Purely a documentation update, no workflow logic change.

Verified during PR #1079 (dashboard restyle) follow-up:
- #807 CLOSED — token redesign delivered AA-compliant entity tokens
- #752 OPEN — D.2 Foundation dark-mode contrast still to fix
- Dashboard restyle itself ships clean a11y (jest-axe 0 violations both themes)

Re-enable path when #752 closes:
```diff
-    continue-on-error: true
+    # restored to blocking
```

Files: .github/workflows/ci.yml lines 607-624 (comment block).

🤖 Generated with Claude Code