### PR TITLE
fix(ci): replace vars.CACHE_VERSION inside composite actions with input pattern (regression from #1124)

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -13,6 +13,15 @@ inputs:
     description: 'Enable NuGet package caching'
     required: false
     default: 'true'
+  cache-version:
+    description: |
+      Cache key version (Issue #850 emergency invalidation knob). Pass
+      `${{ inputs.cache-version }}` from a workflow to inherit
+      the repo-level CACHE_VERSION variable. The `vars` context is NOT
+      available inside composite actions, so resolution must happen at
+      the workflow caller (fix for PR #1124 regression).
+    required: false
+    default: 'v1'
 
 runs:
   using: 'composite'
@@ -36,12 +45,13 @@ runs:
         path: ~/.nuget/packages
         # Issue #850: cache fingerprint widened to include
         # Directory.Packages.props (central dep management) and global.json
-        # (SDK pinning). vars.CACHE_VERSION is the emergency invalidation
-        # knob — bump it from 'v1' → 'v2' to flush all NuGet caches without
-        # code change.
-        key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ vars.CACHE_VERSION || 'v1' }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory), format('{0}/**/Directory.Packages.props', inputs.working-directory), 'global.json') }}
+        # (SDK pinning). The `cache-version` input is the emergency
+        # invalidation knob — callers pass `${{ vars.CACHE_VERSION || 'v1' }}`
+        # to inherit the repo variable. See input docs for why `vars` is
+        # not referenced directly here.
+        key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ inputs.cache-version }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory), format('{0}/**/Directory.Packages.props', inputs.working-directory), 'global.json') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-nuget-${{ vars.CACHE_VERSION || 'v1' }}-
+          ${{ runner.os }}-${{ runner.arch }}-nuget-${{ inputs.cache-version }}-
           ${{ runner.os }}-${{ runner.arch }}-nuget-
 
     - name: Cache .NET build outputs
@@ -52,12 +62,12 @@ runs:
           ${{ inputs.working-directory }}/src/**/bin
           ${{ inputs.working-directory }}/src/**/obj
         # Issue #2152: Include *.json in hash to invalidate cache when appsettings change.
-        # Issue #850: vars.CACHE_VERSION as global invalidation knob.
-        key: ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ vars.CACHE_VERSION || 'v1' }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/*.cs', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/appsettings*.json', inputs.working-directory)) }}
+        # Issue #850: `cache-version` input as global invalidation knob (was vars.CACHE_VERSION).
+        key: ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ inputs.cache-version }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/*.cs', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/appsettings*.json', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ vars.CACHE_VERSION || 'v1' }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/*.cs', inputs.working-directory)) }}-
-          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ vars.CACHE_VERSION || 'v1' }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-
-          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ vars.CACHE_VERSION || 'v1' }}-
+          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ inputs.cache-version }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-${{ hashFiles(format('{0}/**/*.cs', inputs.working-directory)) }}-
+          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ inputs.cache-version }}-${{ hashFiles(format('{0}/**/*.csproj', inputs.working-directory)) }}-
+          ${{ runner.os }}-${{ runner.arch }}-dotnet-build-${{ inputs.cache-version }}-
           ${{ runner.os }}-${{ runner.arch }}-dotnet-build-
 
     - name: Restore .NET dependencies

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -15,11 +15,11 @@ inputs:
     default: 'true'
   cache-version:
     description: |
