### PR TITLE
refactor(game-night-detail): #1171 review followups (refs #951)

### DIFF
--- a/admin-mockups/design_files/sp7-game-night-detail-rsvp.html
+++ b/admin-mockups/design_files/sp7-game-night-detail-rsvp.html
@@ -4,6 +4,17 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=1440"/>
   <title>SP7-B · Game Night · Detail + RSVP — MeepleAI</title>
+  <!--
+    Mockup: sp7-game-night-detail-rsvp
+    Route:  /game-nights/[id]
+    Scope:  SP7 spec-hardening hero + RSVP cluster (issue #951). Covers guest
+            RSVP flow + host action row + cancelled banner. Tabbed surface
+            (Voting/Chat) and mobile sticky CTA deferred to follow-up.
+    Stati:  default · cancelled · not-found · loading
+    Persona: Guest invitato (RSVP Pending/Accepted/Maybe/Declined),
+             Host (organizerId === viewerId), Bystander (private event).
+    Sorgente: e2e/v2-states/game-night-detail.spec.ts (5 AC-H1 scenarios)
+  -->
 
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./state-matrix.schema.json",
-  "generated_at": "2026-05-14T09:33:47.138Z",
+  "generated_at": "2026-05-15T09:22:09.817Z",
   "total_mockups": 65,
   "enforced_count": 1,
   "entries": [
@@ -604,10 +604,20 @@
     },
     {
       "mockup_path": "admin-mockups/design_files/sp7-game-night-detail-rsvp.html",
-      "route": null,
-      "declared_states": [],
+      "route": "/game-nights/[id]",
+      "declared_states": [
+        "default",
+        "cancelled",
+        "not-found",
+        "loading"
+      ],
       "covered_states": [],
-      "missing": [],
+      "missing": [
+        "default",
+        "cancelled",
+        "not-found",
+        "loading"
+      ],
       "enforced": false
     }
   ]

