### PR TITLE
refactor(kb): uniform UoW pattern in AgentDefinitionRepository (closes #942)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/CreateAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/CreateAgentDefinitionCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -16,13 +17,16 @@ internal sealed class CreateAgentDefinitionCommandHandler
     : IRequestHandler<CreateAgentDefinitionCommand, AgentDefinitionDto>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<CreateAgentDefinitionCommandHandler> _logger;
 
     public CreateAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<CreateAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -70,8 +74,9 @@ internal sealed class CreateAgentDefinitionCommandHandler
         if (request.KbCardIds is { Count: > 0 })
             agentDefinition.UpdateKbCardIds(request.KbCardIds);
 
-        // Persist
+        // Persist (ADR-056: explicit UoW save)
         await _repository.AddAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Created AgentDefinition {Id} with name '{Name}'",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/DeleteAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/DeleteAgentDefinitionCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -14,13 +15,16 @@ internal sealed class DeleteAgentDefinitionCommandHandler
     : IRequestHandler<DeleteAgentDefinitionCommand>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<DeleteAgentDefinitionCommandHandler> _logger;
 
     public DeleteAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<DeleteAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -38,6 +42,7 @@ internal sealed class DeleteAgentDefinitionCommandHandler
         // Delete
         await _repository.DeleteAsync(request.Id, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "Deleted AgentDefinition {Id}",
             request.Id);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/PublishAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/PublishAgentDefinitionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -13,13 +14,16 @@ internal sealed class PublishAgentDefinitionCommandHandler
     : IRequestHandler<PublishAgentDefinitionCommand>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<PublishAgentDefinitionCommandHandler> _logger;
 
     public PublishAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<PublishAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -37,6 +41,7 @@ internal sealed class PublishAgentDefinitionCommandHandler
 
         await _repository.UpdateAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "AgentDefinition {Id} published",
             request.Id);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/StartTestingAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/StartTestingAgentDefinitionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -13,13 +14,16 @@ internal sealed class StartTestingAgentDefinitionCommandHandler
     : IRequestHandler<StartTestingAgentDefinitionCommand>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<StartTestingAgentDefinitionCommandHandler> _logger;
 
     public StartTestingAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<StartTestingAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -37,6 +41,7 @@ internal sealed class StartTestingAgentDefinitionCommandHandler
 
         await _repository.UpdateAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "AgentDefinition {Id} transitioned to Testing status",
             request.Id);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/UnpublishAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/UnpublishAgentDefinitionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -13,13 +14,16 @@ internal sealed class UnpublishAgentDefinitionCommandHandler
     : IRequestHandler<UnpublishAgentDefinitionCommand>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<UnpublishAgentDefinitionCommandHandler> _logger;
 
     public UnpublishAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<UnpublishAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -37,6 +41,7 @@ internal sealed class UnpublishAgentDefinitionCommandHandler
 
         await _repository.UpdateAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "AgentDefinition {Id} unpublished (returned to Draft)",
             request.Id);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/UpdateAgentDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AgentDefinition/UpdateAgentDefinitionCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -16,13 +17,16 @@ internal sealed class UpdateAgentDefinitionCommandHandler
     : IRequestHandler<UpdateAgentDefinitionCommand, AgentDefinitionDto>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<UpdateAgentDefinitionCommandHandler> _logger;
 
     public UpdateAgentDefinitionCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<UpdateAgentDefinitionCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -80,6 +84,7 @@ internal sealed class UpdateAgentDefinitionCommandHandler
         // Persist
         await _repository.UpdateAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "Updated AgentDefinition {Id}",
             agentDefinition.Id);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SystemConfiguration.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -26,15 +27,16 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 ///   <item>Default strategy: <c>AgentStrategy.HybridSearch()</c> when not provided.</item>
 ///   <item>Default name: <c>"{AgentType} for {GameName}"</c> if not provided.</item>
 /// </list>
