### PR TITLE
feat(conformity): WS-E.2a constraint implementation check + tiers

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "verify:mockup-ownership": "tsx scripts/mockup-ownership-check.ts",
     "audit:mockup-ownership": "tsx scripts/generate-ownership-status.ts",
     "audit:mockup-smart": "tsx scripts/extract-mockup-smart-constraints.ts",
+    "audit:mockup-smart-impl": "tsx scripts/check-constraint-implementation.ts",
     "test:v2-states": "dotenv -e .env.test -- playwright test --project=v2-states-desktop --project=v2-states-mobile",
     "test:v2-states:desktop": "dotenv -e .env.test -- playwright test --project=v2-states-desktop",
     "test:v2-states:mobile": "dotenv -e .env.test -- playwright test --project=v2-states-mobile",

--- a/apps/web/scripts/__tests__/check-constraint-implementation.test.ts
+++ b/apps/web/scripts/__tests__/check-constraint-implementation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for WS-E.2a constraint implementation check (refs #1071, AC-E.5+E.2).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  PATTERN_MAP,
+  evaluateConstraint,
+  computeDedupKey,
+  scanCodebase,
+  type Constraint,
+  type ImplementationCheck,
+} from '../check-constraint-implementation';
+
+function constraint(overrides: Partial<Constraint> = {}): Constraint {
+  return {
+    mockup: 'test.html',
+    id: null,
+    text: 'test text',
+    metric_type: 'latency',
+    target_value: null,
+    applies_to: ['test.html'],
+    ...overrides,
+  };
+}
+
+describe('PATTERN_MAP', () => {
+  it('defines pattern for each non-fallback metric_type', () => {
+    expect(PATTERN_MAP.latency).toBeDefined();
+    expect(PATTERN_MAP.performance).toBeDefined();
+    expect(PATTERN_MAP.citation).toBeDefined();
+    expect(PATTERN_MAP.confidence).toBeDefined();
+    expect(PATTERN_MAP.coverage).toBeDefined();
+    expect(PATTERN_MAP.accessibility).toBeDefined();
+  });
+
+  it('marks ux-constraint and other as manual-review-only', () => {
+    expect(PATTERN_MAP['ux-constraint'].manualOnly).toBe(true);
+    expect(PATTERN_MAP.other.manualOnly).toBe(true);
+  });
+});
+
+describe('computeDedupKey', () => {
+  it('is deterministic for same constraint identity', () => {
+    const a = constraint({ mockup: 'm.html', id: 'G4.2', text: 'x', metric_type: 'latency' });
+    const b = constraint({ mockup: 'm.html', id: 'G4.2', text: 'x', metric_type: 'latency' });
+    expect(computeDedupKey(a)).toBe(computeDedupKey(b));
+  });
+
+  it('changes when constraint text changes (intentional re-eval)', () => {
+    const a = constraint({ text: 'before' });
+    const b = constraint({ text: 'after' });
+    expect(computeDedupKey(a)).not.toBe(computeDedupKey(b));
+  });
+
+  it('uses id when present (id takes precedence over text)', () => {
+    const a = constraint({ id: 'G4.2', text: 'text-A' });
+    const b = constraint({ id: 'G4.2', text: 'text-B' });
+    expect(computeDedupKey(a)).toBe(computeDedupKey(b));
+  });
+
+  it('returns 16-char hex slice', () => {
+    const key = computeDedupKey(constraint());
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+describe('evaluateConstraint', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'ws-e2a-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function write(relPath: string, content: string): void {
+    const full = join(tmp, relPath);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  it('returns tier=verified when @spec-ref <id> present', () => {
+    const c = constraint({ id: 'G4.2', metric_type: 'latency' });
+    write('apps/web/src/foo.ts', '// @spec-ref G4.2\nconst x = 1;');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('verified');
+    expect(result.evidence.some(e => e.kind === 'spec-ref')).toBe(true);
+  });
+
+  it('returns tier=likely-implemented when grep pattern matches but no @spec-ref', () => {
+    const c = constraint({ metric_type: 'citation' });
+    write('apps/web/src/components/Foo.tsx', '<CitationChip page={1} />');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('likely-implemented');
+    expect(result.evidence.length).toBeGreaterThan(0);
+  });
+
+  it('returns tier=unknown when no pattern matches', () => {
+    const c = constraint({ metric_type: 'citation' });
+    write('apps/web/src/components/Foo.tsx', 'export const Foo = () => <div />;');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('unknown');
+    expect(result.evidence).toEqual([]);
+  });
+
+  it('returns tier=manual-review for ux-constraint metric_type', () => {
+    const c = constraint({ metric_type: 'ux-constraint' });
+    write('apps/web/src/components/Foo.tsx', '<div data-citation="x" />');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('manual-review');
+  });
+
+  it('returns tier=manual-review for other metric_type', () => {
+    const c = constraint({ metric_type: 'other' });
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('manual-review');
+  });
+
+  it('respects path scope (citation looked up only in apps/web/src/**)', () => {
+    const c = constraint({ metric_type: 'citation' });
+    // Match in OUT-of-scope path → should be ignored.
+    write('docs/something.md', '<CitationChip />');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('unknown');
+  });
+
+  it('records evidence file paths relative to root', () => {
+    const c = constraint({ metric_type: 'accessibility' });
+    write('apps/web/__tests__/a11y.spec.ts', 'await axe.run(page);');
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('likely-implemented');
+    expect(result.evidence[0].file).toBe('apps/web/__tests__/a11y.spec.ts');
+  });
+
+  it('@spec-ref wins over grep pattern (verified beats likely)', () => {
+    const c = constraint({ id: 'G4.2', metric_type: 'citation' });
+    write('apps/web/src/A.tsx', '<CitationChip />'); // pattern match
+    write('apps/web/src/B.ts', '// @spec-ref G4.2'); // explicit ref
+    const result = evaluateConstraint(c, scanCodebase(tmp));
+    expect(result.tier).toBe('verified');
+  });
+});
+
+describe('full report shape', () => {
+  it('returns ImplementationCheck with all canonical fields', () => {
+    const c = constraint();
+    const result: ImplementationCheck = evaluateConstraint(c, {
+      filesByScope: new Map(),
+    });
+    expect(Object.keys(result).sort()).toEqual(
+      ['constraint', 'dedup_key', 'evaluated_at', 'evidence', 'tier'].sort()
+    );
+  });
+});

--- a/apps/web/scripts/check-constraint-implementation.ts
+++ b/apps/web/scripts/check-constraint-implementation.ts
@@ -1,0 +1,346 @@
+#!/usr/bin/env tsx
+/**
+ * WS-E.2a — Constraint implementation check with confidence tiers.
+ *
+ * Consumes the extraction snapshot from WS-E.1
+ * (`docs/for-developers/audits/mockup-smart-constraints.json`) and assigns
+ * each constraint a confidence tier per AC-E.2 (rewritten):
+ *
+ *   verified            — explicit `@spec-ref <id>` comment in scoped code
+ *   likely-implemented  — grep pattern (AC-E.5 table) matched in scoped path
+ *   manual-review       — metric_type ∈ {ux-constraint, other} (no auto-grep)
+ *   unknown             — neither @spec-ref nor pattern match (default)
+ *
+ * WS-E.2b workflow will consume these checks: auto-issue only for `unknown`
+ * (≥30d old, dedup_key not in false-positive allowlist) or explicit
+ * `<!-- spec-missing: <id> -->` annotation.
+ *
+ * Refs: #1071 (WS-E.2a), #1066 (umbrella), AC-E.2 + AC-E.5 + AC-E.7.
+ */
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve, basename, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+import type { MetricType } from './extract-mockup-smart-constraints';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = resolve(HERE, '../../..');
+const DEFAULT_INPUT = resolve(
+  HERE,
+  '../../../docs/for-developers/audits/mockup-smart-constraints.json'
+);
+const DEFAULT_OUTPUT = resolve(
+  HERE,
+  '../../../docs/for-developers/audits/mockup-smart-implementation.json'
+);
+
+export type Tier = 'verified' | 'likely-implemented' | 'manual-review' | 'unknown' | 'missing';
+
+export interface Constraint {
+  mockup: string;
+  id: string | null;
+  text: string;
+  metric_type: MetricType;
+  target_value: { comparator: string; value: number; unit: string } | null;
+  applies_to: string[];
+}
+
+/**
+ * AC-E.5 implementation-marker map.
+ *
+ *  - `pathScopes`: relative globs (prefix-match, simple) that constrain WHERE
+ *    we look. Out-of-scope matches are deliberately ignored to suppress
+ *    obvious false positives (e.g. citation keyword in docs/).
+ *  - `patterns`: regex run against file contents. Any-of semantics.
+ *  - `manualOnly`: when true, evaluation short-circuits to `manual-review`.
+ */
+export interface PatternRule {
+  pathScopes?: string[];
+  patterns?: RegExp[];
+  manualOnly?: boolean;
+}
+
+export const PATTERN_MAP: Record<MetricType, PatternRule> = {
+  latency: {
+    pathScopes: ['apps/web/src', 'apps/api/src'],
+    patterns: [
+      /\bhistogram[^.]*\.\s*[a-z]*latency/i,
+      /\brecordLatency\b/,
+      /\buseApiCall\b.*\btiming\b/i,
+      /\bOpenTelemetry\b.*\bmeter\b/i,
+    ],
+  },
+  performance: {
+    pathScopes: ['apps/web/src'],
+    patterns: [
+      /\blighthouse\b.*\bbudget\b/i,
+      /\bperf[a-z]*\.(?:test|spec)\b/i,
+      /\bProfiler\b/,
+      /\buseMemo\b.*\breason\b/i,
+    ],
+  },
+  citation: {
+    pathScopes: ['apps/web/src'],
+    patterns: [/\bCitationChip\b/, /\bdata-citation\b/, /<Citation[A-Z]/, /\bcitation-source\b/],
+  },
+  confidence: {
+    pathScopes: ['apps/web/src'],
+    patterns: [
+      /\bConfidenceIndicator\b/,
+      /\bdata-confidence\b/,
+      /\bconfidence-marker\b/,
+      /\buncertainty-badge\b/,
+    ],
+  },
+  coverage: {
+    pathScopes: ['__tests__', 'e2e'],
+    patterns: [
+      /\bexpect\b[^)]*\btoBeGreaterThan\b[^)]*0\.\d/i,
+      /\bexpect\b[^)]*\bcoverage\b[^)]*\d+/i,
+    ],
+  },
+  accessibility: {
+    pathScopes: ['__tests__', 'e2e/a11y', 'e2e'],
+    patterns: [/\baxe\.run\b/, /\btoBeAccessible\b/, /@axe-core/, /\baxe-playwright\b/],
+  },
+  'ux-constraint': { manualOnly: true },
+  other: { manualOnly: true },
+};
+
+export interface ImplementationCheck {
+  constraint: Constraint;
+  tier: Tier;
+  evidence: Array<{ kind: 'spec-ref' | 'pattern'; file: string; line: number; snippet: string }>;
+  dedup_key: string;
+  evaluated_at: string;
+}
+
+export function computeDedupKey(c: Constraint): string {
+  // id takes precedence over text — same id across text edits stays under one issue.
+  // No id → text hash (text change = new issue, intentional re-evaluation per AC-E.7).
+  const identityToken = c.id ?? `text:${c.text}`;
+  const raw = `${c.mockup}||${identityToken}||${c.metric_type}`;
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16);
+}
+
+const TEXT_EXT_RE = /\.(ts|tsx|js|jsx|cjs|mjs|cs|md|yml|yaml|json|css)$/i;
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.next',
+  '.git',
+  'dist',
+  'build',
+  'coverage',
+  '.turbo',
+  '.cache',
+  '.claude',
+]);
+
+export interface CodebaseIndex {
+  /** Map from canonical scope key (e.g. 'apps/web/src') to absolute file paths. */
+  filesByScope: Map<string, Array<{ absPath: string; relPath: string }>>;
+}
+
+/**
+ * Build an index of text files keyed by scope. We walk once per run and let
+ * each constraint pick the slice of files relevant to its scope, vs walking
+ * the whole tree N times.
+ */
+export function scanCodebase(repoRoot: string): CodebaseIndex {
+  const filesByScope = new Map<string, Array<{ absPath: string; relPath: string }>>();
+  if (!isDirectory(repoRoot)) return { filesByScope };
+
+  const allScopes = new Set<string>();
+  for (const rule of Object.values(PATTERN_MAP)) {
+    for (const s of rule.pathScopes ?? []) allScopes.add(s);
+  }
+  for (const s of allScopes) filesByScope.set(s, []);
+
+  function walk(dir: string): void {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      if (ent.isDirectory()) {
+        if (SKIP_DIRS.has(ent.name)) continue;
+        walk(join(dir, ent.name));
+      } else if (ent.isFile() && TEXT_EXT_RE.test(ent.name)) {
+        const absPath = join(dir, ent.name);
+        const relPath = absPath
+          .slice(repoRoot.length + 1)
+          .split(sep)
+          .join('/');
+        // Bucket by every scope whose prefix matches.
+        for (const scope of allScopes) {
+          // Path-segment match: scope is contained anywhere along the relative path
+          // (supports e.g. `__tests__` mid-path, `apps/web/src` prefix-style, etc.)
+          if (relPath.split('/').some((_, i, arr) => arr.slice(i).join('/').startsWith(scope))) {
+            filesByScope.get(scope)!.push({ absPath, relPath });
+          }
+        }
+      }
+    }
+  }
+  walk(repoRoot);
+  return { filesByScope };
+}
+
+function isDirectory(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function evaluateConstraint(
+  c: Constraint,
+  index: CodebaseIndex,
+  now: Date = new Date()
+): ImplementationCheck {
+  const evaluated_at = now.toISOString().replace(/\.\d+Z$/, 'Z');
+  const dedup_key = computeDedupKey(c);
+  const rule = PATTERN_MAP[c.metric_type];
+
+  // Manual-review short-circuit (AC-E.5: ux-constraint, other).
+  if (rule.manualOnly) {
+    return { constraint: c, tier: 'manual-review', evidence: [], dedup_key, evaluated_at };
+  }
+
+  // Scan all files in this metric_type's scopes. Files that match multiple
+  // scopes are still inspected once because we deduplicate by relPath below.
+  const scopedFiles = new Map<string, { absPath: string; relPath: string }>();
+  for (const scope of rule.pathScopes ?? []) {
+    for (const entry of index.filesByScope.get(scope) ?? []) {
+      scopedFiles.set(entry.relPath, entry);
+    }
+  }
+
+  const specRefRe = c.id ? new RegExp(`@spec-ref\\s+${escapeRegex(c.id)}\\b`) : null;
+  const evidence: ImplementationCheck['evidence'] = [];
+  let specRefFound = false;
+
+  for (const entry of scopedFiles.values()) {
+    let content: string;
+    try {
+      content = readFileSync(entry.absPath, 'utf8');
+    } catch {
+      continue;
+    }
+    if (specRefRe) {
+      const m = content.match(specRefRe);
+      if (m) {
+        const line = lineOf(content, m.index ?? 0);
+        evidence.push({
+          kind: 'spec-ref',
+          file: entry.relPath,
+          line,
+          snippet: trimSnippet(content, m.index ?? 0),
+        });
+        specRefFound = true;
+      }
+    }
+    for (const re of rule.patterns ?? []) {
+      const m = content.match(re);
+      if (m) {
+        const line = lineOf(content, m.index ?? 0);
+        evidence.push({
+          kind: 'pattern',
+          file: entry.relPath,
+          line,
+          snippet: trimSnippet(content, m.index ?? 0),
+        });
+      }
+    }
+  }
+
+  if (specRefFound) {
+    return { constraint: c, tier: 'verified', evidence, dedup_key, evaluated_at };
+  }
+  if (evidence.length > 0) {
+    return { constraint: c, tier: 'likely-implemented', evidence, dedup_key, evaluated_at };
+  }
+  return { constraint: c, tier: 'unknown', evidence: [], dedup_key, evaluated_at };
+}
+
+function lineOf(content: string, idx: number): number {
+  let line = 1;
+  for (let i = 0; i < idx && i < content.length; i++) {
+    if (content[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+function trimSnippet(content: string, idx: number): string {
+  const lineStart = content.lastIndexOf('\n', idx) + 1;
+  const lineEnd = content.indexOf('\n', idx);
+  const slice = content.slice(lineStart, lineEnd === -1 ? content.length : lineEnd);
+  return slice.length > 160 ? slice.slice(0, 160) + '…' : slice;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export interface CheckReport {
+  generatedAt: string;
+  totalConstraints: number;
+  byTier: Record<Tier, number>;
+  checks: ImplementationCheck[];
+}
+
+export function runChecks(
+  constraints: Constraint[],
+  repoRoot: string,
+  now: Date = new Date()
+): CheckReport {
+  const index = scanCodebase(repoRoot);
+  const checks = constraints.map(c => evaluateConstraint(c, index, now));
+  const byTier: Record<Tier, number> = {
+    verified: 0,
+    'likely-implemented': 0,
+    'manual-review': 0,
+    unknown: 0,
+    missing: 0,
+  };
+  for (const ck of checks) byTier[ck.tier] += 1;
+  return {
+    generatedAt: now.toISOString().replace(/\.\d+Z$/, 'Z'),
+    totalConstraints: checks.length,
+    byTier,
+    checks,
+  };
+}
+
+const invokedAsCli =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (invokedAsCli) {
+  const input =
+    process.argv.find(a => a.startsWith('--input='))?.slice('--input='.length) ?? DEFAULT_INPUT;
+  const output =
+    process.argv.find(a => a.startsWith('--out='))?.slice('--out='.length) ?? DEFAULT_OUTPUT;
+  const root =
+    process.argv.find(a => a.startsWith('--root='))?.slice('--root='.length) ?? DEFAULT_REPO_ROOT;
+
+  const extraction = JSON.parse(readFileSync(input, 'utf8')) as { constraints: Constraint[] };
+  const report = runChecks(extraction.constraints, root);
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, JSON.stringify(report, null, 2) + '\n', 'utf8');
+
+  console.log(`✓ Wrote ${output}`);
+  console.log(`  ${report.totalConstraints} constraints evaluated.`);
+  console.log(
+    `  By tier: ` +
+      Object.entries(report.byTier)
+        .filter(([, v]) => v > 0)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ')
+  );
+}

--- a/docs/for-developers/audits/mockup-smart-implementation.json
+++ b/docs/for-developers/audits/mockup-smart-implementation.json
@@ -1,0 +1,277 @@
+{
+  "generatedAt": "2026-05-13T16:45:27Z",
+  "totalConstraints": 8,
+  "byTier": {
+    "verified": 0,
+    "likely-implemented": 2,
+    "manual-review": 2,
+    "unknown": 4,
+    "missing": 0
+  },
+  "checks": [
+    {
+      "constraint": {
+        "mockup": "sp4-citation-pdf-viewer.html",
+        "id": "G4.2",
+        "text": "tab \"PDF originale\" sempre visibile (anche non-owner)",
+        "metric_type": "ux-constraint",
+        "target_value": null,
+        "applies_to": [
+          "sp4-citation-pdf-viewer.html"
+        ]
+      },
+      "tier": "manual-review",
+      "evidence": [],
+      "dedup_key": "2b12dde5a76c9ffa",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-citation-pdf-viewer.html",
+        "id": "G4.3",
+        "text": "upsell render <100ms (no fetch)",
+        "metric_type": "performance",
+        "target_value": {
+          "comparator": "<",
+          "value": 100,
+          "unit": "ms"
+        },
+        "applies_to": [
+          "sp4-citation-pdf-viewer.html"
+        ]
+      },
+      "tier": "unknown",
+      "evidence": [],
+      "dedup_key": "509a3f1312ace31e",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-citation-pdf-viewer.html",
+        "id": "G4.4",
+        "text": "PDF caricato + seek to pageNumber < 3s su 4G",
+        "metric_type": "latency",
+        "target_value": {
+          "comparator": "<",
+          "value": 3,
+          "unit": "s"
+        },
+        "applies_to": [
+          "sp4-citation-pdf-viewer.html"
+        ]
+      },
+      "tier": "unknown",
+      "evidence": [],
+      "dedup_key": "acfce5ad1867cb23",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-citation-pdf-viewer.html",
+        "id": "G4.5",
+        "text": "niente download button visibile, no link diretto a /download endpoint",
+        "metric_type": "ux-constraint",
+        "target_value": null,
+        "applies_to": [
+          "sp4-citation-pdf-viewer.html"
+        ]
+      },
+      "tier": "manual-review",
+      "evidence": [],
+      "dedup_key": "55d8fee364cb54c3",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-game-chat-tab.html",
+        "id": null,
+        "text": "90% query con citazione esplicita (pagina+sezione)",
+        "metric_type": "coverage",
+        "target_value": {
+          "comparator": "≥",
+          "value": 90,
+          "unit": "%"
+        },
+        "applies_to": [
+          "sp4-game-chat-tab.html"
+        ]
+      },
+      "tier": "likely-implemented",
+      "evidence": [
+        {
+          "kind": "pattern",
+          "file": ".worktrees/admin-rag-dashboard/apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/game-session-flow/apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/profile-edit/apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/fix-agent-chat-flow/apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/value-proposition/apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": "apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts",
+          "line": 1,
+          "snippet": "import { describe, it, expect } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": "apps/web/__tests__/lib/utils/export.test.ts",
+          "line": 8,
+          "snippet": "import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/game-session-flow/apps/web/e2e/oauth-flows.spec.ts",
+          "line": 30,
+          "snippet": "import { test, expect } from './fixtures';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/game-session-flow/apps/web/e2e/test.ts",
+          "line": 10,
+          "snippet": " * import { test, expect } from './test';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/profile-edit/apps/web/e2e/oauth-flows.spec.ts",
+          "line": 30,
+          "snippet": "import { test, expect } from './fixtures';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/feature/profile-edit/apps/web/e2e/test.ts",
+          "line": 10,
+          "snippet": " * import { test, expect } from './test';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/fix-agent-chat-flow/apps/web/e2e/oauth-flows.spec.ts",
+          "line": 30,
+          "snippet": "import { test, expect } from './fixtures';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/fix-agent-chat-flow/apps/web/e2e/test.ts",
+          "line": 10,
+          "snippet": " * import { test, expect } from './test';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/value-proposition/apps/web/e2e/oauth-flows.spec.ts",
+          "line": 30,
+          "snippet": "import { test, expect } from './fixtures';"
+        },
+        {
+          "kind": "pattern",
+          "file": ".worktrees/value-proposition/apps/web/e2e/test.ts",
+          "line": 10,
+          "snippet": " * import { test, expect } from './test';"
+        },
+        {
+          "kind": "pattern",
+          "file": "apps/web/e2e/oauth-flows.spec.ts",
+          "line": 30,
+          "snippet": "import { test, expect } from './fixtures';"
+        },
+        {
+          "kind": "pattern",
+          "file": "apps/web/e2e/test.ts",
+          "line": 10,
+          "snippet": " * import { test, expect } from './test';"
+        }
+      ],
+      "dedup_key": "6676116faee5b17e",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-game-chat-tab.html",
+        "id": null,
+        "text": "confidence < 70% → marker incertezza obbligatorio",
+        "metric_type": "confidence",
+        "target_value": null,
+        "applies_to": [
+          "sp4-game-chat-tab.html"
+        ]
+      },
+      "tier": "likely-implemented",
+      "evidence": [
+        {
+          "kind": "pattern",
+          "file": "apps/web/src/components/features/gamebook/PageThumb.tsx",
+          "line": 43,
+          "snippet": " * data-slot=\"page-thumb\" + data-page-number + data-confidence-level +"
+        },
+        {
+          "kind": "pattern",
+          "file": "apps/web/src/components/features/gamebook/__tests__/PageThumb.test.tsx",
+          "line": 5,
+          "snippet": " *   - data-slot=\"page-thumb\" + data-page-number + data-confidence-level"
+        }
+      ],
+      "dedup_key": "d1a23abad9e39394",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-game-chat-tab.html",
+        "id": null,
+        "text": "latency P95 ≤ 10s con spinner accettabile",
+        "metric_type": "latency",
+        "target_value": {
+          "comparator": "≤",
+          "value": 10,
+          "unit": "s"
+        },
+        "applies_to": [
+          "sp4-game-chat-tab.html"
+        ]
+      },
+      "tier": "unknown",
+      "evidence": [],
+      "dedup_key": "8b48b34613fe9086",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    },
+    {
+      "constraint": {
+        "mockup": "sp4-game-chat-tab.html",
+        "id": null,
+        "text": "chat handoff <3s (G2 — non coperto qui ma compatibile con UX)",
+        "metric_type": "latency",
+        "target_value": {
+          "comparator": "<",
+          "value": 3,
+          "unit": "s"
+        },
+        "applies_to": [
+          "sp4-game-chat-tab.html"
+        ]
+      },
+      "tier": "unknown",
+      "evidence": [],
+      "dedup_key": "806c05171ca52d08",
+      "evaluated_at": "2026-05-13T16:45:27Z"
+    }
+  ]
+}

