### PR TITLE
refactor(web): extract getSsrMessages helper — closes #1101

### DIFF
--- a/apps/web/src/app/(public)/shared-games/[id]/page.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.tsx
@@ -24,8 +24,8 @@ import {
   type SharedGameDetailV2,
   type TopContributor,
 } from '@/lib/api/shared-games';
+import { getSsrMessages } from '@/lib/i18n/ssr';
 import { tryLoadVisualTestFixture } from '@/lib/shared-games/visual-test-fixture';
-import itMessages from '@/locales/it.json';
 
 import { SharedGameDetailPageClient } from './page-client';
 
@@ -34,12 +34,12 @@ import type { Metadata } from 'next';
 export const revalidate = 60;
 
 /**
- * SSR-safe i18n metadata source. The `IntlProvider` only runs in the
- * client tree, so `generateMetadata` cannot use `useTranslations`.
- * We import the IT catalogue (project default — see `locales/index.ts`
- * `DEFAULT_LOCALE = LOCALES.IT`) directly. Wave A.4 follow-up — Issue #617.
+ * SSR-safe i18n metadata source. `generateMetadata` runs server-side
+ * (outside the `IntlProvider` client tree), so we resolve labels via
+ * the static helper. Wave A.4 follow-up — Issue #617; helper extracted
+ * in Issue #1101.
  */