-      Cache key version (Issue #850 emergency invalidation knob). Pass
-      `${{ inputs.cache-version }}` from a workflow to inherit
-      the repo-level CACHE_VERSION variable. The `vars` context is NOT
-      available inside composite actions, so resolution must happen at
-      the workflow caller (fix for PR #1124 regression).
+      Cache key version (Issue #850 emergency invalidation knob). The
+      workflow caller is responsible for resolving the repo variable
+      CACHE_VERSION (use the vars context, which is not available
+      inside composite actions). See dev-fast.yml for the canonical
+      caller pattern. Fix for PR #1124 regression.
     required: false
     default: 'v1'
 

--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -19,11 +19,11 @@ inputs:
     default: 'true'
   cache-version:
     description: |
-      Cache key version (Issue #850 emergency invalidation knob). Pass
-      `${{ vars.CACHE_VERSION || 'v1' }}` from a workflow to inherit
-      the repo-level CACHE_VERSION variable. The `vars` context is NOT
-      available inside composite actions, so resolution must happen at
-      the workflow caller (fix for PR #1124 regression).
+      Cache key version (Issue #850 emergency invalidation knob). The
+      workflow caller is responsible for resolving the repo variable
+      CACHE_VERSION (use the vars context, which is not available
+      inside composite actions). See dev-fast.yml for the canonical
+      caller pattern. Fix for PR #1124 regression.
     required: false
     default: 'v1'
 

--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -17,6 +17,15 @@ inputs:
     description: 'Use frozen lockfile for installations'
     required: false
     default: 'true'
+  cache-version:
+    description: |
+      Cache key version (Issue #850 emergency invalidation knob). Pass
+      `${{ vars.CACHE_VERSION || 'v1' }}` from a workflow to inherit
+      the repo-level CACHE_VERSION variable. The `vars` context is NOT
+      available inside composite actions, so resolution must happen at
+      the workflow caller (fix for PR #1124 regression).
+    required: false
+    default: 'v1'
 
 runs:
   using: 'composite'
@@ -44,12 +53,13 @@ runs:
       with:
         path: ${{ env.STORE_PATH }}
         # Issue #850: cache fingerprint widened to include .npmrc (registry +
-        # auth config affects resolution). vars.CACHE_VERSION is the
-        # emergency invalidation knob — bump 'v1' → 'v2' to flush all pnpm
-        # caches without code change.
-        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ vars.CACHE_VERSION || 'v1' }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working-directory), format('{0}/.npmrc', inputs.working-directory)) }}
+        # auth config affects resolution). The emergency invalidation knob
+        # is the `cache-version` input — callers pass
+        # `${{ vars.CACHE_VERSION || 'v1' }}` to inherit the repo variable.
+        # See action input docs above for why `vars` cannot be referenced here.
+        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ inputs.cache-version }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working-directory), format('{0}/.npmrc', inputs.working-directory)) }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ vars.CACHE_VERSION || 'v1' }}-
+          ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ inputs.cache-version }}-
           ${{ runner.os }}-${{ runner.arch }}-pnpm-store-
 
     - name: Install dependencies

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -5,6 +5,15 @@ inputs:
     description: 'Working directory where Playwright is installed'
     required: false
     default: 'apps/web'
