### PR TITLE
fix(ci): shard frontend Vitest into 3 parallel jobs (refs #1115)

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -117,6 +117,7 @@ jobs:
     # skipped because the PR did not touch frontend paths.
     name: Frontend Fast (lint + typecheck + unit)
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     needs: [changes, frontend-static, frontend-tests]
     if: ${{ always() }}
     steps:
@@ -125,9 +126,13 @@ jobs:
           STATIC="${{ needs.frontend-static.result }}"
           TESTS="${{ needs.frontend-tests.result }}"
           FRONTEND_CHANGED="${{ needs.changes.outputs.frontend }}"
-          echo "frontend-static=$STATIC frontend-tests=$TESTS frontend-changed=$FRONTEND_CHANGED"
-          if [[ "$FRONTEND_CHANGED" != "true" ]]; then
-            echo "No frontend changes — aggregator passes (upstream legitimately skipped)."
+          EVENT="${{ github.event_name }}"
+          echo "event=$EVENT frontend-static=$STATIC frontend-tests=$TESTS frontend-changed=$FRONTEND_CHANGED"
+          # Skip early only for PRs that don't touch frontend (upstream jobs
+          # legitimately skipped). workflow_dispatch always runs upstream
+          # regardless of frontend-changed, so we must verify their results.
+          if [[ "$FRONTEND_CHANGED" != "true" ]] && [[ "$EVENT" != "workflow_dispatch" ]]; then
+            echo "No frontend changes on PR — aggregator passes (upstream legitimately skipped)."
             exit 0
           fi
           if [[ "$STATIC" != "success" ]]; then

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -52,12 +52,17 @@ jobs:
               - 'apps/api/**'
               - 'global.json'
 
-  frontend-fast:
-    name: Frontend Fast (lint + typecheck + unit)
+  # Sharding strategy (incident #1115): the apps/web Vitest suite runs >15min
+  # in CI as a single job. Splitting into 3 parallel matrix shards drops
+  # wall-clock to ~5min per shard while preserving full coverage. Lint and
+  # typecheck stay in a separate fast job (no benefit from parallelism).
+  # The frontend-fast aggregator job below preserves the branch-protection
+  # required check name "Frontend Fast (lint + typecheck + unit)".
+
+  frontend-static:
+    name: Frontend Static (lint + typecheck)
     runs-on: ubuntu-latest
-    # Bumped from 5 to 15 (incident #1115): Vitest suite alone runs ~5min
-    # locally and >5min in CI with cold cache, killing every frontend PR.
-    timeout-minutes: 15
+    timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     defaults:
@@ -78,10 +83,62 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Unit tests (Vitest, no coverage)
-        # apps/web/package.json declares `"test": "vitest run"` — already
-        # non-watch. There is no separate `test:unit` script.
-        run: pnpm test
+  frontend-tests:
+    name: Frontend Tests (shard ${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-frontend
+        with:
+          node-version: '20'
+          pnpm-version: '10'
+          working-directory: apps/web
+          frozen-lockfile: 'true'
+
+      - name: Unit tests (Vitest shard ${{ matrix.shard }}/3)
+        # Bypass the "test" pnpm script to forward the --shard flag cleanly.
+        # Vitest 3.x supports deterministic file-level sharding via --shard.
+        run: pnpm exec vitest run --shard ${{ matrix.shard }}/3
+
+  frontend-fast:
+    # Aggregator job — preserves the branch-protection required check name
+    # "Frontend Fast (lint + typecheck + unit)" introduced by #846 / #1086.
+    # Succeeds iff both upstream jobs succeeded, or both were legitimately
+    # skipped because the PR did not touch frontend paths.
+    name: Frontend Fast (lint + typecheck + unit)
+    runs-on: ubuntu-latest
+    needs: [changes, frontend-static, frontend-tests]
+    if: ${{ always() }}
+    steps:
+      - name: Verify upstream results
+        run: |
+          STATIC="${{ needs.frontend-static.result }}"
+          TESTS="${{ needs.frontend-tests.result }}"
+          FRONTEND_CHANGED="${{ needs.changes.outputs.frontend }}"
+          echo "frontend-static=$STATIC frontend-tests=$TESTS frontend-changed=$FRONTEND_CHANGED"
+          if [[ "$FRONTEND_CHANGED" != "true" ]]; then
+            echo "No frontend changes — aggregator passes (upstream legitimately skipped)."
+            exit 0
+          fi
+          if [[ "$STATIC" != "success" ]]; then
+            echo "frontend-static did not succeed (result=$STATIC)"
+            exit 1
+          fi
+          if [[ "$TESTS" != "success" ]]; then
+            echo "frontend-tests did not succeed across all shards (result=$TESTS)"
+            exit 1
+          fi
+          echo "All frontend checks passed."
 
   backend-fast:
     name: Backend Fast (build + unit)


### PR DESCRIPTION
## Summary

Follow-up to PR #1116. The 15-min timeout still wasn't enough — PR #1112 hit 15m16s with tests still running normally (last green file at 10:31:15, cancelled 10:31:16). CI runs Vitest ~3x slower than local, so the full suite is genuinely 12+ min single-threaded and growing.

This refactors `dev-fast.yml` to shard Vitest across 3 parallel matrix jobs:

| Old | New |
|---|---|
| `frontend-fast` (lint + typecheck + unit) — single job, 15-min timeout | `frontend-static` (lint + typecheck) + `frontend-tests` matrix [1/3, 2/3, 3/3] + `frontend-fast` aggregator |

Wall-clock impact:
- Before: ~3min static + ~12-15min unit = **~15-18min single-threaded**
- After: ~3min static (parallel) + ~5min per shard (parallel) = **~5-6min total wall-clock**

## Branch protection preservation

The existing required check is named `Frontend Fast (lint + typecheck + unit)`. The new `frontend-fast` job is an aggregator that keeps this exact name, depends on both implementation jobs via `needs:`, and asserts via shell that both upstream succeeded. Branch protection rules require no update.

The aggregator also handles the "non-frontend PR" case explicitly by reading `needs.changes.outputs.frontend` — if `false`, it exits 0 so branch protection on non-frontend PRs doesn't break.

## Implementation notes

- Vitest 3.x supports file-level deterministic sharding via `--shard <i>/<total>` flag
- Invocation: `pnpm exec vitest run --shard X/3` (bypasses the pnpm test script to forward the flag cleanly)
- `fail-fast: false` on the matrix so a single shard failure doesn't cancel the others — full failure context preserved

## Test plan

- [x] Local: edit verified valid YAML
- [ ] PR's own CI: this PR triggers `dev-fast.yml` on itself; expect 3 frontend-tests shards in parallel + frontend-static + aggregator
- [ ] Re-run PR #1112 (currently failing) after this PR merges — expect ~6min total wall-clock and green aggregator
- [ ] Re-run one other recently-cancelled PR for cross-validation

## Out of scope

- Backend Fast (line 89): still 5-min, not currently failing for any open PR
- Per-shard coverage reporting: dev-async owns coverage runs

Refs: #1115, #1116, #1112, #1086