-const SSR_METADATA = itMessages.pages.sharedGameDetail.metadata;
+const SSR_METADATA = getSsrMessages('pages.sharedGameDetail.metadata');
 
 interface SharedGameDetailRouteParams {
   readonly id: string;

--- a/apps/web/src/app/_not-found-content.tsx
+++ b/apps/web/src/app/_not-found-content.tsx
@@ -1,23 +1,9 @@
 import type { JSX } from 'react';
 
 import { HeroGradient } from '@/components/ui/hero-gradient';
-import itMessages from '@/locales/it.json';
+import { getSsrMessages } from '@/lib/i18n/ssr';
 
-/**
- * SSR-safe i18n source. `IntlProvider` only mounts on the client (see
- * `apps/web/src/app/providers.tsx`), so any component reachable during
- * Next.js SSR — including the global 404 — must NOT use `useTranslation()`,
- * otherwise hydration produces React error #418 (mismatch between the
- * server-rendered message-id key and the client-rendered translation).
- *
- * Pattern mirrors `apps/web/src/app/(public)/shared-games/[id]/page.tsx`
- * (Wave A.4 follow-up — Issue #617). Closes Issue #1076.
- *
- * NOTE: Hardcodes IT locale (project default — `LOCALES.IT`). When SSR
- * locale negotiation is introduced, refactor to read locale from headers
- * and conditionally pick `it.json` vs `en.json` (Issue #1076 AC-4 / TBD).
- */
-const NOT_FOUND_MESSAGES = itMessages.pages.errors.notFound;
+const NOT_FOUND_MESSAGES = getSsrMessages('pages.errors.notFound');
 
 export function NotFoundContent(): JSX.Element {
   return (

--- a/apps/web/src/lib/i18n/__tests__/ssr.test.ts
+++ b/apps/web/src/lib/i18n/__tests__/ssr.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for the SSR-safe i18n helper (Issue #1101).
+ */
+import { describe, expect, it } from 'vitest';
+
+import itMessages from '@/locales/it.json';
+import { getSsrMessages } from '@/lib/i18n/ssr';
+
+describe('getSsrMessages', () => {
+  it('returns the IT subtree for a known path', () => {
+    const subtree = getSsrMessages('pages.errors.notFound');
+
+    expect(subtree).toEqual(itMessages.pages.errors.notFound);
+    expect(subtree.title).toBe('Pagina non trovata');
+    expect(subtree.eyebrow).toBe('404');
+    expect(subtree.homeCta).toBe('Torna alla home');
+  });
+
+  it('resolves a deeply-nested object path', () => {
+    const subtree = getSsrMessages('pages.sharedGameDetail.metadata');
+
+    expect(subtree).toEqual(itMessages.pages.sharedGameDetail.metadata);
+    expect(typeof subtree).toBe('object');
+  });
+
+  it('returns the same reference as the static import (no defensive copying)', () => {
+    const subtree = getSsrMessages('pages.errors.notFound');
+
+    expect(subtree).toBe(itMessages.pages.errors.notFound);
+  });
+
+  it('throws when the runtime catalogue is missing the requested path', () => {
+    // We bypass the compile-time check to simulate a stale type definition.
+    // In production this branch only fires if `it.json` is edited without
+    // updating the types that consumers rely on — a build-time mismatch.
+    const stalePath = 'pages.errors.thisKeyDoesNotExist' as never;
+
+    expect(() => getSsrMessages(stalePath)).toThrow(
+      /path "pages\.errors\.thisKeyDoesNotExist" does not exist/
+    );
+    expect(() => getSsrMessages(stalePath)).toThrow(/failed at segment "thisKeyDoesNotExist"/);
+  });
+
+  it('throws with the failing segment name when the path bottoms out early', () => {
+    const stalePath = 'pages.nope.something' as never;
+
+    expect(() => getSsrMessages(stalePath)).toThrow(/failed at segment "nope"/);
+  });
+});

--- a/apps/web/src/lib/i18n/ssr.ts
+++ b/apps/web/src/lib/i18n/ssr.ts
@@ -1,0 +1,84 @@
+/**
+ * SSR-safe i18n helper.
+ *
+ * The client-side `IntlProvider` is only mounted on the client (see
+ * `apps/web/src/app/providers.tsx`). Components reached during SSR —
+ * server components, `generateMetadata` exports, the global 404, etc. —
+ * cannot use `useTranslation()` without producing React error #418 on
+ * hydration: SSR renders the raw message-id keys while the client
+ * renders the translated strings.
+ *
+ * This helper resolves localized strings statically from the IT
+ * locale catalogue and is safe to call in any server context.
+ *
+ * @example
+ * ```ts
+ * const NOT_FOUND = getSsrMessages('pages.errors.notFound');
+ * // NOT_FOUND.title === 'Pagina non trovata'
+ *
+ * const META = getSsrMessages('pages.sharedGameDetail.metadata');
+ * ```
+ *
+ * The path argument is type-safe: typos and stale references fail
+ * compilation. When SSR locale negotiation lands (Issue #1103), the
+ * signature will gain an optional `locale` parameter and this helper
+ * becomes the single switching point for every SSR callsite.
+ *
+ * @see Issue #1101 (helper extraction)
+ * @see Issue #1076 (root cause)
+ * @see Issue #1103 (future locale negotiation)
+ */
+
+import itMessages from '@/locales/it.json';
+
+type Messages = typeof itMessages;
+
+/**
+ * Recursive dot-path keys over the message catalogue. Excludes leaves
+ * (strings, arrays) so consumers can only ask for object subtrees;
+ * leaf access happens via the returned object's property syntax, which
+ * preserves better IDE support and reads more naturally at call sites.
+ */
+type DotPath<T, Prefix extends string = ''> =
+  T extends Record<string, unknown>
+    ? {
+        [K in keyof T & string]:
+          | (T[K] extends Record<string, unknown> ? `${Prefix}${K}` : never)
+          | (T[K] extends Record<string, unknown> ? DotPath<T[K], `${Prefix}${K}.`> : never);
+      }[keyof T & string]
+    : never;
+
+/** Resolve a dot-path against the catalogue and return the deeply-typed value. */
+type Resolve<T, P extends string> = P extends `${infer Head}.${infer Rest}`
+  ? Head extends keyof T
+    ? Resolve<T[Head], Rest>
+    : never
+  : P extends keyof T
+    ? T[P]
+    : never;
+
+/** All valid dot-paths that resolve to an object subtree of the catalogue. */
+export type SsrMessagesPath = DotPath<Messages>;
+
+/**
+ * Returns the deeply-typed object subtree at `path` from the IT message
+ * catalogue. Compile error on unknown paths.
+ *
+ * @throws {Error} if the runtime catalogue is missing a path that the
+ * compiler thought existed. This indicates `it.json` was modified
+ * without keeping the type system in sync — fix the catalogue, not the
+ * call site.
+ */
+export function getSsrMessages<P extends SsrMessagesPath>(path: P): Resolve<Messages, P> {
+  const segments = path.split('.');
+  let cursor: unknown = itMessages;
+  for (const segment of segments) {
+    if (typeof cursor !== 'object' || cursor === null || !(segment in cursor)) {
+      throw new Error(
+        `getSsrMessages: path "${path}" does not exist in it.json (failed at segment "${segment}")`
+      );
+    }
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor as Resolve<Messages, P>;
+}


### PR DESCRIPTION
## Summary

Consolidate the SSR-safe i18n pattern across the 3 known callsites discovered by audit #1102 into a single typed helper.

**Before**: each callsite imported \`@/locales/it.json\` directly and walked the object literal.
**After**: \`getSsrMessages('pages.errors.notFound')\` — typed dot-path, compile error on typos.

## Callsites migrated

| File | Before | After |
|------|--------|-------|
| \`app/_not-found-content.tsx\` | \`itMessages.pages.errors.notFound\` | \`getSsrMessages('pages.errors.notFound')\` |
| \`app/(public)/shared-games/[id]/page.tsx\` | \`itMessages.pages.sharedGameDetail.metadata\` | \`getSsrMessages('pages.sharedGameDetail.metadata')\` |

(The second file had two consumers — \`generateMetadata\` and a module-level constant — both consuming the same import. One migration covers both.)

## Design

Minimal scope per spec-panel recommendation (Fowler + Newman synthesis, PR #1100 follow-up). Audit #1102 confirmed **zero additional latent #418 bugs** in the codebase, so a wider migration would have been YAGNI.

Helper signature:
\`\`\`ts
function getSsrMessages<P extends SsrMessagesPath>(path: P): Resolve<Messages, P>
\`\`\`

- \`P\` is a dot-path generated from the \`typeof itMessages\` structure (object subtrees only — strings/arrays/leaves rejected at compile time to keep call sites idiomatic)
- Return type is the deeply-typed subtree
- Runtime throw with precise segment trace if \`it.json\` drifts from the types (build-time guard against catalogue edits that bypass the type system)

## Test plan

- [x] 5 new unit tests in \`apps/web/src/lib/i18n/__tests__/ssr.test.ts\` (happy path, deep nesting, reference identity, two runtime-failure paths)
- [x] All 5 regression tests from #1076 still pass (\`apps/web/src/app/__tests__/not-found.test.tsx\`)
- [x] All 12 shared-games page tests still pass
- [x] \`pnpm typecheck\` clean

## Future work (when SSR locale negotiation lands — #1103)

Signature extends to \`getSsrMessages(path, locale?)\`. Until then, single locale (\`it.json\`) is correct behaviour.

## Refs

- Closes #1101
- #1076 / PR #1100 (first consumer)
- #617 (sister callsite in shared-games)
- Audit #1102 / PR #1106 (informed the minimum-viable design)
- #1103 (deferred — this helper becomes the locale switching point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)