### PR TITLE
feat(detail-layout): DetailPageLayout composer primitive (Stage 3 — cross-cutting)

### DIFF
--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * DetailPageLayout — Stage 3 composer primitive (Issue #1026).
+ *
+ * Tests verify slot ordering, conditional rendering, landmark a11y, and
+ * className passthrough. The composer is a pure slot-arranger: tests do not
+ * exercise any business logic because the component contains none.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DetailPageLayout } from './DetailPageLayout';
+
+describe('DetailPageLayout', () => {
+  it('renders header and main with only hero + children (other slots omitted)', () => {
+    render(
+      <DetailPageLayout hero={<span>hero-content</span>}>
+        <p>main-content</p>
+      </DetailPageLayout>,
+    );
+
+    expect(screen.getByRole('banner')).toHaveTextContent('hero-content');
+    expect(screen.getByRole('main')).toHaveTextContent('main-content');
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+  });
+
+  it('renders all five landmarks in DOM order: hero → aside → nav → main → footer', () => {
+    const { container } = render(
+      <DetailPageLayout
+        hero={<span data-testid="slot-hero">H</span>}
+        connections={<span data-testid="slot-connections">C</span>}
+        tabs={<span data-testid="slot-tabs">T</span>}
+        footer={<span data-testid="slot-footer">F</span>}
+      >
+        <span data-testid="slot-main">M</span>
+      </DetailPageLayout>,
+    );
+
+    const order = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid^="slot-"]'),
+    ).map((node) => node.dataset.testid);
+
+    expect(order).toEqual([
+      'slot-hero',
+      'slot-connections',
+      'slot-tabs',
+      'slot-main',
+      'slot-footer',
+    ]);
+  });
+});

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
@@ -50,4 +50,31 @@ describe('DetailPageLayout', () => {
       'slot-footer',
     ]);
   });
+
+  it('omits the <aside> when connections is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
+  it('omits the <nav> when tabs is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('omits the <footer> when footer is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
@@ -77,4 +77,23 @@ describe('DetailPageLayout', () => {
     );
     expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
   });
+
+  it('exposes accessible names on the non-trivial landmarks', () => {
+    render(
+      <DetailPageLayout
+        hero={<span>H</span>}
+        connections={<span>C</span>}
+        tabs={<span>T</span>}
+        footer={<span>F</span>}
+      >
+        <span>M</span>
+      </DetailPageLayout>,
+    );
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('complementary', { name: /related entities/i })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: /detail sections/i })).toBeInTheDocument();
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
@@ -96,4 +96,43 @@ describe('DetailPageLayout', () => {
     expect(screen.getByRole('main')).toBeInTheDocument();
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
+
+  it('passes the className prop through to the root wrapper', () => {
+    const { container } = render(
+      <DetailPageLayout hero={<span>H</span>} className="custom-layout-class">
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(root).toHaveClass('custom-layout-class');
+    // base utilities from the component itself are also present
+    expect(root).toHaveClass('flex');
+    expect(root).toHaveClass('flex-col');
+  });
+
+  it('places a focusable element from each slot in source order', () => {
+    const { container } = render(
+      <DetailPageLayout
+        hero={<button type="button">hero-btn</button>}
+        connections={<button type="button">connections-btn</button>}
+        tabs={<button type="button">tabs-btn</button>}
+        footer={<button type="button">footer-btn</button>}
+      >
+        <button type="button">main-btn</button>
+      </DetailPageLayout>,
+    );
+
+    const labels = Array.from(container.querySelectorAll('button')).map(
+      (b) => b.textContent,
+    );
+    expect(labels).toEqual([
+      'hero-btn',
+      'connections-btn',
+      'tabs-btn',
+      'main-btn',
+      'footer-btn',
+    ]);
+  });
 });

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
@@ -135,4 +135,17 @@ describe('DetailPageLayout', () => {
       'footer-btn',
     ]);
   });
