### PR TITLE
feat(conformity): WS-C Phase 1 — ownership loader + schema (refs #1069)

### DIFF
--- a/apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json
+++ b/apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "./mockup-ownership.schema.json",
+  "version": 1,
+  "defaults": {
+    "threshold": 0.1,
+    "conformityRatio": 0.05,
+    "viewports": [
+      { "name": "desktop", "width": 1280, "height": 720 },
+      { "name": "mobile", "width": 375, "height": 740 }
+    ]
+  },
+  "routes": [
+    {
+      "id": "library",
+      "livePath": "/library",
+      "mockup": "sp4-library-desktop.html",
+      "triggerPaths": [
+        "apps/web/src/app/(authenticated)/library/**",
+        "apps/web/src/components/v2/library/**",
+        "apps/web/src/components/features/library/**"
+      ],
+      "notes": "Wave B.3 stable baseline (PR #638). Sentinel pattern via ?state= URL override (visual-test-fixture)."
+    },
+    {
+      "id": "library-game-detail",
+      "livePath": "/library/{gameId}",
+      "liveFixture": {
+        "gameId": "nanolith-runthrough"
+      },
+      "mockup": "nanolith-runthrough-game-detail.html",
+      "triggerPaths": [
+        "apps/web/src/app/(authenticated)/library/[gameId]/**",
+        "apps/web/src/components/v2/library/**",
+        "apps/web/src/components/features/library/**"
+      ],
+      "notes": "Sinergico WS-B fix (#1068) e WS-D Exemplar (PR #1093). Funzionalmente broken pre-fix (~95% gap)."
+    }
+  ]
+}

--- a/apps/web/e2e/visual-conformity/mockup-ownership.schema.json
+++ b/apps/web/e2e/visual-conformity/mockup-ownership.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meepleai.app/schemas/mockup-ownership.schema.json",
+  "title": "Mockup Ownership Map",
+  "description": "Maps live routes to their canonical mockup HTML and conformity thresholds. WS-C bootstrap (#1069). Schema will be extended by WS-F (#1072) with auto-discovery + ownership metadata.",
+  "type": "object",
+  "required": ["version", "routes"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bumped by WS-F when ownership metadata extended."
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Defaults applied to each route entry unless overridden.",
+      "properties": {
+        "threshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.1,
+          "description": "pixelmatch per-pixel YIQ sensitivity (AC-C.2). Lower = stricter."
+        },
+        "conformityRatio": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.05,
+          "description": "Max ratio mismatchedPixels/totalPixels for pass (AC-C.2)."
+        },
+        "viewports": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name", "width", "height"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+              "width": { "type": "integer", "minimum": 320, "maximum": 3840 },
+              "height": { "type": "integer", "minimum": 240, "maximum": 2160 }
+            }
+          }
+        }
+      }
+    },
+    "routes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/route" }
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "required": ["id", "livePath", "mockup", "triggerPaths"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Slug used in baseline filename: __mockup__/{id}.{viewport}.png"
+        },
+        "livePath": {
+          "type": "string",
+          "pattern": "^/",
+          "description": "Next.js route path. Dynamic segments use {param} placeholder (e.g. /library/{gameId})."
+        },
+        "liveFixture": {
+          "type": "object",
+          "description": "Replacement values for dynamic segments in livePath. Required if livePath contains {param}.",
+          "additionalProperties": { "type": "string" }
+        },
+        "mockup": {
+          "type": "string",
+          "pattern": "\\.html$",
+          "description": "Relative path under admin-mockups/design_files/ (e.g. sp4-library-desktop.html)."
+        },
+        "triggerPaths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Glob patterns that trigger conformity gate. Used by AC-C.1 path detection."
+        },
+        "threshold": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Override defaults.threshold for this route."
+        },
+        "conformityRatio": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Override defaults.conformityRatio for this route."
+        },
+        "viewports": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["name", "width", "height"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+              "width": { "type": "integer", "minimum": 320, "maximum": 3840 },
+              "height": { "type": "integer", "minimum": 240, "maximum": 2160 }
+            }
+          },
+          "description": "Override defaults.viewports for this route."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Free-form rationale (e.g. 'Wave B.3 stable baseline')."
+        }
+      }
+    }
+  }
+}

