### PR TITLE
feat(conformity): WS-C Phase 3b real spec + fixture wiring

### DIFF
--- a/.github/workflows/visual-regression-conformity.yml
+++ b/.github/workflows/visual-regression-conformity.yml
@@ -87,6 +87,11 @@ jobs:
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+          # Phase 3b: enables IS_VISUAL_TEST_BUILD constant so /library
+          # short-circuits to the curated fixture (Wave B.3 pattern).
+          # /library/{gameId} uses ?state= URL override which is also gated
+          # behind this flag in production builds.
+          NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED: '1'
 
       - name: Run Conformity Gate
         run: pnpm test:visual:conformity

--- a/apps/web/e2e/visual-conformity/conformity.spec.ts
+++ b/apps/web/e2e/visual-conformity/conformity.spec.ts
@@ -1,70 +1,138 @@
 /**
- * WS-C Phase 2 — Conformity verify (scaffold).
+ * WS-C Phase 3b — Conformity verify (real).
  *
  * For each entry in `mockup-ownership.bootstrap.json`, navigate the live Next.js
  * route (:3000) and assert the rendered screenshot matches the committed mockup
  * baseline `__mockup__/{route.id}.{viewport}.png` within the per-route
  * `threshold` (per-pixel YIQ) and `maxDiffPixelRatio` (aggregate) budgets.
  *
- * **Phase 2 status**: every spec is currently `test.fixme()`'d. The route
- * cannot match the mockup pixel-for-pixel until backend data is mocked to mirror
- * the mockup's curated dataset (e.g. Nanolith game, 8 library cards). That work
- * lands in Phase 3, alongside the workflow that runs this spec.
+ * Determinism strategy per route (no backend dependency):
+ *   - `/library` → `IS_VISUAL_TEST_BUILD` constant (set via
+ *     `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` at build time) short-circuits
+ *     `LibraryHubV2` to a curated 12-entry fixture (Wave B.3 pattern).
+ *   - `/library/{gameId}` → `?state=default` URL override consumes
+ *     `useStateOverride()` (WS-D Exemplar, PR #1093) to surface the fixture
+ *     detail without hitting any API.
  *
- * Why ship the scaffold now: it documents the consumer contract for the
- * ownership loader, exercises `snapshotPathTemplate` in CI (typecheck only,
- * no execution), and provides a single editing surface when Phase 3 mocks land.
+ * Auth bypass per `(authenticated)/` layout: triple-helper pattern
+ * (`seedAuthSession` + `seedCookieConsent` + `mockAuthEndpoints`) from
+ * `visual-migrated/sp4-library-desktop.spec.ts`.
+ *
+ * Baselines absence is still tolerated: `test.fixme()` on missing PNG documents
+ * that the bootstrap workflow has not yet been dispatched. Once Phase 3 workflow
+ * runs and the auto-PR lands committed baselines, the fixme self-resolves.
  *
  * Refs: #1069 (WS-C), #1066 (umbrella), AC-C.2 + AC-C.6.
  */
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
-import { loadOwnership, resolveLivePath } from '../../scripts/conformity-ownership';
+import {
+  loadOwnership,
+  resolveLivePath,
+  type RouteOwnership,
+} from '../../scripts/conformity-ownership';
+import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import { seedCookieConsent } from '../_helpers/seedCookieConsent';
 
 const ownershipPath = join(__dirname, 'mockup-ownership.bootstrap.json');
 const ownership = loadOwnership(ownershipPath);
 const baselineDir = join(__dirname, '__mockup__');
 
