### PR TITLE
fix(ci): unblock PR #979 — repair lychee anchor + skip expired v1-cookie test

### DIFF
--- a/apps/api/tests/Api.Tests/Routing/CookieHelpersHmacTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/CookieHelpersHmacTests.cs
@@ -131,7 +131,9 @@ public sealed class CookieHelpersHmacTests
             "not silently accepted.");
     }
 
-    [Fact]
+    [Fact(Skip = "v1 grace period expired 2026-05-13 (see CookieHelpers.UserRoleCookieV1SunsetUtc). " +
+                  "After that date, CookieHelpers.ReadUserRoleCookie correctly returns null for v1 cookies, " +
+                  "so this test is obsolete. Remove together with V1 fallback code in a future cleanup.")]
     public void ReadUserRoleCookie_FallbackV1_ReturnsRole_DuringGracePeriod()
     {
         // Only a v1 cookie is present (legacy session pre-deploy). During the

--- a/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
@@ -61,7 +61,7 @@ Concrete operational rules:
 
 ### Negative
 
-- **Co-tenancy fragility**: the dev workstation hosting both `make dev` and `make staging` can race for ports / RAM if pruning discipline lapses (see [Staging disk space memory](../../../../docs/for-developers/operations/operations-manual.md#disk-space) and the related ops notes about cleaning images before rebuilds). Accepted for beta scale.
+- **Co-tenancy fragility**: the dev workstation hosting both `make dev` and `make staging` can race for ports / RAM if pruning discipline lapses (see [Staging disk space memory](../../../../docs/for-developers/operations/operations-manual.md#docker-maintenance) and the related ops notes about cleaning images before rebuilds). Accepted for beta scale.
 - **CI complexity**: four workflow files instead of one is more to maintain. Mitigation: each file has a clear scope (fast PR, async post-merge, staging deploy, prod deploy) and shared steps live in reusable workflows.
 - **Three branches to keep in sync**: drift between `main-staging` and `main` is possible if hotfixes land directly on `main`. Mitigation: hotfixes also fast-forward back into `main-staging` and `main-dev` in the same PR series.
 


### PR DESCRIPTION
## Summary

Two trivial fixes to clear pre-existing red checks on release PR #979 (`main-dev` → `main-staging`):

### 1. Lychee link check
`docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md:64` linked to `operations-manual.md#disk-space` — that anchor doesn't exist. Repointed to `#docker-maintenance`, the section that actually covers `docker system prune` for the image/disk cleanup the original sentence references.

### 2. Backend Unit Tests
`apps/api/tests/.../CookieHelpersHmacTests.cs::ReadUserRoleCookie_FallbackV1_ReturnsRole_DuringGracePeriod` asserts v1 cookies still authenticate "during the 7-day grace window". That window expired at `CookieHelpers.UserRoleCookieV1SunsetUtc = 2026-05-13 00:00 UTC` (`CookieHelpers.cs:34-35`). Today is **2026-05-15**, so production code now correctly returns `null` for v1 cookies, but the test still expects `"admin"`.

Marked `[Fact(Skip = "...")]` with an explicit reason rather than deleted: the test is paired with live V1 fallback code that should be excised in a follow-up cleanup PR. Skip keeps the test in the file as documentation until then.

## Out of scope

Other red checks on PR #979 are pre-existing tech debt unrelated to the release diff:
- **Frontend A11y E2E** — known backlog (`memory/a11y-discover-backlog.md`)
- **Bundle Size** — `/discover` over hard ceiling by 2 KB (introduced by Stage 3 PR #1160)
- **CodeQL** — 3 high alerts attributed to the 216-commit diff; GitHub itself notes alerts may not have been introduced by this PR due to diff size

Those need separate triage and shouldn't block staging promotion.

## Test plan

- [ ] Lychee link check passes on this PR
- [ ] Backend Unit Tests pass (1 less test executed, marked Skipped)
- [ ] Once merged, PR #979 same checks turn green

Refs: #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)