### PR TITLE
feat(devops): staging email allowlist Wave 1 (DB-backed) — closes #845

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommand.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+/// <summary>
+/// Adds a new email to the staging allowlist. Idempotency: throws
+/// <see cref="Api.Middleware.Exceptions.ConflictException"/> (HTTP 409) on duplicate.
+/// </summary>
+/// <param name="Email">Raw email; normalized to lowercase by the handler.</param>
+/// <param name="Note">Optional context (max 500 chars).</param>
+/// <param name="AddedByUserId">User performing the add (superadmin); <c>null</c> only for system seeds.</param>
+public sealed record AddStagingAllowlistEntryCommand(
+    string Email,
+    string? Note,
+    Guid? AddedByUserId) : IRequest<StagingAllowlistEntryDto>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandHandler.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+internal sealed class AddStagingAllowlistEntryCommandHandler
+    : IRequestHandler<AddStagingAllowlistEntryCommand, StagingAllowlistEntryDto>
+{
+    private readonly IStagingAllowlistRepository _repository;
+    private readonly IAuditLogRepository _auditLogRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AddStagingAllowlistEntryCommandHandler(
+        IStagingAllowlistRepository repository,
+        IAuditLogRepository auditLogRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _auditLogRepository = auditLogRepository ?? throw new ArgumentNullException(nameof(auditLogRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<StagingAllowlistEntryDto> Handle(
+        AddStagingAllowlistEntryCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalized = StagingAllowlistEntry.NormalizeEmail(request.Email);
+
+        if (await _repository.ExistsByEmailAsync(normalized, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ConflictException($"Email '{normalized}' is already in the staging allowlist.");
+        }
+
+        var entry = StagingAllowlistEntry.Create(normalized, request.AddedByUserId, request.Note);
+        await _repository.AddAsync(entry, cancellationToken).ConfigureAwait(false);
+
+        var audit = new AuditLog(
+            id: Guid.NewGuid(),
+            userId: request.AddedByUserId,
+            action: "staging_allowlist.added",
+            resource: "staging_allowlist",
+            result: "success",
+            resourceId: normalized,
+            details: request.Note);
+        await _auditLogRepository.AddAsync(audit, cancellationToken).ConfigureAwait(false);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new StagingAllowlistEntryDto(entry.Id, entry.Email, entry.AddedByUserId, entry.AddedAt, entry.Note);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+internal sealed class AddStagingAllowlistEntryCommandValidator : AbstractValidator<AddStagingAllowlistEntryCommand>
+{
+    public AddStagingAllowlistEntryCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required")
+            .EmailAddress().WithMessage("A valid email address is required")
+            .MaximumLength(320).WithMessage("Email cannot exceed 320 characters");
+
+        RuleFor(x => x.Note)
+            .MaximumLength(500).WithMessage("Note cannot exceed 500 characters");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+/// <summary>
+/// Soft-deletes a staging allowlist entry by Id.
+/// </summary>
+/// <param name="EntryId">PK of the entry to remove.</param>
+/// <param name="RemovedByUserId">User performing the removal (superadmin).</param>
+public sealed record RemoveStagingAllowlistEntryCommand(
+    Guid EntryId,
+    Guid? RemovedByUserId) : IRequest<Unit>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommandHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+internal sealed class RemoveStagingAllowlistEntryCommandHandler
+    : IRequestHandler<RemoveStagingAllowlistEntryCommand, Unit>
+{
+    private readonly IStagingAllowlistRepository _repository;
+    private readonly IAuditLogRepository _auditLogRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RemoveStagingAllowlistEntryCommandHandler(
+        IStagingAllowlistRepository repository,
+        IAuditLogRepository auditLogRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _auditLogRepository = auditLogRepository ?? throw new ArgumentNullException(nameof(auditLogRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Unit> Handle(RemoveStagingAllowlistEntryCommand request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entry = await _repository.GetByIdAsync(request.EntryId, cancellationToken).ConfigureAwait(false);
+        if (entry is null)
+        {
+            throw new NotFoundException($"Staging allowlist entry '{request.EntryId}' not found.");
+        }
+
+        entry.SoftDelete(request.RemovedByUserId);
+        await _repository.UpdateAsync(entry, cancellationToken).ConfigureAwait(false);
+
+        var audit = new AuditLog(
+            id: Guid.NewGuid(),
+            userId: request.RemovedByUserId,
+            action: "staging_allowlist.removed",
+            resource: "staging_allowlist",
+            result: "success",
+            resourceId: entry.Email);
+        await _auditLogRepository.AddAsync(audit, cancellationToken).ConfigureAwait(false);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommand.cs
@@ -1,0 +1,11 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+/// <summary>
+/// Bootstraps the staging allowlist with <c>badsworm@gmail.com</c> and (legacy migration)
+/// any emails in the deprecated <c>STAGING_ALLOWED_EMAILS</c> env var.
+/// Idempotent: skips entries already present (no duplicate insert, no error).
+/// Only runs in Staging environment.
+/// </summary>
+public sealed record SeedStagingAllowlistCommand : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommandHandler.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+/// <summary>
+/// Idempotent staging allowlist bootstrap. See <see cref="SeedStagingAllowlistCommand"/> for contract.
+/// </summary>
+/// <remarks>
+/// Migration path from the legacy <c>STAGING_ALLOWED_EMAILS</c> env var:
+/// on first staging deploy after #845, this seeder pulls every email from the env var
+/// and inserts it into the new DB-backed table. After the first successful run +
+/// post-deploy verification, the env var can be removed from
+/// <c>infra/secrets/staging-access.secret</c>.
+/// </remarks>
+internal sealed class SeedStagingAllowlistCommandHandler : ICommandHandler<SeedStagingAllowlistCommand>
+{
+    private const string BootstrapEmail = "badsworm@gmail.com";
+
+    private readonly IStagingAllowlistRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly ILogger<SeedStagingAllowlistCommandHandler> _logger;
+
+    public SeedStagingAllowlistCommandHandler(
+        IStagingAllowlistRepository repository,
+        IUnitOfWork unitOfWork,
+        IConfiguration configuration,
+        IHostEnvironment hostEnvironment,
+        ILogger<SeedStagingAllowlistCommandHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _hostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SeedStagingAllowlistCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!_hostEnvironment.IsStaging())
+        {
+            _logger.LogDebug("Skipping staging_allowlist seed — environment is {Env}", _hostEnvironment.EnvironmentName);
+            return;
+        }
+
+        var inserted = 0;
+
+        inserted += await EnsureSeededAsync(BootstrapEmail, "Bootstrap seed (#845)", cancellationToken).ConfigureAwait(false);
+
+        // Migration path: pull legacy env-var values into the DB
+        var legacy = _configuration["STAGING_ALLOWED_EMAILS"] ?? string.Empty;
+        foreach (var email in legacy.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            inserted += await EnsureSeededAsync(
+                email,
+                "Migrated from STAGING_ALLOWED_EMAILS env var (#845)",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (inserted > 0)
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Seeded {Count} new staging allowlist entries", inserted);
+        }
+        else
+        {
+            _logger.LogDebug("Staging allowlist already seeded — no new entries");
+        }
+    }
+
+    /// <summary>Returns 1 if a new row was added, 0 if already present.</summary>
+    private async Task<int> EnsureSeededAsync(string email, string note, CancellationToken cancellationToken)
+    {
+        var normalized = StagingAllowlistEntry.NormalizeEmail(email);
+        if (await _repository.ExistsByEmailAsync(normalized, cancellationToken).ConfigureAwait(false))
+        {
+            return 0;
+        }
+
+        var entry = StagingAllowlistEntry.Create(normalized, addedByUserId: null, note);
+        await _repository.AddAsync(entry, cancellationToken).ConfigureAwait(false);
+        return 1;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/StagingAllowlistCacheInvalidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/StagingAllowlistCacheInvalidator.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.Administration.Domain.Events;
+using Api.BoundedContexts.Authentication.Application.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Administration.Application.EventHandlers;
+
+/// <summary>
+/// Flushes the <see cref="IStagingAccessGuard"/> in-memory cache whenever an allowlist
+/// entry is added or removed. Keeps the cache TTL low-impact while still giving
+/// admins immediate effect for add/remove operations.
+/// </summary>
+internal sealed class StagingAllowlistCacheInvalidator
+    : INotificationHandler<StagingAllowlistEntryAddedEvent>,
+      INotificationHandler<StagingAllowlistEntryRemovedEvent>
+{
+    private readonly IStagingAccessGuard _guard;
+    private readonly ILogger<StagingAllowlistCacheInvalidator> _logger;
+
+    public StagingAllowlistCacheInvalidator(
+        IStagingAccessGuard guard,
+        ILogger<StagingAllowlistCacheInvalidator> logger)
+    {
+        _guard = guard ?? throw new ArgumentNullException(nameof(guard));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task Handle(StagingAllowlistEntryAddedEvent notification, CancellationToken cancellationToken)
+    {
+        _guard.InvalidateCache();
+        _logger.LogDebug("Staging allowlist cache invalidated after add of {Email}", notification.Email);
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(StagingAllowlistEntryRemovedEvent notification, CancellationToken cancellationToken)
+    {
+        _guard.InvalidateCache();
+        _logger.LogDebug("Staging allowlist cache invalidated after removal of {Email}", notification.Email);
+        return Task.CompletedTask;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+
+/// <summary>
+/// Lists active staging allowlist entries, newest first.
+/// Backs <c>GET /api/v1/admin/staging-allowlist</c>.
+/// </summary>
+public sealed record GetStagingAllowlistQuery : IRequest<IReadOnlyList<StagingAllowlistEntryDto>>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQueryHandler.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+
+internal sealed class GetStagingAllowlistQueryHandler
+    : IRequestHandler<GetStagingAllowlistQuery, IReadOnlyList<StagingAllowlistEntryDto>>
+{
+    private readonly IStagingAllowlistRepository _repository;
+
+    public GetStagingAllowlistQueryHandler(IStagingAllowlistRepository repository) =>
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public async Task<IReadOnlyList<StagingAllowlistEntryDto>> Handle(
+        GetStagingAllowlistQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entries = await _repository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return entries
+            .OrderByDescending(e => e.AddedAt)
+            .Select(e => new StagingAllowlistEntryDto(e.Id, e.Email, e.AddedByUserId, e.AddedAt, e.Note))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/StagingAllowlistEntryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/StagingAllowlist/StagingAllowlistEntryDto.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+
+/// <summary>
+/// Read-model DTO for staging allowlist entries exposed by the admin endpoints.
+/// Mirrors <see cref="Domain.Entities.StagingAllowlistEntry"/> minus soft-delete metadata.
+/// </summary>
+public sealed record StagingAllowlistEntryDto(
+    Guid Id,
+    string Email,
+    Guid? AddedByUserId,
+    DateTimeOffset AddedAt,
+    string? Note);

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/StagingAllowlistEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/StagingAllowlistEntry.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.Administration.Domain.Events;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.Administration.Domain.Entities;
+
+/// <summary>
+/// Email allowlist entry for staging environment access (DevOps Wave 1).
+/// </summary>
+/// <remarks>
+/// Soft-deleted; <see cref="IsDeleted"/> filter applied at query level.
+/// Email is stored normalized to lowercase (responsibility of factory + EF config).
+/// Replaces <c>STAGING_ALLOWED_EMAILS</c> env-var (#845 — see migration note in
+/// <c>StagingAllowlistBootstrapSeeder</c>).
+/// </remarks>
+internal sealed class StagingAllowlistEntry : AggregateRoot<Guid>
+{
+    public string Email { get; private set; }
+    public Guid? AddedByUserId { get; private set; }
+    public DateTimeOffset AddedAt { get; private set; }
+    public string? Note { get; private set; }
+    public bool IsDeleted { get; private set; }
+    public DateTimeOffset? DeletedAt { get; private set; }
+    public Guid? DeletedByUserId { get; private set; }
+
+#pragma warning disable CS8618
+    private StagingAllowlistEntry() : base() { }
+#pragma warning restore CS8618
+
+    private StagingAllowlistEntry(Guid id, string email, Guid? addedByUserId, string? note) : base(id)
+    {
+        Email = email;
+        AddedByUserId = addedByUserId;
+        AddedAt = DateTimeOffset.UtcNow;
+        Note = note;
+        IsDeleted = false;
+    }
+
+    /// <summary>
+    /// Creates a new active allowlist entry.
+    /// </summary>
+    /// <param name="email">Email already normalized to lowercase by caller (use <see cref="NormalizeEmail"/>).</param>
+    /// <param name="addedByUserId">User who added the entry; <c>null</c> for system bootstrap seeds.</param>
+    /// <param name="note">Optional context (max 500 chars enforced at EF level).</param>
+    public static StagingAllowlistEntry Create(string email, Guid? addedByUserId, string? note)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        var normalized = NormalizeEmail(email);
+
+        var entry = new StagingAllowlistEntry(Guid.NewGuid(), normalized, addedByUserId, note);
+        entry.AddDomainEvent(new StagingAllowlistEntryAddedEvent(entry.Id, normalized, addedByUserId));
+        return entry;
+    }
+
+    /// <summary>
+    /// Marks the entry as soft-deleted. Emits <see cref="StagingAllowlistEntryRemovedEvent"/>
+    /// so the in-memory cache in <c>StagingAccessGuard</c> invalidates.
+    /// </summary>
+    public void SoftDelete(Guid? removedByUserId)
+    {
+        if (IsDeleted)
+        {
+            return;
+        }
+
+        IsDeleted = true;
+        DeletedAt = DateTimeOffset.UtcNow;
+        DeletedByUserId = removedByUserId;
+        AddDomainEvent(new StagingAllowlistEntryRemovedEvent(Id, Email, removedByUserId));
+    }
+
+    /// <summary>
+    /// Canonical email normalization. Trim + lowercase invariant.
+    /// Domain rule: equality of two entries is decided on the normalized form,
+    /// preventing PK collisions between e.g. "User@Example.com" and "user@example.com".
+    /// </summary>
+    public static string NormalizeEmail(string email) =>
+        email.Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Rehydrates a persisted entry without emitting domain events.
+    /// Used by the repository when materializing from EF results.
+    /// </summary>
+    internal static StagingAllowlistEntry Reconstitute(
+        Guid id,
+        string email,
+        Guid? addedByUserId,
+        DateTimeOffset addedAt,
+        string? note,
+        bool isDeleted,
+        DateTimeOffset? deletedAt,
+        Guid? deletedByUserId)
+    {
+        return new StagingAllowlistEntry(id, email, addedByUserId, note)
+        {
+            AddedAt = addedAt,
+            IsDeleted = isDeleted,
+            DeletedAt = deletedAt,
+            DeletedByUserId = deletedByUserId
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/StagingAllowlistEntryAddedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/StagingAllowlistEntryAddedEvent.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Domain.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Domain.Events;
+
+/// <summary>
+/// Emitted when an entry is added to the staging allowlist.
+/// Consumed by <c>StagingAccessGuardCacheInvalidator</c> to flush the in-memory cache.
+/// </summary>
+public sealed record StagingAllowlistEntryAddedEvent(
+    Guid EntryId,
+    string Email,
+    Guid? AddedByUserId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+    public Guid EventId { get; } = Guid.NewGuid();
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/StagingAllowlistEntryRemovedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Events/StagingAllowlistEntryRemovedEvent.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Domain.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Domain.Events;
+
+/// <summary>
+/// Emitted when an entry is soft-deleted from the staging allowlist.
+/// Consumed by <c>StagingAccessGuardCacheInvalidator</c> to flush the in-memory cache.
+/// </summary>
+public sealed record StagingAllowlistEntryRemovedEvent(
+    Guid EntryId,
+    string Email,
+    Guid? RemovedByUserId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+    public Guid EventId { get; } = Guid.NewGuid();
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Repositories/IStagingAllowlistRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Repositories/IStagingAllowlistRepository.cs
@@ -1,0 +1,32 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.Administration.Domain.Repositories;
+
+/// <summary>
+/// Repository for staging allowlist entries (DevOps Wave 1).
+/// Exposes a hot-path read method <see cref="GetAllowedEmailsAsync"/> for the
+/// <c>IStagingAccessGuard</c> cache, plus standard CRUD for admin endpoints.
+/// </summary>
+internal interface IStagingAllowlistRepository : IRepository<StagingAllowlistEntry, Guid>
+{
+    /// <summary>
+    /// Returns the active (non-soft-deleted) entry matching <paramref name="normalizedEmail"/>
+    /// (case-insensitive — caller must pass the email already normalized via
+    /// <see cref="StagingAllowlistEntry.NormalizeEmail"/>).
+    /// </summary>
+    Task<StagingAllowlistEntry?> GetByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// True when an active entry exists for the given email.
+    /// Used by the add command to detect duplicates before insert.
+    /// </summary>
+    Task<bool> ExistsByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the set of normalized emails currently allowed.
+    /// Read by <c>StagingAccessGuard</c> for cached membership checks; should be a single
+    /// indexed query (<c>SELECT email FROM staging_allowlist WHERE is_deleted = false</c>).
+    /// </summary>
+    Task<IReadOnlySet<string>> GetAllowedEmailsAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -39,6 +39,7 @@ internal static class AdministrationServiceExtensions
         services.AddScoped<IAlertConfigurationRepository, AlertConfigurationRepository>();  // Issue #2112: Missing DI registration
         services.AddScoped<IAlertRuleRepository, AlertRuleRepository>();  // Issue #2112: Missing DI registration
         services.AddScoped<IAuditLogRepository, AuditLogRepository>();
+        services.AddScoped<IStagingAllowlistRepository, StagingAllowlistRepository>();  // #845: DevOps Wave 1
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
 
         // ISSUE-916: Reporting repositories

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistEntryMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistEntryMapper.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.Infrastructure.Entities.Administration;
+
+namespace Api.BoundedContexts.Administration.Infrastructure.Persistence;
+
+/// <summary>
+/// Mapper between <see cref="StagingAllowlistEntity"/> (persistence) and
+/// <see cref="StagingAllowlistEntry"/> (domain).
+/// </summary>
+internal static class StagingAllowlistEntryMapper
+{
+    public static StagingAllowlistEntry Reconstitute(StagingAllowlistEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return StagingAllowlistEntry.Reconstitute(
+            id: entity.Id,
+            email: entity.Email,
+            addedByUserId: entity.AddedByUserId,
+            addedAt: entity.AddedAt,
+            note: entity.Note,
+            isDeleted: entity.IsDeleted,
+            deletedAt: entity.DeletedAt,
+            deletedByUserId: entity.DeletedByUserId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistRepository.cs
@@ -15,11 +15,15 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
     {
     }
 
+    // Note: `IsDeleted` filtering is enforced globally by the entity's HasQueryFilter
+    // in StagingAllowlistEntityConfiguration. Methods that need to see soft-deleted
+    // rows must call `.IgnoreQueryFilters()` explicitly (see UpdateAsync below).
+
     public async Task<StagingAllowlistEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var entity = await DbContext.StagingAllowlist
             .AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Id == id && !e.IsDeleted, cancellationToken)
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
         return entity is null ? null : MapToDomain(entity);
@@ -29,7 +33,6 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
     {
         var entities = await DbContext.StagingAllowlist
             .AsNoTracking()
-            .Where(e => !e.IsDeleted)
             .OrderByDescending(e => e.AddedAt)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -43,7 +46,7 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
 
         var entity = await DbContext.StagingAllowlist
             .AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Email == normalizedEmail && !e.IsDeleted, cancellationToken)
+            .FirstOrDefaultAsync(e => e.Email == normalizedEmail, cancellationToken)
             .ConfigureAwait(false);
 
         return entity is null ? null : MapToDomain(entity);
@@ -54,7 +57,7 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
         ArgumentNullException.ThrowIfNull(normalizedEmail);
 
         return await DbContext.StagingAllowlist
-            .AnyAsync(e => e.Email == normalizedEmail && !e.IsDeleted, cancellationToken)
+            .AnyAsync(e => e.Email == normalizedEmail, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -62,7 +65,6 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
     {
         var emails = await DbContext.StagingAllowlist
             .AsNoTracking()
-            .Where(e => !e.IsDeleted)
             .Select(e => e.Email)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -71,7 +73,7 @@ internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllow
     }
 
     public Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default) =>
-        DbContext.StagingAllowlist.AnyAsync(e => e.Id == id && !e.IsDeleted, cancellationToken);
+        DbContext.StagingAllowlist.AnyAsync(e => e.Id == id, cancellationToken);
 
     public async Task AddAsync(StagingAllowlistEntry entry, CancellationToken cancellationToken = default)
     {

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Persistence/StagingAllowlistRepository.cs
@@ -1,0 +1,139 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.Administration;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Infrastructure.Persistence;
+
+internal sealed class StagingAllowlistRepository : RepositoryBase, IStagingAllowlistRepository
+{
+    public StagingAllowlistRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task<StagingAllowlistEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.StagingAllowlist
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id && !e.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<StagingAllowlistEntry>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.StagingAllowlist
+            .AsNoTracking()
+            .Where(e => !e.IsDeleted)
+            .OrderByDescending(e => e.AddedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<StagingAllowlistEntry?> GetByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(normalizedEmail);
+
+        var entity = await DbContext.StagingAllowlist
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Email == normalizedEmail && !e.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<bool> ExistsByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(normalizedEmail);
+
+        return await DbContext.StagingAllowlist
+            .AnyAsync(e => e.Email == normalizedEmail && !e.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlySet<string>> GetAllowedEmailsAsync(CancellationToken cancellationToken = default)
+    {
+        var emails = await DbContext.StagingAllowlist
+            .AsNoTracking()
+            .Where(e => !e.IsDeleted)
+            .Select(e => e.Email)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new HashSet<string>(emails, StringComparer.Ordinal);
+    }
+
+    public Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default) =>
+        DbContext.StagingAllowlist.AnyAsync(e => e.Id == id && !e.IsDeleted, cancellationToken);
+
+    public async Task AddAsync(StagingAllowlistEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        CollectDomainEvents(entry);
+        var entity = MapToPersistence(entry);
+        await DbContext.StagingAllowlist.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(StagingAllowlistEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        CollectDomainEvents(entry);
+
+        // Soft-delete path: load tracked entity bypassing the IsDeleted filter
+        var tracked = await DbContext.StagingAllowlist
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(e => e.Id == entry.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tracked is null)
+        {
+            throw new InvalidOperationException($"StagingAllowlistEntry {entry.Id} not found");
+        }
+
+        tracked.Email = entry.Email;
+        tracked.AddedByUserId = entry.AddedByUserId;
+        tracked.AddedAt = entry.AddedAt;
+        tracked.Note = entry.Note;
+        tracked.IsDeleted = entry.IsDeleted;
+        tracked.DeletedAt = entry.DeletedAt;
+        tracked.DeletedByUserId = entry.DeletedByUserId;
+    }
+
+    public Task DeleteAsync(StagingAllowlistEntry entry, CancellationToken cancellationToken = default)
+    {
+        throw new InvalidOperationException(
+            "Hard delete not permitted on staging_allowlist. Use SoftDelete + UpdateAsync to preserve audit history.");
+    }
+
+    private static StagingAllowlistEntry MapToDomain(StagingAllowlistEntity entity)
+    {
+        // Reconstitute domain entity from persistence — bypasses the public factory
+        // (which would set new Id/AddedAt and emit domain events) by using reflection
+        // via the parameterless ctor + direct property writes is not ideal but the
+        // pattern is consistent with AuditLogRepository.MapToDomain (uses public ctor with id).
+        // Here we use a dedicated reconstitution method via factory + state injection.
+        return StagingAllowlistEntryMapper.Reconstitute(entity);
+    }
+
+    private static StagingAllowlistEntity MapToPersistence(StagingAllowlistEntry domain) =>
+        new()
+        {
+            Id = domain.Id,
+            Email = domain.Email,
+            AddedByUserId = domain.AddedByUserId,
+            AddedAt = domain.AddedAt,
+            Note = domain.Note,
+            IsDeleted = domain.IsDeleted,
+            DeletedAt = domain.DeletedAt,
+            DeletedByUserId = domain.DeletedByUserId
+        };
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/IStagingAccessGuard.cs
@@ -1,27 +1,35 @@
 namespace Api.BoundedContexts.Authentication.Application.Services;
 
 /// <summary>
-/// Guards staging environment access via email allowlist (DevOps wave 1).
+/// Guards staging environment access via email allowlist (DevOps Wave 1).
 /// </summary>
 /// <remarks>
-/// Reads <c>STAGING_ALLOWED_EMAILS</c> env var (CSV, case-insensitive, whitespace tolerant).
-/// Empty list = open access (default safe: dev and prod don't need this gate).
-/// Wave 2 will integrate with the existing <c>AccessRequest</c> BC for invite-based flow.
+/// Backed by the <c>staging_allowlist</c> table (#845) — superseded the
+/// <c>STAGING_ALLOWED_EMAILS</c> env-var implementation. Cached in memory with
+/// a short TTL; cache is also invalidated via domain events whenever the
+/// underlying table mutates (see <c>StagingAllowlistCacheInvalidator</c>).
+///
+/// Semantics changed in #845: empty allowlist now FAIL-CLOSED in Staging
+/// (returns false). The previous "empty = open" semantics were a latent
+/// landmine if the bootstrap seed failed silently.
 /// See <c>docs/for-developers/operations/devops-policy.md</c> §4.
 /// </remarks>
 public interface IStagingAccessGuard
 {
     /// <summary>
-    /// Returns <c>true</c> if email is in allowlist OR if allowlist is empty/unset.
-    /// Returns <c>false</c> if allowlist is non-empty AND email not in it
-    /// (or if email is null/whitespace).
+    /// Returns <c>true</c> if the email is in the (DB-backed) allowlist.
+    /// Returns <c>false</c> if the allowlist is empty (fail-closed) or the email is null/whitespace.
     /// </summary>
-    bool IsEmailAllowed(string email);
+    ValueTask<bool> IsEmailAllowedAsync(string email, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// True if <c>STAGING_ALLOWED_EMAILS</c> contains at least one entry.
-    /// Used by startup warning to detect misconfiguration window
-    /// (Staging environment with empty allowlist = silent pass-through).
+    /// True if the allowlist contains at least one entry. Used by startup warning.
     /// </summary>
-    bool HasNonEmptyAllowlist { get; }
+    ValueTask<bool> HasNonEmptyAllowlistAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Drops the in-memory cache. Called by domain event handlers on add/remove
+    /// to give admins an immediate-effect experience.
+    /// </summary>
+    void InvalidateCache();
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Services/StagingAccessGuard.cs
@@ -1,37 +1,75 @@
-using Microsoft.Extensions.Configuration;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.BoundedContexts.Authentication.Application.Services;
 
 /// <summary>
-/// Reads <c>STAGING_ALLOWED_EMAILS</c> from <see cref="IConfiguration"/> at construction time
-/// and caches the parsed allowlist as an immutable <see cref="HashSet{String}"/>.
+/// DB-backed implementation of <see cref="IStagingAccessGuard"/> (#845).
+/// Reads from <c>staging_allowlist</c> via <see cref="IStagingAllowlistRepository"/>
+/// and caches the resulting set in <see cref="IMemoryCache"/> for 60 seconds.
 /// </summary>
+/// <remarks>
+/// Registered as <b>Singleton</b>, but uses <see cref="IServiceScopeFactory"/> to resolve
+/// the scoped repository on cache miss. Cache invalidation on add/remove flows via
+/// the domain event handler <c>StagingAllowlistCacheInvalidator</c>.
+/// </remarks>
 internal sealed class StagingAccessGuard : IStagingAccessGuard
 {
-    private readonly HashSet<string> _allowedEmails;
+    internal const string CacheKey = "staging_allowlist:emails";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(60);
 
-    public StagingAccessGuard(IConfiguration configuration)
+    private readonly IMemoryCache _cache;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public StagingAccessGuard(IMemoryCache cache, IServiceScopeFactory scopeFactory)
     {
-        var raw = configuration["STAGING_ALLOWED_EMAILS"] ?? string.Empty;
-        _allowedEmails = raw
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
     }
 
-    public bool IsEmailAllowed(string email)
+    public async ValueTask<bool> IsEmailAllowedAsync(string email, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(email))
         {
             return false;
         }
 
-        if (_allowedEmails.Count == 0)
+        var allowed = await GetAllowedEmailsAsync(cancellationToken).ConfigureAwait(false);
+
+        // FAIL-CLOSED (#845): empty allowlist denies all in Staging.
+        // The middleware only registers in Staging env, so prod/dev are unaffected.
+        if (allowed.Count == 0)
         {
-            return true;
+            return false;
         }
 
-        return _allowedEmails.Contains(email.Trim());
+        return allowed.Contains(email.Trim().ToLowerInvariant());
     }
 
-    public bool HasNonEmptyAllowlist => _allowedEmails.Count > 0;
+    public async ValueTask<bool> HasNonEmptyAllowlistAsync(CancellationToken cancellationToken = default)
+    {
+        var allowed = await GetAllowedEmailsAsync(cancellationToken).ConfigureAwait(false);
+        return allowed.Count > 0;
+    }
+
+    public void InvalidateCache()
+    {
+        _cache.Remove(CacheKey);
+    }
+
+    private async Task<IReadOnlySet<string>> GetAllowedEmailsAsync(CancellationToken cancellationToken)
+    {
+        if (_cache.TryGetValue<IReadOnlySet<string>>(CacheKey, out var cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IStagingAllowlistRepository>();
+        var emails = await repository.GetAllowedEmailsAsync(cancellationToken).ConfigureAwait(false);
+
+        _cache.Set(CacheKey, emails, CacheTtl);
+        return emails;
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -33,9 +33,11 @@ internal static class AuthenticationServiceExtensions
         // Admin Invitation Flow: singleton channel for game suggestion processing
         services.AddSingleton<GameSuggestionChannel>();
 
-        // DevOps wave 1: staging email allowlist guard.
-        // Singleton: parses STAGING_ALLOWED_EMAILS once at construction, immutable HashSet read-only.
+        // DevOps Wave 1 (#845): staging email allowlist guard.
+        // Singleton: backed by IMemoryCache with 60s TTL + domain-event invalidation.
+        // Reads from staging_allowlist DB table via IServiceScopeFactory on cache miss.
         // Used by StagingAccessMiddleware (active only when ASPNETCORE_ENVIRONMENT=Staging).
+        services.AddMemoryCache();
         services.AddSingleton<IStagingAccessGuard, StagingAccessGuard>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddleware.cs
@@ -62,7 +62,7 @@ internal sealed class StagingAccessMiddleware
         }
 
         var email = context.User.FindFirstValue(ClaimTypes.Email);
-        if (!guard.IsEmailAllowed(email ?? string.Empty))
+        if (!await guard.IsEmailAllowedAsync(email ?? string.Empty, context.RequestAborted).ConfigureAwait(false))
         {
             await WriteDeniedAsync(context).ConfigureAwait(false);
             return;

--- a/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
+++ b/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
@@ -172,14 +172,20 @@ internal static class WebApplicationExtensions
         if (app.Environment.IsEnvironment("Staging"))
         {
             // Resolve singleton directly from root container — no scope needed since
-            // IStagingAccessGuard is registered as Singleton and has no IDisposable
-            // dependencies. Startup code, no concurrency hazard.
+            // IStagingAccessGuard is registered as Singleton with a 60s memory cache (#845).
+            // The hot-path uses a scope factory for DB access; startup probe stays lightweight.
+            // Empty allowlist now FAIL-CLOSED in Staging (denies all) — the previous
+            // "empty = pass-through" semantics were a latent landmine if the bootstrap
+            // seed failed silently.
             var guard = app.Services.GetRequiredService<IStagingAccessGuard>();
-            if (!guard.HasNonEmptyAllowlist)
+            var hasEntries = guard.HasNonEmptyAllowlistAsync().AsTask().GetAwaiter().GetResult();
+            if (!hasEntries)
             {
                 app.Logger.LogWarning(
-                    "STAGING_ACCESS: middleware active but STAGING_ALLOWED_EMAILS is empty. " +
-                    "All authenticated users will pass through. Set STAGING_ALLOWED_EMAILS to enable allowlist.");
+                    "STAGING_ACCESS: middleware active but staging_allowlist is empty — " +
+                    "all authenticated requests will be denied (fail-closed). " +
+                    "Bootstrap seed should have inserted badsworm@gmail.com; " +
+                    "check SeedStagingAllowlistCommand execution.");
             }
             app.UseStagingAccessGuard();
         }

--- a/apps/api/src/Api/Infrastructure/Entities/Administration/StagingAllowlistEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Administration/StagingAllowlistEntity.cs
@@ -1,0 +1,26 @@
+namespace Api.Infrastructure.Entities.Administration;
+
+/// <summary>
+/// EF persistence model for the <c>staging_allowlist</c> table (#845).
+/// Domain twin: <see cref="Api.BoundedContexts.Administration.Domain.Entities.StagingAllowlistEntry"/>.
+/// </summary>
+public class StagingAllowlistEntity
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Normalized (trimmed + lowercase) email.</summary>
+    public required string Email { get; set; }
+
+    /// <summary>User who added the entry; <c>null</c> for system bootstrap seeds.</summary>
+    public Guid? AddedByUserId { get; set; }
+
+    public DateTimeOffset AddedAt { get; set; }
+
+    public string? Note { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public Guid? DeletedByUserId { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/StagingAllowlistEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/StagingAllowlistEntityConfiguration.cs
@@ -1,0 +1,59 @@
+using Api.Infrastructure.Entities.Administration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Administration;
+
+/// <summary>
+/// EF configuration for the staging_allowlist table (#845).
+/// Soft-delete via partial unique index on email (only active rows enforce uniqueness).
+/// </summary>
+internal class StagingAllowlistEntityConfiguration : IEntityTypeConfiguration<StagingAllowlistEntity>
+{
+    public void Configure(EntityTypeBuilder<StagingAllowlistEntity> builder)
+    {
+        builder.ToTable("staging_allowlist");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id");
+
+        builder.Property(e => e.Email)
+            .HasColumnName("email")
+            .IsRequired()
+            .HasMaxLength(320);
+
+        builder.Property(e => e.AddedByUserId)
+            .HasColumnName("added_by_user_id");
+
+        builder.Property(e => e.AddedAt)
+            .HasColumnName("added_at")
+            .IsRequired();
+
+        builder.Property(e => e.Note)
+            .HasColumnName("note")
+            .HasMaxLength(500);
+
+        builder.Property(e => e.IsDeleted)
+            .HasColumnName("is_deleted")
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.DeletedAt)
+            .HasColumnName("deleted_at");
+
+        builder.Property(e => e.DeletedByUserId)
+            .HasColumnName("deleted_by_user_id");
+
+        // Partial unique index: only enforce email uniqueness on active rows.
+        // Allows re-adding a previously soft-deleted email without removing audit history.
+        builder.HasIndex(e => e.Email)
+            .IsUnique()
+            .HasDatabaseName("ix_staging_allowlist_email_active")
+            .HasFilter("is_deleted = false");
+
+        builder.HasIndex(e => e.IsDeleted)
+            .HasDatabaseName("ix_staging_allowlist_is_deleted");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/StagingAllowlistEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/StagingAllowlistEntityConfiguration.cs
@@ -55,5 +55,11 @@ internal class StagingAllowlistEntityConfiguration : IEntityTypeConfiguration<St
 
         builder.HasIndex(e => e.IsDeleted)
             .HasDatabaseName("ix_staging_allowlist_is_deleted");
+
+        // Soft-delete query filter per CLAUDE.md "Key Data Patterns":
+        // IsDeleted + DeletedAt + HasQueryFilter(e => !e.IsDeleted).
+        // Repository methods that need to read soft-deleted rows (e.g. UpdateAsync
+        // soft-delete path) must use .IgnoreQueryFilters() to bypass this filter.
+        builder.HasQueryFilter(e => !e.IsDeleted);
     }
 }

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -111,6 +111,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ValidationAccuracyBaselineEntity> ValidationAccuracyBaselines => Set<ValidationAccuracyBaselineEntity>();
     public DbSet<AlertEntity> Alerts => Set<AlertEntity>(); // OPS-07
     public DbSet<AlertRuleEntity> AlertRules => Set<AlertRuleEntity>(); // ISSUE-921: Dynamic alert rules
+    public DbSet<StagingAllowlistEntity> StagingAllowlist => Set<StagingAllowlistEntity>(); // #845: DevOps Wave 1 staging email allowlist
     public DbSet<AlertConfigurationEntity> AlertConfigurations => Set<AlertConfigurationEntity>(); // ISSUE-921: Dynamic alert config
     public DbSet<ServiceHealthStateEntity> ServiceHealthStates => Set<ServiceHealthStateEntity>(); // ISSUE-448: Service health monitoring
     public DbSet<DatabaseMetricsSnapshotEntity> DatabaseMetricsSnapshots => Set<DatabaseMetricsSnapshotEntity>(); // Database growth tracking

--- a/apps/api/src/Api/Infrastructure/Migrations/20260512193226_AddStagingAllowlist.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260512193226_AddStagingAllowlist.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512193226_AddStagingAllowlist")]
+    partial class AddStagingAllowlist
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260512193226_AddStagingAllowlist.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260512193226_AddStagingAllowlist.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStagingAllowlist : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "staging_allowlist",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    email = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: false),
+                    added_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    added_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    note = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by_user_id = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_staging_allowlist", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_staging_allowlist_email_active",
+                table: "staging_allowlist",
+                column: "email",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_staging_allowlist_is_deleted",
+                table: "staging_allowlist",
+                column: "is_deleted");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "staging_allowlist");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
@@ -34,6 +34,13 @@ internal sealed class CoreSeedLayer : ISeedLayer
         await SafeExecute("staging demo user",
             () => mediator.Send(new SeedStagingDemoUserCommand(), cancellationToken), logger).ConfigureAwait(false);
 
+        // Non-fatal: staging email allowlist (#845, only runs in Staging environment)
+        await SafeExecute("staging allowlist",
+            () => mediator.Send(
+                new Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist.SeedStagingAllowlistCommand(),
+                cancellationToken),
+            logger).ConfigureAwait(false);
+
         // Non-fatal: badsworm demo user (requires SEED_BADSWORM_PASSWORD secret — runs in all envs)
         await SafeExecute("badsworm user",
             () => mediator.Send(new SeedBadswormUserCommand(), cancellationToken), logger).ConfigureAwait(false);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -10,6 +10,7 @@ using Api.Middleware;
 using Api.Models;
 using Api.Observability;
 using Api.Routing;
+using Api.Routing.Admin;
 using Api.Routing.AdministrationDiscover;
 using Api.Routing.GameManagement;
 using Api.Routing.GameToolkit;
@@ -736,6 +737,7 @@ v1Api.MapDashboardEndpoints();         // Issue #3314: User dashboard aggregated
 
 // Admin (users + content only)
 v1Api.MapAdminUserEndpoints();         // User management
+v1Api.MapAdminStagingAllowlistEndpoints(); // #845: DevOps Wave 1 staging email allowlist
 v1Api.MapAdminConfigEndpoints();       // Issue #3673: PDF limits admin UI (per-tier)
 v1Api.MapConfigurationEndpoints();     // System configuration CRUD & operations
 v1Api.MapFeatureFlagEndpoints();       // Feature flag management

--- a/apps/api/src/Api/Routing/Admin/AdminStagingAllowlistEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminStagingAllowlistEndpoints.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+using Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing.Admin;
+
+/// <summary>
+/// Admin endpoints for managing the staging email allowlist (#845).
+/// Superadmin only. Routes under <c>/api/v1/admin/staging-allowlist</c>.
+/// </summary>
+/// <remarks>
+/// All endpoints use the surrogate <c>Guid Id</c> rather than email as the route key —
+/// avoids URL-encoding hazards with email special chars (<c>+</c>, <c>.</c>, <c>@</c>)
+/// and prevents email leakage into access logs.
+/// </remarks>
+internal static class AdminStagingAllowlistEndpoints
+{
+    public static RouteGroupBuilder MapAdminStagingAllowlistEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/admin/staging-allowlist", HandleGetAllowlist)
+            .WithName("GetStagingAllowlist")
+            .WithTags("Admin", "DevOps");
+
+        group.MapPost("/admin/staging-allowlist", HandleAddEntry)
+            .WithName("AddStagingAllowlistEntry")
+            .WithTags("Admin", "DevOps");
+
+        group.MapDelete("/admin/staging-allowlist/{id:guid}", HandleRemoveEntry)
+            .WithName("RemoveStagingAllowlistEntry")
+            .WithTags("Admin", "DevOps");
+
+        return group;
+    }
+
+    private static async Task<IResult> HandleGetAllowlist(
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, _, error) = context.RequireSuperAdminSession();
+        if (!authorized)
+        {
+            return error!;
+        }
+
+        var entries = await mediator.Send(new GetStagingAllowlistQuery(), ct).ConfigureAwait(false);
+        return Results.Ok(entries);
+    }
+
+    private static async Task<IResult> HandleAddEntry(
+        AddStagingAllowlistEntryRequest request,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireSuperAdminSession();
+        if (!authorized)
+        {
+            return error!;
+        }
+
+        var command = new AddStagingAllowlistEntryCommand(
+            Email: request.Email,
+            Note: request.Note,
+            AddedByUserId: session!.User!.Id);
+
+        var dto = await mediator.Send(command, ct).ConfigureAwait(false);
+        return Results.Created($"/api/v1/admin/staging-allowlist/{dto.Id}", dto);
+    }
+
+    private static async Task<IResult> HandleRemoveEntry(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireSuperAdminSession();
+        if (!authorized)
+        {
+            return error!;
+        }
+
+        await mediator.Send(
+            new RemoveStagingAllowlistEntryCommand(id, session!.User!.Id),
+            ct).ConfigureAwait(false);
+
+        return Results.NoContent();
+    }
+}
+
+/// <summary>Request body for <c>POST /api/v1/admin/staging-allowlist</c>.</summary>
+internal sealed record AddStagingAllowlistEntryRequest(string Email, string? Note);

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/AddStagingAllowlistEntryCommandHandlerTests.cs
@@ -1,0 +1,73 @@
+using Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class AddStagingAllowlistEntryCommandHandlerTests
+{
+    private readonly Mock<IStagingAllowlistRepository> _repository = new(MockBehavior.Strict);
+    private readonly Mock<IAuditLogRepository> _auditLog = new(MockBehavior.Strict);
+    private readonly Mock<IUnitOfWork> _uow = new(MockBehavior.Strict);
+
+    private AddStagingAllowlistEntryCommandHandler CreateHandler()
+        => new(_repository.Object, _auditLog.Object, _uow.Object);
+
+    [Fact]
+    public async Task Handle_NewEmail_NormalizesAddsEntryAndAuditLog()
+    {
+        _repository.Setup(r => r.ExistsByEmailAsync("badsworm@gmail.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _repository.Setup(r => r.AddAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _auditLog.Setup(a => a.AddAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(2);
+
+        var userId = Guid.NewGuid();
+        var command = new AddStagingAllowlistEntryCommand("  BADsworm@Gmail.com  ", "test note", userId);
+
+        var dto = await CreateHandler().Handle(command, CancellationToken.None);
+
+        dto.Email.Should().Be("badsworm@gmail.com");
+        dto.AddedByUserId.Should().Be(userId);
+        dto.Note.Should().Be("test note");
+
+        _auditLog.Verify(a => a.AddAsync(
+            It.Is<AuditLog>(log =>
+                log.Action == "staging_allowlist.added"
+                && log.Resource == "staging_allowlist"
+                && log.ResourceId == "badsworm@gmail.com"
+                && log.Result == "success"
+                && log.UserId == userId),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateEmail_ThrowsConflict()
+    {
+        _repository.Setup(r => r.ExistsByEmailAsync("dup@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var act = () => CreateHandler().Handle(
+            new AddStagingAllowlistEntryCommand("dup@example.com", null, Guid.NewGuid()),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*dup@example.com*already*");
+
+        _repository.Verify(r => r.AddAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        _auditLog.VerifyNoOtherCalls();
+        _uow.VerifyNoOtherCalls();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/RemoveStagingAllowlistEntryCommandHandlerTests.cs
@@ -1,0 +1,71 @@
+using Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class RemoveStagingAllowlistEntryCommandHandlerTests
+{
+    private readonly Mock<IStagingAllowlistRepository> _repository = new(MockBehavior.Strict);
+    private readonly Mock<IAuditLogRepository> _auditLog = new(MockBehavior.Strict);
+    private readonly Mock<IUnitOfWork> _uow = new(MockBehavior.Strict);
+
+    private RemoveStagingAllowlistEntryCommandHandler CreateHandler()
+        => new(_repository.Object, _auditLog.Object, _uow.Object);
+
+    [Fact]
+    public async Task Handle_ExistingEntry_SoftDeletesAndAuditLog()
+    {
+        var entry = StagingAllowlistEntry.Create("user@example.com", addedByUserId: null, note: null);
+        entry.ClearDomainEvents();
+
+        _repository.Setup(r => r.GetByIdAsync(entry.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+        _repository.Setup(r => r.UpdateAsync(entry, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _auditLog.Setup(a => a.AddAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(2);
+
+        var removerId = Guid.NewGuid();
+        await CreateHandler().Handle(
+            new RemoveStagingAllowlistEntryCommand(entry.Id, removerId),
+            CancellationToken.None);
+
+        entry.IsDeleted.Should().BeTrue();
+        entry.DeletedByUserId.Should().Be(removerId);
+
+        _auditLog.Verify(a => a.AddAsync(
+            It.Is<AuditLog>(log =>
+                log.Action == "staging_allowlist.removed"
+                && log.Resource == "staging_allowlist"
+                && log.ResourceId == "user@example.com"
+                && log.UserId == removerId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MissingEntry_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repository.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StagingAllowlistEntry?)null);
+
+        var act = () => CreateHandler().Handle(
+            new RemoveStagingAllowlistEntryCommand(id, Guid.NewGuid()),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"*{id}*not found*");
+
+        _repository.Verify(r => r.UpdateAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/StagingAllowlist/SeedStagingAllowlistCommandHandlerTests.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Commands.StagingAllowlist;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class SeedStagingAllowlistCommandHandlerTests
+{
+    private static SeedStagingAllowlistCommandHandler CreateHandler(
+        string environment,
+        string? legacyEnvVar,
+        Mock<IStagingAllowlistRepository> repository,
+        Mock<IUnitOfWork> uow)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["STAGING_ALLOWED_EMAILS"] = legacyEnvVar })
+            .Build();
+        var env = Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environment);
+        return new SeedStagingAllowlistCommandHandler(
+            repository.Object,
+            uow.Object,
+            config,
+            env,
+            NullLogger<SeedStagingAllowlistCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_NotStaging_SkipsCompletely()
+    {
+        var repo = new Mock<IStagingAllowlistRepository>(MockBehavior.Strict);
+        var uow = new Mock<IUnitOfWork>(MockBehavior.Strict);
+        var handler = CreateHandler("Development", null, repo, uow);
+
+        await handler.Handle(new SeedStagingAllowlistCommand(), CancellationToken.None);
+
+        // Strict mocks ensure no methods were called
+        repo.VerifyNoOtherCalls();
+        uow.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_Staging_BootstrapEmailAlreadyExists_NoInsert()
+    {
+        var repo = new Mock<IStagingAllowlistRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.ExistsByEmailAsync("badsworm@gmail.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var uow = new Mock<IUnitOfWork>(MockBehavior.Strict);
+
+        var handler = CreateHandler("Staging", null, repo, uow);
+        await handler.Handle(new SeedStagingAllowlistCommand(), CancellationToken.None);
+
+        repo.Verify(r => r.AddAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()), Times.Never);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Staging_NewBootstrapEmail_InsertsAndSaves()
+    {
+        var repo = new Mock<IStagingAllowlistRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.ExistsByEmailAsync("badsworm@gmail.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        repo.Setup(r => r.AddAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var uow = new Mock<IUnitOfWork>(MockBehavior.Strict);
+        uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = CreateHandler("Staging", null, repo, uow);
+        await handler.Handle(new SeedStagingAllowlistCommand(), CancellationToken.None);
+
+        repo.Verify(r => r.AddAsync(
+            It.Is<StagingAllowlistEntry>(e => e.Email == "badsworm@gmail.com" && e.AddedByUserId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Staging_LegacyEnvVarEmailsMigrated_Idempotent()
+    {
+        var repo = new Mock<IStagingAllowlistRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.ExistsByEmailAsync("badsworm@gmail.com", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        repo.Setup(r => r.ExistsByEmailAsync("legacy1@example.com", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        repo.Setup(r => r.ExistsByEmailAsync("legacy2@example.com", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        repo.Setup(r => r.AddAsync(It.IsAny<StagingAllowlistEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var uow = new Mock<IUnitOfWork>(MockBehavior.Strict);
+        uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = CreateHandler("Staging",
+            legacyEnvVar: "Legacy1@Example.com,legacy2@example.com", repo, uow);
+        await handler.Handle(new SeedStagingAllowlistCommand(), CancellationToken.None);
+
+        repo.Verify(r => r.AddAsync(
+            It.Is<StagingAllowlistEntry>(e => e.Email == "legacy1@example.com"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.AddAsync(
+            It.Is<StagingAllowlistEntry>(e => e.Email == "legacy2@example.com"),
+            It.IsAny<CancellationToken>()), Times.Never,
+            "legacy2 already exists — no duplicate insert");
+
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "single SaveChanges only when at least one row inserted");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/StagingAllowlist/GetStagingAllowlistQueryHandlerTests.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Queries.StagingAllowlist;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class GetStagingAllowlistQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsDtosOrderedByAddedAtDesc()
+    {
+        var older = StagingAllowlistEntry.Reconstitute(
+            Guid.NewGuid(), "a@x.y", Guid.NewGuid(), DateTimeOffset.UtcNow.AddDays(-5), "old", false, null, null);
+        var newer = StagingAllowlistEntry.Reconstitute(
+            Guid.NewGuid(), "b@x.y", Guid.NewGuid(), DateTimeOffset.UtcNow, "new", false, null, null);
+
+        var repo = new Mock<IStagingAllowlistRepository>();
+        repo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StagingAllowlistEntry> { older, newer });
+
+        var handler = new GetStagingAllowlistQueryHandler(repo.Object);
+        var result = await handler.Handle(new GetStagingAllowlistQuery(), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].Email.Should().Be("b@x.y", "newest first");
+        result[1].Email.Should().Be("a@x.y");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyRepository_ReturnsEmptyList()
+    {
+        var repo = new Mock<IStagingAllowlistRepository>();
+        repo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StagingAllowlistEntry>());
+
+        var handler = new GetStagingAllowlistQueryHandler(repo.Object);
+        var result = await handler.Handle(new GetStagingAllowlistQuery(), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Domain/Entities/StagingAllowlistEntryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Domain/Entities/StagingAllowlistEntryTests.cs
@@ -1,0 +1,104 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Events;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Domain.Entities;
+
+/// <summary>
+/// Unit tests for the <see cref="StagingAllowlistEntry"/> domain entity (#845).
+/// Covers factory invariants, normalization rules, soft-delete state, and domain event emission.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class StagingAllowlistEntryTests
+{
+    [Fact]
+    public void Create_AssignsIdAndAddedAt()
+    {
+        var entry = StagingAllowlistEntry.Create("badsworm@gmail.com", addedByUserId: Guid.NewGuid(), note: "bootstrap");
+
+        entry.Id.Should().NotBeEmpty();
+        entry.AddedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        entry.IsDeleted.Should().BeFalse();
+        entry.DeletedAt.Should().BeNull();
+        entry.DeletedByUserId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Badsworm@Gmail.com", "badsworm@gmail.com")]
+    [InlineData("  user@example.com  ", "user@example.com")]
+    [InlineData("USER+tag@EXAMPLE.COM", "user+tag@example.com")]
+    public void NormalizeEmail_TrimsAndLowercases(string input, string expected)
+    {
+        StagingAllowlistEntry.NormalizeEmail(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_ThrowsOnMissingEmail(string? email)
+    {
+        var act = () => StagingAllowlistEntry.Create(email!, addedByUserId: null, note: null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_NormalizesEmail()
+    {
+        var entry = StagingAllowlistEntry.Create("  BADsworm@Gmail.com  ", addedByUserId: null, note: null);
+
+        entry.Email.Should().Be("badsworm@gmail.com");
+    }
+
+    [Fact]
+    public void Create_EmitsAddedDomainEvent()
+    {
+        var userId = Guid.NewGuid();
+
+        var entry = StagingAllowlistEntry.Create("user@example.com", userId, note: null);
+
+        entry.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<StagingAllowlistEntryAddedEvent>()
+            .Which.Email.Should().Be("user@example.com");
+        var evt = (StagingAllowlistEntryAddedEvent)entry.DomainEvents.Single();
+        evt.AddedByUserId.Should().Be(userId);
+        evt.EntryId.Should().Be(entry.Id);
+    }
+
+    [Fact]
+    public void SoftDelete_MarksAsDeletedAndEmitsRemovedEvent()
+    {
+        var entry = StagingAllowlistEntry.Create("user@example.com", addedByUserId: null, note: null);
+        entry.ClearDomainEvents();
+        var removerId = Guid.NewGuid();
+
+        entry.SoftDelete(removerId);
+
+        entry.IsDeleted.Should().BeTrue();
+        entry.DeletedAt.Should().NotBeNull();
+        entry.DeletedByUserId.Should().Be(removerId);
+
+        entry.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<StagingAllowlistEntryRemovedEvent>()
+            .Which.RemovedByUserId.Should().Be(removerId);
+    }
+
+    [Fact]
+    public void SoftDelete_IsIdempotent()
+    {
+        var entry = StagingAllowlistEntry.Create("user@example.com", addedByUserId: null, note: null);
+        entry.ClearDomainEvents();
+
+        entry.SoftDelete(Guid.NewGuid());
+        var firstDeletedAt = entry.DeletedAt;
+        entry.ClearDomainEvents();
+        entry.SoftDelete(Guid.NewGuid());
+
+        entry.DeletedAt.Should().Be(firstDeletedAt, "second SoftDelete must be a no-op");
+        entry.DomainEvents.Should().BeEmpty("second SoftDelete must not re-emit the removed event");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Services/StagingAccessGuardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Services/StagingAccessGuardTests.cs
@@ -1,96 +1,136 @@
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Application.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.Authentication.Application.Services;
 
 /// <summary>
-/// Unit tests for StagingAccessGuard (wave 1 email allowlist).
+/// Unit tests for the DB-backed <see cref="StagingAccessGuard"/> (#845).
 /// </summary>
+/// <remarks>
+/// Replaces the env-var-driven implementation; the test suite is intentionally
+/// rebuilt from scratch to exercise the new contract (async, IMemoryCache,
+/// fail-closed on empty, scope factory + repository for reads).
+/// </remarks>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "Authentication")]
 public class StagingAccessGuardTests
 {
-    private static IStagingAccessGuard CreateGuard(string? allowedEmails)
+    private static StagingAccessGuard CreateGuard(
+        IReadOnlySet<string> allowedEmails,
+        out IMemoryCache cache,
+        out Mock<IStagingAllowlistRepository> repository)
     {
-        var inMemorySettings = new Dictionary<string, string?>
-        {
-            { "STAGING_ALLOWED_EMAILS", allowedEmails }
-        };
-        IConfiguration config = new ConfigurationBuilder()
-            .AddInMemoryCollection(inMemorySettings)
-            .Build();
-        return new StagingAccessGuard(config);
+        cache = new MemoryCache(new MemoryCacheOptions());
+
+        repository = new Mock<IStagingAllowlistRepository>(MockBehavior.Strict);
+        repository
+            .Setup(r => r.GetAllowedEmailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allowedEmails);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(repository.Object);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        return new StagingAccessGuard(cache, scopeFactory);
     }
 
     [Fact]
-    public void IsEmailAllowed_WhenAllowlistEmpty_ReturnsTrue()
+    public async Task IsEmailAllowedAsync_WhenAllowlistEmpty_ReturnsFalse_FailClosed()
     {
-        // Default safe: empty allowlist = open access (dev/prod scenarios)
-        var guard = CreateGuard(null);
-        guard.IsEmailAllowed("anyone@example.com").Should().BeTrue();
+        // Critical semantic change in #845: empty allowlist now DENIES (was: allows).
+        var guard = CreateGuard(new HashSet<string>(), out _, out _);
+
+        (await guard.IsEmailAllowedAsync("anyone@example.com")).Should().BeFalse();
     }
 
     [Fact]
-    public void IsEmailAllowed_WhenEmailInList_ReturnsTrue()
+    public async Task IsEmailAllowedAsync_WhenEmailInList_ReturnsTrue()
     {
-        var guard = CreateGuard("badsworm@gmail.com,marco@example.com");
-        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
-        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+        var allowed = new HashSet<string> { "badsworm@gmail.com", "marco@example.com" };
+        var guard = CreateGuard(allowed, out _, out _);
+
+        (await guard.IsEmailAllowedAsync("badsworm@gmail.com")).Should().BeTrue();
+        (await guard.IsEmailAllowedAsync("marco@example.com")).Should().BeTrue();
     }
 
     [Fact]
-    public void IsEmailAllowed_WhenEmailNotInList_ReturnsFalse()
+    public async Task IsEmailAllowedAsync_WhenEmailNotInList_ReturnsFalse()
     {
-        var guard = CreateGuard("badsworm@gmail.com");
-        guard.IsEmailAllowed("hacker@evil.com").Should().BeFalse();
+        var allowed = new HashSet<string> { "badsworm@gmail.com" };
+        var guard = CreateGuard(allowed, out _, out _);
+
+        (await guard.IsEmailAllowedAsync("hacker@evil.com")).Should().BeFalse();
     }
 
     [Fact]
-    public void IsEmailAllowed_CaseInsensitive_ReturnsTrue()
+    public async Task IsEmailAllowedAsync_NormalizesCase_AndWhitespace()
     {
-        var guard = CreateGuard("Badsworm@Gmail.com");
-        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
-        guard.IsEmailAllowed("BADSWORM@GMAIL.COM").Should().BeTrue();
+        // Repository returns the canonical normalized form.
+        var allowed = new HashSet<string> { "badsworm@gmail.com" };
+        var guard = CreateGuard(allowed, out _, out _);
+
+        (await guard.IsEmailAllowedAsync("BADSWORM@GMAIL.COM")).Should().BeTrue();
+        (await guard.IsEmailAllowedAsync("  badsworm@gmail.com  ")).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task IsEmailAllowedAsync_WhenEmailMissing_ReturnsFalse(string? email)
+    {
+        var allowed = new HashSet<string> { "badsworm@gmail.com" };
+        var guard = CreateGuard(allowed, out _, out _);
+
+        (await guard.IsEmailAllowedAsync(email!)).Should().BeFalse();
     }
 
     [Fact]
-    public void IsEmailAllowed_WhitespaceTolerant_ReturnsTrue()
+    public async Task HasNonEmptyAllowlistAsync_TracksUnderlyingRepository()
     {
-        var guard = CreateGuard(" badsworm@gmail.com , marco@example.com ");
-        guard.IsEmailAllowed("badsworm@gmail.com").Should().BeTrue();
-        guard.IsEmailAllowed("marco@example.com").Should().BeTrue();
+        var guardEmpty = CreateGuard(new HashSet<string>(), out _, out _);
+        var guardFull = CreateGuard(new HashSet<string> { "x@y.z" }, out _, out _);
+
+        (await guardEmpty.HasNonEmptyAllowlistAsync()).Should().BeFalse();
+        (await guardFull.HasNonEmptyAllowlistAsync()).Should().BeTrue();
     }
 
     [Fact]
-    public void IsEmailAllowed_WhenEmailNullOrEmpty_ReturnsFalse()
+    public async Task IsEmailAllowedAsync_CachesResult_HitsRepositoryOnceUntilInvalidate()
     {
-        var guard = CreateGuard("badsworm@gmail.com");
-        guard.IsEmailAllowed(null!).Should().BeFalse();
-        guard.IsEmailAllowed("").Should().BeFalse();
-        guard.IsEmailAllowed("   ").Should().BeFalse();
+        var allowed = new HashSet<string> { "badsworm@gmail.com" };
+        var guard = CreateGuard(allowed, out _, out var repo);
+
+        // 3 calls within TTL window
+        await guard.IsEmailAllowedAsync("badsworm@gmail.com");
+        await guard.IsEmailAllowedAsync("badsworm@gmail.com");
+        await guard.IsEmailAllowedAsync("other@example.com");
+
+        repo.Verify(r => r.GetAllowedEmailsAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        // After invalidation, the next read must hit the repository again
+        guard.InvalidateCache();
+        await guard.IsEmailAllowedAsync("badsworm@gmail.com");
+
+        repo.Verify(r => r.GetAllowedEmailsAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
-    public void HasNonEmptyAllowlist_WhenEmpty_ReturnsFalse()
+    public void InvalidateCache_RemovesEntry()
     {
-        var guard = CreateGuard(null);
-        guard.HasNonEmptyAllowlist.Should().BeFalse();
-    }
+        var guard = CreateGuard(new HashSet<string> { "x@y.z" }, out var cache, out _);
+        cache.Set(StagingAccessGuard.CacheKey, new HashSet<string> { "stale@x.y" });
 
-    [Fact]
-    public void HasNonEmptyAllowlist_WhenWhitespaceOnly_ReturnsFalse()
-    {
-        var guard = CreateGuard("  ");
-        guard.HasNonEmptyAllowlist.Should().BeFalse();
-    }
+        guard.InvalidateCache();
 
-    [Fact]
-    public void HasNonEmptyAllowlist_WhenPopulated_ReturnsTrue()
-    {
-        var guard = CreateGuard("badsworm@gmail.com");
-        guard.HasNonEmptyAllowlist.Should().BeTrue();
+        cache.TryGetValue(StagingAccessGuard.CacheKey, out object? _).Should().BeFalse();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessGateIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessGateIntegrationTests.cs
@@ -1,14 +1,16 @@
 using System.Net;
 using System.Security.Claims;
+using Api.BoundedContexts.Administration.Domain.Entities;
+using Api.BoundedContexts.Administration.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Application.Services;
 using Api.BoundedContexts.Authentication.Infrastructure.Middleware;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -17,22 +19,11 @@ namespace Api.Tests.BoundedContexts.Authentication.Infrastructure.Middleware;
 
 /// <summary>
 /// Integration tests for the conditional registration of <see cref="StagingAccessMiddleware"/>
-/// based on <c>ASPNETCORE_ENVIRONMENT</c>. Replicates the wiring logic of
-/// <c>WebApplicationExtensions.ConfigureAuthMiddleware</c> via TestServer to verify the gate
-/// condition without booting the full app (which would require DB/Redis stack).
+/// based on <c>ASPNETCORE_ENVIRONMENT</c>. Rebuilt in #845 to drive the new DB-backed guard
+/// via a stub <see cref="IStagingAllowlistRepository"/>, exercising:
+/// (1) env-conditional registration, (2) auth claim extraction, (3) FAIL-CLOSED semantics
+/// (empty allowlist denies access in Staging).
 /// </summary>
-/// <remarks>
-/// Why TestServer instead of WebApplicationFactory&lt;Program&gt;: Program.cs has heavy startup
-/// dependencies (DbContext, Redis, embedding services). For testing JUST the env-based gate
-/// activation, TestServer with replicated wiring logic gives identical coverage without the
-/// startup cost.
-///
-/// What is replicated from production: the env check (<c>IsEnvironment("Staging")</c>) and
-/// the <c>app.UseMiddleware&lt;StagingAccessMiddleware&gt;()</c> call. What is NOT replicated:
-/// the eager root-container resolve of <see cref="IStagingAccessGuard"/> at startup and the
-/// empty-allowlist warning log (those are tested via unit tests). If you change the
-/// production wiring, this test should be updated to keep the mirror accurate.
-/// </remarks>
 [Trait("Category", TestCategories.Integration)]
 [Trait("BoundedContext", "Authentication")]
 public class StagingAccessGateIntegrationTests
@@ -42,12 +33,12 @@ public class StagingAccessGateIntegrationTests
         "staging gate active + email in allowlist => pass")]
     [InlineData("Staging", "allowed@example.com", "blocked@example.com", HttpStatusCode.Forbidden,
         "staging gate active + email NOT in allowlist => 403")]
-    [InlineData("Development", "allowed@example.com", "blocked@example.com", HttpStatusCode.OK,
+    [InlineData("Development", "", "anyone@example.com", HttpStatusCode.OK,
         "dev environment => gate not registered, all authenticated requests pass")]
-    [InlineData("Production", "allowed@example.com", "blocked@example.com", HttpStatusCode.OK,
+    [InlineData("Production", "", "anyone@example.com", HttpStatusCode.OK,
         "prod environment => gate not registered, all authenticated requests pass")]
-    [InlineData("Staging", "", "anyone@example.com", HttpStatusCode.OK,
-        "staging gate active but allowlist empty => default-safe pass-through")]
+    [InlineData("Staging", "", "anyone@example.com", HttpStatusCode.Forbidden,
+        "staging gate active + EMPTY allowlist => FAIL-CLOSED 403 (#845)")]
     public async Task ConditionalGate_OnlyDeniesAuthenticatedRequests_OnStagingWithPopulatedAllowlist(
         string aspNetCoreEnvironment,
         string allowlist,
@@ -66,25 +57,23 @@ public class StagingAccessGateIntegrationTests
     [Fact]
     public async Task ConditionalGate_DoesNotInterfere_WithUnauthenticatedRequests()
     {
-        // Even on Staging with populated allowlist, unauthenticated requests must
-        // pass through the staging gate (auth middleware handles 401 separately).
+        // Unauthenticated requests must pass through the staging gate even with
+        // populated allowlist — the auth middleware handles 401 separately.
         using var server = CreateServer(
             aspNetCoreEnvironment: "Staging",
             allowlist: "allowed@example.com",
-            authenticatedEmail: null /* unauthenticated */);
+            authenticatedEmail: null);
         using var client = server.CreateClient();
 
         var response = await client.GetAsync(new Uri("/probe", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK,
-            "unauthenticated requests must NOT be denied by the staging gate (auth middleware territory)");
+            "unauthenticated requests must NOT be denied by the staging gate");
     }
 
     /// <summary>
-    /// Builds a TestServer that replicates the wiring logic of
-    /// <c>WebApplicationExtensions.ConfigureAuthMiddleware</c>:
-    /// register <see cref="IStagingAccessGuard"/>, then conditionally insert
-    /// <see cref="StagingAccessMiddleware"/> only when environment is "Staging".
+    /// Builds a TestServer that registers the new DB-backed <see cref="StagingAccessGuard"/>
+    /// with a stub <see cref="IStagingAllowlistRepository"/>, mirroring the production wiring.
     /// </summary>
     private static TestServer CreateServer(
         string aspNetCoreEnvironment,
@@ -97,26 +86,20 @@ public class StagingAccessGateIntegrationTests
                 webHost.UseTestServer();
                 webHost.UseEnvironment(aspNetCoreEnvironment);
 
-                webHost.ConfigureAppConfiguration((_, configBuilder) =>
-                {
-                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
-                    {
-                        ["STAGING_ALLOWED_EMAILS"] = allowlist,
-                        ["Staging:ContactEmail"] = "test-contact@example.com",
-                    });
-                });
-
                 webHost.ConfigureServices(services =>
                 {
+                    services.AddMemoryCache();
+                    services.AddSingleton<IStagingAllowlistRepository>(
+                        new StubAllowlistRepository(ParseAllowlist(allowlist)));
                     services.AddSingleton<IStagingAccessGuard, StagingAccessGuard>();
                 });
 
                 webHost.Configure((context, app) =>
                 {
-                    // Simulate authentication: inject ClaimsPrincipal if email provided
+                    // Simulate authentication
                     app.Use(async (ctx, next) =>
                     {
-                        if (authenticatedEmail != null)
+                        if (authenticatedEmail is not null)
                         {
                             var identity = new ClaimsIdentity(
                                 new[] { new Claim(ClaimTypes.Email, authenticatedEmail) },
@@ -126,9 +109,7 @@ public class StagingAccessGateIntegrationTests
                         await next().ConfigureAwait(false);
                     });
 
-                    // Mirror of WebApplicationExtensions.ConfigureAuthMiddleware staging gate.
-                    // If this block diverges from production, this test is the regression
-                    // signal: the production wiring should be updated too.
+                    // Mirror of WebApplicationExtensions staging gate.
                     if (context.HostingEnvironment.IsEnvironment("Staging"))
                     {
                         app.UseMiddleware<StagingAccessMiddleware>();
@@ -143,5 +124,48 @@ public class StagingAccessGateIntegrationTests
             });
 
         return hostBuilder.Start().GetTestServer();
+    }
+
+    private static IReadOnlySet<string> ParseAllowlist(string csv) =>
+        csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(e => e.ToLowerInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Stub repository returning a fixed set of emails. Only <see cref="GetAllowedEmailsAsync"/>
+    /// is exercised by the guard hot-path; other members throw to surface unintended use.
+    /// </summary>
+    private sealed class StubAllowlistRepository : IStagingAllowlistRepository
+    {
+        private readonly IReadOnlySet<string> _emails;
+
+        public StubAllowlistRepository(IReadOnlySet<string> emails) => _emails = emails;
+
+        public Task<IReadOnlySet<string>> GetAllowedEmailsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(_emails);
+
+        public Task<StagingAllowlistEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<StagingAllowlistEntry>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StagingAllowlistEntry?> GetByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsByEmailAsync(string normalizedEmail, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task AddAsync(StagingAllowlistEntry entity, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task UpdateAsync(StagingAllowlistEntry entity, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteAsync(StagingAllowlistEntry entity, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Infrastructure/Middleware/StagingAccessMiddlewareTests.cs
@@ -51,13 +51,16 @@ public class StagingAccessMiddlewareTests
         {
             _allowed = emails.ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
-        public bool IsEmailAllowed(string email)
+        public ValueTask<bool> IsEmailAllowedAsync(string email, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrWhiteSpace(email)) return false;
-            if (_allowed.Count == 0) return true;
-            return _allowed.Contains(email);
+            if (string.IsNullOrWhiteSpace(email)) return ValueTask.FromResult(false);
+            // Fail-closed (#845): empty allowlist denies.
+            if (_allowed.Count == 0) return ValueTask.FromResult(false);
+            return ValueTask.FromResult(_allowed.Contains(email));
         }
-        public bool HasNonEmptyAllowlist => _allowed.Count > 0;
+        public ValueTask<bool> HasNonEmptyAllowlistAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(_allowed.Count > 0);
+        public void InvalidateCache() { /* no-op for tests */ }
     }
 
     private static IConfiguration ConfigWithContact(string? contactEmail)
@@ -204,11 +207,12 @@ public class StagingAccessMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_WhenAllowlistEmpty_PassesThroughEvenForUnknownEmails()
+    public async Task InvokeAsync_WhenAllowlistEmpty_DeniesAccess_FailClosed()
     {
-        // Default-safe behavior: empty allowlist = open access.
-        // Combined with Staging-only wiring + startup warning, this prevents
-        // accidental lockout if STAGING_ALLOWED_EMAILS is misconfigured.
+        // Semantic change in #845: empty allowlist now FAIL-CLOSED.
+        // Previously "empty = open" — a latent landmine if the bootstrap seed
+        // failed silently. The new behavior makes a misconfigured Staging env
+        // explicitly deny all rather than silently allow.
         var context = CreateAuthenticatedContext("anyone@example.com");
         var nextCalled = false;
         var middleware = new StagingAccessMiddleware(
@@ -217,8 +221,8 @@ public class StagingAccessMiddlewareTests
 
         await middleware.InvokeAsync(context, new StubGuard(/* empty allowlist */));
 
-        nextCalled.Should().BeTrue();
-        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        nextCalled.Should().BeFalse("empty allowlist now fail-closed");
+        context.Response.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
     }
 
     private sealed record DeniedResponse(string Code, string Message, string ContactEmail);

--- a/apps/web/src/app/admin/(dashboard)/staging-access/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/staging-access/page.tsx
@@ -1,0 +1,214 @@
+/**
+ * Admin Staging Allowlist Page (#845 — DevOps Wave 1)
+ *
+ * Superadmin-only CRUD over the email allowlist that gates access to staging.
+ * Replaces the deprecated STAGING_ALLOWED_EMAILS env-var configuration:
+ * changes apply within ~60s (in-memory cache TTL) without a redeploy.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Trash2Icon, UserPlusIcon, RefreshCwIcon, ShieldCheckIcon } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Card, CardContent } from '@/components/ui/data-display/card';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { StagingAllowlistEntryDto } from '@/lib/api/clients/stagingAllowlistClient';
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function StagingAccessPage() {
+  const queryClient = useQueryClient();
+  const [emailInput, setEmailInput] = useState('');
+  const [noteInput, setNoteInput] = useState('');
+
+  const listQuery = useQuery({
+    queryKey: ['admin', 'staging-allowlist'],
+    queryFn: () => api.stagingAllowlist.list(),
+  });
+
+  const addMutation = useMutation({
+    mutationFn: () =>
+      api.stagingAllowlist.add({ email: emailInput.trim(), note: noteInput.trim() || null }),
+    onSuccess: entry => {
+      toast.success(`Added ${entry.email} to staging allowlist`);
+      setEmailInput('');
+      setNoteInput('');
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'staging-allowlist'] });
+    },
+    onError: (error: Error) => {
+      const message = error.message ?? 'Failed to add entry';
+      if (message.toLowerCase().includes('conflict') || message.includes('409')) {
+        toast.error(`${emailInput.trim()} is already in the allowlist`);
+      } else {
+        toast.error(message);
+      }
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (id: string) => api.stagingAllowlist.remove(id),
+    onSuccess: () => {
+      toast.success('Entry removed from staging allowlist');
+      void queryClient.invalidateQueries({ queryKey: ['admin', 'staging-allowlist'] });
+    },
+    onError: (error: Error) => toast.error(error.message ?? 'Failed to remove entry'),
+  });
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!emailInput.trim()) {
+      toast.error('Email is required');
+      return;
+    }
+    addMutation.mutate();
+  };
+
+  const handleRemove = (entry: StagingAllowlistEntryDto) => {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm(`Remove ${entry.email} from the staging allowlist?`);
+      if (!confirmed) return;
+    }
+    removeMutation.mutate(entry.id);
+  };
+
+  const entries = listQuery.data ?? [];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <ShieldCheckIcon className="size-6" aria-hidden />
+            Staging Allowlist
+          </h1>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            Controls who can access the staging environment. Changes apply within ~60s without a
+            redeploy (in-memory cache invalidates on add/remove). Superadmin only.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => listQuery.refetch()}
+          disabled={listQuery.isFetching}
+          aria-label="Refresh allowlist"
+        >
+          <RefreshCwIcon
+            className={`size-4 ${listQuery.isFetching ? 'animate-spin' : ''}`}
+            aria-hidden
+          />
+          Refresh
+        </Button>
+      </header>
+
+      <Card>
+        <CardContent className="pt-6">
+          <form onSubmit={handleAdd} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div className="flex-1">
+              <label htmlFor="staging-allowlist-email" className="text-sm font-medium">
+                Email
+              </label>
+              <Input
+                id="staging-allowlist-email"
+                type="email"
+                placeholder="user@example.com"
+                value={emailInput}
+                onChange={e => setEmailInput(e.target.value)}
+                required
+                disabled={addMutation.isPending}
+                className="mt-1"
+              />
+            </div>
+            <div className="flex-1">
+              <label htmlFor="staging-allowlist-note" className="text-sm font-medium">
+                Note (optional)
+              </label>
+              <Input
+                id="staging-allowlist-note"
+                type="text"
+                placeholder="Tester for invite-only flow"
+                value={noteInput}
+                onChange={e => setNoteInput(e.target.value)}
+                maxLength={500}
+                disabled={addMutation.isPending}
+                className="mt-1"
+              />
+            </div>
+            <Button type="submit" disabled={addMutation.isPending || !emailInput.trim()}>
+              <UserPlusIcon className="size-4" aria-hidden />
+              {addMutation.isPending ? 'Adding…' : 'Add'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          {listQuery.isLoading ? (
+            <div className="space-y-3 p-6">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : listQuery.isError ? (
+            <div className="p-6 text-sm text-destructive">
+              Failed to load allowlist: {listQuery.error.message ?? 'unknown error'}
+            </div>
+          ) : entries.length === 0 ? (
+            <div className="p-6 text-center text-sm text-muted-foreground">
+              No entries yet. Add the first email above to grant staging access.
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Email</th>
+                  <th className="px-4 py-2 font-medium">Note</th>
+                  <th className="px-4 py-2 font-medium">Added</th>
+                  <th className="px-4 py-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map(entry => (
+                  <tr key={entry.id} className="border-t border-border">
+                    <td className="px-4 py-3 font-mono">{entry.email}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{entry.note ?? '—'}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDateTime(entry.addedAt)}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleRemove(entry)}
+                        disabled={removeMutation.isPending}
+                        aria-label={`Remove ${entry.email}`}
+                      >
+                        <Trash2Icon className="size-4" aria-hidden />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -49,6 +49,7 @@ export * from './featureFlagsClient'; // User Feature Flags
 export * from './sandboxClient'; // RAG Sandbox Dashboard
 export * from './onboardingClient'; // First-time user onboarding
 export * from './accessRequestsClient'; // Invite-only registration
+export * from './stagingAllowlistClient'; // #845 DevOps Wave 1
 export * from './adminNotificationsClient'; // Admin manual notifications
 export * from './contactClient'; // Public contact form
 export * from './agentMemoryClient'; // AgentMemory — groups, game memory, player stats

--- a/apps/web/src/lib/api/clients/stagingAllowlistClient.ts
+++ b/apps/web/src/lib/api/clients/stagingAllowlistClient.ts
@@ -1,0 +1,56 @@
+/**
+ * Staging Allowlist API Client (#845 — DevOps Wave 1)
+ *
+ * Superadmin-only endpoints for managing the email allowlist that gates
+ * access to the staging environment.
+ */
+
+import { type HttpClient } from '../core/httpClient';
+
+export interface StagingAllowlistEntryDto {
+  id: string;
+  email: string;
+  addedByUserId: string | null;
+  addedAt: string;
+  note: string | null;
+}
+
+export interface AddStagingAllowlistEntryRequest {
+  email: string;
+  note: string | null;
+}
+
+export interface CreateStagingAllowlistClientParams {
+  httpClient: HttpClient;
+}
+
+export function createStagingAllowlistClient({ httpClient }: CreateStagingAllowlistClientParams) {
+  return {
+    /** GET /api/v1/admin/staging-allowlist — list active entries, newest first */
+    async list(): Promise<StagingAllowlistEntryDto[]> {
+      const response = await httpClient.get<StagingAllowlistEntryDto[]>(
+        '/api/v1/admin/staging-allowlist'
+      );
+      return response ?? [];
+    },
+
+    /** POST /api/v1/admin/staging-allowlist — add email; 409 on duplicate */
+    async add(request: AddStagingAllowlistEntryRequest): Promise<StagingAllowlistEntryDto> {
+      const response = await httpClient.post<StagingAllowlistEntryDto>(
+        '/api/v1/admin/staging-allowlist',
+        request
+      );
+      if (!response) {
+        throw new Error('Empty response from staging allowlist add endpoint');
+      }
+      return response;
+    },
+
+    /** DELETE /api/v1/admin/staging-allowlist/{id} — soft-delete; 404 if missing */
+    async remove(id: string): Promise<void> {
+      await httpClient.delete(`/api/v1/admin/staging-allowlist/${id}`);
+    },
+  };
+}
+
+export type StagingAllowlistClient = ReturnType<typeof createStagingAllowlistClient>;

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -65,6 +65,7 @@ import {
   createSandboxClient,
   createOnboardingClient,
   createAccessRequestsClient,
+  createStagingAllowlistClient,
   createAdminNotificationsClient,
   createContactClient,
   createAgentMemoryClient,
@@ -116,6 +117,7 @@ import {
   type SandboxClient,
   type OnboardingClient,
   type AccessRequestsClient,
+  type StagingAllowlistClient,
   type AdminNotificationsClient,
   type ContactClient,
   type AgentMemoryClient,
@@ -345,6 +347,9 @@ export interface ApiClient {
   /** Access Requests — invite-only registration */
   accessRequests: AccessRequestsClient;
 
+  /** Staging Allowlist — DevOps Wave 1 (#845) */
+  stagingAllowlist: StagingAllowlistClient;
+
   /** Admin manual notification dispatch */
   adminNotifications: AdminNotificationsClient;
 
@@ -458,6 +463,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     sandbox: createSandboxClient({ httpClient }), // RAG Sandbox Dashboard
     onboarding: createOnboardingClient({ httpClient }), // First-time user onboarding
     accessRequests: createAccessRequestsClient({ httpClient }), // Invite-only registration
+    stagingAllowlist: createStagingAllowlistClient({ httpClient }), // #845 DevOps Wave 1
     adminNotifications: createAdminNotificationsClient({ httpClient }), // Admin manual notifications
     contact: createContactClient({ httpClient }), // Public contact form
     agentMemory: createAgentMemoryClient({ httpClient }), // AgentMemory


### PR DESCRIPTION
Closes #845. Sub-issue of epic #842 (DevOps Multi-Branch Strategy).

## Summary

Replaces the env-var `STAGING_ALLOWED_EMAILS` with a DB-backed allowlist, superadmin CRUD endpoints, and admin UI. Migration path is baked in: the bootstrap seeder pulls legacy env-var values on first staging deploy, so the env-var can be removed from secrets after post-deploy verification.

## Spec-panel critique adjustments

8 design gaps surfaced in spec-panel (Wiegers / Newman / Nygard / Crispin) — addressed in the implementation:

| Gap | Adjustment |
|---|---|
| BC placement of entity (issue spec ambiguous) | Entity + repository in **Administration BC**; `IStagingAccessGuard` interface stays in Authentication BC as the stable service seam |
| Email as PK = URL encoding hazard + log leakage | `Guid Id` PK + partial unique index on email (active rows only); supports re-add of soft-deleted emails |
| Sync guard interface + DB read = blocking call | Async `IsEmailAllowedAsync` + `IMemoryCache` TTL 60s + domain events for immediate invalidation on add/remove |
| Empty allowlist = open access (old) | **FAIL-CLOSED**: empty allowlist now DENIES in Staging (the previous "empty = allow" was a latent landmine) |
| `STAGING_ALLOWED_EMAILS` env-var co-exists with new table | Env-var deprecated; bootstrap seeder migrates values on first deploy |
| Audit log contract unspecified | `Action=staging_allowlist.added/removed`, `Resource=staging_allowlist`, `ResourceId=normalized_email` — matches `LogAiRequestCommand` pattern |
| Test coverage scope vague | Explicit scenarios: domain entity (Reconstitute, factory, soft-delete idempotent, events), guard async + cache, middleware fail-closed, add duplicate→409, remove missing→404, seeder idempotent + migration path |

## Deliverables

**Backend** (~30 files):
- EF migration `AddStagingAllowlist` (table + partial unique email index + is_deleted index)
- Domain entity `StagingAllowlistEntry` (AggregateRoot) + 2 domain events
- Application: `GetStagingAllowlistQuery` + Add/Remove/Seed commands + FluentValidation + handlers (audit log + cache invalidation)
- Infrastructure: persistence entity + EF config + repository + mapper
- Bootstrap seeder wired into `CoreSeedLayer` (Staging-only, idempotent)
- Guard rewrite + middleware async + fail-closed
- 3 admin endpoints under `/api/v1/admin/staging-allowlist`, `RequireSuperAdminSession` gated

**Frontend**:
- TypeScript client + `ApiClient` wiring
- Admin UI `/admin/(dashboard)/staging-access` minimal CRUD (TanStack Query + sonner)

**Tests** (46 passing):
- Domain entity (6 tests): factory, normalization, ArgumentException paths, domain events, soft-delete idempotent
- Guard (9 tests): async, fail-closed, normalization, cache hit, cache invalidate
- Middleware (rebuilt async stub + fail-closed test)
- Add handler (2 tests): success + audit log, 409 conflict
- Remove handler (2 tests): success + audit log, 404 not found
- Get query handler (2 tests): ordering, empty
- Seeder (4 tests): non-staging skip, already exists, new insert, legacy env-var migration

## Operations

- Bootstrap seed runs idempotently on every staging startup; `badsworm@gmail.com` always present
- Cache TTL 60s + immediate invalidation via domain events → admin operations apply within seconds without redeploy
- Empty allowlist in Staging now denies all (was: open) — explicit warning logged at startup if seed produced no entries

## Test plan

- [x] Domain unit tests pass (factory + soft-delete + normalization)
- [x] Handler unit tests pass (add/remove/get/seed)
- [x] Guard async + cache tests pass
- [x] Middleware fail-closed test passes
- [x] Integration test refactored to use stub repository
- [x] Frontend typecheck clean
- [x] Backend build clean
- [ ] `/code-review:code-review` per workflow rule before merge
- [ ] Verify staging deploy reads from DB after seeder execution (post-merge)

## Reference

- Issue: #845
- Epic: #842 DevOps Multi-Branch Strategy
- ADR: docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
- Sibling work: #1091 (rollback runbook, just merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)