### PR TITLE
fix(smoke): disable AuthLogin rate limit in CI to unblock nightly E2E (#1099)

### DIFF
--- a/.github/workflows/e2e-smoke-real-backend.yml
+++ b/.github/workflows/e2e-smoke-real-backend.yml
@@ -92,6 +92,14 @@ jobs:
 
       - name: Boot dev stack (postgres + redis + api)
         working-directory: infra
+        env:
+          # Issue #1099: disable rate limiting in the API container so the
+          # smoke suite — which logs in once per spec from the same runner
+          # IP — doesn't exhaust the AuthLogin policy (10 req/min/IP) and
+          # cause cascading 429s on /api/v1/auth/login. Passthrough wired
+          # in compose.dev.yml; local dev leaves this unset and keeps the
+          # rate limiter active.
+          DISABLE_RATE_LIMITING: "true"
         run: |
           make dev-core
           for i in {1..40}; do

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -65,6 +65,11 @@ services:
       RERANKER_URL: http://reranker-service:8003
       UNSTRUCTURED_API_URL: http://unstructured-service:8001
       SMOLDOCLING_API_URL: http://smoldocling-service:8002
+      # Issue #1099: passthrough for CI smoke tests to bypass AuthLogin
+      # rate limit (10 req/min/IP) which all smoke tests share a single IP.
+      # Empty in local dev → code treats it as disabled flag absent → rate
+      # limit stays enforced. CI workflow sets to "true" when running smoke.
+      DISABLE_RATE_LIMITING: ${DISABLE_RATE_LIMITING:-}
     volumes:
       - ./secrets:/app/infra/secrets:ro
 


### PR DESCRIPTION
## Summary

Nightly E2E smoke ([run 25782454108](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25782454108)) failed with 8 cascading `429 Too Many Requests` on `/api/v1/auth/login`. SEC-05 `AuthLogin` policy caps logins at **10/min/IP**; all ~20 smoke specs call `smokeLogin` once from the **same runner IP**, so the first ~12 burn the budget and the rest get rejected (Playwright retries amplify this).

## Fix

- **`infra/compose.dev.yml`**: add `DISABLE_RATE_LIMITING: \${DISABLE_RATE_LIMITING:-}` passthrough on the `api` service. Default = empty → rate limiter stays active in local dev.
- **`.github/workflows/e2e-smoke-real-backend.yml`**: set `DISABLE_RATE_LIMITING: \"true\"` on the *Boot dev stack* step → only the CI smoke job bypasses the limiter.

The code path is already supported by `RateLimitingServiceExtensions.cs:46` (added for Issue #3102 to keep integration tests green). No production code touched, no policy weakened.

## Scope discipline

- ❌ Did **not** raise `PermitLimit` on AuthLogin (would weaken SEC-05 in prod).
- ❌ Did **not** refactor smoke specs to share a session via `globalSetup` (correct long-term, but invasive — out of scope for a P0 unblock).

## Test plan

- [x] Local diff review — only env-var passthrough, no policy change
- [ ] Nightly smoke run on `main-dev` after merge → all 20 specs pass (auto-trigger or manual `workflow_dispatch`)
- [ ] Verify dev-local `make dev-core` still enforces rate limit (`DISABLE_RATE_LIMITING` unset in interactive shells)

Closes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)