### PR TITLE
feat(notifications): subscriber for AutoAgentCreationFailedEvent (closes #940)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandler.cs
@@ -1,0 +1,106 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles <see cref="AutoAgentCreationFailedEvent"/> — the failure twin of
+/// <see cref="AgentAutoCreatedEvent"/> (handled by <see cref="NotifyAgentReadyHandler"/>).
+///
+/// Fires when <c>AutoCreateAgentOnPdfReadyHandler</c> indexed a PDF successfully but
+/// could not auto-create the user-facing agent (tier-quota slot exceeded, feature
+/// locked behind a higher plan, or generic exception). Without this subscriber the
+/// user sees no agent appear after PDF processing completed and has no idea why —
+/// EPIC #906 SG1 surfaced the silent-failure; this handler closes the loop.
+///
+/// Issue #940 (EPIC #906 follow-up).
+/// Spec-panel maturation 2026-05-13.
+/// </summary>
+internal sealed class NotifyAgentCreationFailedHandler : INotificationHandler<AutoAgentCreationFailedEvent>
+{
+    private readonly INotificationDispatcher _dispatcher;
+    private readonly ILogger<NotifyAgentCreationFailedHandler> _logger;
+
+    public NotifyAgentCreationFailedHandler(
+        INotificationDispatcher dispatcher,
+        ILogger<NotifyAgentCreationFailedHandler> logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(AutoAgentCreationFailedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        try
+        {
+            var (title, body, deepLink) = MapErrorToCopy(notification);
+
+            await _dispatcher.DispatchAsync(new NotificationMessage
+            {
+                Type = NotificationType.AgentCreationFailed,
+                RecipientUserId = notification.UserId,
+                Payload = new GenericPayload(title, body),
+                DeepLinkPath = deepLink
+            }, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "NotifyAgentCreationFailedHandler: Dispatched failure notification for UserId={UserId}, " +
+                "PdfDocumentId={PdfDocumentId}, GameId={GameId}, ErrorCode={ErrorCode}",
+                notification.UserId,
+                notification.PdfDocumentId,
+                notification.GameId,
+                notification.ErrorCode);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            // Defensive swallow: subscriber failure must NOT propagate back through
+            // the MediatR INotification chain to the publisher's transaction
+            // (AutoCreateAgentOnPdfReadyHandler's catch block). The original
+            // creation failure has already been logged; this is best-effort UX.
+            _logger.LogError(ex,
+                "NotifyAgentCreationFailedHandler: Failed to dispatch failure notification for " +
+                "UserId={UserId}, PdfDocumentId={PdfDocumentId}, ErrorCode={ErrorCode}. Notification skipped.",
+                notification.UserId,
+                notification.PdfDocumentId,
+                notification.ErrorCode);
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// Maps the event's <c>ErrorCode</c> to user-facing copy + a deep-link to the
+    /// most useful next action. Italian copy matches the existing
+    /// <see cref="NotifyAgentReadyHandler"/> convention (project default is
+    /// <c>LOCALES.IT</c>; EN deferred to a future SSR locale-negotiation epic).
+    /// </summary>
+    private static (string Title, string Body, string DeepLink) MapErrorToCopy(AutoAgentCreationFailedEvent ev)
+    {
+        return ev.ErrorCode switch
+        {
+            "AGENT_SLOT_QUOTA_EXCEEDED" => (
+                "Limite agent raggiunto",
+                "Hai raggiunto il limite di agent del tuo piano. Esegui l'upgrade o elimina un agent esistente per crearne uno nuovo.",
+                "/settings/subscription"
+            ),
+            "TIER_FEATURE_LOCKED" => (
+                "Funzionalità non disponibile",
+                "La creazione di agent richiede un piano superiore.",
+                "/settings/subscription"
+            ),
+            // Fallback covers both the documented "AGENT_CREATION_FAILED" code and
+            // any unknown ErrorCode value (defensive: don't crash on a value the
+            // publisher adds after this handler ships).
+            _ => (
+                "Creazione agent fallita",
+                "Non siamo riusciti a creare automaticamente un agent per il PDF. Riprova manualmente dal toolkit del gioco o contatta il supporto.",
+                $"/library/private/{ev.GameId}/toolkit"
+            )
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -52,6 +52,10 @@ internal sealed class NotificationType : ValueObject
     // ISSUE-5009: Agent ready notification (merged agent_linked + agent_auto_created)
     public static readonly NotificationType AgentReady = new("agent_ready");
 
+    // ISSUE-940: Failure twin of AgentReady — fires when AutoCreateAgentOnPdfReady
+    // could not create an agent (tier quota, feature locked, generic failure).
+    public static readonly NotificationType AgentCreationFailed = new("agent_creation_failed");
+
     // ISSUE-5084/5085: OpenRouter threshold alert — RPM and budget (admin)
     public static readonly NotificationType AdminOpenRouterThresholdAlert = new("admin_openrouter_threshold_alert");
 
@@ -149,6 +153,7 @@ internal sealed class NotificationType : ValueObject
             "game_proposal_in_review" => GameProposalInReview,
             "game_proposal_kb_merged" => GameProposalKbMerged,
             "agent_ready" => AgentReady,
+            "agent_creation_failed" => AgentCreationFailed,
             "admin_openrouter_threshold_alert" => AdminOpenRouterThresholdAlert,
             "admin_openrouter_daily_summary" => AdminOpenRouterDailySummary,
             "admin_system_health_alert" => AdminSystemHealthAlert,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -196,7 +196,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             || type == NotificationType.AdminStaleShareRequests
             || type == NotificationType.RateLimitReached
             || type == NotificationType.SlackConnectionRevoked
-            || type == NotificationType.MechanicAnalysisRejected)
+            || type == NotificationType.MechanicAnalysisRejected
+            || type == NotificationType.AgentCreationFailed)
             return NotificationSeverity.Warning;
 
         if (type == NotificationType.DocumentReady
@@ -228,6 +229,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         if (type == NotificationType.GameNightReminder) return "Promemoria Serata";
         if (type == NotificationType.GameNightCancelled) return "Serata annullata";
         if (type == NotificationType.AgentReady) return "Agente pronto";
+        if (type == NotificationType.AgentCreationFailed) return "Creazione agent fallita";
         if (type == NotificationType.LoanReminder) return "Promemoria prestito";
         if (type == NotificationType.RateLimitApproaching) return "Quota in avvicinamento";
         if (type == NotificationType.RateLimitReached) return "Quota raggiunta";

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentCreationFailedHandlerTests.cs
@@ -1,0 +1,225 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for <see cref="NotifyAgentCreationFailedHandler"/> (Issue #940).
+///
+/// Verifies that <see cref="AutoAgentCreationFailedEvent"/> is translated into a
+/// user-facing notification with ErrorCode-appropriate copy + deep-link, and that
+/// dispatcher failures do not propagate back to the publisher's catch block.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotifyAgentCreationFailedHandlerTests
+{
+    private readonly Mock<INotificationDispatcher> _dispatcher;
+    private readonly Mock<ILogger<NotifyAgentCreationFailedHandler>> _logger;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _pdfDocumentId = Guid.NewGuid();
+    private readonly Guid _gameId = Guid.NewGuid();
+
+    public NotifyAgentCreationFailedHandlerTests()
+    {
+        _dispatcher = new Mock<INotificationDispatcher>();
+        _logger = new Mock<ILogger<NotifyAgentCreationFailedHandler>>();
+    }
+
+    private NotifyAgentCreationFailedHandler CreateHandler() =>
+        new(_dispatcher.Object, _logger.Object);
+
+    private AutoAgentCreationFailedEvent CreateEvent(string errorCode, string reason = "test failure") =>
+        new(
+            PdfDocumentId: _pdfDocumentId,
+            GameId: _gameId,
+            UserId: _userId,
+            ErrorCode: errorCode,
+            Reason: reason);
+
+    private NotificationMessage CaptureDispatchedMessage()
+    {
+        NotificationMessage? captured = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => captured = msg)
+            .Returns(Task.CompletedTask);
+        return captured!; // populated after Handle() runs; tests assert via the field
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UT-1: AGENT_SLOT_QUOTA_EXCEEDED → tier-quota copy + /settings/subscription
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_QuotaExceeded_DispatchesTierCopyAndSubscriptionDeepLink()
+    {
+        // Arrange
+        NotificationMessage? captured = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => captured = msg)
+            .Returns(Task.CompletedTask);
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_SLOT_QUOTA_EXCEEDED");
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.Type.Should().Be(NotificationType.AgentCreationFailed);
+        captured.RecipientUserId.Should().Be(_userId);
+        captured.DeepLinkPath.Should().Be("/settings/subscription");
+        var payload = captured.Payload.Should().BeOfType<GenericPayload>().Subject;
+        payload.Title.Should().Be("Limite agent raggiunto");
+        payload.Body.Should().Contain("limite di agent");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UT-2: TIER_FEATURE_LOCKED → feature-locked copy + /settings/subscription
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_FeatureLocked_DispatchesUpgradeCopyAndSubscriptionDeepLink()
+    {
+        NotificationMessage? captured = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => captured = msg)
+            .Returns(Task.CompletedTask);
+        var handler = CreateHandler();
+        var evt = CreateEvent("TIER_FEATURE_LOCKED");
+
+        await handler.Handle(evt, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.DeepLinkPath.Should().Be("/settings/subscription");
+        var payload = captured.Payload.Should().BeOfType<GenericPayload>().Subject;
+        payload.Title.Should().Be("Funzionalità non disponibile");
+        payload.Body.Should().Contain("piano superiore");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UT-3: AGENT_CREATION_FAILED (generic) → game-toolkit deep link
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_GenericFailure_DispatchesGenericCopyAndToolkitDeepLink()
+    {
+        NotificationMessage? captured = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => captured = msg)
+            .Returns(Task.CompletedTask);
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_CREATION_FAILED");
+
+        await handler.Handle(evt, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.DeepLinkPath.Should().Be($"/library/private/{_gameId}/toolkit");
+        var payload = captured.Payload.Should().BeOfType<GenericPayload>().Subject;
+        payload.Title.Should().Be("Creazione agent fallita");
+        payload.Body.Should().Contain("Riprova manualmente");
+    }
+
+    [Fact]
+    public async Task Handle_UnknownErrorCode_FallsBackToGenericCopy()
+    {
+        // Defensive: an ErrorCode introduced by the publisher after this handler ships
+        // must NOT crash — fallback to the generic-failure branch.
+        NotificationMessage? captured = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => captured = msg)
+            .Returns(Task.CompletedTask);
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_FUTURE_CODE_NEVER_BEFORE_SEEN");
+
+        await handler.Handle(evt, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        var payload = captured!.Payload.Should().BeOfType<GenericPayload>().Subject;
+        payload.Title.Should().Be("Creazione agent fallita");
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesExactlyOneNotification()
+    {
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_CREATION_FAILED");
+
+        await handler.Handle(evt, CancellationToken.None);
+
+        _dispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UT-4: Dispatcher failure → handler swallows + logs (defensive)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_DispatcherThrows_ExceptionIsCaughtAndDoesNotPropagate()
+    {
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Dispatcher unavailable"));
+
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_SLOT_QUOTA_EXCEEDED");
+
+        var act = async () => await handler.Handle(evt, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_DispatcherThrows_ErrorIsLogged()
+    {
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Connection lost"));
+
+        var handler = CreateHandler();
+        var evt = CreateEvent("AGENT_CREATION_FAILED");
+
+        await handler.Handle(evt, CancellationToken.None);
+
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("NotifyAgentCreationFailedHandler")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Constructor null guards
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullDispatcher_ThrowsArgumentNullException()
+    {
+        var act = () => new NotifyAgentCreationFailedHandler(null!, _logger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new NotifyAgentCreationFailedHandler(_dispatcher.Object, null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #940. Subscriber in `UserNotifications` BC that turns `AutoAgentCreationFailedEvent` (published from `KnowledgeBase/AutoCreateAgentOnPdfReadyHandler`'s catch block) into a user-facing notification with ErrorCode-appropriate copy + deep-link.

Mirror of the success twin `NotifyAgentReadyHandler` (which handles `AgentAutoCreatedEvent`).

## Changes

| File | Change |
|------|--------|
| `NotificationType.cs` | Add `AgentCreationFailed = new("agent_creation_failed")` + Parse round-trip |
| `NotificationDispatcher.cs` | Severity = Warning; title fallback = "Creazione agent fallita" |
| `NotifyAgentCreationFailedHandler.cs` | **NEW** — `INotificationHandler<AutoAgentCreationFailedEvent>` |
| `NotifyAgentCreationFailedHandlerTests.cs` | **NEW** — 9 unit tests (UT-1..UT-4 from spec-panel matrix + 3 ctor null guards + exactly-once dispatch) |

## ErrorCode → copy mapping

| ErrorCode | Title | DeepLink |
|---|---|---|
| `AGENT_SLOT_QUOTA_EXCEEDED` | Limite agent raggiunto | `/settings/subscription` |
| `TIER_FEATURE_LOCKED` | Funzionalità non disponibile | `/settings/subscription` |
| `AGENT_CREATION_FAILED` (+ unknown fallback) | Creazione agent fallita | `/library/private/{GameId}/toolkit` |

Italian copy matches existing `NotifyAgentReadyHandler` convention.

## Scope reductions (panel-recommended)

| Out of scope | Why |
|---|---|
| EN i18n | Existing pattern in BC is IT-only; defer until SSR locale negotiation (#1103) |
| Dedupe by PdfDocumentId | Event fired once from terminal catch; de facto dedup at publisher; reopen if production retry storms observed |
| Direct `IEmailQueue` injection | `INotificationDispatcher` already fans out to email/Slack/in-app per user preferences |

## Defensive design

Handler `try/catch`s all dispatcher exceptions and logs them — must NOT propagate back to the MediatR `INotification` chain (publisher's catch block has already logged the original creation failure; subscriber error would mask root cause). Pattern matches `NotifyAgentReadyHandler` exactly.

## Verification

```
$ dotnet build apps/api/src/Api/Api.csproj                              ✓ clean
$ dotnet test --filter "FullyQualifiedName~NotifyAgentCreationFailed"   ✓ 9/9
$ dotnet test --filter "Category=Unit&BoundedContext=UserNotifications" ✓ 128/128 (no regression)
```

## Test plan

- [x] Build clean, 9 new tests pass
- [x] 128 existing UserNotifications tests pass (no regression)
- [ ] CI: Dev Fast / GitGuardian / Lychee green
- [ ] Post-merge: dev-async integration tests cover the end-to-end happy path

## Refs

- Closes #940
- Spec-panel maturation: /sc:spec-panel #940 session 2026-05-13
- Source event from PR #937 (SG1 closes #902)
- Parent EPIC (closed): #906
- Mirror template: `NotifyAgentReadyHandler.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)