+
+  it('renders the aside wrapper when connections is null (explicit caller intent)', () => {
+    // Contract pin (spec-panel review 2026-05-13 / Crispin): the conditional
+    // is `connections !== undefined`, not truthy. A caller passing `null`
+    // explicitly signals "render the wrapper region" — distinct from
+    // omitting the prop entirely.
+    render(
+      <DetailPageLayout hero={<span>H</span>} connections={null}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.getByRole('complementary', { name: /related entities/i })).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx
@@ -35,7 +35,7 @@ export function DetailPageLayout({
   className,
 }: DetailPageLayoutProps): JSX.Element {
   return (
-    <div className={clsx('flex flex-col gap-6', className)}>
+    <div data-slot="detail-page-layout" className={clsx('flex flex-col gap-6', className)}>
       <header>{hero}</header>
       {connections !== undefined && (
         <aside aria-label="related entities">{connections}</aside>

--- a/apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx
+++ b/apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx
@@ -1,0 +1,48 @@
+/**
+ * DetailPageLayout — composer primitive for entity detail pages.
+ *
+ * Stage 3 cross-cutting (Issue #1026, umbrella #1023). Arranges hero,
+ * connections, tabs, main content and footer ReactNode slots with WAI-ARIA
+ * landmarks. The composer has no state and no business logic; callers pass
+ * already-rendered children for each slot.
+ */
+
+import type { JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+export interface DetailPageLayoutProps {
+  /** Required slot rendered inside the page `<header>` (banner landmark). */
+  readonly hero: ReactNode;
+  /** Optional slot rendered inside an `<aside>` with accessible name "related entities". */
+  readonly connections?: ReactNode;
+  /** Optional slot rendered inside a `<nav>` with accessible name "detail sections". */
+  readonly tabs?: ReactNode;
+  /** Main content — tab panels or flat sections — rendered inside `<main>`. */
+  readonly children: ReactNode;
+  /** Optional slot rendered inside the page `<footer>` (contentinfo landmark). */
+  readonly footer?: ReactNode;
+  /** Optional passthrough class applied to the root wrapper. */
+  readonly className?: string;
+}
+
+export function DetailPageLayout({
+  hero,
+  connections,
+  tabs,
+  children,
+  footer,
+  className,
+}: DetailPageLayoutProps): JSX.Element {
+  return (
+    <div className={clsx('flex flex-col gap-6', className)}>
+      <header>{hero}</header>
+      {connections !== undefined && (
+        <aside aria-label="related entities">{connections}</aside>
+      )}
+      {tabs !== undefined && <nav aria-label="detail sections">{tabs}</nav>}
+      <main>{children}</main>
+      {footer !== undefined && <footer>{footer}</footer>}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/detail-layout/index.ts
+++ b/apps/web/src/components/ui/detail-layout/index.ts
@@ -1,8 +1,14 @@
 /**
- * Wave A.4 (Issue #603) — V2 component family for /shared-games/[id].
+ * Detail-layout primitives.
  *
- * Public API barrel. Consumed by `apps/web/src/app/(public)/shared-games/[id]/page-client.tsx`
- * and Vitest unit tests under `apps/web/src/__tests__/components/ui/v2/shared-game-detail/`.
+ * Wave A.4 (Issue #603) shipped the pieces (Hero, Tabs, StickyCta,
+ * ContributorsStrip, AgentListItem, KbDocItem, ToolkitListItem, and the
+ * EmptyState / ErrorState / NotFoundState family).
+ *
+ * Stage 3 (Issue #1026) adds the DetailPageLayout composer that arranges
+ * these pieces with WAI-ARIA landmarks. The composer is consumer-agnostic:
+ * each slot accepts a ReactNode, so callers can use any of the primitives
+ * above (or none) without the composer knowing.
  */
 
 export { AgentListItem } from '@/components/ui/detail-layout/agent-list-item';
@@ -60,3 +66,6 @@ export type {
   ToolkitListItemLabels,
   ToolkitListItemProps,
 } from '@/components/ui/detail-layout/toolkit-list-item';
+
+export { DetailPageLayout } from './DetailPageLayout';
+export type { DetailPageLayoutProps } from './DetailPageLayout';

--- a/docs/superpowers/plans/2026-05-13-detail-page-layout.md
+++ b/docs/superpowers/plans/2026-05-13-detail-page-layout.md
@@ -157,7 +157,7 @@ export function DetailPageLayout({
   className,
 }: DetailPageLayoutProps): JSX.Element {
   return (
-    <div className={clsx('flex flex-col gap-6', className)}>
+    <div data-slot="detail-page-layout" className={clsx('flex flex-col gap-6', className)}>
       <header>{hero}</header>
       {connections !== undefined && (
         <aside aria-label="related entities">{connections}</aside>

--- a/docs/superpowers/plans/2026-05-13-detail-page-layout.md
+++ b/docs/superpowers/plans/2026-05-13-detail-page-layout.md
@@ -1,0 +1,532 @@
+# DetailPageLayout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a tiny composer primitive `DetailPageLayout` that arranges hero / connections / tabs / main / footer ReactNode slots with WAI-ARIA landmarks, unblocking Stage 3 cluster work (#1026).
+
+**Architecture:** Pure slot-arranger React component. Zero state, zero business logic, zero coupling to other primitives' types. Wrapped in landmark HTML elements (`<header>`, `<aside>`, `<nav>`, `<main>`, `<footer>`) with accessible names on the non-trivial ones. Tailwind utility classes only — no hard-coded colors or spacing.
+
+**Tech Stack:** React 19, TypeScript, Tailwind 4, `clsx` for class composition, Vitest + React Testing Library for unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-detail-page-layout-design.md`
+
+**Branch (already created):** `feature/issue-1026-stage3-detail-page-layout` (parent: `main-dev`)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` | The composer component + exported props interface |
+| `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` | Eight Vitest unit tests covering minimal render, full render, conditional slots, landmark names, className passthrough, reading order |
+| `apps/web/src/components/ui/detail-layout/index.ts` | Barrel: append two named exports for the new component and its props type; replace the leading JSDoc with text that mentions the Stage 3 addition |
+
+No other files. No test fixtures. No new dependencies (`clsx` is already a workspace dependency, RTL + Vitest are already set up in `apps/web`).
+
+---
+
+## Preamble — Commit the plan itself
+
+Before starting Task 1, commit this plan document so that the diff guard in Step 6.2 sees both the spec and the plan as expected files (they were created during brainstorming + writing-plans phases, not during implementation).
+
+```bash
+git add docs/superpowers/plans/2026-05-13-detail-page-layout.md
+git commit -m "docs(plans): DetailPageLayout implementation plan (refs #1026)"
+```
+
+---
+
+## Task 1 — Failing tests scaffold + minimal passing render
+
+**Files:**
+- Create: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx`
+- Create: `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx`
+
+This task seeds the test file with the first two tests (minimal render + full render ordering), watches them fail, then writes the minimal component that makes both pass. The component grows in later tasks as more tests get added.
+
+- [ ] **Step 1.1: Create the failing test file**
+
+Path: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx`
+
+```tsx
+/**
+ * DetailPageLayout — Stage 3 composer primitive (Issue #1026).
+ *
+ * Tests verify slot ordering, conditional rendering, landmark a11y, and
+ * className passthrough. The composer is a pure slot-arranger: tests do not
+ * exercise any business logic because the component contains none.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DetailPageLayout } from './DetailPageLayout';
+
+describe('DetailPageLayout', () => {
+  it('renders header and main with only hero + children (other slots omitted)', () => {
+    render(
+      <DetailPageLayout hero={<span>hero-content</span>}>
+        <p>main-content</p>
+      </DetailPageLayout>,
+    );
+
+    expect(screen.getByRole('banner')).toHaveTextContent('hero-content');
+    expect(screen.getByRole('main')).toHaveTextContent('main-content');
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+  });
+
+  it('renders all five landmarks in DOM order: hero → aside → nav → main → footer', () => {
+    const { container } = render(
+      <DetailPageLayout
+        hero={<span data-testid="slot-hero">H</span>}
+        connections={<span data-testid="slot-connections">C</span>}
+        tabs={<span data-testid="slot-tabs">T</span>}
+        footer={<span data-testid="slot-footer">F</span>}
+      >
+        <span data-testid="slot-main">M</span>
+      </DetailPageLayout>,
+    );
+
+    const order = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid^="slot-"]'),
+    ).map((node) => node.dataset.testid);
+
+    expect(order).toEqual([
+      'slot-hero',
+      'slot-connections',
+      'slot-tabs',
+      'slot-main',
+      'slot-footer',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test file and confirm it fails**
+
+Run from `apps/web/`:
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --run
+```
+
+Expected: tests fail with a module-resolution error (`Cannot find module './DetailPageLayout'`). This is the failing state for both tests.
+
+- [ ] **Step 1.3: Create the minimal component**
+
+Path: `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx`
+
+```tsx
+/**
+ * DetailPageLayout — composer primitive for entity detail pages.
+ *
+ * Stage 3 cross-cutting (Issue #1026, umbrella #1023). Arranges hero,
+ * connections, tabs, main content and footer ReactNode slots with WAI-ARIA
+ * landmarks. The composer has no state and no business logic; callers pass
+ * already-rendered children for each slot.
+ */
+
+import type { JSX, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+export interface DetailPageLayoutProps {
+  /** Required slot rendered inside the page `<header>` (banner landmark). */
+  readonly hero: ReactNode;
+  /** Optional slot rendered inside an `<aside>` with accessible name "related entities". */
+  readonly connections?: ReactNode;
+  /** Optional slot rendered inside a `<nav>` with accessible name "detail sections". */
+  readonly tabs?: ReactNode;
+  /** Main content — tab panels or flat sections — rendered inside `<main>`. */
+  readonly children: ReactNode;
+  /** Optional slot rendered inside the page `<footer>` (contentinfo landmark). */
+  readonly footer?: ReactNode;
+  /** Optional passthrough class applied to the root wrapper. */
+  readonly className?: string;
+}
+
+export function DetailPageLayout({
+  hero,
+  connections,
+  tabs,
+  children,
+  footer,
+  className,
+}: DetailPageLayoutProps): JSX.Element {
+  return (
+    <div className={clsx('flex flex-col gap-6', className)}>
+      <header>{hero}</header>
+      {connections !== undefined && (
+        <aside aria-label="related entities">{connections}</aside>
+      )}
+      {tabs !== undefined && <nav aria-label="detail sections">{tabs}</nav>}
+      <main>{children}</main>
+      {footer !== undefined && <footer>{footer}</footer>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 1.4: Run the tests again and confirm both pass**
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --run
+```
+
+Expected: 2 passing, 0 failing.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx \
+        apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+git commit -m "feat(detail-layout): DetailPageLayout composer minimal slot order (refs #1026)"
+```
+
+---
+
+## Task 2 — Conditional slot rendering (3 tests)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` (append 3 tests)
+
+The component already supports conditional slots from Task 1, so these tests should pass immediately when added. We add them anyway because they document the contract per the spec §7.
+
+- [ ] **Step 2.1: Append three tests to the existing `describe('DetailPageLayout', () => {})` block**
+
+Insert before the closing `});` of the describe block:
+
+```tsx
+  it('omits the <aside> when connections is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+
+  it('omits the <nav> when tabs is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('omits the <footer> when footer is undefined', () => {
+    render(
+      <DetailPageLayout hero={<span>H</span>}>
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+    expect(screen.queryByRole('contentinfo')).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2.2: Run the test file and confirm all 5 pass**
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --run
+```
+
+Expected: 5 passing, 0 failing.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+git commit -m "test(detail-layout): document conditional slot omission contract (refs #1026)"
+```
+
+---
+
+## Task 3 — Landmark accessible names (1 test)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` (append 1 test)
+
+Spec §6 mandates accessible names on the `<aside>` ("related entities") and `<nav>` ("detail sections"). The implementation from Task 1 already provides them; this test pins the contract.
+
+- [ ] **Step 3.1: Append the landmark-name test**
+
+Insert before the closing `});`:
+
+```tsx
+  it('exposes accessible names on the non-trivial landmarks', () => {
+    render(
+      <DetailPageLayout
+        hero={<span>H</span>}
+        connections={<span>C</span>}
+        tabs={<span>T</span>}
+        footer={<span>F</span>}
+      >
+        <span>M</span>
+      </DetailPageLayout>,
+    );
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('complementary', { name: /related entities/i })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: /detail sections/i })).toBeInTheDocument();
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 3.2: Run the test file and confirm all 6 pass**
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --run
+```
+
+Expected: 6 passing, 0 failing.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+git commit -m "test(detail-layout): pin aria-label contract on aside + nav (refs #1026)"
+```
+
+---
+
+## Task 4 — className passthrough + reading order (2 tests)
+
+**Files:**
+- Modify: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` (append 2 tests)
+
+- [ ] **Step 4.1: Append the className passthrough test**
+
+Insert before the closing `});`:
+
+```tsx
+  it('passes the className prop through to the root wrapper', () => {
+    const { container } = render(
+      <DetailPageLayout hero={<span>H</span>} className="custom-layout-class">
+        <p>M</p>
+      </DetailPageLayout>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(root).toHaveClass('custom-layout-class');
+    // base utilities from the component itself are also present
+    expect(root).toHaveClass('flex');
+    expect(root).toHaveClass('flex-col');
+  });
+```
+
+- [ ] **Step 4.2: Append the reading-order test using focusable elements**
+
+```tsx
+  it('places a focusable element from each slot in source order', () => {
+    const { container } = render(
+      <DetailPageLayout
+        hero={<button type="button">hero-btn</button>}
+        connections={<button type="button">connections-btn</button>}
+        tabs={<button type="button">tabs-btn</button>}
+        footer={<button type="button">footer-btn</button>}
+      >
+        <button type="button">main-btn</button>
+      </DetailPageLayout>,
+    );
+
+    const labels = Array.from(container.querySelectorAll('button')).map(
+      (b) => b.textContent,
+    );
+    expect(labels).toEqual([
+      'hero-btn',
+      'connections-btn',
+      'tabs-btn',
+      'main-btn',
+      'footer-btn',
+    ]);
+  });
+```
+
+- [ ] **Step 4.3: Run the test file and confirm all 8 pass**
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --run
+```
+
+Expected: 8 passing, 0 failing.
+
+- [ ] **Step 4.4: Run coverage on this file and confirm 100% line + branch**
+
+```bash
+pnpm test src/components/ui/detail-layout/DetailPageLayout.test.tsx --coverage --run
+```
+
+Expected: in the coverage table, `DetailPageLayout.tsx` shows 100% lines, 100% branches, 100% functions.
+
+If the project uses a coverage-config that does not include this file path by default, check `apps/web/vitest.config.ts` and verify the include glob picks up `src/components/ui/detail-layout/**/*.tsx`. Adjust the run flag to target the coverage report scope if needed (e.g. `--coverage.include='src/components/ui/detail-layout/DetailPageLayout.tsx'`).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+git commit -m "test(detail-layout): className passthrough + reading order (refs #1026)"
+```
+
+---
+
+## Task 5 — Wire into the barrel export
+
+**Files:**
+- Modify: `apps/web/src/components/ui/detail-layout/index.ts`
+
+- [ ] **Step 5.1: Read the existing `index.ts` to confirm its current layout**
+
+```bash
+cat apps/web/src/components/ui/detail-layout/index.ts
+```
+
+Confirm the first lines contain the JSDoc starting with `/**` then `* Wave A.4 (Issue #603) — V2 component family for /shared-games/[id].` and exports start with `export { AgentListItem } ...`.
+
+- [ ] **Step 5.2: Replace the leading JSDoc and append the two new exports**
+
+Replace the leading JSDoc block (the comment that currently reads `Wave A.4 (Issue #603) — V2 component family for /shared-games/[id].`) with:
+
+```ts
+/**
+ * Detail-layout primitives.
+ *
+ * Wave A.4 (Issue #603) shipped the pieces (Hero, Tabs, StickyCta,
+ * ContributorsStrip, AgentListItem, KbDocItem, ToolkitListItem, and the
+ * EmptyState / ErrorState / NotFoundState family).
+ *
+ * Stage 3 (Issue #1026) adds the DetailPageLayout composer that arranges
+ * these pieces with WAI-ARIA landmarks. The composer is consumer-agnostic:
+ * each slot accepts a ReactNode, so callers can use any of the primitives
+ * above (or none) without the composer knowing.
+ */
+```
+
+Then append at the end of the file (after the existing `ToolkitListItem` exports):
+
+```ts
+
+export { DetailPageLayout } from './DetailPageLayout';
+export type { DetailPageLayoutProps } from './DetailPageLayout';
+```
+
+Do not reorder or modify any other export.
+
+- [ ] **Step 5.3: Sanity-import the new symbol from outside the barrel to prove the export resolves**
+
+Run from `apps/web/`:
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors. If TypeScript complains about the new file path, double-check Step 1.3 saved at `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` (note casing).
+
+- [ ] **Step 5.4: Run the full app test suite to make sure no Wave A.4 test broke**
+
+```bash
+pnpm test --run
+```
+
+Expected: full suite green. If any test in `apps/web/src/components/ui/detail-layout/` regresses, revert this task and investigate — Task 5 should be a pure additive change.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add apps/web/src/components/ui/detail-layout/index.ts
+git commit -m "feat(detail-layout): export DetailPageLayout from barrel (refs #1026)"
+```
+
+---
+
+## Task 6 — Final verification + PR
+
+**Files:** none modified.
+
+- [ ] **Step 6.1: Run the full quality gate**
+
+From `apps/web/`:
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test --run
+```
+
+Expected: all three commands exit 0. If lint flags `local/no-hardcoded-color-utility` on `DetailPageLayout.tsx`, that means a hex/rgb value slipped in — open the file and remove it; the only utility classes used should be `flex`, `flex-col`, `gap-6`, plus the caller-provided `className`.
+
+- [ ] **Step 6.2: Confirm no extra files were touched beyond the spec §8 list**
+
+```bash
+git diff --name-only main-dev
+```
+
+Expected output (exact, no extras):
+
+```
+apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx
+apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx
+apps/web/src/components/ui/detail-layout/index.ts
+docs/superpowers/plans/2026-05-13-detail-page-layout.md
+docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
+```
+
+(The two `docs/superpowers/` files were committed in earlier brainstorming + planning steps; everything else must be the three implementation files.)
+
+- [ ] **Step 6.3: Push the branch**
+
+```bash
+git push -u origin feature/issue-1026-stage3-detail-page-layout
+```
+
+- [ ] **Step 6.4: Open the PR against `main-dev`**
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(detail-layout): DetailPageLayout composer primitive (Stage 3 — cross-cutting)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Ships the cross-cutting `DetailPageLayout` composer primitive per spec §4 of the de-versioning roadmap. Unblocks Stage 3 cluster work (#1026): `player-detail`, `toolkit-detail`, `game-nights`, `discover`, and the NEW clusters once their mockups land via #1097.
+
+- New: `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` — pure slot-arranger, 5 `ReactNode` slots (hero / connections / tabs / children / footer), zero state, zero coupling
+- New: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` — 8 Vitest unit tests covering DOM order, conditional slots, landmark accessible names, className passthrough, reading order
+- Updated: `apps/web/src/components/ui/detail-layout/index.ts` — barrel export of the composer + props type; JSDoc header expanded to mention Stage 3
+
+No consumer migrated in this PR (spec NG1). First real consumer will be a separate Stage 3 cluster PR (suggested: `player-detail`).
+
+## Spec & plan
+
+- Design spec: `docs/superpowers/specs/2026-05-13-detail-page-layout-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-05-13-detail-page-layout.md`
+- Parent spec: `docs/for-developers/specs/2026-05-11-design-system-deversioning.md` §4
+
+## Test plan
+
+- [x] `pnpm typecheck` green
+- [x] `pnpm lint` green (no hard-coded colors)
+- [x] `pnpm test --run` green — 8 new tests pass, existing detail-layout tests unchanged
+- [x] `pnpm test --coverage` shows 100% line + branch on `DetailPageLayout.tsx`
+
+Refs: #1026, #1023, #1066
+EOF
+)"
+```
+
+- [ ] **Step 6.5: Link the PR from the parent issue**
+
+```bash
+gh issue comment 1026 --body "Stage 3 cross-cutting primitive shipped: PR opened for the \`DetailPageLayout\` composer. Cluster PRs can now consume it. Suggested next cluster: \`player-detail\` (Wave 3 pending, mockup \`sp4-player-detail.jsx\` exists)."
+```
+
+---
+
+## Self-Review Notes (from plan author)
+
+- **Spec coverage** — Each AC in spec §9 maps to: AC1 → Task 5; AC2/AC7 → Step 6.1; AC3 → Step 4.4; AC4 → Tasks 1-4 (the 8 tests); AC5 → Step 5.4 (full suite run); AC6 → Step 6.2 (diff guard).
+- **Placeholders** — None. Every code block contains the actual content the engineer types in.
+- **Type consistency** — The component name `DetailPageLayout`, props interface `DetailPageLayoutProps`, and barrel export names are identical across Tasks 1, 4, 5, and 6. The `connections`/`tabs`/`footer` slot names match between spec §4, the component signature (Task 1.3), and every test (Tasks 1-4).
+- **No spec drift** — `clsx` is used (codebase convention, verified in `sticky-cta.tsx`, `hero.tsx`, etc.) instead of a hypothetical `cn` util. The component imports `JSX` + `ReactNode` from `react` as a `import type`, matching the Wave A.4 file convention.

--- a/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
+++ b/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
@@ -58,6 +58,53 @@ interface DetailPageLayoutProps {
 
 No default props. No prop-derived behavior. No internal state.
 
+### 4.1 Usage examples
+
+Two canonical compositions emerge from the parent spec's composability table (§4 of `2026-05-11-design-system-deversioning.md`).
+
+**Example 1 — Full authenticated detail page** (e.g. `/games/[id]`):
+
+```tsx
+import { DetailPageLayout, Hero, Tabs } from '@/components/ui/detail-layout';
+import { ConnectionBar } from '@/components/ui/data-display/connection-bar';
+
+<DetailPageLayout
+  hero={<Hero {...heroProps} labels={heroLabels} />}
+  connections={<ConnectionBar items={connectionItems} />}
+  tabs={<Tabs descriptors={tabDescriptors} activeTab={tab} onChange={setTab} labels={tabLabels} />}
+  footer={<ActionsRow {...actionsProps} />}
+>
+  {currentTabPanel}
+</DetailPageLayout>
+```
+
+**Example 2 — Public flat-scroll detail page** (e.g. `/shared-games/[slug]`):
+
+```tsx
+import {
+  DetailPageLayout,
+  Hero,
+  ContributorsStrip,
+  StickyCta,
+} from '@/components/ui/detail-layout';
+import { ConnectionBar } from '@/components/ui/data-display/connection-bar';
+
+<DetailPageLayout
+  hero={<Hero {...heroProps} />}
+  connections={<ConnectionBar items={connectionItems} />}
+  footer={
+    <>
+      <ContributorsStrip avatars={contributors} labels={contributorsLabels} />
+      <StickyCta signInHref="/login" labels={ctaLabels} />
+    </>
+  }
+>
+  {sectionsStacked}
+</DetailPageLayout>
+```
+
+Note on `null` vs `undefined`: passing `connections={null}` renders the `<aside>` wrapper with no children (explicit caller intent — e.g. to reserve the region for a loading placeholder). Omitting the prop (or passing `undefined`) suppresses the wrapper. Test #9 in §7 pins this contract.
+
 ## 5. DOM structure
 
 ```html
@@ -102,6 +149,7 @@ Reading order equals DOM order — no CSS `order` reshuffling. The wrapper uses 
 | 6 | Landmark roles + accessible names: `banner`, `complementary` (name "related entities"), `navigation` (name "detail sections"), `main`, `contentinfo` |
 | 7 | `className` passthrough on the root wrapper |
 | 8 | Reading order equals DOM order — render with a `<button>` placed inside each of hero / connections / tabs / children / footer, then assert that `Array.from(container.querySelectorAll('button'))` matches the expected source order (no `tabIndex` simulation needed, the test inspects static DOM order only) |
+| 9 | `connections={null}` renders the `<aside>` wrapper (explicit caller intent — `null !== undefined` per spec §4.1). Asserts `getByRole('complementary', { name: /related entities/i })` is present even though the slot is empty. |
 
 Coverage target: 100% line and branch (component is roughly 30 lines, all in conditional slot wrappers).
 

--- a/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
+++ b/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
@@ -12,7 +12,9 @@
 
 ## 1. Problem
 
-Spec §4 of the de-versioning roadmap calls for a cross-cutting `DetailPageLayout` primitive that orchestrates `Hero` + `ConnectionBar` + `Tabs` + footer slots. Wave A.4 (issue #603) already shipped the individual pieces under `apps/web/src/components/ui/detail-layout/` (hero, tabs, sticky-cta, contributors-strip, empty/error/not-found states, plus 3 list-item variants) and the canonical `ConnectionBar` primitive lives at `apps/web/src/components/ui/data-display/connection-bar/`. What does not yet exist is the composer that arranges these pieces in the canonical detail-page DOM order with the right landmark a11y semantics. Stage 3 cluster work for `player-detail`, `toolkit-detail`, `game-detail`, `agent-detail`, `kb-detail`, `session-summary`, `hub/<entity>` will all depend on this composer, so it is the right first piece to ship.
+Spec §4 of the de-versioning roadmap calls for a cross-cutting `DetailPageLayout` primitive that orchestrates `Hero` + `ConnectionBar` + `Tabs` + footer slots. Wave A.4 (issue #603) already shipped the individual pieces under `apps/web/src/components/ui/detail-layout/` (hero, tabs, sticky-cta, contributors-strip, empty/error/not-found states, plus 3 list-item variants) and the canonical `ConnectionBar` primitive lives at `apps/web/src/components/ui/data-display/connection-bar/`. What does not yet exist is the composer that arranges these pieces in the canonical detail-page DOM order with the right landmark a11y semantics.
+
+The composer unblocks new Stage 3 clusters that have no current detail implementation: `player-detail`, `toolkit-detail`, `game-nights`, `discover`, plus the NEW clusters `dashboard` and `hub/<entity>` (once their mockups land via #1097). Already-implemented routes (`game-detail`, `agent-detail`, `kb-detail`, `session-summary`, `/shared-games/[id]`) may opt in later via dedicated refactor PRs — they are not part of Stage 3 cluster work per the parent spec §3 priority table.
 
 ## 2. Goals & Non-goals
 
@@ -97,7 +99,7 @@ Reading order equals DOM order — no CSS `order` reshuffling. The wrapper uses 
 | 3 | `connections` omitted → `<aside>` not in the DOM |
 | 4 | `tabs` omitted → `<nav>` not in the DOM |
 | 5 | `footer` omitted → `<footer>` not in the DOM |
-| 6 | Landmark roles present: `banner`, `complementary`, `navigation` (name "detail sections"), `main`, `contentinfo` |
+| 6 | Landmark roles + accessible names: `banner`, `complementary` (name "related entities"), `navigation` (name "detail sections"), `main`, `contentinfo` |
 | 7 | `className` passthrough on the root wrapper |
 | 8 | Reading order equals DOM order — render with a `<button>` placed inside each of hero / connections / tabs / children / footer, then assert that `Array.from(container.querySelectorAll('button'))` matches the expected source order (no `tabIndex` simulation needed, the test inspects static DOM order only) |
 
@@ -111,7 +113,7 @@ No snapshot tests. No Playwright. No Storybook.
 |---|---|
 | `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` | NEW |
 | `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` | NEW |
-| `apps/web/src/components/ui/detail-layout/index.ts` | UPDATED — add 2 exports, update header comment |
+| `apps/web/src/components/ui/detail-layout/index.ts` | UPDATED — append two new export blocks (named export `DetailPageLayout` + type `DetailPageLayoutProps`); replace the leading JSDoc comment "Wave A.4 (Issue #603) — V2 component family for /shared-games/[id]." with "Detail-layout primitives. Wave A.4 (#603) shipped the pieces; Stage 3 (#1026) added the DetailPageLayout composer." Existing exports are not reordered or modified. |
 
 No other files. No migrations. No backend impact.
 

--- a/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
+++ b/docs/superpowers/specs/2026-05-13-detail-page-layout-design.md
@@ -1,0 +1,136 @@
+# DetailPageLayout primitive — design
+
+| Field | Value |
+|---|---|
+| Status | accepted |
+| Date | 2026-05-13 |
+| Author | brainstorming session (user + assistant) |
+| Parent | issue #1026 (Stage 3 cluster fixes) |
+| Umbrella | issue #1023 (De-versioning) |
+| Spec reference | `docs/for-developers/specs/2026-05-11-design-system-deversioning.md` §4 |
+| Branch | `feature/issue-1026-stage3-detail-page-layout` (from `main-dev`) |
+
+## 1. Problem
+
+Spec §4 of the de-versioning roadmap calls for a cross-cutting `DetailPageLayout` primitive that orchestrates `Hero` + `ConnectionBar` + `Tabs` + footer slots. Wave A.4 (issue #603) already shipped the individual pieces under `apps/web/src/components/ui/detail-layout/` (hero, tabs, sticky-cta, contributors-strip, empty/error/not-found states, plus 3 list-item variants) and the canonical `ConnectionBar` primitive lives at `apps/web/src/components/ui/data-display/connection-bar/`. What does not yet exist is the composer that arranges these pieces in the canonical detail-page DOM order with the right landmark a11y semantics. Stage 3 cluster work for `player-detail`, `toolkit-detail`, `game-detail`, `agent-detail`, `kb-detail`, `session-summary`, `hub/<entity>` will all depend on this composer, so it is the right first piece to ship.
+
+## 2. Goals & Non-goals
+
+### Goals
+
+- G1 — Add a new component `DetailPageLayout` under `apps/web/src/components/ui/detail-layout/` that arranges hero / connections / tabs / main content / footer in canonical reading order.
+- G2 — Keep the composer dumb: zero business logic, zero state, zero coupling to specific data types. Everything is a `ReactNode` slot.
+- G3 — Provide a11y landmarks (`<header>`, `<aside>`, `<nav>`, `<main>`, `<footer>`) so screen-reader users get free navigation between detail-page regions.
+- G4 — Achieve 100% line and branch coverage with Vitest unit tests (component is small enough that the cost is negligible).
+- G5 — Export the new component and its props type from `apps/web/src/components/ui/detail-layout/index.ts`.
+
+### Non-goals
+
+- NG1 — Do not migrate any existing consumer (e.g. `/shared-games/[id]` page-client) in this PR. Migration of consumers is the job of each Stage 3 cluster PR.
+- NG2 — Do not introduce a Storybook story. Storybook reconstruction is listed as future work in the parent spec §8.
+- NG3 — Do not introduce a `variant` prop on the composer. The de-versioning spec §4 proposed `variant?: 'authenticated' | 'public'` to drive default footer behavior, but the spec-panel review on 2026-05-13 flagged this as a single-responsibility violation. The composer stays pure — the caller decides what goes into the footer slot.
+- NG4 — Do not accept typed `ConnectionItem[]` or `TabDescriptor[]` as props. The composer is a slot arranger; callers pass an already-rendered `<ConnectionBar>` / `<Tabs>` as a `ReactNode`. This keeps the layout decoupled from the connection/tab primitives and avoids re-exporting their types.
+- NG5 — Do not extend or modify existing pieces (`Hero`, `Tabs`, `StickyCta`, `ContributorsStrip`, etc.). They are consumed unchanged.
+
+## 3. Decisions taken during brainstorming
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Variant prop? | C — no variant, footer is a pure slot | YAGNI; can wrap in `AuthenticatedDetailPage` / `PublicDetailPage` later if duplication emerges |
+| API style (composition vs configuration)? | B — all-composition, `connections`/`tabs` are `ReactNode` | `Tabs` primitive already owns its state; nothing for the composer to centralize. Consistency wins over 3 lines of caller boilerplate. |
+| Scope of the PR? | A — composer only, no consumer migration | Atomic, low-risk PR; aligned with ADR-054 multi-branch hygiene; Wave A.4 already validated the pieces compose for `/shared-games/[id]`. |
+| Test strategy? | A — Vitest unit only | Composer is pure slot-ordering; visual regression belongs to the cluster PRs that consume it. |
+
+## 4. API
+
+```tsx
+interface DetailPageLayoutProps {
+  hero: React.ReactNode;          // required slot
+  connections?: React.ReactNode;  // optional — caller passes <ConnectionBar /> rendered
+  tabs?: React.ReactNode;         // optional — caller passes <Tabs /> rendered
+  children: React.ReactNode;      // tab panels or flat sections
+  footer?: React.ReactNode;       // optional — caller decides actions row / ContributorsStrip+StickyCta / nothing
+  className?: string;             // passthrough on the wrapper element
+}
+```
+
+No default props. No prop-derived behavior. No internal state.
+
+## 5. DOM structure
+
+```html
+<div className={cn('detail-page-layout', className)}>
+  <header>{hero}</header>
+
+  {connections && (
+    <aside aria-label="related entities">{connections}</aside>
+  )}
+
+  {tabs && (
+    <nav aria-label="detail sections">{tabs}</nav>
+  )}
+
+  <main>{children}</main>
+
+  {footer && (
+    <footer>{footer}</footer>
+  )}
+</div>
+```
+
+Reading order equals DOM order — no CSS `order` reshuffling. The wrapper uses `flex flex-col` plus a Tailwind `gap-*` utility for spacing between slots. No hard-coded pixel values, no inline styles, no CSS variables defined inside this component.
+
+## 6. A11y rationale
+
+- `<header>`, `<main>`, `<footer>` give implicit landmark roles `banner`, `main`, `contentinfo`.
+- `<aside aria-label="related entities">` for the connections wrapper produces `role="complementary"` with an accessible name — screen readers can jump straight to the related-entities region.
+- `<nav aria-label="detail sections">` for the tabs wrapper produces `role="navigation"` at page scope. The inner `Tabs` primitive owns the WAI-ARIA tablist semantics (it already uses `role="tablist"` per its existing implementation).
+
+## 7. Test plan
+
+`DetailPageLayout.test.tsx` — Vitest + React Testing Library. Eight deterministic tests:
+
+| # | Verifies |
+|---|---|
+| 1 | Minimal render: only `hero` + `children` produces `<header>` and `<main>` landmarks |
+| 2 | Full render with all slots: DOM order is hero → aside → nav → main → footer |
+| 3 | `connections` omitted → `<aside>` not in the DOM |
+| 4 | `tabs` omitted → `<nav>` not in the DOM |
+| 5 | `footer` omitted → `<footer>` not in the DOM |
+| 6 | Landmark roles present: `banner`, `complementary`, `navigation` (name "detail sections"), `main`, `contentinfo` |
+| 7 | `className` passthrough on the root wrapper |
+| 8 | Reading order equals DOM order — render with a `<button>` placed inside each of hero / connections / tabs / children / footer, then assert that `Array.from(container.querySelectorAll('button'))` matches the expected source order (no `tabIndex` simulation needed, the test inspects static DOM order only) |
+
+Coverage target: 100% line and branch (component is roughly 30 lines, all in conditional slot wrappers).
+
+No snapshot tests. No Playwright. No Storybook.
+
+## 8. Files touched
+
+| File | Action |
+|---|---|
+| `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` | NEW |
+| `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` | NEW |
+| `apps/web/src/components/ui/detail-layout/index.ts` | UPDATED — add 2 exports, update header comment |
+
+No other files. No migrations. No backend impact.
+
+## 9. Acceptance criteria
+
+- AC1 — `DetailPageLayout` exported from `apps/web/src/components/ui/detail-layout/index.ts` along with its props type.
+- AC2 — `pnpm typecheck && pnpm lint && pnpm test` green in `apps/web`.
+- AC3 — Vitest coverage report shows 100% line and branch coverage for `DetailPageLayout.tsx`.
+- AC4 — All eight tests in §7 present and passing.
+- AC5 — No regression in the existing `detail-layout/` tests (hero, tabs, sticky-cta, contributors-strip, empty-state, error-state, not-found-state, agent-list-item, kb-doc-item, toolkit-list-item).
+- AC6 — No new files outside the three listed in §8.
+- AC7 — No use of hard-coded colors, hex values, or pixel spacing in `DetailPageLayout.tsx`. Lint rule `local/no-hardcoded-color-utility` passes.
+
+## 10. Rollback
+
+Delete `DetailPageLayout.tsx` and `DetailPageLayout.test.tsx`; revert the two added export lines and the header-comment change in `index.ts`. Zero consumers after this PR — revert is risk-free.
+
+## 11. Follow-ups (out of scope)
+
+- First real consumer: a Stage 3 cluster PR (suggested order: `player-detail` since it is pending from Wave 3 and Wave 3 mockup `sp4-player-detail.jsx` already exists in `admin-mockups/design_files/`).
+- If duplication emerges across cluster consumers in the footer slot (e.g. all public clusters end up passing the same `ContributorsStrip + StickyCta` combo), introduce thin wrappers `AuthenticatedDetailPage` / `PublicDetailPage` in a later PR. Not before duplication is observed.
+- Storybook story authoring is deferred (parent spec §8 future work).


### PR DESCRIPTION
## Summary

Ships the cross-cutting `DetailPageLayout` composer primitive per spec §4 of the de-versioning roadmap. Unblocks Stage 3 cluster work (#1026): `player-detail`, `toolkit-detail`, `game-nights`, `discover`, and the NEW clusters once their mockups land via #1097.

- New: `apps/web/src/components/ui/detail-layout/DetailPageLayout.tsx` — pure slot-arranger, 5 `ReactNode` slots (hero / connections / tabs / children / footer), zero state, zero coupling
- New: `apps/web/src/components/ui/detail-layout/DetailPageLayout.test.tsx` — 8 Vitest unit tests covering DOM order, conditional slots, landmark accessible names, className passthrough, reading order
- Updated: `apps/web/src/components/ui/detail-layout/index.ts` — barrel export of the composer + props type; JSDoc header expanded to mention Stage 3

No consumer migrated in this PR (spec NG1). First real consumer will be a separate Stage 3 cluster PR (suggested: `player-detail`).

## Brainstorming decisions (see spec §3)

| Question | Decision |
|---|---|
| Variant prop? | C — no variant, footer is a pure slot (YAGNI) |
| API style? | B — all-composition, `connections`/`tabs` are `ReactNode` (consistency) |
| PR scope? | A — composer only, no consumer migration (atomic, low-risk) |
| Test strategy? | A — Vitest unit only, 100% coverage on the composer |

## A11y note

The `<nav aria-label="detail sections">` wraps the tabs slot. The inner Tabs primitive owns `role="tablist"` (a widget role) — landmark navigation and widget tablist are orthogonal ARIA dimensions. A code reviewer flagged a concern about nesting; spec §6 documents the deliberate choice. If users find the page-level "detail sections" navigation landmark redundant in practice, switch the wrapper to a plain `<div>` in a follow-up PR.

## Spec & plan

- Design spec: `docs/superpowers/specs/2026-05-13-detail-page-layout-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-13-detail-page-layout.md`
- Parent spec: `docs/for-developers/specs/2026-05-11-design-system-deversioning.md` §4

## Test plan

- [x] `pnpm typecheck` green (verified locally)
- [x] `pnpm lint` green (0 errors; 36 pre-existing warnings unaffected)
- [x] `pnpm test --run` green (full suite, exit 0)
- [x] Focused `pnpm test src/components/ui/detail-layout/` — 96 tests pass across 11 files
- [x] `pnpm test --coverage` shows 100% line / branch / function / statement on `DetailPageLayout.tsx`

Refs: #1026, #1023, #1066