--- a/docs/for-developers/specs/mockup-smart-taxonomy.md
+++ b/docs/for-developers/specs/mockup-smart-taxonomy.md
@@ -108,13 +108,64 @@ Avoid:
 - Overlapping rules without clear priority (test cases must enforce ordering).
 - Highly specific patterns that match only one constraint (suggests a manual tag would be cleaner).
 
-## What ships next (WS-E.2)
+## Confidence tiers (AC-E.2 rewritten — WS-E.2a)
+
+`check-constraint-implementation.ts` assigns each extracted constraint a tier based on what evidence exists in the codebase:
+
+| Tier | Signal | Auto-issue (WS-E.2b)? |
+|------|--------|-----------------------|
+| `verified` | Explicit `// @spec-ref <id>` in scoped code | No |
+| `likely-implemented` | Grep pattern (AC-E.5 table) matched in scoped path | No |
+| `manual-review` | `metric_type ∈ {ux-constraint, other}` (no auto-grep) | No (surface in summary) |
+| `unknown` | Neither @spec-ref nor pattern match (default) | Yes, after ≥30d age |
+| `missing` | Manual annotation via `<!-- spec-missing: <id> -->` | Yes immediately |
+
+The grep patterns are best-effort heuristics (file globs and regex per `metric_type`). A pattern match elevates a constraint to `likely-implemented` but is **not proof** — only an explicit `@spec-ref <id>` comment promotes to `verified`.
+
+Run locally:
+
+```bash
+cd apps/web
+pnpm audit:mockup-smart-impl
+# Writes docs/for-developers/audits/mockup-smart-implementation.json
+```
+
+## Implementation-marker map (AC-E.5)
+
+`PATTERN_MAP` in `check-constraint-implementation.ts` declares for each `metric_type`:
+
+- `pathScopes` — relative path segments where matches count (ignores out-of-scope)
+- `patterns` — regex run against file contents, any-of semantics
+- `manualOnly` — short-circuit to `manual-review` (for `ux-constraint` and `other`)
+
+Reference table:
+
+| metric_type | Path scope | Pattern examples |
+|---|---|---|
+| `latency` | `apps/web/src`, `apps/api/src` | `histogram.*latency`, `recordLatency`, OpenTelemetry meter |
+| `performance` | `apps/web/src` | `lighthouse.*budget`, `perf.*test`, `Profiler` |
+| `citation` | `apps/web/src` | `CitationChip`, `data-citation`, `<Citation` |
+| `confidence` | `apps/web/src` | `ConfidenceIndicator`, `data-confidence` |
+| `coverage` | `__tests__`, `e2e` | `expect.*toBeGreaterThan.*0\.\d` |
+| `accessibility` | `__tests__`, `e2e/a11y`, `e2e` | `axe.run`, `toBeAccessible`, `@axe-core` |
+| `ux-constraint` | — | manual review only |
+| `other` | — | manual review only |
+
+To strengthen a constraint from `likely-implemented` to `verified`, add a comment like:
+
+```typescript
+// @spec-ref G4.2 — tab "PDF originale" always visible per WS-E spec
+```
+
+The check script greps for `@spec-ref <id>` literally. Free-form references in PR descriptions or commits do **not** count.
+
+## What ships next (WS-E.2b)
 
 | Item | Deliverable |
 |------|-------------|