+  cache-version:
+    description: |
+      Cache key version (Issue #850 emergency invalidation knob). Pass
+      `${{ vars.CACHE_VERSION || 'v1' }}` from a workflow to inherit
+      the repo-level CACHE_VERSION variable. The `vars` context is NOT
+      available inside composite actions, so resolution must happen at
+      the workflow caller (fix for PR #1124 regression).
+    required: false
+    default: 'v1'
 
 runs:
   using: 'composite'
@@ -23,12 +32,13 @@ runs:
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
-        # Issue #850: vars.CACHE_VERSION is the emergency invalidation knob
-        # for the Playwright browser cache. Bump 'v1' → 'v2' to force a fresh
-        # browser download without changing the Playwright pin.
-        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ vars.CACHE_VERSION || 'v1' }}-${{ steps.playwright-version.outputs.version }}
+        # Issue #850: the `cache-version` input is the emergency invalidation
+        # knob for the Playwright browser cache. Callers pass
+        # `${{ vars.CACHE_VERSION || 'v1' }}` to inherit the repo variable.
+        # See input docs for why `vars` is not referenced directly here.
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ inputs.cache-version }}-${{ steps.playwright-version.outputs.version }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-playwright-${{ vars.CACHE_VERSION || 'v1' }}-
+          ${{ runner.os }}-${{ runner.arch }}-playwright-${{ inputs.cache-version }}-
           ${{ runner.os }}-${{ runner.arch }}-playwright-
 
     # Issue #1951: Always install browsers to prevent "Executable doesn't exist" errors

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -7,11 +7,11 @@ inputs:
     default: 'apps/web'
   cache-version:
     description: |
-      Cache key version (Issue #850 emergency invalidation knob). Pass
-      `${{ vars.CACHE_VERSION || 'v1' }}` from a workflow to inherit
-      the repo-level CACHE_VERSION variable. The `vars` context is NOT
-      available inside composite actions, so resolution must happen at
-      the workflow caller (fix for PR #1124 regression).
+      Cache key version (Issue #850 emergency invalidation knob). The
+      workflow caller is responsible for resolving the repo variable
+      CACHE_VERSION (use the vars context, which is not available
+      inside composite actions). See dev-fast.yml for the canonical
+      caller pattern. Fix for PR #1124 regression.
     required: false
     default: 'v1'
 

--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           dotnet-version: '9.0.x'
           working-directory: apps/api
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
       - name: Build (Release)
         working-directory: apps/api
@@ -100,9 +101,11 @@ jobs:
           pnpm-version: '10'
           working-directory: apps/web
           frozen-lockfile: 'true'
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
       - uses: ./.github/actions/setup-playwright
         with:
           working-directory: apps/web
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
       - name: Run smoke specs only
         # Use the dedicated smoke-real-backend folder (3 specs covering the

--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -89,6 +89,7 @@ jobs:
           pnpm-version: '10'
           working-directory: apps/web
           frozen-lockfile: 'true'
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
       - name: Lint
         run: pnpm lint
@@ -117,6 +118,7 @@ jobs:
           pnpm-version: '10'
           working-directory: apps/web
           frozen-lockfile: 'true'
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
       - name: Unit tests (Vitest shard ${{ matrix.shard }}/3)
         # Bypass the "test" pnpm script to forward the --shard flag cleanly.
@@ -170,6 +172,7 @@ jobs:
         with:
           dotnet-version: '9.0.x'
           working-directory: apps/api
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
       - name: Build
         working-directory: apps/api


### PR DESCRIPTION
## Summary

Hot-fix for a CI regression introduced by PR #1124 (merged 10:41 UTC). That PR added \`vars.CACHE_VERSION\` references inside three composite action definitions (\`setup-frontend\`, \`setup-backend\`, \`setup-playwright\`). The \`vars\` context is **not available inside composite actions** — only inside workflow files — so every workflow that uses these actions now fails at action-load with:

\`\`\`
Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.CACHE_VERSION || 'v1'
\`\`\`

**Blast radius**: every frontend PR opened after #1124 merged. Confirmed on PR #1112 run 25795022036 (Frontend Static failed in 29s with the load error).

## Fix

Convert each \`vars.CACHE_VERSION\` reference into an action input named \`cache-version\`, defaulting to \`'v1'\`. Workflow callers pass \`\${{ vars.CACHE_VERSION || 'v1' }}\` as input — \`vars\` IS valid in workflow context. This preserves the #850 emergency invalidation knob without breaking action loading.

| File | Change |
|---|---|
| \`.github/actions/setup-frontend/action.yml\` | Add \`cache-version\` input, replace \`vars.CACHE_VERSION\` in pnpm store cache keys |
| \`.github/actions/setup-backend/action.yml\` | Add \`cache-version\` input, replace \`vars.CACHE_VERSION\` in nuget + dotnet-build cache keys |
| \`.github/actions/setup-playwright/action.yml\` | Add \`cache-version\` input, replace \`vars.CACHE_VERSION\` in browser cache key |
| \`.github/workflows/dev-fast.yml\` | Pass \`cache-version\` to setup-frontend + setup-backend |
| \`.github/workflows/dev-async.yml\` | Pass \`cache-version\` to all three setup actions |

## Backward compatibility

Action input defaults to \`'v1'\`. Callers that don't pass \`cache-version\` get the same effective cache key as the pre-#1124 state. The remaining workflows that call these actions (\`ci.yml\`, \`prod.yml\`, \`staging.yml\`, \`visual-regression-*.yml\`, \`bootstrap-mockup-baselines.yml\`, \`state-coverage-check.yml\`, \`test-e2e.yml\`, \`test-performance.yml\`, \`test-visual.yml\`, \`deploy-staging.yml\`) keep working with the default and can opt into the emergency knob in a follow-up if desired.

## Out of scope

- Updating the 9 remaining workflows to pass \`cache-version\` (low priority — they keep working with the default 'v1')
- Adding a wider test for the action-load error pattern (CI itself is the test)

## Test plan

- [ ] This PR's own CI green (touches \`.github/actions/**\` so Detect Changes triggers Frontend + Backend paths)
- [ ] Re-run PR #1112 confirms Frontend Static + sharded Frontend Tests all pass after this merges into main-dev
- [ ] No other PR currently runs into the action-load error post-merge

Refs: #1124, #850, #1112, #1115