### PR TITLE
test: re-align 36 baseline test failures to DS-15/16 token schema

### DIFF
--- a/apps/web/src/__tests__/entity-theme-tokens.test.ts
+++ b/apps/web/src/__tests__/entity-theme-tokens.test.ts
@@ -2,20 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-describe('globals.css entity tokens (Tailwind 4 @theme)', () => {
+/**
+ * Verifies the canonical entity-token schema in globals.css post DS-15/16:
+ * - `--c-*` are the canonical raw HSL tokens (renamed from `--e-*` in DS-16
+ *   CSS variable migration + bridge removal)
+ * - `--color-entity-*` are the Tailwind 4 @theme utilities consuming `--c-*`
+ */
+describe('globals.css entity tokens (Tailwind 4 @theme, post DS-16)', () => {
   const css = readFileSync(resolve(__dirname, '../styles/globals.css'), 'utf8');
 
-  it('defines raw HSL --e-* vars for all 9 entities in :root', () => {
+  it('defines canonical raw HSL --c-* vars for all 9 entities in :root', () => {
     const rawTokens = [
-      '--e-game',
-      '--e-player',
-      '--e-session',
-      '--e-agent',
-      '--e-document',
-      '--e-chat',
-      '--e-event',
-      '--e-toolkit',
-      '--e-tool',
+      '--c-game',
+      '--c-player',
+      '--c-session',
+      '--c-agent',
+      '--c-kb',
+      '--c-chat',
+      '--c-event',
+      '--c-toolkit',
+      '--c-tool',
     ];
     rawTokens.forEach(t => expect(css).toContain(t));
   });
@@ -35,7 +41,7 @@ describe('globals.css entity tokens (Tailwind 4 @theme)', () => {
     utilityTokens.forEach(t => expect(css).toContain(t));
   });
 
-  it('maps --color-entity-kb to --e-document (alias)', () => {
-    expect(css).toMatch(/--color-entity-kb:\s*hsl\(var\(--e-document\)\)/);
+  it('maps --color-entity-kb to --c-kb (post DS-16: bridge removed, e-document → c-kb)', () => {
+    expect(css).toMatch(/--color-entity-kb:\s*hsl\(var\(--c-kb\)\)/);
   });
 });

--- a/apps/web/src/components/__tests__/CommentItem.test.tsx
+++ b/apps/web/src/components/__tests__/CommentItem.test.tsx
@@ -295,10 +295,10 @@ describe('CommentItem', () => {
       );
 
       // Verify resolved styling is applied - Shadcn/UI uses Tailwind CSS classes
-      // The component applies "bg-gray-100 opacity-70" for resolved comments
+      // Post DS-15: bg-gray-100 → bg-muted (semantic token)
       const commentWrapper = container.firstChild as HTMLElement;
       expect(commentWrapper).toBeInTheDocument();
-      expect(commentWrapper).toHaveClass('bg-gray-100');
+      expect(commentWrapper).toHaveClass('bg-muted');
       expect(commentWrapper).toHaveClass('opacity-70');
     });
 

--- a/apps/web/src/components/admin/agents/__tests__/models-table.test.tsx
+++ b/apps/web/src/components/admin/agents/__tests__/models-table.test.tsx
@@ -31,7 +31,7 @@ describe('ModelsTable', () => {
     const toggle = geminiRow.querySelector('button')!;
 
     // Should have gray background (disabled)
-    expect(toggle).toHaveClass('bg-gray-200');
+    expect(toggle).toHaveClass('bg-muted'); // post DS-15 semantic token
 
     // Click to enable
     fireEvent.click(toggle);
@@ -41,7 +41,7 @@ describe('ModelsTable', () => {
 
     // Click again to disable
     fireEvent.click(toggle);
-    expect(toggle).toHaveClass('bg-gray-200');
+    expect(toggle).toHaveClass('bg-muted'); // post DS-15 semantic token
   });
 
   it('shows cost and latency metrics', () => {

--- a/apps/web/src/components/admin/users/__tests__/role-card.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/role-card.test.tsx
@@ -55,7 +55,7 @@ describe('RoleCard', () => {
     );
 
     const card = container.firstChild as HTMLElement;
-    expect(card).toHaveClass('bg-white/70');
+    expect(card).toHaveClass('bg-card/70'); // post DS-15 semantic token
     expect(card).toHaveClass('backdrop-blur-md');
   });
 });

--- a/apps/web/src/components/agent/config/__tests__/CostPreview.test.tsx
+++ b/apps/web/src/components/agent/config/__tests__/CostPreview.test.tsx
@@ -287,7 +287,8 @@ describe('CostPreview', () => {
         wrapper: createWrapper(),
       });
 
-      const card = container.querySelector('.border-slate-700');
+      // Low warning uses semantic border (post DS-15: border-slate-700 → border-border)
+      const card = container.querySelector('.border-border');
       expect(card).toBeInTheDocument();
     });
 

--- a/apps/web/src/components/agent/config/__tests__/SlotCards.test.tsx
+++ b/apps/web/src/components/agent/config/__tests__/SlotCards.test.tsx
@@ -157,8 +157,8 @@ describe('SlotCards', () => {
 
     it('applies available styling to available slots', () => {
       render(<SlotCards />, { wrapper: createWrapper() });
-      // Check for available slot styling (slate border)
-      const slots = document.querySelectorAll('.border-slate-700');
+      // Available slot uses semantic border (post DS-15: border-slate-700 → border-border)
+      const slots = document.querySelectorAll('.border-border');
       expect(slots.length).toBe(3);
     });
   });

--- a/apps/web/src/components/agent/config/__tests__/TemplateCarousel.test.tsx
+++ b/apps/web/src/components/agent/config/__tests__/TemplateCarousel.test.tsx
@@ -99,9 +99,9 @@ describe('TemplateCarousel', () => {
 
       render(<TemplateCarousel />);
 
-      // Check for unselected template styling
+      // Unselected template uses semantic border (post DS-15: border-slate-700 → border-border)
       const unselectedButton = screen.getByText('Strategy Guide').closest('button');
-      expect(unselectedButton?.className).toContain('border-slate-700');
+      expect(unselectedButton?.className).toContain('border-border');
     });
   });
 

--- a/apps/web/src/components/agent/layout/__tests__/SplitViewLayout.test.tsx
+++ b/apps/web/src/components/agent/layout/__tests__/SplitViewLayout.test.tsx
@@ -94,7 +94,7 @@ describe('SplitViewLayout', () => {
 
       // Chat is selected by default, so PDF should be inactive
       const pdfTab = screen.getByText('PDF');
-      expect(pdfTab.className).toContain('text-slate-400');
+      expect(pdfTab.className).toContain('text-muted-foreground'); // post DS-15
     });
   });
 

