### PR TITLE
fix(web): NotFoundContent SSR-safe i18n — closes #1076

### DIFF
--- a/apps/web/src/app/__tests__/not-found.test.tsx
+++ b/apps/web/src/app/__tests__/not-found.test.tsx
@@ -1,32 +1,85 @@
+/**
+ * Regression tests for Issue #1076 — `NotFoundContent` hydration mismatch.
+ *
+ * `NotFoundContent` MUST NOT depend on the client-only `IntlProvider`
+ * (mounted in `apps/web/src/app/providers.tsx`), otherwise SSR renders
+ * the raw message-id keys (`pages.errors.notFound.title`) while the
+ * client renders the translated strings → React error #418.
+ *
+ * Acceptance criteria validated below:
+ *   - AC-1/AC-2: SSR pass succeeds without IntlProvider (no useTranslation())
+ *   - AC-3:     SSR-rendered string and client-rendered DOM agree on
+ *                the user-visible text (no message-id keys on either side)
+ *   - Coverage: Translated IT strings appear in output (not message-ids)
+ */
+import { renderToString } from 'react-dom/server';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import NotFound from '../not-found';
 
-vi.mock('@/hooks/useTranslation', () => ({
-  useTranslation: () => ({ t: (k: string) => k, locale: 'it' }),
-}));
-
-describe('NotFound', () => {
-  it('renders the localized 404 title, subtitle, and both CTAs', () => {
+describe('NotFound (Issue #1076)', () => {
+  it('renders translated IT strings (not raw message-id keys)', () => {
     render(<NotFound />);
 
     expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Pagina non trovata/ })).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: /pages\.errors\.notFound\.title/ })
+      screen.getByText('La pagina che stai cercando non esiste o è stata spostata.')
     ).toBeInTheDocument();
-    expect(screen.getByText('pages.errors.notFound.subtitle')).toBeInTheDocument();
 
-    const homeCta = screen.getByRole('link', { name: 'pages.errors.notFound.homeCta' });
-    const exploreCta = screen.getByRole('link', { name: 'pages.errors.notFound.exploreCta' });
+    const homeCta = screen.getByRole('link', { name: 'Torna alla home' });
+    const exploreCta = screen.getByRole('link', { name: 'Esplora i giochi' });
     expect(homeCta).toHaveAttribute('href', '/');
     expect(exploreCta).toHaveAttribute('href', '/games');
   });
 
-  it('contains zero hardcoded English strings in rendered output', () => {
+  it('does NOT render raw i18n message-id keys (regression for #1076 root cause)', () => {
+    const { container } = render(<NotFound />);
+    const text = container.textContent ?? '';
+    expect(text).not.toMatch(/pages\.errors\.notFound\./);
+  });
+
+  it('does NOT render English fallback strings (single-locale guarantee)', () => {
     const { container } = render(<NotFound />);
     const text = container.textContent ?? '';
     expect(text).not.toMatch(/Page not found/);
     expect(text).not.toMatch(/Back to home/);
+  });
+
+  it('SSR pass produces translated markup without IntlProvider (AC-1/AC-2)', () => {
+    // Pre-fix: calling `renderToString(<NotFound />)` outside an
+    // IntlProvider made `useTranslation()` return raw message-id keys.
+    // Post-fix: NotFoundContent is a server component reading static IT
+    // messages, so the SSR string already contains the translated copy.
+    const ssrMarkup = renderToString(<NotFound />);
+
+    expect(ssrMarkup).toContain('Pagina non trovata');
+    expect(ssrMarkup).toContain('La pagina che stai cercando non esiste');
+    expect(ssrMarkup).toContain('Torna alla home');
+    expect(ssrMarkup).toContain('Esplora i giochi');
+    expect(ssrMarkup).not.toMatch(/pages\.errors\.notFound\./);
+  });
+
+  it('SSR-rendered text matches client-rendered text (AC-3 — no React #418 surface)', () => {
+    // Equivalence check: the strings produced by `renderToString` and by
+    // `render` must agree on every translated label. If they diverge,
+    // React would emit error #418 during hydration in a real browser.
+    const ssrMarkup = renderToString(<NotFound />);
+    const { container } = render(<NotFound />);
+    const clientText = container.textContent ?? '';
+
+    const labels = [
+      '404',
+      'Pagina non trovata',
+      'La pagina che stai cercando non esiste o è stata spostata.',
+      'Torna alla home',
+      'Esplora i giochi',
+    ];
+
+    for (const label of labels) {
+      expect(ssrMarkup, `SSR markup missing "${label}"`).toContain(label);
+      expect(clientText, `Client DOM missing "${label}"`).toContain(label);
+    }
   });
 });

--- a/apps/web/src/app/_not-found-content.tsx
+++ b/apps/web/src/app/_not-found-content.tsx
@@ -1,25 +1,39 @@
-'use client';
+import type { JSX } from 'react';
 
 import { HeroGradient } from '@/components/ui/hero-gradient';
-import { useTranslation } from '@/hooks/useTranslation';
+import itMessages from '@/locales/it.json';
 
