### PR TITLE
chore(codeql): drop ./ prefix from packs path for canonical form (refs #1181)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,7 +10,7 @@ disable-default-queries: false
 # stop flagging call sites where these sanitizers are already applied.
 # See ADR-058 §1.4 and .github/codeql/extensions/meepleai-sanitizers/qlpack.yml
 packs:
-  - ./.github/codeql/extensions/meepleai-sanitizers
+  - .github/codeql/extensions/meepleai-sanitizers
 
 # Query filters to reduce false positives
 query-filters:


### PR DESCRIPTION
## Follow-up to PR #1183 — drop `./` prefix from CodeQL packs path

Carry-forward from code review on PR #1183. The auto-merge fired before this 1-line precaution was pushed, so it lands as a separate small PR.

### Why

`.github/codeql/codeql-config.yml` uses:
```yaml
packs:
  - ./.github/codeql/extensions/meepleai-sanitizers
```

GitHub Actions CodeQL config canonical examples use repo-root-relative paths **without** the leading `./`. Some action versions resolve `./` relative to the config file location instead, which would silently expand to `.github/codeql/.github/codeql/extensions/meepleai-sanitizers` (nonexistent) and the pack would not load — silent failure mode.

### Risk

Without this fix, the CodeQL scan in `init@v4` may load the pack on some versions and not others. The 87 false-positive auto-closure expected from PR #1183 would not materialize, and the cause would be hard to diagnose post-merge.

### Validation

T1 (YAML syntax): ✅ — single-character change, structure unchanged.
T2 (pack discovery via `gh codeql resolve extensions`): unchanged from PR #1183 since T2 was already invoked with `--additional-packs` (absolute path), not via the config file.

Real validation = CI run on this PR. If the CodeQL workflow loads the pack and applies summaryModel entries, the path form is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
