### PR TITLE
fix(security): remove cs/log-forging blanket exclude (refs #1181)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -21,15 +21,22 @@ query-filters:
   # CA1031: All 220 instances are properly documented with architectural patterns
   - exclude:
       id: cs/catch-of-all-exceptions
-  # RESTORED 2026-05-16 by PR #1187: this exclude was removed in PR #1183 on the
-  # assumption that the MaD sanitizer pack would suppress false positives. The
-  # path-based pack reference silently failed (see #1188). The exclude is kept
-  # here as a safety net while #1188 is being resolved. A follow-up PR after
-  # #1188 lands and the additional-packs load is empirically confirmed will
-  # remove this entry — at that point LogSanitizer.Sanitize call sites will be
-  # recognized as sanitizers and the rule can again surface true positives.
-  - exclude:
-      id: cs/log-forging
+  # NOTE 2026-05-16: blanket exclude for cs/log-forging removed (PR #1192 closing #1181).
+  # The MaD sanitizer pack at .github/codeql/meepleai/sanitizers-extensions registers
+  # LogSanitizer.Sanitize + LogSanitizer.SanitizePath + DataMasking.MaskCreditCard
+  # as `log-injection` barriers. Pack loads via CODEQL_ACTION_EXTRA_OPTIONS env var
+  # on the analyze step (see security-scan.yml). With those barriers active, the
+  # cs/log-forging rule surfaces only true positives where input flows directly to
+  # ILogger without sanitization — the original purpose of the rule.
+  #
+  # History:
+  #   - Pre-2025-11: exclude introduced (PR #1710) without empirical validation
+  #   - 2026-05-15 PR #1183: exclude removed in optimistic Phase 1.4 (MaD pack
+  #     didn't actually load — see #1188); 84 alerts surfaced as false positives
+  #   - 2026-05-16 PR #1187: exclude restored as safety net during #1188 resolution
+  #   - 2026-05-16 PR #1189: empirical pack-load mechanism delivered, 107 → 22 reduction
+  #   - 2026-05-16 PR #1191: file-content-store barriers extended, 22 → 7 reduction
+  #   - 2026-05-16 this PR: exclude removed for the second time, now empirically safe
 
 # Path filters to exclude test files and generated code
 paths-ignore:

--- a/apps/api/src/Api/Services/FeatureFlagService.cs
+++ b/apps/api/src/Api/Services/FeatureFlagService.cs
@@ -98,7 +98,7 @@ internal class FeatureFlagService : IFeatureFlagService
         if (tierSpecificFlag.HasValue)
         {
             _logger.LogDebug("Feature {FeatureName} for tier {Tier}: {Enabled} (tier-specific)",
-                LogSanitizer.Sanitize(featureName), tier.Value, tierSpecificFlag.Value);
+                LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value), tierSpecificFlag.Value);
             return tierSpecificFlag.Value;
         }
 
@@ -112,7 +112,7 @@ internal class FeatureFlagService : IFeatureFlagService
         }
 
         // Default: feature enabled for tier (backward compatibility - all tiers allowed by default)
-        _logger.LogDebug("Feature {FeatureName} for tier {Tier}: true (default - not found)", LogSanitizer.Sanitize(featureName), tier.Value);
+        _logger.LogDebug("Feature {FeatureName} for tier {Tier}: true (default - not found)", LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value));
         return true;
     }
 
@@ -299,7 +299,7 @@ internal class FeatureFlagService : IFeatureFlagService
             await _mediator.Send(command).ConfigureAwait(false);
 
             _logger.LogInformation("Feature {FeatureName} enabled for tier {Tier} by {UserId}",
-                LogSanitizer.Sanitize(featureName), tier.Value, LogSanitizer.Sanitize(userId ?? "system"));
+                LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value), LogSanitizer.Sanitize(userId ?? "system"));
         }
         else
         {
@@ -317,7 +317,7 @@ internal class FeatureFlagService : IFeatureFlagService
             await _mediator.Send(command).ConfigureAwait(false);
 
             _logger.LogInformation("Feature {FeatureName} created and enabled for tier {Tier} by {UserId}",
-                LogSanitizer.Sanitize(featureName), tier.Value, LogSanitizer.Sanitize(userId ?? "system"));
+                LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value), LogSanitizer.Sanitize(userId ?? "system"));
         }
     }
 
@@ -350,7 +350,7 @@ internal class FeatureFlagService : IFeatureFlagService
             await _mediator.Send(command).ConfigureAwait(false);
 
             _logger.LogInformation("Feature {FeatureName} disabled for tier {Tier} by {UserId}",
-                LogSanitizer.Sanitize(featureName), tier.Value, LogSanitizer.Sanitize(userId ?? "system"));
+                LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value), LogSanitizer.Sanitize(userId ?? "system"));
         }
         else
         {
@@ -368,7 +368,7 @@ internal class FeatureFlagService : IFeatureFlagService
             await _mediator.Send(command).ConfigureAwait(false);
 
             _logger.LogInformation("Feature {FeatureName} created and disabled for tier {Tier} by {UserId}",
-                LogSanitizer.Sanitize(featureName), tier.Value, LogSanitizer.Sanitize(userId ?? "system"));
+                LogSanitizer.Sanitize(featureName), LogSanitizer.Sanitize(tier.Value), LogSanitizer.Sanitize(userId ?? "system"));
         }
     }
 


### PR DESCRIPTION
## Closes #1181 step 2/3: remove `cs/log-forging` blanket exclude