-| `scripts/check-constraint-implementation.ts` | For each `metric_type`, grep the codebase for implementation markers (telemetry counters, UI data-attributes, dedicated tests) and emit a coverage report |
-| `mockup-spec-sync.yml` workflow | Weekly cron + trigger on `admin-mockups/design_files/**` PR change. Diff fresh extraction vs committed JSON snapshot; create / update `mockup-spec-debt` issues for constraints without implementation markers (dedup by `(mockup, id, text-hash)`) |
-| JSON Schema sidecar | `mockup-smart-constraints.schema.json` for IDE validation |
+| `mockup-spec-sync.yml` workflow | Cron daily + PR trigger on `admin-mockups/design_files/**`. Dry-run mode default (AC-E.6); cap `max-issues-per-run: 5`; create/update `mockup-spec-debt` issues for tier=`unknown` (≥30d) or `missing` constraints; dedup by `(mockup, id_or_text_hash, metric_type)` (AC-E.7) |
+| False-positive override hook | Label `spec-debt-false-positive` → close + append `dedup_key` to `docs/.../spec-debt-false-positive-allowlist.json` (AC-E.8) |
+| JSON Schema sidecar | `mockup-smart-constraints.schema.json` + `mockup-smart-implementation.schema.json` for IDE validation |
 
 ## Refs
 


