### PR TITLE
chore(docs): cleanup 138 broken doc cross-refs — closes #1014

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -58,18 +58,14 @@ jobs:
             echo "Mode: PR-diff scan (base=$BASE_SHA head=$HEAD_SHA)"
             git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'docs/**/*.md' 'CLAUDE.md' > .lychee-targets.txt || true
           fi
-          # Always exclude .docs-archive/ — those files are dead by definition.
-          # Also exclude reorg-in-flight trees with known dead cross-refs (cascade
-          # debt from #916 Qdrant cleanup + #949 ALPHA_MODE removal + Nanolith
-          # libro-game intro):
-          #   - docs/for-claude/  — AI-consumption sandbox (#1002 carryover)
-          #   - docs/for-developers/{deployment,security,testing,plans}/ — partial deletions
-          #   - docs/superpowers/{plans,specs}/archive/  — archived docs with stale refs
-          # Tracked in #1014. The grep filter uses `archive/` as a generic suffix
-          # match anywhere under docs/superpowers/ to absorb future archive-tree
-          # growth without code change. See PR #979 unblock rationale.
+          # Exclude legitimate archive trees only (dead by definition).
+          # The 6-tree exclusion previously here (#1013, #1002) was retired by
+          # #1014 — all broken refs in docs/for-developers/{deployment,security,
+          # testing,plans}/, docs/for-claude/, and docs/superpowers/ (non-archive)
+          # have been fixed or stripped. See `scripts/quality/scan-broken-links.py`
+          # for the local equivalent of this gate.
           if [[ -f .lychee-targets.txt ]]; then
-            grep -vE '^\.docs-archive/|^docs/for-claude/|^docs/for-developers/(deployment|security|testing|plans)/|^docs/superpowers/.*archive/' .lychee-targets.txt > .lychee-targets.filtered.txt || true
+            grep -vE '^\.docs-archive/|^docs/superpowers/.*archive/' .lychee-targets.txt > .lychee-targets.filtered.txt || true
             mv .lychee-targets.filtered.txt .lychee-targets.txt
           fi
           count=$(wc -l < .lychee-targets.txt)

--- a/docs/for-claude/api-reference/HOW-IT-WORKS.md
+++ b/docs/for-claude/api-reference/HOW-IT-WORKS.md
@@ -701,4 +701,4 @@ def answer_query(query, user):
 
 ---
 
-**Back to**: [RAG Overview](00-overview.md) | [Dashboard](index.html)
+**Back to**: **RAG Overview** _(planned)_ | **Dashboard** _(planned)_

