### PR TITLE
fix(security): wrap 4 pre-existing cs/log-forging call sites (refs #1195)

### DIFF
--- a/apps/api/src/Api/Routing/AdminTestResultEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminTestResultEndpoints.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.Extensions;
+using Api.Helpers;
 using MediatR;
 
 namespace Api.Routing;
@@ -86,7 +87,7 @@ internal static class AdminTestResultEndpoints
             logger.LogDebug(
                 "Admin {UserId} getting test results - TypologyId: {TypologyId}, SavedOnly: {SavedOnly}",
                 session.User!.Id,
-                typologyId,
+                LogSanitizer.Sanitize(typologyId?.ToString()),
                 savedOnly);
 
             var query = new GetTestResultsQuery(

--- a/apps/api/src/Api/Routing/ReportingEndpoints.cs
+++ b/apps/api/src/Api/Routing/ReportingEndpoints.cs
@@ -138,7 +138,7 @@ internal static class ReportingEndpoints
             CancellationToken ct) =>
         {
             logger.LogDebug("GET /api/v1/admin/reports/executions - ReportId={ReportId}, Limit={Limit}",
-                reportId, limit);
+                LogSanitizer.Sanitize(reportId?.ToString()), limit);
 
             var query = new GetReportExecutionsQuery
             {

--- a/apps/api/src/Api/Routing/WorkflowEndpoints.cs
+++ b/apps/api/src/Api/Routing/WorkflowEndpoints.cs
@@ -241,7 +241,7 @@ internal static class WorkflowEndpoints
             };
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
-            logger.LogInformation("Template {TemplateId} imported successfully as workflow {WorkflowId}", id, result.WorkflowId);
+            logger.LogInformation("Template {TemplateId} imported successfully as workflow {WorkflowId}", LogSanitizer.Sanitize(id), result.WorkflowId);
             return Results.Ok(result);
         })
         .RequireSession() // Issue #1446: Automatic session validation

--- a/apps/api/src/Api/Services/HybridCacheService.cs
+++ b/apps/api/src/Api/Services/HybridCacheService.cs
@@ -273,7 +273,7 @@ internal class HybridCacheService : IHybridCacheService
     {
         if (_redisDb == null)
         {
-            _logger.LogWarning("Redis not available for tag tracking. Tags will not be persisted: {CacheKey}", cacheKey);
+            _logger.LogWarning("Redis not available for tag tracking. Tags will not be persisted: {CacheKey}", LogSanitizer.Sanitize(cacheKey));
             return;
         }
 


### PR DESCRIPTION
## Follow-up to PR #1198 (closes #1195 bundle)

The new FU#1 gate (`Check cs/log-forging alert threshold`) caught **4 pre-existing false positives** on the first push-triggered run on `main-dev` (run [25970767792](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25970767792) on commit `7b1a7368c`).

These alerts had been UI-dismissed in the past (when the `cs/log-forging` blanket exclude was active and these specific call sites were never actually evaluated). The SARIF still contains them, and the gate counts SARIF results deterministically (by design — independent of mutable dismissal state). So the gate correctly fired.

**The gate did exactly what it was built to do.** Per the spec in PR #1198 (\"applies LogSanitizer.Sanitize per-site for true positives\"), this PR is the canonical follow-up.

## Sites wrapped

| Alert # | File:line | Tainted arg | Wrap form |
|---------|-----------|-------------|-----------|
| #253 | `HybridCacheService.cs:276` | `cacheKey` (string from caller) | `LogSanitizer.Sanitize(cacheKey)` |
| #205 | `WorkflowEndpoints.cs:244` | `id` (route parameter) | `LogSanitizer.Sanitize(id)` |
| #198 | `ReportingEndpoints.cs:141` | `reportId` (Guid?) | `LogSanitizer.Sanitize(reportId?.ToString())` |
| #146 | `AdminTestResultEndpoints.cs:89` | `typologyId` (Guid?) | `LogSanitizer.Sanitize(typologyId?.ToString())` + new `using Api.Helpers;` |

For `Guid?` args, the wrap is `LogSanitizer.Sanitize(value?.ToString())`. `LogSanitizer.Sanitize` handles null gracefully (returns `string.Empty`).

This pattern is **consistent with existing sanitization** for similar sites elsewhere in those files. For instance, `HybridCacheService.cs:293-310` was already wrapped for `cacheKey`; line 276 was simply missed when the others were sanitized.

## Note on primitives

`int` / `bool` / server-side `Guid` arguments on these same log statements (`limit`, `savedOnly`, `session.User.Id`) remain **unwrapped**. CodeQL does not currently flag them as tainted, so they don't appear in the SARIF and the gate accepts them. If a future CodeQL version starts flagging primitives, we apply the same `.ToString()` wrap pattern.

## Validation

- ✅ Build: 0 errors, 0 warnings (`dotnet build --no-restore`)
- ✅ Pre-commit hooks passed (frontend lint + typecheck)
- ✅ No behavioral change — `Sanitize` is a no-op on already-clean inputs (Guid/path-id/cacheKey values do not contain `\r\n\t` in normal operation)

## Expected post-merge state

- Gate `Check cs/log-forging alert threshold` returns count = 0 on next main-dev push run
- The 4 dismissed alerts auto-transition from `dismissed` to `fixed` (or stay `dismissed`, harmless either way — SARIF level is what matters for the gate)

## Self-test

This PR's own `Security Scan` run will validate the gate empirically. If the gate still fails after this PR, more sites need wrapping; if it passes, the bundle (#1195 + this PR) closes the regression loop end-to-end.

## Refs

- Issue #1195 — parent (CI hardening bundle, closed via #1198)
- PR #1198 — bundle that introduced the gate
- Issue #1181 — sanitizer infrastructure parent epic
- ADR-058 — Canonical Log Sanitizers
- Run [25970767792](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25970767792) — empirical failure that surfaced these 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)