### PR TITLE
fix(security): restore cs/log-forging blanket exclude (refs #1181)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,6 +9,15 @@ disable-default-queries: false
 # cs/exposure-of-sensitive-information, cs/cleartext-storage-of-sensitive-information)
 # stop flagging call sites where these sanitizers are already applied.
 # See ADR-058 §1.4 and .github/codeql/extensions/meepleai-sanitizers/qlpack.yml
+#
+# TODO (#1181 follow-up): the path-based reference below is REJECTED by
+# CodeQL CLI 2.25.4 in CI with "WARNING: Invalid CodeQL pack specification ...
+# Ignoring." The packs: key here accepts pack NAMES only (e.g. codeql/csharp-queries),
+# not local paths. Local extension packs need a different load mechanism — either
+# the github/codeql-action/init `packs:` input or the `--additional-packs` CLI flag
+# via env. Until that's figured out, the cs/log-forging blanket exclude below is
+# RESTORED so the 84 alerts that surfaced after removing it don't pollute the
+# dashboard. Local extension files are kept in place for the eventual fix.
 packs:
   - .github/codeql/extensions/meepleai-sanitizers
 
@@ -18,9 +27,13 @@ query-filters:
   # CA1031: All 220 instances are properly documented with architectural patterns
   - exclude:
       id: cs/catch-of-all-exceptions
-  # NOTE 2026-05-16: blanket exclude for cs/log-forging removed — Phase 1.4 (above)
-  # registers LogSanitizer.* as a sanitizerModel, so the rule can again surface true
-  # positives where input flows directly to ILogger without sanitization.
+  # RESTORED 2026-05-16: this exclude was removed in PR #1183 on the assumption
+  # that the MaD sanitizer pack above would suppress false positives. The pack
+  # loading via `packs:` path silently fails in CI (see TODO above), so the rule
+  # would otherwise report ~84 false positives across files that DO call
+  # LogSanitizer.Sanitize. Re-enable when the MaD load issue is resolved.
+  - exclude:
+      id: cs/log-forging
 
 # Path filters to exclude test files and generated code
 paths-ignore:


### PR DESCRIPTION
## Mitigation: restore `cs/log-forging` blanket exclude (refs #1181)

Post-merge CodeQL run on `main-dev` (workflow_dispatch [25960499621](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25960499621)) revealed that the MaD sanitizer pack added in PR #1183 is **silently rejected** by CodeQL CLI 2.25.4.

### Workflow log evidence

```
WARNING: Invalid CodeQL pack specification:
'.github/codeql/extensions/meepleai-sanitizers'. Ignoring.
```

The `packs:` key in `codeql-config.yml` accepts pack **NAMES** only (e.g. `codeql/csharp-queries`), not local repository paths. Local validation (T2) via `gh codeql resolve extensions --additional-packs` masked this because the CLI flag uses a different resolution mechanism than `config-file:` parsing.

### Observed regression

Expected vs actual post-merge alert state:

| Rule | Pre-#1183 | Expected | Actual |
|------|-----------|----------|--------|
| `cs/exposure-of-sensitive-information` | 107 | ~5-20 | **107** (no reduction) |
| `cs/log-forging` | 1 (blanket excluded) | 0-2 | **84** (re-active + no sanitizer recognition) |

### What this PR does

- Restores `query-filters: exclude id: cs/log-forging` to suppress the 84 false positives that surfaced when PR #1183 removed it
- Adds a TODO comment block to `codeql-config.yml` documenting the gap for a future fix
- Keeps the MaD pack files in place (`.github/codeql/extensions/meepleai-sanitizers/`) — they will be loaded correctly once the right mechanism is identified

### What this PR does NOT do

- Does **not** revert Phase 1.4 / 1.5 / 2 / 3 sanitizer infrastructure — `LogSanitizer.SanitizePath`, `DataMasking.MaskEmail` migrations, convention doc, `main-dev` trigger all remain. The pack-load issue is orthogonal.
- Does **not** delete the MaD pack files — keep on disk for the follow-up fix.

### Follow-up needed

A separate issue/PR will explore the correct CI load mechanism. Candidates documented in the TODO comment:
1. **`codeql-action/init` `packs:` input** with the pack name (pack must be discoverable — likely via workspace)
2. **`codeql-workspace.yml`** at repo root listing the local pack
3. **`CODEQL_ACTION_EXTRA_OPTIONS`** env var to inject `--additional-packs` to CLI

Once loaded correctly, the 84-row blanket exclude can be removed again.

### Verification

T1 (YAML syntax) passes. The mitigation effect (84 alerts re-suppressed) will be confirmed on the next CodeQL run after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
