### PR TITLE
fix(auth): retire expired V1 grace-period assertion (post-#818 sunset)

### DIFF
--- a/apps/api/tests/Api.Tests/Routing/CookieHelpersHmacTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/CookieHelpersHmacTests.cs
@@ -131,7 +131,7 @@ public sealed class CookieHelpersHmacTests
             "not silently accepted.");
     }
 
-    [Fact]
+    [Fact(Skip = "C4 grace period hardcoded sunset (UserRoleCookieV1SunsetUtc = 2026-05-13) is now in the past; pre-sunset behaviour is no longer reachable from a real clock. To restore coverage, refactor CookieHelpers to take an ITimeProvider/clock seam and reintroduce this assertion under a controlled now, or replace with a post-sunset assertion (v1 cookie → null). Tracked separately from #892.")]
     public void ReadUserRoleCookie_FallbackV1_ReturnsRole_DuringGracePeriod()
     {
         // Only a v1 cookie is present (legacy session pre-deploy). During the


### PR DESCRIPTION
## Context

PR #818 (2026-05-07) introduced a 7-day grace period for the legacy plaintext v1 role cookie, with a hardcoded sunset:

\`\`\`csharp
// apps/api/src/Api/Routing/CookieHelpers.cs:34
private static readonly DateTime UserRoleCookieV1SunsetUtc =
    new(2026, 5, 13, 0, 0, 0, DateTimeKind.Utc);
\`\`\`

That date is now ~3 days in the past (today 2026-05-16). Production correctly ignores v1 cookies post-sunset, and the test \`ReadUserRoleCookie_FallbackV1_ReturnsRole_DuringGracePeriod\` — which asserts the pre-sunset behaviour — is no longer reachable from a real clock. The test has been failing on every \`Backend Fast\` CI run on PRs touching \`apps/api/**\` since 2026-05-13.

Recent merged PRs on \`main-dev\` (e.g. #1187–#1192) only touched \`.github/\` paths and the \`Backend Fast\` job was skipped, masking the regression. PR #1193 (#892 PDF claim service) is the first \`apps/api/**\` PR after the sunset, surfaced it.

## Fix

Tactical: \`[Fact(Skip = ...)]\` with a pointer to the proper restoration path:

1. inject an \`ITimeProvider\` / clock seam into \`CookieHelpers\` and re-assert under a controlled \`now\` (preferred — keeps the time-bound semantics covered), **or**
2. replace with a post-sunset assertion (\`v1 cookie → null\`) and delete the obsolete test.

Either option is out of scope for the unrelated PR that surfaced this. Landing the skip separately so the queue can move.

## Test plan

- [x] \`CookieHelpersHmacTests\`: 5 passed, 1 skipped (verified locally).
- [ ] CI \`Backend Fast (build + unit)\` green.

## Out of scope

- ITimeProvider injection into \`CookieHelpers\` — track via follow-up.
- Decision on whether to keep / refactor / delete the test — track via follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)