-/// Persistence pattern mirrors <c>CreateAgentDefinitionCommandHandler</c>:
-/// repository's <c>AddAsync</c> calls <c>DbContext.SaveChangesAsync</c> internally,
-/// so no <c>IUnitOfWork</c> is required.
+/// Persistence pattern (ADR-056): repository <c>AddAsync</c> mutates the
+/// change-tracker only; this handler invokes <c>IUnitOfWork.SaveChangesAsync</c>
+/// explicitly to persist.
 /// </remarks>
 internal sealed class CreateUserAgentCommandHandler
     : IRequestHandler<CreateUserAgentCommand, AgentDto>
 {
     private readonly IAgentDefinitionRepository _repository;
     private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ITierEnforcementService _tierEnforcementService;
     private readonly ILogger<CreateUserAgentCommandHandler> _logger;
 
@@ -42,11 +44,13 @@ internal sealed class CreateUserAgentCommandHandler
         IAgentDefinitionRepository repository,
         ISharedGameRepository sharedGameRepository,
         ITierEnforcementService tierEnforcementService,
+        IUnitOfWork unitOfWork,
         ILogger<CreateUserAgentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
         _tierEnforcementService = tierEnforcementService ?? throw new ArgumentNullException(nameof(tierEnforcementService));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -105,6 +109,7 @@ internal sealed class CreateUserAgentCommandHandler
         if (!agent.IsActive) agent.Activate();
 
         await _repository.AddAsync(agent, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Record usage so CanPerformAsync reflects the new count on next call (Redis atomic counter).
         await _tierEnforcementService

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RestoreUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/RestoreUserAgentCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -21,15 +22,18 @@ internal sealed class RestoreUserAgentCommandHandler
 {
     private readonly IAgentDefinitionRepository _agentRepository;
     private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<RestoreUserAgentCommandHandler> _logger;
 
     public RestoreUserAgentCommandHandler(
         IAgentDefinitionRepository agentRepository,
         ISharedGameRepository sharedGameRepository,
+        IUnitOfWork unitOfWork,
         ILogger<RestoreUserAgentCommandHandler> logger)
     {
         _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
         _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -48,6 +52,7 @@ internal sealed class RestoreUserAgentCommandHandler
         agent.Restore();
         await _agentRepository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
 
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation(
             "AgentDefinition {AgentId} restored by user {UserId}",
             request.AgentId, request.UserId);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SoftDeleteUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SoftDeleteUserAgentCommandHandler.cs
@@ -81,12 +81,10 @@ internal sealed class SoftDeleteUserAgentCommandHandler
             await _chatThreadRepository.UpdateAsync(thread, cancellationToken).ConfigureAwait(false);
         }
 
-        // ChatThreadRepository.UpdateAsync uses Unit-of-Work pattern (no auto SaveChanges).
-        // Trigger persistence explicitly here.
-        if (activeThreads.Count > 0)
-        {
-            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
+        // ADR-056: both AgentDefinitionRepository and ChatThreadRepository now follow
+        // the UoW pattern (no auto SaveChanges). Single SaveChangesAsync at the end
+        // persists the agent soft-delete AND any cascaded thread closures atomically.
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         if (activeThreads.Count > 0)
         {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateAgentConfigurationCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -13,9 +14,9 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// <see cref="Domain.Entities.AgentDefinition"/> and returns the updated view.
 /// </summary>
 /// <remarks>
-/// Persistence pattern mirrors <c>UpdateUserAgentCommandHandler</c>: the repository
-/// <c>UpdateAsync</c> calls <c>DbContext.SaveChangesAsync</c> internally so no explicit
-/// <c>IUnitOfWork</c> is required.
+/// Persistence pattern (ADR-056): repository <c>UpdateAsync</c> mutates the
+/// change-tracker only; this handler invokes <c>IUnitOfWork.SaveChangesAsync</c>
+/// explicitly to persist.
 /// Range validation is delegated to <see cref="AgentDefinitionConfig.Create"/>; invalid
 /// inputs surface as <see cref="ArgumentException"/> which the route maps to <c>400</c>.
 /// SelectedDocumentIds is accepted on the wire but not persisted in MVP (same as PR #695).
@@ -24,13 +25,16 @@ internal sealed class UpdateAgentConfigurationCommandHandler
     : IRequestHandler<UpdateAgentConfigurationCommand, AgentConfigurationDto?>
 {
     private readonly IAgentDefinitionRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<UpdateAgentConfigurationCommandHandler> _logger;
 
     public UpdateAgentConfigurationCommandHandler(
         IAgentDefinitionRepository repository,
+        IUnitOfWork unitOfWork,
         ILogger<UpdateAgentConfigurationCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -64,6 +68,7 @@ internal sealed class UpdateAgentConfigurationCommandHandler
         agent.UpdateConfig(newConfig);
 
         await _repository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Updated AgentDefinition {Id} configuration (Model='{Model}', MaxTokens={MaxTokens}, Temperature={Temperature})",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateUserAgentCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -13,9 +14,9 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// an <see cref="AgentDto"/> with GameName resolved (drift-fix lookup pattern from PR #662).
 /// </summary>
 /// <remarks>
-/// Persistence pattern mirrors <c>CreateUserAgentCommandHandler</c>: repository's
-/// <c>UpdateAsync</c> calls <c>DbContext.SaveChangesAsync</c> internally, so no
-/// <c>IUnitOfWork</c> is required.
+/// Persistence pattern (ADR-056): repository <c>UpdateAsync</c> mutates the
+/// change-tracker only; this handler invokes <c>IUnitOfWork.SaveChangesAsync</c>
+/// explicitly to persist.
 /// Returns <c>null</c> when the agent ID is not found (endpoint maps to 404).
 /// Strategy resolution mirrors the preset-or-Custom pattern used by
 /// <see cref="CreateUserAgentCommandHandler"/>.
@@ -25,15 +26,18 @@ internal sealed class UpdateUserAgentCommandHandler
 {
     private readonly IAgentDefinitionRepository _repository;
     private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<UpdateUserAgentCommandHandler> _logger;
 
     public UpdateUserAgentCommandHandler(
         IAgentDefinitionRepository repository,
         ISharedGameRepository sharedGameRepository,
+        IUnitOfWork unitOfWork,
         ILogger<UpdateUserAgentCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -66,6 +70,7 @@ internal sealed class UpdateUserAgentCommandHandler
         if (changed)
         {
             await _repository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Updated user-owned AgentDefinition {Id} (Name='{Name}', Strategy='{Strategy}') for user {UserId}",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
@@ -77,11 +77,12 @@ public sealed class AgentDefinitionRepository : RepositoryBase, IAgentDefinition
 
     public async Task AddAsync(AgentDefinition agentDefinition, CancellationToken cancellationToken = default)
     {
+        // ADR-056: repository methods mutate the change-tracker only.
+        // Callers are responsible for invoking IUnitOfWork.SaveChangesAsync(ct).
         await DbContext.Set<AgentDefinition>().AddAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
-        await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task UpdateAsync(AgentDefinition agentDefinition, CancellationToken cancellationToken = default)
+    public Task UpdateAsync(AgentDefinition agentDefinition, CancellationToken cancellationToken = default)
     {
         // Avoid IdentityConflict: another entity with same Id may already be tracked from prior reads
         // (test seeding, EF caching). Detach it before re-attaching the modified version.
@@ -92,7 +93,8 @@ public sealed class AgentDefinitionRepository : RepositoryBase, IAgentDefinition
             tracked.State = Microsoft.EntityFrameworkCore.EntityState.Detached;
         }
         DbContext.Set<AgentDefinition>().Update(agentDefinition);
-        await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        // ADR-056: caller persists via IUnitOfWork.SaveChangesAsync.
+        return Task.CompletedTask;
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
@@ -101,7 +103,7 @@ public sealed class AgentDefinitionRepository : RepositoryBase, IAgentDefinition
         if (agentDefinition != null)
         {
             DbContext.Set<AgentDefinition>().Remove(agentDefinition);
-            await DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            // ADR-056: caller persists via IUnitOfWork.SaveChangesAsync.
         }
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandHandlerKbCardsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandHandlerKbCardsTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Tests.Constants;
+using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -21,17 +22,20 @@ public sealed class CreateAgentDefinitionCommandHandlerKbCardsTests
     private static readonly Guid _kbCard2 = Guid.NewGuid();
 
     private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly CreateAgentDefinitionCommandHandler _handler;
 
     public CreateAgentDefinitionCommandHandlerKbCardsTests()
     {
         _mockRepository = new Mock<IAgentDefinitionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockRepository
             .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         _handler = new CreateAgentDefinitionCommandHandler(
             _mockRepository.Object,
+            _mockUnitOfWork.Object,
             new Mock<ILogger<CreateAgentDefinitionCommandHandler>>().Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -18,14 +19,16 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.AgentDefi
 public sealed class CreateAgentDefinitionCommandHandlerTests
 {
     private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<CreateAgentDefinitionCommandHandler>> _mockLogger;
     private readonly CreateAgentDefinitionCommandHandler _handler;
 
     public CreateAgentDefinitionCommandHandlerTests()
     {
         _mockRepository = new Mock<IAgentDefinitionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockLogger = new Mock<ILogger<CreateAgentDefinitionCommandHandler>>();
-        _handler = new CreateAgentDefinitionCommandHandler(_mockRepository.Object, _mockLogger.Object);
+        _handler = new CreateAgentDefinitionCommandHandler(_mockRepository.Object, _mockUnitOfWork.Object, _mockLogger.Object);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/DeleteAgentDefinitionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/DeleteAgentDefinitionCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
+using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -19,14 +20,16 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.AgentDefi
 public sealed class DeleteAgentDefinitionCommandHandlerTests
 {
     private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<DeleteAgentDefinitionCommandHandler>> _mockLogger;
     private readonly DeleteAgentDefinitionCommandHandler _handler;
 
     public DeleteAgentDefinitionCommandHandlerTests()
     {
         _mockRepository = new Mock<IAgentDefinitionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockLogger = new Mock<ILogger<DeleteAgentDefinitionCommandHandler>>();
-        _handler = new DeleteAgentDefinitionCommandHandler(_mockRepository.Object, _mockLogger.Object);
+        _handler = new DeleteAgentDefinitionCommandHandler(_mockRepository.Object, _mockUnitOfWork.Object, _mockLogger.Object);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/UpdateAgentDefinitionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/UpdateAgentDefinitionCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
+using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -20,14 +21,16 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.AgentDefi
 public sealed class UpdateAgentDefinitionCommandHandlerTests
 {
     private readonly Mock<IAgentDefinitionRepository> _mockRepository;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<UpdateAgentDefinitionCommandHandler>> _mockLogger;
     private readonly UpdateAgentDefinitionCommandHandler _handler;
 
     public UpdateAgentDefinitionCommandHandlerTests()
     {
         _mockRepository = new Mock<IAgentDefinitionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockLogger = new Mock<ILogger<UpdateAgentDefinitionCommandHandler>>();
-        _handler = new UpdateAgentDefinitionCommandHandler(_mockRepository.Object, _mockLogger.Object);
+        _handler = new UpdateAgentDefinitionCommandHandler(_mockRepository.Object, _mockUnitOfWork.Object, _mockLogger.Object);
     }
 
     [Fact]

--- a/docs/for-claude/architecture/adr/adr-056-knowledgebase-repo-uow-uniformity.md
+++ b/docs/for-claude/architecture/adr/adr-056-knowledgebase-repo-uow-uniformity.md
@@ -1,0 +1,86 @@
+# ADR-056 — Repository UnitOfWork Uniformity in KnowledgeBase BC
+
+**Status**: Accepted
+**Date**: 2026-05-13
+**Deciders**: @badsworm
+**Tracking**: Issue [#942](https://github.com/meepleAi-app/meepleai-monorepo/issues/942) (EPIC #906 follow-up)
+**Supersedes**: —
+
+## Context
+
+EPIC #906 SG3 (PR #934) uncovered a behavioural asymmetry between two repositories in the `KnowledgeBase` bounded context:
+
+| Repository | `AddAsync` / `UpdateAsync` / `DeleteAsync` |
+|------------|--------------------------------------------|
+| `AgentDefinitionRepository` | calls `DbContext.SaveChangesAsync` internally (auto-save) |
+| `ChatThreadRepository` | mutates the change-tracker only; persistence requires the caller to invoke `IUnitOfWork.SaveChangesAsync` |
+
+The asymmetry caused a real bug during SG3: `SoftDeleteUserAgentCommandHandler` cascade-closed `ChatThread` aggregates via `_chatThreadRepository.UpdateAsync(...)` expecting the save to happen, but `ChatThreadRepository` returned `Task.CompletedTask` without persisting. The cascade test failed; the handler was patched to inject `IUnitOfWork` and call `SaveChangesAsync` explicitly.
+
+The patch fixed the symptom; the asymmetry remained. Every future handler that consumes both repositories must internalise which one auto-saves and which one doesn't — a trap-prone mental-model burden.
+
+## Decision
+
+**Adopt the UnitOfWork pattern uniformly across all `KnowledgeBase` BC repositories.** All `AddAsync` / `UpdateAsync` / `DeleteAsync` methods mutate the change-tracker only; callers MUST invoke `IUnitOfWork.SaveChangesAsync(ct)` to persist.
+
+## Why option A (UoW everywhere), not option B (auto-save everywhere)
+
+| Concern | UoW everywhere (chosen) | Auto-save everywhere (rejected) |
+|---------|-------------------------|--------------------------------|
+| Cross-aggregate transactions | ✅ Native — handler aggregates writes, commits once | ❌ Each repo call commits separately; multi-write atomicity lost |
+| Cognitive load on handler authors | ⚠️ Must remember to call `SaveChangesAsync` | ✅ Lower (but enables silent partial-write bugs) |
+| Dominant existing pattern in BC | ✅ 8 of 18 `IAgentDefinitionRepository` consumers already inject `IUnitOfWork`; `ChatThreadRepository` is already UoW; the broader BC trend is UoW | ❌ Counter to dominant pattern |
+| Test isolation | ✅ Tests assert on the same DbContext that the handler used | ⚠️ Auto-save makes test side-effects harder to bound |
+| DDD orthodoxy | ✅ Aggregate boundary preserved at handler level | ⚠️ Repo becomes a write-through, not a Repository |
+
+The auto-save model also embeds a footgun in the SG3 cascade scenario: if `AgentDefinitionRepository.UpdateAsync` auto-saves but `ChatThreadRepository.UpdateAsync` doesn't, a handler that updates BOTH inside what looks like a single logical operation actually performs two writes with a window in between. UoW everywhere makes this impossible.
+
+## Consequences
+
+### Positive
+
+- One mental model for all `KnowledgeBase` BC repositories
+- Future handlers that touch multiple aggregates are atomic by default
+- Cross-aggregate transaction semantics become explicit (handlers declare intent via `SaveChangesAsync` placement)
+- Aligns with the existing `ChatThreadRepository` and the 8/18 handlers already using UoW
+
+### Negative
+
+- **Migration cost**: 18 handlers consume `IAgentDefinitionRepository`. 10 of them currently do not inject `IUnitOfWork` and must be updated.
+- **Risk of regression**: a handler updated incorrectly (forgetting `SaveChangesAsync`) appears to work in unit tests using in-memory DbContext but fails in integration. Integration tests must run green to confirm migration.
+- **Pattern enforcement**: nothing prevents a future repo from re-introducing auto-save. Recommendation: a `// dotnet test` analyzer or a code-review checklist item — see follow-up.
+
+### Neutral
+
+- Other BCs (`Administration`, `Authentication`, etc.) are NOT in scope for this ADR. They may follow either pattern, evaluated independently when their own asymmetries surface.
+
+## Migration plan
+
+1. **Repository changes** (this ADR's implementation PR):
+   - `AgentDefinitionRepository.AddAsync`: remove `SaveChangesAsync`
+   - `AgentDefinitionRepository.UpdateAsync`: remove `SaveChangesAsync`
+   - `AgentDefinitionRepository.DeleteAsync`: remove `SaveChangesAsync`
+2. **Handler updates** (this ADR's implementation PR):
+   - For each handler using the above 3 methods, inject `IUnitOfWork` (if not already) and call `_unitOfWork.SaveChangesAsync(ct)` immediately after the repo call. 18 handlers — 10 need injection, 8 already have `IUnitOfWork`.
+3. **Test verification**:
+   - Backend unit tests pass (mocked repos already follow the new contract)
+   - Integration tests pass (real DbContext persists as expected)
+4. **Docs**: update `docs/for-developers/backend/repository-pattern.md` (or create it) to reference this ADR as the canonical pattern.
+
+## Other repositories in the BC
+
+The following `KnowledgeBase` repositories also expose `Add/Update/Delete` methods. Each is evaluated for compliance with this ADR:
+
+| Repository | Compliant? | Notes |
+|---|---|---|
+| `ChatThreadRepository` | ✅ Already UoW | Pattern reference |
+| `AgentDefinitionRepository` | ❌ Auto-saves | Migrated by this ADR's PR |
+| Others (see audit in PR) | TBD | Inventoried during migration; non-compliant ones either migrated or flagged for follow-up |
+
+## Refs
+
+- Issue #942 (implementation tracking)
+- PR #934 (SG3 — discovered the asymmetry)
+- Commit `d9fc73128` (SG3 patch on `SoftDeleteUserAgentCommandHandler`)
+- ADR-055 (auto-revert bot — previous ADR number, unrelated)
+- EPIC #906 (parent epic, closed)


### PR DESCRIPTION
## Summary

Closes #942. Introduces ADR-056 and refactors `AgentDefinitionRepository` to the UnitOfWork pattern, matching `ChatThreadRepository` (already UoW) and the dominant pattern across the `KnowledgeBase` BC.

## ADR-056 decision (Accepted)

`docs/for-claude/architecture/adr/adr-056-knowledgebase-repo-uow-uniformity.md`

**All `KnowledgeBase` BC repositories follow the UoW pattern uniformly.** `Add/Update/Delete` methods mutate the change-tracker only; callers persist via `IUnitOfWork.SaveChangesAsync(ct)`.

Rejected alternative (Option B: auto-save everywhere) because it loses cross-aggregate transaction semantics — exactly the trap that SG3 (PR #934) hit.

## Changes

| Layer | File | Change |
|---|---|---|
| Repository | `AgentDefinitionRepository.cs` | `Add/Update/Delete` no longer call `SaveChangesAsync`; `UpdateAsync` returns `Task.CompletedTask` |
| Handler (Add) | `CreateAgentDefinitionCommandHandler`, `CreateUserAgentCommandHandler` | inject `IUnitOfWork`, save after `AddAsync` |
| Handler (Update) | `Publish/Unpublish/StartTesting/UpdateAgentDefinition`, `RestoreUserAgentCommandHandler`, `UpdateAgentConfigurationCommandHandler`, `UpdateUserAgentCommandHandler` | inject `IUnitOfWork`, save after `UpdateAsync` |
| Handler (Delete) | `DeleteAgentDefinitionCommandHandler` | inject `IUnitOfWork`, save after `DeleteAsync` |
| Handler (Cascade fix) | `SoftDeleteUserAgentCommandHandler` | conditional save replaced with unconditional final save — restores atomicity across agent + cascaded threads |
| Doc-comments | 3 handlers | stale "repo auto-saves" remark rewritten to reference ADR-056 |
| Tests | 4 test files | constructor calls updated to inject `Mock<IUnitOfWork>` |

## Verification

```
$ dotnet build apps/api/src/Api/Api.csproj                              ✓ clean
$ dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj                ✓ clean
$ dotnet test --filter "Category=Unit&FullyQualifiedName~AgentDefinition" ✓ 118/118
$ dotnet test --filter "Category=Unit&BoundedContext=KnowledgeBase"     ✓ 1988/1988
```

## What this does NOT touch

- Other BCs (`Administration`, `Authentication`, `GameManagement`, …): each evaluates the pattern independently when an asymmetry surfaces
- Integration tests: covered by the dev-async pipeline post-merge (`Backend Integration (Testcontainers)`)
- Static-analysis enforcement: noted as a follow-up recommendation in ADR-056

## Risk

- **Subtle**: a handler somewhere outside the scoped 10 that called `AgentDefinitionRepository.UpdateAsync` and relied on auto-save would now silently lose its write. I audited all 18 consumers + 2 EventHandlers in the wider repo (grep for `AgentDefinitionRepository.(Add|Update|Delete)Async`) — no orphan callers. CI integration tests provide the final safety net.

## Refs

- Closes #942
- ADR-056 (introduced)
- PR #934 (SG3 — discovered the asymmetry)
- Spec-panel maturation: /sc:spec-panel #940-#943 session 2026-05-13
- EPIC #906 (parent, closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)