+/**
+ * Per-route ready-state selector + URL strategy.
+ *
+ * Each route declares HOW to make the live render deterministic without
+ * hitting the backend. Add a new entry when extending the ownership map.
+ */
+interface RouteRunbook {
+  /** URL appended to resolveLivePath() output (e.g. '?state=default'). */
+  search?: string;
+  /** Wait for this selector before screenshot. */
+  readySelector: string;
+  /** Optional secondary selector for slower-rendering content. */
+  contentSelector?: string;
+}
+
+const RUNBOOKS: Record<string, RouteRunbook> = {
+  library: {
+    readySelector: '[data-slot="library-hub-v2"]',
+    contentSelector: '[data-slot="library-grid-card"]',
+  },
+  'library-game-detail': {
+    search: '?state=default',
+    readySelector: 'main',
+  },
+};
+
+async function waitForRouteReady(page: Page, runbook: RouteRunbook): Promise<void> {
+  await page.waitForSelector(runbook.readySelector, { timeout: 30_000 });
+  if (runbook.contentSelector) {
+    await page.waitForSelector(runbook.contentSelector, { timeout: 10_000 });
+  }
+
+  await page.evaluate(async () => {
+    if (typeof document !== 'undefined' && 'fonts' in document) {
+      await (document as Document & { fonts: { ready: Promise<void> } }).fonts.ready;
+    }
+  });
+
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
+}
+
 test.describe('WS-C Conformity — route vs mockup baseline', () => {
   // Conformity assertions are deterministic; flake should fail-fast.
-  // Project-level `retries: 1` covers transient infra flake only.
+  // Project-level `retries: 1` (playwright.config.ts) covers transient infra flake only.
 
-  for (const route of ownership.routes) {
+  for (const route of ownership.routes as readonly RouteOwnership[]) {
     test(`conformity: ${route.livePath} (id=${route.id})`, async ({ page }, testInfo) => {
       const viewport = testInfo.project.name.includes('mobile') ? 'mobile' : 'desktop';
       const baselinePath = join(baselineDir, `${route.id}.${viewport}.png`);
 
-      // Phase 2 gate: stub Phase 3 prerequisites.
-      // Two independent reasons can fixme this spec; check both for clearer
-      // CI output so we know exactly what to fix when unblocking.
-      const missingBaseline = !existsSync(baselinePath);
-      const missingDataMock = true; // flipped per-route to false in Phase 3 as mocks land
-
-      if (missingBaseline) {
+      // Baseline materialization is performed by `bootstrap-mockup-baselines.yml`.
+      // On a fresh checkout (or before the first workflow run), the PNG is absent;
+      // tolerate that with a fixme so PRs that touch unrelated areas don't block.
+      if (!existsSync(baselinePath)) {
         test.fixme(
           true,
-          `Baseline missing at ${baselinePath}. Run Phase 3 bootstrap workflow ` +
-            `(or \`pnpm test:visual:conformity:bootstrap:update\` locally).`
-        );
-      } else if (missingDataMock) {
-        test.fixme(
-          true,
-          `Route data parity not yet mocked for ${route.id}. ` +
-            `Phase 3 will add page.route() stubs matching the mockup dataset.`
+          `Baseline missing at ${baselinePath}. Dispatch the ` +
+            `\`Conformity — Bootstrap Mockup Baselines\` workflow (workflow_dispatch) ` +
+            `then merge the auto-PR. Local equivalent: ` +
+            `\`pnpm test:visual:conformity:bootstrap:update\`.`
         );
       }
 
-      const target = resolveLivePath(route.livePath, route.liveFixture);
+      const runbook = RUNBOOKS[route.id];
+      if (!runbook) {
+        throw new Error(
+          `No runbook for route id "${route.id}". Add an entry in RUNBOOKS ` +
+            `before mapping a new route in mockup-ownership.bootstrap.json.`
+        );
+      }
+
+      // Triple-helper auth bypass for `(authenticated)/` routes.
+      await seedAuthSession(page);
+      await seedCookieConsent(page);
+      await mockAuthEndpoints(page);
+
+      const target = resolveLivePath(route.livePath, route.liveFixture) + (runbook.search ?? '');
       await page.goto(target, { waitUntil: 'domcontentloaded' });
+      await waitForRouteReady(page, runbook);
 
       // Per-route override the project-level expect defaults.
       await expect(page).toHaveScreenshot(route.id, {
         fullPage: true,
         threshold: route.threshold,
         maxDiffPixelRatio: route.conformityRatio,
+        // Mask dynamic zones to avoid flake (timestamps, randomized counters).
+        mask: [page.locator('[data-dynamic]')],
       });
     });
   }

--- a/docs/for-developers/testing/frontend/mockup-conformity.md
+++ b/docs/for-developers/testing/frontend/mockup-conformity.md
@@ -1,7 +1,7 @@
 # Mockup-to-route Conformity Gate
 
 > **Issue:** #1069 (WS-C Mockup Conformity Roadmap, umbrella #1066)
-> **Status:** Phase 1 + Phase 2 + Phase 3 shipped 2026-05-13 — config, loader, Playwright projects, bootstrap spec, conformity scaffold, pin verifier, **both CI workflows**. Per-route data mocks (Phase 3b) and waiver audit log (Phase 4) land separately.
+> **Status:** Phase 1 + Phase 2 + Phase 3 + Phase 3b shipped 2026-05-13 — config, loader, Playwright projects, bootstrap spec, **real conformity spec** (no more fixme on data), pin verifier, both CI workflows. Only the waiver audit log (Phase 4) is left.
 
 ## Overview
 
@@ -153,12 +153,25 @@ Adding a route does **not** yet make Phase 3 enforce it — until the workflow s
 
 The conformity gate **runs** in CI but every spec is still `test.fixme()`'d pending Phase 3b data mocks. The wiring is present so the next PR that lands `page.route()` stubs can remove fixme guards route-by-route.
 
+### Phase 3b (this PR)
+
+The original Phase 3b plan was to add `page.route()` API stubs per route. That turned out unnecessary: both routes already have deterministic visual-test paths from previous waves.
+
+| Route | Determinism strategy | Source |
+|-------|---------------------|--------|
+| `/library` | `IS_VISUAL_TEST_BUILD` constant set via `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` at build time → `LibraryHubV2` swaps to curated 12-entry fixture | Wave B.3 (PR #638) |
+| `/library/{gameId}` | `?state=default` URL override consumed by `useStateOverride()` → fixture detail, no API call | WS-D Exemplar (PR #1093) |
+
+- `conformity.spec.ts` rewrites the spec body: `seedAuthSession` + `seedCookieConsent` + `mockAuthEndpoints` triple-helper (auth bypass), per-route `RUNBOOKS` table declares `readySelector` + optional `?state=` URL suffix, `mask: [data-dynamic]` for flake-prone zones
+- The only remaining `test.fixme()` is the **baseline-missing** guard — self-resolves once `bootstrap-mockup-baselines.yml` dispatches and the auto-PR lands committed `__mockup__/*.png`
+- `visual-regression-conformity.yml`: build step now passes `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` so the fixture short-circuit is active in CI
+
 ## What ships next
 
 | Phase | Deliverable |
 |-------|-------------|
-| **3b** | Per-route `page.route()` data stubs in `conformity.spec.ts` (mocked Nanolith game + library cards matching mockup dataset); removal of `test.fixme()` guards; first real baseline commit via `bootstrap-mockup-baselines.yml workflow_dispatch` |
 | **4** | `docs/for-developers/audits/conformity-waivers.md` audit log; waiver issue automation (AC-C.5 expiration enforcement) |
+| **post-merge** | Dispatch `bootstrap-mockup-baselines.yml` workflow → auto-PR lands `__mockup__/*.png` → conformity gate produces real diff (expected: large, documenting the 75-85% pre-remediation gap) |
 
 ## Running locally
 


### PR DESCRIPTION
## Summary

Phase 3b di **WS-C** (Mockup Conformity Gate, umbrella #1066) — rimuove i `test.fixme()` data-mock e cabla le strategie di determinismo route-specific.

## Discovery

Il piano originale Phase 3b prevedeva `page.route()` stubs per ciascuna route. Indagando le route ho scoperto che **entrambe hanno già percorsi visual-test deterministici** da fasi precedenti:

| Route | Strategy | Source |
|-------|----------|--------|
| `/library` | `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` → `IS_VISUAL_TEST_BUILD` → `LibraryHubV2` curated 12-entry fixture | Wave B.3 (PR #638) |
| `/library/{gameId}` | `?state=default` URL override → `useStateOverride()` → fixture detail | WS-D Exemplar (PR #1093) |

Zero `page.route()` stubs needed. Più semplice, più allineato col resto del codebase.

## Changes

| File | Change |
|------|--------|
| `conformity.spec.ts` | Rewrite spec body: `seedAuthSession` + `seedCookieConsent` + `mockAuthEndpoints` triple-helper (auth bypass), `RUNBOOKS` table per route (readySelector + ?state= suffix), `mask: [data-dynamic]`. Only fixme rimasto: baseline-missing (self-resolves post-bootstrap dispatch). |
| `visual-regression-conformity.yml` | `pnpm build` env include `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` |
| `mockup-conformity.md` | Phase 3b status + post-merge action |

## Test plan

- [x] `pnpm typecheck` — green
- [x] Pre-commit (lint-staged + prettier + tsc + commitlint) — green
- [ ] CI: la conformity gate triggera su questo PR e tutti gli spec vanno in fixme (baseline mancante) → expected GREEN
- [ ] Post-merge: dispatch `bootstrap-mockup-baselines.yml` con `reason="WS-C Phase 3b — first conformity baselines"` → auto-PR commits `__mockup__/*.png` → subsequent PRs run real gate

## Post-merge runbook

```bash
gh workflow run bootstrap-mockup-baselines.yml \
  --ref main-dev \
  -f reason="WS-C Phase 3b — first conformity baselines for /library + /library/{gameId}"
```

Aspettarsi un auto-PR con label `conformity automation` da review prima del merge.

## WS-C status (4/5 phases shipped)

| Phase | PR | Status |
|-------|-----|--------|
| 1 — Config + loader | #1105 (`82fb3387a`) | ✅ |
| 2 — Playwright + verifier | #1110 (`a1ae9861e`) | ✅ |
| 3 — Workflows + adaptive helper | #1114 (`e52b3dc69`) | ✅ |
| **3b — Real spec + fixture wiring** | **this PR** | 🔄 |
| 4 — Waiver audit log | — | ⏳ |

## Refs

- Refs #1069 (WS-C Phase 3b)
- Refs #1066 (umbrella)
- Builds on Phase 3 (PR #1114, `e52b3dc69`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