--- a/apps/web/src/components/features/game-night-detail/GameNightAvatar.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightAvatar.tsx
@@ -49,13 +49,23 @@ export function GameNightAvatar({
   highlightSelf = false,
   className,
 }: GameNightAvatarProps): React.JSX.Element {
+  // Per-player HSL bg is dynamic (different hue per user GUID), so it cannot
+  // be expressed as a literal Tailwind class — the JIT extractor only sees
+  // class strings statically. We pipe the value through a CSS custom property
+  // and reference it via the literal arbitrary `bg-[var(--avatar-bg)]` class
+  // in the same className as `text-white`. This satisfies the CLAUDE.md DS-15
+  // exemption ("text-white IS allowed when the same className declares a
+  // colored bg [...] arbitrary `bg-[hsl(…)]`") while keeping the hue dynamic.
+  // Issue caught in #1171 review followup.
+  const avatarBg = `hsl(${hue}, 60%, 55%)`;
   return (
     <span
       role="img"
       aria-label={label}
       className={clsx(
         'inline-flex shrink-0 items-center justify-center rounded-full font-display font-extrabold',
-        // eslint-disable-next-line local/no-hardcoded-color-utility -- white text on per-player HSL background; mockup .e-bg pattern.
+        'bg-[var(--avatar-bg)]',
+        // eslint-disable-next-line local/no-hardcoded-color-utility -- white text on per-player HSL background; mockup .e-bg pattern. Exemption satisfied by bg-[var(--avatar-bg)] declared on the same className.
         'text-white',
         // 2px border preserves card-background separation in roster grids; ring color flips for "me".
         highlightSelf
@@ -64,7 +74,7 @@ export function GameNightAvatar({
         SIZE_TO_CLASS[size],
         className
       )}
-      style={{ backgroundColor: `hsl(${hue}, 60%, 55%)` }}
+      style={{ ['--avatar-bg' as string]: avatarBg } as React.CSSProperties}
     >
       {initials}
     </span>

--- a/apps/web/src/components/features/game-night-detail/GameNightAvatar.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightAvatar.tsx
@@ -5,10 +5,13 @@
  * Mapped from `admin-mockups/design_files/sp7-game-night-detail-rsvp.jsx` (Avatar).
  *
  * Pure presentational. The mockup uses inline HSL background derived from a
- * per-player hue (`player.color`); we expose `hue` as a prop and compose the
- * Tailwind arbitrary value so the background tracks the design intent without
- * introducing N entity colors. ESLint local/no-hardcoded-color-utility allows
- * arbitrary `bg-[hsl(...)]` patterns.
+ * per-player hue (`player.color`); we expose `hue` as a prop and pipe the
+ * computed `hsl(...)` value through a CSS custom property (`--avatar-bg`) so
+ * the static class `bg-[var(--avatar-bg)]` can be paired with `text-white` in
+ * the same className — required by the CLAUDE.md DS-15 exemption (Tailwind
+ * JIT cannot extract `bg-[hsl(${hue}_...)]` templated literals, so a literal
+ * class string is necessary regardless). The inline body comment details the
+ * full rationale. #1171 review followup.
  *
  * AC: T V
  */

--- a/apps/web/src/components/features/game-night-detail/__tests__/GameNightAvatar.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/__tests__/GameNightAvatar.test.tsx
@@ -14,10 +14,15 @@ describe('GameNightAvatar', () => {
     expect(el.textContent).toBe('MR');
   });
 
-  it('applies HSL background derived from hue prop', () => {
+  it('applies HSL background derived from hue prop via --avatar-bg custom property', () => {
+    // Dynamic hue is piped through a CSS custom property so the static
+    // `bg-[var(--avatar-bg)]` class can satisfy the CLAUDE.md DS-15 exemption
+    // (text-white requires a colored bg in the same className — see
+    // GameNightAvatar.tsx for the rationale). #1171 review followup.
     render(<GameNightAvatar initials="DC" label="Davide C." hue={120} />);
-    const el = screen.getByRole('img');
-    expect(el).toHaveStyle({ backgroundColor: 'hsl(120, 60%, 55%)' });
+    const el = screen.getByRole('img') as HTMLElement;
+    expect(el.style.getPropertyValue('--avatar-bg')).toBe('hsl(120, 60%, 55%)');
+    expect(el.className).toContain('bg-[var(--avatar-bg)]');
   });
 
   it('switches border to entity-player ring when highlightSelf=true', () => {

--- a/apps/web/src/hooks/queries/useGameNightDetail.ts
+++ b/apps/web/src/hooks/queries/useGameNightDetail.ts
@@ -111,8 +111,6 @@ export interface UseGameNightDetailReturn {
   ) => RsvpSubmitOutcome;
   /** Indicates whether the optimistic mutation is currently running. */
   readonly isSubmitting: boolean;
-  /** Last rollback error (populated only on the most recent failed submit). */
-  readonly rollbackError: Error | undefined;
 }
 
 interface RsvpMutationVariables {
@@ -219,6 +217,5 @@ export function useGameNightDetail(
     pendingResponse,
     submitRsvp,
     isSubmitting: mutation.isPending,
-    rollbackError: mutation.rollbackReason,
   };
 }

--- a/apps/web/src/lib/game-nights/__tests__/rsvp-state-machine.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/rsvp-state-machine.test.ts
@@ -5,12 +5,14 @@
  *   - Scenario "Capacity exceeded" exercises the `allowed` branch (server returns 409 on capacity)
  *   - Scenario "Double-RSVP" → `no-op`
  *   - Scenario "Game-night cancelled" → 410 reject
- *   - Scenario "Concurrent edit" → server 409 path, mapped by describeRsvpRejection
+ *   - Scenario "Concurrent edit" → server 409 path, mapped to i18n keys by the consumer
+ *     (`GameNightDetailView.handleRsvp` translates status codes to
+ *     `gameNightDetail.rsvp.errors.{cancelledGone,directConflict}`)
  */
 
 import { describe, expect, it } from 'vitest';
 
-import { describeRsvpRejection, evaluateRsvpTransition } from '../rsvp-state-machine';
+import { evaluateRsvpTransition } from '../rsvp-state-machine';
 
 describe('evaluateRsvpTransition', () => {
   describe('no-op (same response replay)', () => {
@@ -69,26 +71,5 @@ describe('evaluateRsvpTransition', () => {
       const outcome = evaluateRsvpTransition({ current, desired });
       expect(outcome).toEqual({ kind: 'allowed', from: current, to: desired });
     });
-  });
-});
-
-describe('describeRsvpRejection', () => {
-  it('returns a cancellation message for 410 regardless of response', () => {
-    const message = describeRsvpRejection(410, 'Accepted');
-    expect(message).toContain('cancellata');
-  });
-
-  it('explains Accepted-after-Declined as needing a Maybe hop', () => {
-    expect(describeRsvpRejection(409, 'Accepted')).toContain('declinato');
-  });
-
-  it('explains Declined-after-Accepted as needing a Maybe hop', () => {
-    expect(describeRsvpRejection(409, 'Declined')).toContain('accettato');
-  });
-
-  it('falls back to a generic message for 409 with Maybe response', () => {
-    // Maybe is allowed from any non-terminal state, but the BE could still 409
-    // on a stale RowVersion race — surface a generic message in that edge case.
-    expect(describeRsvpRejection(409, 'Maybe')).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/game-nights/rsvp-state-machine.ts
+++ b/apps/web/src/lib/game-nights/rsvp-state-machine.ts
@@ -75,21 +75,3 @@ export function evaluateRsvpTransition(input: EvaluateRsvpInput): RsvpTransition
 
   return { kind: 'allowed', from: current, to: desired };
 }
-
-/**
- * Server-side error → user-facing reason mapper. Used by hook layer when the
- * BE rejects an `allowed`-classified transition (e.g. race condition where
- * another tab cancelled the event between classification and network call).
- */
-export function describeRsvpRejection(status: 409 | 410, response: RsvpResponse): string {
-  if (status === 410) {
-    return 'La serata è stata cancellata o è scaduta — la tua risposta non può essere registrata.';
-  }
-  if (response === 'Accepted') {
-    return 'Hai già declinato — modifica la tua risposta a "Forse" prima di confermare.';
-  }
-  if (response === 'Declined') {
-    return 'Hai già accettato — modifica la tua risposta a "Forse" prima di declinare.';
-  }
-  return 'Transizione RSVP non consentita.';
-}

--- a/apps/web/src/lib/hooks/__tests__/use-optimistic-mutation.test.tsx
+++ b/apps/web/src/lib/hooks/__tests__/use-optimistic-mutation.test.tsx
@@ -6,7 +6,7 @@
  *   - Snapshot restore on error
  *   - onRollback consumer fires AFTER restore
  *   - Cache invalidation on success (invalidateOnSuccess flag)
- *   - rollbackReason surface
+ *   - reactive mutation.error surfacing on rollback
  */
 
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
@@ -90,7 +90,7 @@ describe('useOptimisticMutation', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
-  it('restores snapshot and surfaces rollbackReason on error', async () => {
+  it('restores snapshot and surfaces error via mutation.error on rollback', async () => {
     const { client, wrapper } = createWrapper();
     const original: CachedRoster = { status: 'Pending', count: 3 };
     client.setQueryData<CachedRoster>(CACHE_KEY, original);

--- a/apps/web/src/lib/hooks/use-optimistic-mutation.ts
+++ b/apps/web/src/lib/hooks/use-optimistic-mutation.ts
@@ -14,12 +14,13 @@
  *      `(cachedValue, variables) => optimisticValue`.
  *   2. On mutate() we snapshot the cache, apply the reducer, then run the network call.
  *   3. On success we invalidate (server is truth).
- *   4. On error we restore the snapshot and surface the error to the caller.
+ *   4. On error we restore the snapshot and surface the error via React Query's
+ *      reactive `mutation.error`.
  *
  * Composition over React Query's built-in `onMutate`:
  *   The built-in pattern requires hand-rolling snapshot/restore in every consumer.
- *   This wrapper enforces the snapshot/restore discipline and exposes a `rollbackReason`
- *   for telemetry hooks.
+ *   This wrapper enforces the snapshot/restore discipline and exposes an
+ *   `onRollback` callback for telemetry hooks.
  */
 
 import { useRef } from 'react';
@@ -31,6 +32,15 @@ import {
   type UseMutationOptions,
   type UseMutationResult,
 } from '@tanstack/react-query';
+
+/**
+ * For error surfacing in consumers, read `mutation.error` from the returned
+ * UseMutationResult — it is React Query's reactive state and re-renders the
+ * consumer on each error transition. An earlier revision of this hook exposed
+ * a ref-backed `rollbackReason` field, but useRef writes don't trigger
+ * re-renders, so the field was either stale or coincidentally correct via
+ * React Query's own re-render. Removed in #1171 review followup.
+ */
 
 export interface UseOptimisticMutationOptions<TData, TError, TVariables, TCached> extends Omit<
   UseMutationOptions<TData, TError, TVariables>,
@@ -54,20 +64,9 @@ export interface UseOptimisticMutationOptions<TData, TError, TVariables, TCached
   invalidateOnSuccess?: boolean;
 }
 
-// UseMutationResult is a discriminated union (status: 'idle' | 'pending' | 'success' | 'error'),
-// so we intersect rather than extend — interfaces can't extend unions.
-export type OptimisticMutationResult<TData, TError, TVariables> = UseMutationResult<
-  TData,
-  TError,
-  TVariables
-> & {
-  /** Last rollback reason — populated only when the most recent mutation was rolled back. */
-  rollbackReason: TError | undefined;
-};
-
 export function useOptimisticMutation<TData, TError, TVariables, TCached>(
   options: UseOptimisticMutationOptions<TData, TError, TVariables, TCached>
-): OptimisticMutationResult<TData, TError, TVariables> {
+): UseMutationResult<TData, TError, TVariables> {
   const {
     cacheKey,
     applyOptimistic,
@@ -79,7 +78,9 @@ export function useOptimisticMutation<TData, TError, TVariables, TCached>(
 
   const queryClient = useQueryClient();
   const snapshotRef = useRef<TCached | undefined>(undefined);
-  const rollbackReasonRef = useRef<TError | undefined>(undefined);
+  // Internal flag for onSettled to skip cache invalidation on the error path.
+  // Not exported — consumers should read the reactive `mutation.error` instead.
+  const errorOccurredRef = useRef<boolean>(false);
 
   const mutation = useMutation<TData, TError, TVariables>({
     ...rest,
@@ -90,7 +91,7 @@ export function useOptimisticMutation<TData, TError, TVariables, TCached>(
 
       const previous = queryClient.getQueryData<TCached>(cacheKey);
       snapshotRef.current = previous;
-      rollbackReasonRef.current = undefined;
+      errorOccurredRef.current = false;
 
       const next = applyOptimistic(previous, variables);
       queryClient.setQueryData(cacheKey, next);
@@ -102,18 +103,15 @@ export function useOptimisticMutation<TData, TError, TVariables, TCached>(
       // here — invalidation on error would race with the snapshot restore and
       // potentially overwrite the user's edit-in-progress in adjacent components.
       queryClient.setQueryData(cacheKey, snapshotRef.current);
-      rollbackReasonRef.current = error;
+      errorOccurredRef.current = true;
       onRollback?.(variables, error);
     },
     onSettled: () => {
-      if (invalidateOnSuccess && rollbackReasonRef.current === undefined) {
+      if (invalidateOnSuccess && !errorOccurredRef.current) {
         void queryClient.invalidateQueries({ queryKey: cacheKey });
       }
     },
   });
 
-  return {
-    ...mutation,
-    rollbackReason: rollbackReasonRef.current,
-  };
+  return mutation;
 }


### PR DESCRIPTION
## Summary

Cleanup PR addressing the 4 non-blocking findings flagged in the #1171 code review (scores 62–75, below the 80-threshold but worth fixing).

- **DS-15 exemption**: GameNightAvatar moves the dynamic HSL bg from inline `style` to a CSS custom property referenced via `bg-[var(--avatar-bg)]` — same className as `text-white`, exemption now satisfied syntactically.
- **Dead rollbackReason API**: removed ref-backed field from `useOptimisticMutation` (consumers read reactive `mutation.error`); dropped `rollbackError` from `useGameNightDetail`.
- **Dead describeRsvpRejection**: removed function + tests (hardcoded Italian strings, never called in production — the page-client maps status codes directly to i18n keys).
- **state-matrix.json**: added Route/Stati header comment to `sp7-game-night-detail-rsvp.html` and regenerated the matrix via `pnpm tsx scripts/extract-mockup-states.ts --write`. Entry now carries `route: "/game-nights/[id]"` + 4 declared states.

## Test plan

- [x] `pnpm typecheck` → clean
- [x] `pnpm lint` → 0 new issues on touched files
- [x] `pnpm vitest src/components/features/game-night-detail src/lib/game-nights src/lib/hooks/__tests__/use-optimistic-mutation` → **104/104 pass** (was 108; 4 deleted `describeRsvpRejection` tests)
- [ ] CI: Frontend Fast / Tests shards on PR

Related: closed issue #951, original PR #1171 ([review comment](https://github.com/meepleAi-app/meepleai-monorepo/pull/1171#issuecomment-4458386665)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)