### PR TITLE
fix(sessions): use raw template for scoreOverflowTemplate [closes #1155]

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx
@@ -188,9 +188,14 @@ export function SessionsLibraryView(): ReactElement {
   const gridCardLabels = useMemo<SessionCardGridLabels>(
     () => ({
       ...cardLabels,
-      scoreOverflowTemplate: t('pages.sessions.card.scoreOverflowTemplate'),
+      // Raw template (not t()) — formatted at render time by SessionCardGrid →
+      // ScoringInline when the overflow count is known. Eager t() on a template
+      // with `{count}` placeholder raises FORMAT_ERROR when no value is provided
+      // (see #1155). Pattern matches playerCountTemplate / turnTemplate / openAriaTemplate above.
+      scoreOverflowTemplate:
+        (intl.messages['pages.sessions.card.scoreOverflowTemplate'] as string) ?? '+{count} altri',
     }),
-    [cardLabels, t]
+    [cardLabels, intl.messages]
   );
 
   const emptyLabels = useMemo<EmptySessionsLabels>(


### PR DESCRIPTION
Closes #1155

## Bug

`apps/web/src/app/(authenticated)/sessions/_components/SessionsLibraryView.tsx:191` calls:

```tsx
scoreOverflowTemplate: t('pages.sessions.card.scoreOverflowTemplate'),
```

The translation value is a template string `'+{count} altri'` containing a `{count}` placeholder. react-intl's `t()` eagerly formats the message — when no `{count}` runtime value is provided, it raises `FORMAT_ERROR`.

## How the bug stayed hidden

The unit test `SessionsLibraryView.test.tsx` mocked `react-intl` with a curated `MESSAGES` dict that **omitted** the `scoreOverflowTemplate` key. react-intl silently fell back to the message ID, masking the format error. The bug was introduced in PR #736 (Wave D.1).

PRs #1151 / #1153 regenerated `state-matrix.json` (under `apps/web/`), triggering the frontend test path filter. Adding the missing key to MESSAGES (commits `771e99a25`, `c1a309575`) flipped the failure mode from `MISSING_TRANSLATION` to `FORMAT_ERROR` — different symptom, same underlying bug. Both PRs admin-merged with this issue as compensating control.

## Fix

Switch to raw-template pattern via `intl.messages[...] as string`, matching the existing pattern in the same `useMemo` block:

```tsx
// Same useMemo, lines 175-182 — already use this pattern:
playerCountTemplate:
  (intl.messages['pages.sessions.card.playerCount'] as string) ?? '{count} giocatori',
turnTemplate: (intl.messages['pages.sessions.card.turnLabel'] as string) ?? 'Turno {turn}',
openSessionAriaTemplate:
  (intl.messages['pages.sessions.card.openAriaLabel'] as string) ?? 'Apri sessione {gameName}',
```

Now `scoreOverflowTemplate` follows the same shape. The template is formatted at render time by `SessionCardGrid` → `ScoringInline` when the overflow count is actually known.

```diff
   const gridCardLabels = useMemo<SessionCardGridLabels>(
     () => ({
       ...cardLabels,
-      scoreOverflowTemplate: t('pages.sessions.card.scoreOverflowTemplate'),
+      // Raw template (not t()) — formatted at render time by SessionCardGrid →
+      // ScoringInline when the overflow count is known. Eager t() on a template
+      // with `{count}` placeholder raises FORMAT_ERROR when no value is provided
+      // (see #1155). Pattern matches playerCountTemplate / turnTemplate / openAriaTemplate above.
+      scoreOverflowTemplate:
+        (intl.messages['pages.sessions.card.scoreOverflowTemplate'] as string) ??
+        '+{count} altri',
     }),
-    [cardLabels, t]
+    [cardLabels, intl.messages]
   );
```

## Verification

```
$ cd apps/web && pnpm test --run SessionsLibraryView
# Test Files  1 passed (1)
#      Tests  23 passed (23)
#   Duration  11.33s
```

No `MissingTranslationError`, no `MessageFormatError` in stderr.

## Why option B (raw template) over option A (lazy format)

Spec-panel review (2026-05-14) chose option B for consistency with the existing pattern in the same `useMemo` block (3 sibling templates already use raw-template via `intl.messages[]`). Option A (lazy format at consumer site) would require modifying `SessionCardGrid`'s interface — significantly more invasive for the same behavioral outcome.

## Out of scope

- Audit other components for the same bug pattern (only this one was flagged in CI; defer broader sweep to dedicated lint rule)
- Refactor `useMemo` to reduce duplication of the `intl.messages[...] as string ?? fallback` pattern (3 occurrences in same block — could become a helper, deferred)

## References

- Issue: #1155 (this PR closes it)
- Bug origin: PR #736 (Wave D.1 brownfield migration)
- Surface PRs: #1151 / #1153 (Pre-Stage-3 mockups, state-matrix.json triggered frontend tests)
- Compensating control: admin-merge of #1151 / #1153 with this issue as tracked tech-debt