### PR TITLE
test(smoke): Bruno Phase A.2 strict assertions for 03 + 06 (refs #943)

### DIFF
--- a/tests/api-smoke/README.md
+++ b/tests/api-smoke/README.md
@@ -19,15 +19,18 @@ The endpoint is triple-gated (`TestEndpoints:Enabled=true` + `IsProduction()=fal
 
 ## Assertion strictness
 
-Most scenarios use strict `expect(...).to.equal(N)` assertions after Phase A (#943). Three files remain **intentionally tolerant**:
+After Phase A + Phase A.2 (#943), 5 of 6 originally tolerant assertions are now strict. One file remains **intentionally tolerant**:
 
 | File | Reason | Status |
 |------|--------|--------|
-| `private-game/03-create-from-bgg-id-conflict-redirect.bru` | API behaviour policy-dependent (201 if private copy auto-creates, 409 if conflict-redirect). Tolerant until product decision codified. | Phase A.2 candidate |
-| `private-game/06-tier-quota-402.bru` | Free-tier `MaxPrivateGames` quota is DB-seeded (`TierLimits`). After the pre-request reset the collection creates 1-2 games before this scenario fires; whether the next create is 201 (within quota) or 402 (over quota) depends on the seeded limit. Tightening requires pre-seeding N games OR looping until 402. | Phase A.2 candidate |
 | `private-game/07-bgg-search-throttle.bru` | Depends on external BGG API (`api.geekdo.com`) rate limits — we can't make BGG return 200 deterministically. **Permanently tolerant by design.** | Won't fix |
 
-Phase A.2 (#943 follow-up) addresses the first two. The third is documented and accepted.
+### Phase A.2 conversions (2026-05-13)
+
+| File | Before | After | Mechanism |
+|------|--------|-------|-----------|
+| `private-game/03-create-from-bgg-id-conflict-redirect.bru` | `[201, 409]` | **strict `409`** (with skip-on-missing-precondition for empty catalog) | API confirmed to throw `ConflictException` when BGG ID is already in SharedGameCatalog (`AddPrivateGameCommandHandler.cs`). Scenario 01 fetches a real catalog BGG ID. |
+| `private-game/06-tier-quota-402.bru` | `[201, 402]` | **strict `402`** | `TierLimits.FreeTier.MaxPrivateGames = 3`. After reset + scenario 04 (1 game), this scenario's `pre-request` seeds 2 more games via direct API calls; the main POST is therefore the 4th attempt and must `402`. |
 
 ## Soft-launch flag
 

--- a/tests/api-smoke/bruno-collection/private-game/03-create-from-bgg-id-conflict-redirect.bru
+++ b/tests/api-smoke/bruno-collection/private-game/03-create-from-bgg-id-conflict-redirect.bru
@@ -20,16 +20,27 @@ body:json {
 }
 
 tests {
-  test("returns 409 Conflict (BGG id already in catalog)", function() {
-    // Note: depending on auto-redirect policy this may also be 201 (creates anyway as private copy)
-    // Smoke proxy — full assertion in integration test.
-    expect([201, 409]).to.include(res.getStatus());
-  });
-  test("if 409, body has redirectTo or sharedGameId hint", function() {
-    if (res.getStatus() === 409) {
-      const body = res.getBody();
-      // Tolerant: spec says body.redirectTo, but actual may use different key
-      expect(JSON.stringify(body).toLowerCase()).to.match(/shared|redirect/);
+  // Phase A.2 conversion (#943): API confirmed to throw ConflictException → HTTP 409
+  // when a BGG ID matches a row in SharedGameCatalog (handler:
+  // AddPrivateGameCommandHandler.cs ~L62). Scenario 01 fetches a real catalog
+  // bggId, so this POST must conflict deterministically.
+  //
+  // Precondition guard: if the catalog returned no BGG-tagged shared games,
+  // `smokeSharedGameBggId` is undefined and the request body is malformed.
+  // Skip the assertion in that case rather than fail spuriously.
+  test("strict 409 when bggId is already in SharedGameCatalog", function() {
+    const seededBggId = bru.getVar("smokeSharedGameBggId");
+    if (!seededBggId) {
+      // No BGG-tagged shared game available in this run; precondition not met.
+      // Treated as a known-skip — does not fail the smoke run.
+      console.warn("[smoke 03] skipped: smokeSharedGameBggId not set (catalog has no BGG-tagged entries)");
+      return;
     }
+    expect(res.getStatus()).to.equal(409);
+  });
+  test("body references the conflicting shared catalog entry", function() {
+    if (res.getStatus() !== 409) return;
+    const body = res.getBody();
+    expect(JSON.stringify(body).toLowerCase()).to.match(/shared|catalog|already exists/);
   });
 }

--- a/tests/api-smoke/bruno-collection/private-game/06-tier-quota-402.bru
+++ b/tests/api-smoke/bruno-collection/private-game/06-tier-quota-402.bru
@@ -1,7 +1,50 @@
 meta {
-  name: SG1 — Tier quota: free-tier 3+ private games → 402
+  name: SG1 — Tier quota: free-tier 4th private game → 402
   type: http
   seq: 7
+}
+
+# Phase A.2 conversion (#943): TierLimits.FreeTier.MaxPrivateGames = 3.
+# Collection-level pre-request hook resets smoke-aaron to 0 games at start.
+# Scenario 04 creates the 1st game. This scenario's pre-request creates the
+# 2nd and 3rd, then the main POST is the 4th attempt — must be 402.
+#
+# Implicit dependency on the reset hook (collection.bru): if the reset is
+# skipped (e.g. unauthenticated) smoke-aaron may have leftover games and the
+# strict 402 will hold trivially (already over quota). Either way the
+# assertion direction is "must be 402".
+
+script:pre-request {
+  // Seed games #2 and #3 to bring smoke-aaron's free-tier quota to the limit.
+  // The reset hook already zeroed the state; scenario 04 (run earlier in this
+  // collection) added #1. We need 2 more so the next POST is the (N+1)th.
+  const apiBase = bru.getEnvVar("apiBase");
+  const authToken = bru.getEnvVar("authToken");
+  if (!authToken) {
+    console.warn("[smoke 06] no authToken — quota pre-seed skipped");
+    return;
+  }
+  for (const suffix of ["2", "3"]) {
+    try {
+      const r = await fetch(apiBase + "/api/v1/private-games", {
+        method: "POST",
+        headers: {
+          "Authorization": "Bearer " + authToken,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          source: "Manual",
+          title: "SG1 Quota Seed " + suffix + " " + Date.now(),
+          minPlayers: 2,
+          maxPlayers: 4,
+          description: "Pre-seed for quota test"
+        })
+      });
+      console.log("[smoke 06] seed " + suffix + " status=" + r.status);
+    } catch (err) {
+      console.warn("[smoke 06] seed " + suffix + " failed: " + err.message);
+    }
+  }
 }
 
 post {
@@ -15,27 +58,17 @@ body:json {
     "title": "SG1 Quota Test {{$randomInt}}",
     "minPlayers": 2,
     "maxPlayers": 4,
-    "description": "Should trigger TIER_QUOTA_EXCEEDED if user already has 3 priv games"
+    "description": "Should trigger TIER_QUOTA_EXCEEDED — 4th private game on free tier"
   }
 }
 
 tests {
-  // Tolerant by design — see tests/api-smoke/README.md "Tolerant assertions".
-  // The smoke collection creates 1-2 priv games before this scenario; the
-  // free-tier MaxPrivateGames limit (DB-seeded TierLimits) determines whether
-  // a 3rd-attempt is 201 (within quota) or 402 (over quota). Tightening this
-  // to strict 402 requires either (a) pre-seeding N priv games into smoke-aaron
-  // such that this attempt is the (N+1)th, or (b) modifying this scenario to
-  // call POST /private-games until 402 is observed. Both are deferred to
-  // Phase A.2 (#943).
-  test("returns 201 OR 402 depending on quota state", function() {
-    expect([201, 402]).to.include(res.getStatus());
+  test("strict 402 — quota exhausted on 4th create (free-tier limit = 3)", function() {
+    expect(res.getStatus()).to.equal(402);
   });
-  test("if 402, body has TIER_QUOTA_EXCEEDED error code", function() {
-    if (res.getStatus() === 402) {
-      const body = res.getBody();
-      const bodyStr = JSON.stringify(body || {});
-      expect(bodyStr).to.match(/TIER_QUOTA_EXCEEDED|quota/i);
-    }
+  test("body has TIER_QUOTA_EXCEEDED error code", function() {
+    const body = res.getBody();
+    const bodyStr = JSON.stringify(body || {});
+    expect(bodyStr).to.match(/TIER_QUOTA_EXCEEDED|quota/i);
   });
 }


### PR DESCRIPTION
## Summary

Phase A.2 of #943, follow-up to Phase A (PR #1137). Tightens the two `.bru` files left tolerant in Phase A. After this PR, **5 of 6** originally tolerant assertions are strict — only `07-bgg-search-throttle.bru` remains (permanently tolerant by design, BGG external API).

## Conversions

| File | Before | After | Mechanism |
|---|---|---|---|
| `03-create-from-bgg-id-conflict-redirect.bru` | `[201, 409]` | **strict `409`** + precondition guard | API confirmed to throw `ConflictException` when BGG ID is in SharedGameCatalog (`AddPrivateGameCommandHandler.cs`). Scenario 01 fetches a real catalog BGG ID. |
| `06-tier-quota-402.bru` | `[201, 402]` | **strict `402`** | `TierLimits.FreeTier.MaxPrivateGames = 3`. After reset + scenario 04 (1 game), this scenario's `script:pre-request` seeds 2 more games via direct API calls. The main POST is the 4th attempt and must `402`. |

## Precondition guard (scenario 03)

If `smokeSharedGameBggId` is unset (catalog has no BGG-tagged shared games), the test logs a console warning and returns early instead of failing spuriously. This preserves smoke determinism without making the test brittle to seed-data variations.

## Pre-request seeding (scenario 06)

Per Crispin's spec-panel critique on implicit reset-hook dependency: the seed pre-request comments document that the games created are intentionally not cleaned up — the next collection invocation's reset hook handles wipeout. Within one invocation, the seeded games + final 4th-attempt are the entire flow.

## What's NOT in this PR

- **`07-bgg-search-throttle.bru`** remains tolerant. BGG is an external API we can't make deterministic.
- **Phase B** (`continue-on-error: false` flip) stays deferred. Stable-streak measurement starts 2026-05-13; earliest flip date 2026-05-27.

## Verification

No code changes — Bruno-only. End-to-end validation comes from the next `main-staging → main` PR that triggers `api-smoke.yml`. The strict assertions will surface any drift between the implemented API and the matured spec.

## Test plan

- [x] Bruno files modified, README updated, no compiler changes needed
- [ ] CI: validate-source-branch + GitGuardian + Lychee green
- [ ] Post-merge: first `main-staging → main` PR runs smoke with strict 03 + 06; observe pass
- [ ] **14-day stable-streak gate** (Phase B): tracked in #943 comment thread

## Refs

- Refs #943 (Phase A.2 — Phase B continues deferred)
- PR #1137 (Phase A — endpoint + 3 conversions)
- Source PRs of original tolerant assertions: #928 (SG2), #937 (SG1)
- Parent EPIC (closed): #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)