-export function NotFoundContent() {
-  const { t } = useTranslation();
+/**
+ * SSR-safe i18n source. `IntlProvider` only mounts on the client (see
+ * `apps/web/src/app/providers.tsx`), so any component reachable during
+ * Next.js SSR — including the global 404 — must NOT use `useTranslation()`,
+ * otherwise hydration produces React error #418 (mismatch between the
+ * server-rendered message-id key and the client-rendered translation).
+ *
+ * Pattern mirrors `apps/web/src/app/(public)/shared-games/[id]/page.tsx`
+ * (Wave A.4 follow-up — Issue #617). Closes Issue #1076.
+ *
+ * NOTE: Hardcodes IT locale (project default — `LOCALES.IT`). When SSR
+ * locale negotiation is introduced, refactor to read locale from headers
+ * and conditionally pick `it.json` vs `en.json` (Issue #1076 AC-4 / TBD).
+ */
+const NOT_FOUND_MESSAGES = itMessages.pages.errors.notFound;
 
+export function NotFoundContent(): JSX.Element {
   return (
     <main>
       <HeroGradient
         title={
           <>
             <span aria-hidden="true" className="block text-xl font-mono text-muted-foreground mb-2">
-              404
+              {NOT_FOUND_MESSAGES.eyebrow}
             </span>
-            {t('pages.errors.notFound.title')}
+            {NOT_FOUND_MESSAGES.title}
           </>
         }
-        subtitle={t('pages.errors.notFound.subtitle')}
-        primaryCta={{ label: t('pages.errors.notFound.homeCta'), href: '/' }}
-        secondaryCta={{ label: t('pages.errors.notFound.exploreCta'), href: '/games' }}
+        subtitle={NOT_FOUND_MESSAGES.subtitle}
+        primaryCta={{ label: NOT_FOUND_MESSAGES.homeCta, href: '/' }}
+        secondaryCta={{ label: NOT_FOUND_MESSAGES.exploreCta, href: '/games' }}
       />
     </main>
   );


### PR DESCRIPTION
## Summary

Fix React error #418 hydration mismatch on every 404 page. Root cause: `NotFoundContent` was a `'use client'` component using `useTranslation()` from the client-only `IntlProvider`. SSR rendered raw message-id keys (`pages.errors.notFound.title`), client rendered translated strings → hydration mismatch.

## Changes

- **`_not-found-content.tsx`**: drop `'use client'`, switch to static `it.json` import. Component is now a pure server component → hydration step eliminated by construction.
- Reuses the SSR-safe i18n pattern from `shared-games/[id]/page.tsx` (Issue #617).
- Re-keyed the hardcoded `"404"` badge to existing `pages.errors.notFound.eyebrow` locale entry.
- **`__tests__/not-found.test.tsx`**: rewritten as regression suite with 5 scenarios covering Wiegers acceptance criteria.

## Acceptance Criteria (per /sc:spec-panel review)

- [x] **AC-1**: 404 route renders without emitting React error #418 (validated by removing the client/SSR mismatch surface entirely — no `useTranslation()` call left in NotFoundContent)
- [x] **AC-2**: No console error containing `Minified React error #418` (same root cause as AC-1)
- [x] **AC-3**: SSR markup matches client markup — `renderToString` + `render` produce identical user-visible text on every label
- [ ] **AC-4** (deferred): SSR locale negotiation. Current fix hardcodes IT (`LOCALES.IT` is the project default). When EN as user-selectable locale is added, refactor to read from request headers. Out of scope.

## Test Coverage

```
✓ renders translated IT strings (not raw message-id keys)
✓ does NOT render raw i18n message-id keys (regression for #1076 root cause)
✓ does NOT render English fallback strings (single-locale guarantee)
✓ SSR pass produces translated markup without IntlProvider (AC-1/AC-2)
✓ SSR-rendered text matches client-rendered text (AC-3 — no React #418 surface)
```

5/5 passing locally.

## Test Plan

- [x] `pnpm test src/app/__tests__/not-found.test.tsx --run` → 5/5 pass
- [x] `pnpm typecheck` → clean
- [x] `pnpm lint` → 0 warnings on touched files
- [ ] CI: full FE suite green
- [ ] Manual verify in dev: navigate to `/this-does-not-exist`, DevTools Console → no error #418

## Refs

- Closes #1076
- #992 (root-cause investigation that surfaced this)
- #1009 (PR that removed the catch-all redirect, exposing the bug)
- #617 / `shared-games/[id]` (SSR-safe i18n pattern reused)

## Follow-up Backlog (from spec-panel review)

1. Extract `getSsrMessages(namespace)` helper consolidating 3+ callsites (Fowler)
2. Audit grep `useTranslation` in server-reachable components (Wiegers)
3. SSR locale negotiation when EN becomes user-selectable (AC-4)
4. Re-evaluate `export const dynamic = 'force-dynamic'` in `not-found.tsx` now that the import is server-component only (note at L5-8 of `not-found.tsx` flagged this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)