### PR TITLE
feat(library): WS-D Exemplar — state-override on /library/[gameId] (refs #1066, re-engages #1070)

### DIFF
--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -2,7 +2,7 @@
   "$schema": "./state-matrix.schema.json",
   "generated_at": "2026-05-12T14:39:28.967Z",
   "total_mockups": 61,
-  "enforced_count": 0,
+  "enforced_count": 1,
   "entries": [
     {
       "mockup_path": "admin-mockups/design_files/00-hub.html",
@@ -143,14 +143,14 @@
         "error",
         "not-found"
       ],
-      "covered_states": [],
-      "missing": [
+      "covered_states": [
         "default",
         "loading",
         "error",
         "not-found"
       ],
-      "enforced": false
+      "missing": [],
+      "enforced": true
     },
     {
       "mockup_path": "admin-mockups/design_files/nanolith-runthrough-game-onboarding.html",

--- a/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * WS-D Exemplar (Issue #1070, umbrella #1066): coverage tests for the four
+ * declared states of `/library/[gameId]` — default · loading · error · not-found.
+ *
+ * Drives the `?state=` URL override via the WS-D Foundation helper. Each test
+ * configures `mockUseStateOverride` to return one canonical state, then
+ * asserts that the corresponding branch renders the expected `data-testid`.
+ *
+ * Mirror of: `apps/web/src/lib/visual-test/__tests__/state-override.test.ts`
+ * (which validates the helper itself).
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
+
+import LibraryGameDetailPage from '../page';
+
+const mockUseLibraryGameDetail = vi.hoisted(() => vi.fn());
+const mockUseStateOverride = vi.hoisted(() => vi.fn());
+const mockTryLoadVisualTestFixture = vi.hoisted(() => vi.fn());
+const mockPush = vi.hoisted(() => vi.fn());
+const mockRefresh = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(() => ({ gameId: 'game-123' })),
+  useRouter: vi.fn(() => ({ push: mockPush, replace: vi.fn(), refresh: mockRefresh })),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibraryGameDetail: mockUseLibraryGameDetail,
+}));
+
+vi.mock('@/lib/visual-test/state-override', () => ({
+  useStateOverride: mockUseStateOverride,
+}));
+
+vi.mock('@/lib/games/game-detail-visual-test-fixture', () => ({
+  tryLoadVisualTestFixture: mockTryLoadVisualTestFixture,
+}));
+
+// Avoid rendering heavy descendant components in the default branch:
+// the test exercises the page's branching logic, not the LibroGameDetailView
+// internals (already covered by their own unit tests).
+vi.mock('@/components/features/gamebook/LibroGameDetailView', () => ({
+  LibroGameDetailView: () => <div data-testid="libro-game-detail-view" />,
+}));
+
+vi.mock('@/components/game-detail/GameDetailDesktop', () => ({
+  GameDetailDesktop: () => <div data-testid="game-detail-desktop" />,
+}));
+
+vi.mock('./game-detail-mobile', () => ({
+  default: () => <div data-testid="game-detail-mobile" />,
+}));
+
+vi.mock('@/components/library/game-table', () => ({
+  GameTableSkeleton: () => <div data-testid="loading-skeleton" />,
+}));
+
+describe('LibraryGameDetailPage state coverage (WS-D Exemplar #1070)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLibraryGameDetail.mockReturnValue({ data: null, isLoading: false, error: null });
+    mockUseStateOverride.mockReturnValue(null);
+    mockTryLoadVisualTestFixture.mockReturnValue(null);
+  });
+
+  it('renders loading skeleton when stateOverride === "loading"', async () => {
+    mockUseStateOverride.mockReturnValue('loading');
+    renderWithQuery(<LibraryGameDetailPage />);
+    await waitFor(() => expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument());
+  });
+
+  it('renders error surface distinct from not-found when stateOverride === "error"', async () => {
+    mockUseStateOverride.mockReturnValue('error');
+    renderWithQuery(<LibraryGameDetailPage />);
+    await waitFor(() => expect(screen.getByTestId('error-state')).toBeInTheDocument());
+    expect(screen.getByText(/Errore di caricamento/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Riprova/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('not-found-state')).not.toBeInTheDocument();
+  });
+
+  it('renders not-found surface distinct from error when stateOverride === "not-found"', async () => {
+    mockUseStateOverride.mockReturnValue('not-found');
+    renderWithQuery(<LibraryGameDetailPage />);
+    await waitFor(() => expect(screen.getByTestId('not-found-state')).toBeInTheDocument());
+    expect(screen.getByText(/Gioco non trovato/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('error-state')).not.toBeInTheDocument();
+  });
+
+  it('renders default surface with fixture data when stateOverride === "default" + fixture available', async () => {
+    mockUseStateOverride.mockReturnValue('default');
+    mockTryLoadVisualTestFixture.mockReturnValue({
+      libraryEntryId: 'fixture-entry',
+      userId: 'fixture-user',
+      gameId: 'game-123',
+      gameTitle: 'Wingspan', // non-libro → renders GameDetailDesktop branch
+      addedAt: '2026-04-15T08:00:00.000Z',
+      notes: null,
+      isFavorite: false,
+      currentState: 'Owned',
+      stateChangedAt: null,
+      stateNotes: null,
+      isAvailableForPlay: true,
+      hasCustomPdf: false,
+      hasRagAccess: false,
+      gamePublisher: null,
+      gameYearPublished: null,
+      gameIconUrl: null,
+      gameImageUrl: null,
+      description: null,
+      minPlayers: 1,
+      maxPlayers: 5,
+      playingTimeMinutes: 70,
+      complexityRating: 2.4,
+      averageRating: null,
+      timesPlayed: 0,
+      lastPlayed: null,
+      winRate: null,
+      avgDuration: null,
+    });
+    renderWithQuery(<LibraryGameDetailPage />);
+    await waitFor(() => expect(screen.getByTestId('game-detail-desktop')).toBeInTheDocument());
+  });
+
+  it('falls back to real fetch when stateOverride === null (production flow)', async () => {
+    mockUseStateOverride.mockReturnValue(null);
+    mockUseLibraryGameDetail.mockReturnValue({ data: null, isLoading: true, error: null });
+    renderWithQuery(<LibraryGameDetailPage />);
+    // Real isLoading=true → skeleton (same render as stateOverride === 'loading')
+    await waitFor(() => expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument());
+    expect(mockUseLibraryGameDetail).toHaveBeenCalledWith('game-123', true);
+  });
+
+  it('disables real fetch when stateOverride is set (avoid wasted backend calls in test mode)', async () => {
+    mockUseStateOverride.mockReturnValue('default');
+    mockTryLoadVisualTestFixture.mockReturnValue({
+      libraryEntryId: 'fixture-entry',
+      userId: 'fixture-user',
+      gameId: 'game-123',
+      gameTitle: 'Wingspan',
+      addedAt: '2026-04-15T08:00:00.000Z',
+      notes: null,
+      isFavorite: false,
+      currentState: 'Owned',
+      stateChangedAt: null,
+      stateNotes: null,
+      isAvailableForPlay: true,
+      hasCustomPdf: false,
+      hasRagAccess: false,
+      gamePublisher: null,
+      gameYearPublished: null,
+      gameIconUrl: null,
+      gameImageUrl: null,
+      description: null,
+      minPlayers: 1,
+      maxPlayers: 5,
+      playingTimeMinutes: 70,
+      complexityRating: 2.4,
+      averageRating: null,
+      timesPlayed: 0,
+      lastPlayed: null,
+      winRate: null,
+      avgDuration: null,
+    });
+    renderWithQuery(<LibraryGameDetailPage />);
+    await waitFor(() => expect(mockUseLibraryGameDetail).toHaveBeenCalled());
+    // Second arg `enabled` should be false when stateOverride is non-null
+    expect(mockUseLibraryGameDetail).toHaveBeenCalledWith('game-123', false);
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/[gameId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/page.tsx
@@ -23,16 +23,37 @@ import { GameTableSkeleton } from '@/components/library/game-table';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/feedback/alert';
 import { Button } from '@/components/ui/primitives/button';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
+import { tryLoadVisualTestFixture } from '@/lib/games/game-detail-visual-test-fixture';
 import { isLibroGame } from '@/lib/games/is-libro-game';
+import { useStateOverride } from '@/lib/visual-test/state-override';
 
 import GameDetailMobile from './game-detail-mobile';
+
+/**
+ * WS-D Exemplar (Issue #1070, umbrella #1066): canonical states declared in
+ * `admin-mockups/design_files/nanolith-runthrough-game-detail.html` Stati line.
+ * Drives `?state=` URL override via the WS-D Foundation helper
+ * (`useStateOverride`) so visual regression CI can exercise each branch.
+ */
+const LIBRARY_GAME_DETAIL_STATES = ['default', 'loading', 'error', 'not-found'] as const;
 
 export default function LibraryGameDetailPage() {
   const params = useParams();
   const router = useRouter();
   const searchParams = useSearchParams();
   const gameId = params?.gameId as string;
-  const { data: gameDetail, isLoading, error } = useLibraryGameDetail(gameId);
+
+  // WS-D Exemplar: state-override takes precedence over real fetch when the
+  // visual-test build flag is set. In production the hook short-circuits to
+  // null and the real fetch flow runs unchanged.
+  const stateOverride = useStateOverride(LIBRARY_GAME_DETAIL_STATES);
+  const fixtureDetail = stateOverride === 'default' ? tryLoadVisualTestFixture('default') : null;
+
+  const {
+    data: gameDetail,
+    isLoading,
+    error,
+  } = useLibraryGameDetail(gameId, stateOverride === null);
 
   // S4 — parse `?tab=` query param to open a specific tab (deep-link support)
   const tabParam = searchParams?.get('tab');
@@ -52,20 +73,30 @@ export default function LibraryGameDetailPage() {
     [gameId, router, searchParams]
   );
 
-  if (isLoading) return <GameTableSkeleton />;
+  // State-override branches (visual-test build only). AC-D.4: `error` and
+  // `not-found` rendered as visually distinct surfaces (red alert + retry CTA
+  // vs neutral alert + "torna alla libreria" CTA).
+  if (stateOverride === 'loading' || (stateOverride === null && isLoading)) {
+    return <GameTableSkeleton />;
+  }
 
-  if (error) {
+  if (stateOverride === 'error' || (stateOverride === null && error)) {
+    const errorMessage =
+      stateOverride === 'error'
+        ? 'Si è verificato un errore di rete nel caricamento del gioco. Riprova.'
+        : error instanceof Error
+          ? error.message
+          : 'Si è verificato un errore nel caricamento del gioco.';
     return (
       <div className="mx-auto max-w-6xl px-4 py-8" data-testid="error-state">
         <Alert variant="destructive">
-          <AlertTitle>Errore</AlertTitle>
-          <AlertDescription>
-            {error instanceof Error
-              ? error.message
-              : 'Si è verificato un errore nel caricamento del gioco.'}
-          </AlertDescription>
+          <AlertTitle>Errore di caricamento</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
         </Alert>
-        <Button variant="outline" className="mt-4" onClick={() => router.push('/library')}>
+        <Button variant="outline" className="mt-4" onClick={() => router.refresh()}>
+          Riprova
+        </Button>
+        <Button variant="ghost" className="ml-2 mt-4" onClick={() => router.push('/library')}>
           <ArrowLeft className="mr-2 h-4 w-4" />
           Torna alla Libreria
         </Button>
@@ -73,7 +104,9 @@ export default function LibraryGameDetailPage() {
     );
   }
 
-  if (!gameDetail) {
+  const effectiveDetail = fixtureDetail ?? gameDetail;
+
+  if (stateOverride === 'not-found' || (stateOverride === null && !effectiveDetail)) {
     return (
       <div className="mx-auto max-w-6xl px-4 py-8" data-testid="not-found-state">
         <Alert>
@@ -88,21 +121,26 @@ export default function LibraryGameDetailPage() {
     );
   }
 
+  // Type-narrowing: not-found branch above already returned when effectiveDetail
+  // is falsy. The `if (!effectiveDetail)` guard re-narrows for TypeScript without
+  // a non-null assertion (lint rule no-non-null-assertion compliance).
+  if (!effectiveDetail) {
+    return null;
+  }
+
   // Iter B1 · Libro-game games render the storyboard-compliant detail view
   // (light warm palette, session+game gradient hero, pip bar, inline tabs).
   // Non-libro-game titles keep the legacy GameDetailDesktop until B2/B3.
-  const renderLibroView = isLibroGame({ gameTitle: gameDetail.gameTitle });
-  // eslint-disable-next-line no-console
-  console.log('[LibroView check]', { gameTitle: gameDetail.gameTitle, renderLibroView });
+  const renderLibroView = isLibroGame({ gameTitle: effectiveDetail.gameTitle });
   if (renderLibroView) {
-    return <LibroGameDetailView gameDetail={gameDetail} />;
+    return <LibroGameDetailView gameDetail={effectiveDetail} />;
   }
 
   return (
     <div className="h-full">
       {/* CTA legacy hook — no-op for non-libro-game games (isLibroGame === false) */}
       <div className="mx-auto w-full max-w-2xl px-4 pt-4 pb-1">
-        <NanolithCampaignCTA gameId={gameId} gameTitle={gameDetail.gameTitle} />
+        <NanolithCampaignCTA gameId={gameId} gameTitle={effectiveDetail.gameTitle} />
       </div>
 
       {/* Mobile layout — replaced by S5 */}


### PR DESCRIPTION
## Summary

WS-D Exemplar PR2 (Mockup Conformity Roadmap umbrella #1066): refactors `LibraryGameDetailPage` to consume the `useStateOverride` helper shipped by Foundation PR #1084. Drives the four canonical states declared in mockup `admin-mockups/design_files/nanolith-runthrough-game-detail.html` (`Stati: default · loading · error · not-found`).

## Changes

### `apps/web/src/app/(authenticated)/library/[gameId]/page.tsx`
- Imports `useStateOverride` from `@/lib/visual-test/state-override` and `tryLoadVisualTestFixture` from existing Wave C.1 fixture
- Top-level `LIBRARY_GAME_DETAIL_STATES` tuple typed `as const`
- All hooks (`useStateOverride`, `useLibraryGameDetail`, `useCallback`) invoked unconditionally — Rules of Hooks compliance
- Real fetch disabled when stateOverride is set: `useLibraryGameDetail(gameId, stateOverride === null)`
- **AC-D.4**: error surface (red Alert + "Riprova" retry CTA + back CTA) visually distinct from not-found surface (neutral Alert + back-only CTA). Different `data-testid` attributes (`error-state` vs `not-found-state`).
- Removed pre-existing `console.log('[LibroView check]', …)` debug noise

### `apps/web/e2e/state-coverage/state-matrix.json`
- Entry `nanolith-runthrough-game-detail.html` flipped to `enforced: true`, `covered_states: ['default', 'loading', 'error', 'not-found']`, `missing: []`
- Top-level `enforced_count: 0 → 1` (first enforced route)

### `apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx` (NEW)
6 unit tests covering:
- Each of 4 declared states renders the expected branch (loading skeleton, error surface, not-found surface, default with fixture)
- `error-state` and `not-found-state` rendered as visually distinct surfaces (AC-D.4 verification)
- Fallback to real fetch when `stateOverride === null` (production flow)
- Real fetch disabled (`enabled === false`) when stateOverride is set

## DoD status (per Issue #1070 ACs)

- [x] **AC-D.1** — 100% declared states covered for enforced route (`/library/{gameId}`). `missing: []` post-merge.
- [x] **AC-D.2** — Generator output deterministic (matrix.json regen idempotent post-edit, verified via `--check` exit 0).
- [x] **AC-D.3** — Fixture pattern uniformato via `state-override.ts` helper (now first consumer).
- [x] **AC-D.4** — Route exemplar cites `error ≠ not-found` distinction. Both branches have distinct `data-testid` and distinct UI affordances. Sinergia with WS-B AC-B.2 (deferred from PR #1074) — this PR also delivers that AC implicitly by introducing the visual distinction.

All 4 ACs satisfied. Issue #1070 → fully closed.

## Test plan

- [x] 6 page tests pass (state coverage)
- [x] 9 useLibrary tests pass (regression after page.tsx adopting `enabled` arg pattern)
- [x] 10 state-override tests pass (regression — helper unchanged)
- [x] 15 parser tests pass (matrix.json regen idempotent)
- [x] `pnpm typecheck` clean (post `.next` rebuild)
- [x] `pnpm lint` 0 errors on touched files
- [x] `pnpm tsx scripts/extract-mockup-states.ts --check` exits 0
- [x] `pnpm tsx scripts/extract-mockup-states.ts --enforced-only` exits 0 (enforced=true entry passes since missing=[])
- [ ] CI workflow `state-coverage-check.yml` runs the same two checks on this PR — validates first end-to-end enforced entry

## Refs

- Re-engages #1070 (WS-D state coverage) — all 4 ACs now satisfied
- Refs umbrella #1066 — Mockup Conformity Roadmap
- Builds on PR #1084 (WS-D Foundation, merged 2026-05-12)
- Companion PR #1074 (WS-B Nanolith bugfix) provides the route fixture data path

Generated with [Claude Code](https://claude.com/claude-code)