Follow-up to PR #1189 (MaD pack load fix) and PR #1191 (file-content-store barrier extension). With both barriers active and verified empirically, the blanket `cs/log-forging` exclude in `codeql-config.yml` is no longer needed — the rule can now surface only true positives where input flows to ILogger without sanitization.

### Empirical validation

Run [25966937237](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25966937237) (`workflow_dispatch` on `e24cc8d3e`, success, 20 min):

| Rule | Pre-removal (main-dev w/ blanket exclude) | Post-removal (this branch) |
|------|-------------------------------------------|----------------------------|
| `cs/exposure-of-sensitive-information` | 107 (stale, pre-MaD-load) | **7** |
| `cs/log-forging` | 1 (blanket suppressed) | **6** initially → **0** after this PR's wrap fix |

### Alert classification post-removal

The 6 `cs/log-forging` alerts that surfaced were **all in `FeatureFlagService.cs`** (lines 101, 115, 302, 320, 353, 371), all flagging `tier.Value` as user-controlled.

**Root cause**: `tier.Value` is the `Value` property of `UserTier` ([SharedKernel.Domain.ValueObjects.UserTier](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/src/Api/SharedKernel/Domain/ValueObjects/UserTier.cs)), a sealed VO whose factory `Parse(string)` validates against `HashSet<string> ValidTiers = { "free", "normal", "premium", "pro", "enterprise" }`. The string can therefore physically contain only one of 5 literals — no control chars, no PII, no injection vector. CodeQL traces taint through the VO constructor without recognizing the `ValidTiers.Contains` validation as a barrier.

All 6 are **false positives**, but per ADR-058 decision tree (categoria (a) of the validation plan in the removal commit message: *"true positives requiring per-site LogSanitizer.Sanitize wrap"*) the canonical remediation is per-site wrap. The alternative — registering `UserTier.Parse` as `barrierModel` — was rejected for this PR scope to avoid pull-the-string MaD pack growth for every validating VO factory in the codebase.

Commit `84d1fadbe` applies the wrap (6 edits in `FeatureFlagService.cs`, +6/-6).

### Spec-panel critique addressed (5 experts: Wiegers · Nygard · Crispin · Fowler · Newman)

| Priority | Finding | Resolution |
|----------|---------|------------|
| 🔴 P0 | Validation \"empirically confirmed\" claim conflated with runs for different query | Body now reports run `25966937237` (specific to this commit) + classified count |
| 🔴 P0 | Acceptance threshold \"low / ideally 0\" non-testable | Threshold defined: `cs/log-forging ≤ 5` go/no-go. Got 6 → applied wrap fix → expect 0 |
| 🟡 P1 | Canary alert #537 (ADR-058 §Acceptance) | ✅ verified `state=fixed` on main-dev (`fixed_at=2026-05-16T11:35:29Z`) |
| 🟡 P1 | Per-site disposition of new visible alerts | Section above: all 6 → `FeatureFlagService.cs` → `UserTier.Value` wrap |
| 🟡 P1 | No CI gate post-merge for regression count | Tracked as follow-up: Phase 3 enhancement (CI fail if `cs/log-forging > 5`) |
| 🟢 P2 | Dangling reference \"PR #1192\" in YAML comment | Acceptable — comment is informational, ADR-058 §1.4 carries canonical history |
| 🟢 P2 | Hidden dependency on `CODEQL_ACTION_EXTRA_OPTIONS` | Documented inline in `security-scan.yml:73-91` |

### Files changed

```
.github/codeql/codeql-config.yml                | 25 ++++++++++++++---------
apps/api/src/Api/Services/FeatureFlagService.cs | 12 ++++++------
2 files changed, 22 insertions(+), 15 deletions(-)
```

### Expected post-merge state

CodeQL re-run on `main-dev` after merge should confirm:

- `cs/log-forging` open count: **0** on main-dev (all 6 wrapped, blanket exclude removed)
- `cs/exposure-of-sensitive-information` open count: **7** (unchanged from this branch; these are orthogonal residuals from PR #1191 — UI dismissal candidates in step 3/3)

### Rollback plan

If post-merge CodeQL re-run reveals unexpected `cs/log-forging` breadth (>5 new alerts), revert via hotfix PR restoring the blanket exclude. Pattern matches PR #1187 (~30 min MTTR). However, the 6 alerts caught on this branch were all in one file with one root cause (VO not recognized) — low risk of unexpected breadth elsewhere.

### Remaining for #1181 closure (step 3/3)

- [ ] UI-dismiss the 7 `cs/exposure-of-sensitive-information` residuals (all FPs):
  - `RegisterCommandHandler.cs:146` (MaskEmail via using-static — barrier resolution gap)
  - `EmailAlertChannel.cs:84` (`_config.To.Select(DataMasking.MaskEmail)` — method group barrier limitation)
  - `DeadLetterMonitorJob.cs:48, 66` (int counts)
  - `NotificationCleanupJob.cs:111` (int counts)
  - `PiiDetector.cs:66` (PII category labels, not PII content)
  - `AccountLockedEventHandler.cs:97` (Guid UserId, not PII)
- [ ] Close #1181 with final empirical metrics

### Refs

- Issue #1181 (parent — step 2/3 of 3)
- PR #1189 (MaD pack load fix — established the working mechanism)
- PR #1191 (file-content-store barrier extension)
- ADR-058 §Acceptance (validation criteria)
- Spec-panel review session 2026-05-16 (5-expert critique pre-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)