### PR TITLE
chore(web): remove force-dynamic from not-found.tsx — closes #1104

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -2,11 +2,6 @@ import { Metadata } from 'next';
 
 import { NotFoundContent } from './_not-found-content';
 
-// NOTE: `export const dynamic = 'force-dynamic'` is retained per spec risk #1
-// (known Next.js 16 DOMMatrix bug with client imports in not-found.tsx). If
-// `pnpm build` succeeds without it, remove in a follow-up — not in this task.
-export const dynamic = 'force-dynamic';
-
 export const metadata: Metadata = {
   title: 'Pagina non trovata | MeepleAI',
   description: 'La pagina che stai cercando non esiste o è stata spostata.',


### PR DESCRIPTION
## Summary

Remove the \`export const dynamic = 'force-dynamic'\` workaround from \`apps/web/src/app/not-found.tsx\`. The 404 page is now statically prerendered.

## Background

The directive was added as a workaround for a Next.js 16 DOMMatrix bug triggered by **client imports** in \`not-found.tsx\`. Its own comment (L5-8) explicitly invited removal once the trigger was gone:

> \"If \`pnpm build\` succeeds without it, remove in a follow-up — not in this task.\"

After PR #1100 (Issue #1076), \`NotFoundContent\` is a server component. After PR #1107 (Issue #1101), it consumes the SSR-safe helper. The DOMMatrix trigger (client imports) no longer applies.

## Verification

Local \`pnpm build\` output:

\`\`\`
Before: ƒ /_not-found      (Dynamic — server-rendered on demand)
After:  ○ /_not-found      (Static — prerendered at build time)
\`\`\`

Effects:
- Restores CDN cacheability of the most-frequently-hit error page
- Eliminates per-request render cost for 404s
- Removes an outdated workaround comment

## Test plan

- [x] \`pnpm build\` succeeds
- [x] Build output shows \`○ /_not-found\` (static)
- [x] \`pnpm typecheck\` clean
- [ ] Manual verify in deployed dev: \`/this-does-not-exist\` still renders 404 correctly
- [ ] CI: full FE suite green

## Rollback plan

If Next.js still has the DOMMatrix bug in some unforeseen way, revert this commit. The directive can be re-added in seconds and the page returns to dynamic rendering.

## Refs

- Closes #1104
- #1076 / PR #1100 (made \`NotFoundContent\` a server component)
- #1101 / PR #1107 (helper migration reinforcing server-only nature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)