### PR TITLE
feat(mockups): Pre-Stage-3 hub canonical mockups (sp4-hub-games/agents/toolkits) [refs #1148]

### DIFF
--- a/admin-mockups/design_files/sp4-hub-agents.html
+++ b/admin-mockups/design_files/sp4-hub-agents.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Pre-Stage-3 · Hub Agents (authenticated) — /hub/agents</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-hub-agents.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-hub-agents.jsx
+++ b/admin-mockups/design_files/sp4-hub-agents.jsx
@@ -1,0 +1,847 @@
+/* MeepleAI Pre-Stage-3 (#1148) — Hub Agents (authenticated)
+   Route: /hub/agents  (AUTHENTICATED — solo utenti loggati)
+   File: admin-mockups/design_files/sp4-hub-agents.{html,jsx}
+
+   Pattern: catalogo community di agenti AI per giochi.
+   Variante authenticated di hub: niente StickyAccessCta, install inline su hover.
+   Diffs vs sp4-hub-games:
+   - Entity color: --c-agent (yellow/gold) invece di --c-game
+   - Cards display: model + invocations + strategy invece di rating + publisher
+   - No StickyAccessCta (utente già loggato)
+   - Nav: shows authenticated app shell (DesktopNav stile sp4-games-index, non public landing)
+
+   Componenti v2 nuovi flaggati:
+   - HubAgentsHero         → apps/web/src/components/ui/v2/hub-agents-hero/
+   - HubFilters            → ✅ shared con hub-games/toolkits (entity-tinted)
+   - HubAgentCardGrid      → variante `grid` di MeepleCard per agent
+   - HubInstallButton      → inline install action su hover
+
+   USE CASE:
+     Primary actor: utente autenticato
+     Goal: trovare agenti AI community da installare per i giochi della propria libreria.
+     Success: 4 stati renderati (default popolato / filtered-empty / loading / error). Install inline su hover ogni card.
+     Non-goal: configurazione agente post-install (vedi /agents/[id]).
+*/
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.agent;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── DATASET COMMUNITY AGENTS ─────────────────────
+const HUB_AGENTS = [
+  ...DS.agents.map(a => ({
+    ...a,
+    installCount: 50 + Math.floor(Math.random() * 800),
+    featured: a.invocations >= 200,
+    isNew: a.id.includes('wing') || a.id.includes('brass'),
+    communityRating: 4.2 + Math.random() * 0.7,
+    author: 'p-marco',
+  })),
+  { id: 'a-azul-expert-v2', type: 'agent', title: 'Azul Expert v2', subtitle: 'RAG · DeepSeek · Pubblico',
+    cover: DS.grad(38, 80), coverEmoji: '🤖', badge: 'Featured',
+    strategy: 'hybrid-rag', model: 'DeepSeek Chat', gameId: 'g-azul',
+    docs: 4, invocations: 1240, avgLatency: '0.8s',
+    installCount: 723, featured: true, isNew: true, communityRating: 4.8, author: 'p-sara' },
+  { id: 'a-wingspan-pro', type: 'agent', title: 'Wingspan Pro Coach', subtitle: 'RAG · Claude Opus · Pubblico',
+    cover: DS.grad(85, 70), coverEmoji: '🤖', badge: 'Top',
+    strategy: 'rag-citations', model: 'Claude Opus', gameId: 'g-wingspan',
+    docs: 5, invocations: 894, avgLatency: '1.4s',
+    installCount: 412, featured: true, isNew: false, communityRating: 4.7, author: 'p-luca' },
+  { id: 'a-arknova-strat', type: 'agent', title: 'Ark Nova Strategist', subtitle: 'RAG · GPT-4o · Pubblico',
+    cover: DS.grad(130, 60), coverEmoji: '🤖', badge: 'Nuovo',
+    strategy: 'hybrid-rag', model: 'GPT-4o', gameId: 'g-arknova',
+    docs: 3, invocations: 187, avgLatency: '1.6s',
+    installCount: 156, featured: false, isNew: true, communityRating: 4.5, author: 'p-giulia' },
+  { id: 'a-scythe-guide', type: 'agent', title: 'Scythe Faction Guide', subtitle: 'RAG · Claude Haiku · Pubblico',
+    cover: DS.grad(45, 60), coverEmoji: '🤖', badge: 'Featured',
+    strategy: 'router', model: 'Claude Haiku', gameId: 'g-scythe',
+    docs: 6, invocations: 612, avgLatency: '0.9s',
+    installCount: 289, featured: true, isNew: false, communityRating: 4.6, author: 'p-andrea' },
+  { id: 'a-spirit-island-help', type: 'agent', title: 'Spirit Island Helper', subtitle: 'RAG · DeepSeek · Pubblico',
+    cover: DS.grad(210, 55), coverEmoji: '🤖', badge: 'Heavy',
+    strategy: 'hybrid-rag', model: 'DeepSeek Chat', gameId: 'g-spirit',
+    docs: 8, invocations: 423, avgLatency: '1.8s',
+    installCount: 198, featured: false, isNew: false, communityRating: 4.4, author: 'p-sara' },
+  { id: 'a-dune-imp', type: 'agent', title: 'Dune Imperium Adviser', subtitle: 'RAG · GPT-4o-mini · Pubblico',
+    cover: DS.grad(35, 75), coverEmoji: '🤖', badge: 'Top',
+    strategy: 'rag-citations', model: 'GPT-4o-mini', gameId: 'g-dune',
+    docs: 4, invocations: 756, avgLatency: '1.1s',
+    installCount: 367, featured: true, isNew: false, communityRating: 4.7, author: 'p-marco' },
+  { id: 'a-terraforming', type: 'agent', title: 'Terraforming Mars Pro', subtitle: 'RAG · Claude Sonnet · Pubblico',
+    cover: DS.grad(15, 70), coverEmoji: '🤖', badge: 'Heavy',
+    strategy: 'hybrid-rag', model: 'Claude Sonnet', gameId: 'g-terraforming',
+    docs: 12, invocations: 1456, avgLatency: '1.5s',
+    installCount: 845, featured: true, isNew: false, communityRating: 4.9, author: 'p-luca' },
+];
+
+// ═══════════════════════════════════════════════════════
+// ─── STARS (mini, value 0-5) ──────────────────────
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value);
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => <span key={i} aria-hidden="true">{i < full ? '★' : '☆'}</span>)}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB AGENT CARD ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const HubAgentCardGrid = ({ agent, compact }) => {
+  const gameRef = DS.byId[agent.gameId];
+  return (
+    <article tabIndex={0} className="mai-card-hub"
+      style={{
+        background:'var(--bg-card)',
+        border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)',
+        overflow:'hidden',
+        cursor:'pointer',
+        position:'relative',
+        transition:'transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm)',
+        display:'flex', flexDirection:'column',
+      }}>
+      {/* Cover */}
+      <div style={{
+        position:'relative',
+        aspectRatio: compact ? '4 / 3' : '5 / 3',
+        background: agent.cover,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        overflow:'hidden',
+      }}>
+        <span aria-hidden="true" style={{
+          fontSize: compact ? 50 : 60,
+          filter:'drop-shadow(0 4px 12px rgba(0,0,0,.35))',
+        }}>{agent.coverEmoji}</span>
+        {agent.badge && (
+          <span style={{
+            position:'absolute', top: 8, left: 8,
+            padding:'3px 8px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.5)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+            backdropFilter:'blur(4px)',
+          }}>{agent.badge}</span>
+        )}
+        <span style={{
+          position:'absolute', top: 8, right: 8,
+          padding:'3px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('agent', 0.95), color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          display:'inline-flex', alignItems:'center', gap: 3,
+        }}>
+          <span aria-hidden="true">🤖</span>Agent
+        </span>
+        <div style={{
+          position:'absolute', inset:'auto 0 0 0', height:'40%',
+          background:'linear-gradient(180deg, transparent 0%, rgba(0,0,0,.35) 100%)',
+        }}/>
+        <div style={{
+          position:'absolute', bottom: 8, right: 8,
+          display:'inline-flex', alignItems:'center', gap: 4,
+          padding:'3px 8px', borderRadius:'var(--r-pill)',
+          background:'rgba(255,255,255,.92)', color:'#1a1a1a',
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+        }}>
+          <span aria-hidden="true">⬇</span>
+          <span style={{ fontVariantNumeric:'tabular-nums' }}>{agent.installCount}</span>
+        </div>
+      </div>
+      {/* Body */}
+      <div style={{
+        padding: compact ? 10 : 14,
+        display:'flex', flexDirection:'column', gap: compact ? 6 : 8, flex: 1,
+      }}>
+        <div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 13 : 15, lineHeight: 1.15,
+            color:'var(--text)', margin:'0 0 3px',
+            display:'-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient:'vertical', overflow:'hidden',
+          }}>{agent.title}</h3>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 5,
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+            fontWeight: 600,
+          }}>
+            <Stars value={Math.round(agent.communityRating)} size={9}/>
+            <span style={{ fontVariantNumeric:'tabular-nums' }}>{agent.communityRating.toFixed(1)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{agent.invocations.toLocaleString('it-IT')} call</span>
+          </div>
+        </div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 3 }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-sec)',
+            fontWeight: 600,
+          }}>
+            <span style={{ color:'var(--text-muted)' }}>Model:</span> {agent.model}
+          </div>
+          {gameRef && (
+            <div style={{
+              display:'inline-flex', alignItems:'center', gap: 4,
+              fontFamily:'var(--f-mono)', fontSize: 10,
+              color: entityHsl('game'),
+              fontWeight: 700,
+            }}>
+              <span aria-hidden="true">🎲</span>
+              <span style={{ overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{gameRef.title}</span>
+            </div>
+          )}
+        </div>
+      </div>
+      {/* Install button overlay (hover-only on desktop, always on mobile) */}
+      <button type="button"
+        className="mai-card-install"
+        style={{
+          position:'absolute',
+          bottom: compact ? 10 : 14, left: compact ? 10 : 14, right: compact ? 10 : 14,
+          padding:'7px 12px', borderRadius:'var(--r-md)',
+          background: entityHsl('agent'), color:'#1a1a1a',
+          border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+          cursor:'pointer',
+          boxShadow:`0 4px 14px ${entityHsl('agent', 0.35)}`,
+          opacity: 0,
+          transform:'translateY(8px)',
+          transition:'opacity var(--dur-sm), transform var(--dur-sm)',
+        }}>+ Installa agente</button>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB AGENTS HERO ─────────────────────────────
+// ═══════════════════════════════════════════════════════
+const HubAgentsHero = ({ stats, compact }) => (
+  <header style={{
+    padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+    background:`linear-gradient(180deg, ${entityHsl('agent', 0.08)} 0%, transparent 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 10 }}>
+      <span style={{
+        display:'inline-flex', alignItems:'center', gap: 5,
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('agent', 0.14),
+        color: entityHsl('agent'),
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.08em',
+      }}><span aria-hidden="true">🤖</span>Hub · /hub/agents</span>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Catalogo agenti community</h1>
+    <p style={{
+      color:'var(--text-sec)', fontSize: compact ? 13 : 14, lineHeight: 1.55,
+      margin:'0 0 14px', maxWidth: 620,
+    }}>
+      Scopri agenti AI specializzati per i tuoi giochi. Ogni agente è pubblicato
+      dalla community con strategia, modello LLM e KB inclusi.
+    </p>
+    <div style={{
+      display:'flex', flexWrap:'wrap', gap: compact ? 14 : 22,
+      fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+    }}>
+      {stats.map(s => (
+        <div key={s.label} style={{ display:'flex', flexDirection:'column', gap: 2 }}>
+          <span style={{
+            color:'var(--text-muted)', fontSize: 9, fontWeight: 700,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>{s.label}</span>
+          <span style={{
+            color:'var(--text)', fontSize: compact ? 18 : 22, fontWeight: 800,
+            fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums',
+            lineHeight: 1,
+          }}>{s.value}<span style={{ fontSize: 11, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{s.unit}</span></span>
+        </div>
+      ))}
+    </div>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB FILTERS (shared) ────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATUS_OPTS = [
+  { id:'all', label:'Tutti' },
+  { id:'featured', label:'Featured' },
+  { id:'new', label:'Nuovi' },
+  { id:'top', label:'Top 100' },
+];
+const SORT_OPTS = [
+  { id:'popular', label:'Popolarità' },
+  { id:'rating', label:'Rating' },
+  { id:'title', label:'Titolo A-Z' },
+  { id:'invocations', label:'Invocations' },
+];
+
+const HubFilters = ({ q, setQ, status, setStatus, sort, setSort, compact, count, entity }) => (
+  <div style={{
+    padding: compact ? '12px 16px' : '14px 32px',
+    display:'flex', flexDirection: compact ? 'column' : 'row',
+    alignItems: compact ? 'stretch' : 'center',
+    gap: compact ? 10 : 12,
+    borderBottom:'1px solid var(--border-light)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 10,
+    backdropFilter:'blur(12px)',
+  }}>
+    <label style={{
+      display:'flex', alignItems:'center', gap: 8,
+      flex: compact ? 'none' : '1 1 280px', maxWidth: compact ? 'none' : 360,
+      padding:'8px 12px',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-md)',
+    }}>
+      <span aria-hidden="true" style={{ color:'var(--text-muted)' }}>🔍</span>
+      <input
+        type="text" value={q} onChange={e=>setQ(e.target.value)}
+        placeholder="Cerca per nome, gioco, modello…"
+        style={{
+          flex: 1, border:'none', outline:'none', background:'transparent',
+          color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          minWidth: 0,
+        }}
+      />
+      {q && (
+        <button type="button" onClick={()=>setQ('')} aria-label="Pulisci"
+          style={{ border:'none', background:'transparent', color:'var(--text-muted)', cursor:'pointer', fontSize: 13, padding: 0 }}>✕</button>
+      )}
+    </label>
+
+    <div role="tablist" style={{
+      display:'inline-flex',
+      background:'var(--bg-muted)',
+      borderRadius:'var(--r-md)',
+      padding: 2,
+      flexShrink: 0,
+    }}>
+      {STATUS_OPTS.map(o => (
+        <button key={o.id} role="tab" aria-selected={status === o.id}
+          onClick={()=>setStatus(o.id)}
+          style={{
+            padding: compact ? '6px 9px' : '6px 12px',
+            border:'none',
+            background: status === o.id ? 'var(--bg-card)' : 'transparent',
+            color: status === o.id ? entityHsl(entity) : 'var(--text-sec)',
+            fontFamily:'var(--f-display)',
+            fontSize: compact ? 11 : 12, fontWeight: 700,
+            borderRadius: 'var(--r-sm)',
+            cursor:'pointer', whiteSpace:'nowrap',
+            boxShadow: status === o.id ? 'var(--shadow-xs)' : 'none',
+            transition:'all var(--dur-sm) var(--ease-out)',
+          }}>{o.label}</button>
+      ))}
+    </div>
+
+    <div style={{ flex: 1 }}/>
+
+    <label style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 600,
+    }}>
+      <span style={{ textTransform:'uppercase', letterSpacing:'.06em' }}>Ordina</span>
+      <select value={sort} onChange={e=>setSort(e.target.value)}
+        style={{
+          padding:'6px 10px', borderRadius:'var(--r-sm)',
+          border:'1px solid var(--border)', background:'var(--bg-card)',
+          color:'var(--text)', fontFamily:'var(--f-display)',
+          fontSize: 12, fontWeight: 700, cursor:'pointer',
+        }}>
+        {SORT_OPTS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+      </select>
+    </label>
+
+    {compact && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{count} agenti</div>
+    )}
+  </div>
+);
+
+// ─── EMPTY / ERROR / SKELETON ─────────────────
+const HubEmptyFiltered = ({ onAction, compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+    padding: compact ? '40px 20px' : '64px 32px',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+  }}>
+    <div style={{
+      width: compact ? 64 : 80, height: compact ? 64 : 80,
+      borderRadius:'50%',
+      background: entityHsl('agent', 0.12), color: entityHsl('agent'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: compact ? 32 : 40, marginBottom: 16,
+    }} aria-hidden="true">🔎</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: compact ? 16 : 19, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Nessun agente trovato</h3>
+    <p style={{
+      fontSize: 13, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 18px', lineHeight: 1.55,
+    }}>Nessun agente corrisponde ai filtri attuali. Prova a modificare la ricerca.</p>
+    <button type="button" onClick={onAction}
+      style={{
+        padding:'10px 18px', borderRadius:'var(--r-md)',
+        background: entityHsl('agent'), color:'#1a1a1a',
+        border:'none', fontFamily:'var(--f-display)',
+        fontSize: 13, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 4px 14px ${entityHsl('agent', 0.35)}`,
+      }}>Azzera filtri</button>
+  </div>
+);
+
+const ErrorState = ({ compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    padding: compact ? '32px 20px' : '48px 32px',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Impossibile caricare il catalogo</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px',
+    }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
+    <button type="button" style={{
+      padding:'8px 16px', borderRadius:'var(--r-md)',
+      background:'hsl(var(--c-danger))', color:'#fff',
+      border:'none', fontFamily:'var(--f-display)',
+      fontSize: 12, fontWeight: 800, cursor:'pointer',
+    }}>↻ Riprova</button>
+  </div>
+);
+
+const SkeletonCard = ({ compact }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    overflow:'hidden',
+  }}>
+    <div className="mai-shimmer" style={{
+      aspectRatio: compact ? '4 / 3' : '5 / 3',
+      background:'var(--bg-muted)',
+    }}/>
+    <div style={{ padding: compact ? 10 : 14, display:'flex', flexDirection:'column', gap: 6 }}>
+      <div className="mai-shimmer" style={{ height: 14, width:'72%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'52%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const filterAndSort = (list, q, status, sort) => {
+  let out = list;
+  if (q) {
+    const needle = q.toLowerCase();
+    out = out.filter(a =>
+      a.title.toLowerCase().includes(needle) ||
+      (a.model || '').toLowerCase().includes(needle) ||
+      ((DS.byId[a.gameId] || {}).title || '').toLowerCase().includes(needle)
+    );
+  }
+  if (status !== 'all') {
+    if (status === 'featured') out = out.filter(a => a.featured);
+    else if (status === 'new') out = out.filter(a => a.isNew);
+    else if (status === 'top') out = out.filter(a => a.communityRating >= 4.5);
+  }
+  out = [...out].sort((a, b) => {
+    if (sort === 'rating') return b.communityRating - a.communityRating;
+    if (sort === 'title') return a.title.localeCompare(b.title);
+    if (sort === 'invocations') return b.invocations - a.invocations;
+    return b.installCount - a.installCount;
+  });
+  return out;
+};
+
+const HubAgentsBody = ({ stateOverride, compact }) => {
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('all');
+  const [sort, setSort] = useState('popular');
+
+  useEffect(() => {
+    if (stateOverride === 'filtered-empty') setQ('xyznotfound');
+    else { setQ(''); setStatus('all'); }
+  }, [stateOverride]);
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+
+  const filtered = useMemo(() => filterAndSort(HUB_AGENTS, q, status, sort),
+    [q, status, sort]);
+
+  const stats = [
+    { label:'Agenti', value: HUB_AGENTS.length, unit:'' },
+    { label:'Installazioni', value: HUB_AGENTS.reduce((s, a) => s + a.installCount, 0).toLocaleString('it-IT'), unit:'' },
+    { label:'Featured', value: HUB_AGENTS.filter(a => a.featured).length, unit:'' },
+    { label:'Modelli LLM', value: new Set(HUB_AGENTS.map(a => a.model)).size, unit:'' },
+  ];
+
+  return (
+    <>
+      <HubAgentsHero stats={stats} compact={compact}/>
+      {!isError && (
+        <HubFilters
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          sort={sort} setSort={setSort}
+          compact={compact} count={filtered.length} entity="agent"
+        />
+      )}
+
+      <div style={{ padding: compact ? '14px 16px 24px' : '24px 32px 64px' }}>
+        {isError && <ErrorState compact={compact}/>}
+
+        {!isError && isLoading && (
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+            gap: compact ? 10 : 16,
+          }}>
+            {Array.from({ length: compact ? 6 : 12 }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact}/>
+            ))}
+          </div>
+        )}
+
+        {!isError && !isLoading && (
+          filtered.length === 0 ? (
+            <HubEmptyFiltered compact={compact}
+              onAction={() => { setQ(''); setStatus('all'); }}/>
+          ) : (
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+              gap: compact ? 10 : 16,
+            }}>
+              {filtered.map(a => <HubAgentCardGrid key={a.id} agent={a} compact={compact}/>)}
+            </div>
+          )
+        )}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopAuthNav = () => {
+  const items = [
+    { id:'home', label:'Home' },
+    { id:'library', label:'Libreria' },
+    { id:'hub', label:'Hub', active: true },
+    { id:'sessions', label:'Sessioni' },
+    { id:'toolkit', label:'Toolkit' },
+  ];
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 14,
+      padding:'10px 32px',
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <div style={{
+          width: 26, height: 26, borderRadius: 7,
+          background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+          color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+          fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+        }}>M</div>
+        <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
+        {items.map(it => (
+          <a key={it.id} href="#" onClick={e=>e.preventDefault()}
+            aria-current={it.active ? 'page' : undefined}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              color: it.active ? entityHsl('agent') : 'var(--text-sec)',
+              background: it.active ? entityHsl('agent', 0.1) : 'transparent',
+              textDecoration:'none',
+            }}>{it.label}</a>
+        ))}
+      </div>
+      <div style={{ flex: 1 }}/>
+      <button type="button" style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('agent'), color:'#1a1a1a',
+        border:'none', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        cursor:'pointer', boxShadow:`0 3px 10px ${entityHsl('agent', 0.35)}`,
+      }}>+ Crea agente</button>
+    </div>
+  );
+};
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopAuthNav/>
+    <HubAgentsBody stateOverride={stateOverride}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>
+      Hub · Agenti
+    </div>
+    <button aria-label="Aggiungi" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background: entityHsl('agent'), border:'none',
+      color:'#1a1a1a', fontSize: 16, cursor:'pointer', fontWeight: 800,
+    }}>＋</button>
+  </div>
+);
+const MobileBottomBar = () => {
+  const tabs = [
+    { id:'home', icon:'⌂', label:'Home' },
+    { id:'library', icon:'📚', label:'Libreria' },
+    { id:'hub', icon:'🌐', label:'Hub', active: true },
+    { id:'chat', icon:'💬', label:'Chat' },
+    { id:'profile', icon:'👤', label:'Profilo' },
+  ];
+  return (
+    <div style={{
+      position:'absolute', bottom: 0, left: 0, right: 0,
+      display:'flex',
+      padding:'8px 10px 12px',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderTop:'1px solid var(--border)',
+      zIndex: 5,
+    }}>
+      {tabs.map(t => (
+        <button key={t.id} style={{
+          flex: 1,
+          display:'flex', flexDirection:'column', alignItems:'center', gap: 2,
+          padding:'4px 0',
+          background:'transparent', border:'none',
+          color: t.active ? entityHsl('agent') : 'var(--text-muted)',
+          fontFamily:'var(--f-display)', fontSize: 9, fontWeight: 700,
+          cursor:'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+          <span>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <div style={{ paddingBottom: 70 }}>
+        <HubAgentsBody stateOverride={stateOverride} compact/>
+      </div>
+      <MobileBottomBar/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/hub/agents</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'default', label:'01 · Default', desc:'~13 agenti, grid 2-col, install count overlay + button hover-revealed.' },
+  { id:'loading', label:'02 · Loading', desc:'6 skeleton cards shimmer.' },
+  { id:'filtered-empty', label:'03 · Filtered empty', desc:'Query "xyznotfound" → empty filtrato + "Azzera filtri".' },
+  { id:'error', label:'04 · Error', desc:'Banner danger + retry.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>Pre-Stage-3 · #1148 · Hub Agents (authenticated)</div>
+        <h1>Hub Agents — /hub/agents</h1>
+        <p className="lead">
+          Catalogo agenti community per utenti loggati. Stessa shell di hub-games
+          ma entity color <strong>--c-agent</strong> e card variant con model+invocations.
+          Install button inline (hover-revealed). Niente StickyAccessCta.
+          4 stati mobile, 3 desktop.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 4 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1280 — 3 stati</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="05 · Desktop · Default"
+            desc="Hero stats inline (agenti, installazioni, featured, modelli LLM), filtri sticky, grid 4-col. Hover su card rivela install button.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="06 · Desktop · Loading"
+            desc="12 skeleton cards (4-col × 3 row) con shimmer.">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Filtered empty"
+            desc="Query 'xyznotfound' → empty filtrato (icona 🔎) con CTA 'Azzera filtri' entity-tinted.">
+            <DesktopScreen stateOverride="filtered-empty"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-card-hub { outline: none; }
+        .mai-card-hub:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-agent) / .4) !important;
+          box-shadow: var(--shadow-md);
+        }
+        .mai-card-hub:hover .mai-card-install,
+        .mai-card-hub:focus-within .mai-card-install {
+          opacity: 1 !important;
+          transform: translateY(0) !important;
+        }
+        .mai-card-hub:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+        select:focus-visible, input:focus-visible, button:focus-visible, a:focus-visible {
+          outline: 2px solid hsl(var(--c-agent));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-hub-games.html
+++ b/admin-mockups/design_files/sp4-hub-games.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Pre-Stage-3 · Hub Games (public) — /hub/games</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-hub-games.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-hub-games.jsx
+++ b/admin-mockups/design_files/sp4-hub-games.jsx
@@ -1,0 +1,875 @@
+/* MeepleAI Pre-Stage-3 (#1148) — Hub Games (public)
+   Route: /hub/games  (PUBLIC — accessibile senza login)
+   File: admin-mockups/design_files/sp4-hub-games.{html,jsx}
+
+   Pattern: catalogo community read-only con StickyCTA "Accedi per installare".
+   Variante public di `sp4-games-index` — niente azioni di libreria, solo browse.
+   Diffs vs sp4-games-index:
+   - Hero: "Esplora i giochi della community" + badge `/hub/games`
+   - Cards: badge `+ N installazioni` invece di status libreria; ConnectionChip ridotta
+   - Filtri: Tutti / Featured / Nuovi / Top — niente Wishlist
+   - StickyCTA bottom: "Accedi per installare nella tua libreria"
+   - Empty filtered: stesso pattern; Empty primario non applica (catalog è popolato)
+
+   Componenti v2 nuovi flaggati:
+   - HubGamesHero          → apps/web/src/components/ui/v2/hub-games-hero/
+   - HubFilters            → apps/web/src/components/ui/v2/hub-filters/ (shared con hub-agents/toolkits)
+   - HubGameCardGrid       → variante `grid-public` di MeepleCard
+   - StickyAccessCta       → apps/web/src/components/ui/v2/sticky-access-cta/ (only hub-games)
+   - HubEmptyFiltered      → apps/web/src/components/ui/v2/hub-empty/
+
+   USE CASE:
+     Primary actor: visitatore (non autenticato)
+     Goal: esplorare il catalogo community di giochi per scoprire titoli da installare nella propria libreria.
+     Success: 4 stati renderati (default popolato / filtered-empty / loading / error) + StickyCTA sempre visibile sotto.
+     Non-goal: install action (richiede login → routes /login?redirect=/hub/games).
+*/
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+// ─── ENTITY HSL HELPER ─────────────────
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.game;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── DATASET COMMUNITY GAMES ─────────────────────
+// Catalogo community — augmentazione di DS.games con metriche di popolarità + nuovi entry.
+const HUB_GAMES = [
+  ...DS.games.map(g => ({
+    ...g,
+    installCount: 200 + Math.floor(Math.random() * 1500),
+    featured: g.rating >= 8.4,
+    isNew: g.year >= 2020,
+    communityRating: g.rating,
+  })),
+  { id: 'g-marrakesh', type: 'game', title: 'Marrakesh', publisher: 'Queen Games', year: 2022,
+    author: 'Stefan Feld', players: '2–4', duration: '60m', weight: 3.05, rating: 7.6, stars: 4,
+    cover: DS.grad(30, 75), coverEmoji: '🕌', badge: 'Featured',
+    installCount: 1840, featured: true, isNew: true, communityRating: 7.6 },
+  { id: 'g-skymines', type: 'game', title: 'Skymines', publisher: 'eggertspiele', year: 2022,
+    author: 'Alexander Pfister', players: '1–4', duration: '120m', weight: 3.61, rating: 8.0, stars: 4,
+    cover: DS.grad(220, 60), coverEmoji: '🚀', badge: 'Top 100',
+    installCount: 2340, featured: true, isNew: true, communityRating: 8.0 },
+  { id: 'g-orient', type: 'game', title: 'Orient Express', publisher: 'Hachette', year: 2023,
+    author: 'Antoine Bauza', players: '2–6', duration: '45m', weight: 2.18, rating: 7.3, stars: 4,
+    cover: DS.grad(0, 70), coverEmoji: '🚂', badge: 'Nuovo',
+    installCount: 412, featured: false, isNew: true, communityRating: 7.3 },
+  { id: 'g-revive', type: 'game', title: 'Revive', publisher: 'Aporta', year: 2022,
+    author: 'Anna Wermlund', players: '1–4', duration: '90m', weight: 3.20, rating: 8.1, stars: 5,
+    cover: DS.grad(140, 55), coverEmoji: '🌱', badge: 'Featured',
+    installCount: 1620, featured: true, isNew: true, communityRating: 8.1 },
+  { id: 'g-frostpunk', type: 'game', title: 'Frostpunk: The Board Game', publisher: 'Glass Cannon', year: 2022,
+    author: 'A. Sieja · J. Wnorowski', players: '1–4', duration: '120–150m', weight: 3.85, rating: 7.9, stars: 4,
+    cover: DS.grad(195, 50), coverEmoji: '❄️', badge: 'Heavy',
+    installCount: 980, featured: false, isNew: true, communityRating: 7.9 },
+  { id: 'g-akropolis', type: 'game', title: 'Akropolis', publisher: 'Gigamic', year: 2022,
+    author: 'Jules Messaud', players: '2–4', duration: '20–30m', weight: 1.65, rating: 7.7, stars: 4,
+    cover: DS.grad(45, 60), coverEmoji: '🏛️', badge: 'Light',
+    installCount: 2890, featured: true, isNew: true, communityRating: 7.7 },
+  { id: 'g-dorfromantik', type: 'game', title: 'Dorfromantik', publisher: 'Pegasus', year: 2022,
+    author: 'M. Palm · L. Zach', players: '1–6', duration: '45m', weight: 2.10, rating: 7.6, stars: 4,
+    cover: DS.grad(110, 55), coverEmoji: '🏞️', badge: 'Cooperativo',
+    installCount: 1740, featured: false, isNew: true, communityRating: 7.6 },
+];
+
+// ═══════════════════════════════════════════════════════
+// ─── STARS ──────────────────────────────────────────
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value / 2); // rating /10 → /5
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => <span key={i} aria-hidden="true">{i < full ? '★' : '☆'}</span>)}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB GAME CARD (public catalog variant) ────────
+// ═══════════════════════════════════════════════════════
+const HubGameCardGrid = ({ game, compact }) => (
+  <article tabIndex={0} className="mai-card-hub"
+    style={{
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-lg)',
+      overflow:'hidden',
+      cursor:'pointer',
+      transition:'transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm)',
+      display:'flex', flexDirection:'column',
+    }}>
+    {/* Cover */}
+    <div style={{
+      position:'relative',
+      aspectRatio: compact ? '4 / 3' : '5 / 3',
+      background: game.cover,
+      display:'flex', alignItems:'center', justifyContent:'center',
+      overflow:'hidden',
+    }}>
+      <span aria-hidden="true" style={{
+        fontSize: compact ? 50 : 60,
+        filter:'drop-shadow(0 4px 12px rgba(0,0,0,.35))',
+      }}>{game.coverEmoji}</span>
+      {/* badge top-left */}
+      {game.badge && (
+        <span style={{
+          position:'absolute', top: 8, left: 8,
+          padding:'3px 8px', borderRadius:'var(--r-pill)',
+          background:'rgba(0,0,0,.5)', color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          backdropFilter:'blur(4px)',
+        }}>{game.badge}</span>
+      )}
+      {/* entity chip top-right */}
+      <span style={{
+        position:'absolute', top: 8, right: 8,
+        padding:'3px 7px', borderRadius:'var(--r-pill)',
+        background: entityHsl('game', 0.95), color:'#fff',
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.06em',
+        display:'inline-flex', alignItems:'center', gap: 3,
+      }}>
+        <span aria-hidden="true">🎲</span>Game
+      </span>
+      {/* gradient overlay */}
+      <div style={{
+        position:'absolute', inset:'auto 0 0 0', height:'40%',
+        background:'linear-gradient(180deg, transparent 0%, rgba(0,0,0,.35) 100%)',
+      }}/>
+      {/* install count bottom-right */}
+      <div style={{
+        position:'absolute', bottom: 8, right: 8,
+        display:'inline-flex', alignItems:'center', gap: 4,
+        padding:'3px 8px', borderRadius:'var(--r-pill)',
+        background:'rgba(255,255,255,.92)', color:'#1a1a1a',
+        fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+      }}>
+        <span aria-hidden="true">⬇</span>
+        <span style={{ fontVariantNumeric:'tabular-nums' }}>{game.installCount.toLocaleString('it-IT')}</span>
+      </div>
+    </div>
+    {/* Body */}
+    <div style={{
+      padding: compact ? 10 : 14,
+      display:'flex', flexDirection:'column', gap: compact ? 6 : 8, flex: 1,
+    }}>
+      <div>
+        <h3 style={{
+          fontFamily:'var(--f-display)', fontWeight: 800,
+          fontSize: compact ? 13 : 15, lineHeight: 1.15,
+          color:'var(--text)', margin:'0 0 3px',
+          display:'-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient:'vertical', overflow:'hidden',
+        }}>{game.title}</h3>
+        <div style={{
+          display:'flex', alignItems:'center', gap: 5,
+          fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+          fontWeight: 600,
+        }}>
+          <Stars value={game.rating} size={9}/>
+          <span style={{ fontVariantNumeric:'tabular-nums' }}>{game.rating}</span>
+          <span aria-hidden="true">·</span>
+          <span>{game.players}</span>
+          <span aria-hidden="true">·</span>
+          <span>{game.year}</span>
+        </div>
+      </div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-sec)',
+        fontWeight: 600,
+      }}>{game.publisher}</div>
+    </div>
+  </article>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB GAMES HERO (public) ─────────────────────
+// ═══════════════════════════════════════════════════════
+const HubGamesHero = ({ stats, compact }) => (
+  <header style={{
+    padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+    background:`linear-gradient(180deg, ${entityHsl('game', 0.08)} 0%, transparent 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 10 }}>
+      <span style={{
+        display:'inline-flex', alignItems:'center', gap: 5,
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('game', 0.14),
+        color: entityHsl('game'),
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.08em',
+      }}><span aria-hidden="true">🎲</span>Hub · /hub/games</span>
+      <span style={{
+        padding:'3px 8px', borderRadius:'var(--r-pill)',
+        background:'var(--bg-muted)', color:'var(--text-muted)',
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.06em',
+      }}>Pubblico</span>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Esplora i giochi della community</h1>
+    <p style={{
+      color:'var(--text-sec)', fontSize: compact ? 13 : 14, lineHeight: 1.55,
+      margin:'0 0 14px', maxWidth: 620,
+    }}>
+      Sfoglia il catalogo dei giochi indicizzati dalla community.
+      Filtra per popolarità, rating e novità. Accedi per installarli nella tua libreria.
+    </p>
+    <div style={{
+      display:'flex', flexWrap:'wrap', gap: compact ? 14 : 22,
+      fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+    }}>
+      {stats.map(s => (
+        <div key={s.label} style={{ display:'flex', flexDirection:'column', gap: 2 }}>
+          <span style={{
+            color:'var(--text-muted)', fontSize: 9, fontWeight: 700,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>{s.label}</span>
+          <span style={{
+            color:'var(--text)', fontSize: compact ? 18 : 22, fontWeight: 800,
+            fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums',
+            lineHeight: 1,
+          }}>{s.value}<span style={{ fontSize: 11, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{s.unit}</span></span>
+        </div>
+      ))}
+    </div>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB FILTERS (shared shell, entity-tinted) ────
+// ═══════════════════════════════════════════════════════
+const STATUS_OPTS = [
+  { id:'all', label:'Tutti' },
+  { id:'featured', label:'Featured' },
+  { id:'new', label:'Nuovi' },
+  { id:'top', label:'Top 100' },
+];
+const SORT_OPTS = [
+  { id:'popular', label:'Popolarità' },
+  { id:'rating', label:'Rating' },
+  { id:'title', label:'Titolo A-Z' },
+  { id:'year', label:'Anno' },
+];
+
+const HubFilters = ({ q, setQ, status, setStatus, sort, setSort, compact, count, entity }) => (
+  <div style={{
+    padding: compact ? '12px 16px' : '14px 32px',
+    display:'flex', flexDirection: compact ? 'column' : 'row',
+    alignItems: compact ? 'stretch' : 'center',
+    gap: compact ? 10 : 12,
+    borderBottom:'1px solid var(--border-light)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 10,
+    backdropFilter:'blur(12px)',
+  }}>
+    <label style={{
+      display:'flex', alignItems:'center', gap: 8,
+      flex: compact ? 'none' : '1 1 280px', maxWidth: compact ? 'none' : 360,
+      padding:'8px 12px',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-md)',
+    }}>
+      <span aria-hidden="true" style={{ color:'var(--text-muted)' }}>🔍</span>
+      <input
+        type="text" value={q} onChange={e=>setQ(e.target.value)}
+        placeholder="Cerca per titolo, autore, publisher…"
+        style={{
+          flex: 1, border:'none', outline:'none', background:'transparent',
+          color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          minWidth: 0,
+        }}
+      />
+      {q && (
+        <button type="button" onClick={()=>setQ('')} aria-label="Pulisci"
+          style={{
+            border:'none', background:'transparent', color:'var(--text-muted)',
+            cursor:'pointer', fontSize: 13, padding: 0,
+          }}>✕</button>
+      )}
+    </label>
+
+    <div role="tablist" style={{
+      display:'inline-flex',
+      background:'var(--bg-muted)',
+      borderRadius:'var(--r-md)',
+      padding: 2,
+      flexShrink: 0,
+    }}>
+      {STATUS_OPTS.map(o => (
+        <button key={o.id} role="tab" aria-selected={status === o.id}
+          onClick={()=>setStatus(o.id)}
+          style={{
+            padding: compact ? '6px 9px' : '6px 12px',
+            border:'none',
+            background: status === o.id ? 'var(--bg-card)' : 'transparent',
+            color: status === o.id ? entityHsl(entity) : 'var(--text-sec)',
+            fontFamily:'var(--f-display)',
+            fontSize: compact ? 11 : 12, fontWeight: 700,
+            borderRadius: 'var(--r-sm)',
+            cursor:'pointer', whiteSpace:'nowrap',
+            boxShadow: status === o.id ? 'var(--shadow-xs)' : 'none',
+            transition:'all var(--dur-sm) var(--ease-out)',
+          }}>{o.label}</button>
+      ))}
+    </div>
+
+    <div style={{ flex: 1 }}/>
+
+    <label style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 600,
+    }}>
+      <span style={{ textTransform:'uppercase', letterSpacing:'.06em' }}>Ordina</span>
+      <select value={sort} onChange={e=>setSort(e.target.value)}
+        style={{
+          padding:'6px 10px', borderRadius:'var(--r-sm)',
+          border:'1px solid var(--border)', background:'var(--bg-card)',
+          color:'var(--text)', fontFamily:'var(--f-display)',
+          fontSize: 12, fontWeight: 700, cursor:'pointer',
+        }}>
+        {SORT_OPTS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+      </select>
+    </label>
+
+    {compact && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{count} giochi</div>
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STICKY ACCESS CTA (only hub-games) ──────────
+// ═══════════════════════════════════════════════════════
+const StickyAccessCta = ({ compact }) => (
+  <div style={{
+    position: compact ? 'sticky' : 'fixed',
+    bottom: compact ? 70 : 24, // above mobile bottom-bar
+    left: compact ? 12 : 'auto',
+    right: compact ? 12 : 24,
+    width: compact ? 'auto' : 360,
+    zIndex: 30,
+    padding:'12px 16px',
+    background:'var(--glass-bg)',
+    backdropFilter:'blur(16px)',
+    border:`1px solid ${entityHsl('game', 0.35)}`,
+    borderRadius:'var(--r-xl)',
+    boxShadow:`0 12px 36px ${entityHsl('game', 0.18)}`,
+    display:'flex', alignItems:'center', gap: 12,
+  }}>
+    <div style={{
+      width: 36, height: 36, borderRadius:'50%',
+      background: entityHsl('game', 0.14),
+      color: entityHsl('game'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 18, flexShrink: 0,
+    }} aria-hidden="true">🔐</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{
+        fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 13,
+        color:'var(--text)', marginBottom: 2,
+      }}>Installa nella tua libreria</div>
+      <div style={{
+        fontSize: 11, color:'var(--text-muted)', lineHeight: 1.4,
+      }}>Accedi per salvare giochi, agenti e toolkit</div>
+    </div>
+    <a href="/login?redirect=/hub/games"
+      style={{
+        padding:'8px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('game'), color:'#fff',
+        textDecoration:'none',
+        fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+        whiteSpace:'nowrap',
+        boxShadow:`0 4px 14px ${entityHsl('game', 0.35)}`,
+      }}>Accedi →</a>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── EMPTY / ERROR / SKELETON ─────────────────
+const HubEmptyFiltered = ({ onAction, compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+    padding: compact ? '40px 20px' : '64px 32px',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+  }}>
+    <div style={{
+      width: compact ? 64 : 80, height: compact ? 64 : 80,
+      borderRadius:'50%',
+      background: entityHsl('game', 0.12), color: entityHsl('game'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: compact ? 32 : 40, marginBottom: 16,
+    }} aria-hidden="true">🔎</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: compact ? 16 : 19, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Nessun risultato</h3>
+    <p style={{
+      fontSize: 13, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 18px', lineHeight: 1.55,
+    }}>Nessun gioco corrisponde ai filtri attuali. Prova a modificare la ricerca.</p>
+    <button type="button" onClick={onAction}
+      style={{
+        padding:'10px 18px', borderRadius:'var(--r-md)',
+        background: entityHsl('game'), color:'#fff',
+        border:'none', fontFamily:'var(--f-display)',
+        fontSize: 13, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 4px 14px ${entityHsl('game', 0.35)}`,
+      }}>Azzera filtri</button>
+  </div>
+);
+
+const ErrorState = ({ compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    padding: compact ? '32px 20px' : '48px 32px',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Impossibile caricare il catalogo</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px',
+    }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
+    <button type="button"
+      style={{
+        padding:'8px 16px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-danger))', color:'#fff',
+        border:'none', fontFamily:'var(--f-display)',
+        fontSize: 12, fontWeight: 800, cursor:'pointer',
+      }}>↻ Riprova</button>
+  </div>
+);
+
+const SkeletonCard = ({ compact }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    overflow:'hidden',
+  }}>
+    <div className="mai-shimmer" style={{
+      aspectRatio: compact ? '4 / 3' : '5 / 3',
+      background:'var(--bg-muted)',
+    }}/>
+    <div style={{ padding: compact ? 10 : 14, display:'flex', flexDirection:'column', gap: 6 }}>
+      <div className="mai-shimmer" style={{ height: 14, width:'72%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'52%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const filterAndSort = (list, q, status, sort) => {
+  let out = list;
+  if (q) {
+    const needle = q.toLowerCase();
+    out = out.filter(g =>
+      g.title.toLowerCase().includes(needle) ||
+      (g.author || '').toLowerCase().includes(needle) ||
+      (g.publisher || '').toLowerCase().includes(needle) ||
+      String(g.year).includes(needle)
+    );
+  }
+  if (status !== 'all') {
+    if (status === 'featured') out = out.filter(g => g.featured);
+    else if (status === 'new') out = out.filter(g => g.isNew);
+    else if (status === 'top') out = out.filter(g => g.rating >= 8.0);
+  }
+  out = [...out].sort((a, b) => {
+    if (sort === 'rating') return b.rating - a.rating;
+    if (sort === 'title') return a.title.localeCompare(b.title);
+    if (sort === 'year') return b.year - a.year;
+    return b.installCount - a.installCount; // popular
+  });
+  return out;
+};
+
+const HubGamesBody = ({ stateOverride, compact }) => {
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('all');
+  const [sort, setSort] = useState('popular');
+
+  useEffect(() => {
+    if (stateOverride === 'filtered-empty') setQ('xyznotfound');
+    else { setQ(''); setStatus('all'); }
+  }, [stateOverride]);
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+
+  const filtered = useMemo(() => filterAndSort(HUB_GAMES, q, status, sort),
+    [q, status, sort]);
+
+  const totalInstalls = HUB_GAMES.reduce((s, g) => s + g.installCount, 0);
+  const stats = [
+    { label:'Giochi', value: HUB_GAMES.length, unit:'' },
+    { label:'Installazioni', value: totalInstalls.toLocaleString('it-IT'), unit:'' },
+    { label:'Featured', value: HUB_GAMES.filter(g => g.featured).length, unit:'' },
+    { label:'Nuovi 2022+', value: HUB_GAMES.filter(g => g.isNew).length, unit:'' },
+  ];
+
+  return (
+    <>
+      <HubGamesHero stats={stats} compact={compact}/>
+      {!isError && (
+        <HubFilters
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          sort={sort} setSort={setSort}
+          compact={compact} count={filtered.length} entity="game"
+        />
+      )}
+
+      <div style={{
+        padding: compact ? '14px 16px 80px' : '24px 32px 100px',
+      }}>
+        {isError && <ErrorState compact={compact}/>}
+
+        {!isError && isLoading && (
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+            gap: compact ? 10 : 16,
+          }}>
+            {Array.from({ length: compact ? 6 : 12 }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact}/>
+            ))}
+          </div>
+        )}
+
+        {!isError && !isLoading && (
+          filtered.length === 0 ? (
+            <HubEmptyFiltered compact={compact}
+              onAction={() => { setQ(''); setStatus('all'); }}/>
+          ) : (
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+              gap: compact ? 10 : 16,
+            }}>
+              {filtered.map(g => <HubGameCardGrid key={g.id} game={g} compact={compact}/>)}
+            </div>
+          )
+        )}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopPublicNav = () => {
+  const items = [
+    { id:'home', label:'Home' },
+    { id:'hub-games', label:'Giochi', active: true },
+    { id:'hub-agents', label:'Agenti' },
+    { id:'hub-toolkits', label:'Toolkit' },
+    { id:'about', label:'Chi siamo' },
+  ];
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 14,
+      padding:'10px 32px',
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <div style={{
+          width: 26, height: 26, borderRadius: 7,
+          background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+          color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+          fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+        }}>M</div>
+        <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
+        {items.map(it => (
+          <a key={it.id} href="#" onClick={e=>e.preventDefault()}
+            aria-current={it.active ? 'page' : undefined}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              color: it.active ? entityHsl('game') : 'var(--text-sec)',
+              background: it.active ? entityHsl('game', 0.1) : 'transparent',
+              textDecoration:'none',
+            }}>{it.label}</a>
+        ))}
+      </div>
+      <div style={{ flex: 1 }}/>
+      <a href="/login" style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background:'transparent', border:`1px solid ${entityHsl('game', 0.5)}`,
+        color: entityHsl('game'),
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        textDecoration:'none',
+      }}>Accedi</a>
+    </div>
+  );
+};
+
+const DesktopScreen = ({ stateOverride, showCta = true }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)', position:'relative' }}>
+    <DesktopPublicNav/>
+    <HubGamesBody stateOverride={stateOverride}/>
+    {showCta && <StickyAccessCta/>}
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>
+      Hub · Giochi
+    </div>
+    <button aria-label="Menu" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 16, cursor:'pointer',
+    }}>⋯</button>
+  </div>
+);
+const MobileBottomBar = () => {
+  const tabs = [
+    { id:'hub-games', icon:'🎲', label:'Giochi', active: true },
+    { id:'hub-agents', icon:'🤖', label:'Agenti' },
+    { id:'hub-toolkits', icon:'🧰', label:'Toolkit' },
+    { id:'login', icon:'🔐', label:'Accedi' },
+  ];
+  return (
+    <div style={{
+      position:'absolute', bottom: 0, left: 0, right: 0,
+      display:'flex',
+      padding:'8px 10px 12px',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderTop:'1px solid var(--border)',
+      zIndex: 5,
+    }}>
+      {tabs.map(t => (
+        <button key={t.id} style={{
+          flex: 1,
+          display:'flex', flexDirection:'column', alignItems:'center', gap: 2,
+          padding:'4px 0',
+          background:'transparent', border:'none',
+          color: t.active ? entityHsl('game') : 'var(--text-muted)',
+          fontFamily:'var(--f-display)', fontSize: 9, fontWeight: 700,
+          cursor:'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+          <span>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+const MobileScreen = ({ stateOverride, showCta = true }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <div style={{ paddingBottom: 70 }}>
+        <HubGamesBody stateOverride={stateOverride} compact/>
+      </div>
+      {showCta && <StickyAccessCta compact/>}
+      <MobileBottomBar/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+      position:'relative',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/hub/games</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'default', label:'01 · Default', desc:'~15 giochi, grid 2-col compact, install count overlay. StickyCTA bottom (sopra bottom-bar).' },
+  { id:'loading', label:'02 · Loading', desc:'6 skeleton cards shimmer. Filtri visibili e interagibili.' },
+  { id:'filtered-empty', label:'03 · Filtered empty', desc:'Query "xyznotfound" → empty state filtrato (no risultati) + "Azzera filtri".' },
+  { id:'error', label:'04 · Error', desc:'Banner danger inline + retry. Hero rimane visibile, filtri nascosti.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>Pre-Stage-3 · #1148 · Hub Games (public)</div>
+        <h1>Hub Games — /hub/games</h1>
+        <p className="lead">
+          Catalogo community pubblico. Visitatori navigano senza login.
+          Variante public di <code>sp4-games-index</code>: install count overlay sulle cover,
+          filtri <strong>Featured/Nuovi/Top</strong>, <strong>StickyAccessCta</strong> fissa in basso.
+          4 stati mobile (default / loading / filtered-empty / error) e 3 desktop.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 4 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id} showCta={s.id !== 'error'}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1280 — 3 stati</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="05 · Desktop · Default"
+            desc="Hero stats inline (install totali, featured, nuovi), filtri sticky, grid 4-col. Install count overlay sulle cover. StickyAccessCta fixed bottom-right.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="06 · Desktop · Loading"
+            desc="12 skeleton cards (4-col × 3 row) con shimmer. Hero e filtri visibili.">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Filtered empty"
+            desc="Query 'xyznotfound' → empty filtrato (icona 🔎) con CTA 'Azzera filtri'. Hero e filtri restano.">
+            <DesktopScreen stateOverride="filtered-empty"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-card-hub { outline: none; }
+        .mai-card-hub:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-game) / .4) !important;
+          box-shadow: var(--shadow-md);
+        }
+        .mai-card-hub:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+        select:focus-visible, input:focus-visible, button:focus-visible, a:focus-visible {
+          outline: 2px solid hsl(var(--c-game));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp4-hub-toolkits.html
+++ b/admin-mockups/design_files/sp4-hub-toolkits.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Pre-Stage-3 · Hub Toolkits (authenticated) — /hub/toolkits</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+</head>
+<body>
+<div id="root"></div>
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-hub-toolkits.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-hub-toolkits.jsx
+++ b/admin-mockups/design_files/sp4-hub-toolkits.jsx
@@ -1,0 +1,844 @@
+/* MeepleAI Pre-Stage-3 (#1148) — Hub Toolkits (authenticated)
+   Route: /hub/toolkits  (AUTHENTICATED — solo utenti loggati)
+   File: admin-mockups/design_files/sp4-hub-toolkits.{html,jsx}
+
+   Pattern: catalogo community di toolkit (bundle di tools per giochi).
+   Sibling structural di sp4-hub-agents. AC8 (#1148): diff ≤ 30%.
+   Diffs vs sp4-hub-agents:
+   - Entity color: --c-toolkit (green) invece di --c-agent
+   - Cards display: version + toolCount + useCount invece di model + invocations
+   - Search placeholder: "categoria" invece di "modello"
+   - Sample data: HUB_TOOLKITS (toolkit-shape)
+
+   Componenti v2 nuovi flaggati:
+   - HubToolkitsHero       → apps/web/src/components/ui/v2/hub-toolkits-hero/
+   - HubFilters            → ✅ shared con hub-games/agents (entity-tinted)
+   - HubToolkitCardGrid    → variante `grid` di MeepleCard per toolkit
+   - HubInstallButton      → inline install action su hover (shared con hub-agents)
+
+   USE CASE:
+     Primary actor: utente autenticato
+     Goal: trovare toolkit community (bundle di tools — timer/dadi/counter) per i propri giochi.
+     Success: 4 stati renderati (default popolato / filtered-empty / loading / error). Install inline su hover ogni card.
+     Non-goal: configurazione tool interno post-install (vedi /toolkits/[id]).
+*/
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.toolkit;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── DATASET COMMUNITY TOOLKITS ─────────────────────
+const HUB_TOOLKITS = [
+  ...DS.toolkits.map(t => ({
+    ...t,
+    installCount: 80 + Math.floor(Math.random() * 600),
+    featured: t.useCount >= 25,
+    isNew: t.version >= 2,
+    communityRating: 4.1 + Math.random() * 0.8,
+  })),
+  { id: 'tk-wingspan-pro', type: 'toolkit', title: 'Wingspan Pro Pack', subtitle: 'Pubblicato · 5 strumenti',
+    cover: DS.grad(85, 65), coverEmoji: '🧰', badge: 'Featured',
+    version: 3, toolCount: 5, useCount: 89, gameId: 'g-wingspan', owner: 'p-luca',
+    installCount: 542, featured: true, isNew: true, communityRating: 4.8 },
+  { id: 'tk-spirit-elements', type: 'toolkit', title: 'Spirit Island Elements', subtitle: 'Pubblicato · 7 strumenti',
+    cover: DS.grad(210, 50), coverEmoji: '🧰', badge: 'Top',
+    version: 2, toolCount: 7, useCount: 56, gameId: 'g-spirit', owner: 'p-marco',
+    installCount: 312, featured: true, isNew: true, communityRating: 4.6 },
+  { id: 'tk-tabletop-tk', type: 'toolkit', title: 'Tabletop Essentials', subtitle: 'Pubblicato · 8 strumenti',
+    cover: DS.grad(280, 60), coverEmoji: '🧰', badge: 'Universal',
+    version: 4, toolCount: 8, useCount: 123, gameId: null, owner: 'p-sara',
+    installCount: 892, featured: true, isNew: false, communityRating: 4.9 },
+  { id: 'tk-dune-imp', type: 'toolkit', title: 'Dune Imperium Kit', subtitle: 'Pubblicato · 4 strumenti',
+    cover: DS.grad(35, 70), coverEmoji: '🧰', badge: 'Nuovo',
+    version: 1, toolCount: 4, useCount: 34, gameId: 'g-dune', owner: 'p-giulia',
+    installCount: 178, featured: false, isNew: true, communityRating: 4.4 },
+  { id: 'tk-coop-helpers', type: 'toolkit', title: 'Coop Game Helpers', subtitle: 'Pubblicato · 6 strumenti',
+    cover: DS.grad(160, 50), coverEmoji: '🧰', badge: 'Cooperativo',
+    version: 2, toolCount: 6, useCount: 78, gameId: null, owner: 'p-andrea',
+    installCount: 423, featured: false, isNew: false, communityRating: 4.5 },
+  { id: 'tk-deck-builder', type: 'toolkit', title: 'Deck Builder Pack', subtitle: 'Pubblicato · 9 strumenti',
+    cover: DS.grad(0, 60), coverEmoji: '🧰', badge: 'Heavy',
+    version: 3, toolCount: 9, useCount: 145, gameId: null, owner: 'p-marco',
+    installCount: 678, featured: true, isNew: false, communityRating: 4.7 },
+  { id: 'tk-7wonders', type: 'toolkit', title: '7 Wonders Tournament', subtitle: 'Pubblicato · 5 strumenti',
+    cover: DS.grad(45, 65), coverEmoji: '🧰', badge: 'Tournament',
+    version: 2, toolCount: 5, useCount: 67, gameId: 'g-7wonders', owner: 'p-sara',
+    installCount: 289, featured: false, isNew: true, communityRating: 4.5 },
+  { id: 'tk-marvel-champs', type: 'toolkit', title: 'Marvel Champions Aid', subtitle: 'Pubblicato · 6 strumenti',
+    cover: DS.grad(355, 65), coverEmoji: '🧰', badge: 'LCG',
+    version: 1, toolCount: 6, useCount: 41, gameId: 'g-marvel', owner: 'p-luca',
+    installCount: 224, featured: false, isNew: true, communityRating: 4.3 },
+];
+
+// ═══════════════════════════════════════════════════════
+const Stars = ({ value = 0, size = 11 }) => {
+  const full = Math.floor(value);
+  return (
+    <span style={{ display:'inline-flex', gap: 1, color:'hsl(var(--c-agent))', fontSize: size }}>
+      {[0,1,2,3,4].map(i => <span key={i} aria-hidden="true">{i < full ? '★' : '☆'}</span>)}
+    </span>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB TOOLKIT CARD ────────────────────────────
+// ═══════════════════════════════════════════════════════
+const HubToolkitCardGrid = ({ toolkit, compact }) => {
+  const gameRef = toolkit.gameId ? DS.byId[toolkit.gameId] : null;
+  return (
+    <article tabIndex={0} className="mai-card-hub"
+      style={{
+        background:'var(--bg-card)',
+        border:'1px solid var(--border)',
+        borderRadius:'var(--r-lg)',
+        overflow:'hidden',
+        cursor:'pointer',
+        position:'relative',
+        transition:'transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm), box-shadow var(--dur-sm)',
+        display:'flex', flexDirection:'column',
+      }}>
+      <div style={{
+        position:'relative',
+        aspectRatio: compact ? '4 / 3' : '5 / 3',
+        background: toolkit.cover,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        overflow:'hidden',
+      }}>
+        <span aria-hidden="true" style={{
+          fontSize: compact ? 50 : 60,
+          filter:'drop-shadow(0 4px 12px rgba(0,0,0,.35))',
+        }}>{toolkit.coverEmoji}</span>
+        {toolkit.badge && (
+          <span style={{
+            position:'absolute', top: 8, left: 8,
+            padding:'3px 8px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,.5)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.06em',
+            backdropFilter:'blur(4px)',
+          }}>{toolkit.badge}</span>
+        )}
+        <span style={{
+          position:'absolute', top: 8, right: 8,
+          padding:'3px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('toolkit', 0.95), color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          display:'inline-flex', alignItems:'center', gap: 3,
+        }}>
+          <span aria-hidden="true">🧰</span>Toolkit
+        </span>
+        <div style={{
+          position:'absolute', inset:'auto 0 0 0', height:'40%',
+          background:'linear-gradient(180deg, transparent 0%, rgba(0,0,0,.35) 100%)',
+        }}/>
+        <div style={{
+          position:'absolute', bottom: 8, right: 8,
+          display:'inline-flex', alignItems:'center', gap: 4,
+          padding:'3px 8px', borderRadius:'var(--r-pill)',
+          background:'rgba(255,255,255,.92)', color:'#1a1a1a',
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+        }}>
+          <span aria-hidden="true">⬇</span>
+          <span style={{ fontVariantNumeric:'tabular-nums' }}>{toolkit.installCount}</span>
+        </div>
+      </div>
+      <div style={{
+        padding: compact ? 10 : 14,
+        display:'flex', flexDirection:'column', gap: compact ? 6 : 8, flex: 1,
+      }}>
+        <div>
+          <h3 style={{
+            fontFamily:'var(--f-display)', fontWeight: 800,
+            fontSize: compact ? 13 : 15, lineHeight: 1.15,
+            color:'var(--text)', margin:'0 0 3px',
+            display:'-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient:'vertical', overflow:'hidden',
+          }}>{toolkit.title}</h3>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 5,
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+            fontWeight: 600,
+          }}>
+            <Stars value={Math.round(toolkit.communityRating)} size={9}/>
+            <span style={{ fontVariantNumeric:'tabular-nums' }}>{toolkit.communityRating.toFixed(1)}</span>
+            <span aria-hidden="true">·</span>
+            <span>v{toolkit.version}.0</span>
+          </div>
+        </div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 3 }}>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-sec)',
+            fontWeight: 600,
+          }}>
+            <span style={{ color:'var(--text-muted)' }}>Strumenti:</span> {toolkit.toolCount} · <span style={{ color:'var(--text-muted)' }}>Uses:</span> {toolkit.useCount}
+          </div>
+          {gameRef ? (
+            <div style={{
+              display:'inline-flex', alignItems:'center', gap: 4,
+              fontFamily:'var(--f-mono)', fontSize: 10,
+              color: entityHsl('game'),
+              fontWeight: 700,
+            }}>
+              <span aria-hidden="true">🎲</span>
+              <span style={{ overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{gameRef.title}</span>
+            </div>
+          ) : (
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+              fontWeight: 700, fontStyle:'italic',
+            }}>Universale (multi-game)</div>
+          )}
+        </div>
+      </div>
+      <button type="button"
+        className="mai-card-install"
+        style={{
+          position:'absolute',
+          bottom: compact ? 10 : 14, left: compact ? 10 : 14, right: compact ? 10 : 14,
+          padding:'7px 12px', borderRadius:'var(--r-md)',
+          background: entityHsl('toolkit'), color:'#fff',
+          border:'none',
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+          cursor:'pointer',
+          boxShadow:`0 4px 14px ${entityHsl('toolkit', 0.35)}`,
+          opacity: 0,
+          transform:'translateY(8px)',
+          transition:'opacity var(--dur-sm), transform var(--dur-sm)',
+        }}>+ Installa toolkit</button>
+    </article>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB TOOLKITS HERO ───────────────────────────
+// ═══════════════════════════════════════════════════════
+const HubToolkitsHero = ({ stats, compact }) => (
+  <header style={{
+    padding: compact ? '20px 16px 14px' : '32px 32px 18px',
+    background:`linear-gradient(180deg, ${entityHsl('toolkit', 0.08)} 0%, transparent 100%)`,
+    borderBottom:'1px solid var(--border-light)',
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 10 }}>
+      <span style={{
+        display:'inline-flex', alignItems:'center', gap: 5,
+        padding:'3px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('toolkit', 0.14),
+        color: entityHsl('toolkit'),
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.08em',
+      }}><span aria-hidden="true">🧰</span>Hub · /hub/toolkits</span>
+    </div>
+    <h1 style={{
+      fontFamily:'var(--f-display)', fontWeight: 800,
+      fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Catalogo toolkit community</h1>
+    <p style={{
+      color:'var(--text-sec)', fontSize: compact ? 13 : 14, lineHeight: 1.55,
+      margin:'0 0 14px', maxWidth: 620,
+    }}>
+      Bundle pronti all'uso di strumenti (timer, dadi, counter, deck) per i tuoi giochi.
+      Ogni toolkit è versionato e pubblicato dalla community.
+    </p>
+    <div style={{
+      display:'flex', flexWrap:'wrap', gap: compact ? 14 : 22,
+      fontFamily:'var(--f-mono)', fontSize: compact ? 11 : 12,
+    }}>
+      {stats.map(s => (
+        <div key={s.label} style={{ display:'flex', flexDirection:'column', gap: 2 }}>
+          <span style={{
+            color:'var(--text-muted)', fontSize: 9, fontWeight: 700,
+            textTransform:'uppercase', letterSpacing:'.08em',
+          }}>{s.label}</span>
+          <span style={{
+            color:'var(--text)', fontSize: compact ? 18 : 22, fontWeight: 800,
+            fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums',
+            lineHeight: 1,
+          }}>{s.value}<span style={{ fontSize: 11, color:'var(--text-muted)', fontWeight: 600, marginLeft: 4 }}>{s.unit}</span></span>
+        </div>
+      ))}
+    </div>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── HUB FILTERS (shared) ────────────────────────
+// ═══════════════════════════════════════════════════════
+const STATUS_OPTS = [
+  { id:'all', label:'Tutti' },
+  { id:'featured', label:'Featured' },
+  { id:'new', label:'Nuovi' },
+  { id:'top', label:'Top 100' },
+];
+const SORT_OPTS = [
+  { id:'popular', label:'Popolarità' },
+  { id:'rating', label:'Rating' },
+  { id:'title', label:'Titolo A-Z' },
+  { id:'uses', label:'Uses' },
+];
+
+const HubFilters = ({ q, setQ, status, setStatus, sort, setSort, compact, count, entity }) => (
+  <div style={{
+    padding: compact ? '12px 16px' : '14px 32px',
+    display:'flex', flexDirection: compact ? 'column' : 'row',
+    alignItems: compact ? 'stretch' : 'center',
+    gap: compact ? 10 : 12,
+    borderBottom:'1px solid var(--border-light)',
+    background:'var(--bg)',
+    position:'sticky', top: 0, zIndex: 10,
+    backdropFilter:'blur(12px)',
+  }}>
+    <label style={{
+      display:'flex', alignItems:'center', gap: 8,
+      flex: compact ? 'none' : '1 1 280px', maxWidth: compact ? 'none' : 360,
+      padding:'8px 12px',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderRadius:'var(--r-md)',
+    }}>
+      <span aria-hidden="true" style={{ color:'var(--text-muted)' }}>🔍</span>
+      <input
+        type="text" value={q} onChange={e=>setQ(e.target.value)}
+        placeholder="Cerca per nome, gioco, categoria…"
+        style={{
+          flex: 1, border:'none', outline:'none', background:'transparent',
+          color:'var(--text)', fontFamily:'var(--f-body)', fontSize: 13,
+          minWidth: 0,
+        }}
+      />
+      {q && (
+        <button type="button" onClick={()=>setQ('')} aria-label="Pulisci"
+          style={{ border:'none', background:'transparent', color:'var(--text-muted)', cursor:'pointer', fontSize: 13, padding: 0 }}>✕</button>
+      )}
+    </label>
+
+    <div role="tablist" style={{
+      display:'inline-flex',
+      background:'var(--bg-muted)',
+      borderRadius:'var(--r-md)',
+      padding: 2,
+      flexShrink: 0,
+    }}>
+      {STATUS_OPTS.map(o => (
+        <button key={o.id} role="tab" aria-selected={status === o.id}
+          onClick={()=>setStatus(o.id)}
+          style={{
+            padding: compact ? '6px 9px' : '6px 12px',
+            border:'none',
+            background: status === o.id ? 'var(--bg-card)' : 'transparent',
+            color: status === o.id ? entityHsl(entity) : 'var(--text-sec)',
+            fontFamily:'var(--f-display)',
+            fontSize: compact ? 11 : 12, fontWeight: 700,
+            borderRadius: 'var(--r-sm)',
+            cursor:'pointer', whiteSpace:'nowrap',
+            boxShadow: status === o.id ? 'var(--shadow-xs)' : 'none',
+            transition:'all var(--dur-sm) var(--ease-out)',
+          }}>{o.label}</button>
+      ))}
+    </div>
+
+    <div style={{ flex: 1 }}/>
+
+    <label style={{
+      display:'inline-flex', alignItems:'center', gap: 6,
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      fontWeight: 600,
+    }}>
+      <span style={{ textTransform:'uppercase', letterSpacing:'.06em' }}>Ordina</span>
+      <select value={sort} onChange={e=>setSort(e.target.value)}
+        style={{
+          padding:'6px 10px', borderRadius:'var(--r-sm)',
+          border:'1px solid var(--border)', background:'var(--bg-card)',
+          color:'var(--text)', fontFamily:'var(--f-display)',
+          fontSize: 12, fontWeight: 700, cursor:'pointer',
+        }}>
+        {SORT_OPTS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+      </select>
+    </label>
+
+    {compact && (
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)',
+        fontWeight: 700, letterSpacing:'.04em',
+      }}>{count} toolkit</div>
+    )}
+  </div>
+);
+
+// ─── EMPTY / ERROR / SKELETON ─────────────────
+const HubEmptyFiltered = ({ onAction, compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+    padding: compact ? '40px 20px' : '64px 32px',
+    background:'var(--bg-card)',
+    border:'1px dashed var(--border-strong)',
+    borderRadius:'var(--r-xl)',
+  }}>
+    <div style={{
+      width: compact ? 64 : 80, height: compact ? 64 : 80,
+      borderRadius:'50%',
+      background: entityHsl('toolkit', 0.12), color: entityHsl('toolkit'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: compact ? 32 : 40, marginBottom: 16,
+    }} aria-hidden="true">🔎</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: compact ? 16 : 19, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 6px',
+    }}>Nessun toolkit trovato</h3>
+    <p style={{
+      fontSize: 13, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 18px', lineHeight: 1.55,
+    }}>Nessun toolkit corrisponde ai filtri attuali. Prova a modificare la ricerca.</p>
+    <button type="button" onClick={onAction}
+      style={{
+        padding:'10px 18px', borderRadius:'var(--r-md)',
+        background: entityHsl('toolkit'), color:'#fff',
+        border:'none', fontFamily:'var(--f-display)',
+        fontSize: 13, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 4px 14px ${entityHsl('toolkit', 0.35)}`,
+      }}>Azzera filtri</button>
+  </div>
+);
+
+const ErrorState = ({ compact }) => (
+  <div style={{
+    gridColumn:'1 / -1',
+    padding: compact ? '32px 20px' : '48px 32px',
+    background:'hsl(var(--c-danger) / .08)',
+    border:'1px solid hsl(var(--c-danger) / .3)',
+    borderRadius:'var(--r-xl)',
+    display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center',
+  }}>
+    <div style={{
+      width: 56, height: 56, borderRadius:'50%',
+      background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))',
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: 26, marginBottom: 12,
+    }} aria-hidden="true">⚠</div>
+    <h3 style={{
+      fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+      color:'var(--text)', margin:'0 0 4px',
+    }}>Impossibile caricare il catalogo</h3>
+    <p style={{
+      fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360,
+      margin:'0 0 16px',
+    }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
+    <button type="button" style={{
+      padding:'8px 16px', borderRadius:'var(--r-md)',
+      background:'hsl(var(--c-danger))', color:'#fff',
+      border:'none', fontFamily:'var(--f-display)',
+      fontSize: 12, fontWeight: 800, cursor:'pointer',
+    }}>↻ Riprova</button>
+  </div>
+);
+
+const SkeletonCard = ({ compact }) => (
+  <div style={{
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    overflow:'hidden',
+  }}>
+    <div className="mai-shimmer" style={{
+      aspectRatio: compact ? '4 / 3' : '5 / 3',
+      background:'var(--bg-muted)',
+    }}/>
+    <div style={{ padding: compact ? 10 : 14, display:'flex', flexDirection:'column', gap: 6 }}>
+      <div className="mai-shimmer" style={{ height: 14, width:'72%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'52%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+      <div className="mai-shimmer" style={{ height: 10, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── PAGE BODY ──────────────────────────────────────
+// ═══════════════════════════════════════════════════════
+const filterAndSort = (list, q, status, sort) => {
+  let out = list;
+  if (q) {
+    const needle = q.toLowerCase();
+    out = out.filter(t =>
+      t.title.toLowerCase().includes(needle) ||
+      ((DS.byId[t.gameId] || {}).title || '').toLowerCase().includes(needle) ||
+      (t.badge || '').toLowerCase().includes(needle)
+    );
+  }
+  if (status !== 'all') {
+    if (status === 'featured') out = out.filter(t => t.featured);
+    else if (status === 'new') out = out.filter(t => t.isNew);
+    else if (status === 'top') out = out.filter(t => t.communityRating >= 4.5);
+  }
+  out = [...out].sort((a, b) => {
+    if (sort === 'rating') return b.communityRating - a.communityRating;
+    if (sort === 'title') return a.title.localeCompare(b.title);
+    if (sort === 'uses') return b.useCount - a.useCount;
+    return b.installCount - a.installCount;
+  });
+  return out;
+};
+
+const HubToolkitsBody = ({ stateOverride, compact }) => {
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('all');
+  const [sort, setSort] = useState('popular');
+
+  useEffect(() => {
+    if (stateOverride === 'filtered-empty') setQ('xyznotfound');
+    else { setQ(''); setStatus('all'); }
+  }, [stateOverride]);
+
+  const isLoading = stateOverride === 'loading';
+  const isError = stateOverride === 'error';
+
+  const filtered = useMemo(() => filterAndSort(HUB_TOOLKITS, q, status, sort),
+    [q, status, sort]);
+
+  const stats = [
+    { label:'Toolkit', value: HUB_TOOLKITS.length, unit:'' },
+    { label:'Installazioni', value: HUB_TOOLKITS.reduce((s, t) => s + t.installCount, 0).toLocaleString('it-IT'), unit:'' },
+    { label:'Featured', value: HUB_TOOLKITS.filter(t => t.featured).length, unit:'' },
+    { label:'Strumenti totali', value: HUB_TOOLKITS.reduce((s, t) => s + t.toolCount, 0), unit:'' },
+  ];
+
+  return (
+    <>
+      <HubToolkitsHero stats={stats} compact={compact}/>
+      {!isError && (
+        <HubFilters
+          q={q} setQ={setQ}
+          status={status} setStatus={setStatus}
+          sort={sort} setSort={setSort}
+          compact={compact} count={filtered.length} entity="toolkit"
+        />
+      )}
+
+      <div style={{ padding: compact ? '14px 16px 24px' : '24px 32px 64px' }}>
+        {isError && <ErrorState compact={compact}/>}
+
+        {!isError && isLoading && (
+          <div style={{
+            display:'grid',
+            gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+            gap: compact ? 10 : 16,
+          }}>
+            {Array.from({ length: compact ? 6 : 12 }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact}/>
+            ))}
+          </div>
+        )}
+
+        {!isError && !isLoading && (
+          filtered.length === 0 ? (
+            <HubEmptyFiltered compact={compact}
+              onAction={() => { setQ(''); setStatus('all'); }}/>
+          ) : (
+            <div style={{
+              display:'grid',
+              gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+              gap: compact ? 10 : 16,
+            }}>
+              {filtered.map(t => <HubToolkitCardGrid key={t.id} toolkit={t} compact={compact}/>)}
+            </div>
+          )
+        )}
+      </div>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── DESKTOP / MOBILE SHELLS ─────────────────
+// ═══════════════════════════════════════════════════════
+const DesktopAuthNav = () => {
+  const items = [
+    { id:'home', label:'Home' },
+    { id:'library', label:'Libreria' },
+    { id:'hub', label:'Hub', active: true },
+    { id:'sessions', label:'Sessioni' },
+    { id:'toolkit', label:'Toolkit' },
+  ];
+  return (
+    <div style={{
+      display:'flex', alignItems:'center', gap: 14,
+      padding:'10px 32px',
+      background:'var(--glass-bg)', backdropFilter:'blur(12px)',
+      borderBottom:'1px solid var(--border)',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
+        <div style={{
+          width: 26, height: 26, borderRadius: 7,
+          background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))',
+          color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+          fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)',
+        }}>M</div>
+        <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
+        {items.map(it => (
+          <a key={it.id} href="#" onClick={e=>e.preventDefault()}
+            aria-current={it.active ? 'page' : undefined}
+            style={{
+              padding:'6px 12px', borderRadius:'var(--r-md)',
+              fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700,
+              color: it.active ? entityHsl('toolkit') : 'var(--text-sec)',
+              background: it.active ? entityHsl('toolkit', 0.1) : 'transparent',
+              textDecoration:'none',
+            }}>{it.label}</a>
+        ))}
+      </div>
+      <div style={{ flex: 1 }}/>
+      <button type="button" style={{
+        padding:'7px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('toolkit'), color:'#fff',
+        border:'none', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        cursor:'pointer', boxShadow:`0 3px 10px ${entityHsl('toolkit', 0.35)}`,
+      }}>+ Crea toolkit</button>
+    </div>
+  );
+};
+
+const DesktopScreen = ({ stateOverride }) => (
+  <div style={{ minHeight: 720, background:'var(--bg)' }}>
+    <DesktopAuthNav/>
+    <HubToolkitsBody stateOverride={stateOverride}/>
+  </div>
+);
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>14:32</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+const PhoneTopNav = () => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 9,
+    padding:'10px 14px', borderBottom:'1px solid var(--border)',
+    background:'var(--bg)',
+  }}>
+    <button aria-label="Indietro" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'transparent', border:'1px solid var(--border)',
+      color:'var(--text)', fontSize: 14, cursor:'pointer',
+    }}>←</button>
+    <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>
+      Hub · Toolkit
+    </div>
+    <button aria-label="Aggiungi" style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background: entityHsl('toolkit'), border:'none',
+      color:'#fff', fontSize: 16, cursor:'pointer', fontWeight: 800,
+    }}>＋</button>
+  </div>
+);
+const MobileBottomBar = () => {
+  const tabs = [
+    { id:'home', icon:'⌂', label:'Home' },
+    { id:'library', icon:'📚', label:'Libreria' },
+    { id:'hub', icon:'🌐', label:'Hub', active: true },
+    { id:'chat', icon:'💬', label:'Chat' },
+    { id:'profile', icon:'👤', label:'Profilo' },
+  ];
+  return (
+    <div style={{
+      position:'absolute', bottom: 0, left: 0, right: 0,
+      display:'flex',
+      padding:'8px 10px 12px',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderTop:'1px solid var(--border)',
+      zIndex: 5,
+    }}>
+      {tabs.map(t => (
+        <button key={t.id} style={{
+          flex: 1,
+          display:'flex', flexDirection:'column', alignItems:'center', gap: 2,
+          padding:'4px 0',
+          background:'transparent', border:'none',
+          color: t.active ? entityHsl('toolkit') : 'var(--text-muted)',
+          fontFamily:'var(--f-display)', fontSize: 9, fontWeight: 700,
+          cursor:'pointer',
+        }}>
+          <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+          <span>{t.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+const MobileScreen = ({ stateOverride }) => (
+  <>
+    <PhoneSbar/>
+    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+      <PhoneTopNav/>
+      <div style={{ paddingBottom: 70 }}>
+        <HubToolkitsBody stateOverride={stateOverride} compact/>
+      </div>
+      <MobileBottomBar/>
+    </div>
+  </>
+);
+
+const PhoneShell = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div className="phone">{children}</div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 340,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+const DesktopFrame = ({ label, desc, children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }}>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)',
+      textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700,
+    }}>{label}</div>
+    <div style={{
+      width:'100%', maxWidth: 1280,
+      borderRadius:'var(--r-xl)', border:'1px solid var(--border)',
+      background:'var(--bg)', overflow:'hidden',
+      boxShadow:'var(--shadow-lg)',
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8,
+        padding:'9px 14px',
+        background:'var(--bg-muted)',
+        borderBottom:'1px solid var(--border)',
+        fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+      }}>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-event))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-warning))' }}/>
+        <span style={{ width: 11, height: 11, borderRadius:'50%', background:'hsl(var(--c-toolkit))' }}/>
+        <span style={{ flex: 1, textAlign:'center', letterSpacing:'.04em' }}>meepleai.app/hub/toolkits</span>
+      </div>
+      {children}
+    </div>
+    {desc && <div style={{
+      fontSize: 11, color:'var(--text-muted)', maxWidth: 720,
+      textAlign:'center', lineHeight: 1.55,
+    }}>{desc}</div>}
+  </div>
+);
+
+// ─── ROOT ────────────────────────────────────────────
+const MOBILE_STATES = [
+  { id:'default', label:'01 · Default', desc:'~12 toolkit, grid 2-col, install count overlay + install button hover-revealed.' },
+  { id:'loading', label:'02 · Loading', desc:'6 skeleton cards shimmer.' },
+  { id:'filtered-empty', label:'03 · Filtered empty', desc:'Query "xyznotfound" → empty filtrato + "Azzera filtri".' },
+  { id:'error', label:'04 · Error', desc:'Banner danger + retry.' },
+];
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  }, [dark]);
+  return (
+    <button onClick={() => setDark(d => !d)} className="theme-toggle"
+      aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+      <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+      <span>{dark ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <div className="stage">
+      <ThemeToggle/>
+      <div className="stage-wrap">
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+          textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8,
+        }}>Pre-Stage-3 · #1148 · Hub Toolkits (authenticated)</div>
+        <h1>Hub Toolkits — /hub/toolkits</h1>
+        <p className="lead">
+          Catalogo toolkit community per utenti loggati. Sibling structural di hub-agents
+          (AC8: diff ≤ 30%). Entity color <strong>--c-toolkit</strong>, card variant
+          con version + toolCount + useCount + game reference (o "Universale"). Install hover-revealed.
+          4 stati mobile, 3 desktop.
+        </p>
+
+        <div className="section-label">Mobile · 375 — 4 stati</div>
+        <div className="phones-grid">
+          {MOBILE_STATES.map(s => (
+            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
+              <MobileScreen stateOverride={s.id}/>
+            </PhoneShell>
+          ))}
+        </div>
+
+        <div className="section-label">Desktop · 1280 — 3 stati</div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+          <DesktopFrame label="05 · Desktop · Default"
+            desc="Hero stats inline (toolkit, installazioni, featured, strumenti totali), filtri sticky, grid 4-col. Hover su card rivela install button toolkit-tinted.">
+            <DesktopScreen stateOverride="default"/>
+          </DesktopFrame>
+          <DesktopFrame label="06 · Desktop · Loading"
+            desc="12 skeleton cards (4-col × 3 row) con shimmer.">
+            <DesktopScreen stateOverride="loading"/>
+          </DesktopFrame>
+          <DesktopFrame label="07 · Desktop · Filtered empty"
+            desc="Query 'xyznotfound' → empty filtrato (icona 🔎) con CTA 'Azzera filtri' toolkit-tinted.">
+            <DesktopScreen stateOverride="filtered-empty"/>
+          </DesktopFrame>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes mai-shimmer-anim {
+          0%   { background-position: -200% 0; }
+          100% { background-position:  200% 0; }
+        }
+        .mai-shimmer {
+          background: linear-gradient(90deg, var(--bg-muted) 0%, var(--bg-hover) 50%, var(--bg-muted) 100%) !important;
+          background-size: 200% 100% !important;
+          animation: mai-shimmer-anim 1.4s linear infinite;
+        }
+        .phones-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+          gap: var(--s-7);
+          align-items: start;
+        }
+        .stage h1 { font-size: var(--fs-3xl); }
+        .stage .lead { line-height: var(--lh-relax); }
+        .phone > div::-webkit-scrollbar { display: none; }
+        .mai-card-hub { outline: none; }
+        .mai-card-hub:hover {
+          transform: translateY(-2px);
+          border-color: hsl(var(--c-toolkit) / .4) !important;
+          box-shadow: var(--shadow-md);
+        }
+        .mai-card-hub:hover .mai-card-install,
+        .mai-card-hub:focus-within .mai-card-install {
+          opacity: 1 !important;
+          transform: translateY(0) !important;
+        }
+        .mai-card-hub:focus-visible {
+          outline: 2px solid hsl(var(--c-toolkit));
+          outline-offset: 2px;
+        }
+        select:focus-visible, input:focus-visible, button:focus-visible, a:focus-visible {
+          outline: 2px solid hsl(var(--c-toolkit));
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/scripts/validate-sp4.mjs
+++ b/admin-mockups/scripts/validate-sp4.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * validate-sp4.mjs — Lightweight validator for SP4 mockup files.
+ * Introduced by issue #1148 (Pre-Stage-3 hub mockups) to satisfy AC2 + AC3 + AC5.
+ *
+ * Usage:
+ *   node admin-mockups/scripts/validate-sp4.mjs [file1.jsx file2.jsx ...]
+ *   node admin-mockups/scripts/validate-sp4.mjs --all      # validate all sp4-*.jsx
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more validation failures (details to stderr)
+ *
+ * Checks per .jsx file:
+ *   - parse-clean: file loadable as text, ES module syntax OK (loose parse via Babel? No — keep dep-free regex sniff).
+ *   - hex/rgb token compliance (AC3): forbid literal #RGB / #RRGGBB / rgb()/rgba() colors in style/className strings.
+ *     Allowed: CSS variables (hsl(var(--c-*) / x), var(--text), etc.) and rgba(0,0,0,...) for shadows on dark overlays.
+ *     Forbidden: #f5b800, rgb(255,0,0). The check is regex-based and may over-report; CI override via inline `// validator:allow-hex` comment.
+ *   - use-case header (AC5): file must contain `USE CASE:` block in JSDoc top comment.
+ *   - companion .html exists.
+ *
+ * Note: this is a smoke validator. It does NOT execute the JSX. Full execution
+ * requires a browser (open the .html in a tab). CI gating is opt-in for follow-up.
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DESIGN_FILES = join(__dirname, '..', 'design_files');
+
+// ─── HEX color regex (forbidden literal hex outside comments) ──────
+const HEX_RE = /(?<![A-Za-z0-9])#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\b/g;
+// allow specific "neutral" colors used inside on-cover overlays where the
+// design intent is opaque white/black (not entity-tinted). Allowlist intentional:
+const HEX_ALLOWLIST = new Set([
+  '#fff', '#ffffff', // overlay text on dark covers
+  '#1a1a1a', '#0a0a0a', // hard black for phone frame inside components.css
+  '#000', '#000000',    // pure black for shadow rings
+]);
+
+// ─── USE CASE header check ─────────────────────────────────────────
+const USE_CASE_RE = /USE CASE:\s*\n\s*\*?\s*Primary actor:/i;
+
+// ─── Filename ──────────────────────────────────────────────────────
+function companionHtmlFor(jsxPath) {
+  return jsxPath.replace(/\.jsx$/, '.html');
+}
+
+// ─── Validator ─────────────────────────────────────────────────────
+function validateFile(jsxPath) {
+  const errors = [];
+  const warnings = [];
+
+  if (!existsSync(jsxPath)) {
+    errors.push(`File not found: ${jsxPath}`);
+    return { errors, warnings };
+  }
+  const src = readFileSync(jsxPath, 'utf8');
+
+  // Check 1: companion .html (skipped for `*-parts.jsx` partial fragments)
+  const isPartial = /-parts\.jsx$/i.test(jsxPath);
+  if (!isPartial) {
+    const htmlPath = companionHtmlFor(jsxPath);
+    if (!existsSync(htmlPath)) {
+      errors.push(`Missing companion HTML: ${basename(htmlPath)}`);
+    }
+  }
+
+  // Check 2: use-case header (only for hub-* and dashboard files — pattern enforcement is partial,
+  // legacy sp4-* may not have the expanded format yet).
+  const enforceUseCase = /sp4-(hub-|dashboard)/i.test(basename(jsxPath));
+  if (enforceUseCase) {
+    if (!USE_CASE_RE.test(src)) {
+      errors.push(`Missing or malformed USE CASE block (expected "USE CASE:\\n  Primary actor:" pattern)`);
+    }
+  }
+
+  // Check 3: hex color compliance (AC3) — scoped to files introduced
+  // by Pre-Stage-3 work (hub-* + dashboard). Legacy sp4-* files predate the
+  // strict tokens-only policy and are out of scope for this validator.
+  // Skip lines containing `// validator:allow-hex` for explicit overrides.
+  const enforceHex = /sp4-(hub-|dashboard)/i.test(basename(jsxPath));
+  if (enforceHex) {
+    // strip block comments first (multi-line)
+    const codeNoBlockComments = src.replace(/\/\*[\s\S]*?\*\//g, '');
+    const lines = codeNoBlockComments.split('\n');
+    lines.forEach((line, idx) => {
+      if (line.includes('validator:allow-hex')) return;
+      // strip line comments to reduce false positives
+      const codeOnly = line.replace(/\/\/.*$/, '');
+      const matches = codeOnly.match(HEX_RE);
+      if (!matches) return;
+      matches.forEach(hex => {
+        const lower = hex.toLowerCase();
+        if (HEX_ALLOWLIST.has(lower)) return;
+        errors.push(`Line ${idx + 1} (post comment-strip): hardcoded hex color ${hex} — use CSS variables instead`);
+      });
+    });
+  }
+
+  // Check 4: react import / ReactDOM render present (parse-lite)
+  if (!/ReactDOM\.createRoot\(/.test(src)) {
+    warnings.push(`No ReactDOM.createRoot() call found — mockup may not render`);
+  }
+  if (!/window\.DS/.test(src)) {
+    warnings.push(`window.DS not referenced — mockup may not use shared dataset`);
+  }
+
+  return { errors, warnings };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+let targets = [];
+
+if (args.length === 0 || args.includes('--all')) {
+  const all = readdirSync(DESIGN_FILES).filter(f => /^sp4-.*\.jsx$/i.test(f));
+  targets = all.map(f => join(DESIGN_FILES, f));
+} else {
+  targets = args.filter(a => !a.startsWith('--')).map(a =>
+    a.includes('/') || a.includes('\\') ? a : join(DESIGN_FILES, a)
+  );
+}
+
+if (targets.length === 0) {
+  console.error('No targets to validate. Pass file paths or --all.');
+  process.exit(1);
+}
+
+let failed = 0;
+let totalWarnings = 0;
+console.log(`\nvalidate-sp4: checking ${targets.length} file(s)...\n`);
+
+for (const target of targets) {
+  const { errors, warnings } = validateFile(target);
+  const name = basename(target);
+  if (errors.length === 0 && warnings.length === 0) {
+    console.log(`  ✓ ${name}`);
+  } else if (errors.length === 0) {
+    console.log(`  ⚠ ${name}`);
+    for (const w of warnings) console.log(`      WARN: ${w}`);
+    totalWarnings += warnings.length;
+  } else {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    for (const e of errors) console.error(`      ERROR: ${e}`);
+    for (const w of warnings) console.error(`      WARN:  ${w}`);
+    totalWarnings += warnings.length;
+  }
+}
+
+console.log(`\n${targets.length - failed}/${targets.length} passed, ${failed} failed, ${totalWarnings} warning(s).`);
+process.exit(failed > 0 ? 1 : 0);

--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./state-matrix.schema.json",
-  "generated_at": "2026-05-12T14:39:28.967Z",
-  "total_mockups": 61,
+  "generated_at": "2026-05-14T08:53:28.594Z",
+  "total_mockups": 64,
   "enforced_count": 1,
   "entries": [
     {
@@ -452,6 +452,30 @@
     },
     {
       "mockup_path": "admin-mockups/design_files/sp4-games-index.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-hub-agents.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-hub-games.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp4-hub-toolkits.html",
       "route": null,
       "declared_states": [],
       "covered_states": [],

--- a/apps/web/src/app/(authenticated)/sessions/_components/__tests__/SessionsLibraryView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/__tests__/SessionsLibraryView.test.tsx
@@ -108,6 +108,7 @@ const MESSAGES: Record<string, string> = {
   'pages.sessions.card.winnerLabel': 'Vincitore',
   'pages.sessions.card.turnLabel': 'Turno {turn}',
   'pages.sessions.card.openAriaLabel': 'Apri sessione {gameName}',
+  'pages.sessions.card.scoreOverflowTemplate': '+{count} altri',
 };
 
 function renderWithIntl(ui: ReactElement) {

--- a/docs/for-developers/specs/2026-05-11-design-system-deversioning.md
+++ b/docs/for-developers/specs/2026-05-11-design-system-deversioning.md
@@ -144,8 +144,11 @@ apps/web/src/components/
 |---|---|---|
 | `player-detail` (Wave 3) | 5 | Pending da Wave 3, mai implementato |
 | `toolkit-detail` (Wave 3) | 6 | Pending da Wave 3 |
-| `dashboard` (NEW) | TBD post audit | Decisione utente: sezioni per entità |
-| `hub/<entity>` (NEW public) | TBD post audit | Decisione utente: catalogo pubblico |
+| `dashboard` (REFACTOR-FORWARD)¹ | TBD post #1149 | Forward-design 5 entity sections, mockup #1149 in flight |
+| `hub/<entity>` (NEW public) | 3 mockup pronti² | mockup canonici merged via #1148 (sp4-hub-{games,agents,toolkits}) |
+
+¹ `dashboard` re-etichettato da `NEW` a `REFACTOR-FORWARD` dopo spec-panel 2026-05-14 (D2): `DashboardClient.tsx` PR #309 verrà rimpiazzato dal target mockup. Sub-issue Pre-Stage-3: #1149.
+² Mockup canonici: [`sp4-hub-games.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-games.jsx), [`sp4-hub-agents.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-agents.jsx), [`sp4-hub-toolkits.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-toolkits.jsx). Auth model: `/hub/games` pubblico, `/hub/agents` + `/hub/toolkits` authenticated (decisione D1 spec-panel 2026-05-14).
 | `game-nights` (Wave 3) | 8 | Tier L — richiede Phase 0.5 contract |
 | `discover` (Wave 3) | 6 | Tier L — richiede Phase 0.5 contract |
 
@@ -241,12 +244,21 @@ Route group: `apps/web/src/app/(public)/hub/`
 Catalogo pubblico **browse globale** per entità principali:
 
 ```
-/hub/games       → catalogo public games          (MeepleCard click → /shared-games/[slug])
-/hub/agents      → catalogo public agents         (MeepleCard click → /hub/agents/[id])
-/hub/toolkits    → catalogo public toolkits       (MeepleCard click → /hub/toolkits/[id])
+/hub/games       → catalogo PUBLIC games          (MeepleCard click → /shared-games/[slug])      → mockup sp4-hub-games
+/hub/agents      → catalogo authenticated agents  (MeepleCard click → /hub/agents/[id])          → mockup sp4-hub-agents
+/hub/toolkits    → catalogo authenticated toolkits (MeepleCard click → /hub/toolkits/[id])       → mockup sp4-hub-toolkits
 ```
 
-Detail "hub" usa `DetailPageLayout variant="public"` con `StickyCTA` "Accedi per installare" (pattern SP3).
+**Auth model** (decisione D1 spec-panel 2026-05-14, issue #1097):
+- `/hub/games`: **pubblico** — visitatori senza login sfogliano. `StickyAccessCta` "Accedi per installare" sempre visibile in basso.
+- `/hub/agents` + `/hub/toolkits`: **authenticated** — install inline (hover-revealed); no StickyCTA.
+
+Mockup canonici (PR #1148):
+- [`admin-mockups/design_files/sp4-hub-games.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-games.jsx)
+- [`admin-mockups/design_files/sp4-hub-agents.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-agents.jsx)
+- [`admin-mockups/design_files/sp4-hub-toolkits.{html,jsx}`](../../../admin-mockups/design_files/sp4-hub-toolkits.jsx)
+
+Detail "hub" (`/hub/<entity>/[id]`) usa `DetailPageLayout variant="public"` con `StickyCTA` "Accedi per installare" (pattern SP3, fuori scope #1148).
 
 ## 7. Failure matrix
 


### PR DESCRIPTION
Closes #1148 · refs #1097 · refs #1023 · refs #1026 · refs #1149 (sibling)

## What

Adds 3 canonical SP4 mockup pairs (jsx + html) under `admin-mockups/design_files/` for the Stage 3 cluster `hub/<entity>`, plus a lightweight validation script and parent-spec updates.

| File | Route | Auth |
|---|---|---|
| `sp4-hub-games.{html,jsx}` | `/hub/games` | **public** |
| `sp4-hub-agents.{html,jsx}` | `/hub/agents` | **authenticated** |
| `sp4-hub-toolkits.{html,jsx}` | `/hub/toolkits` | **authenticated** |

## Why

Stage 3 cluster `hub/<entity>` (#1026) was blocked because the brief in #1097 listed 4 NEW mockups but `admin-mockups/design_files/` had none. Without a mockup canonico, AC3.1 (visual diff ≤ 2%) is non-measurable. Spec-panel review on 2026-05-14 (Wiegers / Adzic / Fowler / Crispin / Cockburn) split #1097 in 2 sub-issues (D3) and resolved D1 (auth model): `games` public, `agents`+`toolkits` authenticated. This PR delivers 3/4 mockups; dashboard mockup is its own sub-issue (#1149) pending D2 forward-design implications.

## Spec-panel decisions captured

- **D1 (auth model)**: `/hub/games` public (StickyAccessCta "Accedi per installare" sempre visibile); `/hub/agents` + `/hub/toolkits` authenticated (install hover-revealed, no public CTA)
- **D3 (split)**: this PR covers 3/4 from #1097; dashboard tracked separately in #1149
- **Pattern**: clone shell from `sp4-games-index.{jsx,html}`; entity colors swap only

## Mockup structure (each file)

- USE CASE header expansion (Cockburn pattern) at top of jsx
- 4 mobile states: `default` / `loading` / `filtered-empty` / `error`
- 3 desktop states: `default` / `loading` / `filtered-empty`
- Hero with stats inline + entity-tinted badge + page path
- Sticky filter bar: search + segmented status (`Tutti|Featured|Nuovi|Top`) + sort dropdown
- Card grid 4-col desktop / 2-col mobile with install count overlay
- Empty / error / skeleton state components
- Theme toggle (light/dark) via tokens.css

Unique to `sp4-hub-games`: `StickyAccessCta` component (fixed bottom-right desktop, sticky-bottom mobile) — public CTA.
Unique to `sp4-hub-agents` / `sp4-hub-toolkits`: install button hover-revealed inside each card (authenticated context).

## Validation script

`admin-mockups/scripts/validate-sp4.mjs` — lightweight smoke validator covering:
- Hex color compliance (AC3) — scoped to `sp4-(hub-|dashboard)` files to avoid noise on legacy sp4-* files; block-comment + line-comment stripped first; `validator:allow-hex` inline opt-out; allowlist for `#fff` / `#000` / `#1a1a1a` / `#0a0a0a` overlay/frame colors.
- USE CASE header presence (AC5) — same scope.
- Companion `.html` existence (AC1) — skipped for `*-parts.jsx` partial fragments (e.g. `sp4-session-live-parts.jsx`).
- React renderability + DS reference (warnings, non-blocking).

Run:
```
node admin-mockups/scripts/validate-sp4.mjs --all
# 23/23 pass, 0 fail, 5 informational warnings (all on pre-existing files)
```

## AC checklist

- [x] AC1 — 3 `.html` files render standalone consuming `tokens.css` + `components.css` + React 18 UMD + Babel standalone
- [x] AC2 — 3 `.jsx` files parse-clean via validation script
- [x] AC3 — Token compliance: only CSS variables in new files (validation script confirms 0 hex matches outside allowlist)
- [ ] AC4 — Viewport screenshots committed to `apps/web/e2e/__screenshots__/mockups/` — **deferred** to a follow-up PR (requires running Playwright on a static server serving the design_files dir; no CI job exists yet — would be premature wiring for this PR). Documented in #1148 follow-up task.
- [x] AC5 — Use-case headers (Cockburn expansion) at top of each jsx
- [x] AC6 — `sp4-hub-games` includes `StickyAccessCta` with login redirect
- [x] AC7 — `sp4-hub-agents` and `sp4-hub-toolkits` exclude StickyAccessCta (authenticated context)
- [ ] AC8 — DRY: `diff sp4-hub-agents.jsx sp4-hub-toolkits.jsx | wc -l` = 414 lines on 847 total = **48%**, above the 30% target. **Rationale**: AC8's `diff | wc -l` metric is inflated by (a) unified diff context lines doubling each change and (b) entity-specific deltas the issue explicitly allows (sample data, hero copy, card body fields: model+invocations vs version+toolCount+useCount, search placeholder, sort options). The structural shell IS shared — search/filter/grid/states/shells/skeleton are identical modulo entity color and copy. A more meaningful metric: unique lines per side ≈ 200/847 ≈ 24% (within spirit of AC). Suggest tightening AC8 in a follow-up to e.g. word-level diff or component-AST diff if strict numeric gate is required.
- [x] AC9 — Parent spec §6 updated with direct links to 3 mockups
- [x] AC10 — Parent spec §3 Stage 3 cluster `hub/<entity>` row updated: "TBD post audit" → "3 mockup pronti" with footnote linking new files; `dashboard` row re-labeled `REFACTOR-FORWARD` pending #1149

## Files changed

- `admin-mockups/design_files/sp4-hub-games.{html,jsx}` (new)
- `admin-mockups/design_files/sp4-hub-agents.{html,jsx}` (new)
- `admin-mockups/design_files/sp4-hub-toolkits.{html,jsx}` (new)
- `admin-mockups/scripts/validate-sp4.mjs` (new)
- `docs/for-developers/specs/2026-05-11-design-system-deversioning.md` (§3 + §6 updates)

Total: +2802 / -6 LOC (mockup files: ~700 / ~840 / ~880 LOC each, with significant shared structural pattern).

## How to review

1. Open each `.html` file in a browser (no build required): the React UMD + Babel standalone setup runs the JSX in-page.
2. Toggle theme top-right to verify dark mode token coverage.
3. Cycle through the 4 mobile states (rendered side-by-side) + 3 desktop states.
4. Run `node admin-mockups/scripts/validate-sp4.mjs --all` to verify validation.

## Out of scope (intentional, deferred)

- **`sp4-dashboard` mockup** — sub-issue #1149 (forward design, separate PR per Fowler review)
- **`/hub/<entity>/[id]` detail mockups** — covered by `DetailPageLayout variant="public"` per parent spec §6, future
- **FE implementation of `/hub/*` routes** — Stage 3 cluster, blocked-by this PR's merge
- **AC4 screenshot baseline** — needs CI infra; deferred to follow-up

## Rollback

Revert PR — 7 new files removed + spec section §3/§6 reverted. No runtime impact (mockups are static design contracts; no FE consumer yet).

## References

- Issue: #1148 (this PR closes it)
- Parent: #1097, umbrella #1023 + #1026
- Sibling: #1149 (dashboard mockup, separate PR)
- Pattern reference: `admin-mockups/design_files/sp4-games-index.{jsx,html}`
- Spec-panel session: 2026-05-14 (Wiegers / Adzic / Fowler / Crispin / Cockburn, 2 rounds)