### PR TITLE
feat(game-nights-index): Stage 3 v2 implementation (closes #1170)

### DIFF
--- a/apps/web/e2e/v2-states/game-nights-index.spec.ts
+++ b/apps/web/e2e/v2-states/game-nights-index.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * E2E state matrix + a11y for /game-nights index v2 (Issue #1170 Stage 3, commit 4).
+ *
+ * Covers the 5 orchestrator branches in
+ * `apps/web/src/app/(authenticated)/game-nights/_content.tsx`:
+ *   - default        — calendar view renders with mixed events (organizing + invited)
+ *   - empty          — both endpoints return [] → game-nights-empty state
+ *   - loading        — endpoints delayed → game-nights-loading skeleton
+ *   - filtered-empty — list view + organizing filter with 0 organizing events
+ *   - error          — both endpoints 500 → game-nights-error state with retry CTA
+ *
+ * Each scenario runs against 3 viewports (375 / 768 / 1280) with axe-core
+ * WCAG 2.1 AA checks. Visual baselines are NOT captured here — the project's
+ * `visual-conformity` framework (CI bootstrap workflow) owns visual baselines
+ * for the /game-nights route (see mockup-ownership.bootstrap.json).
+ *
+ * Implementation note: mirrors the sibling
+ * `e2e/v2-states/game-night-detail.spec.ts` pattern (page.context().route()
+ * backend mocking, no `?fixture=` URL hatch).
+ *
+ * Auth pattern (Wave B.1 lesson, Issue #633): seedAuthSession +
+ * seedCookieConsent + mockAuthEndpoints triple for `(authenticated)` routes.
+ */
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import { seedCookieConsent } from '../_helpers/seedCookieConsent';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+const VIEWER_USER_ID = '00000000-0000-4000-8000-000000000fff';
+const OTHER_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+type GameNightStatus = 'Draft' | 'Published' | 'Cancelled' | 'Completed';
+
+interface EventOverrides {
+  readonly id?: string;
+  readonly organizerId?: string;
+  readonly title?: string;
+  readonly scheduledAt?: string;
+  readonly status?: GameNightStatus;
+  readonly acceptedCount?: number;
+}
+
+function buildEventDto(overrides: EventOverrides): unknown {
+  return {
+    id: overrides.id ?? '00000000-0000-4000-8000-000000001170',
+    organizerId: overrides.organizerId ?? OTHER_USER_ID,
+    organizerName: 'Marco R.',
+    title: overrides.title ?? 'Wingspan night',
+    description: null,
+    scheduledAt: overrides.scheduledAt ?? '2026-06-15T19:00:00Z',
+    location: 'Casa Marco',
+    maxPlayers: 5,
+    gameIds: [],
+    status: overrides.status ?? 'Published',
+    acceptedCount: overrides.acceptedCount ?? 3,
+    pendingCount: 1,
+    totalInvited: 5,
+    createdAt: '2026-06-01T12:00:00Z',
+    updatedAt: null,
+  };
+}
+
+interface MockOptions {
+  /** Payload (or status-only override) for GET /upcoming. */
+  readonly upcoming?: { status?: number; body?: readonly unknown[]; delayMs?: number };
+  /** Payload (or status-only override) for GET /mine. */
+  readonly mine?: { status?: number; body?: readonly unknown[]; delayMs?: number };
+}
+
+async function mockGameNightsApis(page: Page, options: MockOptions = {}): Promise<void> {
+  const upcoming = options.upcoming ?? { body: [] };
+  const mine = options.mine ?? { body: [] };
+
+  await page.context().route(/\/api\/v1\/game-nights\/upcoming(\?.*)?$/, async (route: Route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    if (upcoming.delayMs) await new Promise(r => setTimeout(r, upcoming.delayMs));
+    await route.fulfill({
+      status: upcoming.status ?? 200,
+      contentType: 'application/json',
+      body: JSON.stringify(upcoming.body ?? []),
+    });
+  });
+
+  await page.context().route(/\/api\/v1\/game-nights\/mine(\?.*)?$/, async (route: Route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    if (mine.delayMs) await new Promise(r => setTimeout(r, mine.delayMs));
+    await route.fulfill({
+      status: mine.status ?? 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mine.body ?? []),
+    });
+  });
+}
+
+async function seedAuthAndNavigate(
+  page: Page,
+  options: MockOptions,
+  url: string = '/game-nights'
+): Promise<void> {
+  await seedAuthSession(page);
+  await seedCookieConsent(page);
+  await mockAuthEndpoints(page, { userId: VIEWER_USER_ID });
+  await mockGameNightsApis(page, options);
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+}
+
+const VIEWPORTS = [
+  { name: 'mobile', width: 375, height: 740 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 720 },
+] as const;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures for the "default" scenario — 3 mixed events (1 organizing, 2 invited),
+// 1 of those echoed by /mine so the orchestrator's dedup-merge path is exercised.
+// ───────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_UPCOMING = [
+  buildEventDto({
+    id: '00000000-0000-4000-8000-000000000a01',
+    organizerId: VIEWER_USER_ID,
+    title: 'Carcassonne — viewer organizes',
+    scheduledAt: '2026-06-10T19:00:00Z',
+    status: 'Published',
+  }),
+  buildEventDto({
+    id: '00000000-0000-4000-8000-000000000a02',
+    title: 'Wingspan @ Marco',
+    scheduledAt: '2026-06-15T19:00:00Z',
+    status: 'Published',
+  }),
+  buildEventDto({
+    id: '00000000-0000-4000-8000-000000000a03',
+    title: 'Brass: Birmingham',
+    scheduledAt: '2026-06-22T20:00:00Z',
+    status: 'Draft',
+  }),
+];
+
+const DEFAULT_MINE = [DEFAULT_UPCOMING[1]];
+
+// Invited-only fixtures for the filtered-empty scenario.
+const INVITED_ONLY_UPCOMING = [
+  buildEventDto({
+    id: '00000000-0000-4000-8000-000000000b01',
+    title: 'Wingspan @ Marco',
+    scheduledAt: '2026-06-15T19:00:00Z',
+  }),
+  buildEventDto({
+    id: '00000000-0000-4000-8000-000000000b02',
+    title: 'Brass: Birmingham',
+    scheduledAt: '2026-06-22T20:00:00Z',
+  }),
+];
+
+// ───────────────────────────────────────────────────────────────────────────
+// State-matrix tests — one describe block per scenario, parameterised by viewport.
+// ───────────────────────────────────────────────────────────────────────────
+
+test.describe('Game Nights index — state matrix', () => {
+  for (const vp of VIEWPORTS) {
+    test(`default (calendar + mixed events) @ ${vp.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await seedAuthAndNavigate(page, {
+        upcoming: { body: DEFAULT_UPCOMING },
+        mine: { body: DEFAULT_MINE },
+      });
+
+      await expect(page.locator('[data-testid="game-nights-calendar-month-grid"]')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      const a11y = await new AxeBuilder({ page })
+        .withTags([...WCAG_TAGS])
+        .exclude('#webpack-dev-server-client-overlay')
+        .analyze();
+      expect(a11y.violations).toEqual([]);
+    });
+
+    test(`empty (no events) @ ${vp.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await seedAuthAndNavigate(page, { upcoming: { body: [] }, mine: { body: [] } });
+
+      await expect(page.locator('[data-testid="game-nights-empty"]')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      const a11y = await new AxeBuilder({ page })
+        .withTags([...WCAG_TAGS])
+        .exclude('#webpack-dev-server-client-overlay')
+        .analyze();
+      expect(a11y.violations).toEqual([]);
+    });
+
+    test(`loading (delayed endpoints) @ ${vp.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      // Delay both endpoints so the orchestrator stays in the loading branch
+      // for the duration of the assertion + axe scan. We do NOT wait for the
+      // responses to settle — the loading skeleton is the asserted state.
+      await seedAuthAndNavigate(page, {
+        upcoming: { body: [], delayMs: 10_000 },
+        mine: { body: [], delayMs: 10_000 },
+      });
+
+      await expect(page.locator('[data-testid="game-nights-loading"]')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      const a11y = await new AxeBuilder({ page })
+        .withTags([...WCAG_TAGS])
+        .exclude('#webpack-dev-server-client-overlay')
+        .analyze();
+      expect(a11y.violations).toEqual([]);
+    });
+
+    test(`filtered-empty (list + organizing filter, no organizing events) @ ${vp.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await seedAuthAndNavigate(
+        page,
+        { upcoming: { body: INVITED_ONLY_UPCOMING }, mine: { body: [] } },
+        '/game-nights?view=list&filter=organizing'
+      );
+
+      await expect(page.locator('[data-testid="game-nights-list-empty"]')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      const a11y = await new AxeBuilder({ page })
+        .withTags([...WCAG_TAGS])
+        .exclude('#webpack-dev-server-client-overlay')
+        .analyze();
+      expect(a11y.violations).toEqual([]);
+    });
+
+    test(`error (both endpoints 500) @ ${vp.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await seedAuthAndNavigate(page, {
+        upcoming: { status: 500, body: { error: 'boom' } as unknown as readonly unknown[] },
+        mine: { status: 500, body: { error: 'boom' } as unknown as readonly unknown[] },
+      });
+
+      const errorEl = page.locator('[data-testid="game-nights-error"]');
+      await expect(errorEl).toBeVisible({ timeout: 30_000 });
+      // Retry CTA is a <button> labelled by `gameNightsIndex.states.error.retry` (IT
+      // "Riprova" / EN "Retry") — match either via role + name regex.
+      await expect(errorEl.getByRole('button', { name: /riprova|retry/i })).toBeVisible();
+
+      const a11y = await new AxeBuilder({ page })
+        .withTags([...WCAG_TAGS])
+        .exclude('#webpack-dev-server-client-overlay')
+        .analyze();
+      expect(a11y.violations).toEqual([]);
+    });
+  }
+});

--- a/apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json
+++ b/apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json
@@ -47,6 +47,18 @@
         "apps/web/src/components/features/player-detail/**"
       ],
       "notes": "Stage 3 cluster #1113. Default tab (Sessions) screenshot via IS_VISUAL_TEST_BUILD fixture. Multi-tab visual coverage tracked as follow-up."
+    },
+    {
+      "id": "game-nights-index",
+      "livePath": "/game-nights",
+      "mockup": "sp4-game-nights-index.html",
+      "triggerPaths": [
+        "apps/web/src/app/(authenticated)/game-nights/**",
+        "apps/web/src/components/features/game-nights/**",
+        "apps/web/src/lib/game-nights/**",
+        "apps/web/src/hooks/queries/useGameNights.ts"
+      ],
+      "notes": "Stage 3 #1170 commit 4. Functional + a11y coverage in e2e/v2-states/game-nights-index.spec.ts (5 scenarios x 3 viewports). Visual baselines deferred — auto-generated on Linux CI via visual-regression-migrated workflow (bootstrap mode)."
     }
   ]
 }

--- a/apps/web/src/__tests__/components/dashboard/DashboardHero.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/DashboardHero.test.tsx
@@ -53,7 +53,10 @@ describe('DashboardHero', () => {
       await Promise.resolve();
     });
     expect(kicker?.textContent?.toLowerCase()).toMatch(/benvenuto/);
-    expect(kicker?.textContent?.toLowerCase()).toMatch(/martedì/);
+    // Match any Italian weekday — was hardcoded 'martedì' which fails on other days (issue #1159).
+    expect(kicker?.textContent?.toLowerCase()).toMatch(
+      /luned[iì]|marted[iì]|mercoled[iì]|gioved[iì]|venerd[iì]|sabato|domenica/
+    );
   });
 
   it('renders lead text', () => {

--- a/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
@@ -237,6 +237,37 @@ describe('GameNightsContent (orchestrator)', () => {
     expect(target).toMatch(/view=list/);
   });
 
+  it('renders only organizing events when URL has ?filter=organizing', () => {
+    searchParamsState.view = 'list';
+    searchParamsState.filter = 'organizing';
+    const mine = makeDto({ organizerId: VIEWER_ID, title: 'Mia serata' });
+    const others = makeDto({
+      id: '55555555-5555-5555-5555-555555555555',
+      organizerId: 'someone-else-id-00000000000000000000',
+      title: 'Serata altrui',
+    });
+    useUpcomingMock.mockReturnValue({
+      data: [mine, others],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [mine],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    // List view renders only the organizing event (the viewer's own).
+    const cards = screen.getAllByTestId('game-nights-list-card');
+    expect(cards).toHaveLength(1);
+    expect(screen.getByText('Mia serata')).toBeInTheDocument();
+    expect(screen.queryByText('Serata altrui')).not.toBeInTheDocument();
+  });
+
   it('filters to organizing events when the "Organizzo" filter is clicked', () => {
     const mine = makeDto({ organizerId: VIEWER_ID, title: 'Mia serata' });
     const others = makeDto({

--- a/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * GameNightsContent — Stage 3 orchestrator smoke tests (Issue #1170 commit 3).
+ *
+ * Exercises the v2 orchestrator (calendar/list views, filter pills, drawer,
+ * empty + error branches). Pure-presentational components are covered by
+ * their own unit tests; this suite verifies wiring + state branching.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+const searchParamsState: Record<string, string | null> = {};
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: pushMock }),
+  useSearchParams: () => ({
+    get: (k: string) => searchParamsState[k] ?? null,
+    toString: () =>
+      Object.entries(searchParamsState)
+        .filter(([, v]) => v !== null && v !== undefined)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+        .join('&'),
+  }),
+}));
+
+// Identity translator returning the key (so we can assert by key).
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (k: string, _values?: Record<string, unknown>) => k,
+  }),
+}));
+
+const useUpcomingMock = vi.fn();
+const useMineMock = vi.fn();
+
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  useUpcomingGameNights: () => useUpcomingMock(),
+  useMyGameNights: () => useMineMock(),
+}));
+
+const useCurrentUserMock = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => useCurrentUserMock(),
+}));
+
+// Recents store no-op to avoid persistence side effects.
+vi.mock('@/stores/use-recents', () => ({
+  useRecentsStore: {
+    getState: () => ({ push: vi.fn() }),
+  },
+}));
+
+// ─── Import under test (after mocks) ──────────────────────────────────────
+
+import { GameNightsContent } from '../_content';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const VIEWER_ID = '11111111-1111-1111-1111-111111111111';
+
+function makeDto(overrides: Partial<GameNightDto> = {}): GameNightDto {
+  const now = new Date();
+  // Schedule "today" so the calendar grid will surface it under any month context.
+  const scheduledAt = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    20,
+    30,
+    0
+  ).toISOString();
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    organizerId: VIEWER_ID,
+    organizerName: 'Marco R.',
+    title: 'Serata Catan',
+    description: null,
+    scheduledAt,
+    location: 'Casa Marco',
+    maxPlayers: 6,
+    gameIds: [],
+    status: 'Published',
+    acceptedCount: 3,
+    pendingCount: 0,
+    totalInvited: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(searchParamsState)) delete searchParamsState[k];
+
+  useCurrentUserMock.mockReturnValue({ data: { id: VIEWER_ID } });
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('GameNightsContent (orchestrator)', () => {
+  it('renders the header + calendar view by default when events exist', () => {
+    const dto = makeDto({ title: 'Serata Catan' });
+    const other = makeDto({
+      id: '33333333-3333-3333-3333-333333333333',
+      organizerId: 'someone-else-id-00000000000000000000',
+      title: 'Serata Risk',
+    });
+    useUpcomingMock.mockReturnValue({
+      data: [dto, other],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [dto],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    // Header pulls translation keys (identity translator).
+    expect(screen.getByText('gameNightsIndex.header.title')).toBeInTheDocument();
+    // Calendar grid is the default view.
+    expect(screen.getByTestId('game-nights-calendar-month-grid')).toBeInTheDocument();
+    // The empty/list/error testids must NOT be present.
+    expect(screen.queryByTestId('game-nights-empty')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('game-nights-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('game-nights-error')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when both queries return zero events', () => {
+    useUpcomingMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    expect(screen.getByTestId('game-nights-empty')).toBeInTheDocument();
+    expect(screen.getByText('gameNightsIndex.states.empty.title')).toBeInTheDocument();
+    expect(screen.getByText('gameNightsIndex.states.empty.cta')).toBeInTheDocument();
+    // Calendar grid must not render.
+    expect(screen.queryByTestId('game-nights-calendar-month-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the error state with a retry button when both queries error', () => {
+    const upcomingRefetch = vi.fn();
+    const mineRefetch = vi.fn();
+    useUpcomingMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+      refetch: upcomingRefetch,
+    });
+    useMineMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+      refetch: mineRefetch,
+    });
+
+    render(<GameNightsContent />);
+
+    expect(screen.getByTestId('game-nights-error')).toBeInTheDocument();
+    const retry = screen.getByRole('button', { name: 'gameNightsIndex.states.error.retry' });
+    fireEvent.click(retry);
+    expect(upcomingRefetch).toHaveBeenCalledTimes(1);
+    expect(mineRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads ?view=list from the URL and renders the list view', () => {
+    searchParamsState.view = 'list';
+    const dto = makeDto();
+    useUpcomingMock.mockReturnValue({
+      data: [dto],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    expect(screen.getByTestId('game-nights-list')).toBeInTheDocument();
+    expect(screen.queryByTestId('game-nights-calendar-month-grid')).not.toBeInTheDocument();
+    // The list-card primitive should render at least one row.
+    expect(screen.getAllByTestId('game-nights-list-card').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('updates the URL when the user switches view via the header tablist', () => {
+    const dto = makeDto();
+    useUpcomingMock.mockReturnValue({
+      data: [dto],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    const listTab = screen.getByRole('tab', { name: 'gameNightsIndex.view.list' });
+    fireEvent.click(listTab);
+
+    expect(replaceMock).toHaveBeenCalled();
+    const target = String(replaceMock.mock.calls[0]?.[0] ?? '');
+    expect(target).toMatch(/view=list/);
+  });
+
+  it('filters to organizing events when the "Organizzo" filter is clicked', () => {
+    const mine = makeDto({ organizerId: VIEWER_ID, title: 'Mia serata' });
+    const others = makeDto({
+      id: '44444444-4444-4444-4444-444444444444',
+      organizerId: 'someone-else-id-00000000000000000000',
+      title: 'Serata altrui',
+    });
+    useUpcomingMock.mockReturnValue({
+      data: [mine, others],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useMineMock.mockReturnValue({
+      data: [mine],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GameNightsContent />);
+
+    const organizing = screen.getByRole('button', { name: 'gameNightsIndex.filter.organizing' });
+    fireEvent.click(organizing);
+
+    expect(replaceMock).toHaveBeenCalled();
+    const target = String(replaceMock.mock.calls[0]?.[0] ?? '');
+    expect(target).toMatch(/filter=organizing/);
+  });
+});

--- a/apps/web/src/app/(authenticated)/game-nights/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_content.tsx
@@ -1,100 +1,88 @@
 /**
- * Game Nights Content (client component)
- * Issue #33 — P3 Game Night Frontend
+ * GameNightsContent — v2 orchestrator for /game-nights index (Issue #1170 commit 3).
  *
- * Renders upcoming / my game nights based on ?tab query param.
+ * Composes the v2 primitives from `components/features/game-nights/` (calendar,
+ * list, header, drawer) driven by `useUpcomingGameNights` + `useMyGameNights`
+ * + `useCurrentUser`. URL is the SSOT for `?view=calendar|list` and
+ * `?filter=all|organizing|invited|completed`.
+ *
+ * Backend gaps (out of scope #1170, tracked):
+ *   - per-event RSVP roster → `players={[]}` (avatar stack hidden).
+ *   - per-event game title  → `gameTitle={undefined}` (chip hidden).
+ *
+ * Replaces the legacy `?tab=` upcoming/mine flat grid.
  */
 
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { Calendar, MapPin, Users } from 'lucide-react';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  CalendarMonthGrid,
+  DayDetailDrawer,
+  GameNightListCard,
+  GameNightsHeader,
+  type CalendarDayCellLabels,
+  type CalendarMonthGridLabels,
+  type DayDetailDrawerLabels,
+  type FilterPillBarLabels,
+  type GameNightListCardLabels,
+  type GameNightsHeaderLabels,
+  type GameNightsView,
+  type StatusPillLabels,
+} from '@/components/features/game-nights';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useMyGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
-import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+import { useTranslation, type TranslationFunction } from '@/hooks/useTranslation';
+import type { MonthCell } from '@/lib/game-nights/calendar-grid';
+import { filterEvents, isFilterKey, type FilterKey } from '@/lib/game-nights/event-filter';
+import { groupByMonth } from '@/lib/game-nights/event-grouping';
+import { toGameNightVM, type GameNightVM } from '@/lib/game-nights/view-model';
 import { useRecentsStore } from '@/stores/use-recents';
 
-function GameNightCard({ event }: { event: GameNightDto }) {
-  const scheduledDate = new Date(event.scheduledAt);
-  const isPast = scheduledDate < new Date();
-
-  return (
-    <Link href={`/game-nights/${event.id}`}>
-      <Card className="hover:border-amber-300 transition-colors cursor-pointer">
-        <CardHeader className="pb-2">
-          <div className="flex items-start justify-between gap-2">
-            <CardTitle className="text-lg font-quicksand">{event.title}</CardTitle>
-            <StatusBadge status={event.status} isPast={isPast} />
-          </div>
-          <CardDescription className="font-nunito">
-            Organizzata da {event.organizerName}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-2 text-sm text-muted-foreground font-nunito">
-          <div className="flex items-center gap-2">
-            <Calendar className="h-4 w-4" />
-            <span>
-              {scheduledDate.toLocaleDateString('it-IT', {
-                weekday: 'long',
-                day: 'numeric',
-                month: 'long',
-                hour: '2-digit',
-                minute: '2-digit',
-              })}
-            </span>
-          </div>
-          {event.location && (
-            <div className="flex items-center gap-2">
-              <MapPin className="h-4 w-4" />
-              <span>{event.location}</span>
-            </div>
-          )}
-          <div className="flex items-center gap-2">
-            <Users className="h-4 w-4" />
-            <span>
-              {event.acceptedCount} confermati
-              {event.pendingCount > 0 && ` · ${event.pendingCount} in attesa`}
-              {event.maxPlayers && ` / ${event.maxPlayers} max`}
-            </span>
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
-  );
+function monthAbbrev(year: number, month: number): string {
+  return new Date(year, month, 1)
+    .toLocaleDateString(undefined, { month: 'short' })
+    .replace(/\.$/, '');
 }
 
-function StatusBadge({ status, isPast }: { status: string; isPast: boolean }) {
-  if (status === 'Cancelled') return <Badge variant="destructive">Annullata</Badge>;
-  if (status === 'Draft') return <Badge variant="secondary">Bozza</Badge>;
-  if (isPast) return <Badge variant="outline">Conclusa</Badge>;
-  return <Badge className="bg-amber-100 text-amber-900 border-amber-200">Pubblicata</Badge>;
+function monthLong(year: number, month: number): string {
+  return new Date(year, month, 1).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
 }
 
-function EmptyState({ tab }: { tab: string }) {
-  return (
-    <div className="text-center py-12 text-muted-foreground font-nunito">
-      <Calendar className="h-12 w-12 mx-auto mb-4 opacity-40" />
-      <p className="text-lg font-medium">
-        {tab === 'mine' ? 'Non hai ancora organizzato serate' : 'Nessuna serata in programma'}
-      </p>
-      <p className="text-sm mt-1">
-        {tab === 'mine'
-          ? 'Crea la tua prima serata giochi!'
-          : 'Le prossime serate appariranno qui.'}
-      </p>
-    </div>
-  );
+const K = 'gameNightsIndex';
+
+function makeCardLabels(
+  t: TranslationFunction,
+  statusLabels: StatusPillLabels,
+  vm: GameNightVM
+): GameNightListCardLabels {
+  return {
+    status: statusLabels,
+    organizingBadge: t(`${K}.list.organizingBadge`),
+    participants: (count: number) => t(`${K}.list.participants`, { count }),
+    cta: {
+      edit: t(`${K}.list.cta.edit`),
+      viewSummary: t(`${K}.list.cta.viewSummary`),
+      reschedule: t(`${K}.list.cta.reschedule`),
+      accept: t(`${K}.list.cta.accept`),
+      maybe: t(`${K}.list.cta.maybe`),
+    },
+    monthAbbrev: monthAbbrev(vm.year, vm.month),
+  };
 }
 
-export function GameNightsContent() {
-  const searchParams = useSearchParams();
-  const tab = searchParams.get('tab') ?? 'upcoming';
+export function GameNightsContent(): React.JSX.Element {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const sp = useSearchParams();
+
+  // Register in recents (parity with legacy).
   useEffect(() => {
     useRecentsStore.getState().push({
       id: 'section-game-nights',
@@ -104,48 +92,355 @@ export function GameNightsContent() {
     });
   }, []);
 
-  const upcomingQuery = useUpcomingGameNights();
-  const mineQuery = useMyGameNights();
+  // URL state SSOT.
+  const rawView = sp.get('view');
+  const view: GameNightsView = rawView === 'list' ? 'list' : 'calendar';
+  const rawFilter = sp.get('filter');
+  const filter: FilterKey = isFilterKey(rawFilter) ? rawFilter : 'all';
 
-  const isUpcoming = tab !== 'mine';
-  const { data, isLoading, error } = isUpcoming ? upcomingQuery : mineQuery;
+  function setParam(key: string, value: string): void {
+    const next = new URLSearchParams(sp.toString());
+    next.set(key, value);
+    router.replace(`/game-nights?${next.toString()}`, { scroll: false });
+  }
 
-  if (isLoading) return <GameNightsLoadingSkeleton />;
+  // Data hooks.
+  const { data: viewer } = useCurrentUser();
+  const upcoming = useUpcomingGameNights();
+  const mine = useMyGameNights();
 
-  if (error) {
+  // Merge + dedup by id; map to VMs.
+  const allVms = useMemo<readonly GameNightVM[]>(() => {
+    const byId = new Map<string, GameNightVM>();
+    for (const dto of upcoming.data ?? []) {
+      byId.set(dto.id, toGameNightVM(dto, viewer?.id ?? null));
+    }
+    for (const dto of mine.data ?? []) {
+      if (byId.has(dto.id)) continue;
+      byId.set(dto.id, toGameNightVM(dto, viewer?.id ?? null));
+    }
+    return Array.from(byId.values());
+  }, [upcoming.data, mine.data, viewer?.id]);
+
+  // Today / "this month" header counters (always against the unfiltered set so
+  // the header reflects the underlying month volume, not the active filter).
+  const today = useMemo(() => new Date(), []);
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const thisMonthVms = useMemo(
+    () => allVms.filter(v => v.year === year && v.month === month),
+    [allVms, year, month]
+  );
+  const totalThisMonth = thisMonthVms.length;
+  const confirmedThisMonth = thisMonthVms.filter(v => v.statusKey === 'confirmed').length;
+
+  // Filtered set drives both calendar + list.
+  const filtered = useMemo(() => filterEvents(allVms, filter), [allVms, filter]);
+  const cancelledInFiltered = useMemo(
+    () => filtered.filter(v => v.statusKey === 'cancelled').length,
+    [filtered]
+  );
+
+  // Day-drawer state.
+  const [drawerCell, setDrawerCell] = useState<MonthCell | null>(null);
+  const dayEvents = useMemo<readonly GameNightVM[]>(() => {
+    if (!drawerCell) return [];
+    return filtered.filter(v => v.year === year && v.month === month && v.day === drawerCell.day);
+  }, [drawerCell, filtered, year, month]);
+
+  // ── Label dictionaries (memoised on translator + dependent counts). ──
+  const statusLabels: StatusPillLabels = useMemo(
+    () => ({
+      confirmed: t(`${K}.status.confirmed`),
+      planned: t(`${K}.status.planned`),
+      cancelled: t(`${K}.status.cancelled`),
+      completed: t(`${K}.status.completed`),
+    }),
+    [t]
+  );
+
+  const filterLabels: FilterPillBarLabels = useMemo(
+    () => ({
+      ariaLabel: t(`${K}.filter.ariaLabel`),
+      all: t(`${K}.filter.all`),
+      organizing: t(`${K}.filter.organizing`),
+      invited: t(`${K}.filter.invited`),
+      completed: t(`${K}.filter.completed`),
+    }),
+    [t]
+  );
+
+  const headerLabels: GameNightsHeaderLabels = useMemo(
+    () => ({
+      kicker: t(`${K}.header.kicker`),
+      title: t(`${K}.header.title`),
+      countLine: t(`${K}.header.countLine`, {
+        total: totalThisMonth,
+        confirmed: confirmedThisMonth,
+      }),
+      ctaNew: t(`${K}.header.ctaNew`),
+      viewTablistAriaLabel: t(`${K}.view.tablistAriaLabel`),
+      viewCalendar: t(`${K}.view.calendar`),
+      viewList: t(`${K}.view.list`),
+      filter: filterLabels,
+    }),
+    [t, totalThisMonth, confirmedThisMonth, filterLabels]
+  );
+
+  const cellLabels: CalendarDayCellLabels = useMemo(
+    () => ({
+      todayBadge: t(`${K}.calendar.todayBadge`),
+      dayAriaLabel: (day: number, events: number) =>
+        t(`${K}.calendar.dayAriaLabel`, { day, events }),
+      overflow: (count: number) => t(`${K}.calendar.overflow`, { count }),
+    }),
+    [t]
+  );
+
+  const monthGridLabels: CalendarMonthGridLabels = useMemo(
+    () => ({
+      prevMonth: t(`${K}.calendar.prevMonth`),
+      nextMonth: t(`${K}.calendar.nextMonth`),
+      today: t(`${K}.calendar.today`),
+      monthHeading: monthLong(year, month),
+      dayLabels: t(`${K}.calendar.dayLabels`).split(','),
+      footerCount: t(`${K}.calendar.footerCount`, {
+        total: filtered.length,
+        cancelled: cancelledInFiltered,
+      }),
+      legendEvent: t(`${K}.calendar.legend.event`),
+      legendCancelled: t(`${K}.calendar.legend.cancelled`),
+      legendToday: t(`${K}.calendar.legend.today`),
+      cell: cellLabels,
+    }),
+    [t, year, month, filtered.length, cancelledInFiltered, cellLabels]
+  );
+
+  // ── State branches ────────────────────────────────────────────────
+  // Loading: only show skeleton on first load (both queries pending).
+  const isInitialLoading = upcoming.isLoading && mine.isLoading && allVms.length === 0;
+  const hasError = (upcoming.error || mine.error) && allVms.length === 0;
+
+  if (hasError) {
     return (
-      <div className="text-center py-12 text-destructive font-nunito">
-        <p>Errore nel caricamento delle serate.</p>
+      <div
+        data-testid="game-nights-error"
+        className="flex flex-col items-center gap-3 px-4 py-12 text-center"
+      >
+        <h2 className="font-display text-lg font-extrabold text-foreground">
+          {t(`${K}.states.error.title`)}
+        </h2>
+        <p className="font-mono text-sm text-muted-foreground">{t(`${K}.states.error.body`)}</p>
+        <button
+          type="button"
+          onClick={() => {
+            void upcoming.refetch();
+            void mine.refetch();
+          }}
+          className="rounded-md bg-entity-event px-4 py-2 font-display text-sm font-extrabold text-white"
+        >
+          {t(`${K}.states.error.retry`)}
+        </button>
       </div>
     );
   }
 
-  if (!data || data.length === 0) return <EmptyState tab={tab} />;
+  if (isInitialLoading) {
+    return <GameNightsLoadingSkeleton />;
+  }
+
+  // ── Header always renders (with zeroed counts in true-empty state). ──
+  const headerEl = (
+    <GameNightsHeader
+      view={view}
+      onViewChange={(v: GameNightsView) => setParam('view', v)}
+      filter={filter}
+      onFilterChange={(k: FilterKey) => setParam('filter', k)}
+      onCreate={() => router.push('/game-nights/new')}
+      labels={headerLabels}
+    />
+  );
+
+  // True empty: no events at all.
+  if (allVms.length === 0) {
+    return (
+      <>
+        {headerEl}
+        <EmptyState
+          title={t(`${K}.states.empty.title`)}
+          body={t(`${K}.states.empty.body`)}
+          cta={t(`${K}.states.empty.cta`)}
+          onCta={() => router.push('/game-nights/new')}
+        />
+      </>
+    );
+  }
+
+  // Drawer labels (only built when drawerCell present).
+  const drawerLabels: DayDetailDrawerLabels | null = drawerCell
+    ? {
+        title: t(`${K}.drawer.title`, {
+          day: drawerCell.day,
+          month: new Date(year, month, 1).toLocaleString(undefined, { month: 'long' }),
+          year,
+        }),
+        subtitle: t(`${K}.drawer.subtitle`, { count: dayEvents.length }),
+        close: t(`${K}.drawer.close`),
+        addOnDay: t(`${K}.drawer.addOnDay`),
+        card: {
+          status: statusLabels,
+          organizingBadge: t(`${K}.list.organizingBadge`),
+          participants: (count: number) => t(`${K}.list.participants`, { count }),
+          cta: {
+            edit: t(`${K}.list.cta.edit`),
+            viewSummary: t(`${K}.list.cta.viewSummary`),
+            reschedule: t(`${K}.list.cta.reschedule`),
+            accept: t(`${K}.list.cta.accept`),
+            maybe: t(`${K}.list.cta.maybe`),
+          },
+          monthAbbrev: monthAbbrev(year, month),
+        },
+        monthAbbrev: monthAbbrev(year, month),
+      }
+    : null;
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
-      {data.map(event => (
-        <GameNightCard key={event.id} event={event} />
-      ))}
+    <>
+      {headerEl}
+      {view === 'calendar' ? (
+        <CalendarMonthGrid
+          year={year}
+          month={month}
+          events={filtered}
+          today={today}
+          labels={monthGridLabels}
+          onDayClick={cell => setDrawerCell(cell)}
+        />
+      ) : (
+        <ListView
+          events={filtered}
+          now={today}
+          t={t}
+          statusLabels={statusLabels}
+          emptyTitle={t(`${K}.states.filteredEmpty.title`)}
+          emptyBody={t(`${K}.states.filteredEmpty.body`)}
+        />
+      )}
+      {drawerCell && drawerLabels && (
+        <DayDetailDrawer
+          open
+          day={drawerCell.day}
+          events={dayEvents}
+          labels={drawerLabels}
+          onClose={() => setDrawerCell(null)}
+          onAddOnDay={() => router.push('/game-nights/new')}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── ListView ──────────────────────────────────────────────────────────────
+
+interface ListViewProps {
+  readonly events: readonly GameNightVM[];
+  readonly now: Date;
+  readonly t: TranslationFunction;
+  readonly statusLabels: StatusPillLabels;
+  readonly emptyTitle: string;
+  readonly emptyBody: string;
+}
+
+function ListView({
+  events,
+  now,
+  t,
+  statusLabels,
+  emptyTitle,
+  emptyBody,
+}: ListViewProps): React.JSX.Element {
+  const groups = useMemo(() => groupByMonth(events, now), [events, now]);
+
+  if (groups.length === 0) {
+    return (
+      <div
+        data-testid="game-nights-list-empty"
+        className="flex flex-col items-center gap-2 px-4 py-12 text-center"
+      >
+        <h2 className="font-display text-base font-extrabold text-foreground">{emptyTitle}</h2>
+        <p className="font-mono text-sm text-muted-foreground">{emptyBody}</p>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      data-testid="game-nights-list"
+      className="flex flex-col gap-4 px-4 pb-6 pt-3 md:px-8 md:pt-5 md:pb-8"
+    >
+      {groups.map(group => {
+        const heading = monthLong(group.year, group.month);
+        return (
+          <div key={`${group.year}-${group.month}`} className="flex flex-col gap-2.5">
+            <header className="sticky top-0 z-[5] flex items-baseline justify-between bg-background py-2">
+              <h2 className="font-display text-sm font-extrabold uppercase tracking-wider text-foreground">
+                {heading}
+              </h2>
+              <span className="font-mono text-xs font-bold text-muted-foreground">
+                {t(`${K}.list.groupCount`, { count: group.items.length })}
+              </span>
+            </header>
+            <div className="flex flex-col gap-2.5">
+              {group.items.map(vm => (
+                <GameNightListCard
+                  key={vm.id}
+                  vm={vm}
+                  labels={makeCardLabels(t, statusLabels, vm)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+// ─── Empty state ───────────────────────────────────────────────────────────
+
+interface EmptyStateProps {
+  readonly title: string;
+  readonly body: string;
+  readonly cta: string;
+  readonly onCta: () => void;
+}
+
+function EmptyState({ title, body, cta, onCta }: EmptyStateProps): React.JSX.Element {
+  return (
+    <div
+      data-testid="game-nights-empty"
+      className="flex flex-col items-center gap-3 px-4 py-12 text-center"
+    >
+      <h2 className="font-display text-lg font-extrabold text-foreground">{title}</h2>
+      <p className="max-w-md font-mono text-sm text-muted-foreground">{body}</p>
+      <button
+        type="button"
+        onClick={onCta}
+        className="rounded-md bg-gradient-to-br from-entity-event to-entity-session px-4 py-2.5 font-display text-sm font-extrabold text-white shadow-md shadow-entity-event/30"
+      >
+        {cta}
+      </button>
     </div>
   );
 }
 
-export function GameNightsLoadingSkeleton() {
+// ─── Loading skeleton (preserved for Suspense fallback) ────────────────────
+
+export function GameNightsLoadingSkeleton(): React.JSX.Element {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <Card key={i}>
-          <CardHeader className="pb-2">
-            <Skeleton className="h-5 w-3/4" />
-            <Skeleton className="h-4 w-1/2 mt-1" />
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-2/3" />
-            <Skeleton className="h-4 w-1/2" />
-          </CardContent>
-        </Card>
+    <div data-testid="game-nights-loading" className="flex flex-col gap-3 px-4 py-6 md:px-8">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-28 animate-pulse rounded-lg bg-muted" />
       ))}
     </div>
   );

--- a/apps/web/src/app/(authenticated)/game-nights/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_content.tsx
@@ -141,12 +141,16 @@ export function GameNightsContent(): React.JSX.Element {
     [filtered]
   );
 
-  // Day-drawer state.
-  const [drawerCell, setDrawerCell] = useState<MonthCell | null>(null);
+  // Day-drawer state. The drawer carries its own (year, month) snapshot so that
+  // when month-nav is wired up in a follow-up, filtering doesn't silently fall
+  // back to today's month.
+  type DrawerTarget = { cell: MonthCell; gridYear: number; gridMonth: number };
+  const [drawerTarget, setDrawerTarget] = useState<DrawerTarget | null>(null);
   const dayEvents = useMemo<readonly GameNightVM[]>(() => {
-    if (!drawerCell) return [];
-    return filtered.filter(v => v.year === year && v.month === month && v.day === drawerCell.day);
-  }, [drawerCell, filtered, year, month]);
+    if (!drawerTarget) return [];
+    const { cell, gridYear, gridMonth } = drawerTarget;
+    return filtered.filter(v => v.year === gridYear && v.month === gridMonth && v.day === cell.day);
+  }, [drawerTarget, filtered]);
 
   // ── Label dictionaries (memoised on translator + dependent counts). ──
   const statusLabels: StatusPillLabels = useMemo(
@@ -219,6 +223,9 @@ export function GameNightsContent(): React.JSX.Element {
   // ── State branches ────────────────────────────────────────────────
   // Loading: only show skeleton on first load (both queries pending).
   const isInitialLoading = upcoming.isLoading && mine.isLoading && allVms.length === 0;
+  // Stale-over-error policy: once we have any cached data (allVms > 0), background
+  // refetch failures keep the existing data visible rather than swapping to an error
+  // screen. The error branch only triggers on the initial load with no cache.
   const hasError = (upcoming.error || mine.error) && allVms.length === 0;
 
   if (hasError) {
@@ -276,13 +283,17 @@ export function GameNightsContent(): React.JSX.Element {
     );
   }
 
-  // Drawer labels (only built when drawerCell present).
-  const drawerLabels: DayDetailDrawerLabels | null = drawerCell
+  // Drawer labels (only built when drawerTarget present). Uses the target's
+  // (gridYear, gridMonth) snapshot, not today's — required for month-nav.
+  const drawerLabels: DayDetailDrawerLabels | null = drawerTarget
     ? {
         title: t(`${K}.drawer.title`, {
-          day: drawerCell.day,
-          month: new Date(year, month, 1).toLocaleString(undefined, { month: 'long' }),
-          year,
+          day: drawerTarget.cell.day,
+          month: new Date(drawerTarget.gridYear, drawerTarget.gridMonth, 1).toLocaleString(
+            undefined,
+            { month: 'long' }
+          ),
+          year: drawerTarget.gridYear,
         }),
         subtitle: t(`${K}.drawer.subtitle`, { count: dayEvents.length }),
         close: t(`${K}.drawer.close`),
@@ -298,9 +309,9 @@ export function GameNightsContent(): React.JSX.Element {
             accept: t(`${K}.list.cta.accept`),
             maybe: t(`${K}.list.cta.maybe`),
           },
-          monthAbbrev: monthAbbrev(year, month),
+          monthAbbrev: monthAbbrev(drawerTarget.gridYear, drawerTarget.gridMonth),
         },
-        monthAbbrev: monthAbbrev(year, month),
+        monthAbbrev: monthAbbrev(drawerTarget.gridYear, drawerTarget.gridMonth),
       }
     : null;
 
@@ -314,7 +325,7 @@ export function GameNightsContent(): React.JSX.Element {
           events={filtered}
           today={today}
           labels={monthGridLabels}
-          onDayClick={cell => setDrawerCell(cell)}
+          onDayClick={cell => setDrawerTarget({ cell, gridYear: year, gridMonth: month })}
         />
       ) : (
         <ListView
@@ -326,13 +337,13 @@ export function GameNightsContent(): React.JSX.Element {
           emptyBody={t(`${K}.states.filteredEmpty.body`)}
         />
       )}
-      {drawerCell && drawerLabels && (
+      {drawerTarget && drawerLabels && (
         <DayDetailDrawer
           open
-          day={drawerCell.day}
+          day={drawerTarget.cell.day}
           events={dayEvents}
           labels={drawerLabels}
-          onClose={() => setDrawerCell(null)}
+          onClose={() => setDrawerTarget(null)}
           onAddOnDay={() => router.push('/game-nights/new')}
         />
       )}

--- a/apps/web/src/app/(authenticated)/game-nights/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_content.tsx
@@ -96,7 +96,12 @@ export function GameNightsContent(): React.JSX.Element {
   const rawView = sp.get('view');
   const view: GameNightsView = rawView === 'list' ? 'list' : 'calendar';
   const rawFilter = sp.get('filter');
-  const filter: FilterKey = isFilterKey(rawFilter) ? rawFilter : 'all';
+  // Legacy compat: pre-v2 ?tab=mine → organizing, ?tab=upcoming → all.
+  // Map only when ?filter= is absent to avoid clobbering explicit user state.
+  const legacyTab = sp.get('tab');
+  const filterFromTab: FilterKey | null =
+    rawFilter === null && legacyTab === 'mine' ? 'organizing' : null;
+  const filter: FilterKey = isFilterKey(rawFilter) ? rawFilter : (filterFromTab ?? 'all');
 
   function setParam(key: string, value: string): void {
     const next = new URLSearchParams(sp.toString());

--- a/apps/web/src/components/features/game-nights/CalendarDayCell.tsx
+++ b/apps/web/src/components/features/game-nights/CalendarDayCell.tsx
@@ -1,14 +1,113 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: CalendarDayCell
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * CalendarDayCell - v2 SP4 #1170 commit 2
+ *
+ * Single calendar grid cell. Renders day number, optional "Oggi" badge,
+ * and up to N event chips (1 mobile / 3 desktop). Overflow rendered as
+ * "+N altri".
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx` (CalendarDayCell).
+ */
 
-import type { ReactElement } from 'react';
+import clsx from 'clsx';
 
-export interface CalendarDayCellProps {
-  // TODO: extract props contract from mockup analysis
+import type { MonthCell } from '@/lib/game-nights/calendar-grid';
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+export interface CalendarDayCellLabels {
+  readonly todayBadge: string;
+  readonly dayAriaLabel: (day: number, events: number) => string;
+  readonly overflow: (count: number) => string;
 }
 
-export function CalendarDayCell(_props: CalendarDayCellProps): ReactElement | null {
-  return null;
+export interface CalendarDayCellProps {
+  readonly cell: MonthCell;
+  readonly events: readonly GameNightVM[];
+  readonly isToday: boolean;
+  readonly isMobile?: boolean;
+  readonly labels: CalendarDayCellLabels;
+  readonly onClick?: (cell: MonthCell, events: readonly GameNightVM[]) => void;
+}
+
+export function CalendarDayCell({
+  cell,
+  events,
+  isToday,
+  isMobile = false,
+  labels,
+  onClick,
+}: CalendarDayCellProps): React.JSX.Element {
+  const maxVisible = isMobile ? 1 : 3;
+  const visibleEvents = events.slice(0, maxVisible);
+  const overflow = Math.max(0, events.length - maxVisible);
+  const hasEvents = events.length > 0;
+
+  const handleClick = (): void => {
+    if (!cell.otherMonth && hasEvents) {
+      onClick?.(cell, events);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      data-testid="game-nights-calendar-day-cell"
+      data-day={cell.day}
+      data-other-month={cell.otherMonth || undefined}
+      data-today={isToday || undefined}
+      disabled={cell.otherMonth || !hasEvents}
+      aria-label={labels.dayAriaLabel(cell.day, events.length)}
+      onClick={handleClick}
+      className={clsx(
+        'relative flex flex-col gap-1 rounded-md p-2 text-left transition-colors',
+        isMobile ? 'min-h-[64px] rounded-sm p-1' : 'min-h-[110px]',
+        cell.otherMonth && 'cursor-default opacity-35',
+        !cell.otherMonth && hasEvents && 'cursor-pointer bg-entity-event/5',
+        !cell.otherMonth && !hasEvents && 'bg-card',
+        isToday ? 'border-2 border-entity-event' : 'border border-border-strong'
+      )}
+    >
+      <div className="flex items-start">
+        <span
+          className={clsx(
+            'font-mono text-xs font-bold',
+            isToday && 'font-extrabold text-entity-event',
+            cell.otherMonth && 'text-muted-foreground',
+            !cell.otherMonth && !isToday && 'text-foreground'
+          )}
+        >
+          {cell.day}
+        </span>
+        {isToday && !isMobile && (
+          <span className="ml-auto font-mono text-[8px] font-extrabold uppercase tracking-wider text-entity-event">
+            {labels.todayBadge}
+          </span>
+        )}
+      </div>
+
+      {visibleEvents.map(ev => {
+        const isCancelled = ev.statusKey === 'cancelled';
+        return (
+          <div
+            key={ev.id}
+            className={clsx(
+              'overflow-hidden text-ellipsis whitespace-nowrap rounded border-l-2 px-1.5 py-0.5',
+              'font-display text-[10px] font-bold',
+              isCancelled
+                ? 'border-l-destructive bg-destructive/12 text-destructive line-through opacity-70'
+                : 'border-l-entity-event bg-entity-event/18 text-entity-event'
+            )}
+          >
+            <span className="font-mono font-extrabold">{ev.timeLabel}</span>
+            {!isMobile && ev.title ? ` · ${ev.title}` : null}
+          </div>
+        );
+      })}
+
+      {overflow > 0 && (
+        <div className="px-1 py-0.5 font-mono text-[9px] font-bold text-entity-event">
+          {labels.overflow(overflow)}
+        </div>
+      )}
+    </button>
+  );
 }

--- a/apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx
+++ b/apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx
@@ -1,14 +1,143 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: CalendarMonthGrid
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * CalendarMonthGrid - v2 SP4 #1170 commit 2
+ *
+ * 6×7 month grid (Monday-first). Renders nav row, day labels, 42 day cells,
+ * and a legend row.
+ *
+ * NOTE: month-nav arrows + "Oggi" reset are visual-only per mockup (no
+ * fetch wiring in this commit). Buttons are `disabled` to make the
+ * affordance honest.
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx`
+ * (CalendarMonthGrid).
+ */
 
-import type { ReactElement } from 'react';
+import { buildMonthGrid, type MonthCell } from '@/lib/game-nights/calendar-grid';
+import type { GameNightVM } from '@/lib/game-nights/view-model';
 
-export interface CalendarMonthGridProps {
-  // TODO: extract props contract from mockup analysis
+import { CalendarDayCell, type CalendarDayCellLabels } from './CalendarDayCell';
+
+export interface CalendarMonthGridLabels {
+  readonly prevMonth: string;
+  readonly nextMonth: string;
+  readonly today: string;
+  readonly monthHeading: string;
+  readonly dayLabels: readonly string[];
+  readonly footerCount: string;
+  readonly legendEvent: string;
+  readonly legendCancelled: string;
+  readonly legendToday: string;
+  readonly cell: CalendarDayCellLabels;
 }
 
-export function CalendarMonthGrid(_props: CalendarMonthGridProps): ReactElement | null {
-  return null;
+export interface CalendarMonthGridProps {
+  readonly year: number;
+  readonly month: number;
+  readonly events: readonly GameNightVM[];
+  readonly today?: Date;
+  readonly isMobile?: boolean;
+  readonly labels: CalendarMonthGridLabels;
+  readonly onDayClick: (cell: MonthCell, events: readonly GameNightVM[]) => void;
+}
+
+export function CalendarMonthGrid({
+  year,
+  month,
+  events,
+  today,
+  isMobile = false,
+  labels,
+  onDayClick,
+}: CalendarMonthGridProps): React.JSX.Element {
+  const grid = buildMonthGrid(year, month);
+  const todayDate = today ?? new Date();
+  const todayDay = todayDate.getDate();
+  const todayMonth = todayDate.getMonth();
+  const todayYear = todayDate.getFullYear();
+
+  return (
+    <section
+      data-testid="game-nights-calendar-month-grid"
+      className="flex flex-col gap-3 px-4 pb-6 pt-3 md:px-8 md:pt-5 md:pb-8"
+    >
+      <div className="flex flex-wrap items-center gap-2.5">
+        <button
+          type="button"
+          aria-label={labels.prevMonth}
+          disabled
+          className="h-8 w-8 rounded-md border border-border bg-card text-sm text-foreground"
+        >
+          ‹
+        </button>
+        <h2 className="min-w-[140px] font-display text-base font-extrabold text-foreground md:text-xl">
+          {labels.monthHeading}
+        </h2>
+        <button
+          type="button"
+          aria-label={labels.nextMonth}
+          disabled
+          className="h-8 w-8 rounded-md border border-border bg-card text-sm text-foreground"
+        >
+          ›
+        </button>
+        <button
+          type="button"
+          disabled
+          className="ml-1.5 rounded-md border border-entity-event/40 px-3.5 py-1.5 font-display text-xs font-extrabold text-entity-event"
+        >
+          {labels.today}
+        </button>
+        <span className="ml-auto font-mono text-xs font-bold text-muted-foreground">
+          {labels.footerCount}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-7 gap-1">
+        {labels.dayLabels.map((dayLabel, i) => (
+          <div
+            key={`${dayLabel}-${i}`}
+            className="px-1 py-1.5 text-center font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground md:text-left"
+          >
+            {dayLabel}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1">
+        {grid.map((cell, idx) => {
+          const cellEvents = cell.otherMonth
+            ? []
+            : events.filter(e => e.year === year && e.month === month && e.day === cell.day);
+          const isToday =
+            !cell.otherMonth && cell.day === todayDay && month === todayMonth && year === todayYear;
+          return (
+            <CalendarDayCell
+              key={`${cell.monthOffset}-${cell.day}-${idx}`}
+              cell={cell}
+              events={cellEvents}
+              isToday={isToday}
+              isMobile={isMobile}
+              labels={labels.cell}
+              onClick={onDayClick}
+            />
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap gap-3.5 pt-2 font-mono text-[10px] font-bold text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true" className="h-2 w-2 rounded-sm bg-entity-event" />
+          {labels.legendEvent}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true" className="h-2 w-2 rounded-sm bg-destructive line-through" />
+          {labels.legendCancelled}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true" className="h-2 w-2 rounded-sm border-2 border-entity-event" />
+          {labels.legendToday}
+        </span>
+      </div>
+    </section>
+  );
 }

--- a/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
+++ b/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
@@ -15,6 +15,7 @@ import { useEffect, useId, useRef } from 'react';
 
 import clsx from 'clsx';
 
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 import type { GameNightVM } from '@/lib/game-nights/view-model';
 
 import {
@@ -61,6 +62,9 @@ export function DayDetailDrawer({
 }: DayDetailDrawerProps): React.JSX.Element | null {
   const headingId = useId();
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+  const drawerRef = useRef<HTMLElement | null>(null);
+
+  useFocusTrap(drawerRef, open);
 
   useEffect(() => {
     if (!open) return;
@@ -89,6 +93,7 @@ export function DayDetailDrawer({
       className="absolute inset-0 z-50 flex items-end justify-stretch bg-foreground/50 md:items-stretch md:justify-end"
     >
       <aside
+        ref={drawerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={headingId}

--- a/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
+++ b/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
@@ -1,14 +1,161 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: DayDetailDrawer
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * DayDetailDrawer - v2 SP4 #1170 commit 2
+ *
+ * Bottom sheet (mobile) / right drawer (desktop) listing all events on a
+ * specific day. Renders a list of `GameNightListCard` and a dashed "add
+ * here" button.
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx`
+ * (DayDetailDrawer).
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface DayDetailDrawerProps {
-  // TODO: extract props contract from mockup analysis
+import { useEffect, useId, useRef } from 'react';
+
+import clsx from 'clsx';
+
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+import {
+  GameNightListCard,
+  type GameNightListCardAction,
+  type GameNightListCardLabels,
+} from './GameNightListCard';
+
+import type { AvatarPlayer } from './PlayerAvatars';
+
+export interface DayDetailDrawerLabels {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly close: string;
+  readonly addOnDay: string;
+  readonly card: GameNightListCardLabels;
+  readonly monthAbbrev: string;
 }
 
-export function DayDetailDrawer(_props: DayDetailDrawerProps): ReactElement | null {
-  return null;
+export interface DayDetailDrawerProps {
+  readonly open: boolean;
+  readonly day: number;
+  readonly events: readonly GameNightVM[];
+  readonly isMobile?: boolean;
+  readonly labels: DayDetailDrawerLabels;
+  readonly onClose: () => void;
+  readonly onAddOnDay?: () => void;
+  readonly onCardAction?: (id: string, action: GameNightListCardAction) => void;
+  readonly resolvePlayers?: (vm: GameNightVM) => readonly AvatarPlayer[];
+  readonly resolveGameTitle?: (vm: GameNightVM) => string | undefined;
+}
+
+export function DayDetailDrawer({
+  open,
+  day,
+  events,
+  isMobile = false,
+  labels,
+  onClose,
+  onAddOnDay,
+  onCardAction,
+  resolvePlayers,
+  resolveGameTitle,
+}: DayDetailDrawerProps): React.JSX.Element | null {
+  const headingId = useId();
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    closeBtnRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      data-testid="game-nights-day-detail-backdrop"
+      className="absolute inset-0 z-50 flex items-end justify-stretch bg-foreground/50 md:items-stretch md:justify-end"
+    >
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        data-testid="game-nights-day-detail-drawer"
+        onClick={e => e.stopPropagation()}
+        className={clsx(
+          'max-h-[88vh] w-full max-w-full overflow-auto rounded-t-xl bg-background shadow-xl',
+          'md:h-full md:max-h-full md:w-[480px] md:rounded-tr-none',
+          'motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-300 md:motion-safe:slide-in-from-right'
+        )}
+      >
+        {isMobile && (
+          <div
+            aria-hidden="true"
+            className="mx-auto mt-2.5 h-1 w-9 rounded-full bg-border-strong"
+          />
+        )}
+
+        <header className="sticky top-0 z-[1] flex items-start gap-3 border-b border-border bg-background p-4">
+          <div className="flex h-[50px] w-[50px] flex-col items-center justify-center rounded-md border border-entity-event/22 bg-entity-event/12">
+            <span className="font-mono text-[9px] font-extrabold uppercase tracking-wider text-entity-event">
+              {labels.monthAbbrev}
+            </span>
+            <span className="font-display text-xl font-extrabold leading-none tabular-nums text-entity-event">
+              {day}
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 id={headingId} className="font-display text-base font-extrabold text-foreground">
+              {labels.title}
+            </h2>
+            <p className="font-mono text-xs font-bold text-muted-foreground">{labels.subtitle}</p>
+          </div>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            aria-label={labels.close}
+            onClick={onClose}
+            className="rounded-md border border-border bg-card px-2 py-1 font-mono text-sm font-extrabold text-foreground"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="flex flex-col gap-2.5 p-4 pt-3.5">
+          {events.map(vm => (
+            <GameNightListCard
+              key={vm.id}
+              vm={vm}
+              isMobile={isMobile}
+              labels={labels.card}
+              onAction={onCardAction}
+              gameTitle={resolveGameTitle?.(vm)}
+              players={resolvePlayers?.(vm)}
+            />
+          ))}
+          {onAddOnDay && (
+            <button
+              type="button"
+              onClick={onAddOnDay}
+              className="rounded-lg border-2 border-dashed border-border-strong px-3 py-3 font-display text-xs font-extrabold text-muted-foreground"
+            >
+              {labels.addOnDay}
+            </button>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
 }

--- a/apps/web/src/components/features/game-nights/FilterPillBar.tsx
+++ b/apps/web/src/components/features/game-nights/FilterPillBar.tsx
@@ -1,14 +1,64 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: FilterPillBar
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * FilterPillBar - v2 SP4 #1170 commit 2
+ *
+ * Horizontal pill bar for filtering the index by viewer role / completion.
+ * Pure presentational: labels resolved by orchestrator.
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx` (FilterPillBar).
+ */
 
-import type { ReactElement } from 'react';
+import clsx from 'clsx';
 
-export interface FilterPillBarProps {
-  // TODO: extract props contract from mockup analysis
+import { FILTER_KEYS, type FilterKey } from '@/lib/game-nights/event-filter';
+
+export interface FilterPillBarLabels {
+  readonly ariaLabel: string;
+  readonly all: string;
+  readonly organizing: string;
+  readonly invited: string;
+  readonly completed: string;
 }
 
-export function FilterPillBar(_props: FilterPillBarProps): ReactElement | null {
-  return null;
+export interface FilterPillBarProps {
+  readonly value: FilterKey;
+  readonly onChange: (key: FilterKey) => void;
+  readonly labels: FilterPillBarLabels;
+  readonly className?: string;
+}
+
+export function FilterPillBar({
+  value,
+  onChange,
+  labels,
+  className,
+}: FilterPillBarProps): React.JSX.Element {
+  return (
+    <div
+      role="group"
+      aria-label={labels.ariaLabel}
+      data-testid="game-nights-filter-pill-bar"
+      className={clsx('flex flex-wrap gap-1.5', className)}
+    >
+      {FILTER_KEYS.map(key => {
+        const active = key === value;
+        return (
+          <button
+            key={key}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(key)}
+            className={clsx(
+              'cursor-pointer whitespace-nowrap rounded-full border px-3 py-1.5',
+              'font-display text-[11px] font-extrabold',
+              active
+                ? 'border-entity-event/40 bg-entity-event/15 text-entity-event'
+                : 'border-border bg-card text-muted-foreground'
+            )}
+          >
+            {labels[key]}
+          </button>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/web/src/components/features/game-nights/GameNightListCard.tsx
+++ b/apps/web/src/components/features/game-nights/GameNightListCard.tsx
@@ -1,14 +1,197 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: GameNightListCard
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * GameNightListCard - v2 SP4 #1170 commit 2
+ *
+ * List-view card for a single game night. CTA branches by status + role.
+ * Pure presentational: orchestrator resolves player roster + game title.
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx`
+ * (GameNightListCard).
+ */
 
-import type { ReactElement } from 'react';
+import clsx from 'clsx';
 
-export interface GameNightListCardProps {
-  // TODO: extract props contract from mockup analysis
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+import { PlayerAvatars, type AvatarPlayer } from './PlayerAvatars';
+import { StatusPill, type StatusPillLabels } from './StatusPill';
+
+export type GameNightListCardAction = 'edit' | 'viewSummary' | 'reschedule' | 'accept' | 'maybe';
+
+export interface GameNightListCardCtaLabels {
+  readonly edit: string;
+  readonly viewSummary: string;
+  readonly reschedule: string;
+  readonly accept: string;
+  readonly maybe: string;
 }
 
-export function GameNightListCard(_props: GameNightListCardProps): ReactElement | null {
-  return null;
+export interface GameNightListCardLabels {
+  readonly status: StatusPillLabels;
+  readonly organizingBadge: string;
+  readonly participants: (count: number) => string;
+  readonly cta: GameNightListCardCtaLabels;
+  readonly monthAbbrev: string;
+}
+
+export interface GameNightListCardProps {
+  readonly vm: GameNightVM;
+  readonly isMobile?: boolean;
+  readonly labels: GameNightListCardLabels;
+  readonly onAction?: (id: string, action: GameNightListCardAction) => void;
+  readonly gameTitle?: string;
+  readonly players?: readonly AvatarPlayer[];
+}
+
+export function GameNightListCard({
+  vm,
+  isMobile = false,
+  labels,
+  onAction,
+  gameTitle,
+  players,
+}: GameNightListCardProps): React.JSX.Element {
+  const isCancelled = vm.statusKey === 'cancelled';
+  const playerList = players ?? [];
+  const participantCount = playerList.length > 0 ? playerList.length : vm.playerIds.length;
+
+  const dispatch = (action: GameNightListCardAction): void => {
+    onAction?.(vm.id, action);
+  };
+
+  return (
+    <article
+      data-testid="game-nights-list-card"
+      data-status={vm.statusKey}
+      data-role={vm.role}
+      className={clsx(
+        'flex flex-col gap-2.5 rounded-lg border border-l-4 border-border bg-card p-3.5 transition-all md:flex-row md:gap-3.5 md:p-4',
+        isCancelled ? 'border-l-destructive opacity-[0.78]' : 'border-l-entity-event'
+      )}
+    >
+      <div className="flex flex-row items-center justify-center gap-2 md:w-[78px] md:flex-col md:gap-0 md:rounded-md md:border md:border-entity-event/22 md:bg-entity-event/8 md:px-2.5 md:py-1.5">
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event md:text-[9px]">
+          {labels.monthAbbrev}
+        </span>
+        <span className="font-display text-[22px] font-extrabold leading-none tabular-nums text-entity-event md:text-3xl">
+          {vm.day}
+        </span>
+        <span className="font-mono text-[10px] font-bold text-muted-foreground md:mt-0.5">
+          {vm.timeLabel}
+        </span>
+        {vm.durationLabel && (
+          <span className="ml-auto font-mono text-[9px] text-muted-foreground md:ml-0 md:mt-0.5">
+            {vm.durationLabel}
+          </span>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex flex-wrap items-start gap-2">
+          <h3
+            className={clsx(
+              'min-w-0 flex-1 font-display text-sm font-extrabold leading-snug text-foreground md:text-base',
+              isCancelled && 'line-through'
+            )}
+          >
+            {vm.title}
+          </h3>
+          <StatusPill statusKey={vm.statusKey} labels={labels.status} />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+          {vm.location && (
+            <>
+              <span aria-hidden="true">📍</span>
+              <span className="font-semibold">{vm.location}</span>
+            </>
+          )}
+          {gameTitle && (
+            <>
+              <span aria-hidden="true" className="opacity-40">
+                ·
+              </span>
+              <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-entity-game/22 bg-entity-game/12 px-2 py-0.5 font-display text-[10px] font-extrabold text-entity-game">
+                {gameTitle}
+              </span>
+            </>
+          )}
+          {vm.role === 'organizer' && (
+            <span className="rounded-full border border-entity-player/22 bg-entity-player/12 px-1.5 py-0.5 font-display text-[10px] font-extrabold text-entity-player">
+              {labels.organizingBadge}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2.5 border-t border-border pt-1.5">
+          <PlayerAvatars players={playerList} max={isMobile ? 4 : 5} />
+          <span className="font-mono text-[11px] font-bold text-muted-foreground">
+            {labels.participants(participantCount)}
+          </span>
+          <div className="flex-1" />
+          <CardCta vm={vm} labels={labels.cta} onAction={dispatch} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+interface CardCtaProps {
+  readonly vm: GameNightVM;
+  readonly labels: GameNightListCardCtaLabels;
+  readonly onAction: (action: GameNightListCardAction) => void;
+}
+
+function CardCta({ vm, labels, onAction }: CardCtaProps): React.JSX.Element {
+  if (vm.statusKey === 'completed') {
+    return (
+      <button
+        type="button"
+        onClick={() => onAction('viewSummary')}
+        className="rounded-md border border-border-strong px-3 py-1.5 font-display text-xs font-extrabold text-foreground"
+      >
+        {labels.viewSummary}
+      </button>
+    );
+  }
+  if (vm.statusKey === 'cancelled') {
+    return (
+      <button
+        type="button"
+        onClick={() => onAction('reschedule')}
+        className="rounded-md border border-border px-3 py-1.5 font-display text-xs font-extrabold text-muted-foreground"
+      >
+        {labels.reschedule}
+      </button>
+    );
+  }
+  // confirmed | planned
+  if (vm.role === 'organizer') {
+    return (
+      <button
+        type="button"
+        onClick={() => onAction('edit')}
+        className="rounded-md bg-entity-event px-3 py-1.5 font-display text-xs font-extrabold text-white"
+      >
+        {labels.edit}
+      </button>
+    );
+  }
+  return (
+    <div className="flex gap-1.5">
+      <button
+        type="button"
+        onClick={() => onAction('accept')}
+        className="rounded-md bg-entity-toolkit px-3 py-1.5 font-display text-xs font-extrabold text-white"
+      >
+        {labels.accept}
+      </button>
+      <button
+        type="button"
+        onClick={() => onAction('maybe')}
+        className="rounded-md border border-border px-3 py-1.5 font-display text-xs font-extrabold text-muted-foreground"
+      >
+        {labels.maybe}
+      </button>
+    </div>
+  );
 }

--- a/apps/web/src/components/features/game-nights/GameNightsHeader.tsx
+++ b/apps/web/src/components/features/game-nights/GameNightsHeader.tsx
@@ -41,7 +41,6 @@ export interface GameNightsHeaderProps {
   readonly onFilterChange: (key: FilterKey) => void;
   readonly onCreate: () => void;
   readonly labels: GameNightsHeaderLabels;
-  readonly isMobile?: boolean;
   readonly className?: string;
 }
 
@@ -52,7 +51,6 @@ export function GameNightsHeader({
   onFilterChange,
   onCreate,
   labels,
-  isMobile: _isMobile = false,
   className,
 }: GameNightsHeaderProps): React.JSX.Element {
   const { tabRefs, handleKeyDown } = useTablistKeyboardNav<GameNightsView>({

--- a/apps/web/src/components/features/game-nights/GameNightsHeader.tsx
+++ b/apps/web/src/components/features/game-nights/GameNightsHeader.tsx
@@ -1,14 +1,142 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: GameNightsHeader
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * GameNightsHeader - v2 SP4 #1170 commit 2
+ *
+ * Page header for /game-nights index: kicker pill + title + count line +
+ * "+ Nuova serata" CTA, plus a calendar/list tablist and embedded
+ * `FilterPillBar`. Pure presentational: orchestrator owns state.
+ *
+ * Tablist keyboard nav uses `useTablistKeyboardNav` (WAI-ARIA APG horizontal).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx` (Header).
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface GameNightsHeaderProps {
-  // TODO: extract props contract from mockup analysis
+import clsx from 'clsx';
+
+import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
+import type { FilterKey } from '@/lib/game-nights/event-filter';
+
+import { FilterPillBar, type FilterPillBarLabels } from './FilterPillBar';
+
+export type GameNightsView = 'calendar' | 'list';
+
+const VIEW_ORDER: ReadonlyArray<GameNightsView> = ['calendar', 'list'];
+
+export interface GameNightsHeaderLabels {
+  readonly kicker: string;
+  readonly title: string;
+  readonly countLine: string;
+  readonly ctaNew: string;
+  readonly viewTablistAriaLabel: string;
+  readonly viewCalendar: string;
+  readonly viewList: string;
+  readonly filter: FilterPillBarLabels;
 }
 
-export function GameNightsHeader(_props: GameNightsHeaderProps): ReactElement | null {
-  return null;
+export interface GameNightsHeaderProps {
+  readonly view: GameNightsView;
+  readonly onViewChange: (view: GameNightsView) => void;
+  readonly filter: FilterKey;
+  readonly onFilterChange: (key: FilterKey) => void;
+  readonly onCreate: () => void;
+  readonly labels: GameNightsHeaderLabels;
+  readonly isMobile?: boolean;
+  readonly className?: string;
+}
+
+export function GameNightsHeader({
+  view,
+  onViewChange,
+  filter,
+  onFilterChange,
+  onCreate,
+  labels,
+  isMobile: _isMobile = false,
+  className,
+}: GameNightsHeaderProps): React.JSX.Element {
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<GameNightsView>({
+    orderedKeys: VIEW_ORDER,
+    onChange: onViewChange,
+  });
+
+  return (
+    <header
+      data-testid="game-nights-header"
+      className={clsx(
+        'flex flex-col gap-3 bg-background px-4 pt-3.5 md:gap-4 md:px-8 md:pt-6',
+        className
+      )}
+    >
+      <div className="flex flex-col items-start gap-3 md:flex-row md:flex-wrap md:items-end">
+        <div className="min-w-0 flex-1">
+          <span className="inline-flex items-center gap-2 rounded-full bg-entity-event/12 px-2.5 py-1 font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event">
+            <span aria-hidden="true">📅</span>
+            <span>{labels.kicker}</span>
+          </span>
+          <h1 className="mt-1 font-display text-2xl font-extrabold leading-tight tracking-tight text-foreground md:text-3xl">
+            {labels.title}
+          </h1>
+          <p className="mt-1 font-mono text-xs font-bold text-muted-foreground">
+            {labels.countLine}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={onCreate}
+          className={clsx(
+            'inline-flex items-center justify-center gap-1.5 self-stretch rounded-md px-4 py-2.5 md:self-auto',
+            'bg-gradient-to-br from-entity-event to-entity-session text-white shadow-md shadow-entity-event/30',
+            'font-display text-sm font-extrabold'
+          )}
+        >
+          {labels.ctaNew}
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 md:justify-start">
+        <div
+          role="tablist"
+          aria-label={labels.viewTablistAriaLabel}
+          className="inline-flex items-center gap-1"
+        >
+          {VIEW_ORDER.map(key => {
+            const active = key === view;
+            const label = key === 'calendar' ? labels.viewCalendar : labels.viewList;
+            return (
+              <button
+                key={key}
+                ref={node => {
+                  if (node) tabRefs.current.set(key, node);
+                  else tabRefs.current.delete(key);
+                }}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                tabIndex={active ? 0 : -1}
+                onClick={() => onViewChange(key)}
+                onKeyDown={e => handleKeyDown(e, key)}
+                className={clsx(
+                  'rounded-t-md px-3 py-2 font-display text-xs font-extrabold transition-colors',
+                  active
+                    ? 'border-b-2 border-entity-event text-entity-event'
+                    : 'border-b-2 border-transparent text-muted-foreground'
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
+        <FilterPillBar
+          value={filter}
+          onChange={onFilterChange}
+          labels={labels.filter}
+          className="md:ml-auto"
+        />
+      </div>
+    </header>
+  );
 }

--- a/apps/web/src/components/features/game-nights/PlayerAvatars.tsx
+++ b/apps/web/src/components/features/game-nights/PlayerAvatars.tsx
@@ -1,14 +1,77 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: PlayerAvatars
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * PlayerAvatars - v2 SP4 #1170 commit 2
+ *
+ * Compact stacked-avatar group with overflow chip. Pure presentational.
+ * Per-id deterministic hue is rendered via inline `style.background` (HSL):
+ * documented as an exception to the no-hardcoded-color-utility rule because
+ * the color is dynamic and not a Tailwind utility literal.
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx` (PlayerAvatars).
+ */
 
-import type { ReactElement } from 'react';
+import clsx from 'clsx';
 
-export interface PlayerAvatarsProps {
-  // TODO: extract props contract from mockup analysis
+export interface AvatarPlayer {
+  readonly id: string;
+  readonly initials: string;
+  readonly name?: string;
 }
 
-export function PlayerAvatars(_props: PlayerAvatarsProps): ReactElement | null {
-  return null;
+export interface PlayerAvatarsProps {
+  readonly players: readonly AvatarPlayer[];
+  readonly max?: number;
+  readonly className?: string;
+}
+
+function hueFromId(id: string): number {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) & 0xffffffff;
+  }
+  return Math.abs(hash) % 360;
+}
+
+export function PlayerAvatars({
+  players,
+  max = 5,
+  className,
+}: PlayerAvatarsProps): React.JSX.Element {
+  const visible = players.slice(0, max);
+  const overflow = Math.max(0, players.length - max);
+
+  return (
+    <div
+      data-testid="game-nights-player-avatars"
+      className={clsx('inline-flex items-center', className)}
+    >
+      {visible.map((player, idx) => (
+        <span
+          key={player.id}
+          aria-label={player.name ?? player.initials}
+          title={player.name ?? player.initials}
+          className={clsx(
+            // bg-[hsl(...)] arbitrary value satisfies the colored-bg exemption
+            // for text-white; the inline style overrides with the per-id hue.
+            'inline-flex h-6 w-6 items-center justify-center rounded-full border-2 border-card bg-[hsl(0_0%_50%)] font-display text-[10px] font-extrabold text-white',
+            idx > 0 && '-ml-2'
+          )}
+          style={{ background: `hsl(${hueFromId(player.id)} 55% 50%)` }}
+        >
+          {player.initials}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span
+          aria-label={`+${overflow}`}
+          className={clsx(
+            'inline-flex h-6 min-w-6 items-center justify-center rounded-full border-2 border-card px-1',
+            'bg-muted font-mono text-[10px] font-extrabold text-muted-foreground',
+            visible.length > 0 && '-ml-2'
+          )}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/features/game-nights/StatusPill.tsx
+++ b/apps/web/src/components/features/game-nights/StatusPill.tsx
@@ -1,14 +1,57 @@
-// TODO: implement per admin-mockups/design_files/sp4-game-nights-index.jsx
-// Mapped from mockup component: StatusPill
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * StatusPill - v2 SP4 #1170 commit 2
+ *
+ * Status pill used in calendar/list views for /game-nights index.
+ * Pure presentational: labels resolved by orchestrator (Commit 3).
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-nights-index.jsx` (StatusPill).
+ */
 
-import type { ReactElement } from 'react';
+import clsx from 'clsx';
 
-export interface StatusPillProps {
-  // TODO: extract props contract from mockup analysis
+import type { StatusKey } from '@/lib/game-nights/view-model';
+
+export interface StatusPillLabels {
+  readonly confirmed: string;
+  readonly planned: string;
+  readonly cancelled: string;
+  readonly completed: string;
 }
 
-export function StatusPill(_props: StatusPillProps): ReactElement | null {
-  return null;
+export interface StatusPillProps {
+  readonly statusKey: StatusKey;
+  readonly labels: StatusPillLabels;
+  readonly className?: string;
+}
+
+const VARIANT: Record<StatusKey, string> = {
+  confirmed: 'bg-entity-toolkit/12 text-entity-toolkit border-entity-toolkit/30',
+  planned: 'bg-entity-agent/12 text-entity-agent border-entity-agent/30',
+  cancelled: 'bg-destructive/12 text-destructive border-destructive/30',
+  completed: 'bg-muted text-muted-foreground border-border',
+};
+
+const DOT: Record<StatusKey, string> = {
+  confirmed: 'bg-entity-toolkit',
+  planned: 'bg-entity-agent',
+  cancelled: 'bg-destructive',
+  completed: 'bg-muted-foreground',
+};
+
+export function StatusPill({ statusKey, labels, className }: StatusPillProps): React.JSX.Element {
+  return (
+    <span
+      data-testid="game-nights-status-pill"
+      data-status={statusKey}
+      className={clsx(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+        'font-mono text-[10px] font-extrabold uppercase tracking-wider',
+        VARIANT[statusKey],
+        className
+      )}
+    >
+      <span aria-hidden="true" className={clsx('h-1.5 w-1.5 rounded-full', DOT[statusKey])} />
+      <span>{labels[statusKey]}</span>
+    </span>
+  );
 }

--- a/apps/web/src/components/features/game-nights/__tests__/CalendarDayCell.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/CalendarDayCell.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for CalendarDayCell (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MonthCell } from '@/lib/game-nights/calendar-grid';
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+import { CalendarDayCell, type CalendarDayCellLabels } from '../CalendarDayCell';
+
+const labels: CalendarDayCellLabels = {
+  todayBadge: 'Oggi',
+  dayAriaLabel: (day, events) => `Giorno ${day}, ${events} eventi`,
+  overflow: count => `+${count} altri`,
+};
+
+const cell: MonthCell = { day: 15, otherMonth: false, monthOffset: 0 };
+
+function makeVM(id: string, overrides: Partial<GameNightVM> = {}): GameNightVM {
+  return {
+    id,
+    title: `Title ${id}`,
+    scheduledAtIso: '2026-03-15T19:30:00Z',
+    day: 15,
+    month: 2,
+    year: 2026,
+    timeLabel: '20:30',
+    durationLabel: '',
+    location: 'Casa Marco',
+    gameIds: [],
+    playerIds: [],
+    role: 'invited',
+    statusKey: 'planned',
+    ...overrides,
+  };
+}
+
+describe('CalendarDayCell', () => {
+  it('renders empty current-month cell (no events, button disabled)', () => {
+    render(<CalendarDayCell cell={cell} events={[]} isToday={false} labels={labels} />);
+    const btn = screen.getByTestId('game-nights-calendar-day-cell');
+    expect(btn).toBeDisabled();
+    expect(screen.getByText('15')).toBeInTheDocument();
+  });
+
+  it('renders a single event chip with time label', () => {
+    render(<CalendarDayCell cell={cell} events={[makeVM('e1')]} isToday={false} labels={labels} />);
+    expect(screen.getByText('20:30')).toBeInTheDocument();
+  });
+
+  it('renders 3 chips + overflow on desktop (4 events)', () => {
+    const events = [
+      makeVM('e1', { timeLabel: '10:00' }),
+      makeVM('e2', { timeLabel: '12:00' }),
+      makeVM('e3', { timeLabel: '14:00' }),
+      makeVM('e4', { timeLabel: '16:00' }),
+    ];
+    render(<CalendarDayCell cell={cell} events={events} isToday={false} labels={labels} />);
+    expect(screen.getByText('10:00')).toBeInTheDocument();
+    expect(screen.getByText('12:00')).toBeInTheDocument();
+    expect(screen.getByText('14:00')).toBeInTheDocument();
+    expect(screen.queryByText('16:00')).not.toBeInTheDocument();
+    expect(screen.getByText('+1 altri')).toBeInTheDocument();
+  });
+
+  it('shows "Oggi" badge and today border style when isToday', () => {
+    render(<CalendarDayCell cell={cell} events={[]} isToday={true} labels={labels} />);
+    expect(screen.getByText('Oggi')).toBeInTheDocument();
+    const btn = screen.getByTestId('game-nights-calendar-day-cell');
+    expect(btn.getAttribute('data-today')).toBe('true');
+    expect(btn.className).toContain('border-entity-event');
+  });
+
+  it('disables otherMonth cell and applies opacity', () => {
+    render(
+      <CalendarDayCell
+        cell={{ day: 30, otherMonth: true, monthOffset: -1 }}
+        events={[]}
+        isToday={false}
+        labels={labels}
+      />
+    );
+    const btn = screen.getByTestId('game-nights-calendar-day-cell');
+    expect(btn).toBeDisabled();
+    expect(btn.className).toContain('opacity-35');
+  });
+
+  it('renders cancelled chip with line-through class', () => {
+    render(
+      <CalendarDayCell
+        cell={cell}
+        events={[makeVM('e1', { statusKey: 'cancelled' })]}
+        isToday={false}
+        labels={labels}
+      />
+    );
+    const chip = screen.getByText('20:30').parentElement;
+    expect(chip?.className).toContain('line-through');
+  });
+
+  it('invokes onClick with cell and events when clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <CalendarDayCell
+        cell={cell}
+        events={[makeVM('e1')]}
+        isToday={false}
+        labels={labels}
+        onClick={onClick}
+      />
+    );
+    fireEvent.click(screen.getByTestId('game-nights-calendar-day-cell'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClick.mock.calls[0][0]).toEqual(cell);
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/CalendarMonthGrid.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/CalendarMonthGrid.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for CalendarMonthGrid (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+import { CalendarMonthGrid, type CalendarMonthGridLabels } from '../CalendarMonthGrid';
+
+const labels: CalendarMonthGridLabels = {
+  prevMonth: 'Mese precedente',
+  nextMonth: 'Mese successivo',
+  today: 'Oggi',
+  monthHeading: 'Marzo 2026',
+  dayLabels: ['Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'],
+  footerCount: '10 serate · 1 annullata',
+  legendEvent: 'Serata',
+  legendCancelled: 'Annullata',
+  legendToday: 'Oggi',
+  cell: {
+    todayBadge: 'Oggi',
+    dayAriaLabel: (day, events) => `Giorno ${day}, ${events} eventi`,
+    overflow: count => `+${count} altri`,
+  },
+};
+
+function makeVM(id: string, day: number): GameNightVM {
+  return {
+    id,
+    title: `T${id}`,
+    scheduledAtIso: `2026-03-${day}T20:00:00Z`,
+    day,
+    month: 2,
+    year: 2026,
+    timeLabel: '20:00',
+    durationLabel: '',
+    location: '',
+    gameIds: [],
+    playerIds: [],
+    role: 'invited',
+    statusKey: 'planned',
+  };
+}
+
+describe('CalendarMonthGrid', () => {
+  it('renders 42 day cells and 7 day labels', () => {
+    render(
+      <CalendarMonthGrid
+        year={2026}
+        month={2}
+        events={[]}
+        today={new Date(2026, 2, 15)}
+        labels={labels}
+        onDayClick={() => {}}
+      />
+    );
+    expect(screen.getAllByTestId('game-nights-calendar-day-cell')).toHaveLength(42);
+    expect(screen.getByText('Lun')).toBeInTheDocument();
+    expect(screen.getByText('Dom')).toBeInTheDocument();
+  });
+
+  it('renders month heading and footer count', () => {
+    render(
+      <CalendarMonthGrid
+        year={2026}
+        month={2}
+        events={[]}
+        today={new Date(2026, 2, 15)}
+        labels={labels}
+        onDayClick={() => {}}
+      />
+    );
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Marzo 2026');
+    expect(screen.getByText('10 serate · 1 annullata')).toBeInTheDocument();
+  });
+
+  it('disables prev/next/today nav buttons (visual-only per spec)', () => {
+    render(
+      <CalendarMonthGrid
+        year={2026}
+        month={2}
+        events={[]}
+        today={new Date(2026, 2, 15)}
+        labels={labels}
+        onDayClick={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Mese precedente' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Mese successivo' })).toBeDisabled();
+  });
+
+  it('forwards onDayClick when clicking a cell with events', () => {
+    const onDayClick = vi.fn();
+    const events = [makeVM('e1', 10)];
+    render(
+      <CalendarMonthGrid
+        year={2026}
+        month={2}
+        events={events}
+        today={new Date(2026, 2, 15)}
+        labels={labels}
+        onDayClick={onDayClick}
+      />
+    );
+    const cells = screen.getAllByTestId('game-nights-calendar-day-cell');
+    const cellDay10 = cells.find(
+      c => c.getAttribute('data-day') === '10' && c.getAttribute('data-other-month') !== 'true'
+    );
+    expect(cellDay10).toBeDefined();
+    fireEvent.click(cellDay10!);
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the today cell when today matches month+year', () => {
+    render(
+      <CalendarMonthGrid
+        year={2026}
+        month={2}
+        events={[]}
+        today={new Date(2026, 2, 17)}
+        labels={labels}
+        onDayClick={() => {}}
+      />
+    );
+    const cells = screen.getAllByTestId('game-nights-calendar-day-cell');
+    const todayCell = cells.find(c => c.getAttribute('data-today') === 'true');
+    expect(todayCell).toBeDefined();
+    expect(todayCell?.getAttribute('data-day')).toBe('17');
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/DayDetailDrawer.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/DayDetailDrawer.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { GameNightVM } from '@/lib/game-nights/view-model';
@@ -107,6 +108,33 @@ describe('DayDetailDrawer', () => {
     render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={onClose} />);
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps Tab focus within the drawer when open', async () => {
+    const user = userEvent.setup();
+    render(
+      <DayDetailDrawer
+        open
+        day={15}
+        events={[makeVM('a'), makeVM('b')]}
+        labels={labels}
+        onClose={() => {}}
+        onAddOnDay={() => {}}
+      />
+    );
+
+    const closeBtn = screen.getByRole('button', { name: 'Chiudi' });
+    expect(closeBtn).toHaveFocus();
+
+    // Tab through all interactive elements; cycle should stay inside the dialog.
+    for (let i = 0; i < 8; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.tab();
+    }
+
+    const dialog = screen.getByRole('dialog');
+    expect(document.activeElement).toBeInstanceOf(HTMLElement);
+    expect(dialog.contains(document.activeElement)).toBe(true);
   });
 
   it('renders "add on day" button only when onAddOnDay is provided', () => {

--- a/apps/web/src/components/features/game-nights/__tests__/DayDetailDrawer.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/DayDetailDrawer.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for DayDetailDrawer (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GameNightVM } from '@/lib/game-nights/view-model';
+
+import { DayDetailDrawer, type DayDetailDrawerLabels } from '../DayDetailDrawer';
+
+const labels: DayDetailDrawerLabels = {
+  title: '15 marzo 2026',
+  subtitle: '3 serate in programma',
+  close: 'Chiudi',
+  addOnDay: '+ Aggiungi serata in questo giorno',
+  monthAbbrev: 'Mar',
+  card: {
+    status: {
+      confirmed: 'Confermata',
+      planned: 'Programmata',
+      cancelled: 'Annullata',
+      completed: 'Completata',
+    },
+    organizingBadge: 'Organizzo',
+    participants: n => `${n} partecipanti`,
+    cta: {
+      edit: 'Modifica',
+      viewSummary: 'Vedi summary',
+      reschedule: 'Riprogramma',
+      accept: 'Partecipo',
+      maybe: 'Forse',
+    },
+    monthAbbrev: 'Mar',
+  },
+};
+
+function makeVM(id: string): GameNightVM {
+  return {
+    id,
+    title: `Serata ${id}`,
+    scheduledAtIso: '2026-03-15T20:30:00Z',
+    day: 15,
+    month: 2,
+    year: 2026,
+    timeLabel: '20:30',
+    durationLabel: '',
+    location: 'Casa',
+    gameIds: [],
+    playerIds: [],
+    role: 'invited',
+    statusKey: 'planned',
+  };
+}
+
+describe('DayDetailDrawer', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <DayDetailDrawer open={false} day={15} events={[]} labels={labels} onClose={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders dialog with aria-modal and aria-labelledby when open', () => {
+    render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBeTruthy();
+  });
+
+  it('renders one GameNightListCard per event', () => {
+    render(
+      <DayDetailDrawer
+        open
+        day={15}
+        events={[makeVM('a'), makeVM('b'), makeVM('c')]}
+        labels={labels}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getAllByTestId('game-nights-list-card')).toHaveLength(3);
+  });
+
+  it('invokes onClose when backdrop is clicked', () => {
+    const onClose = vi.fn();
+    render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={onClose} />);
+    fireEvent.click(screen.getByTestId('game-nights-day-detail-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT close when clicking inside the dialog', () => {
+    const onClose = vi.fn();
+    render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('invokes onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Chiudi' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose on Escape key', () => {
+    const onClose = vi.fn();
+    render(<DayDetailDrawer open day={15} events={[]} labels={labels} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders "add on day" button only when onAddOnDay is provided', () => {
+    const { rerender } = render(
+      <DayDetailDrawer open day={15} events={[]} labels={labels} onClose={() => {}} />
+    );
+    expect(
+      screen.queryByRole('button', { name: '+ Aggiungi serata in questo giorno' })
+    ).not.toBeInTheDocument();
+    rerender(
+      <DayDetailDrawer
+        open
+        day={15}
+        events={[]}
+        labels={labels}
+        onClose={() => {}}
+        onAddOnDay={() => {}}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: '+ Aggiungi serata in questo giorno' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/FilterPillBar.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/FilterPillBar.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for FilterPillBar (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FilterPillBar, type FilterPillBarLabels } from '../FilterPillBar';
+
+const labels: FilterPillBarLabels = {
+  ariaLabel: 'Filtri serate',
+  all: 'Tutte',
+  organizing: 'Sto organizzando',
+  invited: 'Invitato',
+  completed: 'Concluse',
+};
+
+describe('FilterPillBar', () => {
+  it('renders four pills with provided labels', () => {
+    render(<FilterPillBar value="all" onChange={() => {}} labels={labels} />);
+    expect(screen.getByRole('group', { name: 'Filtri serate' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tutte' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sto organizzando' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Invitato' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Concluse' })).toBeInTheDocument();
+  });
+
+  it('marks the active pill via aria-pressed=true', () => {
+    render(<FilterPillBar value="organizing" onChange={() => {}} labels={labels} />);
+    expect(
+      screen.getByRole('button', { name: 'Sto organizzando' }).getAttribute('aria-pressed')
+    ).toBe('true');
+    expect(screen.getByRole('button', { name: 'Tutte' }).getAttribute('aria-pressed')).toBe(
+      'false'
+    );
+  });
+
+  it('invokes onChange with the clicked key', () => {
+    const onChange = vi.fn();
+    render(<FilterPillBar value="all" onChange={onChange} labels={labels} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Concluse' }));
+    expect(onChange).toHaveBeenCalledWith('completed');
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/GameNightListCard.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/GameNightListCard.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tests for GameNightListCard (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GameNightVM, StatusKey, RoleKey } from '@/lib/game-nights/view-model';
+
+import { GameNightListCard, type GameNightListCardLabels } from '../GameNightListCard';
+
+const labels: GameNightListCardLabels = {
+  status: {
+    confirmed: 'Confermata',
+    planned: 'Programmata',
+    cancelled: 'Annullata',
+    completed: 'Completata',
+  },
+  organizingBadge: 'Organizzo',
+  participants: n => `${n} partecipanti`,
+  cta: {
+    edit: 'Modifica',
+    viewSummary: 'Vedi summary →',
+    reschedule: 'Riprogramma',
+    accept: '✓ Partecipo',
+    maybe: 'Forse',
+  },
+  monthAbbrev: 'Mar',
+};
+
+function makeVM(
+  statusKey: StatusKey,
+  role: RoleKey,
+  overrides: Partial<GameNightVM> = {}
+): GameNightVM {
+  return {
+    id: 'gn-1',
+    title: 'Serata X',
+    scheduledAtIso: '2026-03-15T20:30:00Z',
+    day: 15,
+    month: 2,
+    year: 2026,
+    timeLabel: '20:30',
+    durationLabel: '',
+    location: 'Casa Marco',
+    gameIds: [],
+    playerIds: [],
+    role,
+    statusKey,
+    ...overrides,
+  };
+}
+
+describe('GameNightListCard', () => {
+  it('renders title, date, time, location, status pill', () => {
+    render(<GameNightListCard vm={makeVM('planned', 'invited')} labels={labels} />);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Serata X');
+    expect(screen.getByText('Mar')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('20:30')).toBeInTheDocument();
+    expect(screen.getByText('Casa Marco')).toBeInTheDocument();
+    expect(screen.getByText('Programmata')).toBeInTheDocument();
+  });
+
+  it('applies line-through on cancelled title', () => {
+    render(<GameNightListCard vm={makeVM('cancelled', 'invited')} labels={labels} />);
+    expect(screen.getByRole('heading', { level: 3 }).className).toContain('line-through');
+  });
+
+  it('shows organizing badge when role=organizer', () => {
+    render(<GameNightListCard vm={makeVM('confirmed', 'organizer')} labels={labels} />);
+    expect(screen.getByText('Organizzo')).toBeInTheDocument();
+  });
+
+  it('does NOT show organizing badge when role=invited', () => {
+    render(<GameNightListCard vm={makeVM('confirmed', 'invited')} labels={labels} />);
+    expect(screen.queryByText('Organizzo')).not.toBeInTheDocument();
+  });
+
+  it('shows game chip when gameTitle provided', () => {
+    render(
+      <GameNightListCard vm={makeVM('planned', 'invited')} labels={labels} gameTitle="Catan" />
+    );
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+  });
+
+  it('does NOT show game chip when gameTitle missing', () => {
+    render(<GameNightListCard vm={makeVM('planned', 'invited')} labels={labels} />);
+    expect(screen.queryByText('Catan')).not.toBeInTheDocument();
+  });
+
+  describe('CTA branches', () => {
+    it('completed → viewSummary', () => {
+      const onAction = vi.fn();
+      render(
+        <GameNightListCard
+          vm={makeVM('completed', 'invited')}
+          labels={labels}
+          onAction={onAction}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Vedi summary →' }));
+      expect(onAction).toHaveBeenCalledWith('gn-1', 'viewSummary');
+    });
+
+    it('cancelled → reschedule', () => {
+      const onAction = vi.fn();
+      render(
+        <GameNightListCard
+          vm={makeVM('cancelled', 'organizer')}
+          labels={labels}
+          onAction={onAction}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Riprogramma' }));
+      expect(onAction).toHaveBeenCalledWith('gn-1', 'reschedule');
+    });
+
+    it('confirmed + organizer → edit', () => {
+      const onAction = vi.fn();
+      render(
+        <GameNightListCard
+          vm={makeVM('confirmed', 'organizer')}
+          labels={labels}
+          onAction={onAction}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Modifica' }));
+      expect(onAction).toHaveBeenCalledWith('gn-1', 'edit');
+    });
+
+    it('planned + invited → accept + maybe', () => {
+      const onAction = vi.fn();
+      render(
+        <GameNightListCard vm={makeVM('planned', 'invited')} labels={labels} onAction={onAction} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: '✓ Partecipo' }));
+      expect(onAction).toHaveBeenCalledWith('gn-1', 'accept');
+      fireEvent.click(screen.getByRole('button', { name: 'Forse' }));
+      expect(onAction).toHaveBeenCalledWith('gn-1', 'maybe');
+    });
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/GameNightsHeader.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/GameNightsHeader.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for GameNightsHeader (SP4 #1170 commit 2).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GameNightsHeader, type GameNightsHeaderLabels } from '../GameNightsHeader';
+
+const labels: GameNightsHeaderLabels = {
+  kicker: 'Game nights',
+  title: 'Le tue serate',
+  countLine: '8 serate questo mese · 5 confermate',
+  ctaNew: '+ Nuova serata',
+  viewTablistAriaLabel: 'Modalità vista',
+  viewCalendar: 'Calendario',
+  viewList: 'Lista',
+  filter: {
+    ariaLabel: 'Filtri',
+    all: 'Tutte',
+    organizing: 'Sto organizzando',
+    invited: 'Invitato',
+    completed: 'Concluse',
+  },
+};
+
+function renderHeader(overrides: Partial<Parameters<typeof GameNightsHeader>[0]> = {}) {
+  const onViewChange = vi.fn();
+  const onFilterChange = vi.fn();
+  const onCreate = vi.fn();
+  render(
+    <GameNightsHeader
+      view="calendar"
+      onViewChange={onViewChange}
+      filter="all"
+      onFilterChange={onFilterChange}
+      onCreate={onCreate}
+      labels={labels}
+      {...overrides}
+    />
+  );
+  return { onViewChange, onFilterChange, onCreate };
+}
+
+describe('GameNightsHeader', () => {
+  it('renders kicker, title, count line, and CTA', () => {
+    renderHeader();
+    expect(screen.getByText('Game nights')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Le tue serate');
+    expect(screen.getByText('8 serate questo mese · 5 confermate')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Nuova serata' })).toBeInTheDocument();
+  });
+
+  it('renders calendar/list tablist with aria-selected on active', () => {
+    renderHeader({ view: 'list' });
+    const tablist = screen.getByRole('tablist', { name: 'Modalità vista' });
+    expect(tablist).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Lista' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'Calendario' }).getAttribute('aria-selected')).toBe(
+      'false'
+    );
+  });
+
+  it('invokes onViewChange when clicking a tab', () => {
+    const { onViewChange } = renderHeader();
+    fireEvent.click(screen.getByRole('tab', { name: 'Lista' }));
+    expect(onViewChange).toHaveBeenCalledWith('list');
+  });
+
+  it('invokes onCreate when clicking CTA', () => {
+    const { onCreate } = renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: '+ Nuova serata' }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards filter changes from the embedded FilterPillBar', () => {
+    const { onFilterChange } = renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: 'Sto organizzando' }));
+    expect(onFilterChange).toHaveBeenCalledWith('organizing');
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/PlayerAvatars.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/PlayerAvatars.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Tests for PlayerAvatars (SP4 #1170 commit 2).
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PlayerAvatars, type AvatarPlayer } from '../PlayerAvatars';
+
+function makePlayers(n: number): AvatarPlayer[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `p-${i}`,
+    initials: `P${i}`,
+    name: `Player ${i}`,
+  }));
+}
+
+describe('PlayerAvatars', () => {
+  it('renders empty when players array is empty', () => {
+    render(<PlayerAvatars players={[]} />);
+    const container = screen.getByTestId('game-nights-player-avatars');
+    expect(container.children.length).toBe(0);
+  });
+
+  it('renders all players when under max', () => {
+    render(<PlayerAvatars players={makePlayers(3)} max={5} />);
+    expect(screen.getByText('P0')).toBeInTheDocument();
+    expect(screen.getByText('P1')).toBeInTheDocument();
+    expect(screen.getByText('P2')).toBeInTheDocument();
+  });
+
+  it('renders exactly max with no overflow chip', () => {
+    render(<PlayerAvatars players={makePlayers(5)} max={5} />);
+    expect(screen.getByText('P4')).toBeInTheDocument();
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it('renders +N overflow chip when over max', () => {
+    render(<PlayerAvatars players={makePlayers(8)} max={5} />);
+    expect(screen.getByText('+3')).toBeInTheDocument();
+    expect(screen.queryByText('P5')).not.toBeInTheDocument();
+  });
+
+  it('applies a deterministic inline background style', () => {
+    // jsdom normalizes hsl() to rgb() in inline style, so assert against
+    // the (non-empty) background property rather than the HSL literal.
+    const { container } = render(<PlayerAvatars players={makePlayers(1)} />);
+    const avatar = container.querySelector('[aria-label="Player 0"]') as HTMLElement;
+    expect(avatar).not.toBeNull();
+    expect(avatar.style.background).not.toBe('');
+  });
+});

--- a/apps/web/src/components/features/game-nights/__tests__/StatusPill.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/StatusPill.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Tests for StatusPill (SP4 #1170 commit 2).
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { StatusKey } from '@/lib/game-nights/view-model';
+
+import { StatusPill, type StatusPillLabels } from '../StatusPill';
+
+const labels: StatusPillLabels = {
+  confirmed: 'Confermata',
+  planned: 'Programmata',
+  cancelled: 'Annullata',
+  completed: 'Completata',
+};
+
+describe('StatusPill', () => {
+  it.each<[StatusKey, string]>([
+    ['confirmed', 'Confermata'],
+    ['planned', 'Programmata'],
+    ['cancelled', 'Annullata'],
+    ['completed', 'Completata'],
+  ])('renders %s label', (statusKey, expected) => {
+    render(<StatusPill statusKey={statusKey} labels={labels} />);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    const pill = screen.getByTestId('game-nights-status-pill');
+    expect(pill.getAttribute('data-status')).toBe(statusKey);
+  });
+
+  it('renders an aria-hidden dot', () => {
+    const { container } = render(<StatusPill statusKey="confirmed" labels={labels} />);
+    const dot = container.querySelector('[aria-hidden="true"]');
+    expect(dot).not.toBeNull();
+  });
+
+  it('forwards className', () => {
+    render(<StatusPill statusKey="planned" labels={labels} className="custom-extra" />);
+    expect(screen.getByTestId('game-nights-status-pill').className).toContain('custom-extra');
+  });
+});

--- a/apps/web/src/components/features/game-nights/index.ts
+++ b/apps/web/src/components/features/game-nights/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Barrel for /game-nights v2 components (SP4 #1170 commit 2).
+ *
+ * Components are pure-presentational; orchestrator (Commit 3) resolves
+ * i18n via `useTranslations` and passes labels through props.
+ */
+
+export { CalendarDayCell } from './CalendarDayCell';
+export type { CalendarDayCellLabels, CalendarDayCellProps } from './CalendarDayCell';
+
+export { CalendarMonthGrid } from './CalendarMonthGrid';
+export type { CalendarMonthGridLabels, CalendarMonthGridProps } from './CalendarMonthGrid';
+
+export { DayDetailDrawer } from './DayDetailDrawer';
+export type { DayDetailDrawerLabels, DayDetailDrawerProps } from './DayDetailDrawer';
+
+export { FilterPillBar } from './FilterPillBar';
+export type { FilterPillBarLabels, FilterPillBarProps } from './FilterPillBar';
+
+export { GameNightListCard } from './GameNightListCard';
+export type {
+  GameNightListCardAction,
+  GameNightListCardCtaLabels,
+  GameNightListCardLabels,
+  GameNightListCardProps,
+} from './GameNightListCard';
+
+export { GameNightsHeader } from './GameNightsHeader';
+export type {
+  GameNightsHeaderLabels,
+  GameNightsHeaderProps,
+  GameNightsView,
+} from './GameNightsHeader';
+
+export { PlayerAvatars } from './PlayerAvatars';
+export type { AvatarPlayer, PlayerAvatarsProps } from './PlayerAvatars';
+
+export { StatusPill } from './StatusPill';
+export type { StatusPillLabels, StatusPillProps } from './StatusPill';

--- a/apps/web/src/lib/game-nights/__tests__/calendar-grid.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/calendar-grid.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for buildMonthGrid (Stage 3 /game-nights index v2 — Foundation).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildMonthGrid } from '../calendar-grid';
+
+describe('buildMonthGrid', () => {
+  it('returns exactly 42 cells (6 rows × 7 cols)', () => {
+    const cells = buildMonthGrid(2026, 2); // March 2026
+    expect(cells).toHaveLength(42);
+  });
+
+  it('March 2026 (Mar 1 = Sunday) — prefixes with prev-month tail', () => {
+    const cells = buildMonthGrid(2026, 2);
+    // Mar 1 2026 is Sunday; Monday-first ISO offset = (0 + 6) % 7 = 6
+    // So cells[0..5] = Feb 23..28 (prev month), cells[6] = Mar 1
+    expect(cells[0]).toEqual({ day: 23, otherMonth: true, monthOffset: -1 });
+    expect(cells[6]).toEqual({ day: 1, otherMonth: false, monthOffset: 0 });
+  });
+
+  it('March 2026 — last cell is from next month', () => {
+    const cells = buildMonthGrid(2026, 2);
+    const last = cells[41];
+    expect(last.otherMonth).toBe(true);
+    expect(last.monthOffset).toBe(1);
+  });
+
+  it('June 2026 starts on Monday — cells[0] is day 1 of current month', () => {
+    const cells = buildMonthGrid(2026, 5); // June 2026
+    expect(cells[0]).toEqual({ day: 1, otherMonth: false, monthOffset: 0 });
+  });
+
+  it('all current-month cells are otherMonth:false and monthOffset:0', () => {
+    const cells = buildMonthGrid(2026, 2);
+    const current = cells.filter(c => !c.otherMonth);
+    expect(current).toHaveLength(31); // March has 31 days
+    for (const c of current) {
+      expect(c.monthOffset).toBe(0);
+    }
+  });
+
+  it('handles January 2026 (Jan 1 = Thursday) — 3 prev-month cells', () => {
+    const cells = buildMonthGrid(2026, 0);
+    // Jan 1 2026 is Thursday; offset = (4 + 6) % 7 = 3
+    // prev tail = Dec 29, 30, 31
+    expect(cells[0]).toEqual({ day: 29, otherMonth: true, monthOffset: -1 });
+    expect(cells[1]).toEqual({ day: 30, otherMonth: true, monthOffset: -1 });
+    expect(cells[2]).toEqual({ day: 31, otherMonth: true, monthOffset: -1 });
+    expect(cells[3]).toEqual({ day: 1, otherMonth: false, monthOffset: 0 });
+  });
+});

--- a/apps/web/src/lib/game-nights/__tests__/event-filter.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/event-filter.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for filterEvents + isFilterKey (Stage 3 /game-nights index v2 — Foundation).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { FILTER_KEYS, filterEvents, isFilterKey } from '../event-filter';
+import type { GameNightVM } from '../view-model';
+
+function vm(overrides: Partial<GameNightVM> = {}): GameNightVM {
+  return {
+    id: 'a',
+    title: 'Test',
+    scheduledAtIso: '2026-06-12T19:00:00',
+    day: 12,
+    month: 5,
+    year: 2026,
+    timeLabel: '19:00',
+    durationLabel: '',
+    location: '',
+    gameIds: [],
+    playerIds: [],
+    role: 'organizer',
+    statusKey: 'planned',
+    ...overrides,
+  };
+}
+
+describe('isFilterKey', () => {
+  it('accepts each canonical key', () => {
+    for (const k of FILTER_KEYS) {
+      expect(isFilterKey(k)).toBe(true);
+    }
+  });
+
+  it('rejects unknown string', () => {
+    expect(isFilterKey('bogus')).toBe(false);
+  });
+
+  it('rejects non-strings', () => {
+    expect(isFilterKey(null)).toBe(false);
+    expect(isFilterKey(undefined)).toBe(false);
+    expect(isFilterKey(123)).toBe(false);
+    expect(isFilterKey({})).toBe(false);
+  });
+});
+
+describe('filterEvents', () => {
+  const a = vm({ id: 'a', role: 'organizer', statusKey: 'planned' });
+  const b = vm({ id: 'b', role: 'invited', statusKey: 'confirmed' });
+  const c = vm({ id: 'c', role: 'organizer', statusKey: 'completed' });
+  const d = vm({ id: 'd', role: 'invited', statusKey: 'completed' });
+  const all = [a, b, c, d];
+
+  it('all → returns all events (shallow copy, not same reference)', () => {
+    const out = filterEvents(all, 'all');
+    expect(out).toEqual(all);
+    expect(out).not.toBe(all);
+  });
+
+  it('organizing → only role=organizer', () => {
+    expect(filterEvents(all, 'organizing')).toEqual([a, c]);
+  });
+
+  it('invited → only role=invited', () => {
+    expect(filterEvents(all, 'invited')).toEqual([b, d]);
+  });
+
+  it('completed → only statusKey=completed', () => {
+    expect(filterEvents(all, 'completed')).toEqual([c, d]);
+  });
+});

--- a/apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for groupByMonth (Stage 3 /game-nights index v2 — Foundation).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { groupByMonth } from '../event-grouping';
+import type { GameNightVM } from '../view-model';
+
+function vm(overrides: Partial<GameNightVM> = {}): GameNightVM {
+  return {
+    id: 'x',
+    title: 'Test',
+    scheduledAtIso: '2026-06-12T19:00:00',
+    day: 12,
+    month: 5,
+    year: 2026,
+    timeLabel: '19:00',
+    durationLabel: '',
+    location: '',
+    gameIds: [],
+    playerIds: [],
+    role: 'organizer',
+    statusKey: 'planned',
+    ...overrides,
+  };
+}
+
+describe('groupByMonth', () => {
+  it('empty input → []', () => {
+    expect(groupByMonth([])).toEqual([]);
+  });
+
+  it('groups events by (year, month) and sorts newest-first', () => {
+    const now = new Date(2026, 5, 15); // June 15 2026 (current)
+    const events: GameNightVM[] = [
+      vm({ id: 'jan', year: 2026, month: 0, day: 5 }),
+      vm({ id: 'jun', year: 2026, month: 5, day: 20 }),
+      vm({ id: 'mar', year: 2026, month: 2, day: 10 }),
+    ];
+    const groups = groupByMonth(events, now);
+    expect(groups.map(g => `${g.year}-${g.month}`)).toEqual(['2026-5', '2026-2', '2026-0']);
+  });
+
+  it('current/future month items sorted ASC by day', () => {
+    const now = new Date(2026, 5, 1);
+    const events: GameNightVM[] = [
+      vm({ id: 'late', year: 2026, month: 5, day: 28 }),
+      vm({ id: 'mid', year: 2026, month: 5, day: 15 }),
+      vm({ id: 'early', year: 2026, month: 5, day: 3 }),
+    ];
+    const [group] = groupByMonth(events, now);
+    expect(group.items.map(i => i.id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('past month items sorted DESC by day', () => {
+    const now = new Date(2026, 5, 15);
+    const events: GameNightVM[] = [
+      vm({ id: 'mar-3', year: 2026, month: 2, day: 3 }),
+      vm({ id: 'mar-25', year: 2026, month: 2, day: 25 }),
+      vm({ id: 'mar-10', year: 2026, month: 2, day: 10 }),
+    ];
+    const [group] = groupByMonth(events, now);
+    expect(group.items.map(i => i.id)).toEqual(['mar-25', 'mar-10', 'mar-3']);
+  });
+
+  it('sorts across year boundaries (newest year first)', () => {
+    const now = new Date(2026, 5, 15);
+    const events: GameNightVM[] = [
+      vm({ id: '2025-dec', year: 2025, month: 11, day: 31 }),
+      vm({ id: '2026-jan', year: 2026, month: 0, day: 1 }),
+    ];
+    const groups = groupByMonth(events, now);
+    expect(groups.map(g => `${g.year}-${g.month}`)).toEqual(['2026-0', '2025-11']);
+  });
+
+  it('groups items into the right buckets', () => {
+    const now = new Date(2026, 5, 15);
+    const events: GameNightVM[] = [
+      vm({ id: 'a', year: 2026, month: 5, day: 10 }),
+      vm({ id: 'b', year: 2026, month: 5, day: 20 }),
+      vm({ id: 'c', year: 2026, month: 2, day: 1 }),
+    ];
+    const groups = groupByMonth(events, now);
+    expect(groups).toHaveLength(2);
+    const june = groups.find(g => g.month === 5);
+    const march = groups.find(g => g.month === 2);
+    expect(june?.items.map(i => i.id).sort()).toEqual(['a', 'b']);
+    expect(march?.items.map(i => i.id)).toEqual(['c']);
+  });
+});

--- a/apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts
@@ -74,6 +74,27 @@ describe('groupByMonth', () => {
     expect(groups.map(g => `${g.year}-${g.month}`)).toEqual(['2026-0', '2025-11']);
   });
 
+  it('sorts same-day events by timeLabel ASC in current/future bucket', () => {
+    const now = new Date(2026, 5, 10);
+    const events: GameNightVM[] = [
+      vm({ id: 'evening', year: 2026, month: 5, day: 15, timeLabel: '20:00' }),
+      vm({ id: 'lunch', year: 2026, month: 5, day: 15, timeLabel: '12:30' }),
+      vm({ id: 'afternoon', year: 2026, month: 5, day: 15, timeLabel: '15:00' }),
+    ];
+    const groups = groupByMonth(events, now);
+    expect(groups[0].items.map(e => e.id)).toEqual(['lunch', 'afternoon', 'evening']);
+  });
+
+  it('sorts same-day events by timeLabel DESC in past bucket', () => {
+    const now = new Date(2026, 5, 10);
+    const events: GameNightVM[] = [
+      vm({ id: 'evening', year: 2026, month: 0, day: 15, timeLabel: '20:00' }),
+      vm({ id: 'lunch', year: 2026, month: 0, day: 15, timeLabel: '12:30' }),
+    ];
+    const groups = groupByMonth(events, now);
+    expect(groups[0].items.map(e => e.id)).toEqual(['evening', 'lunch']);
+  });
+
   it('groups items into the right buckets', () => {
     const now = new Date(2026, 5, 15);
     const events: GameNightVM[] = [

--- a/apps/web/src/lib/game-nights/__tests__/view-model.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/view-model.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for toGameNightVM (Stage 3 /game-nights index v2 — Foundation).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+
+import { toGameNightVM } from '../view-model';
+
+const HOST_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_ID = '22222222-2222-2222-2222-222222222222';
+
+function buildDto(overrides: Partial<GameNightDto> = {}): GameNightDto {
+  return {
+    id: '00000000-0000-0000-0000-0000000000aa',
+    organizerId: HOST_ID,
+    organizerName: 'Marco R.',
+    title: 'Serata Test',
+    description: null,
+    scheduledAt: '2026-06-12T19:00:00',
+    location: 'Da Marco',
+    maxPlayers: 8,
+    gameIds: ['00000000-0000-0000-0000-0000000000bb'],
+    status: 'Published',
+    acceptedCount: 3,
+    pendingCount: 0,
+    totalInvited: 3,
+    createdAt: '2026-05-15T10:00:00Z',
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('toGameNightVM', () => {
+  it('derives day/month/year from scheduledAt (local time)', () => {
+    const vm = toGameNightVM(buildDto({ scheduledAt: '2026-06-12T19:00:00' }), HOST_ID);
+    expect(vm.day).toBe(12);
+    expect(vm.month).toBe(5); // 0-indexed June
+    expect(vm.year).toBe(2026);
+  });
+
+  it('formats timeLabel as HH:mm zero-padded', () => {
+    const vm = toGameNightVM(buildDto({ scheduledAt: '2026-06-12T09:05:00' }), HOST_ID);
+    expect(vm.timeLabel).toBe('09:05');
+  });
+
+  it('role=organizer when currentUserId matches organizerId', () => {
+    const vm = toGameNightVM(buildDto(), HOST_ID);
+    expect(vm.role).toBe('organizer');
+  });
+
+  it('role=invited when currentUserId differs', () => {
+    const vm = toGameNightVM(buildDto(), OTHER_ID);
+    expect(vm.role).toBe('invited');
+  });
+
+  it('role=invited when currentUserId is null', () => {
+    const vm = toGameNightVM(buildDto(), null);
+    expect(vm.role).toBe('invited');
+  });
+
+  it('statusKey=cancelled when status=Cancelled', () => {
+    const vm = toGameNightVM(buildDto({ status: 'Cancelled' }), HOST_ID);
+    expect(vm.statusKey).toBe('cancelled');
+  });
+
+  it('statusKey=completed when status=Completed', () => {
+    const vm = toGameNightVM(buildDto({ status: 'Completed' }), HOST_ID);
+    expect(vm.statusKey).toBe('completed');
+  });
+
+  it('statusKey=confirmed when Published and acceptedCount >= 3', () => {
+    const vm = toGameNightVM(buildDto({ status: 'Published', acceptedCount: 3 }), HOST_ID);
+    expect(vm.statusKey).toBe('confirmed');
+  });
+
+  it('statusKey=planned when Published and acceptedCount < 3', () => {
+    const vm = toGameNightVM(buildDto({ status: 'Published', acceptedCount: 2 }), HOST_ID);
+    expect(vm.statusKey).toBe('planned');
+  });
+
+  it('statusKey=planned when status=Draft', () => {
+    const vm = toGameNightVM(buildDto({ status: 'Draft', acceptedCount: 10 }), HOST_ID);
+    expect(vm.statusKey).toBe('planned');
+  });
+
+  it('exposes gameIds and an empty playerIds list (backend gap)', () => {
+    const vm = toGameNightVM(
+      buildDto({ gameIds: ['00000000-0000-0000-0000-0000000000bb'] }),
+      HOST_ID
+    );
+    expect(vm.gameIds).toEqual(['00000000-0000-0000-0000-0000000000bb']);
+    expect(vm.playerIds).toEqual([]);
+  });
+
+  it('uses empty string for location when null', () => {
+    const vm = toGameNightVM(buildDto({ location: null }), HOST_ID);
+    expect(vm.location).toBe('');
+  });
+
+  it('exposes empty durationLabel (backend gap)', () => {
+    const vm = toGameNightVM(buildDto(), HOST_ID);
+    expect(vm.durationLabel).toBe('');
+  });
+
+  it('preserves id, title and scheduledAtIso', () => {
+    const dto = buildDto();
+    const vm = toGameNightVM(dto, HOST_ID);
+    expect(vm.id).toBe(dto.id);
+    expect(vm.title).toBe(dto.title);
+    expect(vm.scheduledAtIso).toBe(dto.scheduledAt);
+  });
+});

--- a/apps/web/src/lib/game-nights/calendar-grid.ts
+++ b/apps/web/src/lib/game-nights/calendar-grid.ts
@@ -1,0 +1,50 @@
+/**
+ * Calendar grid builder for /game-nights index v2 (Stage 3, refs #1170).
+ *
+ * Pure helper: builds a 42-cell (6×7) Monday-first month grid. Cells outside
+ * the current month are flagged so the renderer can dim them and the click
+ * handler can route to the adjacent month.
+ */
+
+export interface MonthCell {
+  readonly day: number; // 1..31
+  readonly otherMonth: boolean;
+  readonly monthOffset: -1 | 0 | 1; // -1=prev, 0=current, +1=next
+}
+
+/**
+ * Build 42-cell Monday-first month grid.
+ *
+ * @param year  4-digit year
+ * @param month 0-indexed month (0=Jan ... 11=Dec) — matches the JS `Date` API
+ */
+export function buildMonthGrid(year: number, month: number): MonthCell[] {
+  const firstOfMonth = new Date(year, month, 1);
+  // JS getDay: 0=Sun..6=Sat. Convert to ISO Monday-first offset (0=Mon..6=Sun).
+  const offset = (firstOfMonth.getDay() + 6) % 7;
+
+  const daysInCurrent = new Date(year, month + 1, 0).getDate();
+  const daysInPrev = new Date(year, month, 0).getDate();
+
+  const cells: MonthCell[] = [];
+
+  // Prev-month tail.
+  for (let i = 0; i < offset; i++) {
+    const day = daysInPrev - offset + 1 + i;
+    cells.push({ day, otherMonth: true, monthOffset: -1 });
+  }
+
+  // Current month.
+  for (let day = 1; day <= daysInCurrent; day++) {
+    cells.push({ day, otherMonth: false, monthOffset: 0 });
+  }
+
+  // Next-month padding.
+  let nextDay = 1;
+  while (cells.length < 42) {
+    cells.push({ day: nextDay, otherMonth: true, monthOffset: 1 });
+    nextDay++;
+  }
+
+  return cells;
+}

--- a/apps/web/src/lib/game-nights/event-filter.ts
+++ b/apps/web/src/lib/game-nights/event-filter.ts
@@ -1,0 +1,25 @@
+/**
+ * Filter predicate set for /game-nights index v2 (Stage 3, refs #1170).
+ */
+
+import type { GameNightVM } from './view-model';
+
+export const FILTER_KEYS = ['all', 'organizing', 'invited', 'completed'] as const;
+export type FilterKey = (typeof FILTER_KEYS)[number];
+
+export function isFilterKey(value: unknown): value is FilterKey {
+  return typeof value === 'string' && (FILTER_KEYS as readonly string[]).includes(value);
+}
+
+export function filterEvents(events: readonly GameNightVM[], key: FilterKey): GameNightVM[] {
+  switch (key) {
+    case 'all':
+      return events.slice();
+    case 'organizing':
+      return events.filter(e => e.role === 'organizer');
+    case 'invited':
+      return events.filter(e => e.role === 'invited');
+    case 'completed':
+      return events.filter(e => e.statusKey === 'completed');
+  }
+}

--- a/apps/web/src/lib/game-nights/event-grouping.ts
+++ b/apps/web/src/lib/game-nights/event-grouping.ts
@@ -39,7 +39,11 @@ export function groupByMonth(events: readonly GameNightVM[], now: Date = new Dat
   const groups: MonthGroup[] = [];
   for (const bucket of buckets.values()) {
     const past = isPastMonth(bucket.year, bucket.month, now);
-    const sortedItems = bucket.items.slice().sort((a, b) => (past ? b.day - a.day : a.day - b.day));
+    const sortedItems = bucket.items.slice().sort((a, b) => {
+      const dayDiff = past ? b.day - a.day : a.day - b.day;
+      if (dayDiff !== 0) return dayDiff;
+      return past ? b.timeLabel.localeCompare(a.timeLabel) : a.timeLabel.localeCompare(b.timeLabel);
+    });
     groups.push({ year: bucket.year, month: bucket.month, items: sortedItems });
   }
 

--- a/apps/web/src/lib/game-nights/event-grouping.ts
+++ b/apps/web/src/lib/game-nights/event-grouping.ts
@@ -1,0 +1,52 @@
+/**
+ * Month-grouping helper for /game-nights index v2 list view (Stage 3, refs #1170).
+ *
+ * Groups view models into per-month buckets sorted newest-first. Within each
+ * bucket items are ordered ASC if the bucket represents the current month or
+ * a future month (next-up first), DESC otherwise (recent history first).
+ */
+
+import type { GameNightVM } from './view-model';
+
+export interface MonthGroup {
+  readonly year: number;
+  readonly month: number; // 0-indexed
+  readonly items: readonly GameNightVM[];
+}
+
+function isPastMonth(year: number, month: number, now: Date): boolean {
+  const refYear = now.getFullYear();
+  const refMonth = now.getMonth();
+  if (year < refYear) return true;
+  if (year > refYear) return false;
+  return month < refMonth;
+}
+
+export function groupByMonth(events: readonly GameNightVM[], now: Date = new Date()): MonthGroup[] {
+  if (events.length === 0) return [];
+
+  const buckets = new Map<string, { year: number; month: number; items: GameNightVM[] }>();
+  for (const event of events) {
+    const key = `${event.year}-${event.month}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { year: event.year, month: event.month, items: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.items.push(event);
+  }
+
+  const groups: MonthGroup[] = [];
+  for (const bucket of buckets.values()) {
+    const past = isPastMonth(bucket.year, bucket.month, now);
+    const sortedItems = bucket.items.slice().sort((a, b) => (past ? b.day - a.day : a.day - b.day));
+    groups.push({ year: bucket.year, month: bucket.month, items: sortedItems });
+  }
+
+  groups.sort((a, b) => {
+    if (a.year !== b.year) return b.year - a.year;
+    return b.month - a.month;
+  });
+
+  return groups;
+}

--- a/apps/web/src/lib/game-nights/view-model.ts
+++ b/apps/web/src/lib/game-nights/view-model.ts
@@ -1,0 +1,81 @@
+/**
+ * View model adapter for /game-nights index v2 (Stage 3, refs #1170).
+ *
+ * Translates the canonical {@link GameNightDto} into a denormalized,
+ * presentation-friendly shape that calendar/list components consume directly.
+ *
+ * Notes:
+ * - `playerIds` / `durationLabel` are placeholders — backend does not yet
+ *   surface participant roster nor expected duration in the list endpoint.
+ *   Components MUST tolerate empty values.
+ * - Role is derived by comparing `dto.organizerId` against the caller-supplied
+ *   `currentUserId` — the DTO does not carry viewer-specific flags.
+ */
+
+import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+
+export type StatusKey = 'confirmed' | 'planned' | 'cancelled' | 'completed';
+export type RoleKey = 'organizer' | 'invited';
+
+export interface GameNightVM {
+  readonly id: string;
+  readonly title: string;
+  readonly scheduledAtIso: string;
+  readonly day: number; // 1..31
+  readonly month: number; // 0-indexed (matches Date API)
+  readonly year: number;
+  readonly timeLabel: string; // "HH:mm" zero-padded local time
+  readonly durationLabel: string; // empty — backend gap
+  readonly location: string;
+  readonly gameIds: readonly string[];
+  readonly playerIds: readonly string[]; // empty — backend gap
+  readonly role: RoleKey;
+  readonly statusKey: StatusKey;
+}
+
+const CONFIRMED_ACCEPTED_THRESHOLD = 3;
+
+function deriveStatusKey(dto: GameNightDto): StatusKey {
+  switch (dto.status) {
+    case 'Cancelled':
+      return 'cancelled';
+    case 'Completed':
+      return 'completed';
+    case 'Published':
+      return dto.acceptedCount >= CONFIRMED_ACCEPTED_THRESHOLD ? 'confirmed' : 'planned';
+    case 'Draft':
+    default:
+      return 'planned';
+  }
+}
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+export function toGameNightVM(dto: GameNightDto, currentUserId: string | null): GameNightVM {
+  const scheduled = new Date(dto.scheduledAt);
+  const day = scheduled.getDate();
+  const month = scheduled.getMonth();
+  const year = scheduled.getFullYear();
+  const timeLabel = `${pad2(scheduled.getHours())}:${pad2(scheduled.getMinutes())}`;
+
+  const role: RoleKey =
+    currentUserId !== null && dto.organizerId === currentUserId ? 'organizer' : 'invited';
+
+  return {
+    id: dto.id,
+    title: dto.title,
+    scheduledAtIso: dto.scheduledAt,
+    day,
+    month,
+    year,
+    timeLabel,
+    durationLabel: '',
+    location: dto.location ?? '',
+    gameIds: dto.gameIds,
+    playerIds: [],
+    role,
+    statusKey: deriveStatusKey(dto),
+  };
+}

--- a/apps/web/src/lib/game-nights/view-model.ts
+++ b/apps/web/src/lib/game-nights/view-model.ts
@@ -33,6 +33,7 @@ export interface GameNightVM {
   readonly statusKey: StatusKey;
 }
 
+// Mockup spec (sp4-game-nights-index): ≥3 accepted RSVPs promote a Published night to the "Confermata" status chip.
 const CONFIRMED_ACCEPTED_THRESHOLD = 3;
 
 function deriveStatusKey(dto: GameNightDto): StatusKey {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2992,5 +2992,82 @@
         "dismiss": "Dismiss"
       }
     }
+  },
+  "gameNightsIndex": {
+    "header": {
+      "kicker": "Game nights",
+      "title": "Game nights",
+      "countLine": "{total} nights this month · {confirmed} confirmed",
+      "ctaNew": "New night"
+    },
+    "view": {
+      "tablistAriaLabel": "Nights view",
+      "calendar": "Calendar",
+      "list": "List"
+    },
+    "filter": {
+      "ariaLabel": "Filter by role",
+      "all": "All",
+      "organizing": "Organizing",
+      "invited": "Invited",
+      "completed": "Completed"
+    },
+    "status": {
+      "confirmed": "Confirmed",
+      "planned": "Planned",
+      "cancelled": "Cancelled",
+      "completed": "Completed"
+    },
+    "calendar": {
+      "prevMonth": "Previous month",
+      "nextMonth": "Next month",
+      "today": "Today",
+      "todayBadge": "Today",
+      "dayLabels": "Mon,Tue,Wed,Thu,Fri,Sat,Sun",
+      "dayAriaLabel": "Day {day}{events, plural, =0 {} =1 {, 1 event} other {, # events}}",
+      "overflow": "+{count} more",
+      "footerCount": "{total} nights · {cancelled} cancelled",
+      "legend": {
+        "event": "Night",
+        "cancelled": "Cancelled",
+        "today": "Today"
+      }
+    },
+    "list": {
+      "groupSubCurrent": "Current month",
+      "groupSubPast": "History",
+      "groupCount": "{count} {count, plural, =1 {night} other {nights}}",
+      "participants": "{count} {count, plural, =1 {participant} other {participants}}",
+      "organizingBadge": "● Organizing",
+      "cta": {
+        "edit": "Edit",
+        "viewSummary": "View summary →",
+        "reschedule": "Reschedule",
+        "accept": "✓ Attending",
+        "maybe": "Maybe"
+      }
+    },
+    "drawer": {
+      "title": "{day} {month} {year}",
+      "subtitle": "{count} {count, plural, =1 {night} other {nights}} scheduled",
+      "close": "Close",
+      "addOnDay": "+ Add a night on this day"
+    },
+    "states": {
+      "empty": {
+        "title": "No nights scheduled",
+        "body": "Create your first night to organize your games, invite your group and track who plays what.",
+        "cta": "+ Create first night"
+      },
+      "filteredEmpty": {
+        "title": "No nights match this filter",
+        "body": "Change the filter or create a new night."
+      },
+      "error": {
+        "title": "Unable to load nights",
+        "body": "Something went wrong. Try again in a moment.",
+        "retry": "Retry"
+      }
+    }
   }
 }

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3045,5 +3045,82 @@
         "dismiss": "Annulla"
       }
     }
+  },
+  "gameNightsIndex": {
+    "header": {
+      "kicker": "Game nights",
+      "title": "Serate di gioco",
+      "countLine": "{total} serate questo mese · {confirmed} confermate",
+      "ctaNew": "Nuova serata"
+    },
+    "view": {
+      "tablistAriaLabel": "Vista serate",
+      "calendar": "Calendario",
+      "list": "Lista"
+    },
+    "filter": {
+      "ariaLabel": "Filtra per ruolo",
+      "all": "Tutte",
+      "organizing": "Organizzo",
+      "invited": "Invitato",
+      "completed": "Concluse"
+    },
+    "status": {
+      "confirmed": "Confermata",
+      "planned": "In programma",
+      "cancelled": "Annullata",
+      "completed": "Conclusa"
+    },
+    "calendar": {
+      "prevMonth": "Mese precedente",
+      "nextMonth": "Mese successivo",
+      "today": "Oggi",
+      "todayBadge": "Oggi",
+      "dayLabels": "Lun,Mar,Mer,Gio,Ven,Sab,Dom",
+      "dayAriaLabel": "Giorno {day}{events, plural, =0 {} =1 {, 1 evento} other {, # eventi}}",
+      "overflow": "+{count} altri",
+      "footerCount": "{total} serate · {cancelled} annullate",
+      "legend": {
+        "event": "Serata",
+        "cancelled": "Annullata",
+        "today": "Oggi"
+      }
+    },
+    "list": {
+      "groupSubCurrent": "Mese corrente",
+      "groupSubPast": "Storico",
+      "groupCount": "{count} {count, plural, =1 {serata} other {serate}}",
+      "participants": "{count} {count, plural, =1 {partecipante} other {partecipanti}}",
+      "organizingBadge": "● Organizzo",
+      "cta": {
+        "edit": "Modifica",
+        "viewSummary": "Vedi summary →",
+        "reschedule": "Riprogramma",
+        "accept": "✓ Partecipo",
+        "maybe": "Forse"
+      }
+    },
+    "drawer": {
+      "title": "{day} {month} {year}",
+      "subtitle": "{count} {count, plural, =1 {serata} other {serate}} in programma",
+      "close": "Chiudi",
+      "addOnDay": "+ Aggiungi serata in questo giorno"
+    },
+    "states": {
+      "empty": {
+        "title": "Nessuna serata in programma",
+        "body": "Crea la prima serata per organizzare le tue partite, invitare il gruppo e tenere traccia di chi gioca a cosa.",
+        "cta": "+ Crea la prima serata"
+      },
+      "filteredEmpty": {
+        "title": "Nessuna serata in questo filtro",
+        "body": "Cambia filtro o crea una nuova serata."
+      },
+      "error": {
+        "title": "Impossibile caricare le serate",
+        "body": "C'è stato un problema. Riprova fra un momento.",
+        "retry": "Riprova"
+      }
+    }
   }
 }

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -120,7 +120,7 @@ Each route is classified by **Tier** (S/M/L) which gates implementation strategy
 | `/agents/[id]` | **L** | `sp4-agent-detail.html` | useAgent + chat history + KB docs cross-resource (2-step chain agent.gameId) | ✅ done (Wave C.2, PR #711) — `contracts/agents-id-hooks.md` (TBD) |
 | `/sessions/[id]/live` | **L+** | `sp4-session-live.html` + `sp4-session-live-parts.jsx` | Real-time SSE + multi-hook + dialog states | pending — Phase 0.5 + sub-PR split |
 | `/discover` | **L** | `sp4-discover.html` | Multiple horizontal-row hooks | pending — Phase 0.5 required |
-| `/game-nights` | **L** | `sp4-game-nights-index.html` | Calendar + day-detail drawer + filters | pending — Phase 0.5 required |
+| `/game-nights` | **L** | `sp4-game-nights-index.html` | Calendar + day-detail drawer + filters | ✅ done (Stage 3, PR #TBD) |
 | `/sessions` | **M** | `sp4-sessions-index.html` | Sessions list + filters composition | pending |
 | `/sessions/[id]` | **M-L** | `sp4-session-summary.html` + `sp4-session-summary-parts.jsx` | Post-game summary: podium + KPI + diary + photos + share + tie-group computation | ✅ done (Wave D.3, PR #762) — `contracts/sessions-id-summary-hooks.md` (TBD) |
 | `/players/[id]` | **M** | `sp4-player-detail.html` | usePlayerStatistics single hook (current user only — schema reality v1 carryover) | ✅ done (Wave 3, PR #724) |
@@ -312,18 +312,18 @@ the PR review.
 | `sp4-kb-detail.jsx` | `MarkdownRenderBlock` | `apps/web/src/components/features/kb-detail/MarkdownRenderBlock.tsx` | `/kb/[id]` | deferred (G4 v3) | — | T A V |
 | `sp4-kb-detail.jsx` | `KbProcessingState` | `apps/web/src/components/features/kb-detail/KbProcessingState.tsx` | `/kb/[id]` | deferred (G4 v3) | — | T A V |
 
-### Game nights index — `/game-nights` — 8 components — **Tier L** ⚠️ Phase 0.5 required
+### Game nights index — `/game-nights` — 8 components — **Tier L** ✅ Stage 3 complete
 
 | Mockup | Component | Path | Route | Status | PR | AC |
 |--------|-----------|------|-------|--------|----|----|
-| `sp4-game-nights-index.jsx` | `GameNightsHeader` | `apps/web/src/components/features/game-nights/GameNightsHeader.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `CalendarMonthGrid` | `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `CalendarDayCell` | `apps/web/src/components/features/game-nights/CalendarDayCell.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `GameNightListCard` | `apps/web/src/components/features/game-nights/GameNightListCard.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `DayDetailDrawer` | `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx` | `/game-nights` | pending | — | T A M V |
-| `sp4-game-nights-index.jsx` | `FilterPillBar` | `apps/web/src/components/features/game-nights/FilterPillBar.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `StatusPill` | `apps/web/src/components/features/game-nights/StatusPill.tsx` | `/game-nights` | pending | — | T A V |
-| `sp4-game-nights-index.jsx` | `PlayerAvatars` | `apps/web/src/components/features/game-nights/PlayerAvatars.tsx` | `/game-nights` | pending | — | T A V |
+| `sp4-game-nights-index.jsx` | `GameNightsHeader` | `apps/web/src/components/features/game-nights/GameNightsHeader.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `CalendarMonthGrid` | `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `CalendarDayCell` | `apps/web/src/components/features/game-nights/CalendarDayCell.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `GameNightListCard` | `apps/web/src/components/features/game-nights/GameNightListCard.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `DayDetailDrawer` | `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx` | `/game-nights` | done | #TBD | T A M V |
+| `sp4-game-nights-index.jsx` | `FilterPillBar` | `apps/web/src/components/features/game-nights/FilterPillBar.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `StatusPill` | `apps/web/src/components/features/game-nights/StatusPill.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `PlayerAvatars` | `apps/web/src/components/features/game-nights/PlayerAvatars.tsx` | `/game-nights` | done | #TBD | T A V |
 
 ### Discover — `/discover` — 6 components — **Tier L** ⚠️ Phase 0.5 required
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -120,7 +120,7 @@ Each route is classified by **Tier** (S/M/L) which gates implementation strategy
 | `/agents/[id]` | **L** | `sp4-agent-detail.html` | useAgent + chat history + KB docs cross-resource (2-step chain agent.gameId) | ✅ done (Wave C.2, PR #711) — `contracts/agents-id-hooks.md` (TBD) |
 | `/sessions/[id]/live` | **L+** | `sp4-session-live.html` + `sp4-session-live-parts.jsx` | Real-time SSE + multi-hook + dialog states | pending — Phase 0.5 + sub-PR split |
 | `/discover` | **L** | `sp4-discover.html` | Multiple horizontal-row hooks | pending — Phase 0.5 required |
-| `/game-nights` | **L** | `sp4-game-nights-index.html` | Calendar + day-detail drawer + filters | ✅ done (Stage 3, PR #TBD) |
+| `/game-nights` | **L** | `sp4-game-nights-index.html` | Calendar + day-detail drawer + filters | ✅ done (Stage 3, PR #1173) |
 | `/sessions` | **M** | `sp4-sessions-index.html` | Sessions list + filters composition | pending |
 | `/sessions/[id]` | **M-L** | `sp4-session-summary.html` + `sp4-session-summary-parts.jsx` | Post-game summary: podium + KPI + diary + photos + share + tie-group computation | ✅ done (Wave D.3, PR #762) — `contracts/sessions-id-summary-hooks.md` (TBD) |
 | `/players/[id]` | **M** | `sp4-player-detail.html` | usePlayerStatistics single hook (current user only — schema reality v1 carryover) | ✅ done (Wave 3, PR #724) |
@@ -316,14 +316,14 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC |
 |--------|-----------|------|-------|--------|----|----|
-| `sp4-game-nights-index.jsx` | `GameNightsHeader` | `apps/web/src/components/features/game-nights/GameNightsHeader.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `CalendarMonthGrid` | `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `CalendarDayCell` | `apps/web/src/components/features/game-nights/CalendarDayCell.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `GameNightListCard` | `apps/web/src/components/features/game-nights/GameNightListCard.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `DayDetailDrawer` | `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx` | `/game-nights` | done | #TBD | T A M V |
-| `sp4-game-nights-index.jsx` | `FilterPillBar` | `apps/web/src/components/features/game-nights/FilterPillBar.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `StatusPill` | `apps/web/src/components/features/game-nights/StatusPill.tsx` | `/game-nights` | done | #TBD | T A V |
-| `sp4-game-nights-index.jsx` | `PlayerAvatars` | `apps/web/src/components/features/game-nights/PlayerAvatars.tsx` | `/game-nights` | done | #TBD | T A V |
+| `sp4-game-nights-index.jsx` | `GameNightsHeader` | `apps/web/src/components/features/game-nights/GameNightsHeader.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `CalendarMonthGrid` | `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `CalendarDayCell` | `apps/web/src/components/features/game-nights/CalendarDayCell.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `GameNightListCard` | `apps/web/src/components/features/game-nights/GameNightListCard.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `DayDetailDrawer` | `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx` | `/game-nights` | done | #1173 | T A M V |
+| `sp4-game-nights-index.jsx` | `FilterPillBar` | `apps/web/src/components/features/game-nights/FilterPillBar.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `StatusPill` | `apps/web/src/components/features/game-nights/StatusPill.tsx` | `/game-nights` | done | #1173 | T A V |
+| `sp4-game-nights-index.jsx` | `PlayerAvatars` | `apps/web/src/components/features/game-nights/PlayerAvatars.tsx` | `/game-nights` | done | #1173 | T A V |
 
 ### Discover — `/discover` — 6 components — **Tier L** ⚠️ Phase 0.5 required
 
@@ -491,7 +491,7 @@ instead.
 
 ## Route → Mockup index (page-level)
 
-> **Added 2026-05-12** post user-page audit (issue #TBD). This is the
+> **Added 2026-05-12** post user-page audit (issue #1173). This is the
 > *route-first* counterpart to the per-component matrix above: one row per
 > user-reachable Next.js route (excluding `admin/(dashboard)/**`), linked to
 > the canonical mockup file(s). For machine-readable file classification see

--- a/docs/superpowers/plans/2026-05-15-game-nights-index-stage3.md
+++ b/docs/superpowers/plans/2026-05-15-game-nights-index-stage3.md
@@ -1,0 +1,1350 @@
+# game-nights-index Stage 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement 8 v2 components for the `/game-nights` index route, matching the `sp4-game-nights-index` mockup 1:1 (visual diff ≤2%), with WCAG 2.1 AA compliance and full state-matrix coverage (default/empty/loading/filtered-empty/error). Replaces the legacy `Card`/`Badge` based `_content.tsx`.
+
+**Architecture:** Eight presentational components live under `apps/web/src/components/features/game-nights/` (stubs already exist from PR #632). Pure-function helpers (calendar grid builder, event filter FSM, list grouping) live under `apps/web/src/lib/game-nights/`. The page orchestrator `app/(authenticated)/game-nights/_content.tsx` is refactored to consume `useUpcomingGameNights`/`useMyGameNights`, map to `GameNightDto`-derived view models, and route Calendar/List toggle via the `?view=` URL search param. Filter state (`Tutte/Organizzo/Invitato/Concluse`) routes via `?filter=`. i18n strings go under `pages.gameNightsIndex` in `locales/{it,en}.json`.
+
+**Tech Stack:** React 19, TypeScript, Tailwind 4 (entity utilities `bg-entity-event`/`text-entity-event`/etc, no hex/rgb), `clsx`, `lucide-react`, `next-intl` translations, React Query (already wired). Vitest + RTL for unit. Playwright + axe-core for E2E and a11y.
+
+**Branch (already created):** `feature/issue-1170-game-nights-index-stage3` (parent: `main-dev`)
+
+**Refs:** Issue #1170, Audit #1168, Stage 3 umbrella #1026, Stage 2 path migration #1025, Original (superseded) #685, Sibling cluster #951 (PR #1171/#1172), Mockup PR #640.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `apps/web/src/lib/game-nights/calendar-grid.ts` | Pure: build 42-cell month grid (Mon-first), classify other-month vs current |
+| `apps/web/src/lib/game-nights/event-filter.ts` | Pure: `FilterKey` union + `filterEvents()` predicate (Tutte/Organizzo/Invitato/Concluse) |
+| `apps/web/src/lib/game-nights/event-grouping.ts` | Pure: group sorted events by month for list view |
+| `apps/web/src/lib/game-nights/view-model.ts` | Pure: `GameNightDto` → `GameNightVM` (derives day/month/status-key/role) |
+| `apps/web/src/lib/game-nights/__tests__/calendar-grid.test.ts` | Vitest unit tests |
+| `apps/web/src/lib/game-nights/__tests__/event-filter.test.ts` | Vitest unit tests |
+| `apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts` | Vitest unit tests |
+| `apps/web/src/lib/game-nights/__tests__/view-model.test.ts` | Vitest unit tests |
+| `apps/web/src/components/features/game-nights/GameNightsHeader.tsx` | Title row + count + Calendar/List toggle (animated underline) + filter pills + "Nuova serata" CTA |
+| `apps/web/src/components/features/game-nights/FilterPillBar.tsx` | 4 filter pills as `<button aria-pressed>` group |
+| `apps/web/src/components/features/game-nights/StatusPill.tsx` | Status chip (Confermata/In programma/Annullata/Conclusa) |
+| `apps/web/src/components/features/game-nights/PlayerAvatars.tsx` | Avatar overlap stack with "+N" overflow |
+| `apps/web/src/components/features/game-nights/CalendarDayCell.tsx` | Day cell w/ max 3 event chips + overflow "+N altri" |
+| `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx` | 7-col grid + month nav (visual only, no fetch) + legend |
+| `apps/web/src/components/features/game-nights/GameNightListCard.tsx` | List card: date block + body + status pill + meta + contextual CTA |
+| `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx` | Slide-right (desktop) / bottom-sheet (mobile) drawer w/ focus trap |
+| `apps/web/src/components/features/game-nights/index.ts` | Barrel export |
+| `apps/web/src/components/features/game-nights/__tests__/*.test.tsx` | One test file per component (8 files) |
+| `apps/web/src/app/(authenticated)/game-nights/_content.tsx` | REWRITE: orchestrator consuming hooks + components |
+| `apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx` | NEW: orchestrator integration test |
+| `apps/web/src/locales/it.json` | UPDATED: `pages.gameNightsIndex` namespace |
+| `apps/web/src/locales/en.json` | UPDATED: `pages.gameNightsIndex` namespace |
+| `apps/web/e2e/v2-states/game-nights-index.spec.ts` | Playwright state matrix + a11y axe-core |
+| `apps/web/e2e/visual-conformity/game-nights-index.spec.ts` | Visual regression Desktop 1280 + Mobile 375 |
+| `docs/for-developers/frontend/v2-migration-matrix.md` | UPDATED: 8 rows status `done` + PR ref |
+
+The stub files at `components/features/game-nights/*.tsx` (8 files × 14 LOC, from PR #632) will be overwritten with real implementations.
+
+---
+
+## Preamble — Commit the plan itself
+
+```bash
+git add docs/superpowers/plans/2026-05-15-game-nights-index-stage3.md
+git commit -m "docs(plans): game-nights-index Stage 3 implementation plan (refs #1170)"
+```
+
+---
+
+## Commit 1 — Foundation: i18n + lib helpers
+
+### Task 1.1 — Calendar grid helper (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/game-nights/calendar-grid.ts`
+- Create: `apps/web/src/lib/game-nights/__tests__/calendar-grid.test.ts`
+
+- [ ] **Step 1.1.1: Write the failing test**
+
+```ts
+// apps/web/src/lib/game-nights/__tests__/calendar-grid.test.ts
+import { describe, expect, it } from 'vitest';
+import { buildMonthGrid, type MonthCell } from '../calendar-grid';
+
+describe('buildMonthGrid', () => {
+  it('returns exactly 42 cells (6 weeks)', () => {
+    const cells = buildMonthGrid(2026, 2); // March 2026
+    expect(cells).toHaveLength(42);
+  });
+
+  it('starts on Monday (ISO week)', () => {
+    // Mar 1 2026 = Sunday → grid starts Mon Feb 23
+    const cells = buildMonthGrid(2026, 2);
+    expect(cells[0]).toMatchObject({ day: 23, otherMonth: true, monthOffset: -1 });
+    expect(cells[6]).toMatchObject({ day: 1, otherMonth: false, monthOffset: 0 });
+  });
+
+  it('flags otherMonth correctly for trailing days', () => {
+    const cells = buildMonthGrid(2026, 2);
+    const last = cells[41];
+    expect(last.otherMonth).toBe(true);
+    expect(last.monthOffset).toBe(1);
+  });
+
+  it('handles month with Monday start (no prefix days)', () => {
+    // Jun 2026 starts on Monday → no Feb-tail cells
+    const cells = buildMonthGrid(2026, 5);
+    expect(cells[0]).toMatchObject({ day: 1, monthOffset: 0 });
+  });
+});
+```
+
+Run: `cd apps/web && pnpm vitest run src/lib/game-nights/__tests__/calendar-grid.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 1.1.2: Implement**
+
+```ts
+// apps/web/src/lib/game-nights/calendar-grid.ts
+/**
+ * Pure helper to build a 42-cell (6×7) month grid starting Monday.
+ * Used by CalendarMonthGrid; no I/O, no React.
+ */
+export interface MonthCell {
+  /** Day-of-month (1..31) */
+  readonly day: number;
+  /** True for prefix (prev month) and suffix (next month) cells */
+  readonly otherMonth: boolean;
+  /** -1 = prev month, 0 = current, +1 = next month */
+  readonly monthOffset: -1 | 0 | 1;
+}
+
+/**
+ * Build a 42-cell month grid (6 weeks × 7 days) Monday-first.
+ *
+ * @param year  4-digit year
+ * @param month 0-indexed month (0=Jan, 11=Dec) — matches `Date` constructor.
+ */
+export function buildMonthGrid(year: number, month: number): MonthCell[] {
+  const firstOfMonth = new Date(year, month, 1);
+  // JS getDay(): 0=Sun, 1=Mon, ..., 6=Sat → ISO Mon-first offset:
+  // Sun(0) → 6, Mon(1) → 0, Tue(2) → 1, ..., Sat(6) → 5
+  const isoOffset = (firstOfMonth.getDay() + 6) % 7;
+  const daysInPrev = new Date(year, month, 0).getDate();
+  const daysInCurr = new Date(year, month + 1, 0).getDate();
+
+  const cells: MonthCell[] = [];
+
+  // Prev-month prefix
+  for (let i = isoOffset; i > 0; i--) {
+    cells.push({ day: daysInPrev - i + 1, otherMonth: true, monthOffset: -1 });
+  }
+  // Current month
+  for (let d = 1; d <= daysInCurr; d++) {
+    cells.push({ day: d, otherMonth: false, monthOffset: 0 });
+  }
+  // Next-month suffix to fill 42
+  let pad = 42 - cells.length;
+  for (let d = 1; d <= pad; d++) {
+    cells.push({ day: d, otherMonth: true, monthOffset: 1 });
+  }
+  return cells;
+}
+```
+
+Run: `cd apps/web && pnpm vitest run src/lib/game-nights/__tests__/calendar-grid.test.ts`
+Expected: PASS (4 tests).
+
+### Task 1.2 — Event filter FSM (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/game-nights/event-filter.ts`
+- Create: `apps/web/src/lib/game-nights/__tests__/event-filter.test.ts`
+
+- [ ] **Step 1.2.1: Write the failing test**
+
+```ts
+// apps/web/src/lib/game-nights/__tests__/event-filter.test.ts
+import { describe, expect, it } from 'vitest';
+import { filterEvents, FILTER_KEYS, isFilterKey, type FilterKey } from '../event-filter';
+import type { GameNightVM } from '../view-model';
+
+const vm = (id: string, role: 'organizer' | 'invited', status: GameNightVM['statusKey']): GameNightVM => ({
+  id, role, statusKey: status, title: id, day: 1, month: 0, year: 2026,
+  timeLabel: '19:00', durationLabel: '2h', location: '', gameId: null,
+  gameTitle: null, playerIds: [], scheduledAtIso: '',
+});
+
+describe('FILTER_KEYS', () => {
+  it('exposes 4 keys', () => {
+    expect(FILTER_KEYS).toEqual(['all', 'organizing', 'invited', 'completed']);
+  });
+});
+
+describe('isFilterKey', () => {
+  it.each([
+    ['all', true], ['organizing', true], ['invited', true], ['completed', true],
+    ['unknown', false], ['', false], [null, false],
+  ])('isFilterKey(%p) === %p', (input, expected) => {
+    expect(isFilterKey(input)).toBe(expected);
+  });
+});
+
+describe('filterEvents', () => {
+  const events: GameNightVM[] = [
+    vm('a', 'organizer', 'confirmed'),
+    vm('b', 'invited', 'planned'),
+    vm('c', 'organizer', 'completed'),
+    vm('d', 'invited', 'cancelled'),
+  ];
+
+  it('all → returns all', () => {
+    expect(filterEvents(events, 'all').map(e => e.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+  it('organizing → only organizer role', () => {
+    expect(filterEvents(events, 'organizing').map(e => e.id)).toEqual(['a', 'c']);
+  });
+  it('invited → only invited role', () => {
+    expect(filterEvents(events, 'invited').map(e => e.id)).toEqual(['b', 'd']);
+  });
+  it('completed → only status=completed', () => {
+    expect(filterEvents(events, 'completed').map(e => e.id)).toEqual(['c']);
+  });
+});
+```
+
+Run: FAIL.
+
+- [ ] **Step 1.2.2: Implement**
+
+```ts
+// apps/web/src/lib/game-nights/event-filter.ts
+import type { GameNightVM } from './view-model';
+
+export const FILTER_KEYS = ['all', 'organizing', 'invited', 'completed'] as const;
+export type FilterKey = (typeof FILTER_KEYS)[number];
+
+export function isFilterKey(value: unknown): value is FilterKey {
+  return typeof value === 'string' && (FILTER_KEYS as readonly string[]).includes(value);
+}
+
+export function filterEvents(events: readonly GameNightVM[], key: FilterKey): GameNightVM[] {
+  switch (key) {
+    case 'all':
+      return [...events];
+    case 'organizing':
+      return events.filter(e => e.role === 'organizer');
+    case 'invited':
+      return events.filter(e => e.role === 'invited');
+    case 'completed':
+      return events.filter(e => e.statusKey === 'completed');
+  }
+}
+```
+
+Run: PASS.
+
+### Task 1.3 — View model adapter (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/game-nights/view-model.ts`
+- Create: `apps/web/src/lib/game-nights/__tests__/view-model.test.ts`
+
+- [ ] **Step 1.3.1: Check existing GameNightDto shape**
+
+Read `apps/web/src/lib/api/schemas/game-nights.schemas.ts` and grep for `GameNightDto` to confirm field names (`id`, `title`, `scheduledAt`, `organizerId`, `organizerName`, `location`, `status`, `acceptedCount`, `pendingCount`, `maxPlayers`, plus user-relative `isOrganizer` / `userRsvpStatus` if present).
+
+- [ ] **Step 1.3.2: Write the failing test**
+
+```ts
+// apps/web/src/lib/game-nights/__tests__/view-model.test.ts
+import { describe, expect, it } from 'vitest';
+import { toGameNightVM } from '../view-model';
+import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+
+const baseDto: GameNightDto = {
+  id: 'gn-1',
+  title: 'Wingspan night',
+  description: null,
+  scheduledAt: '2026-03-15T19:00:00Z',
+  organizerId: 'u-marco',
+  organizerName: 'Marco',
+  location: 'Casa Marco',
+  status: 'Published',
+  maxPlayers: 5,
+  acceptedCount: 3,
+  pendingCount: 1,
+  declinedCount: 0,
+  gameId: null,
+  gameTitle: null,
+  isOrganizer: true,
+  viewerRsvpStatus: null,
+};
+
+describe('toGameNightVM', () => {
+  it('derives day/month/year from scheduledAt', () => {
+    const vm = toGameNightVM(baseDto);
+    expect(vm.day).toBe(15);
+    expect(vm.month).toBe(2); // 0-indexed March
+    expect(vm.year).toBe(2026);
+  });
+  it('derives role = organizer when isOrganizer=true', () => {
+    expect(toGameNightVM({ ...baseDto, isOrganizer: true }).role).toBe('organizer');
+  });
+  it('derives role = invited when isOrganizer=false', () => {
+    expect(toGameNightVM({ ...baseDto, isOrganizer: false }).role).toBe('invited');
+  });
+  it('maps Status enum to statusKey', () => {
+    expect(toGameNightVM({ ...baseDto, status: 'Published' }).statusKey).toBe('planned');
+    expect(toGameNightVM({ ...baseDto, status: 'Cancelled' }).statusKey).toBe('cancelled');
+    expect(toGameNightVM({ ...baseDto, status: 'Completed' }).statusKey).toBe('completed');
+    expect(toGameNightVM({ ...baseDto, status: 'Draft' }).statusKey).toBe('planned');
+  });
+  it('promotes Published → confirmed when accepted ≥ 3', () => {
+    expect(toGameNightVM({ ...baseDto, status: 'Published', acceptedCount: 3 }).statusKey).toBe('confirmed');
+    expect(toGameNightVM({ ...baseDto, status: 'Published', acceptedCount: 2 }).statusKey).toBe('planned');
+  });
+});
+```
+
+Run: FAIL.
+
+- [ ] **Step 1.3.3: Implement**
+
+```ts
+// apps/web/src/lib/game-nights/view-model.ts
+import type { GameNightDto, GameNightStatus } from '@/lib/api/schemas/game-nights.schemas';
+
+export type StatusKey = 'confirmed' | 'planned' | 'cancelled' | 'completed';
+export type RoleKey = 'organizer' | 'invited';
+
+export interface GameNightVM {
+  readonly id: string;
+  readonly title: string;
+  readonly scheduledAtIso: string;
+  /** 1..31 */
+  readonly day: number;
+  /** 0-indexed month (0=Jan) */
+  readonly month: number;
+  readonly year: number;
+  /** Hour:Minute formatted locally */
+  readonly timeLabel: string;
+  /** Free-form duration ("2h", "3h 30m"); empty if unknown */
+  readonly durationLabel: string;
+  readonly location: string;
+  readonly gameId: string | null;
+  readonly gameTitle: string | null;
+  readonly playerIds: readonly string[];
+  readonly role: RoleKey;
+  readonly statusKey: StatusKey;
+}
+
+const CONFIRMED_THRESHOLD = 3;
+
+function deriveStatusKey(dto: GameNightDto): StatusKey {
+  switch (dto.status) {
+    case 'Cancelled':
+      return 'cancelled';
+    case 'Completed':
+      return 'completed';
+    case 'Published':
+      return dto.acceptedCount >= CONFIRMED_THRESHOLD ? 'confirmed' : 'planned';
+    case 'Draft':
+    default:
+      return 'planned';
+  }
+}
+
+export function toGameNightVM(dto: GameNightDto): GameNightVM {
+  const date = new Date(dto.scheduledAt);
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return {
+    id: dto.id,
+    title: dto.title,
+    scheduledAtIso: dto.scheduledAt,
+    day: date.getDate(),
+    month: date.getMonth(),
+    year: date.getFullYear(),
+    timeLabel: `${hh}:${mm}`,
+    durationLabel: '',
+    location: dto.location ?? '',
+    gameId: dto.gameId ?? null,
+    gameTitle: dto.gameTitle ?? null,
+    playerIds: [],
+    role: dto.isOrganizer ? 'organizer' : 'invited',
+    statusKey: deriveStatusKey(dto),
+  };
+}
+```
+
+> **Note:** `durationLabel` and `playerIds` are intentionally empty in the VM until backend exposes them. The mockup shows them; we degrade gracefully (components hide the meta row if `playerIds.length === 0`).
+
+Run: PASS.
+
+### Task 1.4 — Event grouping helper (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/game-nights/event-grouping.ts`
+- Create: `apps/web/src/lib/game-nights/__tests__/event-grouping.test.ts`
+
+- [ ] **Step 1.4.1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { groupByMonth, type MonthGroup } from '../event-grouping';
+import type { GameNightVM } from '../view-model';
+
+const make = (id: string, year: number, month: number, day: number): GameNightVM => ({
+  id, title: id, scheduledAtIso: '', day, month, year,
+  timeLabel: '19:00', durationLabel: '', location: '', gameId: null,
+  gameTitle: null, playerIds: [], role: 'invited', statusKey: 'planned',
+});
+
+describe('groupByMonth', () => {
+  it('groups events by (year, month) sorted newest-first', () => {
+    const events = [make('a', 2026, 0, 5), make('b', 2026, 2, 10), make('c', 2026, 2, 1)];
+    const groups = groupByMonth(events);
+    expect(groups.map(g => `${g.year}-${g.month}`)).toEqual(['2026-2', '2026-0']);
+  });
+  it('sorts items within current month ASCENDING by day', () => {
+    const events = [make('a', 2026, 2, 20), make('b', 2026, 2, 5), make('c', 2026, 2, 15)];
+    const now = new Date(2026, 2, 12);
+    const groups = groupByMonth(events, now);
+    expect(groups[0].items.map(e => e.day)).toEqual([5, 15, 20]);
+  });
+  it('sorts items in past months DESCENDING by day', () => {
+    const events = [make('a', 2026, 1, 5), make('b', 2026, 1, 20)];
+    const now = new Date(2026, 2, 12);
+    const groups = groupByMonth(events, now);
+    expect(groups[0].items.map(e => e.day)).toEqual([20, 5]);
+  });
+  it('returns empty array for empty input', () => {
+    expect(groupByMonth([])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 1.4.2: Implement**
+
+```ts
+// apps/web/src/lib/game-nights/event-grouping.ts
+import type { GameNightVM } from './view-model';
+
+export interface MonthGroup {
+  readonly year: number;
+  /** 0-indexed (0=Jan) */
+  readonly month: number;
+  readonly items: readonly GameNightVM[];
+}
+
+export function groupByMonth(events: readonly GameNightVM[], now: Date = new Date()): MonthGroup[] {
+  if (events.length === 0) return [];
+  const buckets = new Map<string, GameNightVM[]>();
+  for (const e of events) {
+    const key = `${e.year}-${e.month}`;
+    const arr = buckets.get(key) ?? [];
+    arr.push(e);
+    buckets.set(key, arr);
+  }
+  const currentY = now.getFullYear();
+  const currentM = now.getMonth();
+  return [...buckets.entries()]
+    .map(([key, items]) => {
+      const [y, m] = key.split('-').map(Number);
+      const isCurrentOrFuture = y > currentY || (y === currentY && m >= currentM);
+      const sorted = [...items].sort((a, b) => (isCurrentOrFuture ? a.day - b.day : b.day - a.day));
+      return { year: y, month: m, items: sorted };
+    })
+    .sort((a, b) => (b.year - a.year) * 100 + (b.month - a.month));
+}
+```
+
+Run: PASS.
+
+### Task 1.5 — i18n keys
+
+**Files:**
+- Modify: `apps/web/src/locales/it.json`
+- Modify: `apps/web/src/locales/en.json`
+
+- [ ] **Step 1.5.1: Add `pages.gameNightsIndex` namespace to both locales**
+
+Italian (`it.json`) — insert after `pages.gameNightDetail`:
+
+```json
+"gameNightsIndex": {
+  "header": {
+    "kicker": "Game nights",
+    "title": "Serate di gioco",
+    "countLine": "{total} serate questo mese · {confirmed} confermate",
+    "ctaNew": "Nuova serata"
+  },
+  "view": {
+    "tablistAriaLabel": "Vista serate",
+    "calendar": "Calendario",
+    "list": "Lista"
+  },
+  "filter": {
+    "ariaLabel": "Filtra per ruolo",
+    "all": "Tutte",
+    "organizing": "Organizzo",
+    "invited": "Invitato",
+    "completed": "Concluse"
+  },
+  "status": {
+    "confirmed": "Confermata",
+    "planned": "In programma",
+    "cancelled": "Annullata",
+    "completed": "Conclusa"
+  },
+  "calendar": {
+    "prevMonth": "Mese precedente",
+    "nextMonth": "Mese successivo",
+    "today": "Oggi",
+    "todayBadge": "Oggi",
+    "dayLabels": "Lun,Mar,Mer,Gio,Ven,Sab,Dom",
+    "dayAriaLabel": "Giorno {day}{events, plural, =0 {} =1 {, 1 evento} other {, # eventi}}",
+    "overflow": "+{count} altri",
+    "footerCount": "{total} serate · {cancelled} annullate",
+    "legend": { "event": "Serata", "cancelled": "Annullata", "today": "Oggi" }
+  },
+  "list": {
+    "groupSubCurrent": "Mese corrente",
+    "groupSubPast": "Storico",
+    "groupCount": "{count} {count, plural, =1 {serata} other {serate}}",
+    "participants": "{count} {count, plural, =1 {partecipante} other {partecipanti}}",
+    "organizingBadge": "● Organizzo",
+    "cta": {
+      "edit": "Modifica",
+      "viewSummary": "Vedi summary →",
+      "reschedule": "Riprogramma",
+      "accept": "✓ Partecipo",
+      "maybe": "Forse"
+    }
+  },
+  "drawer": {
+    "title": "{day} {month} {year}",
+    "subtitle": "{count} {count, plural, =1 {serata} other {serate}} in programma",
+    "close": "Chiudi",
+    "addOnDay": "+ Aggiungi serata in questo giorno"
+  },
+  "states": {
+    "empty": {
+      "title": "Nessuna serata in programma",
+      "body": "Crea la prima serata per organizzare le tue partite, invitare il gruppo e tenere traccia di chi gioca a cosa.",
+      "cta": "+ Crea la prima serata"
+    },
+    "filteredEmpty": {
+      "title": "Nessuna serata in questo filtro",
+      "body": "Cambia filtro o crea una nuova serata."
+    },
+    "error": {
+      "title": "Impossibile caricare le serate",
+      "body": "C'è stato un problema. Riprova fra un momento.",
+      "retry": "Riprova"
+    }
+  }
+}
+```
+
+English (`en.json`) — mirror with translated values: `"title": "Game Nights"`, `"all": "All"`, `"organizing": "Organizing"`, etc.
+
+- [ ] **Step 1.5.2: Run typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+Expected: PASS (no JSON-typed translation key errors).
+
+### Task 1.6 — Commit foundation
+
+- [ ] **Step 1.6.1: Commit**
+
+```bash
+git add apps/web/src/lib/game-nights/ apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(game-nights-index): foundation helpers + i18n (refs #1170)"
+```
+
+---
+
+## Commit 2 — Components family (8 components + tests)
+
+> **Pattern:** For each component, write the test first, then implement. Use Tailwind entity utilities (`bg-entity-event`, `text-entity-event`, `border-entity-event/30`, etc.) — NO hex/rgb (ESLint `local/no-hardcoded-color-utility` is error-level). Use semantic tokens (`bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`, `border-border-strong`).
+
+### Task 2.1 — StatusPill (smallest, start here)
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/StatusPill.tsx` (replace 14-LOC stub)
+- Create: `apps/web/src/components/features/game-nights/__tests__/StatusPill.test.tsx`
+
+- [ ] **Step 2.1.1: Write the failing test**
+
+```tsx
+// apps/web/src/components/features/game-nights/__tests__/StatusPill.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithI18n } from '@/test-utils/test-i18n';
+import { StatusPill } from '../StatusPill';
+
+describe('StatusPill', () => {
+  it.each([
+    ['confirmed', 'Confermata'],
+    ['planned', 'In programma'],
+    ['cancelled', 'Annullata'],
+    ['completed', 'Conclusa'],
+  ] as const)('renders %s label', (statusKey, label) => {
+    renderWithI18n(<StatusPill statusKey={statusKey} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('renders an aria-hidden dot', () => {
+    const { container } = renderWithI18n(<StatusPill statusKey="confirmed" />);
+    const dot = container.querySelector('[aria-hidden="true"]');
+    expect(dot).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2.1.2: Implement**
+
+```tsx
+// apps/web/src/components/features/game-nights/StatusPill.tsx
+'use client';
+
+import clsx from 'clsx';
+import { useTranslations } from 'next-intl';
+
+import type { StatusKey } from '@/lib/game-nights/view-model';
+
+const VARIANT: Record<StatusKey, string> = {
+  confirmed: 'bg-entity-toolkit/12 text-entity-toolkit border-entity-toolkit/30',
+  planned: 'bg-entity-agent/12 text-entity-agent border-entity-agent/30',
+  cancelled: 'bg-destructive/12 text-destructive border-destructive/30',
+  completed: 'bg-muted text-muted-foreground border-border',
+};
+
+const DOT: Record<StatusKey, string> = {
+  confirmed: 'bg-entity-toolkit',
+  planned: 'bg-entity-agent',
+  cancelled: 'bg-destructive',
+  completed: 'bg-muted-foreground',
+};
+
+export interface StatusPillProps {
+  readonly statusKey: StatusKey;
+  readonly className?: string;
+}
+
+export function StatusPill({ statusKey, className }: StatusPillProps): JSX.Element {
+  const t = useTranslations('pages.gameNightsIndex.status');
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+        'font-mono text-[10px] font-extrabold uppercase tracking-wider',
+        VARIANT[statusKey],
+        className,
+      )}
+    >
+      <span aria-hidden="true" className={clsx('h-1.5 w-1.5 rounded-full', DOT[statusKey])} />
+      <span>{t(statusKey)}</span>
+    </span>
+  );
+}
+```
+
+Run: `cd apps/web && pnpm vitest run src/components/features/game-nights/__tests__/StatusPill.test.tsx`
+Expected: PASS.
+
+### Task 2.2 — PlayerAvatars
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/PlayerAvatars.tsx`
+- Create: `apps/web/src/components/features/game-nights/__tests__/PlayerAvatars.test.tsx`
+
+- [ ] **Step 2.2.1: Write test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PlayerAvatars } from '../PlayerAvatars';
+
+describe('PlayerAvatars', () => {
+  it('renders up to `max` initials', () => {
+    render(<PlayerAvatars players={[{ id: 'a', initials: 'AA' }, { id: 'b', initials: 'BB' }]} max={5} />);
+    expect(screen.getByText('AA')).toBeInTheDocument();
+    expect(screen.getByText('BB')).toBeInTheDocument();
+  });
+
+  it('shows +N overflow when players exceed max', () => {
+    const players = [1,2,3,4,5,6,7].map(n => ({ id: `p${n}`, initials: `P${n}` }));
+    render(<PlayerAvatars players={players} max={5} />);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('renders nothing for empty array', () => {
+    const { container } = render(<PlayerAvatars players={[]} max={5} />);
+    expect(container.firstChild?.childNodes).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2.2.2: Implement**
+
+```tsx
+// apps/web/src/components/features/game-nights/PlayerAvatars.tsx
+import clsx from 'clsx';
+
+export interface AvatarPlayer {
+  readonly id: string;
+  readonly initials: string;
+  readonly name?: string;
+}
+
+export interface PlayerAvatarsProps {
+  readonly players: readonly AvatarPlayer[];
+  readonly max?: number;
+  readonly className?: string;
+}
+
+/** Deterministic hue from id (0..359) */
+function hueFromId(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return Math.abs(h) % 360;
+}
+
+export function PlayerAvatars({ players, max = 5, className }: PlayerAvatarsProps): JSX.Element {
+  const list = players.slice(0, max);
+  const extra = players.length - max;
+  return (
+    <div className={clsx('inline-flex items-center', className)}>
+      {list.map((p, i) => (
+        <span
+          key={`${p.id}-${i}`}
+          title={p.name ?? p.id}
+          className={clsx(
+            'inline-flex h-6 w-6 items-center justify-center rounded-full border-2 border-card',
+            'font-display text-[10px] font-extrabold text-white',
+            i === 0 ? '' : '-ml-2',
+          )}
+          style={{ background: `hsl(${hueFromId(p.id)} 55% 50%)`, zIndex: max - i }}
+        >
+          {p.initials}
+        </span>
+      ))}
+      {extra > 0 && (
+        <span
+          className={clsx(
+            '-ml-2 inline-flex h-6 w-6 items-center justify-center rounded-full',
+            'border-2 border-card bg-muted text-muted-foreground',
+            'font-mono text-[10px] font-extrabold',
+          )}
+          style={{ zIndex: 0 }}
+        >
+          +{extra}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+Run: PASS.
+
+### Task 2.3 — FilterPillBar
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/FilterPillBar.tsx`
+- Create: `apps/web/src/components/features/game-nights/__tests__/FilterPillBar.test.tsx`
+
+- [ ] **Step 2.3.1: Write test**
+
+Test: renders 4 pills, active pill has `aria-pressed="true"`, click invokes callback with key.
+
+- [ ] **Step 2.3.2: Implement**
+
+Props: `{ value: FilterKey, onChange: (k: FilterKey) => void, className?: string }`.
+
+Uses `useTranslations('pages.gameNightsIndex.filter')`. Iterates `FILTER_KEYS`, each rendered as `<button type="button" aria-pressed={key === value} onClick={() => onChange(key)}>{t(key)}</button>` with active styling `bg-entity-event/15 text-entity-event border-entity-event/40` and inactive `bg-card text-muted-foreground border-border`.
+
+Wrap in `<div role="group" aria-label={t('ariaLabel')}>`.
+
+### Task 2.4 — GameNightsHeader
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/GameNightsHeader.tsx`
+- Create test
+
+Props:
+```ts
+interface GameNightsHeaderProps {
+  totalThisMonth: number;
+  confirmedThisMonth: number;
+  view: 'calendar' | 'list';
+  onViewChange: (view: 'calendar' | 'list') => void;
+  filter: FilterKey;
+  onFilterChange: (filter: FilterKey) => void;
+  onCreate: () => void;
+  isMobile?: boolean;
+}
+```
+
+Layout (mobile-first, no `window.innerWidth` — use `isMobile` prop or CSS-only via Tailwind `md:` modifiers):
+- Kicker pill (event entity) + h1 + count line + "+ Nuova serata" CTA (entity-event → entity-session gradient)
+- Calendar/List tablist (animated underline using `useTablistKeyboardNav` if available, else custom indicator via `useState` + refs)
+- Embedded `<FilterPillBar />`
+
+Test: snapshot ARIA tablist semantics, view-toggle click, filter-change click.
+
+### Task 2.5 — CalendarDayCell
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/CalendarDayCell.tsx`
+- Create test
+
+Props:
+```ts
+interface CalendarDayCellProps {
+  cell: MonthCell;
+  events: readonly GameNightVM[];
+  isToday: boolean;
+  isMobile?: boolean;
+  onClick?: (cell: MonthCell, events: readonly GameNightVM[]) => void;
+}
+```
+
+Render `<button type="button" disabled={cell.otherMonth} aria-label={t('calendar.dayAriaLabel', { day: cell.day, events: events.length })}>`. Inside: day number (entity-event color if today), "Oggi" mini-badge if today (desktop only), then up to `max` event chips (max=1 mobile, max=3 desktop), plus `+N altri` overflow.
+
+Use `bg-entity-event/5` for cells with events, `border-entity-event` (2px) for today, else `border-border`. Cancelled events: `line-through`, destructive bg.
+
+Test: 0 events / 1 event / 4 events → overflow text; today branch; otherMonth disabled.
+
+### Task 2.6 — CalendarMonthGrid
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/CalendarMonthGrid.tsx`
+- Create test
+
+Props:
+```ts
+interface CalendarMonthGridProps {
+  year: number;
+  month: number; // 0-indexed
+  events: readonly GameNightVM[]; // already filtered
+  today?: Date;
+  isMobile?: boolean;
+  onDayClick: (cell: MonthCell, events: readonly GameNightVM[]) => void;
+}
+```
+
+Composition:
+- Month nav row: prev `‹` / `Mese Anno` heading / next `›` / `Oggi` reset / right-side counter ("N serate · M annullate")
+- Day labels row (7 cols)
+- 7-col grid of 42 `<CalendarDayCell>`
+- Legend row: Serata / Annullata / Oggi swatches
+
+`onPrevMonth`/`onNextMonth` are deferred — mockup says these are visual only. Wire them as `disabled`/no-op for now (TODO comment + matrix entry "month-nav purely visual" — acceptable for this scope per issue out-of-scope clause).
+
+> Decision rationale: mockup line 20 confirms "paginazione mese ‹ › è solo visiva, no fetch reale". Backend doesn't yet expose month-by-month query; defer to follow-up.
+
+Test: matches snapshot for known month, day-label localization, today-marker placement, legend render.
+
+### Task 2.7 — GameNightListCard
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/GameNightListCard.tsx`
+- Create test
+
+Props:
+```ts
+interface GameNightListCardProps {
+  vm: GameNightVM;
+  isMobile?: boolean;
+  onAction?: (id: string, action: 'edit' | 'viewSummary' | 'reschedule' | 'accept' | 'maybe') => void;
+}
+```
+
+Sections (mobile vertical / desktop horizontal):
+1. Date block: month abbrev + day + time + duration (entity-event tinted)
+2. Body:
+   - Title (line-through if cancelled) + `<StatusPill>`
+   - Meta row: 📍 location + EntityChip(type=game, label=gameTitle) [if `vm.gameId`] + "● Organizzo" badge [if organizer]
+   - Footer (border-top): `<PlayerAvatars>` + count + spacer + contextual CTA
+
+CTA logic:
+- `completed` → "Vedi summary →" (outlined)
+- `cancelled` → "Riprogramma" (muted outlined)
+- `confirmed`/`planned` + `role==='organizer'` → "Modifica" (solid event)
+- `confirmed`/`planned` + `role==='invited'` → 2 buttons: "✓ Partecipo" (solid toolkit) + "Forse" (outlined)
+
+Card wrapper: `bg-card border-border rounded-lg border-l-4 border-l-entity-event` (or `border-l-destructive` if cancelled), `opacity-70` if cancelled.
+
+Test: 4 role/status branches → 4 different CTA layouts; line-through on cancelled; missing game → no chip.
+
+### Task 2.8 — DayDetailDrawer
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/DayDetailDrawer.tsx`
+- Create test
+
+Props:
+```ts
+interface DayDetailDrawerProps {
+  open: boolean;
+  day: number;
+  month: number;
+  year: number;
+  events: readonly GameNightVM[];
+  isMobile?: boolean;
+  onClose: () => void;
+}
+```
+
+Behavior:
+- Renders nothing if `!open`
+- Backdrop (`absolute inset-0 bg-black/50 z-50`) on click → `onClose()`
+- Aside: `w-full` (mobile) bottom-sheet vs `w-[480px]` (desktop) right-sheet
+- Header: 50×50 date block (entity-event tinted) + "{day} {month} {year}" + count + close button
+- Body: stack of `<GameNightListCard isMobile />` + "+ Aggiungi serata in questo giorno" dashed CTA
+- **Focus trap**: use existing `useFocusTrap` hook (search codebase first) or `react-focus-lock` if installed; fallback: manual trap via `tabindex` + focus on close button on open
+- **a11y**: `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing to header h2 id
+
+Animation: `data-state="open"` + Tailwind `data-[state=open]:animate-in` slide-in-from-bottom (mobile) / slide-in-from-right (desktop). Respect `prefers-reduced-motion` via existing motion utility classes (`motion-safe:` prefix).
+
+Test:
+- `open={false}` → renders nothing
+- backdrop click → invokes `onClose`
+- Escape key → invokes `onClose`
+- focus initially lands on close button
+- contains all event cards passed in `events`
+
+### Task 2.9 — Barrel export
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-nights/index.ts`
+
+```ts
+export { CalendarDayCell } from './CalendarDayCell';
+export { CalendarMonthGrid } from './CalendarMonthGrid';
+export { DayDetailDrawer } from './DayDetailDrawer';
+export { FilterPillBar } from './FilterPillBar';
+export { GameNightListCard } from './GameNightListCard';
+export { GameNightsHeader } from './GameNightsHeader';
+export { PlayerAvatars } from './PlayerAvatars';
+export { StatusPill } from './StatusPill';
+```
+
+### Task 2.10 — Commit components
+
+- [ ] **Step 2.10.1: Run full test for the feature folder**
+
+```bash
+cd apps/web && pnpm vitest run src/components/features/game-nights/ src/lib/game-nights/
+```
+Expected: all green.
+
+- [ ] **Step 2.10.2: Run lint (token guard)**
+
+```bash
+cd apps/web && pnpm lint
+```
+Expected: no `local/no-hardcoded-color-utility` violations.
+
+- [ ] **Step 2.10.3: Commit**
+
+```bash
+git add apps/web/src/components/features/game-nights/
+git commit -m "feat(game-nights-index): 8 components implementing sp4-game-nights-index mockup (refs #1170)"
+```
+
+---
+
+## Commit 3 — Orchestrator + page wiring
+
+### Task 3.1 — Refactor `_content.tsx`
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/game-nights/_content.tsx`
+- Create: `apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx`
+
+The new orchestrator:
+- Reads `?view=` (default `calendar` desktop, `list` mobile via media query) and `?filter=` (default `all`) from URL
+- `useUpcomingGameNights()` + `useMyGameNights()` (existing hooks)
+- Choice of source by filter: `all`/`invited`/`completed` → upcoming, `organizing` → mine (or both merged if simpler)
+- Maps DTOs → VMs via `toGameNightVM`
+- Renders `<GameNightsHeader>` + (calendar branch | list branch) + `<DayDetailDrawer>` for selected day
+- Empty state when 0 events total
+- Filtered-empty state when filter yields 0
+- Error state for query error
+- Loading state via existing skeleton OR per-component `stateOverride="loading"` (mockup pattern)
+
+```tsx
+// apps/web/src/app/(authenticated)/game-nights/_content.tsx
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import {
+  CalendarMonthGrid,
+  DayDetailDrawer,
+  GameNightListCard,
+  GameNightsHeader,
+} from '@/components/features/game-nights';
+import { useMyGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
+import { FILTER_KEYS, type FilterKey, filterEvents, isFilterKey } from '@/lib/game-nights/event-filter';
+import { groupByMonth } from '@/lib/game-nights/event-grouping';
+import { toGameNightVM, type GameNightVM } from '@/lib/game-nights/view-model';
+import type { MonthCell } from '@/lib/game-nights/calendar-grid';
+import { useRecentsStore } from '@/stores/use-recents';
+
+type View = 'calendar' | 'list';
+
+export function GameNightsContent(): JSX.Element {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const t = useTranslations('pages.gameNightsIndex');
+
+  const view: View = sp.get('view') === 'list' ? 'list' : 'calendar';
+  const filterRaw = sp.get('filter');
+  const filter: FilterKey = isFilterKey(filterRaw) ? filterRaw : 'all';
+
+  const [drawerCell, setDrawerCell] = useState<MonthCell | null>(null);
+
+  useEffect(() => {
+    useRecentsStore.getState().push({
+      id: 'section-game-nights', entity: 'event',
+      title: t('header.title'), href: '/game-nights',
+    });
+  }, [t]);
+
+  const upcoming = useUpcomingGameNights();
+  const mine = useMyGameNights();
+
+  const isLoading = upcoming.isLoading || mine.isLoading;
+  const error = upcoming.error || mine.error;
+
+  const allVms: readonly GameNightVM[] = useMemo(() => {
+    const combined = new Map<string, GameNightVM>();
+    [...(upcoming.data ?? []), ...(mine.data ?? [])].forEach(dto => {
+      if (!combined.has(dto.id)) combined.set(dto.id, toGameNightVM(dto));
+    });
+    return [...combined.values()];
+  }, [upcoming.data, mine.data]);
+
+  const filtered = useMemo(() => filterEvents(allVms, filter), [allVms, filter]);
+
+  const today = new Date();
+  const totalThisMonth = filtered.filter(e =>
+    e.year === today.getFullYear() && e.month === today.getMonth()).length;
+  const confirmedThisMonth = filtered.filter(e =>
+    e.year === today.getFullYear() && e.month === today.getMonth() && e.statusKey === 'confirmed').length;
+
+  function navigate(params: Record<string, string>) {
+    const next = new URLSearchParams(sp.toString());
+    for (const [k, v] of Object.entries(params)) next.set(k, v);
+    router.replace(`/game-nights?${next.toString()}`, { scroll: false });
+  }
+
+  // Render error first (terminal state)
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <h2 className="font-display text-lg font-bold text-foreground">{t('states.error.title')}</h2>
+        <p className="mt-2 text-sm text-muted-foreground">{t('states.error.body')}</p>
+        <button
+          type="button"
+          className="mt-4 rounded-md border border-border-strong px-4 py-2 font-display text-sm font-bold"
+          onClick={() => { void upcoming.refetch(); void mine.refetch(); }}
+        >
+          {t('states.error.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  // Empty (no events at all, not just filtered)
+  if (!isLoading && allVms.length === 0) {
+    return (
+      <>
+        <GameNightsHeader
+          totalThisMonth={0}
+          confirmedThisMonth={0}
+          view={view}
+          onViewChange={v => navigate({ view: v })}
+          filter={filter}
+          onFilterChange={f => navigate({ filter: f })}
+          onCreate={() => router.push('/game-nights/new')}
+        />
+        <div className="px-8 py-16 text-center">
+          <h3 className="font-display text-lg font-bold text-foreground">{t('states.empty.title')}</h3>
+          <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{t('states.empty.body')}</p>
+          <button
+            type="button"
+            className="mt-6 rounded-md bg-entity-event px-5 py-2.5 font-display text-sm font-bold text-white"
+            onClick={() => router.push('/game-nights/new')}
+          >
+            {t('states.empty.cta')}
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  const dayEvents = drawerCell
+    ? filtered.filter(e =>
+        e.day === drawerCell.day && e.month === today.getMonth() && e.year === today.getFullYear())
+    : [];
+
+  return (
+    <>
+      <GameNightsHeader
+        totalThisMonth={totalThisMonth}
+        confirmedThisMonth={confirmedThisMonth}
+        view={view}
+        onViewChange={v => navigate({ view: v })}
+        filter={filter}
+        onFilterChange={f => navigate({ filter: f })}
+        onCreate={() => router.push('/game-nights/new')}
+      />
+
+      {view === 'calendar' ? (
+        <CalendarMonthGrid
+          year={today.getFullYear()}
+          month={today.getMonth()}
+          events={filtered}
+          today={today}
+          onDayClick={(cell) => setDrawerCell(cell)}
+        />
+      ) : (
+        <ListView events={filtered} now={today} />
+      )}
+
+      <DayDetailDrawer
+        open={drawerCell !== null}
+        day={drawerCell?.day ?? 0}
+        month={today.getMonth()}
+        year={today.getFullYear()}
+        events={dayEvents}
+        onClose={() => setDrawerCell(null)}
+      />
+    </>
+  );
+}
+
+function ListView({ events, now }: { events: readonly GameNightVM[]; now: Date }): JSX.Element {
+  const t = useTranslations('pages.gameNightsIndex');
+  const groups = useMemo(() => groupByMonth(events, now), [events, now]);
+
+  if (groups.length === 0) {
+    return (
+      <div className="px-8 py-16 text-center">
+        <h3 className="font-display text-base font-bold text-foreground">{t('states.filteredEmpty.title')}</h3>
+        <p className="mt-1 text-sm text-muted-foreground">{t('states.filteredEmpty.body')}</p>
+      </div>
+    );
+  }
+
+  const monthNames = t.raw('calendar.dayLabels'); // reused below; or hardcode Intl.DateTimeFormat
+  return (
+    <div className="flex flex-col gap-6 px-8 pb-8 pt-5">
+      {groups.map(g => {
+        const monthLabel = new Date(g.year, g.month, 1).toLocaleString('it-IT', { month: 'long', year: 'numeric' });
+        const isCurrent = g.year === now.getFullYear() && g.month === now.getMonth();
+        return (
+          <section key={`${g.year}-${g.month}`}>
+            <div className="sticky top-0 z-[5] flex items-baseline gap-2.5 bg-background py-2">
+              <h2 className="font-display text-lg font-extrabold text-foreground">{monthLabel}</h2>
+              <span className="font-mono text-xs font-bold text-muted-foreground">
+                {t('list.groupCount', { count: g.items.length })} · {isCurrent ? t('list.groupSubCurrent') : t('list.groupSubPast')}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2.5">
+              {g.items.map(n => <GameNightListCard key={n.id} vm={n} />)}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+// Loading skeleton kept for backwards-compat with page.tsx Suspense fallback
+export function GameNightsLoadingSkeleton(): JSX.Element {
+  return (
+    <div className="flex flex-col gap-3 px-8 py-6">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-28 animate-pulse rounded-lg bg-muted" />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3.1.1: Orchestrator integration test**
+
+```tsx
+// apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+// Use existing test harness pattern: wrap in QueryClientProvider + i18n + Router mock
+// Mock useUpcomingGameNights to return [], [1 event], or error
+// Assert: empty state, header rendering, view=list query toggle
+```
+
+(Use the same pattern as `apps/web/src/components/features/game-night-detail/__tests__/` for QueryClient + Next router mocking.)
+
+- [ ] **Step 3.1.2: Run tests**
+
+```bash
+cd apps/web && pnpm vitest run src/app/\(authenticated\)/game-nights/
+```
+Expected: PASS.
+
+- [ ] **Step 3.1.3: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/game-nights/
+git commit -m "feat(game-nights-index): orchestrator + page wiring (refs #1170)"
+```
+
+---
+
+## Commit 4 — E2E specs (state matrix + visual + a11y)
+
+### Task 4.1 — State coverage E2E
+
+**Files:**
+- Create: `apps/web/e2e/v2-states/game-nights-index.spec.ts`
+
+Pattern mirrors `apps/web/e2e/v2-states/game-night-detail.spec.ts`:
+- 5 scenarios: default / empty / loading / filtered-empty / error
+- Mock `/api/v1/game-nights/upcoming` and `/api/v1/game-nights/mine` via `page.context().route()`
+- 3 viewports: 375 (mobile) / 768 (tablet) / 1280 (desktop)
+- Each scenario: axe-core scan with `WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']` → expect 0 violations
+- Assert visible content per state (h1 title, empty CTA, error retry button, etc.)
+
+### Task 4.2 — Visual regression
+
+**Files:**
+- Create: `apps/web/e2e/visual-conformity/game-nights-index.spec.ts`
+
+Pattern from sibling Stage 3 specs:
+- 2 viewports: Desktop 1280, Mobile 375
+- 4 snapshots: calendar-view-desktop, calendar-view-mobile, list-view-desktop, list-view-mobile
+- Mock data: fixture matching mockup's NIGHTS (12 events) committed under `apps/web/e2e/_fixtures/game-nights-index.json`
+- Threshold: maxDiffPixelRatio: 0.02 (2%)
+
+### Task 4.3 — Run E2E locally
+
+```bash
+cd apps/web
+pnpm test:e2e -- game-nights-index
+```
+Expected: PASS. If visual baselines don't exist yet, generate with `--update-snapshots` and commit them.
+
+### Task 4.4 — Commit E2E
+
+```bash
+git add apps/web/e2e/
+git commit -m "test(game-nights-index): state-matrix + visual-conformity + a11y (refs #1170)"
+```
+
+---
+
+## Commit 5 — Cleanup + matrix
+
+### Task 5.1 — Verify no legacy imports remain
+
+```bash
+grep -rn "from '@/components/ui/card'" apps/web/src/app/\(authenticated\)/game-nights/ || echo "OK: clean"
+grep -rn "GameNightCard\|StatusBadge" apps/web/src/app/\(authenticated\)/game-nights/_content.tsx || echo "OK: legacy removed"
+```
+
+Expected: no matches in `_content.tsx` (legacy `GameNightCard`/`StatusBadge`/`EmptyState` inline components deleted; replaced by feature imports).
+
+### Task 5.2 — Update v2-migration-matrix.md
+
+**File:** `docs/for-developers/frontend/v2-migration-matrix.md`
+
+Find the 8 rows for game-nights-index components (referenced in issue #1170 as L:313-324, L:121, L:548) and:
+- Set `Status = done`
+- Set `PR = #<this-PR-number>` (will be filled after PR open — leave placeholder `#TBD` and update in final commit)
+
+### Task 5.3 — Run full quality gate
+
+```bash
+cd apps/web
+pnpm typecheck && pnpm lint && pnpm vitest run && pnpm lint:tokens
+```
+Expected: all green, 0 token violations.
+
+### Task 5.4 — Commit cleanup
+
+```bash
+git add apps/web/src/app/\(authenticated\)/game-nights/_content.tsx docs/for-developers/frontend/v2-migration-matrix.md
+git commit -m "chore(game-nights-index): remove legacy + update v2 matrix (closes #1170)"
+```
+
+### Task 5.5 — Push + open PR
+
+```bash
+git push -u origin feature/issue-1170-game-nights-index-stage3
+gh pr create --base main-dev --title "feat(game-nights-index): Stage 3 v2 implementation (closes #1170)" --body "$(cat <<'EOF'
+## Summary
+Implements 8 components for `/game-nights` index matching `sp4-game-nights-index` mockup (closes #1170).
+
+- Foundation: i18n keys + pure helpers (calendar grid, filter FSM, view model, grouping)
+- 8 components under `components/features/game-nights/`
+- Orchestrator refactor in `_content.tsx` (URL state for view+filter)
+- E2E: state matrix (5 states × 3 viewports) + visual regression (4 snapshots) + axe-core a11y
+- Legacy `Card`/`Badge` consumers removed
+
+## Acceptance
+- [x] Visual diff ≤ 2%
+- [x] WCAG 2.1 AA (axe-core 0 violations)
+- [x] `prefers-reduced-motion` respected
+- [x] Light + dark mode
+- [x] Mobile-first 375px clean (no `window.innerWidth`)
+- [x] i18n it+en complete
+- [x] Token compliance (no hex/rgb, ESLint clean)
+- [x] v2-migration-matrix updated
+
+## Test plan
+- [x] `pnpm typecheck && pnpm lint && pnpm vitest run`
+- [x] `pnpm test:e2e -- game-nights-index`
+- [x] `pnpm lint:tokens` (0 violations)
+
+Refs #1170, #1026, #1168
+EOF
+)"
+```
+
+### Task 5.6 — After PR open: update matrix PR ref
+
+Replace `#TBD` in `v2-migration-matrix.md` with actual PR number, amend last commit, push.
+
+---
+
+## Self-Review Checklist (run before declaring plan done)
+
+1. **Spec coverage** — all 8 acceptance criteria from issue #1170 mapped: visual diff (Task 4.2), 5-commit TDD (commits 1-5), visual regression (4.2), WCAG AA (4.1), reduced-motion (2.8 drawer), light+dark (4.2), bundle delta (track in PR description), mobile-first (2.4-2.8 all use `isMobile` prop), i18n (1.5), token compliance (2.x via Tailwind entity utilities), matrix update (5.2). ✓
+
+2. **Placeholder scan** — all "TBD" / "TODO" are bounded: only one TODO (month-nav fetch deferral, justified per mockup line 20). PR# placeholder explicitly addressed in Task 5.6. ✓
+
+3. **Type consistency** — `FilterKey`, `StatusKey`, `RoleKey`, `GameNightVM`, `MonthCell`, `MonthGroup` defined once in lib/, imported consistently. Props interfaces named `<Component>Props` throughout. ✓
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-15-game-nights-index-stage3.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session via `superpowers:executing-plans`, batch with checkpoints.
+
+**Which approach?**


### PR DESCRIPTION
## Summary

Implements 8 v2 components for `/game-nights` index matching `sp4-game-nights-index` mockup. Replaces legacy `Card`/`Badge` consumers in `_content.tsx`.

**Closes #1170** (Stage 3 cluster fix, supersedes #685; under umbrella #1023, parent #1026).

## Architecture

**Label-as-props pattern**: all 8 components are zero-i18n — they accept typed `*Labels` props. The orchestrator (`_content.tsx`) is the single `useTranslation` boundary. Matches sibling cluster game-night-detail (PR #1171/#1172).

**Foundation layer** (`apps/web/src/lib/game-nights/`):
- `calendar-grid` — 42-cell Monday-first month grid builder
- `view-model` — `GameNightDto → GameNightVM` adapter (status FSM, role from organizerId/viewerId comparison)
- `event-filter` — 4-key filter FSM (`all`/`organizing`/`invited`/`completed`)
- `event-grouping` — bucket by (year,month), ASC current/future, DESC past, timeLabel tiebreaker

**Components** (all under `apps/web/src/components/features/game-nights/`):
GameNightsHeader, CalendarMonthGrid, CalendarDayCell, GameNightListCard, DayDetailDrawer, FilterPillBar, StatusPill, PlayerAvatars.

**Orchestrator**: URL state via `?view=` (calendar/list) + `?filter=` (FilterKey, validated), dedup-merge of `useUpcomingGameNights` + `useMyGameNights`, role derivation via `useCurrentUser`. 4 state branches (default / empty / loading / error) + filtered-empty within list view.

## Acceptance (issue #1170)

- [x] Page v2 1:1 con `sp4-game-nights-index` — components mapped to mockup
- [x] 5-commit TDD decomposition: 9 commits (5 logical + 4 review-fix refactors)
- [x] Visual regression Desktop 1280 + Mobile 375 — entry added to `mockup-ownership.bootstrap.json`, baselines deferred to CI bootstrap workflow
- [x] WCAG 2.1 AA: focus-visible, aria, `aria-pressed`, `role=tablist`, `role=dialog aria-modal aria-labelledby`, axe-core scan on every E2E scenario × viewport (15 tests)
- [x] `prefers-reduced-motion` rispettato via `motion-safe:` Tailwind prefix in `DayDetailDrawer`
- [x] Light + dark mode supportati (semantic tokens only)
- [x] Mobile-first 375px clean — no `window.innerWidth`, Tailwind `md:` modifiers only
- [x] i18n keys complete it+en under `gameNightsIndex` namespace
- [x] Token compliance: solo `--c-*`/`--e-*`/`--bg-*`/`--text-*` + entity utilities (ESLint `local/no-hardcoded-color-utility` 0 errors)
- [x] Matrix aggiornata: 8 rows + summary row → `done`, PR ref `#TBD` (will update after PR# assigned)

## Known backend gaps (degraded gracefully, tracked for follow-up)

- **Per-event RSVP roster** not in `GameNightDto` → `PlayerAvatars` renders empty (0-count guard). Tracked.
- **gameTitle**/single game per night not exposed → game chip in `GameNightListCard` hidden. Tracked.
- **durationLabel** empty → list card duration block hidden via `{vm.durationLabel && ...}` guard. Tracked.

## Intentional deferrals (per #1170 out-of-scope)

- **Month-nav** prev/next/today buttons are rendered as `disabled` (visual only) — mockup line 20 explicitly notes "paginazione mese ‹ › è solo visiva, no fetch reale". The `DrawerTarget` state shape (`{cell, gridYear, gridMonth}`) is forward-compatible for when month-nav is wired in a follow-up issue.

## Test coverage

- **Unit (Vitest)**: 127 tests, 15 files
  - 4 helper tests (33 tests): calendar-grid (8), view-model (14), event-filter (7), event-grouping (8)
  - 8 component tests (49 tests): StatusPill (6), PlayerAvatars (5), FilterPillBar (3), GameNightsHeader (5), CalendarDayCell (7), CalendarMonthGrid (5), GameNightListCard (10), DayDetailDrawer (9 incl. focus-trap)
  - 1 orchestrator integration test (7 tests): default + empty + error + view-toggle + filter-write + filter-read + view=list URL
- **E2E (Playwright)**: 15 tests (5 states × 3 viewports), each with axe-core WCAG 2.1 AA scan
- **Visual regression**: bootstrap.json entry added, baselines auto-generated by CI workflow

## Stale-over-error UX policy

`hasError` is gated on `allVms.length === 0` — background refetch failures keep existing cached data visible rather than swapping to an error screen. Documented inline at `_content.tsx`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/lib/game-nights/ src/components/features/game-nights/ 'src/app/(authenticated)/game-nights/'` — 127/127 passing
- [x] `pnpm lint --max-warnings 100` — 0 errors (39 pre-existing warnings in unrelated files)
- [ ] `pnpm test:e2e -- v2-states/game-nights-index` — deferred to CI (Playwright needs running dev server)
- [ ] Visual-regression bootstrap workflow — auto-trigger on first push after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)