### PR TITLE
docs(specs): sync de-versioning spec to delivered state + lift CLAUDE.md freeze (refs #1023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,17 +260,15 @@ tests/Api.Tests/          # Backend test suite
 
 ### 🔒 Active Freezes
 
-**Design System De-versioning FREEZE** (active 2026-05-11, umbrella #1023 / Stage 1 audit #1024)
+**Design System De-versioning FREEZE — LIFTED 2026-05-11** (umbrella #1023)
 
-Until Stage 2 path-migration PR lands, **no new files** may be added under:
-- `apps/web/src/components/v2/**`
-- `apps/web/src/components/ui/v2/**`
-
-Implementations of `missing` components (per [audit report](./docs/for-developers/audits/2026-05-11-mockup-conformity.md)) MUST wait for the post-Stage-2 canonical paths:
+Stage 2 path-migration completed by PR #1032 on 2026-05-11. The unblock condition ("Until Stage 2 path-migration PR lands") is satisfied. Canonical paths are now active:
 - Feature compositions → `apps/web/src/components/features/<feature>/`
 - Primitives → `apps/web/src/components/ui/<primitive>/`
 
-Stage 2 codemod (atomic rename + import fix) is the unblocker. Exceptions require explicit user sign-off in the PR description. Reference: [`docs/for-developers/specs/2026-05-11-design-system-deversioning.md`](./docs/for-developers/specs/2026-05-11-design-system-deversioning.md).
+The legacy directories `apps/web/src/components/v2/**` and `apps/web/src/components/ui/v2/**` are empty post-codemod; do not re-introduce them.
+
+Stage 3 (#1026) — conformity fixes per cluster — is in progress. New cluster work (`dashboard`, `hub/<entity>`) is **blocked on creation of canonical mockups** in `admin-mockups/design_files/sp4-dashboard.jsx` and `sp4-hub-*.jsx` (raised by spec-panel review 2026-05-13). Reference: [`docs/for-developers/specs/2026-05-11-design-system-deversioning.md`](./docs/for-developers/specs/2026-05-11-design-system-deversioning.md) §12.
 
 > **Historical**: SP6 v2 expansion FREEZE (issued 2026-05-06 per [#808](https://github.com/meepleAi-app/meepleai-monorepo/issues/808), tied to A11y audit [#807](https://github.com/meepleAi-app/meepleai-monorepo/issues/807)) was **lifted on 2026-05-10** by PR #876 (token redesign — AA-compliant CSS vars + entity Tailwind utilities). Issues #807 and #808 are both CLOSED. Restore A11y CI job (`Frontend - A11y E2E`) to blocking (`continue-on-error: false`) when verified green on `main-dev`.
 

--- a/docs/for-developers/specs/2026-05-11-design-system-deversioning.md
+++ b/docs/for-developers/specs/2026-05-11-design-system-deversioning.md
@@ -2,8 +2,9 @@
 
 | Field | Value |
 |---|---|
-| **Status** | draft |
+| **Status** | accepted (Stage 1+2 delivered, Stage 3 in progress) |
 | **Date** | 2026-05-11 |
+| **Last sync** | 2026-05-13 (umbrella #1023 spec-panel review) |
 | **Author** | spec-panel (Wiegers/Cockburn/Fowler/Adzic/Crispin/Nygard) |
 | **Supersedes (partial)** | [`2026-04-26-v2-design-migration.md`](./2026-04-26-v2-design-migration.md) — Phase 0 matrix logic obsoleted post-migration |
 | **Related** | [`v2-migration-matrix.md`](../frontend/v2-migration-matrix.md), [`sp3-shared-game-detail.jsx`](../../../admin-mockups/design_files/sp3-shared-game-detail.jsx) |
@@ -278,11 +279,13 @@ Detail "hub" usa `DetailPageLayout variant="public"` con `StickyCTA` "Accedi per
 
 **Total**: ~2 sprint con 1 dev FTE; ~1 sprint con 2 dev paralleli su Stage 3.
 
-## 10. Open questions for implementation
+## 10. Resolved questions
 
-- Q1: Quale subagent per Stage 1 audit? Candidato `frontend-architect` o `general-purpose` con Playwright browser tools? → da decidere al kickoff PR 1.
-- Q2: Naming definitivo `components/features/` vs `components/feature/` vs `components/compositions/`? Proposta corrente: `features/`. Da confermare in PR 2 review.
-- Q3: Tracking issue: aprire una umbrella issue su GitHub con sotto-issue per stage? Convenzione `feature/issue-{N}` lo richiede. Decidere al kickoff.
+Originariamente sezione "Open questions"; tutte chiuse durante Stage 1+2 (vedi §12 change log).
+
+- ~~Q1: Quale subagent per Stage 1 audit?~~ **Risolto** in #1024 / PR #1028 — `frontend-architect` + Playwright visual diff. Report finale: [`docs/for-developers/audits/2026-05-11-mockup-conformity.md`](../audits/2026-05-11-mockup-conformity.md).
+- ~~Q2: Naming definitivo `components/features/` vs `components/feature/` vs `components/compositions/`?~~ **Risolto** in #1025 / PR #1032 — adottato `components/features/` (compositions) e `components/ui/` (primitives).
+- ~~Q3: Aprire umbrella issue per tracking?~~ **Risolto** — umbrella aperta come #1023, sotto-issue #1024 / #1025 / #1026 per stage.
 
 ## 11. References
 
@@ -292,9 +295,21 @@ Detail "hub" usa `DetailPageLayout variant="public"` con `StickyCTA` "Accedi per
 - ConnectionBar reference: PR #549/#552
 - SP3 reference implementation: [`sp3-shared-game-detail.jsx`](../../../admin-mockups/design_files/sp3-shared-game-detail.jsx)
 
+## 12. Change log
+
+| Date | Event | Reference |
+|---|---|---|
+| 2026-05-11 | Spec drafted, decisioni di principio firmate | umbrella #1023 |
+| 2026-05-11 | Stage 1 — Audit automatizzato delivered | issue #1024, PR #1028, report `audits/2026-05-11-mockup-conformity.md` |
+| 2026-05-11 | Stage 2 — Path migration codemod delivered, naming `features/` confermato | issue #1025, PR #1032 |
+| 2026-05-11 | Freeze "Design System De-versioning" issued in `CLAUDE.md` | umbrella #1023 |
+| 2026-05-13 | Spec sync: status `draft` → `accepted`, resolved questions migrate da §10, change log added | this PR |
+
+**Outstanding Stage 3 prerequisite** (raised by spec-panel review 2026-05-13): i cluster `dashboard` e `hub/<entity>` non hanno mockup canonico in `admin-mockups/design_files/`. AC3.1 ("pixel-faithful al mockup HTML") non misurabile fino a creazione mockup. Vedi follow-up issue da aprire pre Stage-3 kickoff su questi cluster.
+
 ---
 
-**Sign-off required from**:
-- [x] Project owner — decisioni di principio confermate 2026-05-11 (vedi umbrella #1023)
-- [ ] Frontend architecture review — naming `features/` finale
-- [ ] PM — apertura umbrella issue + scheduling sprint
+**Sign-off**:
+- [x] Project owner — decisioni di principio confermate 2026-05-11 (umbrella #1023)
+- [x] Frontend architecture review — naming `features/` confermato in Stage 2 (PR #1032)
+- [x] PM — umbrella #1023 + sotto-issue #1024 / #1025 / #1026 aperte, Stage 1+2 delivered


### PR DESCRIPTION
## Summary

- Sync `2026-05-11-design-system-deversioning.md`: status `draft` → `accepted`, `Open questions` § replaced with `Resolved questions` linking the PRs that closed each one (Stage 1 #1024 / PR #1028, Stage 2 #1025 / PR #1032), new §12 change log
- Lift the `Design System De-versioning FREEZE` block in `CLAUDE.md` — Stage 2 unblock condition was met on 2026-05-11 but the freeze text still said "Until Stage 2 path-migration PR lands"
- Document the outstanding Stage 3 prerequisite raised by spec-panel review 2026-05-13: `dashboard` and `hub/<entity>` clusters have no canonical mockup in `admin-mockups/design_files/`, so AC3.1 ("pixel-faithful al mockup HTML") is unmeasurable until those mockups are authored

No code, no migration, no test impact. Pure documentation drift fix.

## Context

Spec-panel review on issue #1023 (Wiegers/Cockburn/Fowler/Adzic/Crispin/Nygard) flagged that after the merge of Stage 1 (#1024) and Stage 2 (#1025) on 2026-05-11 the spec file and `CLAUDE.md` were left out of sync with reality:

- spec still `draft` and listed 3 open questions that were already answered by the merged PRs
- `CLAUDE.md` freeze block still active despite its own unblock condition being satisfied
- the actually-blocking item (missing canonical mockups for the two NEW clusters in §3 Stage 3) was not surfaced anywhere

This PR closes the documentation drift only. The actual Stage 3 cluster work continues to be tracked under #1026.

## Test plan

- [x] `git diff --stat` shows only the two documentation files
- [ ] Reviewer confirms the §12 change log dates match the merge dates of #1028 and #1032
- [ ] Reviewer confirms the lifted-freeze block in `CLAUDE.md` does not contradict any other active freeze (Token Canonicalization block below it is untouched)

Refs: #1023, #1024, #1025, #1026, #1066