### PR TITLE
feat(conformity): WS-C Phase 4a waiver validator + debt-issue automation

### DIFF
--- a/.github/workflows/conformity-debt-issue.yml
+++ b/.github/workflows/conformity-debt-issue.yml
@@ -1,0 +1,295 @@
+name: Conformity — Debt Issue Manager
+
+# WS-C Phase 4a (issue #1069, umbrella #1066) — AC-C.5.2 dedup + AC-C.5.5 audit log.
+#
+# When a PR receives the `conformity-waiver` label:
+#   1. Wait for the rationale validator to have parsed a valid block (we
+#      re-parse here independently — workflows don't share state).
+#   2. Compute dedup key sha256(PR_number || sorted(route_ids) || iso_week(now)).
+#   3. Search for an open issue containing `<!-- waiver-key: {key} -->`.
+#      - Found → post a comment with the updated rationale snapshot.
+#      - Not found → create a new issue with label `conformity-debt`.
+#   4. Open an auto-PR appending an entry to `docs/.../conformity-waivers.md`
+#      (AC-C.5.5 git-as-audit-log).
+#
+# When a PR is closed UNMERGED:
+#   - Auto-close any open debt-issue whose body contains a waiver-key tied to
+#     this PR (`pr=<number>` in machine-readable header).
+
+on:
+  pull_request:
+    branches:
+      - main-dev
+      - main-staging
+      - main
+    types:
+      - labeled
+      - unlabeled
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # Per-PR concurrency; we want issue-create operations serialized so dedup works.
+  group: conformity-debt-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  manage:
+    name: Manage conformity debt issue
+    runs-on: ubuntu-22.04
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'conformity-waiver') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'conformity-waiver') ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == false)
+    steps:
+      - name: Checkout (for audit log update)
+        uses: actions/checkout@v6
+
+      - name: Compute action + dedup key
+        id: ctx
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const action = context.payload.action;
+            const pr = context.payload.pull_request;
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('pr_url', pr.html_url);
+            core.setOutput('pr_author', pr.user?.login ?? 'unknown');
+
+            if (action === 'closed') {
+              core.setOutput('mode', 'close-unmerged');
+              return;
+            }
+            if (action === 'unlabeled') {
+              core.setOutput('mode', 'unlabel');
+              return;
+            }
+            // Labeled — need to parse rationale to extract routes + expiry.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const MARKER = '> Conformity waiver rationale:';
+            const candidate = comments
+              .filter(c => c.body && c.body.includes(MARKER))
+              .find(c => c.user?.login === pr.user?.login || ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(c.author_association));
+            if (!candidate) {
+              core.warning('No valid rationale comment yet — debt-issue creation deferred until comment posted.');
+              core.setOutput('mode', 'skip');
+              return;
+            }
+            const fields = parseRationale(candidate.body);
+            if (!fields) {
+              core.warning('Rationale comment present but malformed — validator will surface details. Skipping.');
+              core.setOutput('mode', 'skip');
+              return;
+            }
+            const crypto = require('node:crypto');
+            const isoWeek = isoWeekString(new Date());
+            const key = crypto
+              .createHash('sha256')
+              .update(`${pr.number}|${fields.routes.slice().sort().join(',')}|${isoWeek}`)
+              .digest('hex')
+              .slice(0, 16);
+            core.setOutput('mode', 'create-or-update');
+            core.setOutput('waiver_key', key);
+            core.setOutput('expiry', fields.expiry);
+            core.setOutput('routes', fields.routes.join(','));
+            core.setOutput('reason', fields.reason);
+            core.setOutput('iso_week', isoWeek);
+
+            function parseRationale(body) {
+              const fields = { reason: null, expiry: null, routes: null };
+              for (const line of body.split('\n').map(l => l.trim())) {
+                const m = line.match(/^>\s*([A-Za-z]+):\s*(.+)$/);
+                if (m && m[1].toLowerCase() in fields) fields[m[1].toLowerCase()] = m[2].trim();
+              }
+              if (!fields.reason || fields.reason.length < 40 || !fields.routes) return null;
+              const routes = fields.routes.split(/\s+/).filter(Boolean);
+              if (routes.length === 0) return null;
+              const now = new Date();
+              const defaultExpiry = new Date(now.getTime() + 30 * 24 * 3600 * 1000);
+              let expiry = defaultExpiry;
+              if (fields.expiry) {
+                const p = new Date(fields.expiry + 'T23:59:59Z');
+                if (Number.isNaN(p.getTime()) || p < now) return null;
+                expiry = p;
+              }
+              return { reason: fields.reason, expiry: expiry.toISOString().slice(0, 10), routes };
+            }
+
+            function isoWeekString(d) {
+              // ISO 8601 week date: YYYY-Www
+              const target = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+              const dayNr = (target.getUTCDay() + 6) % 7;
+              target.setUTCDate(target.getUTCDate() - dayNr + 3);
+              const firstThursday = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
+              const weekNum = 1 + Math.round(((target - firstThursday) / 86400000 - 3 + ((firstThursday.getUTCDay() + 6) % 7)) / 7);
+              return `${target.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+            }
+
+      - name: Create or update debt-issue
+        if: steps.ctx.outputs.mode == 'create-or-update'
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          PR_URL: ${{ steps.ctx.outputs.pr_url }}
+          WAIVER_KEY: ${{ steps.ctx.outputs.waiver_key }}
+          EXPIRY: ${{ steps.ctx.outputs.expiry }}
+          ROUTES: ${{ steps.ctx.outputs.routes }}
+          REASON: ${{ steps.ctx.outputs.reason }}
+        with:
+          script: |
+            const { PR_NUMBER, PR_URL, WAIVER_KEY, EXPIRY, ROUTES, REASON } = process.env;
+            const routes = ROUTES.split(',');
+            const headerMarker = `<!-- conformity-debt: routes=${routes.join(',')}; expiry=${EXPIRY}; waiver-key=${WAIVER_KEY}; pr=${PR_NUMBER} -->`;
+            const keyMarker = `<!-- waiver-key: ${WAIVER_KEY} -->`;
+
+            // Search open debt issues for matching key.
+            const { data: existing } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:conformity-debt in:body "${WAIVER_KEY}"`,
+            });
+
+            if (existing.total_count > 0) {
+              const issue = existing.items[0];
+              core.info(`Found existing debt-issue #${issue.number} for waiver-key ${WAIVER_KEY}; commenting.`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body:
+                  `Re-applied waiver on PR ${PR_URL}.\n\n` +
+                  `Routes: ${routes.join(', ')}\nExpiry: ${EXPIRY}\nReason: ${REASON}`,
+              });
+              core.setOutput('issue_number', String(issue.number));
+              return;
+            }
+
+            const body =
+              `${headerMarker}\n${keyMarker}\n\n` +
+              `## Conformity Debt — auto-generated\n\n` +
+              `A waiver was applied on PR ${PR_URL} to bypass the mockup conformity gate.\n` +
+              `This issue tracks the debt that must be resolved before the cited routes\n` +
+              `can be safely promoted to staging/production.\n\n` +
+              `### Waiver details (AC-C.5.3)\n\n` +
+              `| Field | Value |\n|-------|-------|\n` +
+              `| Routes | \`${routes.join('\`, \`')}\` |\n` +
+              `| Expiry | **${EXPIRY}** |\n` +
+              `| Waiver key | \`${WAIVER_KEY}\` |\n` +
+              `| Origin PR | ${PR_URL} |\n\n` +
+              `### Rationale\n\n${REASON}\n\n` +
+              `### How to close this issue (AC-C.5.6)\n\n` +
+              `1. **Auto-close**: future PR includes \`Closes #<this-issue>\` AND passes the\n` +
+              `   conformity gate green.\n` +
+              `2. **Manual re-validate**: maintainer applies label \`waiver-revalidated\` on\n` +
+              `   a PR demonstrating the routes conform.\n` +
+              `3. **Expiry passed without closure**: \`conformity-debt-gate.yml\` will fail on\n` +
+              `   PRs targeting \`main-staging\`/\`main\`. Either extend (new waiver PR) or\n` +
+              `   remediate.\n\n` +
+              `Refs: #1066 (umbrella), #1069 (WS-C).`;
+
+            const { data: created } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[conformity-debt] PR #${PR_NUMBER} — ${routes.join(', ')} (expires ${EXPIRY})`,
+              body,
+              labels: ['conformity-debt', 'area/frontend'],
+            });
+            core.notice(`Created debt-issue #${created.number}.`);
+            core.setOutput('issue_number', String(created.number));
+
+      - name: Close debt-issues for PR closed-unmerged
+        if: steps.ctx.outputs.mode == 'close-unmerged'
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+        with:
+          script: |
+            const { PR_NUMBER } = process.env;
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:conformity-debt in:body "pr=${PR_NUMBER}"`,
+            });
+            for (const issue of data.items) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `closed_by: auto-cancelled, PR #${PR_NUMBER} closed without merge.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+              core.notice(`Closed debt-issue #${issue.number} (PR not merged).`);
+            }
+
+      - name: Append entry to audit log (AC-C.5.5)
+        if: steps.ctx.outputs.mode == 'create-or-update'
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          PR_URL: ${{ steps.ctx.outputs.pr_url }}
+          WAIVER_KEY: ${{ steps.ctx.outputs.waiver_key }}
+          EXPIRY: ${{ steps.ctx.outputs.expiry }}
+          ROUTES: ${{ steps.ctx.outputs.routes }}
+          REASON: ${{ steps.ctx.outputs.reason }}
+          NOW: ${{ github.event.pull_request.updated_at }}
+        run: |
+          set -euo pipefail
+          LOG_FILE="docs/for-developers/audits/conformity-waivers.md"
+          MONTH=$(date -u +%Y-%m)
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Ensure section header for current month exists.
+          if ! grep -q "^## ${MONTH}\b" "$LOG_FILE" 2>/dev/null; then
+            printf '\n## %s\n\n| Date | PR | Routes | Expiry | Waiver key | Reason (excerpt) |\n|------|-----|--------|--------|------------|-------------------|\n' "$MONTH" >> "$LOG_FILE"
+          fi
+
+          # Append row (escape pipes in reason).
+          REASON_ESC=$(printf '%s' "$REASON" | sed 's/|/\\|/g' | head -c 120)
+          printf '| %s | [#%s](%s) | `%s` | %s | `%s` | %s |\n' \
+            "$DATE" "$PR_NUMBER" "$PR_URL" "$ROUTES" "$EXPIRY" "$WAIVER_KEY" "$REASON_ESC" \
+            >> "$LOG_FILE"
+
+      - name: Open auto-PR with audit log update
+        if: steps.ctx.outputs.mode == 'create-or-update'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/conformity-waiver-${{ steps.ctx.outputs.waiver_key }}
+          base: main-dev
+          commit-message: |
+            docs(audit): record conformity waiver from PR #${{ steps.ctx.outputs.pr_number }} (#1069)
+
+            Routes: ${{ steps.ctx.outputs.routes }}
+            Expiry: ${{ steps.ctx.outputs.expiry }}
+            Waiver key: ${{ steps.ctx.outputs.waiver_key }}
+          title: 'docs(audit): conformity waiver from PR #${{ steps.ctx.outputs.pr_number }}'
+          body: |
+            ## Auto-generated audit trail entry
+
+            Triggered by `conformity-waiver` label on PR #${{ steps.ctx.outputs.pr_number }}.
+
+            - **Routes**: `${{ steps.ctx.outputs.routes }}`
+            - **Expiry**: ${{ steps.ctx.outputs.expiry }}
+            - **Waiver key**: `${{ steps.ctx.outputs.waiver_key }}`
+
+            ### Refs
+
+            - Issue: #1069 (WS-C)
+            - Umbrella: #1066
+            - AC: C.5.5 (audit log)
+          labels: |
+            conformity
+            automation
+            documentation
+          add-paths: |
+            docs/for-developers/audits/conformity-waivers.md

