### PR TITLE
docs(ops): rollback runbook (image-tag revert + DR scenarios) — closes #848

### DIFF
--- a/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
@@ -79,7 +79,7 @@ Concrete operational rules:
    *Deferred*: this is the right end state. It is gated on the user base outgrowing the co-tenant resource budget, or on the ops cost becoming small relative to the value delivered. Tracked implicitly under the [#842](https://github.com/meepleAi-app/meepleai-monorepo/issues/842) epic close-out criteria.
 
 3. **Blue/green production deployments**.
-   *Deferred*: overkill for current scale. A rolling-with-healthcheck deploy + image-tag rollback gives us the recoverability we need at a fraction of the operational complexity.
+   *Deferred*: overkill for current scale. A rolling-with-healthcheck deploy + image-tag rollback gives us the recoverability we need at a fraction of the operational complexity. Procedure documented in [`rollback-runbook.md`](../../../for-developers/operations/rollback-runbook.md); upgrade triggers in [§15 future upgrade path](../../../for-developers/operations/rollback-runbook.md#15-future-upgrade-path).
 
 4. **Auto-deploy from `main-dev` straight to staging** (skip `main-staging`).
    *Rejected*: removes the gate where the full suite runs blocking, which is exactly the friction that protects invited users from `main-dev` flakes.
@@ -92,6 +92,6 @@ Concrete operational rules:
 - Access control Wave 1: [#845](https://github.com/meepleAi-app/meepleai-monorepo/issues/845)
 - Workflow split: [#846](https://github.com/meepleAi-app/meepleai-monorepo/issues/846)
 - Invitation aggregate Wave 2: [#847](https://github.com/meepleAi-app/meepleai-monorepo/issues/847)
-- Prod rollback runbook: [#848](https://github.com/meepleAi-app/meepleai-monorepo/issues/848)
+- Prod rollback runbook: [#848](https://github.com/meepleAi-app/meepleai-monorepo/issues/848) → [`rollback-runbook.md`](../../../for-developers/operations/rollback-runbook.md)
 - CI cost optimisation: [#850](https://github.com/meepleAi-app/meepleai-monorepo/issues/850)
 - Self-hosted ARM64 runner: [ADR-044](./adr-044-self-hosted-arm64-runner.md)

--- a/docs/for-developers/operations/deploy-staging-runbook.md
+++ b/docs/for-developers/operations/deploy-staging-runbook.md
@@ -108,7 +108,22 @@ Post-P1 il trigger è `push: [main-staging]` quindi non si verificano più run v
 
 ## Rollback procedure
 
-`deploy-staging.yml` non ha auto-rollback. Manual rollback richiede:
+Two paths depending on incident urgency:
+
+### Fast path — image-tag revert (≤ 10 min RTO)
+
+For P1 incidents where forward-fix is too slow, use the **image-tag rollback**:
+
+```bash
+bash infra/scripts/rollback-trigger.sh staging staging-YYYYMMDD-<sha7>
+```
+
+Full procedure with safety checks, 3 scenarios, and post-rollback validation:
+[**rollback-runbook.md**](./rollback-runbook.md).
+
+### Slow path — revert PR (forward-fix friendly)
+
+When the broken deploy is non-critical and you want the rollback to flow through CI:
 
 ```bash
 # 1. Identifica merge commit responsabile
@@ -129,6 +144,9 @@ gh pr merge <REVERT_PR_NUM> --merge --delete-branch
 gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
+The slow path takes ~15-25 min (CI rebuild + deploy) vs ~10 min for the image-tag path,
+but produces a clean git history. Use slow path for P2/P3, fast path for P1.
+
 ## Observability
 
 - Slack: notifiche via `notify-start` + `notify-end` jobs (channel configurato in repo secrets `SLACK_GITNOTIFY_WEBHOOK_URL` + `SLACK_CRITICAL_WEBHOOK_URL`)
@@ -139,7 +157,7 @@ gh run watch $(gh run list --workflow "Deploy to Staging" --limit 1 --json datab
 
 - Trigger `push: [main-staging]` accetta qualsiasi push, anche con CI rosso. Affidamento al disciplinare merge process: chi mergia main-dev → main-staging deve aver verificato CI green pre-merge.
 - Smoke test K6 + perf regression sono `continue-on-error: true` — non bloccanti.
-- Auto-rollback assente — richiede manual revert PR.
+- Auto-rollback assente — manuale via `rollback-runbook.md` (fast path, image-tag) o revert PR (slow path).
 
 Future hardening (out of scope P1):
 

--- a/docs/for-developers/operations/dr-walkthrough-log.md
+++ b/docs/for-developers/operations/dr-walkthrough-log.md
@@ -1,0 +1,32 @@
+# DR Walkthrough Log
+
+> Cadence: every 90 days. See [`rollback-runbook.md` §13](./rollback-runbook.md#13-quarterly-dr-drill-cadence).
+> Automated reminder: `infra/scripts/dr-walkthrough-reminder.sh` (cron `0 9 1 1,4,7,10 *`).
+
+Each entry records one quarterly drill of the rollback runbook. Newest entry on top.
+
+## Log
+
+| Date | Operator | Scenario | RTO actual | Drift discovered | Follow-up issues | Commit / PR |
+|---|---|---|---|---|---|---|
+| _(no entries yet — first drill due Q3 2026)_ | | | | | | |
+
+## Entry template
+
+```markdown
+| 2026-MM-DD | <name> | A | <X min> | <description or "none"> | #..., #... | <SHA or PR#> |
+```
+
+Scenarios reference [`rollback-runbook.md` §6](./rollback-runbook.md#6-three-rollback-scenarios):
+- **A** — bad image (no schema change)
+- **B** — bad migration (schema change applied)
+- **C** — slow leak / performance regression
+
+## Drill rotation
+
+| Quarter | Default scenario | Notes |
+|---|---|---|
+| Q1 | A (bad image) | Fastest drill, builds operator muscle memory |
+| Q2 | B (bad migration) | Verifies DB restore path + backup integrity |
+| Q3 | A (bad image) | Most-likely real-world case |
+| Q4 | C (slow leak) | Performance baselining + Grafana flow |

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2214,10 +2214,11 @@ S3_FORCE_PATH_STYLE=false
    └── If disk full:    docker system prune -f
 
 4. RESOLVE
-   ├── Apply fix (config change, restart, rollback)
+   ├── Apply fix (config change, restart, rollback*)
    ├── Verify health:  docker compose ps
    ├── Check logs:     docker logs <container> --tail=20
    └── Run smoke test: curl http://localhost:8080/
+   * For image-tag rollback procedure see rollback-runbook.md
 
 5. POST-MORTEM
    ├── Document: what happened, why, how fixed
@@ -2392,12 +2393,17 @@ echo "=== Backup complete ==="
 
 ### Disaster Recovery Procedures
 
+> **Rollback (image-tag revert)** for a single bad deploy lives in a dedicated runbook:
+> [**rollback-runbook.md**](./rollback-runbook.md) — covers bad image, bad migration, and slow-leak scenarios with RTO ≤ 10 min.
+> Use this section for **infrastructure-level** disasters (VPS loss, DB corruption, ransomware) where rollback alone is insufficient.
+
 #### Recovery Targets
 
-| Metric | Target |
-|--------|--------|
-| **RTO** (Recovery Time Objective) | < 2 hours |
-| **RPO** (Recovery Point Objective) | < 24 hours |
+| Metric | Target | Notes |
+|--------|--------|-------|
+| **RTO** (Recovery Time Objective) — DR scenarios | < 2 hours | This section |
+| **RTO** — single-deploy rollback | < 10 minutes | See [rollback-runbook.md §10](./rollback-runbook.md#10-raci--sla) |
+| **RPO** (Recovery Point Objective) | < 24 hours | Daily `backup.sh` cron |
 
 #### Scenario 1: VPS Failure (Total Loss)
 

--- a/docs/for-developers/operations/rollback-runbook.md
+++ b/docs/for-developers/operations/rollback-runbook.md
@@ -37,8 +37,9 @@
 │  ROLLBACK IN 4 STEPS (≤ 10 min target RTO)                      │
 ├─────────────────────────────────────────────────────────────────┤
 │  1. IDENTIFY previous-good tag                                   │
-│     gh api /repos/meepleAi-app/meepleai-monorepo/packages \      │
-│        /container/api/versions --jq '.[1].metadata.container.tags[0]' │
+│     gh api /orgs/meepleAi-app/packages/container/\               │
+│        meepleai-monorepo%2Fapi/versions \                        │
+│        --jq '.[1].metadata.container.tags[0]'                    │
 │                                                                  │
 │  2. (Optional) DRAIN Hangfire if migrations were applied         │
 │     ssh staging "docker exec meepleai-api dotnet hangfire-stop"  │
@@ -50,7 +51,7 @@
 │        -f restore_db=false                                       │
 │                                                                  │
 │     OR via wrapper: bash infra/scripts/rollback-trigger.sh \     │
-│                       prod <previous-good-tag>                   │
+│                       production <previous-good-tag>             │
 │                                                                  │
 │  4. VALIDATE (5 min budget)                                      │
 │     - Health: curl -sf https://meepleai.app/health               │

--- a/docs/for-developers/operations/rollback-runbook.md
+++ b/docs/for-developers/operations/rollback-runbook.md
@@ -1,0 +1,711 @@
+# Rollback Runbook — Production & Staging
+
+> **Last verified**: 2026-05-12 (DR drill cadence: every 90 days — see [§13](#13-quarterly-dr-drill-cadence))
+> **Audience**: On-call engineer (single operator during beta phase)
+> **Maintenance owner**: @badsworm (founder)
+> **Scope**: Manual revert via image tag for `meepleai.app` (staging) and `meepleai.com` (production, TBD)
+> **Sibling docs**: [deploy-staging-runbook.md](./deploy-staging-runbook.md) · [operations-manual.md §17 Incident Response](./operations-manual.md#17-incident-response) · [operations-manual.md §18 DR Procedures](./operations-manual.md#18-maintenance--disaster-recovery) · [ADR-054 Multi-Branch Strategy](../../for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md)
+
+> **Status of `meepleai.com`**: production host is **not yet provisioned** ([epic #842](https://github.com/meepleAi-app/meepleai-monorepo/issues/842)). This runbook covers the operational model for both environments; staging procedures are validated and prod sections become enforceable when the prod host is provisioned. Until then, treat prod sections as the **target template** to validate on the first prod deploy.
+
+---
+
+## Table of Contents
+
+1. [TL;DR — Emergency Quick Card](#1-tldr--emergency-quick-card)
+2. [Decision tree — when to rollback](#2-decision-tree--when-to-rollback)
+3. [Prerequisites](#3-prerequisites)
+4. [Pre-rollback safety checks](#4-pre-rollback-safety-checks)
+5. [Procedure — happy path](#5-procedure--happy-path)
+6. [Three rollback scenarios](#6-three-rollback-scenarios)
+7. [Multi-service rollback ordering](#7-multi-service-rollback-ordering)
+8. [Database backward-compatibility policy](#8-database-backward-compatibility-policy)
+9. [Post-rollback validation](#9-post-rollback-validation)
+10. [RACI + SLA](#10-raci--sla)
+11. [Image tag retention](#11-image-tag-retention)
+12. [Communication templates](#12-communication-templates)
+13. [Quarterly DR drill cadence](#13-quarterly-dr-drill-cadence)
+14. [Post-mortem & follow-up](#14-post-mortem--follow-up)
+15. [Future upgrade path](#15-future-upgrade-path)
+
+---
+
+## 1. TL;DR — Emergency Quick Card
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ROLLBACK IN 4 STEPS (≤ 10 min target RTO)                      │
+├─────────────────────────────────────────────────────────────────┤
+│  1. IDENTIFY previous-good tag                                   │
+│     gh api /repos/meepleAi-app/meepleai-monorepo/packages \      │
+│        /container/api/versions --jq '.[1].metadata.container.tags[0]' │
+│                                                                  │
+│  2. (Optional) DRAIN Hangfire if migrations were applied         │
+│     ssh staging "docker exec meepleai-api dotnet hangfire-stop"  │
+│                                                                  │
+│  3. TRIGGER rollback workflow                                    │
+│     gh workflow run rollback.yml \                               │
+│        -f environment=production \                               │
+│        -f image_tag=<previous-good-tag> \                        │
+│        -f restore_db=false                                       │
+│                                                                  │
+│     OR via wrapper: bash infra/scripts/rollback-trigger.sh \     │
+│                       prod <previous-good-tag>                   │
+│                                                                  │
+│  4. VALIDATE (5 min budget)                                      │
+│     - Health: curl -sf https://meepleai.app/health               │
+│     - Smoke:  3 critical paths (login + library + chat)          │
+│     - Error rate: Grafana < baseline + 50% sustained 5min        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+If any step fails, **stop and escalate to founder** (see [§10 RACI](#10-raci--sla)).
+
+---
+
+## 2. Decision tree — when to rollback
+
+Not every incident calls for a rollback. Pick the **least invasive** action that resolves user impact within the SLA.
+
+```
+Incident detected
+│
+├─ Severity P1 (service down, > 5% error rate, data corruption suspected)
+│   │
+│   ├─ Caused by NEW deploy in last 60 min?
+│   │   ├─ YES + schema unchanged → IMAGE ROLLBACK (this runbook §5)
+│   │   ├─ YES + schema changed   → IMAGE ROLLBACK + DB RESTORE (§6.2)
+│   │   └─ NO                      → Containment first (operations-manual §17)
+│   │
+│   └─ Suspected data corruption → STOP WRITES, see operations-manual §18
+│
+├─ Severity P2 (degraded but functional)
+│   │
+│   ├─ Hotfix available within 30 min? → FORWARD FIX (deploy-staging-runbook)
+│   ├─ Hotfix would take > 1 hour     → IMAGE ROLLBACK (this runbook §5)
+│   └─ Performance regression only    → CANARY ROLLBACK + analyse (§6.3)
+│
+└─ Severity P3/P4 → No rollback; backlog hotfix
+```
+
+**Heuristic** — *"If the post-deploy diff is small and the fix is obvious, forward-fix. If the diff is large or the failure mode is unknown, rollback first and diagnose offline."*
+
+---
+
+## 3. Prerequisites
+
+### 3.1 Reused existing assets (no duplication)
+
+| Asset | Purpose | Path |
+|---|---|---|
+| Manual Rollback workflow | Pulls image tag + recreates API/Web containers + healthcheck | `.github/workflows/rollback.yml` |
+| Backup automation | Pre-migration `pg_dumpall` + R2 sync (daily 03:00) | `infra/scripts/backup.sh` |
+| Backup verify | Integrity check before restore | `infra/scripts/backup-verify.sh` |
+| Restore test | Restore to temp pgvector container + schema verify | `infra/scripts/backup-restore-test.sh` |
+| DR procedures | Full VPS recovery, DB corruption recovery | `operations-manual.md` §18 |
+| Incident response | P1/P2 severity gates, communication template | `operations-manual.md` §17 |
+| Deploy runbook | Reference for promote main-dev → staging flow | `deploy-staging-runbook.md` |
+| CF Access secrets | Service token for smoke checks behind Cloudflare Access | `infra/secrets/cf-access.secret` |
+
+### 3.2 What you need before triggering rollback
+
+- [ ] `gh` CLI authenticated (`gh auth status`)
+- [ ] Repo write access (you can trigger `workflow_dispatch`)
+- [ ] SSH key for target host loaded (`~/.ssh/meepleai-staging` or prod equivalent)
+- [ ] CF Access service token in `infra/secrets/cf-access.secret` (for post-rollback smoke)
+- [ ] Knowledge of the **previous-good image tag** — see [§1 step 1](#1-tldr--emergency-quick-card)
+- [ ] Decision on `restore_db`: **default `false`**. Only `true` if a migration ran *and* it caused the incident *and* the migration was backward-incompatible (this should be impossible per [§8](#8-database-backward-compatibility-policy), but guarded as escape hatch).
+
+### 3.3 Image tag conventions (must hold for rollback to work)
+
+The `rollback.yml` workflow expects images at `ghcr.io/meepleai-app/meepleai-monorepo/api:<tag>` and `…/web:<tag>`. Tag formats currently in use:
+
+| Source | Tag format | Example |
+|---|---|---|
+| Auto-deploy to staging | `staging-YYYYMMDD-<sha7>` | `staging-20260512-a1b2c3d` |
+| Auto-deploy to staging | `latest` (mutable — **do not use for rollback**) | `latest` |
+| Promoted to prod (future) | `vYYYY.MM.DD-<sha7>` | `v2026.05.12-a1b2c3d` |
+
+**Rule** — never rollback to `latest`. Always use an immutable SHA-suffixed tag.
+
+---
+
+## 4. Pre-rollback safety checks
+
+Run these in the **2-3 minutes** before triggering rollback. Do not skip on a real incident — they make the difference between a clean rollback and amplifying the outage.
+
+### 4.1 Identify the previous-good tag
+
+```bash
+# Latest 5 API image versions (most recent first)
+gh api \
+  /orgs/meepleAi-app/packages/container/meepleai-monorepo%2Fapi/versions \
+  --jq '.[].metadata.container.tags' | head -5
+
+# Or: inspect the running staging container to see the *current* tag
+ssh meepleai-staging "docker inspect meepleai-api --format '{{.Config.Image}}'"
+```
+
+Pick the tag **immediately before** the broken deploy. Confirm with the `Deploy to Staging` workflow log to map tag → commit SHA.
+
+### 4.2 Drain Hangfire jobs (if recent migration ran)
+
+If the broken deploy applied an EF migration, in-flight Hangfire jobs may write data using the *new* schema. Rolling back the schema mid-flight = data corruption.
+
+```bash
+# Count pending jobs
+ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging \
+  -c \"SELECT count(*) FROM hangfire.job WHERE statename IN ('Enqueued', 'Processing');\""
+
+# If count > 0: pause schedulers (graceful)
+ssh meepleai-staging "docker exec meepleai-api curl -sf -X POST http://localhost:8080/admin/hangfire/pause"
+# (Requires admin auth — use bearer token from secrets)
+
+# Wait up to 60s for Processing jobs to finish
+ssh meepleai-staging "for i in {1..30}; do
+  CNT=\$(docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -t -c \"SELECT count(*) FROM hangfire.job WHERE statename='Processing';\" | xargs)
+  if [ \"\$CNT\" = \"0\" ]; then echo 'drained'; break; fi
+  echo \"\$i: \$CNT processing\"; sleep 2
+done"
+```
+
+If jobs do not drain within 60 s, **dump pending job state** for forensic analysis and proceed (data loss accepted in P1 — log the loss in post-mortem):
+
+```bash
+ssh meepleai-staging "docker exec meepleai-postgres pg_dump -U meepleai -d meepleai_staging \
+  -t hangfire.job -t hangfire.state -t hangfire.jobparameter \
+  > /backups/hangfire-pre-rollback-\$(date +%Y%m%d-%H%M%S).sql"
+```
+
+### 4.3 Capture baseline metrics (for post-rollback comparison)
+
+```bash
+# Error rate baseline (last 15 min before incident detection)
+curl -sf "http://meepleai-staging:9090/api/v1/query" \
+  --data-urlencode 'query=rate(http_requests_total{status=~"5.."}[15m])' \
+  -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+  -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+  | jq '.data.result[0].value[1]' > /tmp/error-rate-baseline.txt
+
+# Save current container state for forensic
+ssh meepleai-staging "docker ps --format json > /tmp/pre-rollback-state-\$(date +%Y%m%d-%H%M%S).json"
+```
+
+### 4.4 Confirm backup exists (only if rollback may require DB restore)
+
+```bash
+ssh meepleai-staging "ls -lhrt /backups/meepleai/ | tail -3"
+# Expect a backup directory dated < 24 h ago (per backup.sh cron)
+
+# Verify integrity before relying on it
+ssh meepleai-staging "bash /opt/meepleai/repo/infra/scripts/backup-verify.sh"
+```
+
+---
+
+## 5. Procedure — happy path
+
+### 5.1 Option A — via wrapper script (recommended)
+
+```bash
+# From your local machine, with gh CLI authenticated
+bash infra/scripts/rollback-trigger.sh production v2026.05.11-deadbee
+# Or staging:
+bash infra/scripts/rollback-trigger.sh staging staging-20260511-deadbee
+```
+
+The wrapper validates environment, tag format, GH auth, and asks for **explicit operator confirmation** before calling `gh workflow run rollback.yml`.
+
+### 5.2 Option B — direct workflow_dispatch
+
+```bash
+gh workflow run rollback.yml \
+  -f environment=production \
+  -f image_tag=v2026.05.11-deadbee \
+  -f restore_db=false
+
+# Watch progress
+gh run watch $(gh run list --workflow rollback.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+### 5.3 What the workflow does
+
+The `.github/workflows/rollback.yml` workflow performs (per `rollback-staging` or `rollback-production` job):
+
+1. `docker login` to GHCR
+2. SSH to target host
+3. `docker pull` API + Web images at the requested tag
+4. `docker compose up -d --no-deps api web` with the override `IMAGE` env vars
+5. (Prod only, opt-in) `psql … < pre-migration-backup.sql` to restore DB if `restore_db=true`
+6. 12 × 5 s health check loop on `http://localhost:8080/health` (60 s total budget)
+7. Slack notification on completion or failure (critical channel for prod)
+
+**Healthcheck timeout = 60 s** is intentional. If the rollback image fails to come healthy in 60 s, the workflow fails and the previous (broken) containers are still down — proceed to [§9.5 escalation](#95-escalation-on-rollback-failure).
+
+---
+
+## 6. Three rollback scenarios
+
+### 6.1 Scenario A — bad image (no schema change)
+
+> **Example**: deploy introduced a regression in API logic; no migration ran in this release.
+
+**Indicators**: error rate spike, no new files in `apps/api/src/Api/Migrations/` between previous-good and broken tag.
+
+**Steps**:
+
+1. Identify previous-good tag (§4.1)
+2. Skip Hangfire drain (§4.2 not needed — schema unchanged)
+3. Capture baseline (§4.3)
+4. Trigger rollback **without** `restore_db` (§5)
+5. Validate (§9)
+
+**Expected RTO**: ≤ 5 min (no DB restore overhead)
+
+**Simulation cadence**: Every quarterly DR drill (§13).
+
+### 6.2 Scenario B — bad migration (schema change applied)
+
+> **Example**: migration `AddRequiredColumnX` deployed; existing rows fail constraint; API throws on every write.
+
+**Indicators**: error logs mention column / constraint / FK names from the new migration; `dotnet ef migrations list` on staging shows the broken migration as latest applied.
+
+**Steps**:
+
+1. Identify previous-good tag (§4.1)
+2. **Run §4.2 Hangfire drain** — mandatory for schema rollback
+3. Run §4.4 backup verify
+4. Trigger rollback **with** `restore_db=true` — workflow restores from latest `pre-migration-*.sql` backup
+5. Validate (§9)
+6. **Post-restore migration audit**: confirm `__EFMigrationsHistory` no longer contains the broken migration:
+   ```bash
+   ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging \
+     -c 'SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 5;'"
+   ```
+
+**Expected RTO**: 8-12 min (includes `psql` restore + healthcheck)
+
+**RPO**: Last `backup.sh` run before the broken deploy. If deploy happened > 24 h after last backup, **data loss for that window** is accepted in P1.
+
+> **Migration safety note**: per [§8](#8-database-backward-compatibility-policy), migrations should be backward-compatible. Scenario B should be *rare* and only triggered when [§8](#8-database-backward-compatibility-policy) was violated.
+
+**Simulation cadence**: Every quarterly DR drill (§13).
+
+### 6.3 Scenario C — slow leak / performance regression
+
+> **Example**: P95 latency doubles over 30 min after deploy; no errors but UX degraded.
+
+**Indicators**: Grafana P95 dashboard delta > 100% vs baseline; error rate unchanged; user complaints.
+
+**Steps**:
+
+1. Identify previous-good tag (§4.1)
+2. **Decide forward-fix vs rollback** — if hotfix < 30 min, prefer forward-fix
+3. If rollback chosen:
+   - No Hangfire drain needed (no schema change)
+   - Capture extended baseline metrics: P50, P95, P99, RPS
+   - Trigger rollback (§5)
+4. **Post-rollback root-cause investigation is mandatory** — slow leaks indicate observability gap
+
+**Expected RTO**: ≤ 5 min for the rollback itself.
+
+**Caveat**: rollback hides the symptom; you still need to find the cause. Schedule post-mortem (§14) within 48 h.
+
+**Simulation cadence**: Annually (or after the first real-world slow-leak incident).
+
+---
+
+## 7. Multi-service rollback ordering
+
+When API + Web + Embedding + Reranker are all part of a release, rollback order matters because of contract coupling.
+
+| Change type | Rollback order | Rationale |
+|---|---|---|
+| API + Web coupled (e.g. new endpoint + client) | **Web first, then API** | Client falls back to old contract before server reverts |
+| DB schema change (backward-compat per §8) | **No order constraint** — rollback API+Web together | Schema can serve both versions |
+| DB schema change (breaking, violated §8) | **DB restore first, then API+Web** | Avoid API hitting impossible schema state |
+| Embedding / Reranker only | **Independent** — rollback last | Decoupled from API contract via internal HTTP |
+| Multiple services + DB | **DB → API → Web** | Schema is foundation, API depends on schema, Web depends on API |
+
+> The current `rollback.yml` rolls API+Web together in a single `docker compose up`. This is acceptable for the beta phase (contract coupling rare, blast radius small). When the service surface grows, split into per-service workflow inputs.
+
+---
+
+## 8. Database backward-compatibility policy
+
+**Rule** — every EF migration deployed to production MUST be **rollback-safe**, meaning the *previous* code version can still run against the new schema.
+
+### 8.1 Allowed in a single migration
+
+- `ADD COLUMN … NULL` (with default if NOT NULL needed temporarily)
+- `CREATE TABLE` (new tables)
+- `CREATE INDEX CONCURRENTLY` (if using raw SQL escape — EF doesn't support concurrent natively)
+- `ADD CONSTRAINT … NOT VALID` then validate in follow-up
+- Data backfills behind feature flag
+
+### 8.2 Forbidden in a single migration
+
+- `DROP COLUMN` of column still read by previous code
+- `DROP TABLE` of table still referenced
+- `ALTER COLUMN TYPE` to a narrower or incompatible type
+- `RENAME COLUMN` / `RENAME TABLE` without a temporary alias
+- `ADD COLUMN NOT NULL` without default (fails on existing rows)
+
+### 8.3 Pattern — expand → migrate → contract (two-deploy pattern)
+
+For breaking schema changes, split into two deploys. Example: rename `users.email` → `users.email_address`.
+
+**Deploy N (expand)**:
+```csharp
+public partial class AddEmailAddressColumn : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "email_address",
+            table: "users",
+            type: "varchar(320)",
+            nullable: true);
+
+        migrationBuilder.Sql(@"UPDATE users SET email_address = email WHERE email_address IS NULL;");
+    }
+}
+```
+- API code: dual-write (writes both `email` and `email_address`); reads from `email_address` with fallback to `email`.
+- **Soak time**: ≥ 7 days in staging + prod before next deploy.
+- **Rollback-safe**: yes — previous code still reads `email`.
+
+**Deploy N+1 (contract)**:
+```csharp
+public partial class DropEmailColumn : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(name: "email", table: "users");
+    }
+}
+```
+- API code: reads/writes `email_address` only.
+- **Pre-deploy gate**: confirm zero reads of `email` in last 7 days (log query or feature-flag telemetry).
+- **Rollback-safe within N+1**: still yes — restoring to Deploy N code requires DB restore from §6.2, which is the documented escape hatch.
+
+### 8.4 Enforcement (current state vs target)
+
+**Current**: policy enforced by code review only.
+**Target** (tracked in [#1087](https://github.com/meepleAi-app/meepleai-monorepo/issues/1087)): CI gate in `staging.yml` that parses migration `.sql` artifacts and fails on `DROP COLUMN|DROP TABLE|ALTER COLUMN.*TYPE` without an explicit `-- safe: deferred-contract` directive.
+
+---
+
+## 9. Post-rollback validation
+
+### 9.1 Required success criteria (must all pass before declaring rollback complete)
+
+| Criterion | Check | Pass threshold |
+|---|---|---|
+| **Health endpoint** | `curl -sf https://meepleai.app/health` | HTTP 200, < 500 ms |
+| **API smoke — login** | POST `/api/v1/auth/login` with test account | HTTP 200 + session cookie |
+| **API smoke — library** | GET `/api/v1/library` authenticated | HTTP 200 + non-empty JSON |
+| **API smoke — chat** | POST `/api/v1/chat-threads/<id>/messages` | HTTP 200 + SSE stream starts |
+| **Error rate** | Grafana `rate(http_requests_total{status=~"5.."}[5m])` | < baseline + 50% (from §4.3) |
+| **Hangfire** | `SELECT count(*) FROM hangfire.job WHERE statename='Failed'` | No new Failed jobs in last 5 min |
+| **DB row counts** (if DB restored) | Spot-check 3 critical tables: `users`, `games`, `chat_threads` | Counts within ±5 % of pre-rollback snapshot |
+
+### 9.2 Smoke validation script (through CF Access)
+
+```bash
+set -a; source infra/secrets/cf-access.secret; set +a
+
+# Health
+curl -sf -w "%{http_code}\n" \
+  -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+  -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+  https://meepleai.app/health
+
+# Library (use a smoke account session token from secrets)
+curl -sf -w "%{http_code}\n" \
+  -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+  -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+  -H "Cookie: meepleai_session=${SMOKE_SESSION_TOKEN}" \
+  https://meepleai.app/api/v1/library \
+  | jq '. | length'
+
+unset CF_ACCESS_CLIENT_ID CF_ACCESS_CLIENT_SECRET
+```
+
+### 9.3 Validation budget
+
+- **Soft target**: all checks pass within 5 min of rollback completion
+- **Hard limit**: 15 min — if smoke still failing at 15 min, treat as **failed rollback** and escalate
+
+### 9.4 Observability during validation
+
+Watch in parallel:
+- Grafana `Production Overview` dashboard (P50/P95 latency + error rate)
+- `docker logs meepleai-api -f --tail=20` for ERROR-level entries
+- Sentry incoming events (if integrated)
+
+### 9.5 Escalation on rollback failure
+
+If health/smoke fails after rollback:
+
+1. **Do not retry the same rollback** — it will fail the same way
+2. Capture: workflow run URL + `docker logs` + `docker ps` state
+3. **Notify founder** (badsworm@libero.it) via Slack `#critical` and email
+4. Consider **emergency forward-fix** (small patch on `main-staging`, fast-track promotion)
+5. Worst case: **full DR procedure** (operations-manual §18) — VPS rebuild
+
+---
+
+## 10. RACI + SLA
+
+### 10.1 Roles during beta phase
+
+| Role | Person | Responsibility |
+|---|---|---|
+| **Responsible** | On-call engineer (currently = founder) | Executes rollback steps |
+| **Accountable** | @badsworm (founder) | Authorises rollback decision, signs post-mortem |
+| **Consulted** | None during beta | (Will add team leads when ≥ 3 engineers) |
+| **Informed** | Active users via status banner (when implemented) + Slack `#critical` | Knows there is an incident, gets ETA |
+
+### 10.2 SLA — decision time
+
+| Phase | SLA | Notes |
+|---|---|---|
+| **Detection → Decision** | ≤ 15 min | From P1 alert to "we're rolling back" — see §2 decision tree |
+| **Decision → Workflow trigger** | ≤ 5 min | Includes §4 safety checks |
+| **Workflow trigger → Healthy state** | ≤ 10 min | Per `rollback.yml` healthcheck budget |
+| **Healthy state → User-facing confirmation** | ≤ 5 min | Smoke validation §9 |
+| **Total — incident detection → service restored** | **≤ 35 min** | Soft target during beta; aim for tighter as team grows |
+
+### 10.3 Authorisation matrix
+
+| Action | Requires |
+|---|---|
+| Rollback staging (image only) | Self-authorise (operator) |
+| Rollback staging (with DB restore) | Self-authorise + Slack `#critical` notification |
+| Rollback prod (image only) | Self-authorise (during beta, single operator) |
+| Rollback prod (with DB restore) | Self-authorise + post-incident written record in [§14 post-mortem](#14-post-mortem--follow-up) |
+| **Full DR (VPS rebuild)** | Founder approval (operations-manual §18) |
+
+> **Future expansion** — when the team reaches 3+ engineers, prod DB restore requires a second engineer approval (4-eye rule). Tracked in epic [#842](https://github.com/meepleAi-app/meepleai-monorepo/issues/842) close-out.
+
+---
+
+## 11. Image tag retention
+
+### 11.1 Current state
+
+GHCR has **no automatic retention policy** configured on `meepleai-monorepo/api` or `meepleai-monorepo/web` packages. Untagged versions are pruned by GHCR after 30 days by default; tagged versions persist indefinitely.
+
+### 11.2 Policy
+
+| Image source | Tag pattern | Retention |
+|---|---|---|
+| Staging deploys | `staging-YYYYMMDD-<sha7>` | **Keep last 30 builds** (rolling — ~30 days at current cadence) |
+| Prod releases (future) | `vYYYY.MM.DD-<sha7>` | **Keep last 10 releases** + `latest` |
+| Mutable tags | `latest`, `staging` | Always overwritten — never used for rollback |
+
+### 11.3 Enforcement
+
+Manual prune via GitHub Packages UI for now. To automate (future work):
+
+```yaml
+# .github/workflows/ghcr-retention.yml (not yet implemented)
+- uses: actions/delete-package-versions@v5
+  with:
+    package-name: 'meepleai-monorepo/api'
+    package-type: 'container'
+    min-versions-to-keep: 30
+    delete-only-untagged-versions: false
+```
+
+Tracked as part of [#850 CI cost optimization](https://github.com/meepleAi-app/meepleai-monorepo/issues/850).
+
+---
+
+## 12. Communication templates
+
+### 12.1 Internal — Slack `#critical` (started)
+
+```
+:rotating_light: ROLLBACK INITIATED — production
+Trigger: <one-line description of incident>
+Severity: P1
+Rolling back from <broken-tag> → <previous-good-tag>
+DB restore: <yes/no>
+ETA service restored: 10 min
+Runbook: https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/rollback-runbook.md
+```
+
+### 12.2 Internal — Slack `#critical` (complete)
+
+```
+:white_check_mark: ROLLBACK COMPLETE — production
+Restored to: <previous-good-tag>
+Total downtime: <X min>
+Smoke validation: PASSED
+Hangfire failed jobs in window: <N>
+Post-mortem: <link to doc, created within 48h>
+```
+
+### 12.3 External — status banner (in-app, when implemented)
+
+> Beta-phase placeholder. Status banner component is tracked as follow-up [§14.2](#142-follow-up-issues-spawned-by-848). Until then, manually post in product chat / email active users.
+
+**During incident** (≤ 240 chars):
+```
+We are investigating a service disruption affecting <feature>.
+Service may be briefly unavailable while we apply a fix.
+Updates: <link to status page or email>
+```
+
+**After resolution**:
+```
+The service disruption affecting <feature> has been resolved.
+Total impact window: <X> minutes. We are reviewing the root cause
+and will share a post-mortem within 48 hours.
+```
+
+### 12.4 External — Email to active beta users
+
+```
+Subject: MeepleAI — service incident resolved (DD MMM YYYY)
+
+Hi <name>,
+
+Today between HH:MM and HH:MM (UTC), MeepleAI experienced a service
+disruption affecting <feature>. The issue has been fully resolved.
+
+What happened: <one-paragraph factual summary, no jargon>
+What we did: <reverted the change, restored service>
+What we are doing next: <root-cause analysis + prevention measures>
+
+We will share a public post-mortem within 48 hours at <link>.
+
+Thank you for being part of the beta — your feedback helps us
+build a more reliable service.
+
+— The MeepleAI team
+```
+
+---
+
+## 13. Quarterly DR drill cadence
+
+Every 90 days, the on-call engineer must:
+
+1. Read this runbook end-to-end and confirm each command still matches infrastructure
+2. Execute **one of the three scenarios** ([§6](#6-three-rollback-scenarios)) on **staging only** as a dry run:
+   - Q1: Scenario A (bad image)
+   - Q2: Scenario B (bad migration)
+   - Q3: Scenario A again (most-likely real case)
+   - Q4: Scenario C (slow leak)
+3. Update the **Last verified** header of this file (line 3)
+4. Add an entry to `docs/for-developers/operations/dr-walkthrough-log.md` (created on first drill)
+5. File issues for any drift discovered
+
+### 13.1 Drill reminder automation
+
+The `infra/scripts/dr-walkthrough-reminder.sh` script runs via cron (`0 9 1 1,4,7,10 *`) and posts to Slack. The script was created in [PR #259](https://github.com/meepleAi-app/meepleai-monorepo/pull/259) but referenced obsolete paths (`docs/operations/disaster-recovery-runbook.md` was moved/inlined). Path corrections shipped with this runbook — see [`dr-walkthrough-reminder.sh`](../../../infra/scripts/dr-walkthrough-reminder.sh).
+
+### 13.2 Quarterly checklist (copy-paste template)
+
+```
+## Q<N> YYYY DR Drill
+
+- [ ] Date: YYYY-MM-DD
+- [ ] Operator: <name>
+- [ ] Scenario: <A | B | C>
+- [ ] Pre-drill staging baseline captured: <link to Grafana snapshot>
+- [ ] Rollback executed: <gh run URL>
+- [ ] All §9.1 success criteria met: <yes/no>
+- [ ] RTO actual: <X min> (target ≤ 10 min)
+- [ ] Drift discovered: <list of stale commands, paths, secrets>
+- [ ] Follow-up issues filed: #..., #...
+- [ ] Last verified header updated: <commit SHA>
+```
+
+---
+
+## 14. Post-mortem & follow-up
+
+### 14.1 When required
+
+| Trigger | Post-mortem required? | Timeline |
+|---|---|---|
+| Real prod rollback executed | **Yes** | Within 48 h |
+| Real staging rollback executed | Recommended (1-page) | Within 1 week |
+| DR drill in §13 | Optional unless drift found | — |
+| Scenario C (slow leak) | **Always** — required to find root cause | Within 48 h |
+| Failed rollback (escalated per §9.5) | **Yes, with founder review** | Within 24 h |
+
+### 14.2 Follow-up issues spawned by #848
+
+This runbook intentionally references work that is **out-of-scope** but adjacent. Tracked as follow-up issues:
+
+- [ ] [#1087](https://github.com/meepleAi-app/meepleai-monorepo/issues/1087) — **CI migration safety gate**: parse SQL artifacts in `staging.yml`, fail on forbidden patterns from §8.2
+- [ ] [#1088](https://github.com/meepleAi-app/meepleai-monorepo/issues/1088) — **Post-mortem template doc**: structured Markdown template at `docs/for-developers/operations/post-mortem-template.md`
+- [ ] [#1089](https://github.com/meepleAi-app/meepleai-monorepo/issues/1089) — **Status banner FE component**: implement in-app banner (refs §12.3) with admin controls
+
+### 14.3 Post-mortem skeleton (until full template exists)
+
+```markdown
+# Post-mortem — <Incident title> (YYYY-MM-DD)
+
+## Summary
+One paragraph: what happened, impact, how we fixed it.
+
+## Timeline (UTC)
+- HH:MM — Detection
+- HH:MM — Decision to rollback
+- HH:MM — Workflow triggered
+- HH:MM — Service healthy
+- HH:MM — Smoke validation passed
+
+## Root cause
+What allowed the broken code to reach prod / staging? Where did the
+review / CI / monitoring gap occur?
+
+## Resolution
+What action restored service. Reference §6 scenario.
+
+## What went well
+Concrete: list 2-3 things.
+
+## What went poorly
+Concrete: list 2-3 things. No blame.
+
+## Action items
+- [ ] <Concrete, dated, owner-assigned action>
+- [ ] ...
+```
+
+---
+
+## 15. Future upgrade path
+
+The runbook assumes a **single VPS, manual revert** model. Triggers for upgrading to a more sophisticated model:
+
+| Current model | Upgrade target | Trigger |
+|---|---|---|
+| Manual `workflow_dispatch` rollback | Automated canary + auto-rollback | DAU ≥ 100 sustained 30 days |
+| Single VPS | Blue/green deploy (active + idle pair) | Paying customers OR RTO violations ≥ 2/quarter |
+| Sample-based smoke validation | Synthetic monitoring (24/7 probes) | Active users ≥ 500 |
+| Image-tag rollback only | Feature-flag-based gradual rollout | Multiple concurrent features in flight |
+
+See [ADR-054 §Alternatives](../../for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md#alternatives-considered) for the decision context.
+
+---
+
+## Appendix — quick links
+
+- [`.github/workflows/rollback.yml`](../../../.github/workflows/rollback.yml) — the workflow this runbook drives
+- [`infra/scripts/rollback-trigger.sh`](../../../infra/scripts/rollback-trigger.sh) — local wrapper
+- [`infra/scripts/backup.sh`](../../../infra/scripts/backup.sh) — backup automation
+- [`infra/scripts/backup-restore-test.sh`](../../../infra/scripts/backup-restore-test.sh) — DB restore verification
+- [`infra/scripts/dr-walkthrough-reminder.sh`](../../../infra/scripts/dr-walkthrough-reminder.sh) — quarterly drill reminder
+- [operations-manual.md §17](./operations-manual.md#17-incident-response) — incident response procedure
+- [operations-manual.md §18](./operations-manual.md#18-maintenance--disaster-recovery) — full DR procedures
+- [deploy-staging-runbook.md](./deploy-staging-runbook.md) — staging deploy flow
+- [ADR-054 Multi-Branch Strategy](../../for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md) — the broader DevOps context
+- [Epic #842](https://github.com/meepleAi-app/meepleai-monorepo/issues/842) — DevOps multi-branch tracker

--- a/infra/scripts/dr-walkthrough-reminder.sh
+++ b/infra/scripts/dr-walkthrough-reminder.sh
@@ -19,7 +19,9 @@ if [ -f "${SECRETS_DIR}/backup.secret" ]; then
 fi
 
 WEBHOOK_URL="${BACKUP_WEBHOOK_URL:-}"
-LOG_FILE="${SCRIPT_DIR}/../../docs/operations/dr-walkthrough-log.md"
+# Log path moved when docs/operations/ was inlined into for-developers/operations
+# (see PR#791 reorg and docs/for-developers/operations/rollback-runbook.md §13).
+LOG_FILE="${SCRIPT_DIR}/../../docs/for-developers/operations/dr-walkthrough-log.md"
 
 # Check last walkthrough date from log file
 LAST_WALKTHROUGH=$(grep -oE '^\| [0-9]{4}-[0-9]{2}-[0-9]{2}' "$LOG_FILE" 2>/dev/null | head -1 | tr -d '|' | xargs || echo "")
@@ -34,11 +36,14 @@ PAYLOAD=$(cat <<EOF
 {
   "status": "action_required",
   "task": "DR runbook walkthrough due",
-  "runbook": "docs/operations/disaster-recovery-runbook.md",
-  "log_file": "docs/operations/dr-walkthrough-log.md",
+  "runbooks": [
+    "docs/for-developers/operations/rollback-runbook.md",
+    "docs/for-developers/operations/operations-manual.md#18-maintenance--disaster-recovery"
+  ],
+  "log_file": "docs/for-developers/operations/dr-walkthrough-log.md",
   "last_walkthrough": "${LAST_WALKTHROUGH:-never}",
   "days_since": "${DAYS_SINCE}",
-  "instructions": "Read the runbook end-to-end. Verify each step still matches the current infrastructure. Add an entry to dr-walkthrough-log.md."
+  "instructions": "Read the rollback runbook end-to-end. Execute one §6 scenario as dry-run on staging. Verify each step still matches current infrastructure. Add an entry to dr-walkthrough-log.md and update Last verified header."
 }
 EOF
 )

--- a/infra/scripts/rollback-trigger.sh
+++ b/infra/scripts/rollback-trigger.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# rollback-trigger.sh — Thin local wrapper around .github/workflows/rollback.yml
+#
+# Validates inputs locally (env name, tag format, gh CLI auth) and asks for
+# explicit operator confirmation before invoking the workflow.
+#
+# Usage:
+#   bash infra/scripts/rollback-trigger.sh <staging|production> <image_tag> [--restore-db]
+#
+# Examples:
+#   bash infra/scripts/rollback-trigger.sh staging staging-20260511-deadbee
+#   bash infra/scripts/rollback-trigger.sh production v2026.05.11-deadbee --restore-db
+#
+# See docs/for-developers/operations/rollback-runbook.md §5 for full procedure.
+
+set -euo pipefail
+
+# ─────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: rollback-trigger.sh <staging|production> <image_tag> [--restore-db]
+
+Arguments:
+  environment   Target environment: 'staging' or 'production'
+  image_tag     Image tag to rollback to (immutable SHA-suffixed tag, NOT 'latest')
+
+Options:
+  --restore-db  Also restore DB from latest pre-migration backup (dangerous!)
+                Default: false. Only use for Scenario B (bad migration) — see runbook §6.2.
+
+Examples:
+  rollback-trigger.sh staging staging-20260511-deadbee
+  rollback-trigger.sh production v2026.05.11-deadbee --restore-db
+
+Reference:
+  docs/for-developers/operations/rollback-runbook.md
+EOF
+  exit 1
+}
+
+[[ $# -lt 2 ]] && usage
+
+ENVIRONMENT="$1"
+IMAGE_TAG="$2"
+RESTORE_DB="false"
+
+if [[ $# -ge 3 ]]; then
+  case "$3" in
+    --restore-db) RESTORE_DB="true" ;;
+    -h|--help) usage ;;
+    *) echo "ERROR: unknown option '$3'" >&2; usage ;;
+  esac
+fi
+
+# ─────────────────────────────────────────────
+# Validate environment
+# ─────────────────────────────────────────────
+case "$ENVIRONMENT" in
+  staging|production) ;;
+  *)
+    echo "ERROR: environment must be 'staging' or 'production' (got: '$ENVIRONMENT')" >&2
+    exit 2
+    ;;
+esac
+
+# ─────────────────────────────────────────────
+# Validate tag format (immutable, SHA-suffixed)
+# ─────────────────────────────────────────────
+# Accepted patterns:
+#   staging-YYYYMMDD-<7+ hex chars>
+#   vYYYY.MM.DD-<7+ hex chars>
+TAG_PATTERN_STAGING='^staging-[0-9]{8}-[0-9a-f]{7,}$'
+TAG_PATTERN_PROD='^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f]{7,}$'
+
+if [[ "$IMAGE_TAG" == "latest" || "$IMAGE_TAG" == "staging" ]]; then
+  echo "ERROR: refusing to rollback to mutable tag '$IMAGE_TAG'" >&2
+  echo "       Use an immutable SHA-suffixed tag — see runbook §3.3" >&2
+  exit 3
+fi
+
+if ! [[ "$IMAGE_TAG" =~ $TAG_PATTERN_STAGING || "$IMAGE_TAG" =~ $TAG_PATTERN_PROD ]]; then
+  echo "WARNING: tag '$IMAGE_TAG' does not match expected patterns:" >&2
+  echo "         staging-YYYYMMDD-<sha7>" >&2
+  echo "         vYYYY.MM.DD-<sha7>" >&2
+  echo "         Proceed only if you have manually verified the tag exists in GHCR." >&2
+  read -r -p "Continue anyway? (yes/NO): " confirm
+  if [[ "$confirm" != "yes" ]]; then
+    echo "Aborted." >&2
+    exit 4
+  fi
+fi
+
+# ─────────────────────────────────────────────
+# Validate gh CLI is available and authenticated
+# ─────────────────────────────────────────────
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found in PATH. Install: https://cli.github.com/" >&2
+  exit 5
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not authenticated. Run: gh auth login" >&2
+  exit 6
+fi
+
+# ─────────────────────────────────────────────
+# Verify tag exists in GHCR (non-fatal check)
+# ─────────────────────────────────────────────
+REPO="meepleAi-app/meepleai-monorepo"
+echo "→ Verifying tag '$IMAGE_TAG' exists in GHCR (ghcr.io/$REPO/api:$IMAGE_TAG)..."
+
+if gh api "/orgs/meepleAi-app/packages/container/meepleai-monorepo%2Fapi/versions" \
+     --jq ".[].metadata.container.tags | select(. != null) | .[]" 2>/dev/null \
+   | grep -qFx "$IMAGE_TAG"; then
+  echo "  ✓ Tag found in GHCR"
+else
+  echo "  ⚠ Tag NOT found in GHCR — workflow will fail at 'docker pull'" >&2
+  echo "    Available recent tags:" >&2
+  gh api "/orgs/meepleAi-app/packages/container/meepleai-monorepo%2Fapi/versions" \
+       --jq ".[0:5] | .[].metadata.container.tags | select(. != null) | .[]" 2>/dev/null \
+    | head -10 | sed 's/^/      /' >&2 || true
+  read -r -p "Continue anyway? (yes/NO): " confirm
+  if [[ "$confirm" != "yes" ]]; then
+    echo "Aborted." >&2
+    exit 7
+  fi
+fi
+
+# ─────────────────────────────────────────────
+# Pre-flight summary + operator confirmation
+# ─────────────────────────────────────────────
+cat <<EOF
+
+═══════════════════════════════════════════════════════════════════
+                    ROLLBACK PRE-FLIGHT SUMMARY
+═══════════════════════════════════════════════════════════════════
+  Environment       : $ENVIRONMENT
+  Rollback to tag   : $IMAGE_TAG
+  Restore database  : $RESTORE_DB
+  Target host       : $([ "$ENVIRONMENT" = "staging" ] && echo "meepleai.app (Hetzner CAX21)" || echo "meepleai.com (TBD — prod not provisioned)")
+═══════════════════════════════════════════════════════════════════
+
+Pre-flight reminders (see runbook §4):
+  - Did you identify the correct previous-good tag?               (runbook §4.1)
+  - Did you drain Hangfire if recent migration ran?               (runbook §4.2)
+  - Did you capture baseline metrics for post-rollback compare?   (runbook §4.3)
+EOF
+
+if [[ "$RESTORE_DB" == "true" ]]; then
+  cat <<EOF
+  - DB RESTORE ENABLED — did you verify backup integrity?         (runbook §4.4)
+  - DB RESTORE ENABLED — is this Scenario B (bad migration)?      (runbook §6.2)
+EOF
+fi
+
+cat <<EOF
+
+This will trigger '.github/workflows/rollback.yml' via workflow_dispatch.
+
+EOF
+
+read -r -p "Type 'rollback $ENVIRONMENT' to confirm (anything else aborts): " confirm
+if [[ "$confirm" != "rollback $ENVIRONMENT" ]]; then
+  echo "Aborted by operator." >&2
+  exit 0
+fi
+
+# ─────────────────────────────────────────────
+# Trigger workflow
+# ─────────────────────────────────────────────
+echo "→ Triggering rollback workflow..."
+
+gh workflow run rollback.yml \
+  -f "environment=$ENVIRONMENT" \
+  -f "image_tag=$IMAGE_TAG" \
+  -f "restore_db=$RESTORE_DB"
+
+echo "  ✓ Workflow dispatched"
+echo ""
+
+# Give GitHub a moment to register the run, then surface the URL
+sleep 3
+
+RUN_ID=$(gh run list --workflow=rollback.yml --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+
+if [[ -n "$RUN_ID" ]]; then
+  RUN_URL=$(gh run view "$RUN_ID" --json url --jq '.url')
+  echo "→ Workflow run: $RUN_URL"
+  echo ""
+  echo "To watch progress in this terminal:"
+  echo "  gh run watch $RUN_ID"
+  echo ""
+  echo "Next steps (runbook §9):"
+  echo "  1. Wait for workflow to complete (target: ≤ 10 min)"
+  echo "  2. Run smoke validation script (runbook §9.2)"
+  echo "  3. Verify Grafana metrics within budget (runbook §9.1)"
+  echo "  4. Post completion to Slack #critical (runbook §12.2)"
+  echo "  5. Schedule post-mortem within 48 h (runbook §14)"
+else
+  echo "  ⚠ Could not retrieve run ID — check Actions tab on GitHub manually"
+fi


### PR DESCRIPTION
Closes #848. Sub-issue of epic #842 (DevOps Multi-Branch Strategy).

## Summary

Adds a standalone rollback runbook consolidating and extending operational assets already spread across `rollback.yml`, `backup.sh`, and `operations-manual.md` §17-18. Driven by an expanded **spec-panel review** (Nygard / Hightower / Wiegers / Crispin / Newman, see [#848 comment](https://github.com/meepleAi-app/meepleai-monorepo/issues/848#issuecomment-4432996869)) that flagged 14 gaps in the original 0.5d scope — scope re-negotiated with user to 1-1.5d for ~80% gap closure.

## What's in the runbook

- **3 scenarios** with concrete decision criteria — A: bad image (no schema change) · B: bad migration (DB restore) · C: slow leak / performance regression
- **§4 pre-rollback safety** — Hangfire drain, baseline metrics, backup verify
- **§7 multi-service ordering matrix** — API+Web coupling, DB schema, embedding/reranker
- **§8 expand → migrate → contract** pattern with EF Core example (`users.email` → `users.email_address`)
- **§9 post-rollback validation** — 7 measurable success criteria + CF Access smoke script
- **§10 RACI + SLA** — 35 min total RTO target (15 detect → decision, 5 trigger, 10 healthy, 5 smoke)
- **§11 image tag retention** policy
- **§12 communication templates** — Slack internal, status banner, email to beta users
- **§13 quarterly DR drill** — scenario rotation Q1=A, Q2=B, Q3=A, Q4=C
- **§14 post-mortem** skeleton + follow-up issue links

## Deliverables

| Path | Type | Purpose |
|---|---|---|
| `docs/for-developers/operations/rollback-runbook.md` | NEW (711 LOC) | Full runbook |
| `docs/for-developers/operations/dr-walkthrough-log.md` | NEW (32 LOC) | Quarterly drill log skeleton |
| `infra/scripts/rollback-trigger.sh` | NEW (203 LOC) | Thin wrapper on `gh workflow run rollback.yml` |
| `infra/scripts/dr-walkthrough-reminder.sh` | MODIFIED | Fix obsolete `docs/operations/` paths (inlined per PR#791) |
| `docs/for-developers/operations/operations-manual.md` | MODIFIED | Cross-link from §17 + §18 |
| `docs/for-developers/operations/deploy-staging-runbook.md` | MODIFIED | Fast-path / slow-path split with cross-link |
| `docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md` | MODIFIED | Cross-link from Alternatives + References |

## Out-of-scope (spawned as follow-up issues)

- #1087 — CI migration safety gate (DROP/ALTER detection in `staging.yml`)
- #1088 — Post-mortem template doc
- #1089 — Status banner FE component

## Design decisions

- **`rollback-trigger.sh` is thin** by design — no logic duplication with `.github/workflows/rollback.yml`. Validates env/tag/auth locally + asks for explicit operator confirmation, then calls `gh workflow run`.
- **Prod sections are template-only** until `meepleai.com` is provisioned (host = TBD per epic #842). Header makes the status explicit.
- **DR (infra-level) vs rollback (deploy-level)** distinction preserved — operations-manual §18 still covers VPS rebuild / ransomware; this runbook covers the single-bad-deploy revert path with ≤10 min RTO.
- **Two paths in `deploy-staging-runbook.md`** — fast (image-tag, P1) vs slow (revert PR, P2/P3), guidance on when to use which.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Cross-links validated (all anchors exist in target files)
- [x] Markdown TOC matches headings
- [x] No logic duplication with `rollback.yml` (wrapper only)
- [x] Pre-commit hooks pass (frontend typecheck + frontend build + backend build)
- [ ] Spec-panel-driven review (will run `/code-review:code-review` per workflow rule before merge)
- [ ] First quarterly drill scheduled for Q3 2026 (Scenario A on staging)

## Reference

- Issue: #848 — Rollback runbook prod (rolling + manual revert via image tag)
- Epic: #842 — DevOps Multi-Branch Strategy
- ADR: docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
- Spec-panel review summary: https://github.com/meepleAi-app/meepleai-monorepo/issues/848#issuecomment-4432996869

🤖 Generated with [Claude Code](https://claude.com/claude-code)