### PR TITLE
fix(security): apply canonical sanitizers to remaining log call sites (refs #1181)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Waitlist/JoinWaitlistCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Waitlist/JoinWaitlistCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure.Security;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -87,13 +88,13 @@ internal class JoinWaitlistCommandHandler : ICommandHandler<JoinWaitlistCommand,
                 _logger.LogError(
                     ex,
                     "Waitlist unique-violation race: post-rollback re-query found no row for {Email}",
-                    normalizedEmail);
+                    DataMasking.MaskEmail(normalizedEmail));
                 throw;
             }
 
             _logger.LogInformation(
                 "Waitlist concurrent-duplicate race resolved for {Email} → existing position {Position}",
-                normalizedEmail,
+                DataMasking.MaskEmail(normalizedEmail),
                 raceWinner.Position);
 
             return new JoinWaitlistResult(

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/EmailOutboxService.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/EmailOutboxService.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.UserNotifications.Application.Services;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Entities;
 using Api.Infrastructure;
+using Api.Infrastructure.Security;
 using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.UserNotifications.Infrastructure.Services;
@@ -67,7 +68,7 @@ internal sealed class EmailOutboxService : IEmailOutboxService
             _logger.LogInformation(
                 "Enqueued email {IdempotencyKey} for {ToEmail}",
                 idempotencyKey,
-                toEmail);
+                DataMasking.MaskEmail(toEmail));
             return true;
         }
         catch (DbUpdateException ex) when (IsUniqueViolation(ex))

--- a/apps/api/src/Api/Services/AlertingService.cs
+++ b/apps/api/src/Api/Services/AlertingService.cs
@@ -51,7 +51,7 @@ internal class AlertingService : IAlertingService
     {
         if (!_config.Enabled)
         {
-            _logger.LogWarning("Alerting is disabled. Alert not sent: {AlertType}", alertType);
+            _logger.LogWarning("Alerting is disabled. Alert not sent: {AlertType}", LogSanitizer.Sanitize(alertType));
             throw new InvalidOperationException("Alerting system is disabled");
         }
 
@@ -83,8 +83,8 @@ internal class AlertingService : IAlertingService
 
         _logger.LogInformation(
             "Alert {AlertType} created with severity {Severity}. Channels: {Channels}",
-            alertType,
-            severity,
+            LogSanitizer.Sanitize(alertType),
+            LogSanitizer.Sanitize(severity),
             string.Join(", ", channelResults.Where(c => c.Value).Select(c => c.Key)));
 
         return MapToDto(alertEntity);
@@ -99,7 +99,7 @@ internal class AlertingService : IAlertingService
 
         _logger.LogInformation(
             "Alert {AlertType} is throttled. Skipping send (throttle window: {ThrottleMinutes} minutes)",
-            alertType,
+            LogSanitizer.Sanitize(alertType),
             _config.ThrottleMinutes);
 
         var existingAlert = await _dbContext.Alerts
@@ -137,7 +137,7 @@ internal class AlertingService : IAlertingService
             // FAIL-OPEN PATTERN: Alert channel failures must not stop other alert channels
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error sending alert {AlertType} via {Channel}", alertType, channel.ChannelName);
+                _logger.LogError(ex, "Error sending alert {AlertType} via {Channel}", LogSanitizer.Sanitize(alertType), channel.ChannelName);
                 channelResults[channel.ChannelName] = false;
             }
 #pragma warning restore CA1031
@@ -150,11 +150,11 @@ internal class AlertingService : IAlertingService
     {
         if (success)
         {
-            _logger.LogInformation("Alert {AlertType} sent successfully via {Channel}", alertType, channelName);
+            _logger.LogInformation("Alert {AlertType} sent successfully via {Channel}", LogSanitizer.Sanitize(alertType), channelName);
         }
         else
         {
-            _logger.LogWarning("Failed to send alert {AlertType} via {Channel}", alertType, channelName);
+            _logger.LogWarning("Failed to send alert {AlertType} via {Channel}", LogSanitizer.Sanitize(alertType), channelName);
         }
     }
 

--- a/apps/api/src/Api/Services/EmailAlertChannel.cs
+++ b/apps/api/src/Api/Services/EmailAlertChannel.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Mail;
+using Api.Helpers;
 using Api.Infrastructure.Security;
 using Microsoft.Extensions.Options;
 
@@ -94,7 +95,7 @@ internal class EmailAlertChannel : IAlertChannel
             // failure status. Throwing would prevent other channels from executing (Slack, PagerDuty).
             // Caller (AlertingService) tracks per-channel results for graceful degradation.
             // Context: Email failures are typically external (SMTP down, authentication expired)
-            _logger.LogError(ex, "Failed to send email alert for {AlertType}", alertType);
+            _logger.LogError(ex, "Failed to send email alert for {AlertType}", LogSanitizer.Sanitize(alertType));
             return false;
         }
     }

--- a/apps/api/src/Api/Services/EmailAlertChannel.cs
+++ b/apps/api/src/Api/Services/EmailAlertChannel.cs
@@ -82,7 +82,7 @@ internal class EmailAlertChannel : IAlertChannel
             _logger.LogInformation(
                 "Email alert sent to {Recipients} for {AlertType}",
                 string.Join(", ", _config.To.Select(DataMasking.MaskEmail)),
-                alertType);
+                LogSanitizer.Sanitize(alertType));
 
             return true;
         }

