### PR TITLE
fix(visual-conformity): .png suffix on toHaveScreenshot (refs #979)

### DIFF
--- a/apps/web/e2e/visual-conformity/bootstrap.spec.ts
+++ b/apps/web/e2e/visual-conformity/bootstrap.spec.ts
@@ -95,7 +95,7 @@ test.describe('WS-C Conformity — mockup baseline bootstrap', () => {
       // Snapshot lands at __mockup__/{route.id}.{viewport}.png via project-level
       // snapshotPathTemplate. Bootstrap mode (Phase 3 workflow) passes
       // --update-snapshots to (re)generate; verify mode asserts existence.
-      await expect(page).toHaveScreenshot(route.id, {
+      await expect(page).toHaveScreenshot(`${route.id}.png`, {
         fullPage: true,
       });
     });

--- a/apps/web/e2e/visual-conformity/conformity.spec.ts
+++ b/apps/web/e2e/visual-conformity/conformity.spec.ts
@@ -127,7 +127,7 @@ test.describe('WS-C Conformity — route vs mockup baseline', () => {
       await waitForRouteReady(page, runbook);
 
       // Per-route override the project-level expect defaults.
-      await expect(page).toHaveScreenshot(route.id, {
+      await expect(page).toHaveScreenshot(`${route.id}.png`, {
         fullPage: true,
         threshold: route.threshold,
         maxDiffPixelRatio: route.conformityRatio,


### PR DESCRIPTION
## Summary

Playwright ≥1.44 requires the screenshot `name` argument to end in `.png`. Both visual-conformity specs were passing `route.id` (e.g. `"library"`), relying on `snapshotPathTemplate` `{arg}.desktop{ext}` to append the extension. The newer validator inspects the substituted path → sees `"library.desktop"` (no `.png`) → fails.

Result: 8 failed tests on PR #979 *Bootstrap Baselines* check (4 routes × 2 viewports):
- `library.{desktop,mobile}`
- `library-game-detail.{desktop,mobile}`
- `player-detail.{desktop,mobile}`
- `game-nights-index.{desktop,mobile}`

## Fix

Two-line change: pass `${route.id}.png` instead of `route.id`. The template `{arg}` strips the extension and `{ext}` re-appends — final snapshot path remains `__mockup__/<id>.<viewport>.png` (no baseline regeneration needed).

## Test plan

- [ ] `Conformity — Bootstrap Mockup Baselines` workflow passes on this PR
- [ ] No new baseline PNGs are generated/changed
- [ ] Once merged, PR #979 `Bootstrap Baselines (Desktop + Mobile)` turns green

Refs: #979, #1069, #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)