### PR TITLE
fix(ci): raise backend-fast timeout 5→8 min [closes #1161]

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -163,7 +163,13 @@ jobs:
   backend-fast:
     name: Backend Fast (build + unit)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Issue #1161: raised from 5 → 8 minutes. The Release `dotnet build` step
+    # alone takes ~4min on ubuntu-latest runners (confirmed on PR #1156 cancels);
+    # combined with setup (~30s) and the test step (~30s) the 5-min budget
+    # leaves no headroom and the job is cancelled mid-test. 8 min gives a ~3min
+    # safety buffer. If observed wall-clock sustains > 6 min, revisit and
+    # consider splitting build + test into separate jobs (issue #1161 option b).
+    timeout-minutes: 8
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     steps:


### PR DESCRIPTION
Closes #1161

## What

Bumps `backend-fast` job timeout in `.github/workflows/dev-fast.yml` from **5 → 8 min** with inline rationale comment.

## Why

Release `dotnet build` alone takes ~4 min on ubuntu-latest runners. Combined with backend setup (~30s) and the unit test step (~30s), the 5-min budget left zero headroom and the job was cancelled mid-test on **PR #1156** (issue #1144 toolkit-detail BE) — forcing admin-merge as compensating control.

Spec-panel option (a) per #1161 AC: minimal change, preserves single-job architecture; option (b) split build+test into 2 jobs is the natural next step if 8 min proves insufficient (trigger documented in the inline comment).

## Diff

```diff
   backend-fast:
     name: Backend Fast (build + unit)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Issue #1161: raised from 5 → 8 minutes. The Release `dotnet build` step
+    # alone takes ~4min on ubuntu-latest runners (confirmed on PR #1156 cancels);
+    # combined with setup (~30s) and the test step (~30s) the 5-min budget
+    # leaves no headroom and the job is cancelled mid-test. 8 min gives a ~3min
+    # safety buffer. If observed wall-clock sustains > 6 min, revisit and
+    # consider splitting build + test into separate jobs (issue #1161 option b).
+    timeout-minutes: 8
```

## AC

- [x] Option (a) selected: raise `timeout-minutes` to 8 with rationale comment in the workflow file
- [ ] AC1 (3 consecutive backend-touching runs on main-dev without cancel) — **validated post-merge** via #1144 toolkit-detail BE + future BE PRs (#819 / #822). Will close #1161 after observation streak.

## Out of scope

- Build perf optimisation (.csproj graph) — separate effort
- Cache hit diagnostics (option c) — observe first, then decide
- Split-jobs refactor (option b) — only if 8 min proves insufficient

## Rollback

Revert PR — timeout returns to 5 min. Pre-existing problem reappears but no new risk introduced.

## References

- Issue: #1161
- Victim PR: #1156 (issue #1144) — 2 consecutive cancels at 4-min mark
- Workflow: `.github/workflows/dev-fast.yml` (backend-fast job)