### PR TITLE
fix(ci): pnpm build before frontend-e2e-smoke (refs #979)

### DIFF
--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -107,6 +107,15 @@ jobs:
           working-directory: apps/web
           cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
+      - name: Build Next.js (required by Playwright webServer `next start`)
+        # playwright.config.ts (L561-564) selects `next start` when CI=true to
+        # avoid dev-server crashes under sustained load (Issue #2007). That
+        # requires a prior production build; without it the webServer aborts
+        # with "Could not find a production build in the '.next' directory".
+        run: pnpm build
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+
       - name: Run smoke specs only
         # Use the dedicated smoke-real-backend folder (3 specs covering the
         # game-night flow). The `@smoke` Playwright tag is documented in


### PR DESCRIPTION
## Summary

The `frontend-e2e-smoke` job in `.github/workflows/dev-async.yml` ran `pnpm test:e2e` directly, but Playwright's webServer config (`apps/web/playwright.config.ts:561-564`) selects `next start` whenever `CI=true` (Issue #2007 — dev server crashes under sustained test load). `next start` requires a prior production build, so without it the webServer aborts:

```
[WebServer] Error: Could not find a production build in the '.next' directory.
Try building your app with 'next build' before starting the production server.
Error: Process from config.webServer was not able to start. Exit code: 1
```

This was the only failure mode on PR #979 *Frontend E2E Smoke (Playwright subset)*.

## Fix

Add a `pnpm build` step between `setup-playwright` and the test invocation. Mirrors:
- `test-e2e.yml:192-194`
- `visual-regression-conformity.yml:86-87`
- `e2e-smoke-real-backend.yml:141-143`

Only `NEXT_TELEMETRY_DISABLED=1` env added (consistent with `visual-regression-conformity.yml`). No other build-time flags needed: the smoke folder `e2e/smoke-real-backend/` does not exercise the Mechanic Extractor surfaces gated by `NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED`.

## Test plan

- [ ] `Frontend E2E Smoke (Playwright subset)` check passes on this PR
- [ ] Once merged, PR #979 same check turns green

Refs: #979, #2007

🤖 Generated with [Claude Code](https://claude.com/claude-code)