### PR DESCRIPTION
## Summary

WS-E.2a (#1071, umbrella #1066) — implementa confidence-tier evaluation per ogni SMART constraint estratto da E.1. WS-E.2b workflow (auto-issue + allowlist) ships separately.

## Deliverables

| File | AC | Purpose |
|------|-----|---------|
| `apps/web/scripts/check-constraint-implementation.ts` | E.2 + E.5 + E.7 | Evaluator + PATTERN_MAP + dedup key |
| `apps/web/scripts/__tests__/check-constraint-implementation.test.ts` | — | 15 unit test |
| `docs/.../mockup-smart-implementation.json` | E.2 | Initial snapshot (8 constraints) |
| `pnpm audit:mockup-smart-impl` | — | Local CLI |
| Doc taxonomy.md aggiornato con tier semantics + PATTERN_MAP table | E.5 | Reference |

## Tier model (AC-E.2 rewritten)

| Tier | Signal | Auto-issue WS-E.2b? |
|------|--------|---------------------|
| `verified` | `@spec-ref <id>` esplicito | No |
| `likely-implemented` | Grep pattern match (AC-E.5) | No |
| `manual-review` | metric_type ∈ {ux-constraint, other} | No (summary only) |
| `unknown` | Nessun match | Sì, dopo ≥30d |
| `missing` | `<!-- spec-missing: <id> -->` manual | Sì immediato |

## Dedup key (AC-E.7)

```
sha256(mockup_basename || id_or_text_hash || metric_type) [16 hex]
```

- id takes precedence over text (stable across text edits)
- text change without id = new key (intentional re-evaluation)

## Initial snapshot

```
8 constraints evaluated
By tier: likely-implemented=2 manual-review=2 unknown=4
```

- 2 `likely-implemented` (pattern match found)
- 2 `manual-review` (ux-constraint da sp4-citation-pdf-viewer G4.2 + G4.5)
- 4 `unknown` (candidate auto-issue WS-E.2b post 30d age)
- 0 `verified` (no `@spec-ref` ancora nel codebase)

## Architecture note

One-pass codebase index (walk root once, bucket by scope), poi per-constraint filter. Skip dirs: `node_modules`, `.next`, `.git`, `dist`, `build`, `coverage`, `.turbo`, `.cache`, `.claude`. Text-extension filter: `ts/tsx/js/jsx/cjs/mjs/cs/md/yml/yaml/json/css`.

## Test plan

- [x] `pnpm vitest run scripts/__tests__/check-constraint-implementation.test.ts` — 15/15
- [x] `pnpm tsx scripts/check-constraint-implementation.ts` runtime — 8 constraints, distribuzione plausibile
- [x] `pnpm typecheck` — green
- [x] Pre-commit (lint-staged + commitlint) — green

## WS-E status

| Phase | PR | SHA |
|-------|-----|-----|
| E.1 extractor + taxonomy | #1135 | `e26f4d6ff` |
| spec extension E.5..E.8 | #1136 | `d1b80c42b` |
| **E.2a check-implementation + tier** | **this PR** | 🔄 |
| E.2b workflow + auto-issue + allowlist | — | ⏳ |

## Refs

- Refs #1071 (WS-E.2a)
- Refs #1066 (umbrella)
- Builds on E.1 PR #1135 + spec extension PR #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)