--- a/.github/workflows/conformity-waiver-validator.yml
+++ b/.github/workflows/conformity-waiver-validator.yml
@@ -1,0 +1,191 @@
+name: Conformity — Waiver Rationale Validator
+
+# WS-C Phase 4a (issue #1069, umbrella #1066) — AC-C.5.1 rationale enforcement.
+#
+# When a PR has the `conformity-waiver` label, this workflow enforces that one
+# of the PR comments contains a structured rationale block:
+#
+#     > Conformity waiver rationale:
+#     > Reason: <free text, min 40 char>
+#     > Expiry: <YYYY-MM-DD, optional, default = now+30d, max = now+90d>
+#     > Routes: <space-separated route ids from mockup-ownership.bootstrap.json>
+#
+# The comment must come from the PR author or a member of @meepleAi-app/area-frontend.
+#
+# This is a REQUIRED check on main-dev when the label is present. Without the
+# label, the workflow succeeds trivially (no waiver = no rationale needed).
+#
+# Branch protection update (manual, post-merge):
+#   gh api repos/meepleAi-app/meepleai-monorepo/branches/main-dev/protection \
+#     --method PUT -F required_status_checks.contexts[]="Conformity Waiver Rationale"
+#
+# (See `docs/for-developers/testing/frontend/mockup-conformity.md` for full setup.)
+
+on:
+  pull_request:
+    branches:
+      - main-dev
+      - main-staging
+      - main
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+  issue_comment:
+    types:
+      - created
+      - edited
+      - deleted
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: conformity-waiver-validator-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-waiver:
+    name: Conformity Waiver Rationale
+    runs-on: ubuntu-22.04
+    # Only run on PR comments (skip issue comments that aren't on PRs).
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request != null }}
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // pull_request event: github.event.pull_request.number
+            // issue_comment event on PR: github.event.issue.number
+            const num = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            if (!num) {
+              core.setFailed('Could not resolve PR number from event payload.');
+              return;
+            }
+            core.setOutput('number', String(num));
+
+      - name: Validate rationale (or pass-through when no waiver label)
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const hasWaiverLabel = pr.labels.some(l => l.name === 'conformity-waiver');
+            if (!hasWaiverLabel) {
+              core.info('No `conformity-waiver` label — validator passes trivially.');
+              return;
+            }
+
+            core.info(`Label \`conformity-waiver\` present on PR #${prNumber}. Validating rationale comment.`);
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const MARKER = '> Conformity waiver rationale:';
+            const candidates = comments.filter(c => c.body && c.body.includes(MARKER));
+            if (candidates.length === 0) {
+              core.setFailed(
+                `No comment contains the rationale marker "${MARKER}". ` +
+                `See docs/for-developers/testing/frontend/mockup-conformity.md ` +
+                `for the required block format (AC-C.5.1).`
+              );
+              return;
+            }
+
+            // Authorship: author of PR OR member of area-frontend.
+            // We trust comment.author_association: OWNER | MEMBER | COLLABORATOR | CONTRIBUTOR | NONE.
+            // PR author satisfies "OWNER" or "CONTRIBUTOR" depending on repo relationship.
+            const allowed = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const prAuthor = pr.user?.login;
+
+            const parsed = [];
+            for (const c of candidates) {
+              const okAuthor = c.user?.login === prAuthor || allowed.has(c.author_association);
+              if (!okAuthor) {
+                core.warning(
+                  `Comment ${c.id} ignored: author ${c.user?.login} (${c.author_association}) ` +
+                  `not allowed. PR author or area-frontend member required.`
+                );
+                continue;
+              }
+              parsed.push(parseRationale(c));
+            }
+
+            const valid = parsed.filter(p => p.ok);
+            if (valid.length === 0) {
+              const errors = parsed.map(p => `- ${p.error}`).join('\n');
+              core.setFailed(
+                `Found rationale marker but no comment validates successfully.\n` +
+                `Detected issues:\n${errors || '(none parsed — author check failed)'}`
+              );
+              return;
+            }
+
+            core.info(`✓ Valid rationale found: ${JSON.stringify(valid[0].fields)}`);
+            core.notice(
+              `Waiver rationale validated for PR #${prNumber}. ` +
+              `Routes: ${valid[0].fields.routes.join(', ')}. ` +
+              `Expiry: ${valid[0].fields.expiry}.`
+            );
+
+            function parseRationale(comment) {
+              const body = comment.body;
+              const lines = body.split('\n').map(l => l.trim());
+              const fields = { reason: null, expiry: null, routes: null };
+              for (const line of lines) {
+                const m = line.match(/^>\s*([A-Za-z]+):\s*(.+)$/);
+                if (!m) continue;
+                const key = m[1].toLowerCase();
+                if (key in fields) fields[key] = m[2].trim();
+              }
+              if (!fields.reason) return { ok: false, error: `${comment.html_url}: missing "Reason:"` };
+              if (fields.reason.length < 40) {
+                return { ok: false, error: `${comment.html_url}: Reason too short (${fields.reason.length} < 40 chars)` };
+              }
+              if (!fields.routes) return { ok: false, error: `${comment.html_url}: missing "Routes:"` };
+              const routes = fields.routes.split(/\s+/).filter(Boolean);
+              if (routes.length === 0) return { ok: false, error: `${comment.html_url}: empty Routes:` };
+
+              const now = new Date();
+              const defaultExpiry = new Date(now.getTime() + 30 * 24 * 3600 * 1000);
+              const maxExpiry = new Date(now.getTime() + 90 * 24 * 3600 * 1000);
+
+              let expiry = defaultExpiry;
+              if (fields.expiry) {
+                const parsed = new Date(fields.expiry + 'T23:59:59Z');
+                if (Number.isNaN(parsed.getTime())) {
+                  return { ok: false, error: `${comment.html_url}: Expiry "${fields.expiry}" is not YYYY-MM-DD` };
+                }
+                if (parsed < now) {
+                  return { ok: false, error: `${comment.html_url}: Expiry ${fields.expiry} is in the past` };
+                }
+                if (parsed > maxExpiry) {
+                  return {
+                    ok: false,
+                    error: `${comment.html_url}: Expiry ${fields.expiry} > 90d from now (max ${maxExpiry.toISOString().slice(0, 10)})`,
+                  };
+                }
+                expiry = parsed;
+              }
+
+              return {
+                ok: true,
+                fields: { reason: fields.reason, expiry: expiry.toISOString().slice(0, 10), routes },
+              };
+            }

