### PR TITLE
fix(player-detail): restore data-slot="player-detail-view" wrapper (#1143)

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -58,28 +58,16 @@ import {
 } from '@/lib/player-detail/player-detail-visual-test-fixture';
 
 import { GamesTabPanel, type GamesTabPanelLabels } from './GamesTabPanel';
-import {
-  PlayerConnectionBar,
-  type PlayerConnectionBarLabels,
-} from './PlayerConnectionBar';
-import {
-  PlayerOverviewRegion,
-  type PlayerOverviewRegionLabels,
-} from './PlayerOverviewRegion';
+import { PlayerConnectionBar, type PlayerConnectionBarLabels } from './PlayerConnectionBar';
+import { PlayerOverviewRegion, type PlayerOverviewRegionLabels } from './PlayerOverviewRegion';
 import {
   PLAYER_TAB_KEYS,
   PlayerTabs,
   type PlayerTabKey,
   type PlayerTabsLabels,
 } from './PlayerTabs';
-import {
-  SessionsTabPanel,
-  type SessionsTabPanelLabels,
-} from './SessionsTabPanel';
-import {
-  ToolkitsTabPanel,
-  type ToolkitsTabPanelLabels,
-} from './ToolkitsTabPanel';
+import { SessionsTabPanel, type SessionsTabPanelLabels } from './SessionsTabPanel';
+import { ToolkitsTabPanel, type ToolkitsTabPanelLabels } from './ToolkitsTabPanel';
 
 // ─── State override hatch (dev / visual-test only) ─────────────────────────
 
@@ -100,9 +88,7 @@ const DEFAULT_TAB: PlayerTabKey = 'sessions';
 
 function parseTabFromUrl(raw: string | null): PlayerTabKey {
   if (raw == null) return DEFAULT_TAB;
-  return (PLAYER_TAB_KEYS as readonly string[]).includes(raw)
-    ? (raw as PlayerTabKey)
-    : DEFAULT_TAB;
+  return (PLAYER_TAB_KEYS as readonly string[]).includes(raw) ? (raw as PlayerTabKey) : DEFAULT_TAB;
 }
 
 // ─── Props ─────────────────────────────────────────────────────────────────
@@ -480,43 +466,45 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
   }
 
   return (
-    <DetailPageLayout
-      hero={
-        <>
-          <PlayerHero
-            displayName={safeProfile.displayName}
-            totalSessions={safeProfile.totalSessions}
-            totalWins={safeProfile.totalWins}
-            winRate={safeProfile.winRate}
-            onBack={() => router.push('/players')}
-            labels={heroLabels}
-          />
-          <PlayerOverviewRegion
+    <div data-slot="player-detail-view">
+      <DetailPageLayout
+        hero={
+          <>
+            <PlayerHero
+              displayName={safeProfile.displayName}
+              totalSessions={safeProfile.totalSessions}
+              totalWins={safeProfile.totalWins}
+              winRate={safeProfile.winRate}
+              onBack={() => router.push('/players')}
+              labels={heroLabels}
+            />
+            <PlayerOverviewRegion
+              stats={safeProfile}
+              labels={overviewLabels}
+              onFavoriteAgentClick={
+                safeProfile.favoriteAgentName != null ? () => router.push('/agents') : undefined
+              }
+            />
+          </>
+        }
+        connections={
+          <PlayerConnectionBar
             stats={safeProfile}
-            labels={overviewLabels}
-            onFavoriteAgentClick={
-              safeProfile.favoriteAgentName != null ? () => router.push('/agents') : undefined
-            }
+            gameCount={gameCount}
+            labels={connectionLabels}
           />
-        </>
-      }
-      connections={
-        <PlayerConnectionBar
-          stats={safeProfile}
-          gameCount={gameCount}
-          labels={connectionLabels}
-        />
-      }
-      tabs={
-        <PlayerTabs
-          activeTab={tab}
-          onChange={onTabChange}
-          counts={tabCounts}
-          labels={tabLabels}
-        />
-      }
-    >
-      {tabPanel}
-    </DetailPageLayout>
+        }
+        tabs={
+          <PlayerTabs
+            activeTab={tab}
+            onChange={onTabChange}
+            counts={tabCounts}
+            labels={tabLabels}
+          />
+        }
+      >
+        {tabPanel}
+      </DetailPageLayout>
+    </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/__tests__/PlayerDetailView.test.tsx
@@ -163,6 +163,11 @@ describe('PlayerDetailView', () => {
 
   it('Cell 5: renders default view when stats are loaded', () => {
     const { container } = renderView('sara-rossi');
+    // #1143: feature-specific wrapper that 4 E2E specs (smoke / a11y /
+    // v2-states / sp4-visual) use as the readiness anchor for the default
+    // branch. Guards against the regression that #1138 introduced when the
+    // DetailPageLayout primitive replaced the legacy wrapper.
+    expect(getBySlot(container, 'player-detail-view')).toBeDefined();
     expect(getBySlot(container, 'detail-page-layout')).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary

Stage 3 refactor #1138 (DetailPageLayout adoption) dropped the legacy `data-slot="player-detail-view"` anchor on the success path. The default branch now renders `<DetailPageLayout>` whose internal wrapper emits `data-slot="detail-page-layout"` instead — but **four E2E specs** still wait on the feature-specific hook:

- `apps/web/e2e/smoke-real-backend/player-detail.smoke.spec.ts` (failure source for #1099 / #1143)
- `apps/web/e2e/a11y/player-detail.spec.ts`
- `apps/web/e2e/v2-states/player-detail.spec.ts`
- `apps/web/e2e/visual-migrated/sp4-player-detail.spec.ts`

[Smoke run 25814518760](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25814518760) (post-#1142 rate-limit fix) timed out on `waitForSelector` for exactly this reason.

## Fix

Wrap the default return of `PlayerDetailView` in `<div data-slot=\"player-detail-view\">`. Loading / error / not-found shells already emit their own data-slots unchanged. The generic `detail-page-layout` slot remains nested inside for primitive-level consumers (unit test line 219 also keeps passing).

## Scope discipline

- ❌ Did **not** rewrite the four E2E specs to use the generic `detail-page-layout` slot — that would conflate feature-specific contract with a layout primitive used across many entity routes (game, agent, toolkit, …) and lose the regression-detection signal of \"this is the *player* default render\".
- ❌ Did **not** touch loading / error / not-found shells — their data-slots were never broken.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run PlayerDetailView.test.tsx` — 20/20 pass (incl. line 219 default-render assertion)
- [x] `pnpm lint` — 0 errors (warnings preexisting)
- [ ] Nightly E2E smoke run on `main-dev` after merge → all player-detail specs green
- [ ] Optional: run a11y + v2-states + sp4-visual specs locally to confirm DOM contract restored

Closes #1143
Refs #1138 #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)