--- a/apps/api/src/Api/Services/PagerDutyAlertChannel.cs
+++ b/apps/api/src/Api/Services/PagerDutyAlertChannel.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using Api.Helpers;
 using Microsoft.Extensions.Options;
 using System.Globalization;
 
@@ -80,7 +81,7 @@ internal class PagerDutyAlertChannel : IAlertChannel
             {
                 _logger.LogInformation(
                     "PagerDuty incident created for {AlertType}",
-                    alertType);
+                    LogSanitizer.Sanitize(alertType));
                 return true;
             }
 
@@ -107,7 +108,7 @@ internal class PagerDutyAlertChannel : IAlertChannel
             // failure status. Throwing would prevent other channels from executing (email, Slack).
             // Caller (AlertingService) tracks per-channel results for graceful degradation.
             // Context: PagerDuty failures are typically external (API timeout, rate limit, auth)
-            _logger.LogError(ex, "Failed to send PagerDuty alert for {AlertType}", alertType);
+            _logger.LogError(ex, "Failed to send PagerDuty alert for {AlertType}", LogSanitizer.Sanitize(alertType));
             return false;
         }
     }

--- a/apps/api/src/Api/Services/SlackAlertChannel.cs
+++ b/apps/api/src/Api/Services/SlackAlertChannel.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using Api.Helpers;
 using Microsoft.Extensions.Options;
 using System.Globalization;
 
@@ -66,14 +67,14 @@ internal class SlackAlertChannel : IAlertChannel
                 _logger.LogInformation(
                     "Slack alert sent to {Channel} for {AlertType}",
                     resolvedChannel,
-                    alertType);
+                    LogSanitizer.Sanitize(alertType));
                 return true;
             }
 
             _logger.LogWarning(
                 "Slack webhook returned {StatusCode} for {AlertType}",
                 response.StatusCode,
-                alertType);
+                LogSanitizer.Sanitize(alertType));
             return false;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -85,7 +86,7 @@ internal class SlackAlertChannel : IAlertChannel
             // failure status. Throwing would prevent other channels from executing (email, PagerDuty).
             // Caller (AlertingService) tracks per-channel results for graceful degradation.
             // Context: Slack failures are typically external (webhook timeout, API rate limit)
-            _logger.LogError(ex, "Failed to send Slack alert for {AlertType}", alertType);
+            _logger.LogError(ex, "Failed to send Slack alert for {AlertType}", LogSanitizer.Sanitize(alertType));
             return false;
         }
     }


### PR DESCRIPTION
## Phase 2 of [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) — PII adoption sweep (15 true positives)

Follow-up to PR #1183 (MaD pack registration). Addresses the 20 alerts that the audit identified as genuine sanitizer-missing cases (after the 87 false positives auto-closed by the MaD pack).

### Decision tree applied (per [ADR-058](docs/for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md))

| Tipo | Helper | Count | Files |
|------|--------|-------|-------|
| Email PII content | `DataMasking.MaskEmail` | 3 | EmailOutboxService, JoinWaitlistCommandHandler (×2) |
| User-controlled string log-forging | `LogSanitizer.Sanitize` | 12 | AlertingService (×6), SlackAlertChannel (×3), PagerDutyAlertChannel (×2), EmailAlertChannel (×1) |
| Not PII / not user-controlled | (no code change — UI dismissal candidate) | 5 | see below |

### Why 5 alerts are deferred to post-merge UI dismissal

CodeQL `cs/exposure-of-sensitive-information` flagged some sites where the logged value is **not actual PII**:

| File | Line | What's logged | Why FP |
|------|------|---------------|--------|
| `DeadLetterMonitorJob.cs` | 48, 66 | `int` count from repository query | Not a string; CodeQL taint inference is conservative |
| `NotificationCleanupJob.cs` | 111 | `int` counts of deleted records | Same |
| `AccountLockedEventHandler.cs` | 97 | `Guid UserId` | Identifier, not PII |
| `PiiDetector.cs` | 66 | PII *category names* (e.g. `"EMAIL"`, `"SSN"`) from `match.Type.Distinct()` | Type label, not the matched PII content |

CodeQL alerts do not support inline `[SuppressMessage]` (that's Roslyn analyzers only). The standard path is GitHub UI dismissal with justification after the next scan. These 5 will be dismissed post-merge with the rationale documented in this PR body.

### Verification

- [x] Build: `dotnet build apps/api/src/Api/Api.csproj` → 0 errors, 0 warnings
- [ ] CI Security Scan: `Frontend - Bundle Size`, `Backend - Lint`, etc. green
- [ ] Post-merge CodeQL re-run on `main-dev`: open `cs/exposure-of-sensitive-information` alerts drop from ~20 → ~5 (the deferred non-PII candidates)
- [ ] UI dismissal of the 5 non-PII alerts with link to this PR for justification

### Behavior change disclosure

Log statements that previously contained raw email addresses now show masked form (`j***n@example.com`). This affects debugging UX (cannot grep operational logs by full email) — intentional trade-off for GDPR Art. 32 compliance. Audit log (separate from operational log) retains full email by design.

Log statements with `alertType` user-controlled string now have CRLF stripped before logging — prevents log-forging injection (CWE-117). No visible UX change.

### Refs

- ADR-058 §1.4 + §Decision tree
- Issue #1181 (Phase 2 of overall remediation plan)
- PR #1182 (Phase 1.1-1.3+1.5, sanitizer consolidation + workflow fix)
- PR #1183 (Phase 1.4, MaD sanitizer registration)
- PR #1184 (chore: canonical `packs:` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