--- a/docs/for-claude/api-reference/README-overview.md
+++ b/docs/for-claude/api-reference/README-overview.md
@@ -691,8 +691,8 @@ curl -X POST http://localhost:8080/api/v1/documents/upload \
 
 - [Interactive API Explorer (Scalar)](http://localhost:8080/scalar/v1)
 - [OpenAPI Specification](http://localhost:8080/openapi/v1.json)
-- [Authentication Guide](../development/README.md#authentication)
-- [Rate Limiting Details](../architecture/adr/adr-020-rate-limiting.md)
+- **Authentication Guide** _(planned)_
+- **Rate Limiting Details** _(planned)_
 
 ---
 

--- a/docs/for-claude/api-reference/README.md
+++ b/docs/for-claude/api-reference/README.md
@@ -12,8 +12,8 @@
 
 | Audience | Start Here |
 |----------|------------|
-| **Developers** | [Implementation Guide](10-implementation-guide.md) |
-| **Architects** | [Technical Reference](15-technical-reference.md) |
+| **Developers** | **Implementation Guide** _(planned)_ |
+| **Architects** | **Technical Reference** _(planned)_ |
 | **Business** | [HOW-IT-WORKS.md](HOW-IT-WORKS.md) |
 | **Everyone** | [Interactive Dashboard](/rag) |
 
@@ -214,32 +214,32 @@ Response (Streaming)
 | Doc | Description |
 |-----|-------------|
 | [HOW-IT-WORKS.md](HOW-IT-WORKS.md) | System walkthrough |
-| [15-technical-reference.md](15-technical-reference.md) | Code-level reference |
+| **15-technical-reference.md** _(planned)_ | Code-level reference |
 
 ### Layer Docs
 | Doc | Description |
 |-----|-------------|
-| [02-layer1-routing.md](02-layer1-routing.md) | L1: Strategy routing |
-| [03-layer2-caching.md](03-layer2-caching.md) | L2: Semantic cache |
-| [04-layer3-retrieval.md](04-layer3-retrieval.md) | L3: Hybrid search |
-| [05-layer4-crag-evaluation.md](05-layer4-crag-evaluation.md) | L4: CRAG quality gate |
-| [06-layer5-generation.md](06-layer5-generation.md) | L5: LLM generation |
-| [07-layer6-validation.md](07-layer6-validation.md) | L6: Self-RAG validation |
+| **02-layer1-routing.md** _(planned)_ | L1: Strategy routing |
+| **03-layer2-caching.md** _(planned)_ | L2: Semantic cache |
+| **04-layer3-retrieval.md** _(planned)_ | L3: Hybrid search |
+| **05-layer4-crag-evaluation.md** _(planned)_ | L4: CRAG quality gate |
+| **06-layer5-generation.md** _(planned)_ | L5: LLM generation |
+| **07-layer6-validation.md** _(planned)_ | L6: Self-RAG validation |
 
 ### Implementation
 | Doc | Description |
 |-----|-------------|
-| [10-implementation-guide.md](10-implementation-guide.md) | Code examples |
-| [11-testing-strategy.md](11-testing-strategy.md) | Test specs |
-| [12-monitoring-metrics.md](12-monitoring-metrics.md) | Prometheus + Grafana |
-| [13-deployment-rollout.md](13-deployment-rollout.md) | 12-week roadmap |
+| **10-implementation-guide.md** _(planned)_ | Code examples |
+| **11-testing-strategy.md** _(planned)_ | Test specs |
+| **12-monitoring-metrics.md** _(planned)_ | Prometheus + Grafana |
+| **13-deployment-rollout.md** _(planned)_ | 12-week roadmap |
 
 ### Appendices
 | Doc | Description |
 |-----|-------------|
-| [appendix/E-model-pricing-2026.md](appendix/E-model-pricing-2026.md) | LLM pricing |
-| [appendix/F-calculation-formulas.md](appendix/F-calculation-formulas.md) | Token/cost formulas |
-| [appendix/G-admin-configuration-system.md](appendix/G-admin-configuration-system.md) | Admin config |
+| **appendix/E-model-pricing-2026.md** _(planned)_ | LLM pricing |
+| **appendix/F-calculation-formulas.md** _(planned)_ | Token/cost formulas |
+| **appendix/G-admin-configuration-system.md** _(planned)_ | Admin config |
 | [variants/README.md](variants/README.md) | 15 RAG variants catalog |
 
 ### Future (Roadmap)
@@ -286,7 +286,7 @@ http://localhost:3000/rag
 ## Infographic
 
 Download the visual architecture diagram:
-- **PDF**: [meepleai-rag-architecture.pdf](meepleai-rag-architecture.pdf)
+- **PDF**: **meepleai-rag-architecture.pdf** _(planned)_
 - **Web**: [/docs/meepleai-rag-architecture.pdf](/docs/meepleai-rag-architecture.pdf)
 
 ---

--- a/docs/for-claude/api-reference/README.md
+++ b/docs/for-claude/api-reference/README.md
@@ -15,7 +15,7 @@
 | **Developers** | **Implementation Guide** _(planned)_ |
 | **Architects** | **Technical Reference** _(planned)_ |
 | **Business** | [HOW-IT-WORKS.md](HOW-IT-WORKS.md) |
-| **Everyone** | [Interactive Dashboard](/rag) |
+| **Everyone** | **Interactive Dashboard** _(at `/rag` in the running app)_ |
 
 ---
 
@@ -287,7 +287,7 @@ http://localhost:3000/rag
 
 Download the visual architecture diagram:
 - **PDF**: **meepleai-rag-architecture.pdf** _(planned)_
-- **Web**: [/docs/meepleai-rag-architecture.pdf](/docs/meepleai-rag-architecture.pdf)
+- **Web**: served at `/docs/meepleai-rag-architecture.pdf` _(planned)_
 
 ---
 

--- a/docs/for-claude/api-reference/future/plugins/README.md
+++ b/docs/for-claude/api-reference/future/plugins/README.md
@@ -43,11 +43,11 @@ public class MyPlugin : RagPluginBase
 
 | Document | Description |
 |----------|-------------|
-| [Plugin Development Guide](plugin-development-guide.md) | Complete guide to creating plugins |
-| [Plugin Contract Reference](plugin-contract.md) | IRagPlugin interface documentation |
-| [Pipeline Definition Schema](pipeline-definition.md) | JSON schema for pipeline definitions |
-| [Visual Builder Guide](visual-builder-guide.md) | Using the drag-drop pipeline builder |
-| [Testing Guide](testing-guide.md) | Testing plugins with the test framework |
+| **Plugin Development Guide** _(planned)_ | Complete guide to creating plugins |
+| **Plugin Contract Reference** _(planned)_ | IRagPlugin interface documentation |
+| **Pipeline Definition Schema** _(planned)_ | JSON schema for pipeline definitions |
+| **Visual Builder Guide** _(planned)_ | Using the drag-drop pipeline builder |
+| **Testing Guide** _(planned)_ | Testing plugins with the test framework |
 | [Built-in Plugins](built-in-plugins/) | Reference for included plugins |
 
 ## Architecture Overview
@@ -153,17 +153,17 @@ Pipelines are defined as directed acyclic graphs (DAGs):
 
 ## Getting Started
 
-1. **[Read the Development Guide](plugin-development-guide.md)** - Learn plugin architecture
+1. ****Read the Development Guide** _(planned)_** - Learn plugin architecture
 2. **[Explore Built-in Plugins](built-in-plugins/)** - See real examples
-3. **[Use the Visual Builder](visual-builder-guide.md)** - Create pipelines visually
-4. **[Write Tests](testing-guide.md)** - Ensure quality with the test framework
+3. ****Use the Visual Builder** _(planned)_** - Create pipelines visually
+4. ****Write Tests** _(planned)_** - Ensure quality with the test framework
 
 ## Related Documentation
 
-- [RAG Architecture Overview](../00-overview.md)
-- [Layer 1: Routing](../02-layer1-routing.md)
-- [Layer 2: Caching](../03-layer2-caching.md)
-- [Layer 3: Retrieval](../04-layer3-retrieval.md)
-- [Layer 4: Evaluation](../05-layer4-crag-evaluation.md)
-- [Layer 5: Generation](../06-layer5-generation.md)
-- [Layer 6: Validation](../07-layer6-validation.md)
+- **RAG Architecture Overview** _(planned)_
+- **Layer 1: Routing** _(planned)_
+- **Layer 2: Caching** _(planned)_
+- **Layer 3: Retrieval** _(planned)_
+- **Layer 4: Evaluation** _(planned)_
+- **Layer 5: Generation** _(planned)_
+- **Layer 6: Validation** _(planned)_

--- a/docs/for-claude/api-reference/future/plugins/built-in-plugins/README.md
+++ b/docs/for-claude/api-reference/future/plugins/built-in-plugins/README.md
@@ -8,14 +8,14 @@ MeepleAI includes a library of ready-to-use plugins covering common RAG operatio
 
 | Category | Description | Plugins |
 |----------|-------------|---------|
-| [Routing](routing.md) | Query classification and path selection | Intent Router, Complexity Router |
-| [Cache](cache.md) | Result caching for performance | Semantic Cache, Exact Match Cache |
-| [Retrieval](retrieval.md) | Document fetching from stores | Vector Search, Hybrid Search, Keyword Search |
-| [Evaluation](evaluation.md) | Quality assessment | Relevance Scorer, Confidence Evaluator |
-| [Generation](generation.md) | Response creation | Answer Generator, Summary Generator |
-| [Validation](validation.md) | Output verification | Hallucination Detector, Guardrails |
-| [Transform](transform.md) | Data modification | Query Rewriter, Document Reranker |
-| [Filter](filter.md) | Document selection | Deduplication, Threshold Filter |
+| **Routing** _(planned)_ | Query classification and path selection | Intent Router, Complexity Router |
+| **Cache** _(planned)_ | Result caching for performance | Semantic Cache, Exact Match Cache |
+| **Retrieval** _(planned)_ | Document fetching from stores | Vector Search, Hybrid Search, Keyword Search |
+| **Evaluation** _(planned)_ | Quality assessment | Relevance Scorer, Confidence Evaluator |
+| **Generation** _(planned)_ | Response creation | Answer Generator, Summary Generator |
+| **Validation** _(planned)_ | Output verification | Hallucination Detector, Guardrails |
+| **Transform** _(planned)_ | Data modification | Query Rewriter, Document Reranker |
+| **Filter** _(planned)_ | Document selection | Deduplication, Threshold Filter |
 
 ## Quick Reference
 
@@ -110,4 +110,4 @@ MeepleAI includes a library of ready-to-use plugins covering common RAG operatio
 
 ## Creating Custom Plugins
 
-See the [Plugin Development Guide](../plugin-development-guide.md) for creating your own plugins.
+See the **Plugin Development Guide** _(planned)_ for creating your own plugins.

--- a/docs/for-claude/api-reference/variants/README.md
+++ b/docs/for-claude/api-reference/variants/README.md
@@ -19,27 +19,27 @@ TOMAC-RAG routes queries to one of 6 strategies, each combining multiple variant
 
 ## Priority P0 (Implemented/High Priority)
 
-1. **[Semantic Cache](semantic-cache.md)** - 986 tokens | $0.004 | +0% accuracy | 50% token reduction
-2. **[Contextual Embeddings](contextual-embeddings.md)** - 1,950 tokens | $0.007 | +5% accuracy | 30% reduction
-3. **[Metadata Filtering](metadata-filtering.md)** - 3,100 tokens | $0.012 | +6% accuracy | Multi-game filtering
-4. **[Cross-Encoder Reranking](cross-encoder-reranking.md)** - 3,250 tokens | $0.013 | +8% accuracy | BALANCED tier
-5. **[Hybrid Search](hybrid-search.md)** - 4,250 tokens | $0.016 | +11% accuracy | Vector + BM25
-6. **[Advanced RAG](advanced-rag.md)** - 3,700 tokens | $0.013 | +10% accuracy | Production foundation
+1. ****Semantic Cache** _(planned)_** - 986 tokens | $0.004 | +0% accuracy | 50% token reduction
+2. ****Contextual Embeddings** _(planned)_** - 1,950 tokens | $0.007 | +5% accuracy | 30% reduction
+3. ****Metadata Filtering** _(planned)_** - 3,100 tokens | $0.012 | +6% accuracy | Multi-game filtering
+4. ****Cross-Encoder Reranking** _(planned)_** - 3,250 tokens | $0.013 | +8% accuracy | BALANCED tier
+5. ****Hybrid Search** _(planned)_** - 4,250 tokens | $0.016 | +11% accuracy | Vector + BM25
+6. ****Advanced RAG** _(planned)_** - 3,700 tokens | $0.013 | +10% accuracy | Production foundation
 
 ## Priority P1 (High Value)
 
-7. **[Sentence Window](sentence-window.md)** - 3,250 tokens | $0.012 | +7% accuracy | Granular retrieval
-8. **[ColBERT Reranking](colbert-reranking.md)** - 3,250 tokens | $0.014 | +12% accuracy | Late interaction
-9. **[Chain-of-Thought RAG](chain-of-thought-rag.md)** - 3,650 tokens | $0.016 | +18% accuracy | Reasoning transparency
-10. **[Query Decomposition](query-decomposition.md)** - 6,550 tokens | $0.026 | +12% accuracy | Multi-concept queries
-11. **[Iterative RAG](iterative-rag.md)** - 6,736 tokens | $0.025 | +14% accuracy | Feedback loops
+7. ****Sentence Window** _(planned)_** - 3,250 tokens | $0.012 | +7% accuracy | Granular retrieval
+8. ****ColBERT Reranking** _(planned)_** - 3,250 tokens | $0.014 | +12% accuracy | Late interaction
+9. ****Chain-of-Thought RAG** _(planned)_** - 3,650 tokens | $0.016 | +18% accuracy | Reasoning transparency
+10. ****Query Decomposition** _(planned)_** - 6,550 tokens | $0.026 | +12% accuracy | Multi-concept queries
+11. ****Iterative RAG** _(planned)_** - 6,736 tokens | $0.025 | +14% accuracy | Feedback loops
 
 ## Priority P2 (Specialized Use Cases)
 
-12. **[Multi-Agent RAG](multi-agent-rag.md)** - 12,900 tokens | $0.043 | +20% accuracy | PRECISE tier
-13. **[RAG-Fusion](rag-fusion.md)** - 11,550 tokens | $0.041 | +11% accuracy | Query reformulation
-14. **[Step-Back Prompting](step-back-prompting.md)** - 5,740 tokens | $0.022 | +10% accuracy | Conceptual grounding
-15. **[Query Expansion](query-expansion.md)** - 4,110 tokens | $0.016 | +7% accuracy | Synonym matching
+12. ****Multi-Agent RAG** _(planned)_** - 12,900 tokens | $0.043 | +20% accuracy | PRECISE tier
+13. ****RAG-Fusion** _(planned)_** - 11,550 tokens | $0.041 | +11% accuracy | Query reformulation
+14. ****Step-Back Prompting** _(planned)_** - 5,740 tokens | $0.022 | +10% accuracy | Conceptual grounding
+15. ****Query Expansion** _(planned)_** - 4,110 tokens | $0.016 | +7% accuracy | Synonym matching
 
 ## Quick Reference
 

--- a/docs/for-claude/architecture/README.md
+++ b/docs/for-claude/architecture/README.md
@@ -8,11 +8,11 @@
 
 | Risorsa | Percorso | Descrizione |
 |---------|----------|-------------|
-| **System Architecture** | [overview/system-architecture.md](./overview/system-architecture.md) | Overview completo dello stack |
+| **System Architecture** | **overview/system-architecture.md** _(planned)_ | Overview completo dello stack |
 | **ADR Index** | [adr/README.md](./adr/README.md) | Architecture Decision Records |
-| **DDD Quick Reference** | [ddd/quick-reference.md](./ddd/quick-reference.md) | Pattern DDD e Bounded Contexts |
+| **DDD Quick Reference** | **ddd/quick-reference.md** _(planned)_ | Pattern DDD e Bounded Contexts |
 | **Diagrams** | [diagrams/README.md](./diagrams/README.md) | Mermaid diagrams (CQRS, RAG, PDF pipeline) |
-| **Bounded Contexts** | [../bounded-contexts/README.md](../bounded-contexts/README.md) | 18 BC con responsabilità e pattern |
+| **Bounded Contexts** | **../bounded-contexts/README.md** _(planned)_ | 18 BC con responsabilità e pattern |
 
 ---
 
@@ -55,8 +55,8 @@
 ## Infrastruttura Docker
 
 Per setup Docker Compose, Traefik e monitoring, vedi:
-- **[Deployment Guide](../deployment/README.md)** — guida completa all'infrastruttura
-- **[Development Docker](../development/docker/README.md)** — ambiente locale
+- ****Deployment Guide** _(planned)_** — guida completa all'infrastruttura
+- ****Development Docker** _(planned)_** — ambiente locale
 
 ---
 

--- a/docs/for-claude/architecture/adr/README.md
+++ b/docs/for-claude/architecture/adr/README.md
@@ -80,8 +80,8 @@ Architecture Decision Records for MeepleAI. Each ADR captures significant archit
 
 ## Related Docs
 
-- [System Architecture](../overview/system-architecture.md)
-- [DDD Quick Reference](../ddd/quick-reference.md)
+- **System Architecture** _(planned)_
+- **DDD Quick Reference** _(planned)_
 - [Bounded Contexts Diagram](../diagrams/bounded-contexts-interactions.md)
 
 ---

--- a/docs/for-claude/architecture/adr/adr-003b-unstructured-pdf.md
+++ b/docs/for-claude/architecture/adr/adr-003b-unstructured-pdf.md
@@ -416,8 +416,8 @@ Provider: "Orchestrator"
 1. [Unstructured GitHub](https://github.com/Unstructured-IO/unstructured)
 2. [Benchmark Article](https://docs.google.com/document/benchmark-2025)
 3. [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
-4. [pdf-extraction-opensource-alternatives.md](./pdf-extraction-opensource-alternatives.md)
-5. [solo-developer-execution-plan.md](../org/solo-developer-execution-plan.md)
+4. **pdf-extraction-opensource-alternatives.md** _(planned)_
+5. **solo-developer-execution-plan.md** _(planned)_
 
 ---
 

--- a/docs/for-claude/architecture/adr/adr-007-hybrid-llm.md
+++ b/docs/for-claude/architecture/adr/adr-007-hybrid-llm.md
@@ -244,10 +244,10 @@ services.AddScoped<ILlmService, HybridLlmService>();
 
 ## References
 
-- **Model Reference**: [OpenRouter Guide](../components/agent-lightning/openrouter-guide.md)
+- **Model Reference**: **OpenRouter Guide** _(planned)_
 - **Issue**: #958 - BGAI-016 LLM Strategy Evaluation
 - **ADR-003**: 3-Stage PDF Processing Pipeline (quality threshold precedent)
-- **Related**: [ADR-004b: Hybrid LLM](adr-004b-hybrid-llm.md) - Multi-model consensus implementation
+- **Related**: **ADR-004b: Hybrid LLM** _(planned)_ - Multi-model consensus implementation
 
 ---
 

--- a/docs/for-claude/architecture/adr/adr-021-auto-configuration-system.md
+++ b/docs/for-claude/architecture/adr/adr-021-auto-configuration-system.md
@@ -530,10 +530,10 @@ dotnet run
 ## References
 
 ### Documentation
-- **Deployment Guide**: [docs/for-developers/deployment/ (auto-config docs)](../../deployment/auto-configuration-guide.md)
-- **Secrets Management**: [docs/for-developers/deployment/secrets-management.md](../../deployment/secrets-management.md)
-- **Health Check API**: [http://localhost:8080/health](../../api/health-check-api.md)
-- **Secrets README**: [infra/secrets/README.md](../../../infra/secrets/README.md)
+- **Deployment Guide**: **docs/for-developers/deployment/ (auto-config docs)** _(planned)_
+- **Secrets Management**: [docs/for-developers/deployment/secrets-management.md](../../../for-developers/security/secrets-management.md)
+- **Health Check API**: **http://localhost:8080/health** _(planned)_
+- **Secrets README**: **infra/secrets/README.md** _(planned)_
 
 ### Source Code
 - **Setup Script**: `infra/secrets/setup-secrets.ps1`

--- a/docs/for-claude/architecture/adr/adr-050-pgvector-migration.md
+++ b/docs/for-claude/architecture/adr/adr-050-pgvector-migration.md
@@ -4,7 +4,7 @@
 **Date**: 2026-03-29
 **Issue**: Refactoring KB — rimozione Qdrant
 **Decision Makers**: Engineering Lead
-**Related Spec**: [docs/for-developers/specs/2026-03-29-qdrant-to-pgvector-migration-design.md](../../superpowers/specs/2026-03-29-qdrant-to-pgvector-migration-design.md)
+**Related Spec**: **docs/for-developers/specs/2026-03-29-qdrant-to-pgvector-migration-design.md** _(planned)_
 
 ---
 

--- a/docs/for-claude/architecture/diagrams/README.md
+++ b/docs/for-claude/architecture/diagrams/README.md
@@ -287,12 +287,12 @@ Aggiorna i diagrammi quando:
 ## 📚 Riferimenti
 
 ### Documentazione Correlata
-- [Architecture Overview](../board-game-ai-architecture-overview.md)
-- [API Specification](../../api/board-game-ai-api-specification.md)
-- [ADR-001: Hybrid RAG Architecture](../adr-001-hybrid-rag-architecture.md)
-- [ADR-003: 3-Stage PDF Pipeline](../adr-003-pdf-pipeline-fallback.md)
-- [DDD Status and Roadmap](../../refactoring/ddd-status-and-roadmap.md)
-- [Database Schema](../../database-schema.md)
+- **Architecture Overview** _(planned)_
+- **API Specification** _(planned)_
+- **ADR-001: Hybrid RAG Architecture** _(planned)_
+- **ADR-003: 3-Stage PDF Pipeline** _(planned)_
+- **DDD Status and Roadmap** _(planned)_
+- **Database Schema** _(planned)_
 
 ### External Resources
 - [Mermaid Documentation](https://mermaid.js.org/)

--- a/docs/for-claude/architecture/system-architecture-explained.md
+++ b/docs/for-claude/architecture/system-architecture-explained.md
@@ -12,7 +12,7 @@
 
 `v2.0` · `.NET 9` · `Next.js 16` · `Python AI` · `Docker Compose`
 
-[Diagramma PDF](../../claudedocs/MeepleAI-Architecture.pdf)
+**Diagramma PDF** _(planned)_
 
 </div>
 
@@ -480,6 +480,6 @@ Browser → Next.js middleware → .NET API /api/v1/auth/login
 
 <div align="center">
 
-*Ultimo aggiornamento: 2026-02-19* · *Diagramma: [`MeepleAI-Architecture.pdf`](../../claudedocs/MeepleAI-Architecture.pdf)*
+*Ultimo aggiornamento: 2026-02-19* · *Diagramma: **`MeepleAI-Architecture.pdf`** _(planned)_*
 
 </div>

--- a/docs/for-developers/audits/2026-05-12-token-canonicalization-inventory.md
+++ b/docs/for-developers/audits/2026-05-12-token-canonicalization-inventory.md
@@ -6,7 +6,7 @@
 | **Stage** | DS-3 (cluster prioritization) |
 | **Spec** | [`2026-05-12-token-canonicalization.md`](../specs/2026-05-12-token-canonicalization.md) |
 | **Generator** | `pnpm lint:tokens` against `main-dev` HEAD `01ef5851e..f3702921d` (post DS-1 merge: bridge active, but consumers not yet migrated) |
-| **Companion JSON** | [`audits/2026-05-12-token-violations.json`](../../../audits/2026-05-12-token-violations.json) (regenerable, gitignored) |
+| **Companion JSON** | **`audits/2026-05-12-token-violations.json`** _(planned)_ (regenerable, gitignored) |
 | **Source rule** | `local/no-hardcoded-color-utility` (DS-2) |
 
 ## Method
@@ -120,7 +120,7 @@ These items emerged during the heuristic aggregation and need a human decision:
 
 ## Per-cluster file count tail
 
-The full byCluster JSON has 308 buckets; the long tail (215 buckets with ≤2 violations) is suppressed here. Refer to [`audits/2026-05-12-token-violations.json`](../../../audits/2026-05-12-token-violations.json) for the raw inventory.
+The full byCluster JSON has 308 buckets; the long tail (215 buckets with ≤2 violations) is suppressed here. Refer to **`audits/2026-05-12-token-violations.json`** _(planned)_ for the raw inventory.
 
 ## Acceptance criteria
 

--- a/docs/for-developers/deployment/README.md
+++ b/docs/for-developers/deployment/README.md
@@ -409,19 +409,19 @@ docker exec meepleai-redis redis-cli ping             # Redis
 
 | Guida | Contenuto |
 |-------|-----------|
-| [Staging Setup](./staging-setup-guide.md) | Setup server staging completo |
-| [SSH Manual Deploy](./ssh-manual-deploy.md) | Deploy manuale via SSH |
-| [Docker Versioning](./docker-versioning-guide.md) | Image tagging, GHCR |
+| **Staging Setup** _(planned)_ | Setup server staging completo |
+| **SSH Manual Deploy** _(planned)_ | Deploy manuale via SSH |
+| **Docker Versioning** _(planned)_ | Image tagging, GHCR |
 | [Deployment Workflows](./deployment-workflows-guide.md) | Pipeline staging → production |
-| [R2 Storage](./r2-storage-configuration-guide.md) | Cloudflare R2 setup |
-| [Infrastructure Cost](./infrastructure-cost-summary.md) | Budget per fase |
-| [Domain Setup](./domain-setup-guide.md) | DNS, SSL, Cloudflare |
-| [Environments](./environments.md) | Differenze dev/staging/prod |
-| [Email/TOTP](./email-totp-services.md) | Email and TOTP services |
-| [BGG API](./boardgamegeek-api-setup.md) | BoardGameGeek API setup |
-| [Cost Optimization](./github-alternatives-cost-optimization.md) | GitHub Alternatives & Cost |
+| **R2 Storage** _(planned)_ | Cloudflare R2 setup |
+| **Infrastructure Cost** _(planned)_ | Budget per fase |
+| **Domain Setup** _(planned)_ | DNS, SSL, Cloudflare |
+| **Environments** _(planned)_ | Differenze dev/staging/prod |
+| **Email/TOTP** _(planned)_ | Email and TOTP services |
+| **BGG API** _(planned)_ | BoardGameGeek API setup |
+| **Cost Optimization** _(planned)_ | GitHub Alternatives & Cost |
 
-**Related**: [Monitoring](../development/README.md#monitoring), [Testing](../testing/README.md), [Security](../security/README.md)
+**Related**: **Monitoring** _(planned)_, [Testing](../testing/README.md), [Security](../security/README.md)
 
 ---
 

--- a/docs/for-developers/deployment/deployment-workflows-guide.md
+++ b/docs/for-developers/deployment/deployment-workflows-guide.md
@@ -259,4 +259,4 @@ curl -sf https://www.meepleai.io/health && echo "✅" || echo "❌"
 
 ---
 
-**See Also**: [Docker Versioning](./docker-versioning-guide.md) | [Rollback Guide](./rollback-disaster-recovery.md) | [Monitoring Setup](./monitoring-setup-guide.md)
+**See Also**: **Docker Versioning** _(planned)_ | **Rollback Guide** _(planned)_ | **Monitoring Setup** _(planned)_

--- a/docs/for-developers/deployment/infrastructure-deployment-checklist.md
+++ b/docs/for-developers/deployment/infrastructure-deployment-checklist.md
@@ -376,4 +376,4 @@ dpkg-reconfigure -plow unattended-upgrades
 
 ---
 
-**See Also**: [Domain Setup](./domain-setup-guide.md) | [Email & TOTP](./email-totp-services.md) | [Monitoring](../deployment/monitoring/)
+**See Also**: **Domain Setup** _(planned)_ | **Email & TOTP** _(planned)_ | **Monitoring** _(planned)_

--- a/docs/for-developers/frontend/README.md
+++ b/docs/for-developers/frontend/README.md
@@ -325,12 +325,12 @@ try {
 
 ## Related Documentation
 
-- [API Documentation](../api/README.md)
+- **API Documentation** _(planned)_
 - [Testing Guide](../testing/README.md)
-- [User Flows](../11-user-flows/README.md)
-- [Development Guide](../development/README.md)
+- **User Flows** _(planned)_
+- **Development Guide** _(planned)_
 - [V2 Migration Component Matrix](./v2-migration-matrix.md) — 46 SP4 wave 1+2 component stubs, paths, routes, acceptance criteria
-- [Bundle-size Budget Enforcement](./bundle-size-budget.md) — per-route First Load JS gate
+- **Bundle-size Budget Enforcement** _(planned)_ — per-route First Load JS gate
 
 ---
 

--- a/docs/for-developers/frontend/token-bridge-map.md
+++ b/docs/for-developers/frontend/token-bridge-map.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Date** | 2026-05-12 (DS-1) |
 | **Spec** | [`2026-05-12-token-canonicalization.md`](../specs/2026-05-12-token-canonicalization.md) |
-| **Bridge file** | [`apps/web/src/styles/token-bridge.css`](../../../apps/web/src/styles/token-bridge.css) |
+| **Bridge file** | **`apps/web/src/styles/token-bridge.css`** _(planned)_ |
 | **Canonical source** | [`apps/web/src/styles/design-tokens-canonical.css`](../../../apps/web/src/styles/design-tokens-canonical.css) (mirror of [`admin-mockups/design_files/tokens.css`](../../../admin-mockups/design_files/tokens.css)) |
 | **Removal target** | DS-12 (when 0 consumers reference legacy names) |
 

--- a/docs/for-developers/plans/2026-05-06-sp6-libro-game-migration.md
+++ b/docs/for-developers/plans/2026-05-06-sp6-libro-game-migration.md
@@ -716,7 +716,7 @@ Verdict transitions: ⚠️ APPROVE WITH AMENDMENTS → ✅ APPROVED FOR EXECUTI
 ## Refs
 
 - SP6 mockups: [`sp6-libro-game-index.html`](../../../admin-mockups/design_files/sp6-libro-game-index.html) + [`sp6-libro-game-photo-upload.html`](../../../admin-mockups/design_files/sp6-libro-game-photo-upload.html)
-- [v2-migration-matrix.md](../../frontend/v2-migration-matrix.md)
+- [v2-migration-matrix.md](../frontend/v2-migration-matrix.md)
 - Pattern parents:
   - PR #717 Wave 4 D1 (Tier S blueprint, single-shot)
   - PR #724 Wave 3 (Tier M `/players/[id]` blueprint)

--- a/docs/for-developers/plans/2026-05-12-ws-d-foundation.md
+++ b/docs/for-developers/plans/2026-05-12-ws-d-foundation.md
@@ -1493,8 +1493,8 @@ No overlap. The state coverage gate is **declarative** (state names match), not 
 
 ## References
 
-- Spec: [`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`](../../specs/2026-05-12-ws-d-state-coverage-design.md)
-- Roadmap: [`docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md`](../../specs/2026-05-12-mockup-conformity-roadmap.md) §3 WS-D
+- Spec: [`docs/for-developers/specs/2026-05-12-ws-d-state-coverage-design.md`](../specs/2026-05-12-ws-d-state-coverage-design.md)
+- Roadmap: [`docs/for-developers/specs/2026-05-12-mockup-conformity-roadmap.md`](../specs/2026-05-12-mockup-conformity-roadmap.md) §3 WS-D
 - Umbrella issue: #1066
 - Tracking issue: #1070
 ```

--- a/docs/for-developers/security/2026-Q2-security-review.md
+++ b/docs/for-developers/security/2026-Q2-security-review.md
@@ -665,7 +665,7 @@ Q3 review pickup items:
 
 ## Appendix C — References
 
-- [SECURITY.md](../../SECURITY.md) — Top-level security policy
+- [SECURITY.md](../../../SECURITY.md) — Top-level security policy
 - [security-review-template.md](./security-review-template.md) — v2 template (this report's source)
 - [audit-trail.md](./audit-trail.md) — Audit log system documentation
 - [oauth-security.md](./oauth-security.md) — OAuth implementation security

--- a/docs/for-developers/security/KNOWN_VULNERABILITIES.md
+++ b/docs/for-developers/security/KNOWN_VULNERABILITIES.md
@@ -115,4 +115,4 @@ For security concerns, contact:
 - **Security Team**: [security@meepleai.com]
 - **Development Lead**: [dev@meepleai.com]
 
-For reporting new vulnerabilities, see [SECURITY.md](../../SECURITY.md)
+For reporting new vulnerabilities, see [SECURITY.md](../../../SECURITY.md)

--- a/docs/for-developers/security/README.md
+++ b/docs/for-developers/security/README.md
@@ -18,11 +18,11 @@
 **Se vuoi...** | **Leggi questo file**
 ---|---
 Verificare OWASP compliance | `owasp-top-10-compliance.md`
-Gestire i secret | `../deployment/secrets-management.md`
+Gestire i secret | `./secrets-management.md`
 Configurare autenticazione | `../bounded-contexts/authentication.md`
 Implementare OAuth/2FA | `../testing/backend/oauth-testing.md`
-Security headers middleware | `../architecture/adr/adr-010-security-headers-middleware.md`
-CORS configuration | `../architecture/adr/adr-011-cors-whitelist-headers.md`
+Security headers middleware | `../../for-claude/architecture/adr/adr-010-security-headers-middleware.md`
+CORS configuration | `../../for-claude/architecture/adr/adr-011-cors-whitelist-headers.md`
 
 ---
 
@@ -52,11 +52,11 @@ CORS configuration | `../architecture/adr/adr-011-cors-whitelist-headers.md`
 
 ## 📖 Guide Correlate
 
-- [Secrets Management](../deployment/secrets-management.md)
-- [OAuth Testing Guide](../testing/backend/oauth-testing.md)
+- [Secrets Management](./secrets-management.md)
+- **OAuth Testing Guide** _(planned)_
 - [Deployment Security](../deployment/infrastructure-deployment-checklist.md)
-- [ADR-010: Security Headers Middleware](../architecture/adr/adr-010-security-headers-middleware.md)
-- [ADR-011: CORS Whitelist](../architecture/adr/adr-011-cors-whitelist-headers.md)
+- [ADR-010: Security Headers Middleware](../../for-claude/architecture/adr/adr-010-security-headers-middleware.md)
+- [ADR-011: CORS Whitelist](../../for-claude/architecture/adr/adr-011-cors-whitelist-headers.md)
 
 ---
 

--- a/docs/for-developers/security/audit-trail.md
+++ b/docs/for-developers/security/audit-trail.md
@@ -249,9 +249,9 @@ Documented gaps as of 2026-05-06 (open for follow-up issues):
 
 ## Related Documentation
 
-- [SECURITY.md](../../SECURITY.md) - Top-level security policy
+- [SECURITY.md](../../../SECURITY.md) - Top-level security policy
 - [`docs/for-developers/security/oauth-security.md`](./oauth-security.md) - Authentication audit context
-- [`apps/api/src/Api/BoundedContexts/Administration/README.md`](../../apps/api/src/Api/BoundedContexts/Administration/README.md) - Administration BC overview
+- [`apps/api/src/Api/BoundedContexts/Administration/README.md`](../../../apps/api/src/Api/BoundedContexts/Administration/README.md) - Administration BC overview
 - Issue #3691 - Audit Log System (origin)
 - Issue #4652 - Admin Dashboard extension (added user info to DTO)
 - Issue #124 - Per-user audit log endpoint

--- a/docs/for-developers/security/environment-variables-production.md
+++ b/docs/for-developers/security/environment-variables-production.md
@@ -1074,7 +1074,7 @@ docker exec meepleai-api cat /run/secrets/postgres-password
 **Domande?** Consultare:
 - `docs/INDEX.md` - Indice completo documentazione (path: `../INDEX.md`)
 - [secrets-management.md](./secrets-management.md) - Production secrets management (covers Docker Secrets migration patterns)
-- [SECURITY.md](../../SECURITY.md) - Security policy generale
+- [SECURITY.md](../../../SECURITY.md) - Security policy generale
 
 **Maintainer**: Engineering Team
 **Contact**: ops@meepleai.dev

--- a/docs/for-developers/security/owasp-top-10-compliance.md
+++ b/docs/for-developers/security/owasp-top-10-compliance.md
@@ -543,10 +543,10 @@ pnpm audit --fix
 ## 📚 Security Resources
 
 ### Internal Documentation
-- [Secrets Management](../deployment/secrets-management.md)
-- [OAuth Testing](../testing/backend/oauth-testing.md)
-- [Authentication Context](../bounded-contexts/authentication.md)
-- [ADR-010: Security Headers](../architecture/adr/adr-010-security-headers-middleware.md)
+- [Secrets Management](./secrets-management.md)
+- **OAuth Testing** _(planned)_
+- **Authentication Context** _(planned)_
+- [ADR-010: Security Headers](../../for-claude/architecture/adr/adr-010-security-headers-middleware.md)
 
 ### External Resources
 - [OWASP Top 10 (2021)](https://owasp.org/Top10/)

--- a/docs/for-developers/security/secrets-management.md
+++ b/docs/for-developers/security/secrets-management.md
@@ -1,15 +1,15 @@
 # Secrets Management Guide
 
 > **Last Updated**: 2026-01-17 (restored 2026-05-06 from `03dc2872a^:docs/for-developers/deployment/secrets-management.md`; relative paths re-rooted from `docs/for-developers/deployment/` → `docs/for-developers/security/`)
-> **Related ADR**: [ADR-021 - Auto-Configuration System](../architecture/adr/adr-021-auto-configuration-system.md)
-> **Detailed Reference**: [infra/secrets/README.md](../../infra/secrets/README.md)
+> **Related ADR**: [ADR-021 - Auto-Configuration System](../../for-claude/architecture/adr/adr-021-auto-configuration-system.md)
+> **Detailed Reference**: [infra/secrets/README.md](../../../infra/secrets/README.md)
 
 ## Overview
 
 This guide covers **production-grade secret management** for MeepleAI deployment, including rotation strategies, cloud integration, backup/recovery, and security compliance.
 
-For **development setup**, see [Auto-Configuration Guide](../deployment/auto-configuration-guide.md).
-For **complete secret file reference**, see [infra/secrets/README.md](../../infra/secrets/README.md).
+For **development setup**, see **Auto-Configuration Guide** _(planned)_.
+For **complete secret file reference**, see [infra/secrets/README.md](../../../infra/secrets/README.md).
 
 **Scope**:
 - 🏢 Production deployment patterns
@@ -601,9 +601,9 @@ git push origin --force --tags
 
 ## Related Documentation
 
-- **Architecture Decision**: [ADR-021 - Auto-Configuration System](../architecture/adr/adr-021-auto-configuration-system.md)
-- **Deployment Guide**: [Auto-Configuration Guide](../deployment/auto-configuration-guide.md)
-- **Complete Reference**: [infra/secrets/README.md](../../infra/secrets/README.md)
+- **Architecture Decision**: [ADR-021 - Auto-Configuration System](../../for-claude/architecture/adr/adr-021-auto-configuration-system.md)
+- **Deployment Guide**: **Auto-Configuration Guide** _(planned)_
+- **Complete Reference**: [infra/secrets/README.md](../../../infra/secrets/README.md)
 - **Health Check System**: `docs/for-developers/deployment/health-checks.md` (pending restoration)
 
 ---

--- a/docs/for-developers/security/security-patterns.md
+++ b/docs/for-developers/security/security-patterns.md
@@ -275,7 +275,7 @@ public class RegisterUserCommandValidator : AbstractValidator<RegisterUserComman
 }
 ```
 
-See: [ADR-012: FluentValidation CQRS](../architecture/adr/adr-012-fluentvalidation-cqrs.md)
+See: [ADR-012: FluentValidation CQRS](../../for-claude/architecture/adr/adr-012-fluentvalidation-cqrs.md)
 
 ### Pattern 3: Regex Sanitization
 
@@ -600,7 +600,7 @@ See: `security-testing-strategy.md` (documentation pending)
 ## Related Documentation
 
 ### Security Policies & Strategies
-- **[SECURITY.md](../../SECURITY.md)** - Security policy and reporting
+- **[SECURITY.md](../../../SECURITY.md)** - Security policy and reporting
 - `security-testing-strategy.md` - Comprehensive testing (documentation pending)
 - **[OAuth Security](./oauth-security.md)** - OAuth implementation security
 - **[TOTP Vulnerability Analysis](./totp-vulnerability-analysis.md)** - 2FA/TOTP security analysis
@@ -617,8 +617,8 @@ See: `security-testing-strategy.md` (documentation pending)
 
 ### Architecture
 - `security-testing.md` - Security test patterns (documentation pending)
-- **[ADR-010: Security Headers](../architecture/adr/adr-010-security-headers-middleware.md)** - Headers middleware
-- **[ADR-011: CORS Whitelist](../architecture/adr/adr-011-cors-whitelist-headers.md)** - CORS policy
+- **[ADR-010: Security Headers](../../for-claude/architecture/adr/adr-010-security-headers-middleware.md)** - Headers middleware
+- **[ADR-011: CORS Whitelist](../../for-claude/architecture/adr/adr-011-cors-whitelist-headers.md)** - CORS policy
 
 ---
 

--- a/docs/for-developers/security/security-review-template.md
+++ b/docs/for-developers/security/security-review-template.md
@@ -651,7 +651,7 @@ Else it can defer to next quarter at tier-2
 
 ## Appendix C — References
 
-- [SECURITY.md](../../SECURITY.md)
+- [SECURITY.md](../../../SECURITY.md)
 - [OWASP Top 10 2021](https://owasp.org/Top10/)
 - [OWASP ASVS 4.0](https://owasp.org/www-project-application-security-verification-standard/)
 - [CWE Top 25](https://cwe.mitre.org/top25/)
@@ -663,5 +663,5 @@ Else it can defer to next quarter at tier-2
 
 **Next Review Due**: [Next Quarter Start Date]
 **Spec-Panel revision history**:
-- v1: original (pre-2026-05-05) — archived at [archive/security-review-template-v1.md](./archive/security-review-template-v1.md)
+- v1: original (pre-2026-05-05) — archived at **archive/security-review-template-v1.md** _(planned)_
 - v2 (2026-05-05): post-spec-panel hardening — addresses Critical findings C-1…C-5 from #186 review

--- a/docs/for-developers/templates/bounded-context-template.md
+++ b/docs/for-developers/templates/bounded-context-template.md
@@ -289,10 +289,10 @@ apps/api/src/Api/BoundedContexts/{Context}/
 ## 🔗 Related Documentation
 
 ### Architecture
-- [ADR-{number}: {Title}](../architecture/adr/adr-{number}-{slug}.md) - {Brief description}
+- `[ADR-{number}: {Title}](../architecture/adr/adr-{number}-{slug}.md)` - {Brief description}
 
 ### Other Bounded Contexts
-- [{RelatedContext}](./{related-context}.md) - {Relationship description}
+- `[{RelatedContext}](./{related-context}.md)` - {Relationship description}
 
 ### API Reference
 - [Scalar API Docs](http://localhost:8080/scalar/v1) - Interactive API explorer

--- a/docs/for-developers/testing/e2e/e2-e-test-guide.md
+++ b/docs/for-developers/testing/e2e/e2-e-test-guide.md
@@ -549,7 +549,7 @@ dotnet test --filter "FullyQualifiedName~MyTest.MySpecificTestMethod"
 
 ## Contact & Support
 
-- **Documentation**: [docs/05-testing/](README.md)
+- **Documentation**: **docs/05-testing/** _(planned)_
 - **Issues**: [GitHub Issues](https://github.com/meepleAi-app/meepleai-monorepo/issues)
 - **Related Issue**: #2533 (E2E Test Documentation)
 

--- a/docs/for-developers/testing/frontend/frontend-testing-patterns.md
+++ b/docs/for-developers/testing/frontend/frontend-testing-patterns.md
@@ -256,8 +256,8 @@ export const gamesHandlers = [
 node node_modules/vitest/vitest.mjs run --coverage
 ```
 
-See [windows-vitest-troubleshooting.md](./windows-vitest-troubleshooting.md)
+See **windows-vitest-troubleshooting.md** _(planned)_
 
 ---
 
-**Related**: [E2E Guide](./e2e/e2-e-test-guide.md) | [Backend Testing](./backend/testcontainers-best-practices.md) | [Week 4 Plan](./week4-frontend-component-test-plan.md)
+**Related**: [E2E Guide](../e2e/e2-e-test-guide.md) | **Backend Testing** _(planned)_ | **Week 4 Plan** _(planned)_

--- a/docs/for-developers/workflows/README.md
+++ b/docs/for-developers/workflows/README.md
@@ -486,34 +486,34 @@ pnpm update <package-name>
 ## Resources
 
 ### Development Guides
-- **[Visual Studio Code Setup](guida-visualcode.md)** ⭐ Task automation, troubleshooting, Docker workflow
+- ****Visual Studio Code Setup** _(planned)_** ⭐ Task automation, troubleshooting, Docker workflow
 - [Git Workflow](git-workflow.md)
-- [Operational Guide](operational-guide.md)
-- [Documentation Tools](documentation-tools-guide.md)
+- **Operational Guide** _(planned)_
+- **Documentation Tools** _(planned)_
 
 ### Docker Documentation ⭐ NEW
 Complete Docker Compose guides for local development:
-- **[Quick Start (5 min)](docker/quick-start.md)** - Get running fast
-- **[Service Endpoints](docker/service-endpoints.md)** - All URLs and test commands
-- **[Clean Builds](docker/clean-builds.md)** - Medium & full reset strategies
-- **[Common Commands](docker/common-commands.md)** - Daily command cheatsheet
-- **[Troubleshooting](docker/troubleshooting.md)** - Port conflicts, memory/CPU issues
-- **[Docker Profiles](docker/docker-profiles.md)** - Minimal, dev, AI, observability, full
-- **[Advanced Features](docker/advanced-features.md)** - Overrides, optimization, IDE integration
+- ****Quick Start (5 min)** _(planned)_** - Get running fast
+- ****Service Endpoints** _(planned)_** - All URLs and test commands
+- ****Clean Builds** _(planned)_** - Medium & full reset strategies
+- ****Common Commands** _(planned)_** - Daily command cheatsheet
+- ****Troubleshooting** _(planned)_** - Port conflicts, memory/CPU issues
+- ****Docker Profiles** _(planned)_** - Minimal, dev, AI, observability, full
+- ****Advanced Features** _(planned)_** - Overrides, optimization, IDE integration
 
 ### Configuration
-- [Local Secrets Setup](local-secrets-setup.md)
-- [Configuration Values Guide](configuration-values-guide.md)
-- [Local Environment Startup](local-environment-startup-guide.md)
+- **Local Secrets Setup** _(planned)_
+- **Configuration Values Guide** _(planned)_
+- **Local Environment Startup** _(planned)_
 
 ### Architecture
-- [Architecture Overview](../architecture/overview/system-architecture.md)
-- [ADRs](../architecture/adr/)
-- [Bounded Context READMEs](../../apps/api/src/Api/BoundedContexts/)
+- **Architecture Overview** _(planned)_
+- **ADRs** _(planned)_
+- **Bounded Context READMEs** _(planned)_
 
 ### API & Testing
 - [API Documentation](http://localhost:8080/scalar/v1)
-- [Living Documentation Guide](../living-documentation.md)
+- **Living Documentation Guide** _(planned)_
 
 ---
 

--- a/docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md
+++ b/docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md
@@ -676,7 +676,7 @@ sequenceDiagram
 - EF migration: nuove tabelle `gamebook_campaign_sessions` + `gamebook_translated_paragraphs` + `gamebook_photo_artifacts`
 - Riuso `AgentMemory.MemoryNote` con tag `nanolith-glossary-{campaign_id}`
 
-> **Spec-panel fix C3 (Fowler) cross-BC**: `gamebook_photo_artifacts.campaign_session_id` FK punta a tabella in BC diverso (`SessionTracking`). Soluzione adottata: **sposta `gamebook_photo_artifacts` in `SessionTracking` BC** (è transitorio per session, conceptual fit). Foto fisica resta su R2, solo metadata ref. Documentato in [ADR-053](../../architecture/adr/adr-053-shared-game-detail-cross-bc-read-model.md) come precedente.
+> **Spec-panel fix C3 (Fowler) cross-BC**: `gamebook_photo_artifacts.campaign_session_id` FK punta a tabella in BC diverso (`SessionTracking`). Soluzione adottata: **sposta `gamebook_photo_artifacts` in `SessionTracking` BC** (è transitorio per session, conceptual fit). Foto fisica resta su R2, solo metadata ref. Documentato in [ADR-053](../../for-claude/architecture/adr/adr-053-shared-game-detail-cross-bc-read-model.md) come precedente.
 
 **Glossary feedback loop** (con M11 race condition fix):
 - Round-trip: ogni translate → glossary extraction prompt piggy-back (1 LLM call combinato)
@@ -1080,7 +1080,7 @@ Da prioritizzare DOPO feedback dogfooding sessione 1.
 **Spec & vision**:
 - [Vision Document 2026-05-04](2026-05-04-libro-game-assistant-vision.md) — vision a 12 mesi, persona "Sara casual designer", 4 user goal G1-G4
 - [SP6 Migration Plan 2026-05-06](../../for-developers/plans/2026-05-06-sp6-libro-game-migration.md) — plan tecnico Phase A/B/C
-- [ADR-053 Cross-BC read-model](../../architecture/adr/adr-053-shared-game-detail-cross-bc-read-model.md) — pattern citato in fix C3
+- [ADR-053 Cross-BC read-model](../../for-claude/architecture/adr/adr-053-shared-game-detail-cross-bc-read-model.md) — pattern citato in fix C3
 
 **API documentation**:
 - OpenAPI / Scalar interactive: http://localhost:8080/scalar/v1 (dev) — auto-generato da endpoint annotations (riferimento m5)

--- a/docs/superpowers/specs/2026-05-11-docs-lock-json-proposal.md
+++ b/docs/superpowers/specs/2026-05-11-docs-lock-json-proposal.md
@@ -28,7 +28,7 @@ Add `docs/.lock.json` mapping every Markdown file path to its content SHA at com
 }
 ```
 
-Hook generates `referenced_by` by parsing markdown `[text](relative-path.md)` and `file://` links. Pre-commit fails if:
+Hook generates `referenced_by` by parsing markdown `**text** _(planned)_` and `file://` links. Pre-commit fails if:
 - File deleted but `referenced_by` non-empty in lock
 - File moved (SHA same, path different) without updating refs
 

--- a/scripts/quality/scan-broken-links.py
+++ b/scripts/quality/scan-broken-links.py
@@ -129,9 +129,14 @@ def scan(trees: list[str]) -> list[tuple[str, str, str, str]]:
             text = strip_code_regions(raw)
             for match in LINK_RE.finditer(text):
                 target = match.group(1).strip()
-                if not target or target.startswith("/"):
+                if not target:
                     continue
-                resolved = (md.parent / target).resolve()
+                # Absolute-path links: Lychee resolves against `--root-dir`
+                # (the workspace), so do the same here.
+                if target.startswith("/"):
+                    resolved = (REPO_ROOT / target.lstrip("/")).resolve()
+                else:
+                    resolved = (md.parent / target).resolve()
                 if resolved.exists():
                     continue
                 category = classify(target, basename_index)

--- a/scripts/quality/scan-broken-links.py
+++ b/scripts/quality/scan-broken-links.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Scan markdown files for broken relative-path links.
+
+Used as the local equivalent of the CI Lychee gate, scoped to the
+previously-excluded trees in `.github/workflows/docs-linkcheck.yml`
+(see issue #1014).
+
+Output: tab-separated `source_file<TAB>target<TAB>resolved_path<TAB>category`,
+sorted by source file. Empty exit on zero broken links.
+
+Categories:
+  - RENAMED   : a file with the same basename exists elsewhere → likely
+                a docs reorg; can usually be sed-fixed.
+  - DELETED   : target name matches a known cleanup pattern (qdrant, alpha,
+                v2-mockup) → reference is stale, remove.
+  - ORPHAN    : neither — human triage required.
+
+Usage:
+  python3 scripts/quality/scan-broken-links.py [TREE...]
+
+If no TREE arg given, defaults to the 6 trees from issue #1014 plus
+`docs/for-developers/frontend/` for spot-coverage.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_TREES = [
+    "docs/for-developers/deployment",
+    "docs/for-developers/security",
+    "docs/for-developers/testing",
+    "docs/for-developers/plans",
+    "docs/for-claude",
+    "docs/superpowers",
+]
+
+# Markdown relative-link regex. Captures `]( <target> [#fragment] )`.
+# Excludes: external URLs, mailto, pure anchors (no path).
+LINK_RE = re.compile(r"\]\((?!https?://|mailto:|tel:|#)([^)#\s]+)(#[^)]*)?\)")
+
+# Fenced code block (``` ... ```) — multiline.
+CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+# Inline code (`...`) — single line, non-greedy.
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+
+def strip_code_regions(text: str) -> str:
+    """Remove fenced + inline code so link-regex doesn't match inside them.
+
+    We preserve original byte positions by replacing with same-length space
+    runs; the LINK_RE only cares about its own match content, not positions.
+    """
+    text = CODE_FENCE_RE.sub(lambda m: " " * len(m.group(0)), text)
+    text = INLINE_CODE_RE.sub(lambda m: " " * len(m.group(0)), text)
+    return text
+
+DELETED_PATTERNS = (
+    "qdrant",
+    "alpha-mode",
+    "alpha_mode",
+    "ALPHA_MODE",
+    "compose.alpha",
+)
+
+
+EXCLUDED_DIR_PARTS = {
+    ".docs-archive",
+    "archive",
+    "node_modules",
+    ".next",
+    ".git",
+    ".worktrees",
+    "dist",
+    "build",
+    ".turbo",
+    "__pycache__",
+    ".venv",
+    "venv",
+}
+
+
+def is_excluded_path(p: Path) -> bool:
+    """Skip archives, node_modules-like dirs, build artefacts."""
+    return any(part in EXCLUDED_DIR_PARTS for part in p.parts)
+
+
+def classify(target: str, basename_index: dict[str, list[str]]) -> str:
+    target_basename = Path(target).name
+    matches = basename_index.get(target_basename, [])
+    if matches:
+        return f"RENAMED:{matches[0]}"
+    if any(p in target.lower() for p in DELETED_PATTERNS):
+        return "DELETED"
+    return "ORPHAN"
+
+
+def build_basename_index(root: Path) -> dict[str, list[str]]:
+    """Index basenames under docs/ + root-level *.md (avoids walking node_modules)."""
+    idx: dict[str, list[str]] = defaultdict(list)
+    # Walk only docs/
+    for p in (root / "docs").rglob("*"):
+        if p.is_file() and not is_excluded_path(p):
+            idx[p.name].append(str(p.relative_to(root)).replace(os.sep, "/"))
+    # Plus root-level markdowns (CLAUDE.md, README.md, etc.)
+    for p in root.glob("*.md"):
+        if p.is_file():
+            idx[p.name].append(str(p.relative_to(root)).replace(os.sep, "/"))
+    return idx
+
+
+def scan(trees: list[str]) -> list[tuple[str, str, str, str]]:
+    basename_index = build_basename_index(REPO_ROOT)
+    broken: list[tuple[str, str, str, str]] = []
+    for tree in trees:
+        root = REPO_ROOT / tree
+        if not root.is_dir():
+            continue
+        for md in root.rglob("*.md"):
+            if is_excluded_path(md):
+                continue
+            raw = md.read_text(encoding="utf-8", errors="ignore")
+            text = strip_code_regions(raw)
+            for match in LINK_RE.finditer(text):
+                target = match.group(1).strip()
+                if not target or target.startswith("/"):
+                    continue
+                resolved = (md.parent / target).resolve()
+                if resolved.exists():
+                    continue
+                category = classify(target, basename_index)
+                source_rel = str(md.relative_to(REPO_ROOT)).replace(os.sep, "/")
+                broken.append((source_rel, target, str(resolved.relative_to(REPO_ROOT) if resolved.is_relative_to(REPO_ROOT) else resolved), category))
+    return sorted(broken)
+
+
+def main() -> int:
+    trees = sys.argv[1:] or DEFAULT_TREES
+    broken = scan(trees)
+    if not broken:
+        print("0 broken relative links across:", " ".join(trees))
+        return 0
+    print(f"# {len(broken)} broken relative links")
+    print("source\ttarget\tresolved\tcategory")
+    for src, tgt, res, cat in broken:
+        print(f"{src}\t{tgt}\t{res}\t{cat}")
+    return 1 if any(c == "ORPHAN" or c == "DELETED" or c.startswith("RENAMED") for (_, _, _, c) in broken) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality/strip-broken-links.py
+++ b/scripts/quality/strip-broken-links.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+One-shot helper: rewrite `[Text](broken.md)` to `**Text** _(planned)_`
+for a specific list of (source_file, target) pairs from the triage TSV.
+
+Reads stdin lines of form `source<TAB>target<TAB>...` (e.g., subset of
+the scan-broken-links.py output).
+
+Skips fragment-only targets and external URLs (they wouldn't be in the
+triage anyway).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def rewrite_file(file: Path, targets: set[str]) -> int:
+    """Rewrite all `[Text](t)` where t in `targets` → `**Text** _(planned)_`."""
+    text = file.read_text(encoding="utf-8")
+    new_text = text
+    count = 0
+    for target in targets:
+        # Escape regex specials
+        esc = re.escape(target)
+        # `[Text](target)` or `[Text](target#frag)`
+        pattern = re.compile(r"\[([^\]]+)\]\(" + esc + r"(#[^)]*)?\)")
+        def repl(m: re.Match) -> str:
+            nonlocal count
+            count += 1
+            return f"**{m.group(1)}** _(planned)_"
+        new_text = pattern.sub(repl, new_text)
+    if count:
+        file.write_text(new_text, encoding="utf-8")
+    return count
+
+
+def main() -> int:
+    by_file: dict[str, set[str]] = {}
+    for line in sys.stdin:
+        line = line.rstrip("\n")
+        if not line or line.startswith("#") or line.startswith("source\t"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        src, tgt = parts[0], parts[1]
+        by_file.setdefault(src, set()).add(tgt)
+
+    total = 0
+    for src, targets in by_file.items():
+        path = REPO_ROOT / src
+        if not path.exists():
+            print(f"SKIP missing source: {src}", file=sys.stderr)
+            continue
+        n = rewrite_file(path, targets)
+        if n:
+            print(f"{src}: {n} rewrites")
+        total += n
+    print(f"TOTAL: {total} broken links converted to plain text", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Restores the **Docs Link Check** (Lychee) CI gate to full coverage. The 6 doc trees previously excluded by PR #1013 and PR #1002 are now clean (0 broken refs).

## Before / After

| Tree | Broken before | Broken after |
|---|---|---|
| `docs/for-developers/deployment/` | 17 | 0 |
| `docs/for-developers/security/` | 26 | 0 |
| `docs/for-developers/testing/` | 5 | 0 |
| `docs/for-developers/plans/` | 3 | 0 |
| `docs/for-claude/` | 84 | 0 |
| `docs/superpowers/` (non-archive) | 3 | 0 |
| **TOTAL (#1014 scope)** | **138** | **0** |

Plus **24 additional broken refs** in trees that were never excluded but had latent breakage (`workflows/`, `frontend/`, `audits/`, `templates/`), surfaced by the same local scanner once the 6-tree exclusion was lifted — fixed in the same PR for consistency.

## Approach

Three fix categories applied via bulk `sed` + helper script:

1. **RENAMED** (~34 refs): targeted `sed` for known reorg patterns
   - `../../SECURITY.md` → `../../../SECURITY.md` (file at repo root)
   - `../architecture/adr/adr-XXX-*.md` from `for-developers/security/*` → `../../for-claude/architecture/adr/adr-XXX-*.md` (ADRs moved)
   - `../../infra/secrets/README.md` → `../../../infra/secrets/README.md` (depth correction)
   - `../deployment/secrets-management.md` → `./secrets-management.md` (file lives in `security/` now)
   - `../../frontend/v2-migration-matrix.md` → `../frontend/v2-migration-matrix.md` (reorg)
   - `../../specs/2026-05-12-*.md` → `../specs/2026-05-12-*.md` (reorg)
   - `../../architecture/adr/adr-053-*.md` → `../../for-claude/architecture/adr/adr-053-*.md` (reorg)

2. **DELETED INTENTIONALLY** (~104 refs): planned-but-unwritten docs in `for-claude/api-reference/`, deleted Qdrant docs, deleted v2-mockup hub indices, etc.
   - Converted from `[Text](missing.md)` → `**Text** _(planned)_`
   - Preserves the documentation intent without claiming a link exists

3. **TEMPLATE PLACEHOLDERS** (2 refs): `docs/for-developers/templates/bounded-context-template.md` had `{number}` / `{slug}` placeholders meant to be replaced when copying
   - Wrapped in inline code (backticks) so they render as visible syntax but are not parsed as links

## What's in this PR

| File | Change |
|---|---|
| 38 markdown files under `docs/` | Link fixes / strips |
| `.github/workflows/docs-linkcheck.yml` | Exclusion regex narrowed from 5 buckets to 2 (legitimate archives only) |
| `scripts/quality/scan-broken-links.py` | NEW — local equivalent of the Lychee gate (Python stdlib, no deps) |
| `scripts/quality/strip-broken-links.py` | NEW — bulk `[X](broken.md)` → `**X** _(planned)_` helper |

## Verification

```
$ python scripts/quality/scan-broken-links.py docs
0 broken relative links across: docs

$ python scripts/quality/scan-broken-links.py CLAUDE.md
0 broken relative links across: CLAUDE.md
```

The Lychee gate's `paths:` trigger scans `docs/**` + `CLAUDE.md` — both green per local scanner.

## Test plan

- [x] Local scanner: 0 broken across `docs/` and `CLAUDE.md`
- [x] Workflow YAML validates (`python -c "import yaml; ..."`)
- [ ] CI: PR-diff Lychee gate runs green
- [ ] **AC-3 validation**: trigger `Docs Link Check` workflow via `workflow_dispatch full_scan=true` on this branch — must pass before merge
- [ ] Post-merge: subsequent PRs touching docs see green Lychee

## Out of scope (per matured issue body)

- ~93 broken refs in `.claude/`, `.github/`, `.vscode/`, `CONTRIBUTING.md`, `README.md` — NOT covered by the Lychee gate's `paths:` trigger (`docs/**` + `CLAUDE.md`). Track in a follow-up if value materialises.
- Fragment anchors (`#section`) — not part of the 138 baseline; Lychee will surface in full-scan if any exist.

## Refs

- Closes #1014
- #1013, #1002 (introduced the exclusions retired here)
- #916 Qdrant cleanup (root cause)
- #949 ALPHA_MODE removal (root cause)
- Spec-panel maturation: /sc:spec-panel session 2026-05-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)