--- a/apps/web/src/components/editor/__tests__/EditorToolbar.test.tsx
+++ b/apps/web/src/components/editor/__tests__/EditorToolbar.test.tsx
@@ -198,8 +198,8 @@ describe("EditorToolbar", () => {
   it("renders toolbar dividers for visual grouping", () => {
     const { container } = render(<EditorToolbar editor={mockEditor as Editor} />);
 
-    // Dividers now use Tailwind classes (bg-gray-200)
-    const dividers = container.querySelectorAll("div.bg-gray-200");
+    // Dividers now use Tailwind semantic class (post DS-15)
+    const dividers = container.querySelectorAll("div.bg-muted");
     expect(dividers.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/components/editor/__tests__/RichTextEditor.test.tsx
+++ b/apps/web/src/components/editor/__tests__/RichTextEditor.test.tsx
@@ -121,8 +121,8 @@ describe("RichTextEditor", () => {
       />
     );
 
-    // Border now uses Tailwind classes (border-2 border-gray-300)
-    const editorWrapper = container.querySelector("div.border-2.border-gray-300");
+    // Border now uses Tailwind semantic token (border-2 border-border, post DS-15)
+    const editorWrapper = container.querySelector("div.border-2.border-border");
     expect(editorWrapper).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/editor/__tests__/ViewModeToggle.test.tsx
+++ b/apps/web/src/components/editor/__tests__/ViewModeToggle.test.tsx
@@ -20,7 +20,7 @@ describe('ViewModeToggle', () => {
 
     const richButton = screen.getByText(/📝 Editor Visuale/);
     // Check Tailwind classes instead of inline styles
-    expect(richButton).toHaveClass('bg-white', 'text-blue-600', 'font-bold', 'shadow-sm');
+    expect(richButton).toHaveClass('bg-card', 'text-blue-600', 'font-bold', 'shadow-sm');
   });
 
   it('highlights json mode when active', () => {
@@ -28,7 +28,7 @@ describe('ViewModeToggle', () => {
 
     const jsonButton = screen.getByText(/\{ \} Codice JSON/);
     // Check Tailwind classes instead of inline styles
-    expect(jsonButton).toHaveClass('bg-white', 'text-blue-600', 'font-bold', 'shadow-sm');
+    expect(jsonButton).toHaveClass('bg-card', 'text-blue-600', 'font-bold', 'shadow-sm');
   });
 
   it('does not highlight inactive rich mode', () => {
@@ -36,7 +36,7 @@ describe('ViewModeToggle', () => {
 
     const richButton = screen.getByText(/📝 Editor Visuale/);
     // Check Tailwind classes instead of inline styles
-    expect(richButton).toHaveClass('bg-transparent', 'text-gray-600', 'font-normal');
+    expect(richButton).toHaveClass('bg-transparent', 'text-muted-foreground', 'font-normal');
   });
 
   it('does not highlight inactive json mode', () => {
@@ -44,7 +44,7 @@ describe('ViewModeToggle', () => {
 
     const jsonButton = screen.getByText(/\{ \} Codice JSON/);
     // Check Tailwind classes instead of inline styles
-    expect(jsonButton).toHaveClass('bg-transparent', 'text-gray-600', 'font-normal');
+    expect(jsonButton).toHaveClass('bg-transparent', 'text-muted-foreground', 'font-normal');
   });
 
   it("calls onModeChange with 'rich' when rich button is clicked", () => {
@@ -91,7 +91,7 @@ describe('ViewModeToggle', () => {
 
     const wrapper = container.firstChild as HTMLElement;
     // Check Tailwind classes instead of inline styles
-    expect(wrapper).toHaveClass('inline-flex', 'bg-gray-100', 'rounded', 'p-0.5');
+    expect(wrapper).toHaveClass('inline-flex', 'bg-muted', 'rounded', 'p-0.5');
   });
 
   it('applies box shadow to active button', () => {

--- a/apps/web/src/components/empty-state/__tests__/EmptyState.test.tsx
+++ b/apps/web/src/components/empty-state/__tests__/EmptyState.test.tsx
@@ -116,7 +116,7 @@ describe('EmptyState', () => {
         />
       );
       const button = screen.getByRole('button', { name: 'Add item' });
-      expect(button).toHaveClass('bg-slate-100');
+      expect(button).toHaveClass('bg-muted'); // semantic token (post DS-15)
     });
 
     it('should not render action button when not provided', () => {

--- a/apps/web/src/components/empty-state/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/apps/web/src/components/empty-state/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`EmptyState > Snapshot tests > should match snapshot for default variant
 >
   <div
     aria-hidden="true"
-    class="mb-4 p-4 rounded-full bg-slate-100 dark:bg-slate-800 transition-transform duration-200 hover:scale-105"
+    class="mb-4 p-4 rounded-full bg-muted transition-transform duration-200 hover:scale-105"
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-inbox w-8 h-8 text-slate-400 dark:text-slate-500"
+      class="lucide lucide-inbox w-8 h-8 text-muted-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -33,12 +33,12 @@ exports[`EmptyState > Snapshot tests > should match snapshot for default variant
     </svg>
   </div>
   <h3
-    class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2"
+    class="text-lg font-semibold text-foreground mb-2"
   >
     No items
   </h3>
   <p
-    class="text-sm text-slate-600 dark:text-slate-400 max-w-sm mb-4"
+    class="text-sm text-muted-foreground max-w-sm mb-4"
   >
     Add your first item
   </p>
@@ -62,7 +62,7 @@ exports[`EmptyState > Snapshot tests > should match snapshot for error variant 1
 >
   <div
     aria-hidden="true"
-    class="mb-4 p-4 rounded-full bg-slate-100 dark:bg-slate-800 transition-transform duration-200 hover:scale-105"
+    class="mb-4 p-4 rounded-full bg-muted transition-transform duration-200 hover:scale-105"
   >
     <svg
       aria-hidden="true"
@@ -97,12 +97,12 @@ exports[`EmptyState > Snapshot tests > should match snapshot for error variant 1
     </svg>
   </div>
   <h3
-    class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2"
+    class="text-lg font-semibold text-foreground mb-2"
   >
     Something went wrong
   </h3>
   <p
-    class="text-sm text-slate-600 dark:text-slate-400 max-w-sm mb-4"
+    class="text-sm text-muted-foreground max-w-sm mb-4"
   >
     Please try again later
   </p>
@@ -133,7 +133,7 @@ exports[`EmptyState > Snapshot tests > should match snapshot for noAccess varian
 >
   <div
     aria-hidden="true"
-    class="mb-4 p-4 rounded-full bg-slate-100 dark:bg-slate-800 transition-transform duration-200 hover:scale-105"
+    class="mb-4 p-4 rounded-full bg-muted transition-transform duration-200 hover:scale-105"
   >
     <svg
       aria-hidden="true"
@@ -162,12 +162,12 @@ exports[`EmptyState > Snapshot tests > should match snapshot for noAccess varian
     </svg>
   </div>
   <h3
-    class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2"
+    class="text-lg font-semibold text-foreground mb-2"
   >
     Access denied
   </h3>
   <p
-    class="text-sm text-slate-600 dark:text-slate-400 max-w-sm mb-4"
+    class="text-sm text-muted-foreground max-w-sm mb-4"
   >
     You do not have permission
   </p>
@@ -191,7 +191,7 @@ exports[`EmptyState > Snapshot tests > should match snapshot for noResults varia
 >
   <div
     aria-hidden="true"
-    class="mb-4 p-4 rounded-full bg-slate-100 dark:bg-slate-800 transition-transform duration-200 hover:scale-105"
+    class="mb-4 p-4 rounded-full bg-muted transition-transform duration-200 hover:scale-105"
   >
     <svg
       aria-hidden="true"
@@ -217,12 +217,12 @@ exports[`EmptyState > Snapshot tests > should match snapshot for noResults varia
     </svg>
   </div>
   <h3
-    class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2"
+    class="text-lg font-semibold text-foreground mb-2"
   >
     No results found
   </h3>
   <p
-    class="text-sm text-slate-600 dark:text-slate-400 max-w-sm mb-4"
+    class="text-sm text-muted-foreground max-w-sm mb-4"
   >
     Try adjusting your search
   </p>
@@ -253,11 +253,11 @@ exports[`EmptyState > Snapshot tests > should match snapshot with custom icon 1`
 >
   <div
     aria-hidden="true"
-    class="mb-4 p-4 rounded-full bg-slate-100 dark:bg-slate-800 transition-transform duration-200 hover:scale-105"
+    class="mb-4 p-4 rounded-full bg-muted transition-transform duration-200 hover:scale-105"
   >
     <svg
       aria-hidden="true"
-      class="lucide lucide-upload w-8 h-8 text-slate-400 dark:text-slate-500"
+      class="lucide lucide-upload w-8 h-8 text-muted-foreground"
       fill="none"
       height="24"
       stroke="currentColor"
@@ -280,12 +280,12 @@ exports[`EmptyState > Snapshot tests > should match snapshot with custom icon 1`
     </svg>
   </div>
   <h3
-    class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-2"
+    class="text-lg font-semibold text-foreground mb-2"
   >
     Upload files
   </h3>
   <p
-    class="text-sm text-slate-600 dark:text-slate-400 max-w-sm mb-4"
+    class="text-sm text-muted-foreground max-w-sm mb-4"
   >
     Drag and drop files here
   </p>

--- a/apps/web/src/components/loading/__tests__/SkeletonLoader.test.tsx
+++ b/apps/web/src/components/loading/__tests__/SkeletonLoader.test.tsx
@@ -131,7 +131,7 @@ describe('SkeletonLoader', () => {
       const { container } = render(<SkeletonLoader variant="games" className="text-red-500" />);
       const skeleton = container.querySelector('[role="status"]');
       expect(skeleton).toHaveClass('text-red-500');
-      expect(skeleton).toHaveClass('bg-slate-200'); // Base class
+      expect(skeleton).toHaveClass('bg-muted'); // Base class (post DS-15 semantic token)
     });
   });
 

--- a/apps/web/src/components/loading/__tests__/__snapshots__/SkeletonLoader.test.tsx.snap
+++ b/apps/web/src/components/loading/__tests__/__snapshots__/SkeletonLoader.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
     class="
             h-20 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -24,16 +24,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
       class="h-full flex items-center p-3 space-x-3"
     >
       <div
-        class="w-12 h-12 bg-slate-300 dark:bg-slate-600 rounded-full flex-shrink-0"
+        class="w-12 h-12 bg-muted dark:bg-slate-600 rounded-full flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2"
       >
         <div
-          class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+          class="h-4 bg-muted dark:bg-slate-600 rounded w-1/2"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
       </div>
     </div>
@@ -44,7 +44,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
     class="
             h-20 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -58,16 +58,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
       class="h-full flex items-center p-3 space-x-3"
     >
       <div
-        class="w-12 h-12 bg-slate-300 dark:bg-slate-600 rounded-full flex-shrink-0"
+        class="w-12 h-12 bg-muted dark:bg-slate-600 rounded-full flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2"
       >
         <div
-          class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+          class="h-4 bg-muted dark:bg-slate-600 rounded w-1/2"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
       </div>
     </div>
@@ -78,7 +78,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
     class="
             h-20 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -92,16 +92,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for agents vari
       class="h-full flex items-center p-3 space-x-3"
     >
       <div
-        class="w-12 h-12 bg-slate-300 dark:bg-slate-600 rounded-full flex-shrink-0"
+        class="w-12 h-12 bg-muted dark:bg-slate-600 rounded-full flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2"
       >
         <div
-          class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+          class="h-4 bg-muted dark:bg-slate-600 rounded w-1/2"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
       </div>
     </div>
@@ -119,7 +119,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
     class="
             h-12 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -133,16 +133,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
       class="h-full flex items-center p-3 space-x-2"
     >
       <div
-        class="w-6 h-6 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-6 h-6 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-1/3"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-1/3"
         />
       </div>
     </div>
@@ -153,7 +153,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
     class="
             h-12 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -167,16 +167,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
       class="h-full flex items-center p-3 space-x-2"
     >
       <div
-        class="w-6 h-6 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-6 h-6 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-1/3"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-1/3"
         />
       </div>
     </div>
@@ -187,7 +187,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
     class="
             h-12 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -201,16 +201,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
       class="h-full flex items-center p-3 space-x-2"
     >
       <div
-        class="w-6 h-6 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-6 h-6 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-1/3"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-1/3"
         />
       </div>
     </div>
@@ -221,7 +221,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
     class="
             h-12 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -235,16 +235,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for chatHistory
       class="h-full flex items-center p-3 space-x-2"
     >
       <div
-        class="w-6 h-6 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-6 h-6 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-1/3"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-1/3"
         />
       </div>
     </div>
@@ -262,7 +262,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for gameSelecti
     class="
             h-16 rounded-md
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -276,10 +276,10 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for gameSelecti
       class="h-full flex items-center p-3 space-x-3"
     >
       <div
-        class="flex-1 h-10 bg-slate-300 dark:bg-slate-600 rounded"
+        class="flex-1 h-10 bg-muted dark:bg-slate-600 rounded"
       />
       <div
-        class="w-24 h-10 bg-slate-300 dark:bg-slate-600 rounded"
+        class="w-24 h-10 bg-muted dark:bg-slate-600 rounded"
       />
     </div>
   </div>
@@ -296,7 +296,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for games varia
     class="
             h-64 rounded-lg
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -310,16 +310,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for games varia
       class="h-full flex flex-col p-4 space-y-3"
     >
       <div
-        class="flex-1 bg-slate-300 dark:bg-slate-600 rounded"
+        class="flex-1 bg-muted dark:bg-slate-600 rounded"
       />
       <div
-        class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+        class="h-4 bg-muted dark:bg-slate-600 rounded w-3/4"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-full"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-full"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-5/6"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-5/6"
       />
     </div>
   </div>
@@ -329,7 +329,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for games varia
     class="
             h-64 rounded-lg
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -343,16 +343,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for games varia
       class="h-full flex flex-col p-4 space-y-3"
     >
       <div
-        class="flex-1 bg-slate-300 dark:bg-slate-600 rounded"
+        class="flex-1 bg-muted dark:bg-slate-600 rounded"
       />
       <div
-        class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+        class="h-4 bg-muted dark:bg-slate-600 rounded w-3/4"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-full"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-full"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-5/6"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-5/6"
       />
     </div>
   </div>
@@ -369,7 +369,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for message var
     class="
             h-16 rounded-xl
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -383,16 +383,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for message var
       class="h-full flex items-start p-3 space-x-3"
     >
       <div
-        class="w-10 h-10 bg-slate-300 dark:bg-slate-600 rounded-full flex-shrink-0"
+        class="w-10 h-10 bg-muted dark:bg-slate-600 rounded-full flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2 pt-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-full"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-full"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-4/5"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-4/5"
         />
       </div>
     </div>
@@ -403,7 +403,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for message var
     class="
             h-16 rounded-xl
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -417,16 +417,16 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for message var
       class="h-full flex items-start p-3 space-x-3"
     >
       <div
-        class="w-10 h-10 bg-slate-300 dark:bg-slate-600 rounded-full flex-shrink-0"
+        class="w-10 h-10 bg-muted dark:bg-slate-600 rounded-full flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2 pt-1"
       >
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-full"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-full"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-4/5"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-4/5"
         />
       </div>
     </div>
@@ -444,7 +444,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for processingP
     class="
             h-40 rounded-lg
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -458,28 +458,28 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for processingP
       class="h-full flex flex-col p-4 space-y-3"
     >
       <div
-        class="h-5 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+        class="h-5 bg-muted dark:bg-slate-600 rounded w-1/2"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-full"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-full"
       />
       <div
-        class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-1/4"
+        class="h-3 bg-muted dark:bg-slate-600 rounded w-1/4"
       />
       <div
         class="flex space-x-2 mt-2"
       >
         <div
-          class="w-8 h-8 bg-slate-300 dark:bg-slate-600 rounded-full"
+          class="w-8 h-8 bg-muted dark:bg-slate-600 rounded-full"
         />
         <div
-          class="w-8 h-8 bg-slate-300 dark:bg-slate-600 rounded-full"
+          class="w-8 h-8 bg-muted dark:bg-slate-600 rounded-full"
         />
         <div
-          class="w-8 h-8 bg-slate-300 dark:bg-slate-600 rounded-full"
+          class="w-8 h-8 bg-muted dark:bg-slate-600 rounded-full"
         />
         <div
-          class="w-8 h-8 bg-slate-300 dark:bg-slate-600 rounded-full"
+          class="w-8 h-8 bg-muted dark:bg-slate-600 rounded-full"
         />
       </div>
     </div>
@@ -497,7 +497,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for uploadQueue
     class="
             h-24 rounded-lg
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -511,19 +511,19 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for uploadQueue
       class="h-full flex items-center p-4 space-x-4"
     >
       <div
-        class="w-12 h-12 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-12 h-12 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2"
       >
         <div
-          class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-4 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-1/2"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-full"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-full"
         />
       </div>
     </div>
@@ -534,7 +534,7 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for uploadQueue
     class="
             h-24 rounded-lg
             animate-pulse
-            bg-slate-200 dark:bg-slate-700
+            bg-muted dark:bg-card
             
           "
     role="status"
@@ -548,19 +548,19 @@ exports[`SkeletonLoader > Snapshot tests > should match snapshot for uploadQueue
       class="h-full flex items-center p-4 space-x-4"
     >
       <div
-        class="w-12 h-12 bg-slate-300 dark:bg-slate-600 rounded flex-shrink-0"
+        class="w-12 h-12 bg-muted dark:bg-slate-600 rounded flex-shrink-0"
       />
       <div
         class="flex-1 space-y-2"
       >
         <div
-          class="h-4 bg-slate-300 dark:bg-slate-600 rounded w-3/4"
+          class="h-4 bg-muted dark:bg-slate-600 rounded w-3/4"
         />
         <div
-          class="h-3 bg-slate-300 dark:bg-slate-600 rounded w-1/2"
+          class="h-3 bg-muted dark:bg-slate-600 rounded w-1/2"
         />
         <div
-          class="h-2 bg-slate-300 dark:bg-slate-600 rounded w-full"
+          class="h-2 bg-muted dark:bg-slate-600 rounded w-full"
         />
       </div>
     </div>

--- a/apps/web/src/components/loading/__tests__/__snapshots__/TypingIndicator.test.tsx.snap
+++ b/apps/web/src/components/loading/__tests__/__snapshots__/TypingIndicator.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TypingIndicator > Snapshot test > should match snapshot when visible 1`
   animate="animate"
   aria-label="AI Assistant is typing"
   aria-live="polite"
-  class="flex items-center space-x-1 px-4 py-2 bg-slate-100 dark:bg-slate-800 rounded-2xl w-fit "
+  class="flex items-center space-x-1 px-4 py-2 bg-muted rounded-2xl w-fit "
   exit="exit"
   initial="initial"
   role="status"
@@ -26,21 +26,21 @@ exports[`TypingIndicator > Snapshot test > should match snapshot when visible 1`
   >
     <span
       animate="animate"
-      class="w-2 h-2 bg-slate-500 dark:bg-slate-400 rounded-full"
+      class="w-2 h-2 bg-muted-foreground dark:bg-muted-foreground rounded-full"
       initial="initial"
       transition="[object Object]"
       variants="[object Object]"
     />
     <span
       animate="animate"
-      class="w-2 h-2 bg-slate-500 dark:bg-slate-400 rounded-full"
+      class="w-2 h-2 bg-muted-foreground dark:bg-muted-foreground rounded-full"
       initial="initial"
       transition="[object Object]"
       variants="[object Object]"
     />
     <span
       animate="animate"
-      class="w-2 h-2 bg-slate-500 dark:bg-slate-400 rounded-full"
+      class="w-2 h-2 bg-muted-foreground dark:bg-muted-foreground rounded-full"
       initial="initial"
       transition="[object Object]"
       variants="[object Object]"

--- a/apps/web/src/components/ui/auth-card/auth-card.test.tsx
+++ b/apps/web/src/components/ui/auth-card/auth-card.test.tsx
@@ -95,8 +95,8 @@ describe('AuthCard', () => {
     expect(brandMark).not.toBeNull();
     const bg = brandMark?.style.background ?? '';
     expect(bg).toMatch(/linear-gradient/);
-    expect(bg).toMatch(/--e-game/);
-    expect(bg).toMatch(/--e-event/);
-    expect(bg).toMatch(/--e-player/);
+    expect(bg).toMatch(/--c-game/); // post DS-16: bridge removed, --e-* → --c-*
+    expect(bg).toMatch(/--c-event/);
+    expect(bg).toMatch(/--c-player/);
   });
 });

--- a/apps/web/src/components/upload/__tests__/UploadSummary.test.tsx
+++ b/apps/web/src/components/upload/__tests__/UploadSummary.test.tsx
@@ -154,9 +154,9 @@ describe('UploadSummary - Issue #2308 Phase 2', () => {
       <UploadSummary stats={statsWithCancelled} onClose={vi.fn()} onClearAll={vi.fn()} />
     );
 
-    // Assert - Cancelled card visible
+    // Assert - Cancelled card visible (post DS-15: text-gray-600 → text-muted-foreground)
     expect(
-      screen.getByText('2', { selector: 'div.text-2xl.font-bold.text-gray-600' })
+      screen.getByText('2', { selector: 'div.text-2xl.font-bold.text-muted-foreground' })
     ).toBeInTheDocument();
     expect(screen.getByText('Cancelled')).toBeInTheDocument();
 

--- a/apps/web/src/hooks/__tests__/useAlertDialog.test.tsx
+++ b/apps/web/src/hooks/__tests__/useAlertDialog.test.tsx
@@ -261,7 +261,7 @@ describe('useAlertDialog', () => {
 
     await waitFor(() => {
       const icon = screen.getByText('Loading').parentElement?.querySelector('svg');
-      expect(icon).toHaveClass('text-gray-600');
+      expect(icon).toHaveClass('text-muted-foreground'); // post DS-15
       expect(icon).toHaveClass('animate-spin');
     });
   });

--- a/apps/web/src/styles/__tests__/entity-tokens.test.ts
+++ b/apps/web/src/styles/__tests__/entity-tokens.test.ts
@@ -6,21 +6,21 @@ import path from 'node:path';
  * P2 #807 token redesign — AA-compliant values (audit Iter 2, 2026-05-09)
  *
  * Source of truth: docs/for-developers/frontend/v2-a11y-token-audit.md
- * Mockup `admin-mockups/design_files/tokens.css` values were not WCAG 2.1 AA
- * compliant; redesign collapsed --c-* (design-tokens.css) and --e-* (globals.css)
- * onto the same AA-aligned palette per #807.
  *
- *   --e-document (kb): 174 60% 30%   (was 174 60% 40% — Iter 2 darken for AA on white)
- *   --e-toolkit:       142 70% 30%   (was 142 70% 45% — Iter 2 darken for AA on white)
+ * Post DS-16 (CSS variable migration + bridge removal), the `--e-*` bridge
+ * tokens were removed; canonical names are `--c-*` only. AA-aligned values:
+ *
+ *   --c-kb:      174 60% 30%   (KB teal — darkened from L=40% for AA on white)
+ *   --c-toolkit: 142 70% 30%   (Toolkit green — darkened from L=45% for AA on white)
  */
-describe('entity tokens alignment (post-#807 AA)', () => {
+describe('entity tokens alignment (post-#807 AA, post DS-16)', () => {
   const css = fs.readFileSync(path.join(__dirname, '../globals.css'), 'utf8');
 
-  it('--e-document matches AA-aligned --c-kb (174 60% 30%)', () => {
-    expect(css).toMatch(/--e-document:\s*174\s+60%\s+30%/);
+  it('--c-kb matches AA-aligned value (174 60% 30%)', () => {
+    expect(css).toMatch(/--c-kb:\s*174\s+60%\s+30%/);
   });
 
-  it('--e-toolkit matches AA-aligned --c-toolkit (142 70% 30%)', () => {
-    expect(css).toMatch(/--e-toolkit:\s*142\s+70%\s+30%/);
+  it('--c-toolkit matches AA-aligned value (142 70% 30%)', () => {
+    expect(css).toMatch(/--c-toolkit:\s*142\s+70%\s+30%/);
   });
 });


### PR DESCRIPTION
Bring 36 test assertions in line with component output post DS-13/14/15/16 token canonicalization.

## Context

CI Build & Test on `main-dev` was failing with 36 baseline test failures (test files: 18) due to drift after the DS migration codemod. The frontend-a11y job depends on Build & Test, so it has been cancelled on every CI run.

## Categories

### Snapshot regenerations (13)
Captured with `pnpm test -u` on:
- `EmptyState.test.tsx.snap` (5 variants)
- `SkeletonLoader.test.tsx.snap` (7 variants)
- `TypingIndicator.test.tsx.snap` (1)

### Token assertion updates (23)
| Test file | Old | New |
|---|---|---|
| entity-theme-tokens / entity-tokens | `--e-*` | `--c-*` (DS-16 bridge removed) |
| CommentItem, ModelsTable, EmptyState | `bg-gray-100`, `bg-gray-200`, `bg-slate-200` | `bg-muted` |
| RoleCard, EditorToolbar dividers | `bg-white/70`, `bg-gray-200` | `bg-card/70`, `bg-muted` |
| ViewModeToggle | `bg-white`, `text-gray-600`, `bg-gray-100` | `bg-card`, `text-muted-foreground`, `bg-muted` |
| useAlertDialog, UploadSummary | `text-gray-600` | `text-muted-foreground` |
| SplitViewLayout | `text-slate-400` | `text-muted-foreground` |
| RichTextEditor | `border-gray-300` | `border-border` |
| CostPreview, SlotCards, TemplateCarousel | `border-slate-700` | `border-border` |
| auth-card brand-mark gradient | `--e-game/event/player` | `--c-game/event/player` |

## Test plan

- [x] pnpm typecheck: 0 errors
- [x] pnpm test: **17603 passing, 27 skipped, 0 failing** (was 17540 pass + 36 fail)
- [x] No source file changes (test-only PR)

## Unblocks

Frontend-a11y CI gate restore (#752 follow-up). Next step: separate PR to flip `continue-on-error: false` at `.github/workflows/ci.yml:619` once a fresh manual run confirms the a11y job is also clean.

🤖 Generated with Claude Code