--- a/apps/web/scripts/__tests__/conformity-ownership.test.ts
+++ b/apps/web/scripts/__tests__/conformity-ownership.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for WS-C Phase 1 ownership loader (refs #1069, umbrella #1066).
+ * Spec: docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md §3 WS-C
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadOwnership, resolveLivePath, type OwnershipFile } from '../conformity-ownership';
+
+const validMinimal: OwnershipFile = {
+  version: 1,
+  routes: [
+    {
+      id: 'library',
+      livePath: '/library',
+      mockup: 'sp4-library-desktop.html',
+      triggerPaths: ['apps/web/src/app/(authenticated)/library/**'],
+    },
+  ],
+};
+
+const validWithFixture: OwnershipFile = {
+  version: 1,
+  defaults: {
+    threshold: 0.2,
+    conformityRatio: 0.1,
+    viewports: [{ name: 'desktop', width: 1920, height: 1080 }],
+  },
+  routes: [
+    {
+      id: 'detail',
+      livePath: '/library/{gameId}',
+      liveFixture: { gameId: 'nanolith-runthrough' },
+      mockup: 'nanolith.html',
+      triggerPaths: ['apps/web/src/app/(authenticated)/library/[gameId]/**'],
+      threshold: 0.05,
+    },
+  ],
+};
+
+describe('loadOwnership', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'conformity-ownership-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJson(name: string, data: unknown): string {
+    const p = join(tmpDir, name);
+    writeFileSync(p, JSON.stringify(data));
+    return p;
+  }
+
+  it('loads valid minimal config and applies framework defaults', () => {
+    const path = writeJson('minimal.json', validMinimal);
+    const config = loadOwnership(path);
+
+    expect(config.version).toBe(1);
+    expect(config.routes).toHaveLength(1);
+    const route = config.routes[0];
+    expect(route.id).toBe('library');
+    expect(route.threshold).toBe(0.1); // framework default
+    expect(route.conformityRatio).toBe(0.05); // framework default
+    expect(route.viewports).toEqual([
+      { name: 'desktop', width: 1280, height: 720 },
+      { name: 'mobile', width: 375, height: 740 },
+    ]);
+  });
+
+  it('user defaults override framework defaults', () => {
+    const path = writeJson('overrides.json', validWithFixture);
+    const config = loadOwnership(path);
+    const route = config.routes[0];
+
+    expect(route.threshold).toBe(0.05); // route override wins
+    expect(route.conformityRatio).toBe(0.1); // defaults.conformityRatio
+    expect(route.viewports).toEqual([{ name: 'desktop', width: 1920, height: 1080 }]);
+  });
+
+  it('rejects unknown version', () => {
+    const path = writeJson('bad-version.json', { ...validMinimal, version: 99 });
+    expect(() => loadOwnership(path)).toThrow(/version/i);
+  });
+
+  it('rejects missing routes', () => {
+    const path = writeJson('no-routes.json', { version: 1, routes: [] });
+    expect(() => loadOwnership(path)).toThrow(/route/i);
+  });
+
+  it('rejects duplicate route ids', () => {
+    const path = writeJson('dup.json', {
+      version: 1,
+      routes: [validMinimal.routes[0], { ...validMinimal.routes[0] }],
+    });
+    expect(() => loadOwnership(path)).toThrow(/duplicate.*library/i);
+  });
+
+  it('rejects threshold out of range', () => {
+    const path = writeJson('bad-threshold.json', {
+      version: 1,
+      routes: [{ ...validMinimal.routes[0], threshold: 1.5 }],
+    });
+    expect(() => loadOwnership(path)).toThrow(/threshold/i);
+  });
+
+  it('rejects conformityRatio out of range', () => {
+    const path = writeJson('bad-ratio.json', {
+      version: 1,
+      routes: [{ ...validMinimal.routes[0], conformityRatio: -0.1 }],
+    });
+    expect(() => loadOwnership(path)).toThrow(/conformityRatio/i);
+  });
+
+  it('rejects livePath without leading slash', () => {
+    const path = writeJson('bad-path.json', {
+      version: 1,
+      routes: [{ ...validMinimal.routes[0], livePath: 'library' }],
+    });
+    expect(() => loadOwnership(path)).toThrow(/livePath/i);
+  });
+
+  it('rejects livePath with {param} but no liveFixture', () => {
+    const path = writeJson('missing-fixture.json', {
+      version: 1,
+      routes: [
+        {
+          id: 'detail',
+          livePath: '/library/{gameId}',
+          mockup: 'x.html',
+          triggerPaths: ['apps/web/**'],
+        },
+      ],
+    });
+    expect(() => loadOwnership(path)).toThrow(/liveFixture.*gameId/i);
+  });
+
+  it('rejects liveFixture missing a {param} placeholder', () => {
+    const path = writeJson('partial-fixture.json', {
+      version: 1,
+      routes: [
+        {
+          id: 'detail',
+          livePath: '/library/{gameId}/{tab}',
+          liveFixture: { gameId: 'x' },
+          mockup: 'x.html',
+          triggerPaths: ['apps/web/**'],
+        },
+      ],
+    });
+    expect(() => loadOwnership(path)).toThrow(/liveFixture.*tab/i);
+  });
+
+  it('rejects empty triggerPaths', () => {
+    const path = writeJson('no-triggers.json', {
+      version: 1,
+      routes: [{ ...validMinimal.routes[0], triggerPaths: [] }],
+    });
+    expect(() => loadOwnership(path)).toThrow(/triggerPaths/i);
+  });
+
+  it('rejects malformed JSON', () => {
+    const p = join(tmpDir, 'malformed.json');
+    writeFileSync(p, '{ not json');
+    expect(() => loadOwnership(p)).toThrow();
+  });
+
+  it('rejects unknown top-level keys (strict mode)', () => {
+    const path = writeJson('extra.json', { ...validMinimal, unknownField: 'oops' });
+    expect(() => loadOwnership(path)).toThrow(/unknownField|unknown/i);
+  });
+});
+
+describe('resolveLivePath', () => {
+  it('returns livePath unchanged when no placeholders', () => {
+    expect(resolveLivePath('/library', {})).toBe('/library');
+  });
+
+  it('substitutes single placeholder', () => {
+    expect(resolveLivePath('/library/{gameId}', { gameId: 'nano' })).toBe('/library/nano');
+  });
+
+  it('substitutes multiple placeholders', () => {
+    expect(
+      resolveLivePath('/games/{gameId}/sessions/{sessionId}', {
+        gameId: 'g1',
+        sessionId: 's2',
+      })
+    ).toBe('/games/g1/sessions/s2');
+  });
+
+  it('throws on unresolved placeholder', () => {
+    expect(() => resolveLivePath('/library/{gameId}', {})).toThrow(/gameId/);
+  });
+
+  it('URL-encodes fixture values', () => {
+    expect(resolveLivePath('/q/{term}', { term: 'a b/c' })).toBe('/q/a%20b%2Fc');
+  });
+});

