### PR TITLE
fix(ci): bump Frontend Fast timeout 5min -> 15min (closes #1115)

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -55,7 +55,9 @@ jobs:
   frontend-fast:
     name: Frontend Fast (lint + typecheck + unit)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Bumped from 5 to 15 (incident #1115): Vitest suite alone runs ~5min
+    # locally and >5min in CI with cold cache, killing every frontend PR.
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     defaults:


### PR DESCRIPTION
## Summary

One-line fix for incident #1115. \`.github/workflows/dev-fast.yml\` Frontend Fast job had \`timeout-minutes: 5\`, but the apps/web Vitest suite + lint + typecheck consistently take >5min in CI. Result: every frontend PR opened since 2026-05-12 17:39 UTC has been cancelled by this timeout (10+ branches confirmed in #1115).

Bumps the budget to 15 min. Local Vitest suite is ~5min, CI overhead ~2-3min cold start → 8min realistic, 15min provides buffer for organic growth.

## Why this approach

Option A from incident #1115 — single-line edit, low risk, unblocks merges today. Option B (move unit tests out of dev-fast into dev-async) is a larger architectural change that requires an ADR-054 amendment; deferred until the team confirms the sub-5-min fast-lane contract matters.

## Out of scope

- Backend Fast (line 89) still has 5min — currently skipping for frontend-only PRs and not reported as failing. Re-evaluate if it ever exceeds budget.
- Splitting unit tests into dev-async (Option B) — separate follow-up.

## Test plan

- [x] Local: branch passes own Frontend Fast (only changes a workflow file, but the workflow still runs against this PR)
- [ ] Verify CI green on this PR (the change itself takes effect on this run)
- [ ] Re-run PR #1112 (recently cancelled) and confirm it now passes
- [ ] Re-run one other recently-cancelled PR for cross-validation

Refs: #1115, #1086, #1112