### PR TITLE
feat(security): register canonical sanitizers as CodeQL MaD models (refs #1181)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,17 +4,23 @@ description: "Custom CodeQL configuration with false positive filters for Meeple
 # Disable specific queries that produce false positives
 disable-default-queries: false
 
+# Custom Models-as-Data extensions: registers MeepleAI canonical sanitizers
+# (DataMasking.Mask*, LogSanitizer.*) so taint-tracking queries (cs/log-forging,
+# cs/exposure-of-sensitive-information, cs/cleartext-storage-of-sensitive-information)
+# stop flagging call sites where these sanitizers are already applied.
+# See ADR-058 §1.4 and .github/codeql/extensions/meepleai-sanitizers/qlpack.yml
+packs:
+  - ./.github/codeql/extensions/meepleai-sanitizers
+
 # Query filters to reduce false positives
 query-filters:
-  # Exclude log forging warnings where LogForgingSanitizationPolicy is in use
-  # CWE-117: All 426 instances are false positives due to global sanitization policy
-  - exclude:
-      id: cs/log-forging
-
   # Exclude generic exception handling warnings where properly justified with #pragma
   # CA1031: All 220 instances are properly documented with architectural patterns
   - exclude:
       id: cs/catch-of-all-exceptions
+  # NOTE 2026-05-16: blanket exclude for cs/log-forging removed — Phase 1.4 (above)
+  # registers LogSanitizer.* as a sanitizerModel, so the rule can again surface true
+  # positives where input flows directly to ILogger without sanitization.
 
 # Path filters to exclude test files and generated code
 paths-ignore:

--- a/.github/codeql/extensions/meepleai-sanitizers/codeql-pack.lock.yml
+++ b/.github/codeql/extensions/meepleai-sanitizers/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml
+++ b/.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml
@@ -1,0 +1,41 @@
+# MeepleAI canonical sanitizers (ADR-058, issue #1181 Phase 1.4)
+#
+# Registers DataMasking.Mask* and LogSanitizer.* methods as value-flow summary
+# models so CodeQL stops flagging call sites that already pass through them.
+#
+# Kind "value" = data flows from input to output but TAINT does NOT propagate.
+# Effectively marks the method as a sanitizer for taint-tracking queries:
+# - cs/log-forging (CWE-117)
+# - cs/exposure-of-sensitive-information (CWE-359)
+# - cs/cleartext-storage-of-sensitive-information (CWE-312)
+#
+# C# tuple format (10 columns):
+#   namespace, type, subtypes, method, signature, ext, input, output, kind, provenance
+#
+# References:
+# - ADR-058 §1.4 Implementation plan
+# - https://codeql.github.com/docs/codeql-language-guides/customizing-library-models-for-csharp/
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: summaryModel
+    data:
+      # ----------------------------------------------------------------
+      # LogSanitizer (Api.Helpers) — log-forging integrity sanitizer
+      # Strips \r\n\t before logging to prevent CWE-117 injection.
+      # ----------------------------------------------------------------
+      - ["Api.Helpers", "LogSanitizer", false, "Sanitize", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Helpers", "LogSanitizer", false, "Sanitize", "(System.String,System.Int32)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Helpers", "LogSanitizer", false, "SanitizePath", "(Microsoft.AspNetCore.Http.PathString)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+
+      # ----------------------------------------------------------------
+      # DataMasking (Api.Infrastructure.Security) — PII confidentiality masking
+      # Irreversibly transforms PII for safe logging (GDPR Art. 32).
+      # ----------------------------------------------------------------
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskEmail", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskString", "(System.String,System.Int32)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskJwt", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskCreditCard", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskIpAddress", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "RedactConnectionString", "(System.String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
+      - ["Api.Infrastructure.Security", "DataMasking", false, "MaskResponseBody", "(System.String,System.Int32)", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/.github/codeql/extensions/meepleai-sanitizers/qlpack.yml
+++ b/.github/codeql/extensions/meepleai-sanitizers/qlpack.yml
@@ -1,0 +1,7 @@
+name: meepleai/sanitizers-extensions
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/csharp-all: '*'
+dataExtensions:
+  - models/**/*.yml


### PR DESCRIPTION
## Phase 1.4 of [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) — CodeQL Models-as-Data sanitizer registration

Implements [ADR-058 §1.4](docs/for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md). Follow-up to PR #1182.

### Why this matters (audit findings 2026-05-16)

Cross-reference of the 107 open `cs/exposure-of-sensitive-information` alerts vs `DataMasking`/`LogSanitizer` call patterns revealed an extreme distribution:

| Category | Count | % |
|---|---|---|
| **False positives** (sanitizer already applied, CodeQL didn't recognize) | 87 | **81%** |
| True positives (PII raw in log) | 20 | 19% |

Without this PR, the Phase 2 sweep would "fix" 87 alerts that don't need code changes. Phase 1.4 closes them with a single config-level pack registration.

### What the pack does

`.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml` registers 10 `summaryModel` entries with `kind: value` (not `taint`) — telling CodeQL that data flows from input to output but the taint is removed. Effectively marks each method as a sanitizer barrier for taint-tracking queries.

Methods registered:

- **LogSanitizer** (`Api.Helpers`) — `Sanitize(string)`, `Sanitize(string, int)`, `SanitizePath(PathString)`
- **DataMasking** (`Api.Infrastructure.Security`) — `MaskEmail`, `MaskString`, `MaskJwt`, `MaskCreditCard`, `MaskIpAddress`, `RedactConnectionString`, `MaskResponseBody`

### codeql-config.yml updates

- ✅ Adds `packs: - ./.github/codeql/extensions/meepleai-sanitizers`
- ✅ **Removes** the blanket `query-filters: exclude cs/log-forging`. That exclude was hiding true positives. The query is now active again, but with our sanitizers properly recognized.

### Validation

- **T1** YAML syntax: ✅ all 3 files parse with `python yaml.safe_load`
- **T2** Pack load: ✅ `gh codeql resolve extensions --extension-packs="meepleai/sanitizers-extensions" -- "codeql/csharp-queries"` reports `rowCount: 10` from `sanitizers.model.yml` loaded into `summaryModel`
- **T3** Full database analyze: deferred to CI on this PR

### Expected CI outcome

After this PR merges, the next CodeQL run on `main-dev` should:

- Close **~87** of the 108 currently-open `severity=error` alerts (false positives)
- Leave **~20** open alerts that are genuine true positives, concentrated in 10 files:
  - `Services/AlertingService.cs` (6)
  - `Services/SlackAlertChannel.cs` (3), `PagerDutyAlertChannel.cs` (2), `EmailAlertChannel.cs` (1)
  - `UserNotifications/Infrastructure/Scheduling/{DeadLetterMonitorJob,NotificationCleanupJob}.cs` (3 total)
  - `UserNotifications/Infrastructure/Services/EmailOutboxService.cs` (1)
  - `Authentication/Application/Commands/Waitlist/JoinWaitlistCommandHandler.cs` (2)
  - `Authentication/Application/EventHandlers/AccountLockedEventHandler.cs` (1)
  - `KnowledgeBase/Infrastructure/Services/PiiDetector.cs` (1)
- Re-enable `cs/log-forging` as a meaningful signal (was globally suppressed before)

If alert reduction is significantly less than 87, the C# method signatures in the model file may need adjustment — push fix-up commit.

### Test plan

- [x] T1 + T2 local validation passed
- [ ] CI `Security Scan / CodeQL Analysis (csharp)` completes on this PR without YAML/signature parse errors
- [ ] Post-merge CodeQL re-run on `main-dev`: count of open `severity=error` alerts decreases from 108 → ~20
- [ ] No new `cs/log-forging` alerts opened on previously-clean files (would indicate the un-suppression caught a regression rather than just rule de-shadowing)

### Files

- `.github/codeql/extensions/meepleai-sanitizers/qlpack.yml` (new)
- `.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml` (new)
- `.github/codeql/extensions/meepleai-sanitizers/codeql-pack.lock.yml` (new, generated by `codeql pack install`)
- `.github/codeql/codeql-config.yml` (packs entry + blanket exclude removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