--- a/docs/for-developers/audits/conformity-waivers.md
+++ b/docs/for-developers/audits/conformity-waivers.md
@@ -1,0 +1,54 @@
+# Conformity Waivers — Audit Log
+
+> **WS-C** (#1069, umbrella #1066) — AC-C.5.5
+> **Status**: append-only by convention (git-as-audit-log). All entries are
+> appended by the `conformity-debt-issue.yml` workflow via auto-PR. Manual
+> edits other than appending a new row are reviewed and flagged at PR review
+> time. Tampering is visible in `git log` / `git blame` of this file.
+
+## Purpose
+
+Every time a `conformity-waiver` label is applied to a PR, this log records:
+
+- the **date** the waiver was registered
+- the **origin PR** that triggered it
+- the affected **routes** (from `mockup-ownership.bootstrap.json`)
+- the **expiry date** after which `conformity-debt-gate.yml` will fail on PRs
+  targeting `main-staging` / `main`
+- the **waiver key** (dedup hash, also embedded in the matching debt-issue
+  header)
+- an **excerpt of the rationale** (first ~120 chars, raw text)
+
+The full rationale and current status live in the corresponding `conformity-debt`
+issue (linked via the waiver key marker `<!-- waiver-key: {key} -->`).
+
+## How a row gets added
+
+1. Author applies the `conformity-waiver` label to a PR.
+2. Author posts a comment with the structured rationale block (see
+   [`docs/for-developers/testing/frontend/mockup-conformity.md`](../testing/frontend/mockup-conformity.md)
+   for the format and validator rules — AC-C.5.1).
+3. `conformity-debt-issue.yml` parses the rationale, creates/updates the
+   `conformity-debt` issue (AC-C.5.2), appends a row to this file under the
+   current `YYYY-MM` section, and opens an auto-PR for human review.
+4. A reviewer (typically `area/frontend`) approves and merges the auto-PR.
+
+## How a row gets resolved
+
+Rows are **not removed**. The debt-issue referenced via `waiver-key` carries
+the state:
+
+- closed via `Closes #<debt-issue>` on a remediation PR → status: remediated
+- closed via `waiver-revalidated` label on a manual approval PR → status:
+  manually-cleared
+- still open past `Expiry` → `conformity-debt-gate.yml` blocks `main-staging` /
+  `main` merges; reviewer manually decides to extend (new waiver) or remediate
+
+For aggregate stats (active count, oldest expiring, top routes by debt) see
+the AC-C.5.7 weekly summary at
+`docs/for-developers/audits/conformity-waivers-summary.md` (lands in Phase 4c).
+
+## Log
+
+<!-- New entries appended below by conformity-debt-issue.yml. The most recent
+     month appears first by reading order once a few months accumulate. -->

--- a/docs/for-developers/testing/frontend/mockup-conformity.md
+++ b/docs/for-developers/testing/frontend/mockup-conformity.md
@@ -1,7 +1,7 @@
 # Mockup-to-route Conformity Gate
 
 > **Issue:** #1069 (WS-C Mockup Conformity Roadmap, umbrella #1066)
-> **Status:** Phase 1 + Phase 2 + Phase 3 + Phase 3b shipped 2026-05-13 — config, loader, Playwright projects, bootstrap spec, **real conformity spec** (no more fixme on data), pin verifier, both CI workflows. Only the waiver audit log (Phase 4) is left.
+> **Status:** Phase 1–4a shipped 2026-05-13 — config, loader, Playwright projects, real conformity spec, pin verifier, both CI workflows + waiver validator + debt-issue manager + audit log scaffold. Phase 4b (cross-branch gate) ship next.
 
 ## Overview
 
@@ -166,11 +166,51 @@ The original Phase 3b plan was to add `page.route()` API stubs per route. That t
 - The only remaining `test.fixme()` is the **baseline-missing** guard — self-resolves once `bootstrap-mockup-baselines.yml` dispatches and the auto-PR lands committed `__mockup__/*.png`
 - `visual-regression-conformity.yml`: build step now passes `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` so the fixture short-circuit is active in CI
 
+### Phase 4a (this PR)
+
+- `.github/workflows/conformity-waiver-validator.yml` — required check (post-merge branch protection update) that parses PR comments for the structured rationale marker when `conformity-waiver` label is present (AC-C.5.1)
+- `.github/workflows/conformity-debt-issue.yml` — on label-add: parses rationale, computes `sha256(PR, sorted(routes), iso_week)` dedup key (AC-C.5.2), creates/updates a `conformity-debt` issue (AC-C.5.3 machine-readable header), appends row to audit log via auto-PR (AC-C.5.5). On PR-closed-unmerged: auto-closes matching debt-issues.
+- `docs/for-developers/audits/conformity-waivers.md` — audit log scaffold
+
+### Waiver rationale format (AC-C.5.1)
+
+Apply the `conformity-waiver` label, then post a PR comment containing:
+
+```
+> Conformity waiver rationale:
+> Reason: <free text, min 40 char — describe why the diff is acceptable to merge>
+> Expiry: 2026-06-12
+> Routes: library library-game-detail
+```
+
+- `Reason` must be ≥ 40 characters.
+- `Expiry` is optional. Default = now + 30 days. Maximum = now + 90 days.
+- `Routes` must list one or more route ids present in `mockup-ownership.bootstrap.json`.
+- The comment author must be the PR author OR a member with `OWNER` / `MEMBER` /
+  `COLLABORATOR` association.
+
+The validator fails with a guidance link if the block is missing, malformed, or
+the expiry is out of range.
+
+### Branch protection update (manual, post-Phase-4a)
+
+To make the waiver validator block merges, add it to the required-status-check
+list on `main-dev`, `main-staging`, and `main`:
+
+```bash
+gh api repos/meepleAi-app/meepleai-monorepo/branches/main-dev/protection \
+  --method PUT \
+  --raw-field required_status_checks='{"strict":false,"contexts":["GitGuardian Security Checks","Conformity Waiver Rationale"]}'
+```
+
+(Repeat for `main-staging` and `main`.)
+
 ## What ships next
 
 | Phase | Deliverable |
 |-------|-------------|
-| **4** | `docs/for-developers/audits/conformity-waivers.md` audit log; waiver issue automation (AC-C.5 expiration enforcement) |
+| **4b** | `.github/workflows/conformity-debt-gate.yml` — required check on PR `main-dev → main-staging` and `main-staging → main`; fails if ≥1 open `conformity-debt` issue has expired (AC-C.5.4) |
+| **4c** (opt) | Weekly observability summary `conformity-waivers-summary.md` (AC-C.5.7) |
 | **post-merge** | Dispatch `bootstrap-mockup-baselines.yml` workflow → auto-PR lands `__mockup__/*.png` → conformity gate produces real diff (expected: large, documenting the 75-85% pre-remediation gap) |
 
 ## Running locally


### PR DESCRIPTION
## Summary

Phase 4a di **WS-C** (Mockup Conformity Gate, umbrella #1066) — waiver enforcement machinery secondo AC-C.5.1–C.5.3 + C.5.5 (post spec extension PR #1119).

## Deliverables

| File | AC | Purpose |
|------|-----|---------|
| `.github/workflows/conformity-waiver-validator.yml` | C.5.1 | Required-check workflow che parsifica `> Conformity waiver rationale:` marker quando `conformity-waiver` label è presente |
| `.github/workflows/conformity-debt-issue.yml` | C.5.2, C.5.3, C.5.5, C.5.6 | Crea/aggiorna `conformity-debt` issue con dedup key + auto-PR per audit log + auto-close su PR closed-unmerged |
| `docs/for-developers/audits/conformity-waivers.md` | C.5.5 | Audit log scaffold (append-only by convention, git-as-audit-log) |
| `docs/.../mockup-conformity.md` | — | Phase 4a status + waiver format documentation + branch protection update command |

## Waiver rationale format

```
> Conformity waiver rationale:
> Reason: <free text, min 40 char>
> Expiry: 2026-06-12
> Routes: library library-game-detail
```

- `Reason` ≥ 40 char
- `Expiry` optional (default now+30d, max now+90d)
- `Routes` non-empty list from ownership map
- Author must be PR author OR repo member (OWNER/MEMBER/COLLABORATOR)

## Dedup key (AC-C.5.2)

`sha256(PR_number || sorted(route_ids) || iso_week(now))` truncated 16 hex.
Stored in debt-issue body as `<!-- waiver-key: {key} -->`. Re-applying the
label same week + same routes → comment-update on existing issue, no duplicates.

## Machine-readable header (AC-C.5.3)

```
<!-- conformity-debt: routes=library,library-game-detail; expiry=2026-06-12; waiver-key=ABC123DEF456; pr=1120 -->
```

Phase 4b workflow `conformity-debt-gate.yml` will parse `expiry=` from this header
to fail PRs to `main-staging` when ≥1 issue has `expiry < now`.

## Post-merge manual step

Update branch protection per `mockup-conformity.md`:

```bash
gh api repos/meepleAi-app/meepleai-monorepo/branches/main-dev/protection \
  --method PUT \
  --raw-field required_status_checks='{"strict":false,"contexts":["GitGuardian Security Checks","Conformity Waiver Rationale"]}'
```

(Repeat per `main-staging` e `main`.)

## Test plan

- [x] `pnpm typecheck` (no code changes) — N/A
- [x] Pre-commit (lint-staged + commitlint) — green
- [x] Workflow YAML schema (manual inspection: trigger types, permissions, actions versions)
- [x] SHA-pin verified: `peter-evans/create-pull-request@22a9089...` (resolved post-PR #1114)
- [ ] CI: validator workflow triggera su questo PR e passa trivially (label assente)
- [ ] Post-merge: testare manualmente applicando `conformity-waiver` label su un PR draft + posting rationale → verifica issue creation + audit log auto-PR

## WS-C status (5/6 sub-phases shipped)

| Phase | PR | Status |
|-------|-----|--------|
| 1 — Config + loader | #1105 | ✅ |
| 2 — Playwright + verifier | #1110 | ✅ |
| 3 — Workflows + adaptive helper | #1114 | ✅ |
| 3b — Real spec + fixture wiring | #1117 | ✅ |
| **4-spec — AC-C.5 sub-criteria** | #1119 | ✅ |
| **4a — Waiver validator + debt-issue** | **this PR** | 🔄 |
| 4b — Cross-branch gate | — | ⏳ |
| 4c (opt) — Observability summary | — | ⏳ |

## Refs

- Refs #1069 (WS-C Phase 4a)
- Refs #1066 (umbrella)
- Builds on PR #1119 (AC-C.5 sub-criteria extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
