### PR TITLE
feat(security): Phase 3 regression guard for PII logging (refs #1181)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,7 +2,11 @@ name: Security Scan
 
 on:
   pull_request:
-    branches: [main, main-staging]
+    # Phase 3 of #1181 (ADR-058): main-dev added so PII / log-forging
+    # regressions are caught at the first integration target, not only when
+    # they propagate to staging. paths-ignore below already excludes docs-only
+    # PRs so the cost stays bounded.
+    branches: [main, main-staging, main-dev]
     # Issue #850: docs-only PRs do not change dependency or code surface,
     # so SCA / SAST scans add no signal. The Monday-02:00-UTC cron still
     # runs the full scan weekly regardless of recent PR activity.

--- a/docs/for-developers/security/pii-safe-logging.md
+++ b/docs/for-developers/security/pii-safe-logging.md
@@ -1,0 +1,199 @@
+# PII-Safe Logging Conventions
+
+**Status**: active — enforced by CodeQL Models-as-Data pack + `Security Scan` workflow on every PR to `main-dev`/`main-staging`/`main`
+
+**See also**: [ADR-058 — Canonical Log Sanitizers](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md), issue [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181)
+
+---
+
+## TL;DR
+
+Two helpers, two concerns:
+
+| Concern | Helper | Namespace | When |
+|---|---|---|---|
+| **Integrity** (log-forging, CWE-117) | `LogSanitizer.Sanitize(value)` | `Api.Helpers` | Logging any string that originated from user input (HTTP request, webhook body, CLI flag) |
+| **Confidentiality** (PII exposure, CWE-359, GDPR Art. 32) | `DataMasking.Mask*` | `Api.Infrastructure.Security` | Logging email, JWT, credit card, IP address, connection string, user object, response body |
+
+The two are **orthogonal**. A user-provided email needs **both** (`DataMasking.MaskEmail(LogSanitizer.Sanitize(rawInput))` if the field is untrusted free-form text). In practice the two pipelines rarely overlap because PII fields come from validated, typed properties.
+
+---
+
+## Decision tree
+
+```
+You are about to log a value via ILogger.
+│
+├─ Is the value a primitive (int / Guid / bool / enum)?
+│   └─ Yes → log it raw. No sanitization required. CodeQL may flag a false
+│            positive due to interprocedural taint; dismiss via GitHub UI
+│            with link to this document.
+│
+├─ Does the value contain PII (email, full name, phone, JWT, IP, credit card)?
+│   ├─ This is an OPERATIONAL log (debug, info, warn, error for ops/dev consumption)
+│   │   └─ Apply DataMasking.Mask* (mask in-place, never the raw value)
+│   │
+│   └─ This is an AUDIT log (compliance event, security incident record)
+│       └─ Audit logs go through a SEPARATE pipeline (AuditService).
+│          Do NOT log PII via ILogger.LogInformation. See AuditService.LogAsync.
+│
+├─ Is the value a free-form string from user/external input
+│   (request path, query string, header value, webhook body, alert type)?
+│   └─ Apply LogSanitizer.Sanitize. The helper strips CR/LF/TAB to prevent
+│      log-forging (CWE-117 injection vectors %0D, %0A, %0D%0A).
+│
+└─ Is the value an internal constant or framework-generated identifier
+   (controller name, channel name, exception type)?
+    └─ Log it raw. No sanitization needed.
+```
+
+---
+
+## Examples
+
+### Email in operational log → MaskEmail
+
+```csharp
+// Wrong
+_logger.LogInformation("User {Email} created account", email);
+
+// Right
+using Api.Infrastructure.Security;
+_logger.LogInformation("User {Email} created account", DataMasking.MaskEmail(email));
+// → log entry: User u***r@example.com created account
+```
+
+### User-controlled string in operational log → Sanitize
+
+```csharp
+// Wrong (CWE-117 vector if alertType contains %0A — attacker can forge log lines)
+_logger.LogWarning("Alert {AlertType} suppressed", alertType);
+
+// Right
+using Api.Helpers;
+_logger.LogWarning("Alert {AlertType} suppressed", LogSanitizer.Sanitize(alertType));
+```
+
+### Request path → SanitizePath
+
+```csharp
+// Wrong
+_logger.LogError("Request to {Path} failed", context.Request.Path);
+
+// Right (URL-decodes %0D/%0A first, then strips them)
+using Api.Helpers;
+_logger.LogError("Request to {Path} failed", LogSanitizer.SanitizePath(context.Request.Path));
+```
+
+### Full user object → SanitizeUser
+
+```csharp
+using Api.Infrastructure.Security;
+
+// SanitizeUser returns an anonymous object with Email already masked and
+// sensitive fields (PasswordHash, TotpSecretEncrypted) removed.
+_logger.LogDebug("Loaded user {@User}", DataMasking.SanitizeUser(user));
+```
+
+### Audit event (NOT operational log)
+
+```csharp
+// Right — full email persisted in audit pipeline, NOT in ILogger
+await _auditService.LogAsync(
+    userId: user.Id.ToString(),
+    action: "PASSWORD_RESET_REQUESTED",
+    resource: "User",
+    details: new { Email = user.Email });
+// Operational log gets only the actionable summary
+_logger.LogInformation("Password reset requested for {UserId}", user.Id);
+```
+
+### Structured logging with `{@object}` — beware
+
+```csharp
+// Wrong — {@User} serializes ALL public properties, including PII
+_logger.LogInformation("Login attempt {@User}", user);
+
+// Right — sanitize first
+_logger.LogInformation("Login attempt {@User}", DataMasking.SanitizeUser(user));
+```
+
+---
+
+## Available sanitizers — API reference
+
+### `Api.Helpers.LogSanitizer` (public static)
+
+| Method | Use |
+|---|---|
+| `Sanitize(string? value)` | Strip `\r\n\t` from any user-controlled string |
+| `Sanitize(string? value, int maxLength)` | Same + truncate (use for long inputs) |
+| `SanitizePath(PathString path)` | URL-decode first, then strip CRLF — for request paths |
+
+### `Api.Infrastructure.Security.DataMasking` (public static)
+
+| Method | Output example |
+|---|---|
+| `MaskEmail(string?)` | `j***n@example.com` |
+| `MaskString(string?, int visibleChars = 4)` | `abcd...wxyz` |
+| `MaskJwt(string?)` | `eyJhbGciOi...***` |
+| `MaskCreditCard(string?)` | `****-****-****-1234` |
+| `MaskIpAddress(string?)` | `192.168.1.***` (IPv4) — GDPR-compliant |
+| `RedactConnectionString(string?)` | password value redacted, other params preserved |
+| `MaskResponseBody(string?, int maxLength = 500)` | inline-redacts emails, bearer tokens, api_key, password, secret + truncates |
+| `SanitizeUser(UserEntity)` | anonymous object with safe fields only |
+
+> **Note on `RedactConnectionString`**: pattern-based, best-effort. Catches `password=`, `Password=`, `pwd:`. Does NOT catch uppercase `PASSWORD=`, MongoDB URIs, or URI-encoded form. Treat as defense-in-depth, not a primary safeguard.
+
+---
+
+## How the guard rail works
+
+1. **CodeQL Models-as-Data pack** (`.github/codeql/extensions/meepleai-sanitizers`) registers every public method of `LogSanitizer` and `DataMasking` as a sanitizer for `cs/exposure-of-sensitive-information` and `cs/log-forging` queries.
+2. **`security-scan.yml`** runs CodeQL on every PR to `main-dev`/`main-staging`/`main` (Phase 3 of #1181).
+3. A PR that introduces `_logger.LogInformation("{Email}", rawEmail)` without `MaskEmail` triggers a new `cs/exposure-of-sensitive-information` alert. Branch protection on the target branch should require the CodeQL check to pass.
+4. Conversely, a PR that wraps the call in `DataMasking.MaskEmail(...)` is auto-recognized as safe by the MaD pack — no alert opened, no friction.
+
+### Verifying the guard rail
+
+A synthetic test PR that intentionally adds:
+
+```csharp
+_logger.LogInformation("DEBUG raw email {Email}", "test@example.com");
+```
+
+…must open a `cs/exposure-of-sensitive-information` alert on the next CodeQL run. If it doesn't, the MaD pack or workflow trigger is broken — file a bug against this convention.
+
+---
+
+## When CodeQL flags a false positive
+
+A non-PII value (int, Guid, internal constant) sometimes gets flagged because CodeQL's interprocedural taint tracking is conservative. In those cases:
+
+1. **Verify** the value really isn't PII (cross-check with the data source — repository query, framework property, etc.)
+2. **Dismiss** the alert via GitHub UI with the reason `"Won't fix — value is non-PII per docs/for-developers/security/pii-safe-logging.md"` and a link to the specific source line
+3. Do **not** add `[SuppressMessage]` — that attribute is for Roslyn analyzers, not CodeQL
+
+If a class of false positives recurs (e.g. all `int` counts logged in a hot path), consider extending the MaD pack with a `neutralModel` entry instead of per-alert dismissal.
+
+---
+
+## When the helpers are insufficient
+
+If you need to log a new PII category not covered (e.g. phone numbers, IBAN, physical addresses):
+
+1. Add a new method to `DataMasking` (e.g. `MaskPhone`)
+2. Register it in `.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml` as a `summaryModel` with `kind: value`
+3. Update this document with the new helper
+4. **Do not** create a new helper class — ADR-058 §Extension policy: one canonical sanitizer per concern.
+
+---
+
+## Related
+
+- [ADR-058 — Canonical Log Sanitizers](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md) — architectural decision behind the two-helper design
+- `.github/codeql/extensions/meepleai-sanitizers/models/sanitizers.model.yml` — CodeQL recognition pack
+- `apps/api/src/Api/Helpers/LogSanitizer.cs` — source
+- `apps/api/src/Api/Infrastructure/Security/DataMasking.cs` — source
+- `apps/api/tests/Api.Tests/Helpers/LogSanitizerTests.cs` — coverage
+- CWE-117 (Improper Output Neutralization for Logs), CWE-359 (Exposure of Private Information), GDPR Art. 32 (Security of processing)

--- a/docs/for-developers/security/pii-safe-logging.md
+++ b/docs/for-developers/security/pii-safe-logging.md
@@ -98,12 +98,16 @@ _logger.LogDebug("Loaded user {@User}", DataMasking.SanitizeUser(user));
 ### Audit event (NOT operational log)
 
 ```csharp
-// Right — full email persisted in audit pipeline, NOT in ILogger
+// Right — full email persisted in audit pipeline, NOT in ILogger.
+// AuditService.LogAsync signature: userId, action, resource, resourceId,
+// result, details (string?), ipAddress?, userAgent?, cancellationToken?
 await _auditService.LogAsync(
     userId: user.Id.ToString(),
     action: "PASSWORD_RESET_REQUESTED",
     resource: "User",
-    details: new { Email = user.Email });
+    resourceId: user.Id.ToString(),
+    result: "Success",
+    details: JsonSerializer.Serialize(new { Email = user.Email }));
 // Operational log gets only the actionable summary
 _logger.LogInformation("Password reset requested for {UserId}", user.Id);
 ```
@@ -136,33 +140,40 @@ _logger.LogInformation("Login attempt {@User}", DataMasking.SanitizeUser(user));
 |---|---|
 | `MaskEmail(string?)` | `j***n@example.com` |
 | `MaskString(string?, int visibleChars = 4)` | `abcd...wxyz` |
-| `MaskJwt(string?)` | `eyJhbGciOi...***` |
+| `MaskJwt(string?)` | `eyJhbGciOiJIUzI1NiIs...***` (first 20 chars + `...***`) |
 | `MaskCreditCard(string?)` | `****-****-****-1234` |
 | `MaskIpAddress(string?)` | `192.168.1.***` (IPv4) — GDPR-compliant |
 | `RedactConnectionString(string?)` | password value redacted, other params preserved |
 | `MaskResponseBody(string?, int maxLength = 500)` | inline-redacts emails, bearer tokens, api_key, password, secret + truncates |
 | `SanitizeUser(UserEntity)` | anonymous object with safe fields only |
 
-> **Note on `RedactConnectionString`**: pattern-based, best-effort. Catches `password=`, `Password=`, `pwd:`. Does NOT catch uppercase `PASSWORD=`, MongoDB URIs, or URI-encoded form. Treat as defense-in-depth, not a primary safeguard.
+> **Note on `RedactConnectionString`**: pattern-based, best-effort. Catches `password=` / `PASSWORD=` / `pwd=` (case-insensitive) and `password:value` / `pwd:value` (key-colon form). Does NOT catch MongoDB / Redis URIs (`mongodb://user:pass@host`), URI-encoded passwords, or non-standard key names outside the three documented patterns. Treat as defense-in-depth, not a primary safeguard.
 
 ---
 
 ## How the guard rail works
 
-1. **CodeQL Models-as-Data pack** (`.github/codeql/extensions/meepleai-sanitizers`) registers every public method of `LogSanitizer` and `DataMasking` as a sanitizer for `cs/exposure-of-sensitive-information` and `cs/log-forging` queries.
+1. **CodeQL Models-as-Data pack** (`.github/codeql/extensions/meepleai-sanitizers`) registers every public **string-returning** method of `LogSanitizer` and `DataMasking` as a sanitizer for `cs/exposure-of-sensitive-information` and `cs/log-forging` queries. `SanitizeUser` is the one exception — it returns an anonymous object, which doesn't fit the `Argument[0] → ReturnValue` taint-flow shape. Call sites of `SanitizeUser` are recognized via the field-level masking inside the helper (each `Email = MaskEmail(...)` field already has its own sanitizer model).
 2. **`security-scan.yml`** runs CodeQL on every PR to `main-dev`/`main-staging`/`main` (Phase 3 of #1181).
 3. A PR that introduces `_logger.LogInformation("{Email}", rawEmail)` without `MaskEmail` triggers a new `cs/exposure-of-sensitive-information` alert. Branch protection on the target branch should require the CodeQL check to pass.
 4. Conversely, a PR that wraps the call in `DataMasking.MaskEmail(...)` is auto-recognized as safe by the MaD pack — no alert opened, no friction.
 
 ### Verifying the guard rail
 
-A synthetic test PR that intentionally adds:
+CodeQL `cs/exposure-of-sensitive-information` is a taint-tracking query: it needs an actual **taint source** (user input, HTTP request data, database read), not a hard-coded literal. A meaningful synthetic test PR adds something like:
 
 ```csharp
-_logger.LogInformation("DEBUG raw email {Email}", "test@example.com");
+// In an endpoint or controller
+app.MapGet("/_test/pii-guard", (string email, ILogger<Program> logger) =>
+{
+    logger.LogInformation("DEBUG raw email {Email}", email); // email is taint source
+    return Results.Ok();
+});
 ```
 
-…must open a `cs/exposure-of-sensitive-information` alert on the next CodeQL run. If it doesn't, the MaD pack or workflow trigger is broken — file a bug against this convention.
+…then runs CodeQL on the PR. The flow `Request query parameter → ILogger sink` without a sanitizer must open a `cs/exposure-of-sensitive-information` alert. If it doesn't, the MaD pack or workflow trigger is broken — file a bug against this convention.
+
+The complementary positive test wraps the sink in `DataMasking.MaskEmail(email)` and confirms the alert does **not** open.
 
 ---
 


### PR DESCRIPTION
## Phase 3 of [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) — regression guard for PII logging

Closes the Phase 3 acceptance criteria of [ADR-058](docs/for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md). With this PR, the work tracked by #1181 is **functionally complete** (modulo the post-merge UI dismissal of 5 non-PII CodeQL alerts).

### What changed

1. **`.github/workflows/security-scan.yml`** — adds `main-dev` to the PR trigger branches.

   Before this PR: CodeQL ran on PRs to `main` / `main-staging` only. A feature branch introducing `_logger.LogInformation("{Email}", rawEmail)` was caught only when promoted to staging — too late, and divorced from the original author.

   After: the Phase 1.4 MaD sanitizer pack fires on the first integration target. `paths-ignore` is unchanged so docs-only PRs still skip the scan.

2. **`docs/for-developers/security/pii-safe-logging.md`** (new) — convention document covering:
   - TL;DR table mapping concern → helper
   - Full decision tree (PII vs user-input vs internal constant vs primitive)
   - Worked examples for `MaskEmail`, `MaskJwt`, `SanitizePath`, `SanitizeUser`, structured-logging gotcha
   - API reference for `LogSanitizer` + `DataMasking` with output examples
   - How the guard rail works + how to verify it with a synthetic test PR
   - False-positive workflow (GitHub UI dismissal, **not** `[SuppressMessage]`)
   - Extension policy (new methods → `DataMasking`, not new classes)

### ADR-058 §Phase 3 acceptance criteria

- [x] Regression guard attivo — **CI gate path** chosen per the ADR's `analyzer OR CI gate` semantics. CodeQL now runs on `main-dev` PRs with the MaD sanitizer pack active, so new unmasked logs trigger alerts before merge.
- [x] `docs/for-developers/conventions/pii-safe-logging.md` pubblicato (final path: `docs/for-developers/security/pii-safe-logging.md` — `security/` folder already exists, `conventions/` would have been a singleton)
- [ ] Roslyn analyzer (`MeepleAi.Analyzers.NoPiiInLog`) — explicitly **deferred** per ADR's OR semantics. Tracked as potential follow-up for richer in-IDE feedback; non-blocking for issue closure.

### Verification plan

- [x] T1: YAML syntax valid (`python yaml.safe_load`)
- [ ] CI: this PR triggers the (now-included) `Security Scan / CodeQL Analysis (csharp)` job and it completes successfully
- [ ] Negative verification: a follow-up synthetic test PR with `_logger.LogInformation("{Email}", "test@example.com")` should open a `cs/exposure-of-sensitive-information` alert. If it doesn't, the MaD pack or workflow trigger is broken — file a bug against the new convention doc.

### Cost analysis

Adding `main-dev` to the trigger means CodeQL runs on every C# / JS PR (modulo paths-ignore). Approximate added wallclock: 5-8 min per PR (matrix: 2 languages, parallel). Trade-off accepted because:
- The cost is **prevention**, not remediation — far cheaper than retroactive sweeps like Phases 1+2
- `paths-ignore` excludes docs / config-only PRs from triggering CodeQL (line 8-13 of workflow)
- `concurrency: cancel-in-progress: true` ensures stale runs are killed on force-push

### Refs

- ADR-058 §"Phase 3 — Prevention"
- Issue #1181 (Phase 3 of overall remediation plan)
- PR #1182 (Phase 1.1-1.3+1.5, sanitizer consolidation)
- PR #1183 (Phase 1.4, MaD sanitizer registration)
- PR #1184 (chore: canonical packs path)
- PR #1185 (Phase 2, 15 PII sanitizer applications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
