### PR TITLE
refactor(pdf-pipeline): #892 extract IPdfClaimService + migrate perf test to BenchmarkDotNet

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfClaimService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfClaimService.cs
@@ -1,0 +1,26 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Atomically claims a PDF document for processing.
+///
+/// Issue #892 (follow-up to #890/#891): extracted from
+/// <see cref="PdfProcessingPipelineService.ProcessAsync"/> to eliminate the
+/// runtime branch on <c>_db.Database.IsRelational()</c>. The atomic-claim semantics is the
+/// load-bearing concurrency invariant of the pipeline — exposing it as a typed seam ensures
+/// the invariant is preserved by interface, not by a conditional.
+///
+/// Production code is wired exclusively to the relational (raw SQL UPDATE) implementation.
+/// Tests inject an in-memory implementation that uses tracked Find + SaveChanges.
+/// </summary>
+internal interface IPdfClaimService
+{
+    /// <summary>
+    /// Attempts to transition the PDF document from <c>Pending</c> to <c>Extracting</c>.
+    /// Clears <c>ProcessingError</c> on success.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the claim succeeded and this caller owns the job;
+    /// <c>false</c> if the PDF is not in <c>Pending</c> state (already claimed, terminal, or missing).
+    /// </returns>
+    Task<bool> TryClaimPendingAsync(Guid pdfDocumentId, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -25,6 +25,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     private const int EmbeddingBatchSize = 20;
 
     private readonly MeepleAiDbContext _db;
+    private readonly IPdfClaimService _pdfClaimService;
     private readonly IPdfTextExtractor _pdfTextExtractor;
     private readonly IPdfTableExtractor _tableExtractor;
     private readonly ITextChunkingService _chunkingService;
@@ -41,6 +42,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
     public PdfProcessingPipelineService(
         MeepleAiDbContext db,
+        IPdfClaimService pdfClaimService,
         IPdfTextExtractor pdfTextExtractor,
         IPdfTableExtractor tableExtractor,
         ITextChunkingService chunkingService,
@@ -56,6 +58,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         IFeatureFlagService? featureFlagService = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _pdfClaimService = pdfClaimService ?? throw new ArgumentNullException(nameof(pdfClaimService));
         _pdfTextExtractor = pdfTextExtractor ?? throw new ArgumentNullException(nameof(pdfTextExtractor));
         _tableExtractor = tableExtractor ?? throw new ArgumentNullException(nameof(tableExtractor));
         _chunkingService = chunkingService ?? throw new ArgumentNullException(nameof(chunkingService));
@@ -83,48 +86,13 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
         try
         {
-            // Atomic claim: transition Pending → Extracting in a single UPDATE.
-            // - Returns 1 row if this worker successfully claimed the job.
-            // - Returns 0 rows if any other state (Uploading, Ready, Failed, …)
-            //   meaning another worker (e.g. the upload-time background task) owns it
-            //   or the PDF is already terminal. Stuck-state recovery is handled
-            //   separately by RetryFailedPdfsJob, not here.
-            // FindAsync would suffer L1-cache staleness when another scope writes the
-            // row mid-flight; an atomic UPDATE bypasses that entirely.
-            //
-            // Issue #890: ExecuteSqlInterpolatedAsync is relational-only. Unit tests
-            // that exercise this pipeline use the InMemory provider (no concurrency,
-            // no L1-cache staleness concern), where the equivalent operation is a
-            // tracked Find + SaveChanges. Production paths still go through the
-            // atomic SQL UPDATE.
-            int rowsClaimed;
-            if (_db.Database.IsRelational())
-            {
-                rowsClaimed = await _db.Database.ExecuteSqlInterpolatedAsync(
-                    $@"UPDATE pdf_documents
-                       SET processing_state = 'Extracting', ""ProcessingError"" = NULL
-                       WHERE ""Id"" = {pdfDocumentId} AND processing_state = 'Pending'",
-                    cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                var existing = await _db.PdfDocuments
-                    .FindAsync(new object[] { pdfDocumentId }, cancellationToken)
-                    .ConfigureAwait(false);
-                if (existing != null && string.Equals(existing.ProcessingState, "Pending", StringComparison.Ordinal))
-                {
-                    existing.ProcessingState = "Extracting";
-                    existing.ProcessingError = null;
-                    await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    rowsClaimed = 1;
-                }
-                else
-                {
-                    rowsClaimed = 0;
-                }
-            }
-
-            if (rowsClaimed == 0)
+            // Atomic claim: transition Pending → Extracting in a single operation.
+            // Issue #892: extracted to IPdfClaimService — production uses raw SQL UPDATE
+            // (RelationalPdfClaimService) for atomic guarantees under contention; tests
+            // inject InMemoryPdfClaimService which uses tracked Find + SaveChanges.
+            // Stuck-state recovery is RetryFailedPdfsJob's responsibility, not the claim.
+            var claimed = await _pdfClaimService.TryClaimPendingAsync(pdfDocumentId, cancellationToken).ConfigureAwait(false);
+            if (!claimed)
             {
                 _logger.LogInformation(
                     "[PdfPipeline] PDF {PdfId} not in Pending state (already claimed or terminal), skipping",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -152,6 +152,10 @@ internal static class DocumentProcessingServiceExtensions
         // Libro Game AI Assistant MVP Phase 1 — Task 1.6: parallel photo batch processor
         services.AddScoped<IPhotoBatchProcessor, PhotoBatchProcessor>();
 
+        // Issue #892: Atomic PDF claim service — raw SQL UPDATE against PostgreSQL
+        // for production. Tests inject the InMemoryPdfClaimService helper directly.
+        services.AddScoped<IPdfClaimService, RelationalPdfClaimService>();
+
         // Shared PDF processing pipeline (used by recovery job and future handler consolidation)
         services.AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimService.cs
@@ -32,6 +32,13 @@ public sealed class RelationalPdfClaimService : IPdfClaimService
         //     responsibility, not the claim service.
         // FindAsync would suffer L1-cache staleness when another scope writes the row
         // mid-flight; an atomic UPDATE bypasses that entirely.
+        //
+        // Identifier quoting mirrors PdfDocumentEntityConfiguration: `processing_state`
+        // has an explicit HasColumnName(snake_case) mapping, while `Id` and
+        // `ProcessingError` use EF Core's default PascalCase quoted column names. The
+        // RelationalPdfClaimServiceTests integration suite is the safety net if either
+        // mapping ever changes — without it a silent column-not-found at runtime is the
+        // only signal.
         var rowsClaimed = await _db.Database.ExecuteSqlInterpolatedAsync(
             $@"UPDATE pdf_documents
                SET processing_state = 'Extracting', ""ProcessingError"" = NULL

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimService.cs
@@ -1,0 +1,43 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// Production <see cref="IPdfClaimService"/> implementation backed by a raw SQL
+/// atomic UPDATE against PostgreSQL. Row-level locking guarantees that exactly one
+/// worker can transition <c>Pending → Extracting</c> for a given PDF document,
+/// preventing duplicate processing under concurrent claims.
+///
+/// Issue #892: extracted from the runtime branch previously embedded in
+/// <see cref="Api.BoundedContexts.DocumentProcessing.Application.Services.PdfProcessingPipelineService.ProcessAsync"/>.
+/// The SQL body is unchanged from PR #891 — only the seam has moved.
+/// </summary>
+public sealed class RelationalPdfClaimService : IPdfClaimService
+{
+    private readonly MeepleAiDbContext _db;
+
+    public RelationalPdfClaimService(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<bool> TryClaimPendingAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        // Atomic transition Pending → Extracting in a single UPDATE.
+        //   - Returns 1 row claimed if this worker won the race for a Pending PDF.
+        //   - Returns 0 rows if the PDF is in any other state (already claimed by another
+        //     worker, terminal, or missing). Stuck-state recovery is RetryFailedPdfsJob's
+        //     responsibility, not the claim service.
+        // FindAsync would suffer L1-cache staleness when another scope writes the row
+        // mid-flight; an atomic UPDATE bypasses that entirely.
+        var rowsClaimed = await _db.Database.ExecuteSqlInterpolatedAsync(
+            $@"UPDATE pdf_documents
+               SET processing_state = 'Extracting', ""ProcessingError"" = NULL
+               WHERE ""Id"" = {pdfDocumentId} AND processing_state = 'Pending'",
+            cancellationToken).ConfigureAwait(false);
+
+        return rowsClaimed > 0;
+    }
+}

--- a/apps/api/tests/Api.Tests/Benchmarks/NgramCopyrightLeakGuardBenchmark.cs
+++ b/apps/api/tests/Api.Tests/Benchmarks/NgramCopyrightLeakGuardBenchmark.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Api.Tests.Benchmarks;
+
+/// <summary>
+/// Benchmark for <see cref="NgramCopyrightLeakGuard.ScanAsync"/> over 5 chunks of
+/// 1500 words. Captures the algorithmic baseline so gradual O(n) → O(n log n) drift
+/// is detected with statistical confidence intervals — not via CI-noise-prone xUnit
+/// timeouts.
+///
+/// Issue #892 (follow-up to PR #891 §4): replaces the xUnit assertion
+/// <c>Given_5ChunksOf1500Words_WhenScanned_ThenCompletesUnder50ms</c> whose threshold has
+/// drifted 50ms → 500ms → 1000ms tracking CI environment noise rather than algorithm
+/// behavior. At 1000ms the assertion catches only 20x+ regressions vs the 50ms local
+/// target — so the signal is dominated by noise.
+///
+/// Run via:
+///   dotnet run -c Release --project apps/api/tests/Api.Tests/Api.Tests.csproj \
+///       --filter "*NgramCopyrightLeakGuardBenchmark*"
+/// </summary>
+[MemoryDiagnoser]
+public class NgramCopyrightLeakGuardBenchmark
+{
+    private const int VerbatimThreshold = 12;
+    private const int ScanTimeoutMs = 5000; // generous so the algorithm always runs to completion
+
+    private NgramCopyrightLeakGuard _guard = null!;
+    private string _body = null!;
+    private ChunkCitation[] _chunks = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _guard = new NgramCopyrightLeakGuard(
+            Options.Create(new CopyrightLeakGuardOptions
+            {
+                VerbatimRunThreshold = VerbatimThreshold,
+                ScanTimeoutMs = ScanTimeoutMs
+            }),
+            NullLogger<NgramCopyrightLeakGuard>.Instance);
+
+        // Mirror the original xUnit workload exactly: 5 chunks of 1500 unique words each.
+        _chunks = Enumerable.Range(0, 5).Select(i =>
+            new ChunkCitation(
+                DocumentId: $"doc-{i}",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: $"chunk-{i}-preview",
+                CopyrightTier: CopyrightTier.Protected)
+            {
+                FullText = string.Join(' ', Enumerable.Range(0, 1500).Select(j => $"word{i}_{j}"))
+            }).ToArray();
+
+        _body = string.Join(' ', Enumerable.Range(0, 500).Select(i => $"bodytok{i}"));
+    }
+
+    /// <summary>Scan 500 body tokens against 5 chunks of 1500 words. Local target: &lt;50ms.</summary>
+    [Benchmark]
+    public async Task<bool> Scan_5ChunksOf1500Words()
+    {
+        // Return HasLeak to consume the result and prevent dead-code elimination in Release.
+        var result = await _guard.ScanAsync(_body, _chunks, CancellationToken.None);
+        return result.HasLeak;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/InMemoryPdfClaimServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/InMemoryPdfClaimServiceTests.cs
@@ -1,0 +1,129 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="InMemoryPdfClaimService"/> — the test-only implementation
+/// of <c>IPdfClaimService</c> backing tests that use the EF Core InMemory provider.
+///
+/// Issue #892: pins down the claim semantics so the production
+/// <c>RelationalPdfClaimService</c> and this helper stay observably equivalent.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class InMemoryPdfClaimServiceTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+
+    public InMemoryPdfClaimServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"InMemoryPdfClaimTest_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfIsPending_ReturnsTrueAndTransitionsToExtracting()
+    {
+        // Arrange
+        var pdfId = SeedPdf("Pending");
+        var sut = new InMemoryPdfClaimService(_db);
+
+        // Act
+        var claimed = await sut.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeTrue();
+        var doc = await _db.PdfDocuments.FindAsync(pdfId);
+        doc!.ProcessingState.Should().Be("Extracting");
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfIsPendingWithStaleError_ClearsProcessingError()
+    {
+        // Arrange — PDF in Pending with a stale ProcessingError left over from a prior failed run
+        var pdfId = SeedPdf("Pending", processingError: "stale failure from prior worker");
+        var sut = new InMemoryPdfClaimService(_db);
+
+        // Act
+        var claimed = await sut.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeTrue();
+        var doc = await _db.PdfDocuments.FindAsync(pdfId);
+        doc!.ProcessingState.Should().Be("Extracting");
+        doc.ProcessingError.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Uploading")]   // upload still in progress on another worker
+    [InlineData("Extracting")]  // already claimed
+    [InlineData("Chunking")]
+    [InlineData("Embedding")]
+    [InlineData("Indexing")]
+    [InlineData("Ready")]       // terminal
+    [InlineData("Failed")]      // terminal
+    public async Task TryClaimPendingAsync_WhenPdfIsNotPending_ReturnsFalseAndDoesNotMutateState(string state)
+    {
+        // Arrange
+        var pdfId = SeedPdf(state);
+        var sut = new InMemoryPdfClaimService(_db);
+
+        // Act
+        var claimed = await sut.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeFalse();
+        var doc = await _db.PdfDocuments.FindAsync(pdfId);
+        doc!.ProcessingState.Should().Be(state);
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfDoesNotExist_ReturnsFalse()
+    {
+        // Arrange — no PDF seeded
+        var sut = new InMemoryPdfClaimService(_db);
+
+        // Act
+        var claimed = await sut.TryClaimPendingAsync(Guid.NewGuid(), CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeFalse();
+    }
+
+    private Guid SeedPdf(string processingState, string? processingError = null)
+    {
+        var id = Guid.NewGuid();
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = processingState,
+            ProcessingError = processingError
+        });
+        _db.SaveChanges();
+        return id;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
@@ -20,6 +20,8 @@ namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 [Trait("BoundedContext", "DocumentProcessing")]
 public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<RelationalPdfClaimService>
 {
+    private Guid _testUserId;
+
     public RelationalPdfClaimServiceTests(SharedTestcontainersFixture fixture) : base(fixture)
     {
     }
@@ -27,11 +29,24 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     protected override RelationalPdfClaimService CreateRepository(MeepleAiDbContext dbContext)
         => new RelationalPdfClaimService(dbContext);
 
+    private async Task SeedTestUserAsync()
+    {
+        _testUserId = Guid.NewGuid();
+        DbContext.Users.Add(new UserEntity
+        {
+            Id = _testUserId,
+            Email = $"claim-test-{_testUserId:N}@example.test",
+            CreatedAt = DateTime.UtcNow
+        });
+        await DbContext.SaveChangesAsync();
+    }
+
     [Fact]
     public async Task TryClaimPendingAsync_WhenPdfIsPending_ReturnsTrueAndTransitionsToExtracting()
     {
         // Arrange
         await ResetDatabaseAsync();
+        await SeedTestUserAsync();
         var pdfId = await SeedPdfAsync("Pending");
 
         // Act
@@ -48,6 +63,7 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     {
         // Arrange
         await ResetDatabaseAsync();
+        await SeedTestUserAsync();
         var pdfId = await SeedPdfAsync("Pending", processingError: "stale failure from prior worker");
 
         // Act
@@ -72,6 +88,7 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     {
         // Arrange
         await ResetDatabaseAsync();
+        await SeedTestUserAsync();
         var pdfId = await SeedPdfAsync(state);
 
         // Act
@@ -88,6 +105,7 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     {
         // Arrange
         await ResetDatabaseAsync();
+        await SeedTestUserAsync();
 
         // Act
         var claimed = await Repository.TryClaimPendingAsync(Guid.NewGuid(), CancellationToken.None);
@@ -101,6 +119,7 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     {
         // Arrange — single Pending PDF, two independent service instances (their own DbContext)
         await ResetDatabaseAsync();
+        await SeedTestUserAsync();
         var pdfId = await SeedPdfAsync("Pending");
 
         var sutA = Repository;
@@ -129,7 +148,7 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
             FileName = "test.pdf",
             FilePath = "/tmp/test.pdf",
             FileSizeBytes = 1024,
-            UploadedByUserId = Guid.NewGuid(),
+            UploadedByUserId = _testUserId,
             ProcessingState = processingState,
             ProcessingError = processingError
         });

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
@@ -117,20 +117,25 @@ public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<Rela
     [Fact]
     public async Task TryClaimPendingAsync_TwoConcurrentClaimsOnSamePending_OnlyOneWins()
     {
-        // Arrange — single Pending PDF, two independent service instances (their own DbContext)
+        // Arrange — single Pending PDF, two independent service instances (their own DbContext).
         await ResetDatabaseAsync();
         await SeedTestUserAsync();
         var pdfId = await SeedPdfAsync("Pending");
 
+        // Own the second DbContext explicitly so it's disposed at the end of the test —
+        // CreateIndependentRepository() builds a context that the base class does not track
+        // for cleanup, and Task.WhenAll otherwise leaves the Npgsql connection in the pool
+        // until GC.
         var sutA = Repository;
-        var sutB = CreateIndependentRepository();
+        await using var independentCtx = CreateIndependentDbContext();
+        var sutB = CreateRepository(independentCtx);
 
-        // Act — fire both claims as close to simultaneously as possible
+        // Act — fire both claims as close to simultaneously as possible.
         var taskA = Task.Run(() => sutA.TryClaimPendingAsync(pdfId, CancellationToken.None));
         var taskB = Task.Run(() => sutB.TryClaimPendingAsync(pdfId, CancellationToken.None));
         await Task.WhenAll(taskA, taskB);
 
-        // Assert — atomic SQL UPDATE guarantees exactly one winner
+        // Assert — atomic SQL UPDATE guarantees exactly one winner.
         var winners = new[] { taskA.Result, taskB.Result };
         winners.Count(r => r).Should().Be(1, "exactly one concurrent claim must transition the row");
         winners.Count(r => !r).Should().Be(1, "the loser must observe the row already claimed");

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/RelationalPdfClaimServiceTests.cs
@@ -1,0 +1,149 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// Integration tests for <see cref="RelationalPdfClaimService"/>.
+/// Issue #892: verifies the atomic SQL UPDATE semantics — observable parity with
+/// <c>InMemoryPdfClaimService</c> plus the concurrency invariant that exactly one
+/// worker can claim a Pending PDF under contention.
+/// </summary>
+[Collection("SharedTestcontainers")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class RelationalPdfClaimServiceTests : SharedDatabaseTestBase<RelationalPdfClaimService>
+{
+    public RelationalPdfClaimServiceTests(SharedTestcontainersFixture fixture) : base(fixture)
+    {
+    }
+
+    protected override RelationalPdfClaimService CreateRepository(MeepleAiDbContext dbContext)
+        => new RelationalPdfClaimService(dbContext);
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfIsPending_ReturnsTrueAndTransitionsToExtracting()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var pdfId = await SeedPdfAsync("Pending");
+
+        // Act
+        var claimed = await Repository.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeTrue();
+        var doc = await ReadFreshAsync(pdfId);
+        doc!.ProcessingState.Should().Be("Extracting");
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfIsPendingWithStaleError_ClearsProcessingError()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var pdfId = await SeedPdfAsync("Pending", processingError: "stale failure from prior worker");
+
+        // Act
+        var claimed = await Repository.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeTrue();
+        var doc = await ReadFreshAsync(pdfId);
+        doc!.ProcessingState.Should().Be("Extracting");
+        doc.ProcessingError.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Uploading")]
+    [InlineData("Extracting")]
+    [InlineData("Chunking")]
+    [InlineData("Embedding")]
+    [InlineData("Indexing")]
+    [InlineData("Ready")]
+    [InlineData("Failed")]
+    public async Task TryClaimPendingAsync_WhenPdfIsNotPending_ReturnsFalseAndDoesNotMutateState(string state)
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var pdfId = await SeedPdfAsync(state);
+
+        // Act
+        var claimed = await Repository.TryClaimPendingAsync(pdfId, CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeFalse();
+        var doc = await ReadFreshAsync(pdfId);
+        doc!.ProcessingState.Should().Be(state);
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_WhenPdfDoesNotExist_ReturnsFalse()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        // Act
+        var claimed = await Repository.TryClaimPendingAsync(Guid.NewGuid(), CancellationToken.None);
+
+        // Assert
+        claimed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryClaimPendingAsync_TwoConcurrentClaimsOnSamePending_OnlyOneWins()
+    {
+        // Arrange — single Pending PDF, two independent service instances (their own DbContext)
+        await ResetDatabaseAsync();
+        var pdfId = await SeedPdfAsync("Pending");
+
+        var sutA = Repository;
+        var sutB = CreateIndependentRepository();
+
+        // Act — fire both claims as close to simultaneously as possible
+        var taskA = Task.Run(() => sutA.TryClaimPendingAsync(pdfId, CancellationToken.None));
+        var taskB = Task.Run(() => sutB.TryClaimPendingAsync(pdfId, CancellationToken.None));
+        await Task.WhenAll(taskA, taskB);
+
+        // Assert — atomic SQL UPDATE guarantees exactly one winner
+        var winners = new[] { taskA.Result, taskB.Result };
+        winners.Count(r => r).Should().Be(1, "exactly one concurrent claim must transition the row");
+        winners.Count(r => !r).Should().Be(1, "the loser must observe the row already claimed");
+
+        var doc = await ReadFreshAsync(pdfId);
+        doc!.ProcessingState.Should().Be("Extracting");
+    }
+
+    private async Task<Guid> SeedPdfAsync(string processingState, string? processingError = null)
+    {
+        var id = Guid.NewGuid();
+        DbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = "test.pdf",
+            FilePath = "/tmp/test.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = processingState,
+            ProcessingError = processingError
+        });
+        await DbContext.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// Reads the PDF from a fresh DbContext so we observe the row state written by
+    /// the raw SQL UPDATE, bypassing any L1 cache staleness on the test's context.
+    /// </summary>
+    private async Task<PdfDocumentEntity?> ReadFreshAsync(Guid id)
+    {
+        await using var fresh = CreateIndependentDbContext();
+        return await fresh.PdfDocuments.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/NgramCopyrightLeakGuardScenarios.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/NgramCopyrightLeakGuardScenarios.cs
@@ -144,7 +144,8 @@ public class NgramCopyrightLeakGuardScenarios
             () => guard.ScanAsync(longText, new[] { chunk }, cts.Token));
     }
 
-    [Fact]
+    [Trait("Category", TestCategories.Performance)]
+    [Fact(Skip = "Issue #892: replaced by NgramCopyrightLeakGuardBenchmark (BenchmarkDotNet) — the xUnit time-based assertion tracked CI environment noise, not algorithm behavior. See apps/api/tests/Api.Tests/Benchmarks/NgramCopyrightLeakGuardBenchmark.cs.")]
     public async Task Given_5ChunksOf1500Words_WhenScanned_ThenCompletesUnder50ms()
     {
         var guard = CreateGuard(threshold: 12);
@@ -158,10 +159,8 @@ public class NgramCopyrightLeakGuardScenarios
         sw.Stop();
 
         Assert.False(result.HasLeak);
-        // CI tolerance: 1000ms allowance on shared/contended runners (target <50ms locally,
-        // <500ms typical on a clean CI box). Issue #890: 521ms observed on a contended GH
-        // Actions runner — bumped to 1000ms to keep the assertion as a regression-catcher
-        // (flagging 20x+ degradations) without being a flake source.
+        // Local-only sanity bound — the authoritative perf signal is the BenchmarkDotNet
+        // run referenced in the Skip reason above.
         Assert.True(sw.ElapsedMilliseconds < 1000,
             $"Scan took {sw.ElapsedMilliseconds}ms, expected <1000ms on CI (target <50ms local)");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
@@ -264,6 +264,7 @@ public sealed class GraphRagExtractionTests : IDisposable
 
         return new PdfProcessingPipelineService(
             _db,
+            new Api.Tests.TestHelpers.InMemoryPdfClaimService(_db),
             _pdfTextExtractorMock.Object,
             _tableExtractorMock.Object,
             _chunkingServiceMock.Object,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
@@ -285,6 +285,7 @@ public sealed class RaptorPipelineIntegrationTests : IDisposable
 
         return new PdfProcessingPipelineService(
             _db,
+            new Api.Tests.TestHelpers.InMemoryPdfClaimService(_db),
             _pdfTextExtractorMock.Object,
             _tableExtractorMock.Object,
             _chunkingServiceMock.Object,

--- a/apps/api/tests/Api.Tests/TestHelpers/InMemoryPdfClaimService.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/InMemoryPdfClaimService.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Tests.TestHelpers;
+
+/// <summary>
+/// Test-only <see cref="IPdfClaimService"/> implementation backed by the EF Core
+/// InMemory provider. Uses tracked <c>Find</c> + <c>SaveChanges</c> because the
+/// InMemory provider does not support relational <c>ExecuteSqlInterpolatedAsync</c>.
+///
+/// Issue #892: replaces the runtime <c>IsRelational()</c> branch previously
+/// embedded in <c>PdfProcessingPipelineService.ProcessAsync</c>.
+/// </summary>
+internal sealed class InMemoryPdfClaimService : IPdfClaimService
+{
+    private readonly MeepleAiDbContext _db;
+
+    public InMemoryPdfClaimService(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<bool> TryClaimPendingAsync(Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        var existing = await _db.PdfDocuments
+            .FindAsync(new object[] { pdfDocumentId }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing == null || !string.Equals(existing.ProcessingState, "Pending", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        existing.ProcessingState = "Extracting";
+        existing.ProcessingError = null;
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #892.

Follow-up to PR #891 code-review: tech-debt items accepted as out-of-scope for the urgency of unblocking CI. Now tracked and resolved here.

## 1. `IPdfClaimService` extraction (eliminates `_db.Database.IsRelational()` branch)

The atomic-claim semantics in `PdfProcessingPipelineService.ProcessAsync` was a load-bearing concurrency invariant routed through a runtime conditional on the DB provider. Future callers wiring an InMemory context outside test code would have silently bypassed atomicity. Extracted to a typed seam:

- **`IPdfClaimService`** (internal interface) — single `TryClaimPendingAsync` method.
- **`RelationalPdfClaimService`** (production) — raw SQL UPDATE (body unchanged from #891). `public` because `SharedDatabaseTestBase<T>` requires it; the interface stays `internal`.
- **`InMemoryPdfClaimService`** (test helper in `Api.Tests.TestHelpers`) — tracked `Find` + `SaveChanges` for the InMemory provider.

DI: registered `IPdfClaimService → RelationalPdfClaimService` in `DocumentProcessingServiceExtensions`. Tests inject `InMemoryPdfClaimService` directly through the pipeline ctor.

`PdfProcessingPipelineService.ProcessAsync` is now a single seamless line:

```csharp
var claimed = await _pdfClaimService.TryClaimPendingAsync(pdfDocumentId, cancellationToken);
if (!claimed) { /* log + return */ }
```

## 2. `Given_5ChunksOf1500Words` perf assertion → BenchmarkDotNet

The xUnit threshold drifted 50ms → 500ms → 1000ms across two iterations on the same workload — the assertion was tracking CI environment noise, not algorithm behavior. At 1000ms it caught only 20× + regressions.

- Added `apps/api/tests/Api.Tests/Benchmarks/NgramCopyrightLeakGuardBenchmark.cs` with `[MemoryDiagnoser]` and the same 5 chunks × 1500 words workload.
- Skipped the xUnit `Fact` with a pointer to the benchmark file; the scenario body is preserved for manual local sanity runs.

## Test plan

- [x] 10 new `InMemoryPdfClaimServiceTests` (Pending→true+state+error-clear; Theory across 7 non-Pending states; missing PDF) — green locally.
- [x] 11 new `RelationalPdfClaimServiceTests` for the Postgres SQL UPDATE path, including a concurrency invariant test that two concurrent claims on the same Pending PDF produce exactly one winner. Run via Testcontainers in CI (Docker not available locally).
- [x] 8 `RaptorPipelineIntegrationTests` still green after refactor.
- [x] 4 `GraphRagExtractionTests` still green after refactor.
- [x] 16 `StalePdfRecoveryServiceTests` still green.
- [x] 16 `UploadPrivatePdfCommandHandlerTests` still green (mocked `IPdfProcessingPipelineService`).
- [x] `NgramCopyrightLeakGuardScenarios` — 12 passed, 1 skipped (the migrated perf test).
- [ ] CI confirms `RelationalPdfClaimServiceTests` 11/11 green on a real Postgres container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)