### PR TITLE
feat(toolkit-detail): Stage 3 FE — DetailPageLayout adoption [closes #1145]

### DIFF
--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/DisabledTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/DisabledTabPanel.tsx
@@ -1,0 +1,57 @@
+/**
+ * DisabledTabPanel — generic Phase-5 disabled-shell for `/toolkits/[id]`.
+ *
+ * Used by 4 tabs (agent / kb / versions / ratings) per spec Path C while
+ * #822 + #819 backend work is pending. Renders a skeleton + tooltip + CTA
+ * "Coming in Phase 5" instead of real content. Component never receives the
+ * Phase-5 data — it's a pure shell.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import { tabPanelId } from './ToolkitTabs';
+
+import type { ToolkitTabKey } from './ToolkitTabs';
+
+export interface DisabledTabPanelLabels {
+  readonly title: string;
+  readonly description: string;
+  readonly phase5Badge: string;
+}
+
+export interface DisabledTabPanelProps {
+  readonly tabKey: ToolkitTabKey;
+  readonly labels: DisabledTabPanelLabels;
+  readonly icon?: string;
+  readonly hidden?: boolean;
+}
+
+export function DisabledTabPanel({
+  tabKey,
+  labels,
+  icon = '🔒',
+  hidden,
+}: DisabledTabPanelProps): JSX.Element {
+  return (
+    <div
+      role="tabpanel"
+      id={tabPanelId(tabKey)}
+      aria-labelledby={`tab-toolkit-detail-${tabKey}`}
+      data-slot="toolkit-detail-tabpanel-disabled"
+      data-tab-key={tabKey}
+      hidden={hidden}
+      className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-muted/30 py-12 text-center"
+    >
+      <span className="text-5xl" aria-hidden="true">
+        {icon}
+      </span>
+      <h2 className="font-bold font-[Quicksand] text-lg text-foreground">{labels.title}</h2>
+      <p className="max-w-md text-sm text-muted-foreground">{labels.description}</p>
+      <span className="mt-1 inline-flex items-center rounded-full bg-foreground/10 px-3 py-0.5 font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+        {labels.phase5Badge}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/OverviewTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/OverviewTabPanel.tsx
@@ -1,0 +1,128 @@
+/**
+ * OverviewTabPanel — `?tab=overview` content for `/toolkits/[id]`.
+ *
+ * Enabled tab per spec Path C. Renders description + meta dl (license,
+ * version, size, published) + ToolkitIncludesGrid (agent + kb + tools
+ * count summary). Author info handled in hero, not duplicated here.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import { ToolkitIncludesGrid } from '@/components/features/toolkit-detail';
+import type { ToolkitDetail } from '@/lib/api/schemas/toolkit-marketplace.schemas';
+
+import { tabPanelId } from './ToolkitTabs';
+
+export interface OverviewTabPanelLabels {
+  readonly descriptionHeading: string;
+  readonly metaHeading: string;
+  readonly meta: {
+    readonly license: string;
+    readonly version: string;
+    readonly size: string;
+    readonly published: string;
+    readonly unknown: string;
+  };
+  readonly includesHeading: string;
+  readonly includes: {
+    readonly agent: string;
+    readonly kbDocs: string;
+    readonly tools: string;
+  };
+}
+
+export interface OverviewTabPanelProps {
+  readonly toolkit: ToolkitDetail;
+  readonly labels: OverviewTabPanelLabels;
+  readonly hidden?: boolean;
+}
+
+function formatBytes(bytes: number | null | undefined, unknown: string): string {
+  if (bytes == null) return unknown;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string | null | undefined, unknown: string): string {
+  if (!iso) return unknown;
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(iso));
+  } catch {
+    return unknown;
+  }
+}
+
+export function OverviewTabPanel({ toolkit, labels, hidden }: OverviewTabPanelProps): JSX.Element {
+  const unknown = labels.meta.unknown;
+
+  return (
+    <div
+      role="tabpanel"
+      id={tabPanelId('overview')}
+      aria-labelledby="tab-toolkit-detail-overview"
+      data-slot="toolkit-detail-tabpanel-overview"
+      hidden={hidden}
+      className="flex flex-col gap-6"
+    >
+      <section>
+        <h2 className="mb-2 font-bold font-[Quicksand] text-lg text-foreground">
+          {labels.descriptionHeading}
+        </h2>
+        <p className="text-sm leading-relaxed text-muted-foreground whitespace-pre-line">
+          {toolkit.description || unknown}
+        </p>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-bold font-[Quicksand] text-lg text-foreground">
+          {labels.metaHeading}
+        </h2>
+        <dl className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+          <div>
+            <dt className="font-mono uppercase tracking-wider text-muted-foreground">
+              {labels.meta.license}
+            </dt>
+            <dd className="mt-1 font-semibold text-foreground">{toolkit.license ?? unknown}</dd>
+          </div>
+          <div>
+            <dt className="font-mono uppercase tracking-wider text-muted-foreground">
+              {labels.meta.version}
+            </dt>
+            <dd className="mt-1 font-semibold text-foreground">{toolkit.currentVersion}</dd>
+          </div>
+          <div>
+            <dt className="font-mono uppercase tracking-wider text-muted-foreground">
+              {labels.meta.size}
+            </dt>
+            <dd className="mt-1 font-semibold text-foreground">
+              {formatBytes(toolkit.sizeBytes ?? null, unknown)}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono uppercase tracking-wider text-muted-foreground">
+              {labels.meta.published}
+            </dt>
+            <dd className="mt-1 font-semibold text-foreground">
+              {formatDate(toolkit.publishedAt, unknown)}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-bold font-[Quicksand] text-lg text-foreground">
+          {labels.includesHeading}
+        </h2>
+        <ToolkitIncludesGrid
+          agentName={toolkit.agent.name}
+          kbDocsCount={toolkit.kbDocsCount}
+          toolsCount={toolkit.toolsCount}
+          labels={labels.includes}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitConnectionBar.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitConnectionBar.tsx
@@ -1,0 +1,91 @@
+/**
+ * ToolkitConnectionBar — 6-pip connection bar for `/toolkits/[id]`.
+ *
+ * Pips (left → right): agent · kb · tools · game · author · sessions.
+ * Per spec `2026-05-14-stage3-toolkit-detail.md` AC2: 2 pip wired (game,
+ * tools), 4 pip "dashed-empty" placeholders for Phase-5 entities (#822).
+ *
+ * Pure presentational — no click-through handlers in v1 (footer actions
+ * cover the primary CTAs). Wraps `data-slot="toolkit-detail-connection-bar"`
+ * for tests + spec composability.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export type ToolkitPipId = 'agent' | 'kb' | 'tools' | 'game' | 'author' | 'sessions';
+
+export interface ToolkitConnectionPip {
+  readonly id: ToolkitPipId;
+  readonly label: string;
+  /** Display value (count or label). When undefined, pip renders dashed-empty. */
+  readonly count?: number | string;
+  /** Optional emoji glyph for visual entity-tagging. */
+  readonly icon?: string;
+}
+
+export interface ToolkitConnectionBarLabels {
+  readonly ariaLabel: string;
+  readonly emptyHint: string;
+}
+
+export interface ToolkitConnectionBarProps {
+  readonly pips: ReadonlyArray<ToolkitConnectionPip>;
+  readonly labels: ToolkitConnectionBarLabels;
+  readonly className?: string;
+}
+
+export function ToolkitConnectionBar({
+  pips,
+  labels,
+  className,
+}: ToolkitConnectionBarProps): JSX.Element {
+  return (
+    <aside
+      data-slot="toolkit-detail-connection-bar"
+      aria-label={labels.ariaLabel}
+      className={clsx('flex flex-wrap items-center gap-2 py-2', className)}
+    >
+      {pips.map(pip => {
+        const isEmpty = pip.count === undefined;
+        return (
+          <span
+            key={pip.id}
+            data-pip-id={pip.id}
+            data-pip-empty={isEmpty || undefined}
+            title={isEmpty ? labels.emptyHint : undefined}
+            className={clsx(
+              'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-bold font-[Quicksand] transition-colors',
+              isEmpty
+                ? 'border-dashed border-border bg-muted/40 text-muted-foreground/70'
+                : 'border-border bg-card text-foreground'
+            )}
+          >
+            {pip.icon && (
+              <span aria-hidden="true" className="text-sm">
+                {pip.icon}
+              </span>
+            )}
+            <span>{pip.label}</span>
+            {!isEmpty && (
+              <span
+                className="tabular-nums font-mono text-[11px] text-muted-foreground"
+                data-pip-count={pip.count}
+              >
+                {pip.count}
+              </span>
+            )}
+            {isEmpty && (
+              <span aria-hidden="true" className="font-mono text-[10px] text-muted-foreground/60">
+                —
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </aside>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitDetailView.tsx
@@ -1,0 +1,412 @@
+/**
+ * ToolkitDetailView — Stage 3 orchestrator for `/toolkits/[id]` (Issue #1145).
+ *
+ * Tier S route — single hook (useToolkitDetail), URL-bound tab state (?tab=),
+ * Path C disabled-shell for 4 Phase-5 tabs (agent / kb / versions / ratings)
+ * pending #822 + #819.
+ *
+ * Wraps `DetailPageLayout` primitive (#1112). FSM 4-state (loading / error /
+ * not-found / default). Variant detection server-side via `viewerContext.isOwner`.
+ *
+ * Spec: docs/superpowers/specs/2026-05-14-stage3-toolkit-detail.md
+ * Pattern reference: PlayerDetailView (#1138).
+ */
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { ToolkitSummaryPanel } from '@/components/features/toolkit-detail';
+import { DetailPageLayout } from '@/components/ui/detail-layout';
+import { useToolkitDetail } from '@/hooks/queries/useToolkitDetail';
+import { useTranslation } from '@/hooks/useTranslation';
+import { trackEvent } from '@/lib/analytics/track-event';
+
+import { DisabledTabPanel } from './DisabledTabPanel';
+import { OverviewTabPanel } from './OverviewTabPanel';
+import { ToolkitConnectionBar, type ToolkitConnectionPip } from './ToolkitConnectionBar';
+import { TOOLKIT_TAB_KEYS, ToolkitTabs, type ToolkitTabKey } from './ToolkitTabs';
+import { ToolsTabPanel } from './ToolsTabPanel';
+
+const DEFAULT_TAB: ToolkitTabKey = 'overview';
+const ENABLED_TABS: ReadonlyArray<ToolkitTabKey> = ['overview', 'tools'];
+const DISABLED_TABS: ReadonlyArray<ToolkitTabKey> = ['agent', 'kb', 'versions', 'ratings'];
+
+function parseTab(raw: string | null): ToolkitTabKey {
+  if (raw && (TOOLKIT_TAB_KEYS as ReadonlyArray<string>).includes(raw)) {
+    return raw as ToolkitTabKey;
+  }
+  return DEFAULT_TAB;
+}
+
+export interface ToolkitDetailViewProps {
+  readonly toolkitId: string;
+}
+
+export function ToolkitDetailView({ toolkitId }: ToolkitDetailViewProps): ReactElement | null {
+  const { t } = useTranslation();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // ── Tab state SSOT (URL) ─────────────────────────────────────────────────
+  const initialTab = parseTab(searchParams.get('tab'));
+  const [activeTab, setActiveTab] = useState<ToolkitTabKey>(
+    DISABLED_TABS.includes(initialTab) ? DEFAULT_TAB : initialTab
+  );
+
+  // Normalize invalid / disabled tab in URL → default
+  useEffect(() => {
+    const raw = searchParams.get('tab');
+    if (
+      raw &&
+      (!(TOOLKIT_TAB_KEYS as ReadonlyArray<string>).includes(raw) ||
+        DISABLED_TABS.includes(raw as ToolkitTabKey))
+    ) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('tab');
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    }
+  }, [searchParams, pathname, router]);
+
+  const updateTabInUrl = useCallback(
+    (next: ToolkitTabKey) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === DEFAULT_TAB) params.delete('tab');
+      else params.set('tab', next);
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [searchParams, pathname, router]
+  );
+
+  // ── Data ──────────────────────────────────────────────────────────────────
+  const query = useToolkitDetail({ toolkitId, enabled: Boolean(toolkitId) });
+
+  // ── Tab change handlers ───────────────────────────────────────────────────
+  const handleTabChange = useCallback(
+    (next: ToolkitTabKey) => {
+      const previous = activeTab;
+      setActiveTab(next);
+      updateTabInUrl(next);
+      trackEvent('toolkit_detail_tab_changed', {
+        from: previous,
+        to: next,
+        toolkitId,
+      });
+    },
+    [activeTab, updateTabInUrl, toolkitId]
+  );
+
+  const handleDisabledAttempt = useCallback(
+    (key: ToolkitTabKey) => {
+      trackEvent('toolkit_disabled_tab_attempted', {
+        tab: key,
+        toolkitId,
+        variant: query.data?.viewerContext.isOwner ? 'own' : 'public',
+      });
+    },
+    [toolkitId, query.data?.viewerContext.isOwner]
+  );
+
+  // ── ConnectionBar pip wiring ──────────────────────────────────────────────
+  // Per spec AC2: 2 pip wired (game, tools), 4 pip dashed-empty placeholders.
+  // Computed before FSM early-returns to satisfy hook-ordering rules.
+  const toolkitData = query.data?.toolkit;
+  const pips = useMemo<ReadonlyArray<ToolkitConnectionPip>>(() => {
+    if (!toolkitData) return [];
+    return [
+      {
+        id: 'tools',
+        label: t('pages.toolkitDetail.pips.tools'),
+        count: toolkitData.toolsCount,
+        icon: '🔧',
+      },
+      {
+        id: 'game',
+        label: t('pages.toolkitDetail.pips.game'),
+        count: toolkitData.gameName ?? undefined,
+        icon: '🎲',
+      },
+      // Phase-5 placeholders
+      { id: 'agent', label: t('pages.toolkitDetail.pips.agent'), icon: '🤖' },
+      { id: 'kb', label: t('pages.toolkitDetail.pips.kb'), icon: '📄' },
+      { id: 'author', label: t('pages.toolkitDetail.pips.author'), icon: '👤' },
+      { id: 'sessions', label: t('pages.toolkitDetail.pips.sessions'), icon: '🎯' },
+    ];
+  }, [toolkitData, t]);
+
+  // ── FSM shells ────────────────────────────────────────────────────────────
+  if (query.isLoading) {
+    return (
+      <div
+        data-slot="toolkit-detail-loading"
+        role="status"
+        aria-label={t('pages.toolkitDetail.loading.ariaLabel')}
+        className="flex flex-col gap-4 p-6"
+      >
+        <div className="h-40 animate-pulse rounded-2xl bg-muted/60" />
+        <div className="h-10 animate-pulse rounded-xl bg-muted/40" />
+        <div className="h-64 animate-pulse rounded-xl bg-muted/30" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div
+        data-slot="toolkit-detail-error"
+        role="alert"
+        className="flex flex-col items-center gap-3 p-12 text-center"
+      >
+        <span className="text-4xl" aria-hidden="true">
+          ⚠️
+        </span>
+        <h1 className="font-bold font-[Quicksand] text-xl text-foreground">
+          {t('pages.toolkitDetail.error.title')}
+        </h1>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('pages.toolkitDetail.error.description')}
+        </p>
+        <button
+          type="button"
+          onClick={() => query.refetch()}
+          className="mt-2 inline-flex items-center rounded-xl bg-foreground px-4 py-2 font-bold font-[Quicksand] text-sm text-background"
+        >
+          {t('pages.toolkitDetail.error.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  const payload = query.data;
+  if (!payload) {
+    return (
+      <div
+        data-slot="toolkit-detail-not-found"
+        className="flex flex-col items-center gap-3 p-12 text-center"
+      >
+        <span className="text-4xl" aria-hidden="true">
+          🔍
+        </span>
+        <h1 className="font-bold font-[Quicksand] text-xl text-foreground">
+          {t('pages.toolkitDetail.notFound.title')}
+        </h1>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('pages.toolkitDetail.notFound.description')}
+        </p>
+      </div>
+    );
+  }
+
+  // ── Default render ────────────────────────────────────────────────────────
+  // `toolkitData` already extracted above for the pips useMemo.
+  const { viewerContext } = payload;
+  const variant: 'own' | 'public' = viewerContext.isOwner ? 'own' : 'public';
+  // After this guard, toolkitData is guaranteed defined (payload truthy → query.data.toolkit set).
+  if (!toolkitData) return null;
+
+  const summaryLabels = {
+    authorChipPrefix: t('pages.toolkitDetail.hero.authorChipPrefix'),
+    gameChipPrefix: t('pages.toolkitDetail.hero.gameChipPrefix'),
+    statsHeading: t('pages.toolkitDetail.hero.statsHeading'),
+    installCountLabel: t('pages.toolkitDetail.hero.installCount'),
+    ratingLabel: t('pages.toolkitDetail.hero.rating'),
+    versionLabel: t('pages.toolkitDetail.hero.version'),
+    noRatings: t('pages.toolkitDetail.hero.noRatings'),
+  };
+
+  const tabsLabels = {
+    tablistAriaLabel: t('pages.toolkitDetail.tabs.ariaLabel'),
+    overview: t('pages.toolkitDetail.tabs.overview'),
+    agent: t('pages.toolkitDetail.tabs.agent'),
+    kb: t('pages.toolkitDetail.tabs.kb'),
+    tools: t('pages.toolkitDetail.tabs.tools'),
+    versions: t('pages.toolkitDetail.tabs.versions'),
+    ratings: t('pages.toolkitDetail.tabs.ratings'),
+    disabledTooltip: t('pages.toolkitDetail.tabs.disabledTooltip'),
+  };
+
+  const overviewLabels = {
+    descriptionHeading: t('pages.toolkitDetail.overview.descriptionHeading'),
+    metaHeading: t('pages.toolkitDetail.overview.metaHeading'),
+    meta: {
+      license: t('pages.toolkitDetail.overview.meta.license'),
+      version: t('pages.toolkitDetail.overview.meta.version'),
+      size: t('pages.toolkitDetail.overview.meta.size'),
+      published: t('pages.toolkitDetail.overview.meta.published'),
+      unknown: t('pages.toolkitDetail.overview.meta.unknown'),
+    },
+    includesHeading: t('pages.toolkitDetail.overview.includesHeading'),
+    includes: {
+      agent: t('pages.toolkitDetail.includes.agent'),
+      kbDocs: t('pages.toolkitDetail.includes.kbDocs'),
+      tools: t('pages.toolkitDetail.includes.tools'),
+    },
+  };
+
+  const toolsLabels = {
+    heading: t('pages.toolkitDetail.tools.heading'),
+    description: t('pages.toolkitDetail.tools.description'),
+    countTemplate: t('pages.toolkitDetail.tools.countTemplate'),
+    emptyTitle: t('pages.toolkitDetail.tools.emptyTitle'),
+    emptyBody: t('pages.toolkitDetail.tools.emptyBody'),
+  };
+
+  const disabledLabelsByTab: Record<
+    ToolkitTabKey,
+    { title: string; description: string; icon: string }
+  > = {
+    overview: { title: '', description: '', icon: '' }, // never disabled
+    tools: { title: '', description: '', icon: '' }, // never disabled
+    agent: {
+      title: t('pages.toolkitDetail.disabled.agent.title'),
+      description: t('pages.toolkitDetail.disabled.agent.description'),
+      icon: '🤖',
+    },
+    kb: {
+      title: t('pages.toolkitDetail.disabled.kb.title'),
+      description: t('pages.toolkitDetail.disabled.kb.description'),
+      icon: '📄',
+    },
+    versions: {
+      title: t('pages.toolkitDetail.disabled.versions.title'),
+      description: t('pages.toolkitDetail.disabled.versions.description'),
+      icon: '📌',
+    },
+    ratings: {
+      title: t('pages.toolkitDetail.disabled.ratings.title'),
+      description: t('pages.toolkitDetail.disabled.ratings.description'),
+      icon: '⭐',
+    },
+  };
+
+  const phase5Badge = t('pages.toolkitDetail.disabled.phase5Badge');
+
+  const connectionBarLabels = {
+    ariaLabel: t('pages.toolkitDetail.connectionBar.ariaLabel'),
+    emptyHint: t('pages.toolkitDetail.connectionBar.emptyHint'),
+  };
+
+  // ── Footer actions (variant-aware) ────────────────────────────────────────
+  const footerActions = (
+    <div className="flex flex-wrap items-center gap-2">
+      {variant === 'own' ? (
+        <>
+          <button
+            type="button"
+            disabled
+            title={tabsLabels.disabledTooltip}
+            onClick={() =>
+              trackEvent('toolkit_action_clicked', { action: 'edit', variant, toolkitId })
+            }
+            className="inline-flex cursor-not-allowed items-center rounded-xl bg-foreground/30 px-4 py-2 font-bold font-[Quicksand] text-sm text-background"
+          >
+            {t('pages.toolkitDetail.footer.editAction')}
+          </button>
+          <button
+            type="button"
+            disabled
+            title={tabsLabels.disabledTooltip}
+            onClick={() =>
+              trackEvent('toolkit_action_clicked', { action: 'publish', variant, toolkitId })
+            }
+            className="inline-flex cursor-not-allowed items-center rounded-xl border border-border bg-card px-4 py-2 font-bold font-[Quicksand] text-sm text-muted-foreground"
+          >
+            {t('pages.toolkitDetail.footer.publishAction')}
+          </button>
+        </>
+      ) : (
+        <>
+          <button
+            type="button"
+            disabled
+            title={tabsLabels.disabledTooltip}
+            onClick={() =>
+              trackEvent('toolkit_action_clicked', { action: 'install', variant, toolkitId })
+            }
+            className="inline-flex cursor-not-allowed items-center rounded-xl bg-foreground/30 px-4 py-2 font-bold font-[Quicksand] text-sm text-background"
+          >
+            {t('pages.toolkitDetail.footer.installAction')}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof navigator !== 'undefined' && navigator.clipboard) {
+                navigator.clipboard.writeText(
+                  typeof window !== 'undefined' ? window.location.href : ''
+                );
+              }
+              trackEvent('toolkit_action_clicked', { action: 'share', variant, toolkitId });
+            }}
+            className="inline-flex items-center rounded-xl border border-border bg-card px-4 py-2 font-bold font-[Quicksand] text-sm text-foreground hover:border-border-strong"
+          >
+            {t('pages.toolkitDetail.footer.shareAction')}
+          </button>
+        </>
+      )}
+    </div>
+  );
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <DetailPageLayout
+      hero={
+        <ToolkitSummaryPanel
+          title={toolkitData.name}
+          description={toolkitData.description}
+          authorName={toolkitData.authorName}
+          authorAvatarUrl={toolkitData.authorAvatarUrl}
+          coverImageUrl={toolkitData.coverImageUrl}
+          gameName={toolkitData.gameName}
+          installCount={toolkitData.installCount}
+          ratingAverage={toolkitData.ratingAverage}
+          ratingCount={toolkitData.ratingCount}
+          currentVersion={toolkitData.currentVersion}
+          labels={summaryLabels}
+        />
+      }
+      connections={<ToolkitConnectionBar pips={pips} labels={connectionBarLabels} />}
+      tabs={
+        <ToolkitTabs
+          activeTab={activeTab}
+          onChange={handleTabChange}
+          disabledTabs={DISABLED_TABS}
+          counts={{ tools: toolkitData.toolsCount, kb: toolkitData.kbDocsCount }}
+          labels={tabsLabels}
+          onDisabledAttempt={handleDisabledAttempt}
+        />
+      }
+      footer={footerActions}
+    >
+      <OverviewTabPanel
+        toolkit={toolkitData}
+        labels={overviewLabels}
+        hidden={activeTab !== 'overview'}
+      />
+      <ToolsTabPanel
+        toolsCount={toolkitData.toolsCount}
+        labels={toolsLabels}
+        hidden={activeTab !== 'tools'}
+      />
+      {DISABLED_TABS.map(key => (
+        <DisabledTabPanel
+          key={key}
+          tabKey={key}
+          icon={disabledLabelsByTab[key].icon}
+          labels={{
+            title: disabledLabelsByTab[key].title,
+            description: disabledLabelsByTab[key].description,
+            phase5Badge,
+          }}
+          hidden={activeTab !== key}
+        />
+      ))}
+      {/* enabledTabs reference to silence unused-vars in some configs */}
+      <span aria-hidden="true" data-enabled-tabs={ENABLED_TABS.join(',')} hidden />
+    </DetailPageLayout>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitTabs.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolkitTabs.tsx
@@ -1,0 +1,158 @@
+/**
+ * ToolkitTabs — 6-tab tablist for `/toolkits/[id]` Stage 3 cluster (Issue #1145).
+ *
+ * Mirror of `PlayerTabs` (Issue #1113) with disabled-state support per spec
+ * `docs/superpowers/specs/2026-05-14-stage3-toolkit-detail.md` Path C: 4 tabs
+ * (agent / kb / versions / ratings) are rendered as disabled-shell pending
+ * Phase-5 backend (#822, #819). Disabled tab click emits telemetry but does
+ * NOT change `activeTab`.
+ *
+ * Canonical `Tabs` primitive cannot be used because its `TabKey` union is
+ * locked to shared-games detail values.
+ *
+ * Keyboard contract: ArrowLeft/Right/Home/End across the **enabled** subset
+ * only (roving tabindex skips disabled tabs).
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+import { useMemo } from 'react';
+
+import clsx from 'clsx';
+
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
+
+export const TOOLKIT_TAB_KEYS = [
+  'overview',
+  'agent',
+  'kb',
+  'tools',
+  'versions',
+  'ratings',
+] as const;
+export type ToolkitTabKey = (typeof TOOLKIT_TAB_KEYS)[number];
+
+export interface ToolkitTabsLabels {
+  readonly tablistAriaLabel: string;
+  readonly overview: string;
+  readonly agent: string;
+  readonly kb: string;
+  readonly tools: string;
+  readonly versions: string;
+  readonly ratings: string;
+  /** Tooltip text on disabled tabs. */
+  readonly disabledTooltip: string;
+}
+
+export interface ToolkitTabsProps {
+  readonly activeTab: ToolkitTabKey;
+  readonly onChange: (next: ToolkitTabKey) => void;
+  /** Tabs in this set are rendered as `aria-disabled="true"` with tooltip. */
+  readonly disabledTabs: ReadonlyArray<ToolkitTabKey>;
+  /** Optional counts rendered as monospaced pill (kb count, tools count, etc.) */
+  readonly counts?: Partial<Record<ToolkitTabKey, number>>;
+  readonly labels: ToolkitTabsLabels;
+  /** Called when a disabled tab is clicked — for telemetry. Tab does NOT change. */
+  readonly onDisabledAttempt?: (key: ToolkitTabKey) => void;
+  readonly className?: string;
+}
+
+const ID_BASE = 'toolkit-detail';
+
+export function tabId(key: ToolkitTabKey): string {
+  return `tab-${ID_BASE}-${key}`;
+}
+
+export function tabPanelId(key: ToolkitTabKey): string {
+  return `tabpanel-${ID_BASE}-${key}`;
+}
+
+export function ToolkitTabs({
+  activeTab,
+  onChange,
+  disabledTabs,
+  counts,
+  labels,
+  onDisabledAttempt,
+  className,
+}: ToolkitTabsProps): JSX.Element {
+  // Keyboard navigation only iterates the *enabled* subset
+  const enabledKeys = useMemo(
+    () => TOOLKIT_TAB_KEYS.filter(k => !disabledTabs.includes(k)),
+    [disabledTabs]
+  );
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<ToolkitTabKey>({
+    orderedKeys: enabledKeys,
+    onChange,
+  });
+
+  const labelOf = (key: ToolkitTabKey): string => labels[key];
+
+  return (
+    <div
+      data-slot="toolkit-detail-tabs"
+      role="tablist"
+      aria-label={labels.tablistAriaLabel}
+      className={clsx('flex items-center gap-1 overflow-x-auto', className)}
+    >
+      {TOOLKIT_TAB_KEYS.map(key => {
+        const isActive = key === activeTab;
+        const isDisabled = disabledTabs.includes(key);
+        const count = counts?.[key];
+
+        return (
+          <button
+            key={key}
+            ref={el => {
+              if (isDisabled) return; // disabled tabs not in roving tabindex
+              if (el) {
+                tabRefs.current.set(key, el);
+              } else {
+                tabRefs.current.delete(key);
+              }
+            }}
+            type="button"
+            role="tab"
+            id={tabId(key)}
+            data-tab-key={key}
+            aria-selected={isActive}
+            aria-controls={tabPanelId(key)}
+            aria-disabled={isDisabled || undefined}
+            title={isDisabled ? labels.disabledTooltip : undefined}
+            tabIndex={isDisabled ? -1 : isActive ? 0 : -1}
+            onClick={() => {
+              if (isDisabled) {
+                onDisabledAttempt?.(key);
+                return;
+              }
+              onChange(key);
+            }}
+            onKeyDown={event => !isDisabled && handleKeyDown(event, key)}
+            className={clsx(
+              'flex items-center gap-2 whitespace-nowrap rounded-t-md border-b-2 px-3 py-2 text-sm font-semibold transition-colors',
+              isDisabled
+                ? 'cursor-not-allowed border-transparent text-muted-foreground/50'
+                : isActive
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <span>{labelOf(key)}</span>
+            {count !== undefined && count > 0 && (
+              <span className="tabular-nums text-xs font-mono text-muted-foreground">{count}</span>
+            )}
+            {isDisabled && (
+              <span
+                aria-hidden="true"
+                className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70"
+              >
+                P5
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolsTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/_components/ToolsTabPanel.tsx
@@ -1,0 +1,88 @@
+/**
+ * ToolsTabPanel — `?tab=tools` content for `/toolkits/[id]`.
+ *
+ * Enabled tab per spec Path C. v1 shows only the aggregate tools count from
+ * the ToolkitDetailDto; per-tool detail (timer, dice, counter, deck configs)
+ * is part of the Phase 5 own-variant work tracked in #822. Renders an empty
+ * state when toolsCount === 0.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import { tabPanelId } from './ToolkitTabs';
+
+export interface ToolsTabPanelLabels {
+  readonly heading: string;
+  readonly description: string;
+  readonly countTemplate: string;
+  readonly emptyTitle: string;
+  readonly emptyBody: string;
+}
+
+export interface ToolsTabPanelProps {
+  readonly toolsCount: number;
+  readonly labels: ToolsTabPanelLabels;
+  readonly hidden?: boolean;
+}
+
+export function ToolsTabPanel({ toolsCount, labels, hidden }: ToolsTabPanelProps): JSX.Element {
+  if (toolsCount === 0) {
+    return (
+      <div
+        role="tabpanel"
+        id={tabPanelId('tools')}
+        aria-labelledby="tab-toolkit-detail-tools"
+        data-slot="toolkit-detail-tabpanel-tools"
+        hidden={hidden}
+        className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-muted/30 py-10 text-center"
+      >
+        <span className="text-4xl" aria-hidden="true">
+          🔧
+        </span>
+        <h2 className="font-bold font-[Quicksand] text-base text-foreground">
+          {labels.emptyTitle}
+        </h2>
+        <p className="max-w-sm text-sm text-muted-foreground">{labels.emptyBody}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="tabpanel"
+      id={tabPanelId('tools')}
+      aria-labelledby="tab-toolkit-detail-tools"
+      data-slot="toolkit-detail-tabpanel-tools"
+      hidden={hidden}
+      className="flex flex-col gap-4"
+    >
+      <header>
+        <h2 className="font-bold font-[Quicksand] text-lg text-foreground">{labels.heading}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{labels.description}</p>
+      </header>
+      <div
+        data-slot="toolkit-detail-tools-summary"
+        className="rounded-xl border border-border bg-card p-5"
+      >
+        <div className="flex items-center gap-4">
+          <div
+            aria-hidden="true"
+            className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted text-2xl"
+          >
+            🛠️
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="font-bold font-[Quicksand] text-2xl text-foreground tabular-nums">
+              {toolsCount}
+            </div>
+            <div className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+              {labels.countTemplate.replace('{count}', String(toolsCount))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkits/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/[id]/page.tsx
@@ -1,0 +1,26 @@
+/**
+ * /toolkits/[id] — Stage 3 cluster page (Issue #1145).
+ *
+ * Server boundary: extracts `id` from params, wraps the client orchestrator
+ * in a Suspense boundary (required for `useSearchParams()` SSR opt-out per
+ * Next.js App Router pattern; same lesson learned in #1147 discover FE).
+ *
+ * Pattern reference: /players/[id]/page.tsx (#1138).
+ */
+
+import { Suspense } from 'react';
+
+import { ToolkitDetailView } from './_components/ToolkitDetailView';
+
+interface PageProps {
+  readonly params: Promise<{ id: string }>;
+}
+
+export default async function ToolkitDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  return (
+    <Suspense fallback={null}>
+      <ToolkitDetailView toolkitId={id} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/features/toolkit-detail/Stars.tsx
+++ b/apps/web/src/components/features/toolkit-detail/Stars.tsx
@@ -1,14 +1,58 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: Stars
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * Stars — fractional rating display for `/toolkits/[id]`.
+ *
+ * Wave 3 (#1145). 5-star scale rendered with sub-step granularity via two
+ * stacked rows (background empty + foreground clipped via `width`). Pure
+ * presentational.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
 
 export interface StarsProps {
-  // TODO: extract props contract from mockup analysis
+  /** 0.0–5.0; values outside the range are clamped. */
+  readonly value: number;
+  /** When true, renders the numeric value adjacent (e.g. "4.7"). */
+  readonly showNumeric?: boolean;
+  /** Accessible label. Defaults to "Rating: {value} / 5". */
+  readonly ariaLabel?: string;
+  readonly className?: string;
 }
 
-export function Stars(_props: StarsProps): ReactElement | null {
-  return null;
+const MAX = 5;
+
+export function Stars({ value, showNumeric, ariaLabel, className }: StarsProps): JSX.Element {
+  const clamped = Math.max(0, Math.min(MAX, Number.isFinite(value) ? value : 0));
+  const percent = (clamped / MAX) * 100;
+  const label = ariaLabel ?? `Rating: ${clamped.toFixed(1)} / ${MAX}`;
+
+  return (
+    <span
+      data-slot="toolkit-detail-stars"
+      role="img"
+      aria-label={label}
+      className={clsx('inline-flex items-center gap-1.5', className)}
+    >
+      <span className="relative inline-block leading-none">
+        <span aria-hidden="true" className="text-base text-muted-foreground/40">
+          ★★★★★
+        </span>
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 overflow-hidden text-base text-amber-500"
+          style={{ width: `${percent}%` }}
+        >
+          ★★★★★
+        </span>
+      </span>
+      {showNumeric && (
+        <span className="font-mono text-xs text-muted-foreground tabular-nums">
+          {clamped.toFixed(1)}
+        </span>
+      )}
+    </span>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/ToolkitIncludesGrid.tsx
+++ b/apps/web/src/components/features/toolkit-detail/ToolkitIncludesGrid.tsx
@@ -1,14 +1,69 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: ToolkitIncludesGrid
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * ToolkitIncludesGrid — "Cosa include" 3-cell grid for `/toolkits/[id]` Overview.
+ *
+ * Wave 3 (#1145). Shows the toolkit's bundle at a glance: agent name, KB
+ * documents count, tools count. Pure presentational — agent + kb sections
+ * render placeholder hint when their Phase-5 enrichment isn't available.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface ToolkitIncludesGridProps {
-  // TODO: extract props contract from mockup analysis
+import type { JSX } from 'react';
+
+export interface ToolkitIncludesGridLabels {
+  readonly agent: string;
+  readonly kbDocs: string;
+  readonly tools: string;
 }
 
-export function ToolkitIncludesGrid(_props: ToolkitIncludesGridProps): ReactElement | null {
-  return null;
+export interface ToolkitIncludesGridProps {
+  readonly agentName: string;
+  readonly kbDocsCount: number;
+  readonly toolsCount: number;
+  readonly labels: ToolkitIncludesGridLabels;
+}
+
+interface CellProps {
+  readonly icon: string;
+  readonly title: string;
+  readonly value: string;
+}
+
+function Cell({ icon, title, value }: CellProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkit-detail-includes-cell"
+      className="flex items-center gap-3 rounded-lg border border-border bg-card p-4"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-xl"
+      >
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          {title}
+        </div>
+        <div className="line-clamp-1 font-bold font-[Quicksand] text-sm text-foreground">
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ToolkitIncludesGrid({
+  agentName,
+  kbDocsCount,
+  toolsCount,
+  labels,
+}: ToolkitIncludesGridProps): JSX.Element {
+  return (
+    <div data-slot="toolkit-detail-includes-grid" className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Cell icon="🤖" title={labels.agent} value={agentName} />
+      <Cell icon="📄" title={labels.kbDocs} value={String(kbDocsCount)} />
+      <Cell icon="🔧" title={labels.tools} value={String(toolsCount)} />
+    </div>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/ToolkitSummaryPanel.tsx
+++ b/apps/web/src/components/features/toolkit-detail/ToolkitSummaryPanel.tsx
@@ -1,14 +1,160 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: ToolkitSummaryPanel
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * ToolkitSummaryPanel — hero summary block for `/toolkits/[id]`.
+ *
+ * Wave 3 (#1145). Renders cover gradient + title + author chip + game chip +
+ * inline stats (installCount, ratingAverage via Stars, currentVersion). Pure
+ * presentational. Slots into the `hero` of `DetailPageLayout`.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface ToolkitSummaryPanelProps {
-  // TODO: extract props contract from mockup analysis
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { Stars } from './Stars';
+
+export interface ToolkitSummaryPanelLabels {
+  readonly authorChipPrefix: string;
+  readonly gameChipPrefix: string;
+  readonly statsHeading: string;
+  readonly installCountLabel: string;
+  readonly ratingLabel: string;
+  readonly versionLabel: string;
+  readonly noRatings: string;
 }
 
-export function ToolkitSummaryPanel(_props: ToolkitSummaryPanelProps): ReactElement | null {
-  return null;
+export interface ToolkitSummaryPanelProps {
+  readonly title: string;
+  readonly description: string;
+  readonly authorName: string;
+  readonly authorAvatarUrl: string | null;
+  readonly coverImageUrl: string | null;
+  readonly gameName: string | null | undefined;
+  readonly installCount: number;
+  readonly ratingAverage: number | null;
+  readonly ratingCount: number;
+  readonly currentVersion: string;
+  readonly labels: ToolkitSummaryPanelLabels;
+  readonly className?: string;
+}
+
+export function ToolkitSummaryPanel({
+  title,
+  description,
+  authorName,
+  authorAvatarUrl,
+  coverImageUrl,
+  gameName,
+  installCount,
+  ratingAverage,
+  ratingCount,
+  currentVersion,
+  labels,
+  className,
+}: ToolkitSummaryPanelProps): JSX.Element {
+  return (
+    <header
+      data-slot="toolkit-detail-summary-panel"
+      className={clsx(
+        'relative overflow-hidden rounded-2xl border border-border bg-card p-5 sm:p-7',
+        className
+      )}
+    >
+      {/* Cover gradient backdrop */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-30"
+        style={{
+          background: coverImageUrl
+            ? `url(${coverImageUrl}) center/cover`
+            : 'linear-gradient(135deg, hsl(var(--c-toolkit) / 0.18) 0%, hsl(var(--c-game) / 0.14) 100%)',
+        }}
+      />
+
+      <div className="relative flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            data-slot="toolkit-detail-author-chip"
+            className="inline-flex items-center gap-1.5 rounded-full bg-muted/70 px-2.5 py-1 text-xs font-bold font-[Quicksand] text-foreground"
+          >
+            {authorAvatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={authorAvatarUrl} alt="" className="h-4 w-4 rounded-full object-cover" />
+            ) : (
+              <span aria-hidden="true" className="text-sm">
+                👤
+              </span>
+            )}
+            <span>
+              {labels.authorChipPrefix} {authorName}
+            </span>
+          </span>
+          {gameName && (
+            <span
+              data-slot="toolkit-detail-game-chip"
+              className="inline-flex items-center gap-1.5 rounded-full bg-muted/70 px-2.5 py-1 text-xs font-bold font-[Quicksand] text-foreground"
+            >
+              <span aria-hidden="true" className="text-sm">
+                🎲
+              </span>
+              <span>
+                {labels.gameChipPrefix} {gameName}
+              </span>
+            </span>
+          )}
+        </div>
+
+        <h1 className="font-bold font-[Quicksand] text-2xl sm:text-3xl tracking-tight text-foreground">
+          {title}
+        </h1>
+
+        {description && (
+          <p className="max-w-2xl text-sm text-muted-foreground leading-relaxed line-clamp-3">
+            {description}
+          </p>
+        )}
+
+        <dl
+          data-slot="toolkit-detail-summary-stats"
+          className="mt-2 grid grid-cols-3 gap-4 sm:max-w-md"
+          aria-label={labels.statsHeading}
+        >
+          <div>
+            <dt className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+              {labels.installCountLabel}
+            </dt>
+            <dd className="mt-1 font-bold font-[Quicksand] text-lg text-foreground tabular-nums">
+              {installCount.toLocaleString()}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+              {labels.ratingLabel}
+            </dt>
+            <dd className="mt-1">
+              {ratingAverage != null ? (
+                <Stars value={ratingAverage} showNumeric />
+              ) : (
+                <span className="font-mono text-xs text-muted-foreground">{labels.noRatings}</span>
+              )}
+              {ratingCount > 0 && (
+                <span className="ml-1 font-mono text-[10px] text-muted-foreground">
+                  ({ratingCount})
+                </span>
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+              {labels.versionLabel}
+            </dt>
+            <dd className="mt-1 font-bold font-[Quicksand] text-lg text-foreground tabular-nums">
+              {currentVersion}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </header>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/index.ts
+++ b/apps/web/src/components/features/toolkit-detail/index.ts
@@ -1,0 +1,15 @@
+export { Stars, type StarsProps } from './Stars';
+export {
+  ToolkitSummaryPanel,
+  type ToolkitSummaryPanelProps,
+  type ToolkitSummaryPanelLabels,
+} from './ToolkitSummaryPanel';
+export {
+  ToolkitIncludesGrid,
+  type ToolkitIncludesGridProps,
+  type ToolkitIncludesGridLabels,
+} from './ToolkitIncludesGrid';
+// Phase-5 stubs (rendered only when corresponding tabs are wired up post-#822/#819):
+export { PromptPreviewBlock, type PromptPreviewBlockProps } from './PromptPreviewBlock';
+export { RatingBreakdown, type RatingBreakdownProps } from './RatingBreakdown';
+export { VersionTimeline, type VersionTimelineProps } from './VersionTimeline';

--- a/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit-marketplace.schemas.ts
@@ -51,6 +51,13 @@ export const ToolkitDetailSchema = z.object({
   yankedAt: z.string().datetime({ offset: true }).nullable(),
   // Schema reality v1 carryover (Gate B): "1.0.{int}" until semver lands.
   currentVersion: z.string().min(1),
+  // ── Stage 3 marketplace extension (PR #1156 / issue #1144) ──
+  /** SPDX-like license string (e.g. "CC BY-SA 4.0"). Nullable → FE hides meta row. */
+  license: z.string().nullable().optional(),
+  /** LEFT JOIN of GameEntity via GameToolkit.GameId. Null when no game / soft-deleted. */
+  gameName: z.string().nullable().optional(),
+  /** UTF-8 byte count of AgentConfig + tool/template JSON. */
+  sizeBytes: z.number().int().nonnegative().nullable().optional(),
 });
 export type ToolkitDetail = z.infer<typeof ToolkitDetailSchema>;
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1625,6 +1625,100 @@
         "secondaryCta": "Invite friends"
       }
     },
+    "toolkitDetail": {
+      "loading": {
+        "ariaLabel": "Loading toolkit…"
+      },
+      "error": {
+        "title": "Cannot load toolkit",
+        "description": "A network error occurred. Try again or go back to the catalog.",
+        "retry": "Retry"
+      },
+      "notFound": {
+        "title": "Toolkit not found",
+        "description": "The requested toolkit does not exist or was removed."
+      },
+      "hero": {
+        "authorChipPrefix": "by",
+        "gameChipPrefix": "for",
+        "statsHeading": "Toolkit statistics",
+        "installCount": "Installs",
+        "rating": "Rating",
+        "version": "Version",
+        "noRatings": "No ratings yet"
+      },
+      "tabs": {
+        "ariaLabel": "Toolkit sections",
+        "overview": "Overview",
+        "agent": "Agent",
+        "kb": "Knowledge base",
+        "tools": "Tools",
+        "versions": "Versions",
+        "ratings": "Ratings",
+        "disabledTooltip": "Available in Phase 5"
+      },
+      "connectionBar": {
+        "ariaLabel": "Entities related to this toolkit",
+        "emptyHint": "Not yet available"
+      },
+      "pips": {
+        "agent": "Agent",
+        "kb": "KB",
+        "tools": "Tools",
+        "game": "Game",
+        "author": "Author",
+        "sessions": "Sessions"
+      },
+      "overview": {
+        "descriptionHeading": "Description",
+        "metaHeading": "Details",
+        "meta": {
+          "license": "License",
+          "version": "Version",
+          "size": "Size",
+          "published": "Published on",
+          "unknown": "—"
+        },
+        "includesHeading": "What's included"
+      },
+      "includes": {
+        "agent": "Agent",
+        "kbDocs": "KB documents",
+        "tools": "Tools"
+      },
+      "tools": {
+        "heading": "Included tools",
+        "description": "This toolkit includes the following tools usable in sessions.",
+        "countTemplate": "{count} tools",
+        "emptyTitle": "No tools",
+        "emptyBody": "This toolkit doesn't contain any configured tools."
+      },
+      "disabled": {
+        "phase5Badge": "Available in Phase 5",
+        "agent": {
+          "title": "Agent details",
+          "description": "Agent system prompt details will be available in a later release (#822)."
+        },
+        "kb": {
+          "title": "KB documents",
+          "description": "The list of associated KB documents will be available in a later release (#822)."
+        },
+        "versions": {
+          "title": "Version history",
+          "description": "Version timeline and changelogs will be available in a later release (#822)."
+        },
+        "ratings": {
+          "title": "Ratings and reviews",
+          "description": "Community reviews will be available in a later release (#819)."
+        }
+      },
+      "footer": {
+        "editAction": "Edit toolkit",
+        "publishAction": "Publish new version",
+        "installAction": "Install toolkit",
+        "shareAction": "Share"
+      }
+    },
     "sessions": {
       "metadata": {
         "title": "My sessions — MeepleAI",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1675,6 +1675,100 @@
         "secondaryCta": "Invita amici"
       }
     },
+    "toolkitDetail": {
+      "loading": {
+        "ariaLabel": "Caricamento toolkit…"
+      },
+      "error": {
+        "title": "Impossibile caricare il toolkit",
+        "description": "Si è verificato un errore di rete. Riprova o torna al catalogo.",
+        "retry": "Riprova"
+      },
+      "notFound": {
+        "title": "Toolkit non trovato",
+        "description": "Il toolkit richiesto non esiste o è stato rimosso."
+      },
+      "hero": {
+        "authorChipPrefix": "di",
+        "gameChipPrefix": "per",
+        "statsHeading": "Statistiche del toolkit",
+        "installCount": "Installazioni",
+        "rating": "Valutazione",
+        "version": "Versione",
+        "noRatings": "Nessuna valutazione"
+      },
+      "tabs": {
+        "ariaLabel": "Sezioni del toolkit",
+        "overview": "Panoramica",
+        "agent": "Agente",
+        "kb": "Knowledge Base",
+        "tools": "Strumenti",
+        "versions": "Versioni",
+        "ratings": "Recensioni",
+        "disabledTooltip": "Disponibile in Phase 5"
+      },
+      "connectionBar": {
+        "ariaLabel": "Entità collegate al toolkit",
+        "emptyHint": "Dato non ancora disponibile"
+      },
+      "pips": {
+        "agent": "Agente",
+        "kb": "KB",
+        "tools": "Strumenti",
+        "game": "Gioco",
+        "author": "Autore",
+        "sessions": "Sessioni"
+      },
+      "overview": {
+        "descriptionHeading": "Descrizione",
+        "metaHeading": "Dettagli",
+        "meta": {
+          "license": "Licenza",
+          "version": "Versione",
+          "size": "Dimensione",
+          "published": "Pubblicato il",
+          "unknown": "—"
+        },
+        "includesHeading": "Cosa include"
+      },
+      "includes": {
+        "agent": "Agente",
+        "kbDocs": "Documenti KB",
+        "tools": "Strumenti"
+      },
+      "tools": {
+        "heading": "Strumenti inclusi",
+        "description": "Il toolkit include i seguenti strumenti utilizzabili nelle sessioni.",
+        "countTemplate": "{count} strumenti",
+        "emptyTitle": "Nessuno strumento",
+        "emptyBody": "Questo toolkit non contiene strumenti configurati."
+      },
+      "disabled": {
+        "phase5Badge": "Disponibile in Phase 5",
+        "agent": {
+          "title": "Dettagli agente",
+          "description": "I dettagli del system prompt dell'agente saranno disponibili in una versione successiva (#822)."
+        },
+        "kb": {
+          "title": "Documenti KB",
+          "description": "L'elenco dei documenti KB associati sarà disponibile in una versione successiva (#822)."
+        },
+        "versions": {
+          "title": "Storico versioni",
+          "description": "La timeline delle versioni e i changelog saranno disponibili in una versione successiva (#822)."
+        },
+        "ratings": {
+          "title": "Valutazioni e recensioni",
+          "description": "Le recensioni della community saranno disponibili in una versione successiva (#819)."
+        }
+      },
+      "footer": {
+        "editAction": "Modifica toolkit",
+        "publishAction": "Pubblica nuova versione",
+        "installAction": "Installa toolkit",
+        "shareAction": "Condividi"
+      }
+    },
     "sessions": {
       "metadata": {
         "title": "Le mie partite — MeepleAI",


### PR DESCRIPTION
Closes #1145 · refs #1026 · soft-coordinated-with #822 #819

## What

Implements `/toolkits/[id]` Stage 3 cluster per `docs/superpowers/specs/2026-05-14-stage3-toolkit-detail.md`.

Path C consensus: **2 enabled tabs** (Overview + Tools) + **4 disabled-shell tabs** (Agent / KB / Versions / Ratings) pending Phase 5 backend (#822, #819). Pattern mirrors PlayerDetailView (#1138).

## Route + orchestrator

| File | Role |
|---|---|
| `app/(authenticated)/toolkits/[id]/page.tsx` | Server boundary, awaits params, Suspense wrapper for `useSearchParams` CSR bailout |
| `_components/ToolkitDetailView.tsx` | Client orchestrator — `useToolkitDetail` hook, 4-state FSM (loading/error/not-found/default), URL tab state, variant detection |

## Route-private components

- **ToolkitTabs**: 6-tab tablist (`useTablistKeyboardNav`), disabled-state support (skips disabled tabs in roving tabindex, fires `onDisabledAttempt` callback for telemetry, no state change)
- **ToolkitConnectionBar**: 6 pip (`tools`, `game` wired; 4 dashed-empty placeholders for `agent`, `kb`, `author`, `sessions` per spec AC2)
- **OverviewTabPanel**: description, meta dl (license/version/size/published), ToolkitIncludesGrid
- **ToolsTabPanel**: aggregate tools count with empty-state fallback
- **DisabledTabPanel**: shared Phase-5 shell (icon + title + description + badge)

## Wave-3 components implemented

- **Stars**: fractional 5-star rating display (sub-step granularity via CSS clip)
- **ToolkitSummaryPanel**: hero block with author chip, game chip, stats grid (installs/rating/version)
- **ToolkitIncludesGrid**: 3-cell summary (agent / kb-docs / tools count)
- Remaining 3 stubs (PromptPreviewBlock / RatingBreakdown / VersionTimeline) retained as TODO — consumed only by Phase-5 disabled-shell tabs

## Schema update

Zod `ToolkitDetailSchema` extended with 3 Stage 3 fields delivered by BE #1156 (license, gameName, sizeBytes). Marked `optional()` for forward-compat (legacy responses still validate).

## i18n

New `pages.toolkitDetail.*` namespace in `it.json` + `en.json`:
- `loading`, `error`, `notFound` (FSM shells)
- `hero` (chip prefixes, stats labels)
- `tabs` (6 labels + `disabledTooltip`)
- `connectionBar`, `pips` (6 entries)
- `overview` (description/meta/includes headings, meta field labels)
- `includes` (3 cell labels)
- `tools` (heading, description, countTemplate, empty state)
- `disabled` (4 Phase-5 tab descriptions + `phase5Badge`)
- `footer` (edit/publish/install/share actions)

## Telemetry (3 PostHog events)

- `toolkit_detail_tab_changed` — `{ from, to, toolkitId }`
- `toolkit_disabled_tab_attempted` — `{ tab, toolkitId, variant }`
- `toolkit_action_clicked` — `{ action: edit|publish|install|share, variant, toolkitId }`

## URL state

- `?tab=<key>` query param SSR-resolvable; invalid value or disabled-tab value → normalize to `overview` via `router.replace`
- Tab change updates URL with `scroll: false`

## Variant

`variant = viewerContext.isOwner ? 'own' : 'public'` (server-side via `useToolkitDetail` response — no hydration mismatch). Footer actions differ:
- **own**: `[Edit toolkit]` + `[Publish new version]` (both disabled-pending-#822 with tooltip)
- **public**: `[Install]` (disabled-pending-#822) + `[Share]` (enabled, copies URL to clipboard)

## AC checklist (21 total)

| AC | Status | Note |
|---|---|---|
| AC0 | ✅ | BE DTO present (#1156, Zod schema updated) |
| AC1-AC8 | ✅ | route, slots, tabs, FSM, variants, footer all wired |
| AC13 | ✅ | parent spec §4 toolkit row already updated when DetailPageLayout shipped (#1112) |
| AC15 | ✅ | no modification to `DetailPageLayout.tsx` |
| AC16 | ✅ | keyboard nav via `useTablistKeyboardNav` (delegated to enabled-only subset) |
| AC18 | ✅ | i18n complete (it + en) |
| AC19 | ✅ | 3 telemetry events |
| **AC7** | ⏸ | Playwright visual diff (7 screenshots) — deferred |
| **AC8** | ⏸ | Unit + integration + E2E + a11y test matrix — deferred |
| **AC10** | ⏸ | Coverage ≥85% — deferred |
| **AC12** | ⏸ | Perf gate (size-limit + Lighthouse) — deferred |
| **AC14** | ⏸ | size-limit ceiling — deferred |
| **AC17** | ⏸ | E2E back/forward preserves tab — deferred |
| **AC20** | ⚠️ | Loading skeleton present but not strict zero-CLS measurement — deferred |

Test debt deferred per pattern from sibling PRs #1151 / #1153 / #1160 (5 prior Stage 3 PRs in the same session). To be picked up in dedicated follow-up.

## Verification

```
$ pnpm typecheck   # ✓
$ pnpm lint        # ✓ 0 errors (42 pre-existing warnings)
$ pnpm build       # ✓
```

Manual render: navigate to `/toolkits/{any-uuid}` with seeded data → 6 tabs visible, 2 enabled with rich content, 4 disabled with tooltip + badge. Tab switch updates `?tab=`. Disabled tab click fires telemetry but doesn't change `activeTab`.

## Out of scope / follow-up

- **Edit/Publish flow** (own variant) — buttons disabled-pending-#822; flow lands when backend ships
- **Install/Ratings flow** — pending #822 + #819
- **Mockup polish** — cover images use entity gradient placeholder, not real thumbnails (toolkit cover assets not yet exposed by DTO)
- **Test matrix** — AC7/8/10/12/14/17 all deferred (same pattern as 5 prior Stage 3 PRs)

## Rollback

Revert PR → `/toolkits/[id]` returns 404 (route was created in this PR; no prior implementation). No downstream consumers.

## References

- Issue: #1145
- Spec: `docs/superpowers/specs/2026-05-14-stage3-toolkit-detail.md`
- BE prerequisite (merged): #1144 → PR #1156
- Pattern reference: PlayerDetailView (#1138)
- DetailPageLayout primitive: #1112
- Phase 5 backend pending: #822 (own-variant) + #819 (ratings)