--- a/apps/web/scripts/conformity-ownership.ts
+++ b/apps/web/scripts/conformity-ownership.ts
@@ -1,0 +1,308 @@
+/**
+ * WS-C Phase 1 — Mockup ownership loader.
+ *
+ * Loads `mockup-ownership.bootstrap.json` (or any schema-conformant file),
+ * validates against the v1 contract, applies framework defaults, and returns a
+ * fully-resolved `RouteOwnership[]`.
+ *
+ * Consumed by:
+ *   - Phase 2 Playwright specs (conformity-desktop/mobile projects)
+ *   - Phase 3 workflows (path-trigger derivation, bootstrap script)
+ *   - WS-F future auto-discovery tooling
+ *
+ * Refs: #1069 (WS-C), #1066 (umbrella).
+ */
+import { readFileSync } from 'node:fs';
+
+const FRAMEWORK_DEFAULTS = {
+  threshold: 0.1,
+  conformityRatio: 0.05,
+  viewports: [
+    { name: 'desktop', width: 1280, height: 720 },
+    { name: 'mobile', width: 375, height: 740 },
+  ],
+} as const;
+
+export interface Viewport {
+  name: string;
+  width: number;
+  height: number;
+}
+
+export interface RouteEntry {
+  id: string;
+  livePath: string;
+  liveFixture?: Record<string, string>;
+  mockup: string;
+  triggerPaths: string[];
+  threshold?: number;
+  conformityRatio?: number;
+  viewports?: Viewport[];
+  notes?: string;
+}
+
+export interface OwnershipDefaults {
+  threshold?: number;
+  conformityRatio?: number;
+  viewports?: Viewport[];
+}
+
+export interface OwnershipFile {
+  version: 1;
+  defaults?: OwnershipDefaults;
+  routes: RouteEntry[];
+}
+
+export interface RouteOwnership {
+  id: string;
+  livePath: string;
+  liveFixture: Record<string, string>;
+  mockup: string;
+  triggerPaths: string[];
+  threshold: number;
+  conformityRatio: number;
+  viewports: Viewport[];
+  notes?: string;
+}
+
+export interface ResolvedOwnership {
+  version: 1;
+  routes: RouteOwnership[];
+}
+
+const TOP_LEVEL_KEYS = new Set(['$schema', 'version', 'defaults', 'routes']);
+const ROUTE_KEYS = new Set([
+  'id',
+  'livePath',
+  'liveFixture',
+  'mockup',
+  'triggerPaths',
+  'threshold',
+  'conformityRatio',
+  'viewports',
+  'notes',
+]);
+const ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+const PLACEHOLDER_PATTERN = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+
+export function loadOwnership(path: string): ResolvedOwnership {
+  const raw = readFileSync(path, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse ${path}: ${(err as Error).message}`);
+  }
+  return validateAndResolve(parsed, path);
+}
+
+function validateAndResolve(input: unknown, source: string): ResolvedOwnership {
+  if (!isPlainObject(input)) {
+    throw new Error(`${source}: root must be an object`);
+  }
+
+  for (const key of Object.keys(input)) {
+    if (!TOP_LEVEL_KEYS.has(key)) {
+      throw new Error(`${source}: unknown top-level key "${key}"`);
+    }
+  }
+
+  if (input.version !== 1) {
+    throw new Error(`${source}: unsupported version ${String(input.version)} (expected 1)`);
+  }
+
+  const defaults = mergeDefaults(input.defaults, source);
+
+  if (!Array.isArray(input.routes) || input.routes.length === 0) {
+    throw new Error(`${source}: routes must be a non-empty array`);
+  }
+
+  const seenIds = new Set<string>();
+  const routes: RouteOwnership[] = input.routes.map((raw, idx) =>
+    resolveRoute(raw, defaults, source, idx, seenIds)
+  );
+
+  return { version: 1, routes };
+}
+
+function mergeDefaults(value: unknown, source: string): Required<OwnershipDefaults> {
+  if (value === undefined) {
+    return { ...FRAMEWORK_DEFAULTS, viewports: [...FRAMEWORK_DEFAULTS.viewports] };
+  }
+  if (!isPlainObject(value)) {
+    throw new Error(`${source}: defaults must be an object`);
+  }
+  const threshold =
+    pickNumber(value.threshold, 'defaults.threshold', source) ?? FRAMEWORK_DEFAULTS.threshold;
+  const conformityRatio =
+    pickNumber(value.conformityRatio, 'defaults.conformityRatio', source) ??
+    FRAMEWORK_DEFAULTS.conformityRatio;
+  const viewports = pickViewports(value.viewports, 'defaults.viewports', source) ?? [
+    ...FRAMEWORK_DEFAULTS.viewports,
+  ];
+  return { threshold, conformityRatio, viewports };
+}
+
+function resolveRoute(
+  raw: unknown,
+  defaults: Required<OwnershipDefaults>,
+  source: string,
+  idx: number,
+  seenIds: Set<string>
+): RouteOwnership {
+  const ctx = `${source} routes[${idx}]`;
+  if (!isPlainObject(raw)) {
+    throw new Error(`${ctx}: must be an object`);
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (!ROUTE_KEYS.has(key)) {
+      throw new Error(`${ctx}: unknown key "${key}"`);
+    }
+  }
+
+  const id = pickString(raw.id, `${ctx}.id`, source);
+  if (!ID_PATTERN.test(id)) {
+    throw new Error(`${ctx}.id "${id}" must match ${ID_PATTERN}`);
+  }
+  if (seenIds.has(id)) {
+    throw new Error(`${ctx}.id duplicate "${id}"`);
+  }
+  seenIds.add(id);
+
+  const livePath = pickString(raw.livePath, `${ctx}.livePath`, source);
+  if (!livePath.startsWith('/')) {
+    throw new Error(`${ctx}.livePath "${livePath}" must start with /`);
+  }
+
+  const mockup = pickString(raw.mockup, `${ctx}.mockup`, source);
+  if (!mockup.endsWith('.html')) {
+    throw new Error(`${ctx}.mockup "${mockup}" must end with .html`);
+  }
+
+  const triggerPaths = pickStringArray(raw.triggerPaths, `${ctx}.triggerPaths`, source);
+  if (triggerPaths.length === 0) {
+    throw new Error(`${ctx}.triggerPaths must be a non-empty array`);
+  }
+
+  const placeholders = collectPlaceholders(livePath);
+  const liveFixture = pickRecord(raw.liveFixture, `${ctx}.liveFixture`, source) ?? {};
+  for (const placeholder of placeholders) {
+    if (!(placeholder in liveFixture)) {
+      throw new Error(`${ctx}.liveFixture missing key "${placeholder}" required by livePath`);
+    }
+  }
+
+  const threshold = pickNumber(raw.threshold, `${ctx}.threshold`, source) ?? defaults.threshold;
+  const conformityRatio =
+    pickNumber(raw.conformityRatio, `${ctx}.conformityRatio`, source) ?? defaults.conformityRatio;
+  const viewports = pickViewports(raw.viewports, `${ctx}.viewports`, source) ?? defaults.viewports;
+  const notes = raw.notes === undefined ? undefined : pickString(raw.notes, `${ctx}.notes`, source);
+
+  return {
+    id,
+    livePath,
+    liveFixture,
+    mockup,
+    triggerPaths,
+    threshold,
+    conformityRatio,
+    viewports: viewports.map(v => ({ ...v })),
+    notes,
+  };
+}
+
+export function resolveLivePath(livePath: string, fixture: Record<string, string>): string {
+  return livePath.replace(PLACEHOLDER_PATTERN, (_, key: string) => {
+    if (!(key in fixture)) {
+      throw new Error(`resolveLivePath: missing fixture key "${key}" for "${livePath}"`);
+    }
+    return encodeURIComponent(fixture[key]);
+  });
+}
+
+function collectPlaceholders(livePath: string): string[] {
+  const out: string[] = [];
+  for (const match of livePath.matchAll(PLACEHOLDER_PATTERN)) {
+    out.push(match[1]);
+  }
+  return out;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function pickString(value: unknown, field: string, source: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${source}: ${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function pickNumber(value: unknown, field: string, source: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`${source}: ${field} must be a number`);
+  }
+  if (value < 0 || value > 1) {
+    throw new Error(`${source}: ${field} ${value} out of range [0, 1]`);
+  }
+  return value;
+}
+
+function pickStringArray(value: unknown, field: string, source: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: ${field} must be an array`);
+  }
+  return value.map((entry, i) => pickString(entry, `${field}[${i}]`, source));
+}
+
+function pickRecord(
+  value: unknown,
+  field: string,
+  source: string
+): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainObject(value)) {
+    throw new Error(`${source}: ${field} must be an object`);
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v !== 'string') {
+      throw new Error(`${source}: ${field}.${k} must be a string`);
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+function pickViewports(value: unknown, field: string, source: string): Viewport[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${source}: ${field} must be a non-empty array`);
+  }
+  return value.map((entry, i) => {
+    const ctx = `${field}[${i}]`;
+    if (!isPlainObject(entry)) {
+      throw new Error(`${source}: ${ctx} must be an object`);
+    }
+    const name = pickString(entry.name, `${ctx}.name`, source);
+    if (!ID_PATTERN.test(name)) {
+      throw new Error(`${source}: ${ctx}.name "${name}" must match ${ID_PATTERN}`);
+    }
+    const width = pickInt(entry.width, `${ctx}.width`, source, 320, 3840);
+    const height = pickInt(entry.height, `${ctx}.height`, source, 240, 2160);
+    return { name, width, height };
+  });
+}
+
+function pickInt(value: unknown, field: string, source: string, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new Error(`${source}: ${field} must be an integer`);
+  }
+  if (value < min || value > max) {
+    throw new Error(`${source}: ${field} ${value} out of range [${min}, ${max}]`);
+  }
+  return value;
+}

--- a/docs/for-developers/testing/frontend/mockup-conformity.md
+++ b/docs/for-developers/testing/frontend/mockup-conformity.md
@@ -1,0 +1,137 @@
+# Mockup-to-route Conformity Gate
+
+> **Issue:** #1069 (WS-C Mockup Conformity Roadmap, umbrella #1066)
+> **Status:** Phase 1 shipped 2026-05-13 — config + loader. Workflows + Playwright projects ship in Phase 2/3.
+
+## Overview
+
+The conformity gate answers a question that the two existing visual-regression workflows do **not**:
+
+| Workflow | Compares | Catches |
+|----------|----------|---------|
+| `visual-regression-mockups.yml` | mockup HTML vs committed PNG | mockup HTML drift |
+| `visual-regression-migrated.yml` | live route vs committed PNG | route implementation drift |
+| **`visual-regression-conformity.yml`** (Phase 3) | **live route vs mockup PNG** | **route deviation from canonical mockup** |
+
+Without this gate, an implementation can drift 75–85% from its canonical mockup and every check stays green (this is exactly what the 2026-05-12 audit measured).
+
+## Phase 1 deliverables (this PR)
+
+- `apps/web/e2e/visual-conformity/mockup-ownership.schema.json` — JSON Schema for the ownership map (versioned)
+- `apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json` — minimal bootstrap with **2 routes** (AC-C.7)
+- `apps/web/scripts/conformity-ownership.ts` — loader, validator, default merger
+- `apps/web/scripts/__tests__/conformity-ownership.test.ts` — unit tests
+
+The Playwright spec, workflows, and committed baselines arrive in Phase 2/3.
+
+## Bootstrap route set (AC-C.7)
+
+The bootstrap intentionally maps only two routes so the gate can ship without depending on WS-F (ownership metadata):
+
+| Route | Mockup | Rationale |
+|-------|--------|-----------|
+| `/library` | `sp4-library-desktop.html` | Wave B.3 stable baseline (PR #638). Brownfield migration complete, sentinel `?state=` pattern in place. |
+| `/library/{gameId}` | `nanolith-runthrough-game-detail.html` | Synergistic with WS-B (#1068) fix and WS-D Exemplar (#1093). Pre-fix gap ~95%. |
+
+WS-F (#1072) will generalize the schema and auto-discover route↔mockup pairs.
+
+## Conformity formula (AC-C.2)
+
+The gate uses Playwright's built-in screenshot comparison, which is a thin wrapper over `pixelmatch`:
+
+```ts
+await expect(page).toHaveScreenshot('library.desktop.png', {
+  threshold: route.threshold,           // per-pixel YIQ sensitivity (default 0.1)
+  maxDiffPixelRatio: route.conformityRatio, // aggregate pass criterion (default 0.05)
+});
+```
+
+Definitions:
+
+| Parameter | Meaning | Default |
+|-----------|---------|---------|
+| `threshold` | Per-pixel YIQ color-space delta below which two pixels are considered identical. Range `[0, 1]`. Lower = stricter. | `0.1` |
+| `maxDiffPixelRatio` | `mismatchedPixels / totalPixels` must be **less than** this for the test to pass. Range `[0, 1]`. | `0.05` |
+
+### Numerical example
+
+A 1280×720 viewport has **921,600** total pixels. With `maxDiffPixelRatio: 0.05` (5%):
+
+- Pass: ≤ 46,080 pixels differ (after `threshold` filter)
+- Fail: ≥ 46,081 pixels differ
+
+If a route has tight margins (e.g. complex gradients that always anti-alias differently), override per route in `mockup-ownership.bootstrap.json`:
+
+```json
+{
+  "id": "library",
+  "conformityRatio": 0.08,
+  "threshold": 0.15
+}
+```
+
+Both fields are validated to `[0, 1]` by the loader. Tighter overrides (lower values) are encouraged once a route stabilizes.
+
+## Default viewports
+
+Bootstrap defaults match the canonical mockup viewports:
+
+| Viewport | Dimensions | Source |
+|----------|------------|--------|
+| `desktop` | 1280×720 | Wave B/C/D pattern |
+| `mobile` | 375×740 | Wave B/C/D pattern |
+
+Routes can override per-viewport (e.g. add `tablet`) via `viewports[]` on the route entry.
+
+## Editing the ownership map
+
+1. Edit `apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json`. The file references `mockup-ownership.schema.json` via `$schema` — your IDE will validate inline.
+2. Run the loader test to confirm the change is valid:
+   ```bash
+   cd apps/web
+   pnpm vitest run scripts/__tests__/conformity-ownership.test.ts
+   ```
+3. Commit the JSON change. Once Phase 3 ships, the workflow will pick up the change automatically.
+
+### Adding a new route
+
+Append to `routes[]`:
+
+```json
+{
+  "id": "sessions-live",
+  "livePath": "/sessions/{sessionId}/live",
+  "liveFixture": { "sessionId": "demo-session" },
+  "mockup": "sp4-session-live.html",
+  "triggerPaths": [
+    "apps/web/src/app/(authenticated)/sessions/[sessionId]/live/**",
+    "apps/web/src/components/features/sessions/**"
+  ],
+  "notes": "Wave D.2 (PR #749 + #753 + #754)"
+}
+```
+
+Rules enforced by the loader:
+
+- `id` must be unique and match `^[a-z][a-z0-9-]*$` (slug)
+- `livePath` must start with `/`
+- Every `{placeholder}` in `livePath` must have a matching key in `liveFixture`
+- `mockup` must end with `.html` (relative to `admin-mockups/design_files/`)
+- `triggerPaths` must be a non-empty array of globs
+
+Adding a route does **not** yet make Phase 3 enforce it — until the workflow ships, this is data-only.
+
+## What ships in Phases 2/3/4
+
+| Phase | Deliverable |
+|-------|-------------|
+| **2** | `playwright.config.ts` projects `conformity-desktop` + `conformity-mobile`; `apps/web/e2e/visual-conformity/library.spec.ts` + `library-game-detail.spec.ts`; font lock in `serve-mockups.cjs` (AC-C.8) |
+| **3** | `.github/workflows/visual-regression-conformity.yml` (gate) + `bootstrap-mockup-baselines.yml` (manual + auto-trigger on mockup change); committed `__mockup__/*.png` baselines |
+| **4** | `docs/for-developers/audits/conformity-waivers.md` audit log; waiver issue automation (AC-C.5) |
+
+## References
+
+- Umbrella: [#1066](https://github.com/meepleAi-app/meepleai-monorepo/issues/1066)
+- WS-C issue: [#1069](https://github.com/meepleAi-app/meepleai-monorepo/issues/1069)
+- Spec: `docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md` §3 WS-C
+- Sibling: `docs/for-developers/testing/frontend/visual-state-coverage.md` (WS-D Foundation)


### PR DESCRIPTION
## Summary

Phase 1 di **WS-C** (Mockup Conformity Gate, umbrella #1066) — foundation di configurazione che Phase 2/3 consumeranno.

- JSON Schema + bootstrap config con 2 route (AC-C.7)
- Loader TypeScript con 18/18 unit test verdi
- Doc `mockup-conformity.md` con formula AC-C.2 + esempio numerico

## What's in this PR

| File | Purpose |
|------|---------|
| `apps/web/e2e/visual-conformity/mockup-ownership.schema.json` | JSON Schema v1, strict mode |
| `apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json` | Bootstrap: `/library` + `/library/{gameId}` |
| `apps/web/scripts/conformity-ownership.ts` | Loader + validator + default merger + `resolveLivePath()` |
| `apps/web/scripts/__tests__/conformity-ownership.test.ts` | 18 test cases (happy + 12 invalid inputs + URL encoding) |
| `docs/for-developers/testing/frontend/mockup-conformity.md` | Doc Phase 1 + roadmap Phase 2/3/4 |

## Architecture note

Lo spec deliverable §5 originale menzionava `conformity-runner.ts` per orchestrare diff. Durante Phase 1 ho realizzato che **Playwright `toHaveScreenshot({ threshold, maxDiffPixelRatio })` implementa esattamente la formula AC-C.2 nativamente** (usa pixelmatch sotto). Quindi:

- ❌ Skipped: custom runner (zero value-add vs Playwright primitive)
- ✅ "Runner" diventa lo spec Playwright stesso in Phase 2

Doc cattura questa scelta di design. AC-C.2 formula resta autoritativa.

## Phase roadmap (post-merge)

| Phase | Scope | ACs |
|-------|-------|------|
| **2** | Playwright projects + 2 specs + `serve-mockups` font lock | C.8 (font determinism), parziale C.2 |
| **3** | Workflows `visual-regression-conformity.yml` + `bootstrap-mockup-baselines.yml` + committed `__mockup__/*.png` | C.1, C.3, C.4, C.6, C.9 |
| **4** | `conformity-waivers.md` audit log + waiver automation | C.5 |

## Test plan

- [x] `pnpm vitest run scripts/__tests__/conformity-ownership.test.ts` — 18/18 verde
- [x] `pnpm typecheck` — green
- [x] Pre-commit hook (lint-staged + prettier + tsc) — green
- [ ] CI checks su PR

## Refs

- Refs #1069 (WS-C, parziale — Phase 1 di 4)
- Refs #1066 (umbrella)
- Sibling: WS-D Foundation pattern in `extract-mockup-states.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
