### PR TITLE
feat(state-coverage): WS-D Foundation — parser + matrix + helper + CI gate (closes #1070)

### DIFF
--- a/.github/workflows/state-coverage-check.yml
+++ b/.github/workflows/state-coverage-check.yml
@@ -1,0 +1,98 @@
+name: State Coverage Check
+
+# Issue #1070 (WS-D Mockup Conformity Roadmap, umbrella #1066)
+# Verifies state-matrix.json is in sync with admin-mockups/design_files/*.html
+# and enforces missing.length === 0 for mockups flagged `enforced: true`.
+
+on:
+  pull_request:
+    branches: [main, main-dev, main-staging]
+    paths:
+      - 'admin-mockups/design_files/**'
+      - 'apps/web/e2e/state-coverage/**'
+      - 'apps/web/scripts/extract-mockup-states.ts'
+      - 'apps/web/scripts/__tests__/extract-mockup-states.test.ts'
+      - '.github/workflows/state-coverage-check.yml'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'check (diff fail) | regenerate (write matrix.json artifact)'
+        required: true
+        default: 'check'
+        type: choice
+        options:
+          - check
+          - regenerate
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: state-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  state-coverage:
+    name: State Matrix Sync + Enforcement
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          node-version: '20'
+          pnpm-version: '10'
+          working-directory: apps/web
+          frozen-lockfile: 'true'
+
+      - name: Run state matrix sync check
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'check'
+        run: pnpm tsx scripts/extract-mockup-states.ts --check
+
+      - name: Run enforcement check (enforced=true entries)
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'check'
+        run: pnpm tsx scripts/extract-mockup-states.ts --enforced-only
+
+      - name: Regenerate matrix.json (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        run: pnpm tsx scripts/extract-mockup-states.ts --write
+
+      - name: Upload regenerated matrix
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        uses: actions/upload-artifact@v7
+        with:
+          name: state-matrix-regenerated-${{ github.run_number }}
+          path: apps/web/e2e/state-coverage/state-matrix.json
+          retention-days: 14
+
+      - name: Comment on PR (sync failure)
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = `## State Coverage Check failed
+
+            \`state-matrix.json\` is out-of-sync with mockup HTML files in \`admin-mockups/design_files/\`.
+
+            **To fix**:
+            \`\`\`bash
+            cd apps/web
+            pnpm tsx scripts/extract-mockup-states.ts --write
+            git add e2e/state-coverage/state-matrix.json
+            git commit -m "chore(state-coverage): refresh matrix from mockup edits"
+            \`\`\`
+
+            See \`docs/for-developers/testing/frontend/visual-state-coverage.md\` for full workflow.
+            `;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -1,5 +1,6 @@
 {
-  "generated_at": "2026-05-12T14:38:00.257Z",
+  "$schema": "./state-matrix.schema.json",
+  "generated_at": "2026-05-12T14:39:28.967Z",
   "total_mockups": 61,
   "enforced_count": 0,
   "entries": [

--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -1,0 +1,581 @@
+{
+  "generated_at": "2026-05-12T14:38:00.257Z",
+  "total_mockups": 61,
+  "enforced_count": 0,
+  "entries": [
+    {
+      "mockup_path": "admin-mockups/design_files/00-hub.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/01-screens.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/02-desktop-patterns.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/03-drawer-variants.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/04-design-system.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/05-dark-mode.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/auth-flow.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-game-night-storyboard.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-nav-bottom-mobile.html",
+      "route": null,
+      "declared_states": [
+        "state-01-no-session"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-no-session"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-nav-chat-panel.html",
+      "route": null,
+      "declared_states": [
+        "state-01-closed"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-closed"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-nav-topbar.html",
+      "route": null,
+      "declared_states": [
+        "state-01-idle"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-idle"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-encounter-cheatsheet.html",
+      "route": "/library/{gameId}/play/{campaignId}/encounter",
+      "declared_states": [
+        "A",
+        "entry-from-story  (paragrafo Storybook §147 chiama \"→ Encounter §218\", CTA \"Apri Encounter Book\")"
+      ],
+      "covered_states": [],
+      "missing": [
+        "A",
+        "entry-from-story  (paragrafo Storybook §147 chiama \"→ Encounter §218\", CTA \"Apri Encounter Book\")"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-error-states.html",
+      "route": "trasversale",
+      "declared_states": [
+        "A",
+        "stream-timeout      (chat agente N2: nessun token > 30s",
+        "retry/cambia agent/copy)"
+      ],
+      "covered_states": [],
+      "missing": [
+        "A",
+        "stream-timeout      (chat agente N2: nessun token > 30s",
+        "retry/cambia agent/copy)"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-detail.html",
+      "route": "/library/{gameId}",
+      "declared_states": [
+        "default",
+        "loading",
+        "error",
+        "not-found"
+      ],
+      "covered_states": [],
+      "missing": [
+        "default",
+        "loading",
+        "error",
+        "not-found"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-onboarding.html",
+      "route": "/library/{gameId}",
+      "declared_states": [
+        "A",
+        "prereq-missing   (3 step todo: PDF upload, KB indexing, agente Tutor)"
+      ],
+      "covered_states": [],
+      "missing": [
+        "A",
+        "prereq-missing   (3 step todo: PDF upload, KB indexing, agente Tutor)"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-glossary-editor.html",
+      "route": "/library/nanolith/play/{campaignId}?glossary=add",
+      "declared_states": [
+        "state-01-edit-pristine"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-edit-pristine"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-library-search.html",
+      "route": "/library",
+      "declared_states": [
+        "state-01-default-grid"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-default-grid"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-play-session.html",
+      "route": "/library/nanolith/play/{campaignId}",
+      "declared_states": [
+        "state-01-story-tab"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-story-tab"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-quota-credits.html",
+      "route": "/library/nanolith/play/{campaignId}",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-resume-picker.html",
+      "route": "/library/{gameId}/play",
+      "declared_states": [
+        "state-01-first-time"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-first-time"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-session-end.html",
+      "route": "overlay",
+      "declared_states": [
+        "state-01-paused"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-paused"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-setup-chat.html",
+      "route": "/library/{gameId}/play/{campaignId}?tab=chat",
+      "declared_states": [
+        "default"
+      ],
+      "covered_states": [],
+      "missing": [
+        "default"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-setup-wizard.html",
+      "route": "/library/{gameId}",
+      "declared_states": [
+        "state-01-step1-name"
+      ],
+      "covered_states": [],
+      "missing": [
+        "state-01-step1-name"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-translate-viewer.html",
+      "route": "/library/{gameId}/play/{campaignId}/translate",
+      "declared_states": [
+        "A",
+        "camera-ready    (CameraViewfinder primitive, frame tratteggiato + scatto button)"
+      ],
+      "covered_states": [],
+      "missing": [
+        "A",
+        "camera-ready    (CameraViewfinder primitive, frame tratteggiato + scatto button)"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/notifications.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/onboarding.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/public.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/settings.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-accept-invite.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-faq-enhanced.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-how-it-works.html",
+      "route": "/how-it-works",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-join.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-legal.html",
+      "route": "/terms",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-library-public.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-shared-game-detail.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp3-shared-games.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-add-game-bgg-step.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-add-game-pdf-dedup.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-agent-detail.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-agents-index.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-citation-pdf-viewer.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-discover.html",
+      "route": "/discover",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-game-chat-tab.html",
+      "route": "/library/games/{gameId}?tab=aiChat",
+      "declared_states": [
+        "default",
+        "confidence-bassa",
+        "out-of-context",
+        "loading"
+      ],
+      "covered_states": [],
+      "missing": [
+        "default",
+        "confidence-bassa",
+        "out-of-context",
+        "loading"
+      ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-game-detail.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-game-nights-index.html",
+      "route": "/game-nights",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-games-index.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-kb-detail.html",
+      "route": "/kb/[id]",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-kb-hub.html",
+      "route": "/library/private/[gameId]/kb",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-library-desktop.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-player-detail.html",
+      "route": "/players/[id]",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-players-index.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-session-live.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-session-summary.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-sessions-index.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-toolkit-detail.html",
+      "route": "/toolkits/[id]",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-upload-wizard-extended.html",
+      "route": "/kb/upload",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp6-libro-game-index.html",
+      "route": "/gamebook",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp6-libro-game-photo-upload.html",
+      "route": "/gamebook/upload",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp6-libro-game-resume-state.html",
+      "route": "/library/games/[gameId]/play",
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp7-game-night-create.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp7-game-night-detail-rsvp.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    }
+  ]
+}

--- a/apps/web/e2e/state-coverage/state-matrix.schema.json
+++ b/apps/web/e2e/state-coverage/state-matrix.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://meepleai.app/schemas/state-matrix.schema.json",
+  "title": "State Coverage Matrix",
+  "description": "WS-D Mockup state coverage tracking. Issue #1070 (umbrella #1066).",
+  "type": "object",
+  "required": ["generated_at", "total_mockups", "enforced_count", "entries"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp. Bumped only when content effectively differs."
+    },
+    "total_mockups": { "type": "integer", "minimum": 0 },
+    "enforced_count": { "type": "integer", "minimum": 0 },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/MockupStateEntry" }
+    }
+  },
+  "definitions": {
+    "MockupStateEntry": {
+      "type": "object",
+      "required": [
+        "mockup_path",
+        "route",
+        "declared_states",
+        "covered_states",
+        "missing",
+        "enforced"
+      ],
+      "properties": {
+        "mockup_path": {
+          "type": "string",
+          "pattern": "^admin-mockups/design_files/[\\w-]+\\.html$"
+        },
+        "route": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "declared_states": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "States declared in mockup `Stati:` comment line. Order preserves author declaration order."
+        },
+        "covered_states": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "States covered by Playwright tests. Manually curated; preserved across regenerations."
+        },
+        "missing": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "declared_states - covered_states. Computed."
+        },
+        "enforced": {
+          "type": "boolean",
+          "description": "If true, CI gate fails on missing.length > 0. Bootstrap: all false."
+        }
+      }
+    }
+  }
+}

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -3,7 +3,7 @@
  * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { extractStatesFromComment } from '../extract-mockup-states';
+import { extractStatesFromComment, extractRouteFromComment } from '../extract-mockup-states';
 
 describe('extractStatesFromComment', () => {
   it('parses single-line Stati with · separator', () => {
@@ -38,5 +38,20 @@ describe('extractStatesFromComment', () => {
   it('returns empty array when no Stati line present', () => {
     const comment = `Mockup: foo\nRoute: /bar`;
     expect(extractStatesFromComment(comment)).toEqual([]);
+  });
+});
+
+describe('extractRouteFromComment', () => {
+  it('extracts Route: from comment', () => {
+    const comment = `
+      Mockup: foo
+      Route:  /library/{gameId}
+      Stati: default`;
+    expect(extractRouteFromComment(comment)).toBe('/library/{gameId}');
+  });
+
+  it('returns null when no Route declared', () => {
+    const comment = `Mockup: foo\nStati: default`;
+    expect(extractRouteFromComment(comment)).toBeNull();
   });
 });

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -2,12 +2,16 @@
  * Tests for WS-D Foundation parser (refs #1070, umbrella #1066).
  * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   extractStatesFromComment,
   extractRouteFromComment,
   parseMockupFile,
   mergeMatrix,
+  runCli,
 } from '../extract-mockup-states';
 import type { StateMatrix } from '../extract-mockup-states';
 
@@ -188,5 +192,111 @@ describe('mergeMatrix', () => {
       'admin-mockups/design_files/alpha.html',
       'admin-mockups/design_files/zeta.html',
     ]);
+  });
+});
+
+describe('runCli', () => {
+  let tmp: string;
+  let mockupsDir: string;
+  let matrixPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'state-coverage-test-'));
+    mockupsDir = join(tmp, 'admin-mockups', 'design_files');
+    mkdirSync(mockupsDir, { recursive: true });
+    matrixPath = join(tmp, 'matrix.json');
+    writeFileSync(
+      join(mockupsDir, 'foo.html'),
+      `<!--\n  Mockup: foo\n  Stati: default · loading\n-->`
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('--write creates matrix.json with parsed entries', async () => {
+    const exitCode = await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(0);
+    const matrix = JSON.parse(readFileSync(matrixPath, 'utf-8'));
+    expect(matrix.total_mockups).toBe(1);
+    expect(matrix.entries[0].declared_states).toEqual(['default', 'loading']);
+  });
+
+  it('--check exits 0 when matrix.json in sync', async () => {
+    await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    const exitCode = await runCli({
+      mode: 'check',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it('--check exits 1 when mockup changed but matrix.json stale', async () => {
+    await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    writeFileSync(
+      join(mockupsDir, 'foo.html'),
+      `<!--\n  Mockup: foo\n  Stati: default · loading · error\n-->`
+    );
+    const exitCode = await runCli({
+      mode: 'check',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(1);
+  });
+
+  it('--enforced-only exits 0 when no enforced entries have missing', async () => {
+    await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    const exitCode = await runCli({
+      mode: 'enforced-only',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it('--enforced-only exits 1 when enforced entry has missing states', async () => {
+    await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    const matrix = JSON.parse(readFileSync(matrixPath, 'utf-8'));
+    matrix.entries[0].enforced = true;
+    matrix.enforced_count = 1;
+    writeFileSync(matrixPath, JSON.stringify(matrix, null, 2));
+    const exitCode = await runCli({
+      mode: 'enforced-only',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(1);
   });
 });

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -14,4 +14,29 @@ describe('extractStatesFromComment', () => {
       Persona: Aaron`;
     expect(extractStatesFromComment(comment)).toEqual(['default', 'loading', 'error', 'not-found']);
   });
+
+  it('parses multi-line Stati with indented continuation', () => {
+    const comment = `
+      Mockup: sp4-game-chat-tab
+      Stati:
+        default            (Aaron query "azione carta uccello + 2 cibo" su Wingspan,
+                           risposta IT + citation Manuale p.12 + confidence alta verde)
+        confidence-bassa   (edge "mazzo finisce a metà partita", disclaimer
+                           "non sono certo" + suggerimento BGG)
+        out-of-context     (utente chiede regole di Tainted Grail mentre è su Wingspan,
+                           agente declina + propone switch gioco/agente)
+        loading            (typing indicator + meta latency live, budget P95 ≤ 10s da Q6)
+      Persona: Aaron`;
+    expect(extractStatesFromComment(comment)).toEqual([
+      'default',
+      'confidence-bassa',
+      'out-of-context',
+      'loading',
+    ]);
+  });
+
+  it('returns empty array when no Stati line present', () => {
+    const comment = `Mockup: foo\nRoute: /bar`;
+    expect(extractStatesFromComment(comment)).toEqual([]);
+  });
 });

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Tests for WS-D Foundation parser (refs #1070, umbrella #1066).
+ * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+ */
+import { describe, it, expect } from 'vitest';
+import { extractStatesFromComment } from '../extract-mockup-states';
+
+describe('extractStatesFromComment', () => {
+  it('parses single-line Stati with · separator', () => {
+    const comment = `
+      Mockup: nanolith-runthrough-game-detail
+      Route:  /library/{gameId}
+      Stati:  default · loading · error · not-found
+      Persona: Aaron`;
+    expect(extractStatesFromComment(comment)).toEqual(['default', 'loading', 'error', 'not-found']);
+  });
+});

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -3,7 +3,11 @@
  * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { extractStatesFromComment, extractRouteFromComment } from '../extract-mockup-states';
+import {
+  extractStatesFromComment,
+  extractRouteFromComment,
+  parseMockupFile,
+} from '../extract-mockup-states';
 
 describe('extractStatesFromComment', () => {
   it('parses single-line Stati with · separator', () => {
@@ -53,5 +57,37 @@ describe('extractRouteFromComment', () => {
   it('returns null when no Route declared', () => {
     const comment = `Mockup: foo\nStati: default`;
     expect(extractRouteFromComment(comment)).toBeNull();
+  });
+});
+
+describe('parseMockupFile', () => {
+  it('extracts MockupStateEntry from HTML string', () => {
+    const html = `<!doctype html>
+<html>
+<head><title>test</title></head>
+<!--
+  Mockup: test-mockup
+  Route:  /test/{id}
+  Stati:  default · loading · error
+  Persona: Aaron
+-->
+<body></body>
+</html>`;
+    const entry = parseMockupFile('admin-mockups/design_files/test-mockup.html', html);
+    expect(entry).toEqual({
+      mockup_path: 'admin-mockups/design_files/test-mockup.html',
+      route: '/test/{id}',
+      declared_states: ['default', 'loading', 'error'],
+      covered_states: [],
+      missing: ['default', 'loading', 'error'],
+      enforced: false,
+    });
+  });
+
+  it('returns entry with empty declared_states when no Stati line', () => {
+    const html = `<!--\n  Mockup: foo\n-->`;
+    const entry = parseMockupFile('admin-mockups/design_files/foo.html', html);
+    expect(entry.declared_states).toEqual([]);
+    expect(entry.missing).toEqual([]);
   });
 });

--- a/apps/web/scripts/__tests__/extract-mockup-states.test.ts
+++ b/apps/web/scripts/__tests__/extract-mockup-states.test.ts
@@ -7,7 +7,9 @@ import {
   extractStatesFromComment,
   extractRouteFromComment,
   parseMockupFile,
+  mergeMatrix,
 } from '../extract-mockup-states';
+import type { StateMatrix } from '../extract-mockup-states';
 
 describe('extractStatesFromComment', () => {
   it('parses single-line Stati with · separator', () => {
@@ -89,5 +91,102 @@ describe('parseMockupFile', () => {
     const entry = parseMockupFile('admin-mockups/design_files/foo.html', html);
     expect(entry.declared_states).toEqual([]);
     expect(entry.missing).toEqual([]);
+  });
+});
+
+describe('mergeMatrix', () => {
+  it('preserves covered_states and enforced from existing matrix', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 1,
+      enforced_count: 1,
+      entries: [
+        {
+          mockup_path: 'admin-mockups/design_files/foo.html',
+          route: '/foo',
+          declared_states: ['a', 'b'],
+          covered_states: ['a'],
+          missing: ['b'],
+          enforced: true,
+        },
+      ],
+    };
+    const fresh = [
+      {
+        mockup_path: 'admin-mockups/design_files/foo.html',
+        route: '/foo',
+        declared_states: ['a', 'b', 'c'],
+        covered_states: [],
+        missing: ['a', 'b', 'c'],
+        enforced: false,
+      },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries[0].covered_states).toEqual(['a']);
+    expect(merged.entries[0].enforced).toBe(true);
+    expect(merged.entries[0].declared_states).toEqual(['a', 'b', 'c']);
+    expect(merged.entries[0].missing).toEqual(['b', 'c']);
+  });
+
+  it('drops covered states no longer in declared', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 1,
+      enforced_count: 0,
+      entries: [
+        {
+          mockup_path: 'admin-mockups/design_files/foo.html',
+          route: '/foo',
+          declared_states: ['a', 'b'],
+          covered_states: ['a', 'b', 'obsolete'],
+          missing: [],
+          enforced: false,
+        },
+      ],
+    };
+    const fresh = [
+      {
+        mockup_path: 'admin-mockups/design_files/foo.html',
+        route: '/foo',
+        declared_states: ['a'],
+        covered_states: [],
+        missing: ['a'],
+        enforced: false,
+      },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries[0].covered_states).toEqual(['a']);
+  });
+
+  it('sorts entries alphabetically by mockup_path', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 0,
+      enforced_count: 0,
+      entries: [],
+    };
+    const fresh = [
+      {
+        mockup_path: 'admin-mockups/design_files/zeta.html',
+        route: null,
+        declared_states: [],
+        covered_states: [],
+        missing: [],
+        enforced: false,
+      },
+      {
+        mockup_path: 'admin-mockups/design_files/alpha.html',
+        route: null,
+        declared_states: [],
+        covered_states: [],
+        missing: [],
+        enforced: false,
+      },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries.map(e => e.mockup_path)).toEqual([
+      'admin-mockups/design_files/alpha.html',
+      'admin-mockups/design_files/zeta.html',
+    ]);
   });
 });

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -58,3 +58,12 @@ export function extractStatesFromComment(commentText: string): string[] {
     .map(l => l.trim().split(/\s+/)[0])
     .filter(token => /^[a-zA-Z][\w-]*$/.test(token));
 }
+
+/**
+ * Extract `Route:` value from comment text.
+ * Returns null if not declared.
+ */
+export function extractRouteFromComment(commentText: string): string | null {
+  const match = commentText.match(/Route:\s*(\S+)/);
+  return match ? match[1] : null;
+}

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -7,6 +7,8 @@
  */
 
 import { JSDOM } from 'jsdom';
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 export interface MockupStateEntry {
   mockup_path: string;
@@ -156,4 +158,107 @@ export function mergeMatrix(existing: StateMatrix, fresh: MockupStateEntry[]): S
     enforced_count: merged.filter(e => e.enforced).length,
     entries: merged,
   };
+}
+
+export type CliMode = 'check' | 'write' | 'enforced-only';
+
+export interface CliOptions {
+  mode: CliMode;
+  mockupsDir: string;
+  matrixPath: string;
+  /** Path prefix written into matrix entries (e.g. 'admin-mockups/design_files'). */
+  mockupsPathPrefix: string;
+}
+
+/**
+ * Glob mockup HTML files in `opts.mockupsDir` and parse each into a MockupStateEntry.
+ */
+function collectAllMockupEntries(opts: CliOptions): MockupStateEntry[] {
+  const files = readdirSync(opts.mockupsDir)
+    .filter(f => f.endsWith('.html'))
+    .sort();
+  return files.map(filename => {
+    const absPath = join(opts.mockupsDir, filename);
+    const html = readFileSync(absPath, 'utf-8');
+    const repoRelative = `${opts.mockupsPathPrefix}/${filename}`;
+    return parseMockupFile(repoRelative, html);
+  });
+}
+
+function loadExistingMatrix(matrixPath: string): StateMatrix {
+  if (!existsSync(matrixPath)) {
+    return { generated_at: '', total_mockups: 0, enforced_count: 0, entries: [] };
+  }
+  return JSON.parse(readFileSync(matrixPath, 'utf-8'));
+}
+
+/**
+ * Stringify matrix omitting meta keys (`generated_at`, `$schema`) for diff
+ * comparison — avoids spurious diffs from timestamp bumps or schema link.
+ */
+function stringifyForDiff(matrix: StateMatrix & { $schema?: string }): string {
+  const { generated_at: _gen, $schema: _s, ...rest } = matrix;
+  void _gen;
+  void _s;
+  return JSON.stringify({ ...rest, generated_at: '' }, null, 2);
+}
+
+/**
+ * CLI orchestrator. Returns exit code (0 OK, 1 fail).
+ */
+export async function runCli(opts: CliOptions): Promise<number> {
+  const fresh = collectAllMockupEntries(opts);
+  const existing = loadExistingMatrix(opts.matrixPath);
+  const merged = mergeMatrix(existing, fresh);
+
+  switch (opts.mode) {
+    case 'write': {
+      writeFileSync(opts.matrixPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+      return 0;
+    }
+    case 'check': {
+      if (stringifyForDiff(existing) === stringifyForDiff(merged)) return 0;
+      console.error('state-matrix.json out of sync with admin-mockups/design_files.');
+      console.error('Run: pnpm tsx apps/web/scripts/extract-mockup-states.ts --write');
+      return 1;
+    }
+    case 'enforced-only': {
+      const violations = merged.entries.filter(e => e.enforced && e.missing.length > 0);
+      if (violations.length === 0) return 0;
+      console.error(`Found ${violations.length} enforced entries with missing states:`);
+      for (const v of violations) {
+        console.error(`  ${v.mockup_path}: missing ${JSON.stringify(v.missing)}`);
+      }
+      return 1;
+    }
+  }
+}
+
+// ─── CLI entry point ───────────────────────────────────────────────────────────
+// Runs only when invoked directly via `pnpm tsx scripts/extract-mockup-states.ts`
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  typeof process.argv[1] === 'string' &&
+  process.argv[1].endsWith('extract-mockup-states.ts');
+
+if (invokedDirectly) {
+  const args = process.argv.slice(2);
+  let mode: CliMode = 'check';
+  if (args.includes('--write')) mode = 'write';
+  else if (args.includes('--enforced-only')) mode = 'enforced-only';
+  else if (args.includes('--check')) mode = 'check';
+
+  // Resolve repo root from script location: apps/web/scripts/ → ../../..
+  const scriptDir = new URL('.', import.meta.url).pathname;
+  // On Windows, pathname has leading slash that needs trimming: /D:/...
+  const normalizedScriptDir =
+    process.platform === 'win32' && /^\/[A-Z]:/.test(scriptDir) ? scriptDir.slice(1) : scriptDir;
+  const repoRoot = join(normalizedScriptDir, '..', '..', '..');
+
+  runCli({
+    mode,
+    mockupsDir: join(repoRoot, 'admin-mockups', 'design_files'),
+    matrixPath: join(repoRoot, 'apps', 'web', 'e2e', 'state-coverage', 'state-matrix.json'),
+    mockupsPathPrefix: 'admin-mockups/design_files',
+  }).then(code => process.exit(code));
 }

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -213,7 +213,12 @@ export async function runCli(opts: CliOptions): Promise<number> {
 
   switch (opts.mode) {
     case 'write': {
-      writeFileSync(opts.matrixPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+      // Prepend $schema link so IDE auto-validates the file
+      const output = {
+        $schema: './state-matrix.schema.json',
+        ...merged,
+      };
+      writeFileSync(opts.matrixPath, JSON.stringify(output, null, 2) + '\n', 'utf-8');
       return 0;
     }
     case 'check': {

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -6,6 +6,17 @@
  * Issue: #1070 (umbrella #1066)
  */
 
+import { JSDOM } from 'jsdom';
+
+export interface MockupStateEntry {
+  mockup_path: string;
+  route: string | null;
+  declared_states: string[];
+  covered_states: string[];
+  missing: string[];
+  enforced: boolean;
+}
+
 /**
  * Extract state names from a single comment text block.
  * Supports two declaration styles:
@@ -66,4 +77,39 @@ export function extractStatesFromComment(commentText: string): string[] {
 export function extractRouteFromComment(commentText: string): string | null {
   const match = commentText.match(/Route:\s*(\S+)/);
   return match ? match[1] : null;
+}
+
+/**
+ * Walk DOM, collect all COMMENT_NODE text concatenated with newline separators.
+ * jsdom: comment nodes have nodeType === 8 (Node.COMMENT_NODE).
+ */
+function collectAllCommentsText(html: string): string {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const walker = doc.createNodeIterator(doc, dom.window.NodeFilter.SHOW_COMMENT);
+  const parts: string[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    parts.push(node.nodeValue ?? '');
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Parse a single mockup HTML file into a MockupStateEntry.
+ * Preserves declared_states in source order; covered_states starts empty,
+ * enforced starts false (bootstrap-then-enforce per spec §2).
+ */
+export function parseMockupFile(mockupPath: string, html: string): MockupStateEntry {
+  const commentsText = collectAllCommentsText(html);
+  const declared = extractStatesFromComment(commentsText);
+  const route = extractRouteFromComment(commentsText);
+  return {
+    mockup_path: mockupPath,
+    route,
+    declared_states: declared,
+    covered_states: [],
+    missing: declared.slice(), // declared - covered (all declared at bootstrap)
+    enforced: false,
+  };
 }

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -195,12 +195,18 @@ function loadExistingMatrix(matrixPath: string): StateMatrix {
 /**
  * Stringify matrix omitting meta keys (`generated_at`, `$schema`) for diff
  * comparison — avoids spurious diffs from timestamp bumps or schema link.
+ *
+ * Both keys are dropped entirely (not re-inserted with sentinel values) so
+ * the comparison output reflects only content fields. Tightened after PR
+ * #1084 review feedback: the previous `{ ...rest, generated_at: '' }`
+ * version reinserted the field as an empty string, which made the comparison
+ * shape diverge from on-disk JSON and could mask the bootstrap edge case.
  */
 function stringifyForDiff(matrix: StateMatrix & { $schema?: string }): string {
   const { generated_at: _gen, $schema: _s, ...rest } = matrix;
   void _gen;
   void _s;
-  return JSON.stringify({ ...rest, generated_at: '' }, null, 2);
+  return JSON.stringify(rest, null, 2);
 }
 
 /**

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -95,6 +95,13 @@ function collectAllCommentsText(html: string): string {
   return parts.join('\n');
 }
 
+export interface StateMatrix {
+  generated_at: string;
+  total_mockups: number;
+  enforced_count: number;
+  entries: MockupStateEntry[];
+}
+
 /**
  * Parse a single mockup HTML file into a MockupStateEntry.
  * Preserves declared_states in source order; covered_states starts empty,
@@ -111,5 +118,42 @@ export function parseMockupFile(mockupPath: string, html: string): MockupStateEn
     covered_states: [],
     missing: declared.slice(), // declared - covered (all declared at bootstrap)
     enforced: false,
+  };
+}
+
+/**
+ * Merge fresh-parsed entries into an existing matrix, preserving manually-curated
+ * fields (`covered_states`, `enforced`). Filters covered_states down to those
+ * still in declared_states (drops obsolete coverage).
+ *
+ * Output sorted alphabetically by `mockup_path` for deterministic diffs.
+ */
+export function mergeMatrix(existing: StateMatrix, fresh: MockupStateEntry[]): StateMatrix {
+  const byPath = new Map<string, MockupStateEntry>();
+  for (const e of existing.entries) {
+    byPath.set(e.mockup_path, e);
+  }
+
+  const merged: MockupStateEntry[] = fresh.map(freshEntry => {
+    const prior = byPath.get(freshEntry.mockup_path);
+    if (!prior) return freshEntry;
+    const declared = freshEntry.declared_states;
+    const covered = prior.covered_states.filter(s => declared.includes(s));
+    const missing = declared.filter(s => !covered.includes(s));
+    return {
+      ...freshEntry,
+      covered_states: covered,
+      missing,
+      enforced: prior.enforced,
+    };
+  });
+
+  merged.sort((a, b) => a.mockup_path.localeCompare(b.mockup_path));
+
+  return {
+    generated_at: new Date().toISOString(),
+    total_mockups: merged.length,
+    enforced_count: merged.filter(e => e.enforced).length,
+    entries: merged,
   };
 }

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -1,0 +1,45 @@
+/**
+ * WS-D Foundation: parser estrae stati canonici dichiarati nei commenti
+ * HTML dei mockup (`admin-mockups/design_files/*.html`).
+ *
+ * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+ * Issue: #1070 (umbrella #1066)
+ */
+
+/**
+ * Extract state names from a single comment text block.
+ * Supports two declaration styles:
+ *  - Inline: `Stati:  default · loading · error · not-found`
+ *  - Multi-line: `Stati:` on first line, indented `<name> (description)` lines after
+ *
+ * Returns empty array if no `Stati:` line found.
+ */
+export function extractStatesFromComment(commentText: string): string[] {
+  // Match "Stati:" + everything until next field header or end of comment
+  const match = commentText.match(
+    /Stati:\s*([\s\S]+?)(?=\n\s*(?:Route|Persona|Scope|Mockup|Vincoli|Sorgente|Phase|CSS|Note)[:\s]|$)/
+  );
+  if (!match) return [];
+
+  const block = match[1];
+  const firstLine = block.split('\n')[0].trim();
+
+  // Inline form: contains a known separator on first line
+  if (/[·|,]/.test(firstLine)) {
+    return firstLine
+      .split(/[·|,]/)
+      .map(s => s.trim())
+      .filter(Boolean);
+  }
+
+  // Multi-line form: each non-blank line's first token is a state name.
+  // Filter lines that don't start with a word char to skip description
+  // continuation lines (e.g. lines starting with `(` or whitespace-only).
+  return block
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+    .filter(line => /^[a-zA-Z]/.test(line))
+    .map(line => line.split(/\s+/)[0])
+    .filter(Boolean);
+}

--- a/apps/web/scripts/extract-mockup-states.ts
+++ b/apps/web/scripts/extract-mockup-states.ts
@@ -15,31 +15,46 @@
  * Returns empty array if no `Stati:` line found.
  */
 export function extractStatesFromComment(commentText: string): string[] {
-  // Match "Stati:" + everything until next field header or end of comment
+  // Match "Stati:" + everything until next field header or end of comment.
+  // Use `[ \t]*` (inline whitespace only) instead of `\s*` to PRESERVE the
+  // newline + indentation of the first multi-line state declaration, so the
+  // indent-depth heuristic below can distinguish state lines from
+  // description continuations.
   const match = commentText.match(
-    /Stati:\s*([\s\S]+?)(?=\n\s*(?:Route|Persona|Scope|Mockup|Vincoli|Sorgente|Phase|CSS|Note)[:\s]|$)/
+    /Stati:[ \t]*([\s\S]+?)(?=\n\s*(?:Route|Persona|Scope|Mockup|Vincoli|Sorgente|Phase|CSS|Note)[:\s]|$)/
   );
   if (!match) return [];
 
   const block = match[1];
-  const firstLine = block.split('\n')[0].trim();
+  // First non-blank line drives inline-vs-multiline detection
+  const firstLine =
+    block
+      .split('\n')
+      .find(l => l.trim().length > 0)
+      ?.trim() ?? '';
 
-  // Inline form: contains a known separator on first line
-  if (/[·|,]/.test(firstLine)) {
+  // Inline form: contains `·` (middot) or `|` separator on first line.
+  // `,` is intentionally excluded — descriptions on multi-line declarations
+  // often contain commas (e.g. `default (foo, bar)`) which would defeat
+  // detection. `·` is the canonical separator in admin-mockups/.
+  if (/[·|]/.test(firstLine)) {
     return firstLine
-      .split(/[·|,]/)
+      .split(/[·|]/)
       .map(s => s.trim())
       .filter(Boolean);
   }
 
-  // Multi-line form: each non-blank line's first token is a state name.
-  // Filter lines that don't start with a word char to skip description
-  // continuation lines (e.g. lines starting with `(` or whitespace-only).
-  return block
-    .split('\n')
-    .map(l => l.trim())
-    .filter(Boolean)
-    .filter(line => /^[a-zA-Z]/.test(line))
-    .map(line => line.split(/\s+/)[0])
-    .filter(Boolean);
+  // Multi-line form: state declarations have the *minimum* indentation among
+  // non-blank lines in the block; description continuations are indented more
+  // deeply (and often start with `(`). Distinguish by indent depth.
+  const nonBlankLines = block.split('\n').filter(l => l.trim().length > 0);
+  if (nonBlankLines.length === 0) return [];
+
+  const indents = nonBlankLines.map(l => (l.match(/^(\s*)/)?.[1] ?? '').length);
+  const minIndent = Math.min(...indents);
+
+  return nonBlankLines
+    .filter((_, i) => indents[i] === minIndent)
+    .map(l => l.trim().split(/\s+/)[0])
+    .filter(token => /^[a-zA-Z][\w-]*$/.test(token));
 }

--- a/apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+++ b/apps/web/src/lib/visual-test/__tests__/state-override.test.ts
@@ -6,6 +6,18 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
+
+// Hoisted mock for next/navigation. Tests configure return value per-case via
+// `mockUseSearchParams.mockReturnValue(...)`. This is the recommended pattern
+// for top-level ESM imports in vitest — `vi.doMock` in beforeEach does not
+// retroactively replace the bound `useSearchParams` reference inside
+// state-override.ts after its first module load.
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(),
+}));
+
+const mockUseSearchParams = vi.mocked(useSearchParams);
 
 describe('readStateOverride', () => {
   const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
@@ -95,19 +107,19 @@ describe('useStateOverride', () => {
 
   beforeEach(() => {
     vi.resetModules();
+    mockUseSearchParams.mockReset();
   });
 
   afterEach(() => {
     if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
     else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
-    vi.doUnmock('next/navigation');
   });
 
   it('returns null in production regardless of route params', async () => {
     delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
-    vi.doMock('next/navigation', () => ({
-      useSearchParams: () => new URLSearchParams('state=loading'),
-    }));
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams('state=loading') as unknown as ReturnType<typeof useSearchParams>
+    );
     const { useStateOverride } = await import('../state-override');
     const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
     expect(result.current).toBeNull();
@@ -115,9 +127,9 @@ describe('useStateOverride', () => {
 
   it('returns typed value in visual-test mode', async () => {
     process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
-    vi.doMock('next/navigation', () => ({
-      useSearchParams: () => new URLSearchParams('state=loading'),
-    }));
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams('state=loading') as unknown as ReturnType<typeof useSearchParams>
+    );
     const { useStateOverride } = await import('../state-override');
     const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
     expect(result.current).toBe('loading');

--- a/apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+++ b/apps/web/src/lib/visual-test/__tests__/state-override.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for WS-D Foundation `state-override.ts` helper.
+ * Refs #1070 (umbrella #1066).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+describe('readStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+  });
+
+  it('returns null when IS_VISUAL_TEST_BUILD=false (production)', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    expect(readStateOverride(params)).toBeNull();
+  });
+
+  it('returns ?state value when IS_VISUAL_TEST_BUILD=true', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    expect(readStateOverride(params)).toBe('loading');
+  });
+
+  it('returns null when searchParams is null', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    expect(readStateOverride(null)).toBeNull();
+  });
+
+  it('returns null when searchParams lacks state key', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('other=foo');
+    expect(readStateOverride(params)).toBeNull();
+  });
+});
+
+describe('readTypedStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+  });
+
+  it('returns typed value when state in allowedStates', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, ['default', 'loading', 'error'] as const);
+    expect(result).toBe('loading');
+  });
+
+  it('returns null when state value not in allowedStates', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=bogus');
+    const result = readTypedStateOverride(params, ['default', 'loading'] as const);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when allowedStates is empty', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, []);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when IS_VISUAL_TEST_BUILD=false even with valid state', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, ['default', 'loading'] as const);
+    expect(result).toBeNull();
+  });
+});
+
+describe('useStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+    vi.doUnmock('next/navigation');
+  });
+
+  it('returns null in production regardless of route params', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    vi.doMock('next/navigation', () => ({
+      useSearchParams: () => new URLSearchParams('state=loading'),
+    }));
+    const { useStateOverride } = await import('../state-override');
+    const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns typed value in visual-test mode', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    vi.doMock('next/navigation', () => ({
+      useSearchParams: () => new URLSearchParams('state=loading'),
+    }));
+    const { useStateOverride } = await import('../state-override');
+    const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
+    expect(result.current).toBe('loading');
+  });
+});

--- a/apps/web/src/lib/visual-test/state-override.ts
+++ b/apps/web/src/lib/visual-test/state-override.ts
@@ -13,6 +13,8 @@
  * Issue: #1070 (umbrella #1066)
  */
 
+import { useSearchParams } from 'next/navigation';
+
 /** Compile-time flag set by Next.js build via env var. */
 export const IS_VISUAL_TEST_BUILD: boolean = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD === '1';
 
@@ -42,8 +44,6 @@ export function readTypedStateOverride<S extends string>(
   if (!allowedStates.includes(raw as S)) return null;
   return raw as S;
 }
-
-import { useSearchParams } from 'next/navigation';
 
 /**
  * React hook variant. Reads `?state=` from Next.js `useSearchParams()`.

--- a/apps/web/src/lib/visual-test/state-override.ts
+++ b/apps/web/src/lib/visual-test/state-override.ts
@@ -1,0 +1,66 @@
+/**
+ * WS-D Foundation: shared `?state=` URL override helper for visual regression tests.
+ *
+ * Gated by NEXT_PUBLIC_VISUAL_TEST_BUILD env flag — production builds eliminate
+ * all bodies via terser dead-code-elimination (bundle delta: 0 KB).
+ *
+ * Three-layer API:
+ *   - readStateOverride: standalone, no React (fast unit tests)
+ *   - readTypedStateOverride: standalone + type-safety
+ *   - useStateOverride: React hook for component consumers
+ *
+ * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+ * Issue: #1070 (umbrella #1066)
+ */
+
+/** Compile-time flag set by Next.js build via env var. */
+export const IS_VISUAL_TEST_BUILD: boolean = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD === '1';
+
+/**
+ * Read `?state=` URL param. Returns null in production regardless of URL contents.
+ */
+export function readStateOverride(searchParams: URLSearchParams | null): string | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  if (!searchParams) return null;
+  return searchParams.get('state');
+}
+
+/**
+ * Type-safe variant. Validates raw value is one of `allowedStates`.
+ * Returns null when:
+ *  - IS_VISUAL_TEST_BUILD=false
+ *  - searchParams is null
+ *  - state param missing
+ *  - state value not in allowedStates
+ */
+export function readTypedStateOverride<S extends string>(
+  searchParams: URLSearchParams | null,
+  allowedStates: readonly S[]
+): S | null {
+  const raw = readStateOverride(searchParams);
+  if (raw === null) return null;
+  if (!allowedStates.includes(raw as S)) return null;
+  return raw as S;
+}
+
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * React hook variant. Reads `?state=` from Next.js `useSearchParams()`.
+ *
+ * In production (IS_VISUAL_TEST_BUILD=false), the hook still runs (Rules of
+ * Hooks require unconditional calls) but the body returns null early so the
+ * `?state=` value is ignored. `next/navigation` is already in the bundle for
+ * other routes, so the import adds no incremental cost.
+ *
+ * @example
+ *   const STATES = ['default', 'loading', 'error'] as const;
+ *   const state = useStateOverride(STATES); // 'default' | 'loading' | 'error' | null
+ */
+export function useStateOverride<S extends string>(allowedStates: readonly S[]): S | null {
+  const params = useSearchParams() as URLSearchParams | null;
+  // Rules of Hooks: useSearchParams must be called unconditionally.
+  // Production gate applies AFTER the hook invocation.
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  return readTypedStateOverride(params, allowedStates);
+}

--- a/docs/for-developers/plans/2026-05-12-ws-d-foundation.md
+++ b/docs/for-developers/plans/2026-05-12-ws-d-foundation.md
@@ -1,0 +1,1612 @@
+# WS-D Foundation — Mockup State Coverage Matrix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Foundation deliverables for WS-D: HTML mockup parser, `state-matrix.json` inventory, `state-override.ts` helper, CI gate workflow, adoption doc.
+
+**Architecture:** Standalone TypeScript script (`extract-mockup-states.ts`) using jsdom walks `admin-mockups/design_files/*.html` and emits deterministic `state-matrix.json`. CI workflow runs the script in `--check` mode on PR. React helper `state-override.ts` (three-layer API) provides typed `?state=` URL override gated by `IS_VISUAL_TEST_BUILD` env flag.
+
+**Tech Stack:** TypeScript, jsdom ^29.1.1, tsx ^4.21.0, Vitest, GitHub Actions, Next.js 16 `next/navigation`.
+
+**Spec:** [`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`](../specs/2026-05-12-ws-d-state-coverage-design.md)
+**Branch:** `feature/issue-1070-mockup-conformity-states`
+**Umbrella:** #1066 · **Tracking:** #1070
+
+---
+
+## Task 1: Parser core — single-line `Stati:` extraction (TDD)
+
+**Files:**
+- Create: `apps/web/scripts/extract-mockup-states.ts`
+- Create: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+
+- [ ] **Step 1.1: Write the failing test (single-line · separator)**
+
+```ts
+// apps/web/scripts/__tests__/extract-mockup-states.test.ts
+import { describe, it, expect } from 'vitest';
+import { extractStatesFromComment } from '../extract-mockup-states';
+
+describe('extractStatesFromComment', () => {
+  it('parses single-line Stati with · separator', () => {
+    const comment = `
+      Mockup: nanolith-runthrough-game-detail
+      Route:  /library/{gameId}
+      Stati:  default · loading · error · not-found
+      Persona: Aaron`;
+    expect(extractStatesFromComment(comment)).toEqual([
+      'default',
+      'loading',
+      'error',
+      'not-found',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test, verify FAIL**
+
+Run from `apps/web/`:
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: FAIL with "Cannot find module '../extract-mockup-states'" or "is not a function".
+
+- [ ] **Step 1.3: Write minimal implementation**
+
+```ts
+// apps/web/scripts/extract-mockup-states.ts
+/**
+ * WS-D Foundation: parser estrae stati canonici dichiarati nei commenti
+ * HTML dei mockup (`admin-mockups/design_files/*.html`).
+ *
+ * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+ * Issue: #1070 (umbrella #1066)
+ */
+
+/**
+ * Extract state names from a single comment text block.
+ * Supports two declaration styles:
+ *  - Inline: `Stati:  default · loading · error · not-found`
+ *  - Multi-line: `Stati:` on first line, indented `<name> (description)` lines after
+ *
+ * Returns empty array if no `Stati:` line found.
+ */
+export function extractStatesFromComment(commentText: string): string[] {
+  // Match "Stati:" + everything until next field header or end of comment
+  const match = commentText.match(/Stati:\s*([\s\S]+?)(?=\n\s*(?:Route|Persona|Scope|Mockup|Vincoli|Sorgente|Phase|CSS|Note)[:\s]|$)/);
+  if (!match) return [];
+
+  const block = match[1];
+  const firstLine = block.split('\n')[0].trim();
+
+  // Inline form: contains a known separator on first line
+  if (/[·|,]/.test(firstLine)) {
+    return firstLine
+      .split(/[·|,]/)
+      .map(s => s.trim())
+      .filter(Boolean);
+  }
+
+  // Multi-line form: each non-blank line's first token is a state name
+  return block
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+    .map(line => line.split(/\s+/)[0])
+    .filter(Boolean);
+}
+```
+
+- [ ] **Step 1.4: Run test, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 1 test passed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): parse single-line Stati declarations (refs #1070)"
+```
+
+---
+
+## Task 2: Parser — multi-line `Stati:` extraction (TDD)
+
+**Files:**
+- Modify: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+- (Implementation already supports multi-line from Task 1; this task verifies)
+
+- [ ] **Step 2.1: Add failing test for multi-line declaration**
+
+Append to `extract-mockup-states.test.ts`:
+
+```ts
+  it('parses multi-line Stati with indented continuation', () => {
+    const comment = `
+      Mockup: sp4-game-chat-tab
+      Stati:
+        default            (Aaron query "azione carta uccello + 2 cibo" su Wingspan,
+                           risposta IT + citation Manuale p.12 + confidence alta verde)
+        confidence-bassa   (edge "mazzo finisce a metà partita", disclaimer
+                           "non sono certo" + suggerimento BGG)
+        out-of-context     (utente chiede regole di Tainted Grail mentre è su Wingspan,
+                           agente declina + propone switch gioco/agente)
+        loading            (typing indicator + meta latency live, budget P95 ≤ 10s da Q6)
+      Persona: Aaron`;
+    expect(extractStatesFromComment(comment)).toEqual([
+      'default',
+      'confidence-bassa',
+      'out-of-context',
+      'loading',
+    ]);
+  });
+
+  it('returns empty array when no Stati line present', () => {
+    const comment = `Mockup: foo\nRoute: /bar`;
+    expect(extractStatesFromComment(comment)).toEqual([]);
+  });
+```
+
+- [ ] **Step 2.2: Run tests, verify all pass**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 3 tests passed (multi-line parsing works via the fallback branch added in Task 1).
+
+If multi-line fails: the first non-blank line after `Stati:` is empty (continuation lines have descriptions). Fix in `extract-mockup-states.ts`:
+- Filter out lines that don't start with a word character (skips description continuation lines that begin with parenthesis or are pure whitespace).
+
+```ts
+  return block
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+    .filter(line => /^[a-zA-Z]/.test(line)) // skip description continuations starting with `(`
+    .map(line => line.split(/\s+/)[0])
+    .filter(Boolean);
+```
+
+- [ ] **Step 2.3: Re-run tests, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 3 tests passed.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): parse multi-line Stati declarations (refs #1070)"
+```
+
+---
+
+## Task 3: Parser — extract `Route:` from comment (TDD)
+
+**Files:**
+- Modify: `apps/web/scripts/extract-mockup-states.ts`
+- Modify: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+
+- [ ] **Step 3.1: Add failing test**
+
+Append:
+
+```ts
+import { extractRouteFromComment } from '../extract-mockup-states';
+
+describe('extractRouteFromComment', () => {
+  it('extracts Route: from comment', () => {
+    const comment = `
+      Mockup: foo
+      Route:  /library/{gameId}
+      Stati: default`;
+    expect(extractRouteFromComment(comment)).toBe('/library/{gameId}');
+  });
+
+  it('returns null when no Route declared', () => {
+    const comment = `Mockup: foo\nStati: default`;
+    expect(extractRouteFromComment(comment)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: FAIL "extractRouteFromComment is not a function".
+
+- [ ] **Step 3.3: Implement**
+
+Append to `extract-mockup-states.ts`:
+
+```ts
+/**
+ * Extract `Route:` value from comment text.
+ * Returns null if not declared.
+ */
+export function extractRouteFromComment(commentText: string): string | null {
+  const match = commentText.match(/Route:\s*(\S+)/);
+  return match ? match[1] : null;
+}
+```
+
+- [ ] **Step 3.4: Run, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 5 tests passed.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): parse Route metadata from mockup comments (refs #1070)"
+```
+
+---
+
+## Task 4: Parser — process single HTML file via jsdom (TDD)
+
+**Files:**
+- Modify: `apps/web/scripts/extract-mockup-states.ts`
+- Modify: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+
+- [ ] **Step 4.1: Add failing test for full file parse**
+
+Append:
+
+```ts
+import { parseMockupFile } from '../extract-mockup-states';
+
+describe('parseMockupFile', () => {
+  it('extracts MockupStateEntry from HTML string', () => {
+    const html = `<!doctype html>
+<html>
+<head><title>test</title></head>
+<!--
+  Mockup: test-mockup
+  Route:  /test/{id}
+  Stati:  default · loading · error
+  Persona: Aaron
+-->
+<body></body>
+</html>`;
+    const entry = parseMockupFile('admin-mockups/design_files/test-mockup.html', html);
+    expect(entry).toEqual({
+      mockup_path: 'admin-mockups/design_files/test-mockup.html',
+      route: '/test/{id}',
+      declared_states: ['default', 'loading', 'error'],
+      covered_states: [],
+      missing: ['default', 'loading', 'error'],
+      enforced: false,
+    });
+  });
+
+  it('returns entry with empty declared_states when no Stati line', () => {
+    const html = `<!--\n  Mockup: foo\n-->`;
+    const entry = parseMockupFile('admin-mockups/design_files/foo.html', html);
+    expect(entry.declared_states).toEqual([]);
+    expect(entry.missing).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: FAIL "parseMockupFile is not a function".
+
+- [ ] **Step 4.3: Implement**
+
+Add type + function to `extract-mockup-states.ts`:
+
+```ts
+import { JSDOM } from 'jsdom';
+
+export interface MockupStateEntry {
+  mockup_path: string;
+  route: string | null;
+  declared_states: string[];
+  covered_states: string[];
+  missing: string[];
+  enforced: boolean;
+}
+
+/**
+ * Walk DOM, collect all COMMENT_NODE text concatenated.
+ * jsdom: comment nodes have nodeType === 8 (Node.COMMENT_NODE).
+ */
+function collectAllCommentsText(html: string): string {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const COMMENT_NODE = 8;
+  const walker = doc.createNodeIterator(doc, dom.window.NodeFilter.SHOW_COMMENT);
+  const parts: string[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    if (node.nodeType === COMMENT_NODE) {
+      parts.push(node.nodeValue ?? '');
+    }
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Parse a single mockup HTML file into a MockupStateEntry.
+ * Preserves declared_states in source order; covered_states starts empty,
+ * enforced starts false (bootstrap-then-enforce per spec §2).
+ */
+export function parseMockupFile(mockupPath: string, html: string): MockupStateEntry {
+  const commentsText = collectAllCommentsText(html);
+  const declared = extractStatesFromComment(commentsText);
+  const route = extractRouteFromComment(commentsText);
+  return {
+    mockup_path: mockupPath,
+    route,
+    declared_states: declared,
+    covered_states: [],
+    missing: declared.slice(), // declared - covered (all declared at bootstrap)
+    enforced: false,
+  };
+}
+```
+
+- [ ] **Step 4.4: Run, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 7 tests passed.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): parse single mockup file via jsdom (refs #1070)"
+```
+
+---
+
+## Task 5: Matrix builder — merge with existing matrix.json preserving curated fields (TDD)
+
+**Files:**
+- Modify: `apps/web/scripts/extract-mockup-states.ts`
+- Modify: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+
+- [ ] **Step 5.1: Add failing test**
+
+Append:
+
+```ts
+import { mergeMatrix } from '../extract-mockup-states';
+import type { StateMatrix } from '../extract-mockup-states';
+
+describe('mergeMatrix', () => {
+  it('preserves covered_states and enforced from existing matrix', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 1,
+      enforced_count: 1,
+      entries: [
+        {
+          mockup_path: 'admin-mockups/design_files/foo.html',
+          route: '/foo',
+          declared_states: ['a', 'b'],
+          covered_states: ['a'],
+          missing: ['b'],
+          enforced: true,
+        },
+      ],
+    };
+    const fresh = [
+      {
+        mockup_path: 'admin-mockups/design_files/foo.html',
+        route: '/foo',
+        declared_states: ['a', 'b', 'c'], // new state added
+        covered_states: [],
+        missing: ['a', 'b', 'c'],
+        enforced: false,
+      },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries[0].covered_states).toEqual(['a']);
+    expect(merged.entries[0].enforced).toBe(true);
+    expect(merged.entries[0].declared_states).toEqual(['a', 'b', 'c']);
+    expect(merged.entries[0].missing).toEqual(['b', 'c']); // declared - covered
+  });
+
+  it('drops covered states no longer in declared', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 1,
+      enforced_count: 0,
+      entries: [
+        {
+          mockup_path: 'admin-mockups/design_files/foo.html',
+          route: '/foo',
+          declared_states: ['a', 'b'],
+          covered_states: ['a', 'b', 'obsolete'],
+          missing: [],
+          enforced: false,
+        },
+      ],
+    };
+    const fresh = [
+      {
+        mockup_path: 'admin-mockups/design_files/foo.html',
+        route: '/foo',
+        declared_states: ['a'], // 'b' removed by mockup edit
+        covered_states: [],
+        missing: ['a'],
+        enforced: false,
+      },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries[0].covered_states).toEqual(['a']);
+  });
+
+  it('sorts entries alphabetically by mockup_path', () => {
+    const existing: StateMatrix = {
+      generated_at: '2026-05-01T00:00:00.000Z',
+      total_mockups: 0,
+      enforced_count: 0,
+      entries: [],
+    };
+    const fresh = [
+      { mockup_path: 'admin-mockups/design_files/zeta.html', route: null, declared_states: [], covered_states: [], missing: [], enforced: false },
+      { mockup_path: 'admin-mockups/design_files/alpha.html', route: null, declared_states: [], covered_states: [], missing: [], enforced: false },
+    ];
+    const merged = mergeMatrix(existing, fresh);
+    expect(merged.entries.map(e => e.mockup_path)).toEqual([
+      'admin-mockups/design_files/alpha.html',
+      'admin-mockups/design_files/zeta.html',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 5.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: FAIL "mergeMatrix is not a function".
+
+- [ ] **Step 5.3: Implement**
+
+Append to `extract-mockup-states.ts`:
+
+```ts
+export interface StateMatrix {
+  generated_at: string;
+  total_mockups: number;
+  enforced_count: number;
+  entries: MockupStateEntry[];
+}
+
+/**
+ * Merge fresh-parsed entries into existing matrix, preserving manually-curated
+ * fields (`covered_states`, `enforced`). Filters covered_states down to those
+ * still in declared_states (drops obsolete coverage).
+ *
+ * Output sorted alphabetically by mockup_path for deterministic diffs.
+ */
+export function mergeMatrix(existing: StateMatrix, fresh: MockupStateEntry[]): StateMatrix {
+  const byPath = new Map<string, MockupStateEntry>();
+  for (const e of existing.entries) {
+    byPath.set(e.mockup_path, e);
+  }
+
+  const merged: MockupStateEntry[] = fresh.map(freshEntry => {
+    const prior = byPath.get(freshEntry.mockup_path);
+    if (!prior) return freshEntry;
+    const declared = freshEntry.declared_states;
+    const covered = prior.covered_states.filter(s => declared.includes(s));
+    const missing = declared.filter(s => !covered.includes(s));
+    return {
+      ...freshEntry,
+      covered_states: covered,
+      missing,
+      enforced: prior.enforced,
+    };
+  });
+
+  merged.sort((a, b) => a.mockup_path.localeCompare(b.mockup_path));
+
+  return {
+    generated_at: new Date().toISOString(),
+    total_mockups: merged.length,
+    enforced_count: merged.filter(e => e.enforced).length,
+    entries: merged,
+  };
+}
+```
+
+- [ ] **Step 5.4: Run, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 10 tests passed.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): merge fresh entries preserving curated fields (refs #1070)"
+```
+
+---
+
+## Task 6: CLI — `--check`, `--write`, `--enforced-only` modes (TDD)
+
+**Files:**
+- Modify: `apps/web/scripts/extract-mockup-states.ts`
+- Modify: `apps/web/scripts/__tests__/extract-mockup-states.test.ts`
+
+- [ ] **Step 6.1: Add failing tests for CLI orchestrator**
+
+Append:
+
+```ts
+import { runCli } from '../extract-mockup-states';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('runCli', () => {
+  let tmp: string;
+  let mockupsDir: string;
+  let matrixPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'state-coverage-test-'));
+    mockupsDir = join(tmp, 'admin-mockups', 'design_files');
+    require('node:fs').mkdirSync(mockupsDir, { recursive: true });
+    matrixPath = join(tmp, 'matrix.json');
+    writeFileSync(
+      join(mockupsDir, 'foo.html'),
+      `<!--\n  Mockup: foo\n  Stati: default · loading\n-->`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('--write creates matrix.json with parsed entries', async () => {
+    const exitCode = await runCli({
+      mode: 'write',
+      mockupsDir,
+      matrixPath,
+      mockupsPathPrefix: 'admin-mockups/design_files',
+    });
+    expect(exitCode).toBe(0);
+    const matrix = JSON.parse(readFileSync(matrixPath, 'utf-8'));
+    expect(matrix.total_mockups).toBe(1);
+    expect(matrix.entries[0].declared_states).toEqual(['default', 'loading']);
+  });
+
+  it('--check exits 0 when matrix.json in sync', async () => {
+    await runCli({ mode: 'write', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    const exitCode = await runCli({ mode: 'check', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    expect(exitCode).toBe(0);
+  });
+
+  it('--check exits 1 when mockup changed but matrix.json stale', async () => {
+    await runCli({ mode: 'write', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    // mutate mockup
+    writeFileSync(
+      join(mockupsDir, 'foo.html'),
+      `<!--\n  Mockup: foo\n  Stati: default · loading · error\n-->`,
+    );
+    const exitCode = await runCli({ mode: 'check', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    expect(exitCode).toBe(1);
+  });
+
+  it('--enforced-only exits 0 when no enforced entries have missing', async () => {
+    await runCli({ mode: 'write', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    const exitCode = await runCli({ mode: 'enforced-only', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    expect(exitCode).toBe(0); // bootstrap: all enforced=false
+  });
+
+  it('--enforced-only exits 1 when enforced entry has missing states', async () => {
+    await runCli({ mode: 'write', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    // manually flip enforced=true
+    const matrix = JSON.parse(readFileSync(matrixPath, 'utf-8'));
+    matrix.entries[0].enforced = true;
+    matrix.enforced_count = 1;
+    writeFileSync(matrixPath, JSON.stringify(matrix, null, 2));
+    const exitCode = await runCli({ mode: 'enforced-only', mockupsDir, matrixPath, mockupsPathPrefix: 'admin-mockups/design_files' });
+    expect(exitCode).toBe(1); // covered=[] but enforced=true → missing.length > 0
+  });
+});
+```
+
+Add `beforeEach` + `afterEach` imports at top of test file:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+```
+
+- [ ] **Step 6.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: FAIL "runCli is not a function".
+
+- [ ] **Step 6.3: Implement**
+
+Append to `extract-mockup-states.ts`:
+
+```ts
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+export type CliMode = 'check' | 'write' | 'enforced-only';
+
+export interface CliOptions {
+  mode: CliMode;
+  mockupsDir: string;
+  matrixPath: string;
+  /** Path prefix written into matrix entries (e.g. 'admin-mockups/design_files'). */
+  mockupsPathPrefix: string;
+}
+
+/**
+ * Glob mockup HTML files and parse each into a MockupStateEntry.
+ */
+function collectAllMockupEntries(opts: CliOptions): MockupStateEntry[] {
+  const files = readdirSync(opts.mockupsDir).filter(f => f.endsWith('.html'));
+  return files.map(filename => {
+    const absPath = join(opts.mockupsDir, filename);
+    const html = readFileSync(absPath, 'utf-8');
+    const repoRelative = `${opts.mockupsPathPrefix}/${filename}`;
+    return parseMockupFile(repoRelative, html);
+  });
+}
+
+function loadExistingMatrix(matrixPath: string): StateMatrix {
+  if (!existsSync(matrixPath)) {
+    return { generated_at: '', total_mockups: 0, enforced_count: 0, entries: [] };
+  }
+  return JSON.parse(readFileSync(matrixPath, 'utf-8'));
+}
+
+/**
+ * Stringify matrix omitting `generated_at` for diff comparison (ignore mtime noise).
+ */
+function stringifyForDiff(matrix: StateMatrix): string {
+  const copy = { ...matrix, generated_at: '' };
+  return JSON.stringify(copy, null, 2);
+}
+
+/**
+ * CLI orchestrator. Returns exit code (0 OK, 1 fail).
+ */
+export async function runCli(opts: CliOptions): Promise<number> {
+  const fresh = collectAllMockupEntries(opts);
+  const existing = loadExistingMatrix(opts.matrixPath);
+  const merged = mergeMatrix(existing, fresh);
+
+  switch (opts.mode) {
+    case 'write': {
+      writeFileSync(opts.matrixPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+      return 0;
+    }
+    case 'check': {
+      const existingForDiff = stringifyForDiff(existing);
+      const mergedForDiff = stringifyForDiff(merged);
+      if (existingForDiff === mergedForDiff) return 0;
+      console.error('state-matrix.json out of sync with admin-mockups/design_files.');
+      console.error('Run: pnpm tsx apps/web/scripts/extract-mockup-states.ts --write');
+      return 1;
+    }
+    case 'enforced-only': {
+      const violations = merged.entries.filter(e => e.enforced && e.missing.length > 0);
+      if (violations.length === 0) return 0;
+      console.error(`Found ${violations.length} enforced entries with missing states:`);
+      for (const v of violations) {
+        console.error(`  ${v.mockup_path}: missing ${JSON.stringify(v.missing)}`);
+      }
+      return 1;
+    }
+  }
+}
+
+// CLI entry point — only runs when invoked directly via `pnpm tsx ...`
+const isMain = import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('extract-mockup-states.ts');
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  let mode: CliMode = 'check';
+  if (args.includes('--write')) mode = 'write';
+  else if (args.includes('--enforced-only')) mode = 'enforced-only';
+  else if (args.includes('--check')) mode = 'check';
+
+  const repoRoot = join(import.meta.dirname ?? '.', '..', '..', '..');
+  runCli({
+    mode,
+    mockupsDir: join(repoRoot, 'admin-mockups', 'design_files'),
+    matrixPath: join(repoRoot, 'apps', 'web', 'e2e', 'state-coverage', 'state-matrix.json'),
+    mockupsPathPrefix: 'admin-mockups/design_files',
+  }).then(code => process.exit(code));
+}
+```
+
+- [ ] **Step 6.4: Run, verify PASS**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 15 tests passed.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add apps/web/scripts/extract-mockup-states.ts apps/web/scripts/__tests__/extract-mockup-states.test.ts
+git commit -m "feat(state-coverage): CLI modes --check/--write/--enforced-only (refs #1070)"
+```
+
+---
+
+## Task 7: Bootstrap `state-matrix.json` — run parser on real mockups
+
+**Files:**
+- Create: `apps/web/e2e/state-coverage/state-matrix.json`
+- Create: `apps/web/e2e/state-coverage/.gitkeep` (only if no other file ensures dir exists)
+
+- [ ] **Step 7.1: Run parser in `--write` mode**
+
+From repo root:
+
+```bash
+cd apps/web
+pnpm tsx scripts/extract-mockup-states.ts --write
+```
+Expected: no errors. File `apps/web/e2e/state-coverage/state-matrix.json` created (or updated) with ~60+ entries.
+
+- [ ] **Step 7.2: Inspect bootstrap output**
+
+```bash
+head -40 e2e/state-coverage/state-matrix.json
+```
+
+Verify shape:
+- `generated_at` is current ISO timestamp
+- `total_mockups` matches `admin-mockups/design_files/*.html` count
+- `enforced_count` is `0`
+- `entries[]` sorted alphabetically by `mockup_path`
+- At least one entry with route `/library/{gameId}` and `declared_states: ["default", "loading", "error", "not-found"]`
+
+```bash
+ls admin-mockups/design_files/*.html | wc -l
+```
+Expected: equal to `total_mockups` in matrix.json.
+
+- [ ] **Step 7.3: Verify `--check` mode is green after bootstrap**
+
+```bash
+cd apps/web && pnpm tsx scripts/extract-mockup-states.ts --check
+echo "Exit code: $?"
+```
+Expected: Exit code 0.
+
+- [ ] **Step 7.4: Commit bootstrap matrix**
+
+```bash
+cd ../..
+git add apps/web/e2e/state-coverage/state-matrix.json
+git commit -m "chore(state-coverage): bootstrap state-matrix.json from current mockups (refs #1070)"
+```
+
+---
+
+## Task 8: JSON Schema sidecar for IDE validation
+
+**Files:**
+- Create: `apps/web/e2e/state-coverage/state-matrix.schema.json`
+
+- [ ] **Step 8.1: Write the schema file**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://meepleai.app/schemas/state-matrix.schema.json",
+  "title": "State Coverage Matrix",
+  "description": "WS-D Mockup state coverage tracking. Issue #1070 (umbrella #1066).",
+  "type": "object",
+  "required": ["generated_at", "total_mockups", "enforced_count", "entries"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp. Bumped only when content effectively differs."
+    },
+    "total_mockups": { "type": "integer", "minimum": 0 },
+    "enforced_count": { "type": "integer", "minimum": 0 },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/MockupStateEntry" }
+    }
+  },
+  "definitions": {
+    "MockupStateEntry": {
+      "type": "object",
+      "required": ["mockup_path", "route", "declared_states", "covered_states", "missing", "enforced"],
+      "properties": {
+        "mockup_path": {
+          "type": "string",
+          "pattern": "^admin-mockups/design_files/[\\w-]+\\.html$"
+        },
+        "route": {
+          "anyOf": [{ "type": "string" }, { "type": "null" }]
+        },
+        "declared_states": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "States declared in mockup `Stati:` comment line. Order preserves author declaration order."
+        },
+        "covered_states": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "States covered by Playwright tests. Manually curated; preserved across regenerations."
+        },
+        "missing": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "declared_states - covered_states. Computed."
+        },
+        "enforced": {
+          "type": "boolean",
+          "description": "If true, CI gate fails on missing.length > 0. Bootstrap: all false."
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 8.2: Add `$schema` link to matrix.json**
+
+Edit `apps/web/e2e/state-coverage/state-matrix.json`, add as first key:
+
+```json
+{
+  "$schema": "./state-matrix.schema.json",
+  "generated_at": "...",
+  ...
+}
+```
+
+Then update the parser to preserve this on `--write`. Edit `extract-mockup-states.ts` `runCli` case `'write'`:
+
+```ts
+    case 'write': {
+      const output = {
+        $schema: './state-matrix.schema.json',
+        ...merged,
+      };
+      writeFileSync(opts.matrixPath, JSON.stringify(output, null, 2) + '\n', 'utf-8');
+      return 0;
+    }
+```
+
+Also update `stringifyForDiff` to ignore `$schema` for diff:
+
+```ts
+function stringifyForDiff(matrix: StateMatrix): string {
+  // Strip generated_at and $schema (meta keys, not content) before diff
+  const { generated_at: _gen, $schema: _s, ...rest } = matrix as StateMatrix & { $schema?: string };
+  return JSON.stringify({ ...rest, generated_at: '' }, null, 2);
+}
+```
+
+- [ ] **Step 8.3: Verify `--check` still green after schema addition**
+
+```bash
+cd apps/web && pnpm tsx scripts/extract-mockup-states.ts --write
+pnpm tsx scripts/extract-mockup-states.ts --check
+echo "Exit code: $?"
+```
+Expected: Exit code 0.
+
+- [ ] **Step 8.4: Run unit tests**
+
+```bash
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts
+```
+Expected: 15 tests still passing.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+cd ../..
+git add apps/web/e2e/state-coverage/state-matrix.schema.json apps/web/e2e/state-coverage/state-matrix.json apps/web/scripts/extract-mockup-states.ts
+git commit -m "feat(state-coverage): JSON Schema sidecar for IDE validation (refs #1070)"
+```
+
+---
+
+## Task 9: `state-override.ts` helper — `readStateOverride` (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/visual-test/state-override.ts`
+- Create: `apps/web/src/lib/visual-test/__tests__/state-override.test.ts`
+
+- [ ] **Step 9.1: Write the failing test**
+
+```ts
+// apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('readStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+  });
+
+  it('returns null when IS_VISUAL_TEST_BUILD=false (production)', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    expect(readStateOverride(params)).toBeNull();
+  });
+
+  it('returns ?state value when IS_VISUAL_TEST_BUILD=true', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    expect(readStateOverride(params)).toBe('loading');
+  });
+
+  it('returns null when searchParams is null', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    expect(readStateOverride(null)).toBeNull();
+  });
+
+  it('returns null when searchParams lacks state key', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    const { readStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('other=foo');
+    expect(readStateOverride(params)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 9.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: FAIL "Cannot find module '../state-override'".
+
+- [ ] **Step 9.3: Implement minimal**
+
+```ts
+// apps/web/src/lib/visual-test/state-override.ts
+/**
+ * WS-D Foundation: shared `?state=` URL override helper for visual regression tests.
+ *
+ * Gated by NEXT_PUBLIC_VISUAL_TEST_BUILD env flag — production builds eliminate
+ * all bodies via terser dead-code-elimination (bundle delta: 0 KB).
+ *
+ * Spec: docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+ * Issue: #1070 (umbrella #1066)
+ */
+
+/** Compile-time flag set by Next.js build via env var. */
+export const IS_VISUAL_TEST_BUILD: boolean =
+  process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD === '1';
+
+/**
+ * Read `?state=` URL param. Returns null in production regardless of URL contents.
+ */
+export function readStateOverride(searchParams: URLSearchParams | null): string | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  if (!searchParams) return null;
+  return searchParams.get('state');
+}
+```
+
+- [ ] **Step 9.4: Run, verify PASS**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: 4 tests passed.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add apps/web/src/lib/visual-test/state-override.ts apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+git commit -m "feat(visual-test): readStateOverride helper with IS_VISUAL_TEST_BUILD gate (refs #1070)"
+```
+
+---
+
+## Task 10: `state-override.ts` — `readTypedStateOverride` (TDD)
+
+**Files:**
+- Modify: `apps/web/src/lib/visual-test/state-override.ts`
+- Modify: `apps/web/src/lib/visual-test/__tests__/state-override.test.ts`
+
+- [ ] **Step 10.1: Add failing tests**
+
+Append to test file:
+
+```ts
+describe('readTypedStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+  });
+
+  it('returns typed value when state in allowedStates', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, ['default', 'loading', 'error'] as const);
+    expect(result).toBe('loading');
+  });
+
+  it('returns null when state value not in allowedStates', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=bogus');
+    const result = readTypedStateOverride(params, ['default', 'loading'] as const);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when allowedStates is empty', async () => {
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, []);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when IS_VISUAL_TEST_BUILD=false even with valid state', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    const { readTypedStateOverride } = await import('../state-override');
+    const params = new URLSearchParams('state=loading');
+    const result = readTypedStateOverride(params, ['default', 'loading'] as const);
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 10.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: FAIL "readTypedStateOverride is not a function".
+
+- [ ] **Step 10.3: Implement**
+
+Append to `state-override.ts`:
+
+```ts
+/**
+ * Type-safe variant. Validates the raw value is one of `allowedStates`.
+ * Returns null when:
+ *  - IS_VISUAL_TEST_BUILD=false
+ *  - searchParams is null
+ *  - state param missing
+ *  - state value not in allowedStates
+ */
+export function readTypedStateOverride<S extends string>(
+  searchParams: URLSearchParams | null,
+  allowedStates: readonly S[]
+): S | null {
+  const raw = readStateOverride(searchParams);
+  if (raw === null) return null;
+  if (!allowedStates.includes(raw as S)) return null;
+  return raw as S;
+}
+```
+
+- [ ] **Step 10.4: Run, verify PASS**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: 8 tests passed.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add apps/web/src/lib/visual-test/state-override.ts apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+git commit -m "feat(visual-test): readTypedStateOverride type-safe variant (refs #1070)"
+```
+
+---
+
+## Task 11: `state-override.ts` — `useStateOverride` React hook (TDD)
+
+**Files:**
+- Modify: `apps/web/src/lib/visual-test/state-override.ts`
+- Modify: `apps/web/src/lib/visual-test/__tests__/state-override.test.ts`
+
+- [ ] **Step 11.1: Add failing test**
+
+Append to test file:
+
+```ts
+import { renderHook } from '@testing-library/react';
+
+describe('useStateOverride', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    else process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = ORIGINAL_ENV;
+  });
+
+  it('returns null in production regardless of route params', async () => {
+    delete process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD;
+    vi.doMock('next/navigation', () => ({
+      useSearchParams: () => new URLSearchParams('state=loading'),
+    }));
+    const { useStateOverride } = await import('../state-override');
+    const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns typed value in visual-test mode', async () => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD = '1';
+    vi.doMock('next/navigation', () => ({
+      useSearchParams: () => new URLSearchParams('state=loading'),
+    }));
+    const { useStateOverride } = await import('../state-override');
+    const { result } = renderHook(() => useStateOverride(['default', 'loading'] as const));
+    expect(result.current).toBe('loading');
+  });
+});
+```
+
+- [ ] **Step 11.2: Run, verify FAIL**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: FAIL "useStateOverride is not a function".
+
+- [ ] **Step 11.3: Implement**
+
+Append to `state-override.ts`:
+
+```ts
+/**
+ * React hook variant. Reads `?state=` from Next.js `useSearchParams()`.
+ *
+ * In production (IS_VISUAL_TEST_BUILD=false), this is a no-op that always
+ * returns null and never imports next/navigation at runtime — dead-code
+ * elimination strips the body entirely.
+ *
+ * @example
+ *   const STATES = ['default', 'loading', 'error'] as const;
+ *   const state = useStateOverride(STATES);  // 'default' | 'loading' | 'error' | null
+ */
+export function useStateOverride<S extends string>(
+  allowedStates: readonly S[]
+): S | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  // Dynamic require pattern: next/navigation only loaded in test builds
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { useSearchParams } = require('next/navigation');
+  const params = useSearchParams() as URLSearchParams | null;
+  return readTypedStateOverride(params, allowedStates);
+}
+```
+
+- [ ] **Step 11.4: Run, verify PASS**
+
+```bash
+pnpm vitest run src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: 10 tests passed.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add apps/web/src/lib/visual-test/state-override.ts apps/web/src/lib/visual-test/__tests__/state-override.test.ts
+git commit -m "feat(visual-test): useStateOverride React hook (refs #1070)"
+```
+
+---
+
+## Task 12: CI workflow `state-coverage-check.yml`
+
+**Files:**
+- Create: `.github/workflows/state-coverage-check.yml`
+
+- [ ] **Step 12.1: Write the workflow file**
+
+```yaml
+name: State Coverage Check
+
+# Issue #1070 (WS-D Mockup Conformity Roadmap, umbrella #1066)
+# Verifies state-matrix.json is in sync with admin-mockups/design_files/*.html
+# and enforces missing.length === 0 for mockups flagged `enforced: true`.
+
+on:
+  pull_request:
+    branches: [main, main-dev, main-staging]
+    paths:
+      - 'admin-mockups/design_files/**'
+      - 'apps/web/e2e/state-coverage/**'
+      - 'apps/web/scripts/extract-mockup-states.ts'
+      - 'apps/web/scripts/__tests__/extract-mockup-states.test.ts'
+      - '.github/workflows/state-coverage-check.yml'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'check (diff fail) | regenerate (write matrix.json artifact)'
+        required: true
+        default: 'check'
+        type: choice
+        options:
+          - check
+          - regenerate
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: state-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  state-coverage:
+    name: State Matrix Sync + Enforcement
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+        with:
+          node-version: '20'
+          pnpm-version: '10'
+          working-directory: apps/web
+          frozen-lockfile: 'true'
+
+      - name: Run state matrix sync check
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'check'
+        run: pnpm tsx scripts/extract-mockup-states.ts --check
+
+      - name: Run enforcement check (enforced: true entries)
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'check'
+        run: pnpm tsx scripts/extract-mockup-states.ts --enforced-only
+
+      - name: Regenerate matrix.json (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        run: pnpm tsx scripts/extract-mockup-states.ts --write
+
+      - name: Upload regenerated matrix
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'regenerate'
+        uses: actions/upload-artifact@v7
+        with:
+          name: state-matrix-regenerated-${{ github.run_number }}
+          path: apps/web/e2e/state-coverage/state-matrix.json
+          retention-days: 14
+
+      - name: Comment on PR (sync failure)
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = `## State Coverage Check failed
+
+            \`state-matrix.json\` is out-of-sync with mockup HTML files in \`admin-mockups/design_files/\`.
+
+            **To fix**:
+            \`\`\`bash
+            cd apps/web
+            pnpm tsx scripts/extract-mockup-states.ts --write
+            git add e2e/state-coverage/state-matrix.json
+            git commit -m "chore(state-coverage): refresh matrix from mockup edits"
+            \`\`\`
+
+            See \`docs/for-developers/testing/frontend/visual-state-coverage.md\` for full workflow.
+            `;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+```
+
+- [ ] **Step 12.2: Validate YAML locally**
+
+```bash
+cd ../..
+# Quick syntax check via pnpm (any installed yaml linter), or eyeball it
+cat .github/workflows/state-coverage-check.yml | head -10
+```
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add .github/workflows/state-coverage-check.yml
+git commit -m "feat(ci): state-coverage-check workflow (refs #1070)"
+```
+
+---
+
+## Task 13: Documentation — adoption guide
+
+**Files:**
+- Create: `docs/for-developers/testing/frontend/visual-state-coverage.md`
+
+- [ ] **Step 13.1: Write the doc**
+
+```markdown
+# Visual State Coverage
+
+> **Issue:** #1070 (WS-D Mockup Conformity Roadmap, umbrella #1066)
+> **Status:** Foundation shipped 2026-05-12
+
+## Overview
+
+Each mockup in `admin-mockups/design_files/*.html` declares canonical states in a header comment (e.g. `Stati: default · loading · error · not-found`). The Foundation tooling extracts those states into a machine-readable matrix and provides:
+
+- `apps/web/scripts/extract-mockup-states.ts` — parser (jsdom)
+- `apps/web/e2e/state-coverage/state-matrix.json` — inventory
+- `apps/web/src/lib/visual-test/state-override.ts` — `?state=` URL override helper
+- `.github/workflows/state-coverage-check.yml` — CI gate
+
+## Workflow
+
+### When a mockup is edited
+
+1. Edit `admin-mockups/design_files/<mockup>.html`. Update `Stati:` line if states change.
+2. Regenerate matrix locally:
+   ```bash
+   cd apps/web
+   pnpm tsx scripts/extract-mockup-states.ts --write
+   ```
+3. Commit both the mockup change and the regenerated `state-matrix.json`:
+   ```bash
+   git add admin-mockups/design_files/<mockup>.html apps/web/e2e/state-coverage/state-matrix.json
+   git commit -m "feat(mockup): update <feature> states"
+   ```
+
+If you forget step 2, CI will fail at the `state-coverage` step with a guidance comment on the PR.
+
+### When a state gets test coverage
+
+After implementing a Playwright test that exercises a specific declared state for a route:
+
+1. Open `apps/web/e2e/state-coverage/state-matrix.json`.
+2. Find the entry by `mockup_path`.
+3. Add the state name to `covered_states`:
+   ```json
+   {
+     "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-detail.html",
+     "route": "/library/{gameId}",
+     "declared_states": ["default", "loading", "error", "not-found"],
+     "covered_states": ["loading"],   // ← added
+     "missing": ["default", "error", "not-found"],   // ← recomputed
+     "enforced": false
+   }
+   ```
+4. Or run `pnpm tsx scripts/extract-mockup-states.ts --write` to let the parser recompute `missing` for you.
+
+### When a route is ready for enforcement
+
+Once all declared states have test coverage and the team wants to block regression:
+
+1. Set `enforced: true` on the matrix entry.
+2. Increment `enforced_count` accordingly.
+3. CI `--enforced-only` check now blocks PRs that leave declared states uncovered.
+
+## CLI reference
+
+```bash
+# Dry-run: exit 1 if matrix.json out-of-sync with mockup HTML
+pnpm tsx scripts/extract-mockup-states.ts --check
+
+# Regenerate matrix.json (preserves covered_states + enforced)
+pnpm tsx scripts/extract-mockup-states.ts --write
+
+# Validate enforced entries have no missing states
+pnpm tsx scripts/extract-mockup-states.ts --enforced-only
+```
+
+## Using `state-override.ts` in a route component (PR2 Exemplar onward)
+
+```tsx
+'use client';
+import { useStateOverride } from '@/lib/visual-test/state-override';
+
+const LIBRARY_GAME_DETAIL_STATES = ['default', 'loading', 'error', 'not-found'] as const;
+
+export default function LibraryGameDetailPage() {
+  const stateOverride = useStateOverride(LIBRARY_GAME_DETAIL_STATES);
+  // stateOverride is `null` in production (dead-code-eliminated body).
+  // In `?state=loading` visual test mode, returns 'loading' for branching.
+
+  if (stateOverride === 'loading') return <SkeletonView />;
+  if (stateOverride === 'error') return <ErrorBoundary />;
+  // ... real data fetch + render
+}
+```
+
+**Production guarantee**: `NEXT_PUBLIC_VISUAL_TEST_BUILD=1` is set **only** by `playwright.config.ts:webServer.env`. Production `pnpm build` never sets the flag → terser drops the entire body → bundle delta 0 KB.
+
+## Distinction vs other visual workflows
+
+| Workflow | Scope |
+|---|---|
+| `visual-regression-mockups.yml` | Mockup HTML → baseline PNG (visual stability of mockups) |
+| `visual-regression-migrated.yml` | Route live → baseline PNG (implementation stability) |
+| **`state-coverage-check.yml`** | Mockup `Stati:` ↔ matrix.json consistency (declarative gate) |
+| `visual-regression-conformity.yml` (WS-C future) | Route ↔ mockup pixel diff (visual gate) |
+
+No overlap. The state coverage gate is **declarative** (state names match), not **visual** (pixel diff).
+
+## Known limitations
+
+- Mockups with hybrid `A · state-name` declaration format (e.g. `nanolith-runthrough-error-states.html`) may extract the prefix letter as a state name; manual cleanup of `state-matrix.json` after first run is acceptable.
+- State proliferation cap: keep canonical states to 4-6 per route. Document timing-dependent states (SSE, real-time) as exceptions in PR description and cover via unit tests rather than visual.
+
+## References
+
+- Spec: [`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`](../../specs/2026-05-12-ws-d-state-coverage-design.md)
+- Roadmap: [`docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md`](../../specs/2026-05-12-mockup-conformity-roadmap.md) §3 WS-D
+- Umbrella issue: #1066
+- Tracking issue: #1070
+```
+
+- [ ] **Step 13.2: Commit**
+
+```bash
+git add docs/for-developers/testing/frontend/visual-state-coverage.md
+git commit -m "docs(state-coverage): adoption workflow guide (refs #1070)"
+```
+
+---
+
+## Task 14: Final smoke + push + open PR
+
+**Files:** (verification only)
+
+- [ ] **Step 14.1: Run full unit test suite for touched files**
+
+```bash
+cd apps/web
+pnpm vitest run scripts/__tests__/extract-mockup-states.test.ts src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: 25 tests passed across 2 files (15 parser + 10 state-override).
+
+- [ ] **Step 14.2: Run typecheck (clean build)**
+
+```bash
+rm -rf .next .next-dev 2>&1 || true
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 14.3: Run lint on touched files**
+
+```bash
+pnpm lint scripts/extract-mockup-states.ts scripts/__tests__/extract-mockup-states.test.ts src/lib/visual-test/state-override.ts src/lib/visual-test/__tests__/state-override.test.ts
+```
+Expected: 0 errors (warnings acceptable).
+
+- [ ] **Step 14.4: Verify CLI behavior end-to-end**
+
+```bash
+pnpm tsx scripts/extract-mockup-states.ts --check
+echo "Check exit: $?"
+pnpm tsx scripts/extract-mockup-states.ts --enforced-only
+echo "Enforced exit: $?"
+```
+Expected: both exit code 0 (matrix in sync, zero enforced entries to validate).
+
+- [ ] **Step 14.5: Push branch**
+
+```bash
+cd ../..
+git push -u origin feature/issue-1070-mockup-conformity-states
+```
+
+- [ ] **Step 14.6: Open PR via gh CLI**
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(state-coverage): WS-D Foundation — parser + matrix + helper + CI gate (refs #1070)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+WS-D Foundation deliverables (Mockup Conformity Roadmap umbrella #1066):
+
+- Parser `apps/web/scripts/extract-mockup-states.ts` (jsdom) extracts canonical `Stati:` declarations from `admin-mockups/design_files/*.html` mockups
+- Inventory `apps/web/e2e/state-coverage/state-matrix.json` with all current mockups bootstrapped at `enforced: false`
+- Helper `apps/web/src/lib/visual-test/state-override.ts` (three-layer API: standalone, typed, React hook) gated by `IS_VISUAL_TEST_BUILD` env flag for zero production impact
+- CI workflow `.github/workflows/state-coverage-check.yml` with two-stage check (sync + enforcement)
+- Adoption doc `docs/for-developers/testing/frontend/visual-state-coverage.md`
+
+## DoD status (per Issue #1070 ACs)
+
+- [x] **AC-D.2** — generator output deterministic (parser preserves curated fields, sorted alphabetically, `generated_at` bumped only on content diff)
+- [x] **AC-D.3** — fixture pattern uniformato via `state-override.ts` helper (consumo opzionale)
+- [ ] **AC-D.1** — 100% declared states covered for enforced routes → **deferred to PR2 Exemplar** (post-merge #1074)
+- [ ] **AC-D.4** — route exemplar `/library/[gameId]` cites `error ≠ not-found` → **deferred to PR2 Exemplar**
+
+## Test plan
+
+- [x] 15 parser unit tests (single-line, multi-line, route extraction, file parse, matrix merge, CLI modes)
+- [x] 10 state-override unit tests (readStateOverride, readTypedStateOverride, useStateOverride)
+- [x] `pnpm typecheck` clean (after `.next` rebuild)
+- [x] `pnpm lint` clean on touched files
+- [x] `pnpm tsx scripts/extract-mockup-states.ts --check` exits 0 (matrix bootstrap in sync)
+- [x] `pnpm tsx scripts/extract-mockup-states.ts --enforced-only` exits 0 (zero enforced entries at bootstrap)
+- [ ] CI `state-coverage-check.yml` green on PR (validates first end-to-end run)
+
+## Refs
+
+- Refs umbrella #1066
+- Refs tracking #1070
+- Spec: \`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md\`
+- Roadmap: \`docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md\` §3 WS-D
+- Companion: PR #1074 (WS-B Nanolith bugfix, coordination via Wait & rebase strategy)
+- Future: PR2 Exemplar starts post-merge #1074
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Verify mergeStateStatus in subsequent `gh pr view`.
+
+---
+
+## Notes for the implementer
+
+- All file paths in this plan are **repo-relative**, matching `git ls-files` output.
+- Work in branch `feature/issue-1070-mockup-conformity-states` (already created and configured with parent `main-dev`).
+- The branch already has commit `c2e821d2e` (design doc) — Tasks 1-14 add on top.
+- After PR opens, monitor CI status via `gh pr checks 1076` (or whatever PR number is assigned).
+- Do not bundle PR2 Exemplar changes (`/library/[gameId]/page.tsx` modifications) into this PR — that work is deliberately deferred per spec §2 to avoid file conflict with PR #1074.

--- a/docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
+++ b/docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md
@@ -1,0 +1,327 @@
+# WS-D Foundation — Mockup State Coverage Matrix (Design)
+
+| Field | Value |
+|---|---|
+| **Status** | approved (brainstorming 2026-05-12) |
+| **Date** | 2026-05-12 |
+| **Author** | brainstorming session — user + assistant |
+| **Implements** | WS-D from [`2026-05-12-mockup-conformity-roadmap.md`](./2026-05-12-mockup-conformity-roadmap.md) §3 |
+| **Umbrella issue** | #1066 |
+| **Tracking issue** | #1070 |
+| **Branch convention** | `feature/issue-1070-mockup-conformity-states` (Foundation), `feature/issue-1070-mockup-conformity-states-exemplar` (Exemplar PR2) |
+
+## 1. Problem statement
+
+Ogni mockup HTML in `admin-mockups/design_files/` dichiara stati canonici nel commento header (es. `Stati: default · loading · error · not-found`). Pattern sentinel `?state=...` Wave B.1/B.2/B.3 copre 4-5 stati per route migrate ma:
+
+- non uniformato cross-route (Wave A non lo usa)
+- non lega gli stati alle dichiarazioni del mockup (drift possibile)
+- 5 file `*-visual-test-fixture.ts` esistenti seguono pattern simili ma divergenti
+
+Mancano:
+
+- Parser automatico che estrae `Stati:` dai mockup
+- Matrix machine-readable che traccia copertura
+- Helper unificato cross-route per `?state=` URL override
+- CI gate che blocca drift
+
+## 2. Scope decisions (brainstorming 2026-05-12)
+
+| Decision | Choice |
+|---|---|
+| Foundation vs Foundation+Exemplar PR1 | **Foundation only** (route exemplar split in PR2 dopo merge #1074) |
+| Coordination con PR #1074 (`/library/[gameId]` shared file) | **Wait & rebase** — PR2 Exemplar parte dopo merge #1074 |
+| HTML parser | **jsdom** (`^29.1.1` già installato, edge-case-safe) |
+| Approach matrix sync | **Approach 1: bootstrap-then-enforce** (progressive adoption, no big-bang regression) |
+
+## 3. Goals & Non-goals
+
+### Goals
+
+- **G1** — Parser standalone (`scripts/extract-mockup-states.ts`) che estrae `Stati:` da TUTTI i mockup, output deterministico
+- **G2** — Matrix JSON canonica `apps/web/e2e/state-coverage/state-matrix.json` con shape stabile + JSON schema sidecar
+- **G3** — Helper unificato `apps/web/src/lib/visual-test/state-override.ts` (tree-shakeable, zero impact production)
+- **G4** — CI workflow `state-coverage-check.yml` con dual-check (sync + enforcement)
+- **G5** — Doc `docs/for-developers/testing/frontend/visual-state-coverage.md` adoption guide
+
+### Non-goals
+
+- **NG1** — Route exemplar migration (split a PR2 post-#1074)
+- **NG2** — Migrazione dei 5 `*-visual-test-fixture.ts` esistenti a `state-override.ts` (progressive, future PRs)
+- **NG3** — Implementare visual-conformity workflow WS-C (separato issue #1069)
+- **NG4** — Generare PR di update mockup-by-mockup automaticamente
+
+## 4. Architecture
+
+### 4.1 File layout
+
+```
+apps/web/
+├── scripts/
+│   └── extract-mockup-states.ts         NEW  parser jsdom (regenerates matrix)
+├── src/
+│   └── lib/
+│       └── visual-test/                  NEW
+│           ├── state-override.ts         helper unificato `?state=` URL override
+│           └── __tests__/
+│               └── state-override.test.ts
+└── e2e/
+    └── state-coverage/
+        ├── state-matrix.json             NEW  bootstrap inventory (~60 mockup)
+        └── state-matrix.schema.json      NEW  JSON Schema sidecar (IDE validation)
+
+.github/workflows/
+└── state-coverage-check.yml              NEW  CI gate
+
+docs/for-developers/
+└── testing/
+    └── frontend/
+        └── visual-state-coverage.md      NEW  adoption workflow doc
+```
+
+### 4.2 Parser (`extract-mockup-states.ts`)
+
+**Input**: glob `admin-mockups/design_files/*.html`
+
+**Output**: `state-matrix.json` deterministic
+
+**Algorithm**:
+
+1. Glob `admin-mockups/design_files/*.html`
+2. Per file: read → `new JSDOM(html).window.document`
+3. Walk DOM, collect `NODE_COMMENT` (filter `Node.COMMENT_NODE === 8`)
+4. Regex su comment text:
+   - `Route:\s*(\S+)` → route string (può essere null)
+   - `Stati:\s*([^\n]+)` → state list raw (multiline `/m` flag)
+5. Split state list su `·` (middot) primario, fallback `,` o `|`. Normalize: trim, lowercase, no diacritics
+6. Build entry. Ordering alphabetic per `mockup_path` (deterministic)
+7. Confronta con `state-matrix.json` esistente: **preserva** `covered_states` + `enforced` (manualmente curati), aggiorna `declared_states` + `missing` + `generated_at`
+8. Write file. Exit 0 se nessun diff content; exit 1 se diff non-meta
+
+**CLI flags**:
+
+| Flag | Behavior |
+|---|---|
+| `--check` | Dry-run, exit 1 se matrix.json out-of-sync con mockup |
+| `--write` | Regenera e scrive matrix.json |
+| `--enforced-only` | Filtra entries `enforced: true`, fail se `missing.length > 0` |
+
+**Edge cases**:
+
+- Mockup senza `Stati:` → `declared_states: []`, entry presente per inventory
+- Multi-line `Stati:` (es. `sp4-game-chat-tab.html:23-31`) → match prima linea + continuation lines indented
+- Route placeholder `{gameId}` vs `[gameId]` → preservato as-is
+
+### 4.3 Matrix schema (`state-matrix.json`)
+
+```json
+{
+  "$schema": "./state-matrix.schema.json",
+  "generated_at": "2026-05-12T16:42:00.000Z",
+  "total_mockups": 62,
+  "enforced_count": 0,
+  "entries": [
+    {
+      "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-detail.html",
+      "route": "/library/{gameId}",
+      "declared_states": ["default", "loading", "error", "not-found"],
+      "covered_states": [],
+      "missing": ["default", "loading", "error", "not-found"],
+      "enforced": false
+    }
+  ]
+}
+```
+
+**TypeScript interface** (anche esportato da `extract-mockup-states.ts`):
+
+```ts
+interface MockupStateEntry {
+  mockup_path: string;
+  route: string | null;
+  declared_states: string[];     // preserva ordering autore
+  covered_states: string[];      // curated manualmente
+  missing: string[];             // declared - covered, computed
+  enforced: boolean;             // bootstrap PR1: tutti false
+}
+
+interface StateMatrix {
+  generated_at: string;
+  total_mockups: number;
+  enforced_count: number;
+  entries: MockupStateEntry[];
+}
+```
+
+**Sorting** (deterministic):
+- `entries[]` ordered by `mockup_path` alphabetic ASC
+- `declared_states[]` + `covered_states[]` + `missing[]` ordered per **declaration order** del mockup
+
+**Versioning**:
+- Parser preserva `covered_states` + `enforced` su update
+- `generated_at` bumped solo se content effettivo differs (no spurious commits)
+
+### 4.4 State override helper (`state-override.ts`)
+
+```ts
+export const IS_VISUAL_TEST_BUILD: boolean =
+  process.env.NEXT_PUBLIC_VISUAL_TEST_BUILD === '1';
+
+export function readStateOverride(searchParams: URLSearchParams | null): string | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  if (!searchParams) return null;
+  return searchParams.get('state');
+}
+
+export function readTypedStateOverride<S extends string>(
+  searchParams: URLSearchParams | null,
+  allowedStates: readonly S[]
+): S | null {
+  const raw = readStateOverride(searchParams);
+  if (raw === null) return null;
+  if (!allowedStates.includes(raw as S)) return null;
+  return raw as S;
+}
+
+export function useStateOverride<S extends string>(
+  allowedStates: readonly S[]
+): S | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+  const { useSearchParams } = require('next/navigation');
+  const params = useSearchParams() as URLSearchParams | null;
+  return readTypedStateOverride(params, allowedStates);
+}
+```
+
+**Production guarantee**:
+- `NEXT_PUBLIC_VISUAL_TEST_BUILD=1` settato solo in `playwright.config.ts:webServer.env`
+- Production build: env var absent → `IS_VISUAL_TEST_BUILD === false` → terser dead-code-elimination rimuove **tutto** il body
+- Bundle size delta atteso: 0 KB
+
+**Three-layer API**:
+- `readStateOverride`: standalone, testabile senza React
+- `readTypedStateOverride`: type-safety opzionale
+- `useStateOverride`: React-friendly per consumer components
+
+### 4.5 CI workflow (`state-coverage-check.yml`)
+
+**Trigger**:
+
+| Source | Behavior |
+|---|---|
+| PR tocca `admin-mockups/design_files/**` | Sync check |
+| PR tocca `state-matrix.json` direttamente | Sync check |
+| PR tocca `extract-mockup-states.ts` | Sync check (regression parser logic) |
+| `workflow_dispatch` mode=`regenerate` | Bootstrap/refresh, uploads artifact |
+| PR su altri path | Skipped (path filter) |
+
+**Two-stage check** (entrambi run su PR):
+
+1. **`--check`**: parser rigenera in memoria, diff vs committed → fail su diff content
+2. **`--enforced-only`**: per ogni entry `enforced: true`, fail se `missing.length > 0`
+
+PR1 bootstrap: tutte `enforced: false` → stage 2 passa sempre.
+
+**Cost CI atteso**: ~2-3min job (no Playwright, no browser, no Next build — solo tsx script + jsdom).
+
+**PR comment on failure** (sync): istruzioni `pnpm tsx ... --write` + commit guide.
+
+### 4.6 Distinzione vs workflow esistenti (no overlap)
+
+| Workflow | Scope |
+|---|---|
+| `visual-regression-mockups.yml` (#571) | Mockup HTML → baseline PNG (visual stability) |
+| `visual-regression-migrated.yml` (Wave A/B) | Route live → baseline PNG (implementation stability) |
+| **`state-coverage-check.yml`** (NEW PR1) | Mockup `Stati:` ↔ matrix.json consistency (gate ≠ visual) |
+| `visual-regression-conformity.yml` (WS-C future) | Route ↔ mockup pixel diff (gate visual) |
+
+## 5. Three levels of "data"
+
+Distinzione esplicitata durante brainstorming (clarification post-sezione 3):
+
+| Layer | Source | Type | Example |
+|---|---|---|---|
+| **1. Mockup** | `admin-mockups/design_files/*.html` | Hardcoded fictitious | "Nanolith" hardcoded |
+| **2. Route in production** | Browser utente reale | Backend reale | Aaron vede sua libreria reale |
+| **3. Route in visual-test** | CI Playwright `?state=...` | **Sentinel fixture deterministica** | `gameTitle: 'Test Game'` |
+
+**WS-D traccia SOLO nomi degli stati** (livello dichiarativo). I dati live (livello 2) e i fixture sentinel (livello 3) sono fuori scope.
+
+## 6. Acceptance Criteria (per Issue #1070)
+
+- **AC-D.1** — 100% degli stati dichiarati nel mockup di ciascuna route registrata sono coperti (`missing.length === 0` in state-matrix.json) **per route con `enforced: true`**. PR1 bootstrap: zero route enforced.
+- **AC-D.2** — Generator output deterministico (run idempotente, ordering stabile, `generated_at` bumped solo su content diff)
+- **AC-D.3** — Fixture pattern uniformato disponibile via `state-override.ts` helper (consumo opzionale)
+- **AC-D.4** — Route exemplar `/library/[gameId]` cita stato `error ≠ not-found` (sinergia WS-B AC-B.2) → **deferred PR2 Exemplar**
+
+PR1 Foundation soddisfa **AC-D.2 + AC-D.3** (parser deterministico + helper disponibile).
+PR2 Exemplar soddisfa **AC-D.1 + AC-D.4** (prima route enforced, `error ≠ not-found` distinction).
+
+## 7. Test plan (PR1 Foundation)
+
+**Unit tests** (`state-override.test.ts`):
+
+- `readStateOverride`:
+  - returns null when `IS_VISUAL_TEST_BUILD=false`
+  - returns `?state` value when `IS_VISUAL_TEST_BUILD=true`
+  - returns null when searchParams missing param
+- `readTypedStateOverride`:
+  - returns typed value when in allowedStates
+  - returns null when value not in allowedStates
+  - handles empty allowedStates array
+
+**Integration tests** (parser, `__tests__/extract-mockup-states.test.ts`):
+
+- Parse `nanolith-runthrough-game-detail.html` fixture → 4 stati estratti
+- Parse `nanolith-runthrough-error-states.html` fixture → 4 stati estratti (no Route)
+- Parse `sp4-game-chat-tab.html` fixture → 4 stati multi-line correttamente parsati
+- Mockup senza `Stati:` → entry con `declared_states: []`
+- Re-run idempotente: `generated_at` invariato su content stable
+
+**CI integration**:
+
+- `pnpm tsx scripts/extract-mockup-states.ts --check` su matrix bootstrap → exit 0
+- Simulare drift via test fixture (modifica mockup senza update matrix) → exit 1
+
+## 8. Failure matrix
+
+| Mode | Detection | Mitigation |
+|---|---|---|
+| Mockup edit senza matrix update | CI `--check` exit 1 | PR comment guida `--write` + commit |
+| Parser breaking change rinomina mockup field | Diff content | Test fixture regression catch |
+| State proliferation (>20 per route) | Manual review matrix.json | Cap canonical 4-6 stati documentato in doc |
+| Stati timing-dependent (es. SSE) non visual-testable | Manual review | Exception list documentata (mirror Wave D.3 `error` state escluso visual, coperto unit) |
+| Workflow path filter rinomina parser senza update | Workflow non triggera, silenzioso | Future PR: lint rule check filter ↔ script path (out-of-scope PR1) |
+| Bundle size delta da `state-override.ts` | `pnpm build` size report | `IS_VISUAL_TEST_BUILD=false` in production garantisce dead-code-elim → 0 KB |
+
+## 9. Rollback
+
+- Workflow disable via revert PR
+- `state-matrix.json` retained come documentation snapshot (no breaking change)
+- `state-override.ts` zero consumer in production → safe da rimuovere
+
+## 10. Sequencing post-PR1
+
+| PR | Scope | Pre-requisite |
+|---|---|---|
+| **PR1 Foundation** | parser + matrix.json + CI + state-override.ts + doc | Niente |
+| **PR2 Exemplar** | `/library/[gameId]` usa `state-override`, 4 stati covered, `enforced: true` | **Merge #1074 (WS-B)** prima di toccare `page.tsx` |
+| **PR3+ Wave migration** | Progressive enforcement route-by-route | PR2 |
+
+## 11. References
+
+- Roadmap spec: [`2026-05-12-mockup-conformity-roadmap.md`](./2026-05-12-mockup-conformity-roadmap.md) §3 WS-D
+- Token canonicalization companion: [`2026-05-12-token-canonicalization.md`](./2026-05-12-token-canonicalization.md) — finished via DS-1..DS-16 series
+- Existing visual regression workflows: [`visual-regression-mockups.yml`](../../../.github/workflows/visual-regression-mockups.yml), [`visual-regression-migrated.yml`](../../../.github/workflows/visual-regression-migrated.yml)
+- Existing fixture pattern Wave B: 5 files `*-visual-test-fixture.ts` in `apps/web/src/lib/sessions*/`
+- Sample mockups con `Stati:` declaration:
+  - [`nanolith-runthrough-game-detail.html`](../../../admin-mockups/design_files/nanolith-runthrough-game-detail.html) — 4 stati
+  - [`nanolith-runthrough-error-states.html`](../../../admin-mockups/design_files/nanolith-runthrough-error-states.html) — 4 stati tecnici
+  - [`sp4-game-chat-tab.html`](../../../admin-mockups/design_files/sp4-game-chat-tab.html) — 4 stati multi-line
+
+---
+
+**Sign-off**:
+- [x] Project owner — design approved 2026-05-12 brainstorming session
+- [ ] User review of written spec (next step)
+- [ ] Implementation plan via writing-plans skill

--- a/docs/for-developers/testing/frontend/visual-state-coverage.md
+++ b/docs/for-developers/testing/frontend/visual-state-coverage.md
@@ -1,0 +1,117 @@
+# Visual State Coverage
+
+> **Issue:** #1070 (WS-D Mockup Conformity Roadmap, umbrella #1066)
+> **Status:** Foundation shipped 2026-05-12
+
+## Overview
+
+Each mockup in `admin-mockups/design_files/*.html` declares canonical states in a header comment (e.g. `Stati: default · loading · error · not-found`). The Foundation tooling extracts those states into a machine-readable matrix and provides:
+
+- `apps/web/scripts/extract-mockup-states.ts` — parser (jsdom)
+- `apps/web/e2e/state-coverage/state-matrix.json` — inventory
+- `apps/web/e2e/state-coverage/state-matrix.schema.json` — JSON Schema sidecar (IDE validation)
+- `apps/web/src/lib/visual-test/state-override.ts` — `?state=` URL override helper
+- `.github/workflows/state-coverage-check.yml` — CI gate
+
+## Workflow
+
+### When a mockup is edited
+
+1. Edit `admin-mockups/design_files/<mockup>.html`. Update `Stati:` line if states change.
+2. Regenerate matrix locally:
+   ```bash
+   cd apps/web
+   pnpm tsx scripts/extract-mockup-states.ts --write
+   ```
+3. Commit both the mockup change and the regenerated `state-matrix.json`:
+   ```bash
+   git add admin-mockups/design_files/<mockup>.html apps/web/e2e/state-coverage/state-matrix.json
+   git commit -m "feat(mockup): update <feature> states"
+   ```
+
+If you forget step 2, CI will fail at the `state-coverage` job with a guidance comment on the PR.
+
+### When a state gets test coverage
+
+After implementing a Playwright test that exercises a specific declared state for a route:
+
+1. Open `apps/web/e2e/state-coverage/state-matrix.json`.
+2. Find the entry by `mockup_path`.
+3. Add the state name to `covered_states`:
+   ```json
+   {
+     "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-detail.html",
+     "route": "/library/{gameId}",
+     "declared_states": ["default", "loading", "error", "not-found"],
+     "covered_states": ["loading"],
+     "missing": ["default", "error", "not-found"],
+     "enforced": false
+   }
+   ```
+4. Or run `pnpm tsx scripts/extract-mockup-states.ts --write` to let the parser recompute `missing` for you.
+
+### When a route is ready for enforcement
+
+Once all declared states have test coverage and the team wants to block regression:
+
+1. Set `enforced: true` on the matrix entry.
+2. Increment `enforced_count` accordingly.
+3. CI `--enforced-only` check now blocks PRs that leave declared states uncovered.
+
+## CLI reference
+
+```bash
+# Dry-run: exit 1 if matrix.json out-of-sync with mockup HTML
+pnpm tsx scripts/extract-mockup-states.ts --check
+
+# Regenerate matrix.json (preserves covered_states + enforced)
+pnpm tsx scripts/extract-mockup-states.ts --write
+
+# Validate enforced entries have no missing states
+pnpm tsx scripts/extract-mockup-states.ts --enforced-only
+```
+
+## Using `state-override.ts` in a route component (PR2 Exemplar onward)
+
+```tsx
+'use client';
+import { useStateOverride } from '@/lib/visual-test/state-override';
+
+const LIBRARY_GAME_DETAIL_STATES = ['default', 'loading', 'error', 'not-found'] as const;
+
+export default function LibraryGameDetailPage() {
+  const stateOverride = useStateOverride(LIBRARY_GAME_DETAIL_STATES);
+  // stateOverride is `null` in production (early-return after Rules-of-Hooks call).
+  // In `?state=loading` visual test mode, returns 'loading' for branching.
+
+  if (stateOverride === 'loading') return <SkeletonView />;
+  if (stateOverride === 'error') return <ErrorBoundary />;
+  // ... real data fetch + render
+}
+```
+
+**Production guarantee**: `NEXT_PUBLIC_VISUAL_TEST_BUILD=1` is set **only** by `playwright.config.ts:webServer.env`. Production `pnpm build` never sets the flag → `useStateOverride` early-returns null after the unconditional `useSearchParams()` call. `next/navigation` is already part of the bundle, so no incremental cost.
+
+## Distinction vs other visual workflows
+
+| Workflow | Scope |
+|---|---|
+| `visual-regression-mockups.yml` | Mockup HTML → baseline PNG (visual stability of mockups) |
+| `visual-regression-migrated.yml` | Route live → baseline PNG (implementation stability) |
+| **`state-coverage-check.yml`** | Mockup `Stati:` ↔ matrix.json consistency (declarative gate) |
+| `visual-regression-conformity.yml` (WS-C future) | Route ↔ mockup pixel diff (visual gate) |
+
+No overlap. The state coverage gate is **declarative** (state names match), not **visual** (pixel diff).
+
+## Known limitations
+
+- Mockups with hybrid `A · state-name` declaration format (e.g. `nanolith-runthrough-error-states.html`) may extract the prefix letter as a state name; manual cleanup of `state-matrix.json` after first run is acceptable.
+- State proliferation cap: keep canonical states to 4-6 per route. Document timing-dependent states (SSE, real-time) as exceptions in PR description and cover via unit tests rather than visual.
+
+## References
+
+- Spec: [`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`](../../specs/2026-05-12-ws-d-state-coverage-design.md)
+- Roadmap: [`docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md`](../../specs/2026-05-12-mockup-conformity-roadmap.md) §3 WS-D
+- Plan: [`docs/for-developers/plans/2026-05-12-ws-d-foundation.md`](../../plans/2026-05-12-ws-d-foundation.md)
+- Umbrella issue: #1066
+- Tracking issue: #1070


### PR DESCRIPTION
## Summary

WS-D Foundation deliverables (Mockup Conformity Roadmap umbrella #1066):

- **Parser** `apps/web/scripts/extract-mockup-states.ts` (jsdom) extracts canonical `Stati:` declarations from `admin-mockups/design_files/*.html` mockups. Supports both inline (`·`-separated) and multi-line indented formats.
- **Inventory** `apps/web/e2e/state-coverage/state-matrix.json` bootstrapped from current 61 mockups, all `enforced: false` (progressive enforcement model).
- **JSON Schema sidecar** `state-matrix.schema.json` for IDE auto-validation.
- **Helper** `apps/web/src/lib/visual-test/state-override.ts` — three-layer API (`readStateOverride`, `readTypedStateOverride`, `useStateOverride`) gated by `NEXT_PUBLIC_VISUAL_TEST_BUILD` env flag.
- **CI workflow** `.github/workflows/state-coverage-check.yml` with two-stage check (sync + enforcement).
- **Adoption doc** `docs/for-developers/testing/frontend/visual-state-coverage.md`.

## Approach

- TDD per task (RED → GREEN → commit) — 14 bite-sized tasks per plan
- Bootstrap-then-enforce: matrix.json starts with all mockups at `enforced: false`, progressive route-by-route enforcement in follow-up PRs
- `useStateOverride` follows Rules of Hooks: top-level `useSearchParams()` import, early-return null AFTER hook call when `IS_VISUAL_TEST_BUILD=false`. `next/navigation` already in app bundle (zero incremental cost).

## DoD status (per Issue #1070 ACs)

- [x] **AC-D.2** — Generator output deterministic (parser preserves curated fields `covered_states` + `enforced`, sorted alphabetically by `mockup_path`, `generated_at` is the only meta key that changes across runs)
- [x] **AC-D.3** — Fixture pattern uniformato via `state-override.ts` helper (consumo opzionale per consumer)
- [ ] **AC-D.1** — 100% declared states covered for enforced routes → **deferred to PR2 Exemplar** (post-merge #1074)
- [ ] **AC-D.4** — Route exemplar `/library/[gameId]` cites `error ≠ not-found` → **deferred to PR2 Exemplar** (synergy with WS-B AC-B.2)

## Test plan

- [x] 15 parser unit tests (single-line, multi-line, route extraction, file parse, matrix merge, CLI three-mode orchestrator)
- [x] 10 state-override unit tests (`readStateOverride`, `readTypedStateOverride`, `useStateOverride` × env flag matrix)
- [x] `pnpm typecheck` clean (post `.next` rebuild — pre-existing stale type validator references to pre-#1037 paths cleared)
- [x] `pnpm lint` 0 errors on touched files (warnings on unrelated pre-existing files)
- [x] `pnpm tsx scripts/extract-mockup-states.ts --check` exits 0 (matrix bootstrap in sync)
- [x] `pnpm tsx scripts/extract-mockup-states.ts --enforced-only` exits 0 (zero enforced entries at bootstrap)
- [ ] CI `state-coverage-check.yml` green on this PR (validates first end-to-end run)

## Coordination

This PR **does not** touch `/library/[gameId]/page.tsx` to avoid conflict with #1074 (WS-B Nanolith bugfix). PR2 Exemplar will refactor that page to consume `state-override.ts` after #1074 merges.

## Refs

- Closes #1070
- Refs umbrella #1066
- Spec: `docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`
- Plan: `docs/for-developers/plans/2026-05-12-ws-d-foundation.md`
- Roadmap: `docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md` §3 WS-D
- Companion: #1074 (WS-B Nanolith bugfix, Wait & rebase strategy)
- Companion: #1075 (Mockup Conformity Roadmap umbrella spec doc)

Generated with [Claude Code](https://claude.com/claude-code)