### PR TITLE
feat(security): #1196 CodeQL barrier probes + monthly verification

### DIFF
--- a/.github/codeql/codeql-config-with-probes.yml
+++ b/.github/codeql/codeql-config-with-probes.yml
@@ -1,0 +1,39 @@
+name: "MeepleAI CodeQL Configuration (with synthetic barrier probes)"
+description: |
+  Variant of codeql-config.yml used ONLY by .github/workflows/barrier-verification.yml
+  (issue #1196). The single difference from the default config is the absence of the
+  `apps/api/tests/CodeqlBarrierSmoke/**` exclude in paths-ignore, allowing the
+  synthetic probes to be analysed.
+  See docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md.
+
+disable-default-queries: false
+
+# Same MaD sanitizer pack load mechanism documented in codeql-config.yml.
+# Activation happens via CODEQL_ACTION_EXTRA_OPTIONS in barrier-verification.yml.
+
+query-filters:
+  - exclude:
+      id: cs/catch-of-all-exceptions
+
+# Probes deliberately scanned here — DO NOT add CodeqlBarrierSmoke to this list.
+paths-ignore:
+  - "**/Tests/**"
+  - "**/test/**"
+  - "**/obj/**"
+  - "**/bin/**"
+  - "**/*.Designer.cs"
+  - "**/Migrations/**"
+  - "**/node_modules/**"
+  - "**/dist/**"
+  - "**/.next/**"
+
+# Restrict scope to the probe project so the workflow stays fast and the SARIF
+# only contains alerts attributable to the synthetic file set.
+paths:
+  - apps/api/tests/CodeqlBarrierSmoke
+  - apps/api/src/Api/Helpers/LogSanitizer.cs
+  - apps/api/src/Api/Infrastructure/Security/DataMasking.cs
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -49,6 +49,13 @@ paths-ignore:
   - "**/node_modules/**"
   - "**/dist/**"
   - "**/.next/**"
+  # Issue #1196: synthetic CodeQL barrier probes (positive + negative).
+  # The lowercase `tests/` path does not match `**/Tests/**` on Linux runners
+  # (case-sensitive glob), so the probes need an explicit exclude here. They
+  # are intentionally scanned only by `.github/workflows/barrier-verification.yml`
+  # via `codeql-config-with-probes.yml`. See
+  # `docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md`.
+  - "apps/api/tests/CodeqlBarrierSmoke/**"
 
 # Paths to include in analysis
 paths:

--- a/.github/workflows/barrier-verification.yml
+++ b/.github/workflows/barrier-verification.yml
@@ -1,0 +1,181 @@
+name: CodeQL Barrier Verification
+
+# Issue #1196 — synthetic positive+negative probe verification for ADR-058 §5.
+# Runs monthly to assert:
+#   - sanitized probe produces 0 `cs/exposure-of-sensitive-information` alerts
+#     (barrier registration in MaD pack works)
+#   - unsanitized probe produces >=1 alert (the rule itself is alive)
+# See docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md
+
+on:
+  schedule:
+    # First day of every month at 04:00 UTC. Offset from security-scan.yml's
+    # Monday 02:00 UTC cron to avoid concurrent CodeQL action contention.
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Dump full SARIF probe-related rows to log'
+        required: false
+        default: 'false'
+        type: boolean
+  # Also run when the probes / config / workflow itself change so a PR can
+  # validate end-to-end before being merged.
+  pull_request:
+    paths:
+      - 'apps/api/tests/CodeqlBarrierSmoke/**'
+      - '.github/codeql/codeql-config-with-probes.yml'
+      - '.github/codeql/meepleai/sanitizers-extensions/**'
+      - '.github/workflows/barrier-verification.yml'
+
+concurrency:
+  group: barrier-verification-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  verify-barrier:
+    name: Verify CodeQL barrier probes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Regression-guard — assert probe files still exist
+        # If a future refactor accidentally deletes either probe file, fail
+        # loudly here rather than silently producing a green run.
+        run: |
+          set -euo pipefail
+          for probe in \
+            apps/api/tests/CodeqlBarrierSmoke/Probes/Sanitized.cs \
+            apps/api/tests/CodeqlBarrierSmoke/Probes/Unsanitized.cs; do
+            if [ ! -f "$probe" ]; then
+              echo "::error file=$probe::Synthetic barrier probe deleted — barrier verification cannot run. Restore the file or update docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md if removal is intentional."
+              exit 1
+            fi
+          done
+          echo "::notice::Both barrier probes present."
+
+      - name: Verify MaD sanitizer pack content
+        # Mirrors the gate in security-scan.yml. Expected count = 6 LogSanitizer
+        # rows + 8 DataMasking rows = 14. Bump deliberately when the pack grows.
+        env:
+          EXPECTED_PACK_ROWS: '14'
+        run: |
+          set -euo pipefail
+          pack_file=".github/codeql/meepleai/sanitizers-extensions/models/sanitizers.model.yml"
+          if [ ! -f "$pack_file" ]; then
+            echo "::error file=$pack_file::MaD sanitizer pack file missing — barrier coverage disabled"
+            exit 1
+          fi
+          actual=$(grep -cE '^\s*- \[' "$pack_file" || true)
+          if [ "$actual" -ne "$EXPECTED_PACK_ROWS" ]; then
+            echo "::error file=$pack_file::MaD barrier rowCount mismatch — expected=$EXPECTED_PACK_ROWS actual=$actual"
+            exit 1
+          fi
+          echo "::notice::MaD pack barrier rowCount OK: $actual"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+          queries: security-extended
+          # Variant config WITHOUT the CodeqlBarrierSmoke paths-ignore exclude.
+          config-file: ./.github/codeql/codeql-config-with-probes.yml
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore + Build probe project
+        working-directory: apps/api
+        run: |
+          sudo apt-get update && sudo apt-get install -y libgdiplus
+          dotnet restore tests/CodeqlBarrierSmoke/CodeqlBarrierSmoke.csproj
+          dotnet build tests/CodeqlBarrierSmoke/CodeqlBarrierSmoke.csproj --no-restore -c Release
+
+      - name: Perform CodeQL Analysis
+        id: codeql-analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:csharp-barrier-verification'
+          # Deterministic SARIF output path for the downstream assertion step.
+          output: ${{ runner.temp }}/codeql-sarif
+        env:
+          # Same pack-load mechanism as security-scan.yml (ADR-058 §1.4).
+          CODEQL_ACTION_EXTRA_OPTIONS: >-
+            {"database":{"run-queries":["--additional-packs=${{ github.workspace }}/.github/codeql","--extension-packs=meepleai/sanitizers-extensions"]}}
+
+      - name: Assert probe alert counts
+        env:
+          VERBOSE: ${{ inputs.verbose || 'false' }}
+        run: |
+          set -euo pipefail
+          sarif="${{ runner.temp }}/codeql-sarif/csharp.sarif"
+          if [ ! -f "$sarif" ]; then
+            echo "::error::SARIF not found at $sarif — CodeQL analyze step likely failed"
+            exit 1
+          fi
+
+          rule_id='cs/exposure-of-sensitive-information'
+
+          sanitized=$(jq --arg r "$rule_id" \
+            '[.runs[].results[]? | select(.ruleId == $r)
+              | select(.locations[0].physicalLocation.artifactLocation.uri
+                       | contains("CodeqlBarrierSmoke/Probes/Sanitized.cs"))] | length' "$sarif")
+
+          unsanitized=$(jq --arg r "$rule_id" \
+            '[.runs[].results[]? | select(.ruleId == $r)
+              | select(.locations[0].physicalLocation.artifactLocation.uri
+                       | contains("CodeqlBarrierSmoke/Probes/Unsanitized.cs"))] | length' "$sarif")
+
+          echo "::notice::Probe alert counts — sanitized=$sanitized unsanitized=$unsanitized"
+
+          if [ "$VERBOSE" = "true" ]; then
+            echo "----- Sanitized probe results -----"
+            jq --arg r "$rule_id" \
+              '[.runs[].results[]? | select(.ruleId == $r)
+                | select(.locations[0].physicalLocation.artifactLocation.uri | contains("CodeqlBarrierSmoke/Probes/Sanitized.cs"))]' "$sarif"
+            echo "----- Unsanitized probe results -----"
+            jq --arg r "$rule_id" \
+              '[.runs[].results[]? | select(.ruleId == $r)
+                | select(.locations[0].physicalLocation.artifactLocation.uri | contains("CodeqlBarrierSmoke/Probes/Unsanitized.cs"))]' "$sarif"
+          fi
+
+          failed=0
+          if [ "$sanitized" != "0" ]; then
+            echo "::error::Barrier broken — sanitized probe raised $sanitized alert(s). Investigate MaD pack registration (.github/codeql/meepleai/sanitizers-extensions/models/sanitizers.model.yml) and the pack-load mechanism in codeql-config-with-probes.yml."
+            failed=1
+          fi
+          if [ "$unsanitized" -lt 1 ]; then
+            echo "::error::Rule appears disabled — unsanitized probe raised 0 alerts. Check codeql-config-with-probes.yml query-filters and paths-ignore; verify cs/exposure-of-sensitive-information is still in security-extended."
+            failed=1
+          fi
+
+          if [ "$failed" -eq 1 ]; then
+            exit 1
+          fi
+          echo "::notice::Barrier verification PASSED."
+
+  notify-end:
+    if: always() && contains(join(needs.*.result, ','), 'failure')
+    needs: [verify-barrier]
+    uses: ./.github/workflows/notify-slack.yml
+    with:
+      event: failed
+      workflow_name: 'CodeQL Barrier Verification'
+      environment: security
+      is_critical: true
+      branch: ${{ github.head_ref || github.ref_name }}
+      actor: ${{ github.actor }}
+      commit_sha: ${{ github.sha }}
+      commit_message: ${{ github.event.head_commit.message || 'Scheduled run or manual trigger' }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_GITNOTIFY_WEBHOOK_URL: ${{ secrets.SLACK_GITNOTIFY_WEBHOOK_URL }}
+      SLACK_CRITICAL_WEBHOOK_URL: ${{ secrets.SLACK_CRITICAL_WEBHOOK_URL }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,5 +119,8 @@
     }
   },
   "postman.settings.dotenv-detection-notification-visibility": false,
-  "liveServer.settings.port": 5506
+  "liveServer.settings.port": 5506,
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main-dev"
+  ]
 }

--- a/apps/api/tests/CodeqlBarrierSmoke/CodeqlBarrierSmoke.csproj
+++ b/apps/api/tests/CodeqlBarrierSmoke/CodeqlBarrierSmoke.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <NoWarn>$(NoWarn);CA1848;CA2254</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Api\Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/api/tests/CodeqlBarrierSmoke/Probes/Sanitized.cs
+++ b/apps/api/tests/CodeqlBarrierSmoke/Probes/Sanitized.cs
@@ -1,0 +1,39 @@
+// =====================================================================
+// SYNTHETIC barrier verification probe — POSITIVE side.
+//
+// Purpose:
+//   Validate that the CodeQL MaD sanitizer pack
+//   (.github/codeql/meepleai/sanitizers-extensions/) recognises canonical
+//   sanitizer composition as a barrier for `cs/exposure-of-sensitive-information`.
+//
+// Expected outcome when the monthly `barrier-verification.yml` workflow runs:
+//   ZERO alerts produced from this file. A non-zero count means the barrier
+//   registration has silently regressed.
+//
+// DO NOT delete this file. DO NOT remove the sanitizer composition.
+// If a refactor needs to touch this code, update
+// `docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md` first.
+//
+// References:
+//   - ADR-058 §Acceptance bullet 5
+//   - Issue #1196
+// =====================================================================
+
+using Api.Helpers;
+using Api.Infrastructure.Security;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Tests.CodeqlBarrierSmoke.Probes;
+
+public static class Sanitized
+{
+    public static void Probe(ILogger logger, string email)
+    {
+        // BOTH masking (file-content-store barrier — PII confidentiality)
+        // AND log-forging stripping (log-injection barrier — CRLF safety).
+        // CodeQL barrierModel registrations must recognise this composition
+        // as safe for `cs/exposure-of-sensitive-information`.
+        var safe = LogSanitizer.Sanitize(DataMasking.MaskEmail(email));
+        logger.LogInformation("user email (masked): {Email}", safe);
+    }
+}

--- a/apps/api/tests/CodeqlBarrierSmoke/Probes/Unsanitized.cs
+++ b/apps/api/tests/CodeqlBarrierSmoke/Probes/Unsanitized.cs
@@ -1,0 +1,35 @@
+// =====================================================================
+// SYNTHETIC barrier verification probe — NEGATIVE side.
+//
+// Purpose:
+//   Validate that the CodeQL rule `cs/exposure-of-sensitive-information`
+//   is still alive and not globally disabled by drift in
+//   `.github/codeql/codeql-config.yml` query-filters or paths-ignore.
+//
+// Expected outcome when the monthly `barrier-verification.yml` workflow runs:
+//   AT LEAST ONE alert produced from this file. A zero count means the rule
+//   has silently been disabled / suppressed / excluded.
+//
+// DO NOT "fix" this code. The lack of sanitizer is INTENTIONAL.
+// DO NOT delete this file — the workflow's regression-guard step explicitly
+// asserts its presence and fails loudly if missing.
+//
+// References:
+//   - ADR-058 §Acceptance bullet 5
+//   - Issue #1196
+// =====================================================================
+
+using Microsoft.Extensions.Logging;
+
+namespace Api.Tests.CodeqlBarrierSmoke.Probes;
+
+public static class Unsanitized
+{
+    public static void Probe(ILogger logger, string email)
+    {
+        // INTENTIONAL violation — raw user-controlled email flows directly
+        // into a structured logger template without any sanitizer applied.
+        // CodeQL MUST flag this as `cs/exposure-of-sensitive-information`.
+        logger.LogInformation("user email (raw): {Email}", email);
+    }
+}

--- a/docs/for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md
+++ b/docs/for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md
@@ -190,7 +190,11 @@ Esecuzione segue le fasi già definite in #1181 (revised body 2026-05-15):
 ## References
 
 - Issue [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) — Phase 1 traccia l'esecuzione di questo ADR
+- Issue [#1196](https://github.com/meepleAi-app/meepleai-monorepo/issues/1196) — Barrier verification via synthetic probes (Acceptance bullet 5)
+- Spec [2026-05-17-codeql-barrier-probes.md](../../../for-developers/specs/2026-05-17-codeql-barrier-probes.md) — design Option C
+- Workflow `.github/workflows/barrier-verification.yml` — monthly cron + on-demand probe verification
 - Spec-panel session 2026-05-15 (memoria conversazione `/sc:spec-panel 1181`)
+- Spec-panel session 2026-05-16 (`/sc:spec-panel 1196`)
 - File esistenti:
   - `apps/api/src/Api/Infrastructure/Security/DataMasking.cs`
   - `apps/api/src/Api/Helpers/LogSanitizer.cs`

--- a/docs/for-developers/security/pii-safe-logging.md
+++ b/docs/for-developers/security/pii-safe-logging.md
@@ -189,6 +189,27 @@ If a class of false positives recurs (e.g. all `int` counts logged in a hot path
 
 ---
 
+## Barrier verification (#1196)
+
+The MaD sanitizer pack registration is itself a piece of configuration that can silently regress (paths-ignore drift, query-suite mismatch, pack-load failure — see PR #1188 for an instance where the pack appeared to load but didn't). To detect this, two synthetic probes under `apps/api/tests/CodeqlBarrierSmoke/Probes/` are exercised by `.github/workflows/barrier-verification.yml`:
+
+- **Sanitized.cs** — composes `LogSanitizer.Sanitize(DataMasking.MaskEmail(...))`. Expected to produce **zero** `cs/exposure-of-sensitive-information` alerts (barrier recognised).
+- **Unsanitized.cs** — logs a raw email. Expected to produce **≥1** alert (rule alive).
+
+The workflow runs **monthly** (first day of month, 04:00 UTC) and on demand via `workflow_dispatch`. If either expectation fails, Slack `#security` channel is paged.
+
+**To run on demand**:
+```bash
+gh workflow run barrier-verification.yml --field verbose=true
+gh run watch
+```
+
+The `verbose=true` input dumps the full SARIF probe-related rows so you can diagnose mismatches.
+
+**Do not delete or "fix" the probe files**. Their content is intentional. The workflow's first step asserts both files exist and fails loudly if either is missing. Design rationale lives in [`docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md`](../specs/2026-05-17-codeql-barrier-probes.md).
+
+---
+
 ## When the helpers are insufficient
 
 If you need to log a new PII category not covered (e.g. phone numbers, IBAN, physical addresses):

--- a/docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md
+++ b/docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md
@@ -1,0 +1,187 @@
+# CodeQL Barrier Verification — Synthetic Probes Design
+
+**Spec date**: 2026-05-17
+**Issue**: [#1196](https://github.com/meepleAi-app/meepleai-monorepo/issues/1196)
+**Parent ADR**: [ADR-058](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md) §Acceptance bullet 5
+**Spec-panel review**: 2026-05-16 (Wiegers, Adzic, Crispin, Fowler, Nygard)
+**Status**: Accepted
+
+## Problem
+
+ADR-058 §Acceptance bullet 5 requires empirical, periodic validation that the CodeQL barrier system is **alive on both sides**:
+
+- **Positive**: a sanitized log statement (`LogSanitizer.Sanitize(DataMasking.MaskEmail(...))`) produces **zero** `cs/exposure-of-sensitive-information` alerts → barrier recognition works
+- **Negative**: an unsanitized log statement (`_logger.LogInformation("{Email}", rawEmail)`) produces **at least one** alert → the rule is still active and not globally disabled
+
+Without continuous validation we cannot empirically distinguish between:
+1. The barrier is working perfectly, and
+2. The rule is silently inert (e.g. `paths-ignore` drift, MaD pack load failure, query-suite mismatch).
+
+The barrier infrastructure went through 8 empirical iterations in PR #1189 before pack-loading stabilised; nothing today prevents a similar silent regression.
+
+## Decision
+
+**Option C** (per spec-panel recommendation 2026-05-16): hybrid synthetic probes inside a dedicated test project, exercised by a separate workflow on a monthly cadence + on-demand `workflow_dispatch`.
+
+### Rejected alternatives
+
+| Option | Why rejected |
+|--------|--------------|
+| A — persistent synthetic file with `[SuppressMessage]` in production assembly | Synthetic code in production assembly is fragile (future refactor may delete it) and `[SuppressMessage]` hides the very signal the probe is meant to assert. |
+| B — documentation-only manual procedure | Empirically never executed in practice; relies on human memory which is the failure mode the barrier infrastructure already exhibited (#1188). |
+
+## Architecture
+
+### 1. Probe project
+
+A new test-tier C# project, never shipped to production:
+
+```
+apps/api/tests/CodeqlBarrierSmoke/
+├── CodeqlBarrierSmoke.csproj       # netstandard / net9.0, ProjectReference to Api.csproj
+└── Probes/
+    ├── Sanitized.cs                 # SHOULD produce 0 alerts (barrier verification)
+    └── Unsanitized.cs               # MUST produce ≥1 alert (rule alive verification)
+```
+
+Two-file split (vs single file with line-range markers) chosen because SARIF assertions filter by `physicalLocation.artifactLocation.uri` — robust against line shifts caused by future edits, comments, or formatting.
+
+### 2. CodeQL configuration split
+
+| File | Used by | Includes probes? |
+|------|---------|-------------------|
+| `.github/codeql/codeql-config.yml` | `security-scan.yml` (every PR + Monday cron) | **No** — adds explicit exclude `apps/api/tests/CodeqlBarrierSmoke/**` to `paths-ignore`. The pre-existing `**/Tests/**` exclude is case-sensitive on Linux runners and does not match the lowercase `tests/` directory. |
+| `.github/codeql/codeql-config-with-probes.yml` (new) | `barrier-verification.yml` only | **Yes** — clone of the default config without the probe exclude. |
+
+This avoids polluting normal PR scans with probe-induced alerts while letting the barrier-verification workflow surface them deliberately.
+
+### 3. Workflow `barrier-verification.yml`
+
+```yaml
+on:
+  schedule:
+    - cron: '0 4 1 * *'   # First day of month at 04:00 UTC (after the Monday 02:00 security-scan cron)
+  workflow_dispatch:       # Manual run for ad-hoc verification
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+```
+
+#### Job steps
+
+1. **Checkout**.
+2. **Regression guard for the regression guard**: assert both probe files still exist on disk. If a refactor accidentally deletes either, fail loudly here rather than silently producing a green run.
+3. **MaD pack rowCount verify** — same step as `security-scan.yml` (`EXPECTED_PACK_ROWS=14`).
+4. **Setup .NET 9.0** + `dotnet build apps/api/tests/CodeqlBarrierSmoke/`.
+5. **CodeQL init** with `config-file: ./.github/codeql/codeql-config-with-probes.yml`.
+6. **CodeQL analyze** with `CODEQL_ACTION_EXTRA_OPTIONS` injecting the MaD pack (same pattern as `security-scan.yml`).
+7. **Assertion step** — SARIF-based:
+
+```bash
+sarif="${{ runner.temp }}/codeql-sarif/csharp.sarif"
+rule_id="cs/exposure-of-sensitive-information"
+
+sanitized=$(jq --arg r "$rule_id" \
+  '[.runs[].results[]? | select(.ruleId == $r)
+   | select(.locations[0].physicalLocation.artifactLocation.uri
+            | contains("CodeqlBarrierSmoke/Probes/Sanitized.cs"))] | length' "$sarif")
+
+unsanitized=$(jq --arg r "$rule_id" \
+  '[.runs[].results[]? | select(.ruleId == $r)
+   | select(.locations[0].physicalLocation.artifactLocation.uri
+            | contains("CodeqlBarrierSmoke/Probes/Unsanitized.cs"))] | length' "$sarif")
+
+[[ "$sanitized" == "0" ]] || { echo "::error::Sanitized probe raised $sanitized alert(s) — barrier broken"; exit 1; }
+[[ "$unsanitized" -ge 1 ]] || { echo "::error::Unsanitized probe raised 0 alerts — rule appears disabled"; exit 1; }
+echo "::notice::Barrier verification OK: sanitized=0, unsanitized=$unsanitized"
+```
+
+8. **Slack notify on failure** — reuse `notify-slack.yml` pattern from `security-scan.yml`.
+
+### 4. Probe content
+
+#### Sanitized.cs (expected: 0 alerts)
+
+```csharp
+// SYNTHETIC barrier verification probe — see ADR-058 §5 + issue #1196.
+// Removing this file breaks the monthly barrier-verification workflow.
+namespace Api.Tests.CodeqlBarrierSmoke.Probes;
+
+public static class Sanitized
+{
+    public static void Probe(ILogger logger, string email)
+    {
+        // BOTH masking (file-content-store barrier) AND log-forging stripping
+        // applied → CodeQL must recognize this as safe.
+        var safe = LogSanitizer.Sanitize(DataMasking.MaskEmail(email));
+        logger.LogInformation("user email (masked): {Email}", safe);
+    }
+}
+```
+
+#### Unsanitized.cs (expected: ≥1 alert)
+
+```csharp
+// SYNTHETIC negative probe — raw user input flows into log statement.
+// MUST raise `cs/exposure-of-sensitive-information` for the rule to be considered alive.
+// Removing this file breaks the monthly barrier-verification workflow.
+namespace Api.Tests.CodeqlBarrierSmoke.Probes;
+
+public static class Unsanitized
+{
+    public static void Probe(ILogger logger, string email)
+    {
+        // INTENTIONAL violation — do not "fix" this. See ADR-058 §5.
+        logger.LogInformation("user email (raw): {Email}", email);
+    }
+}
+```
+
+## Acceptance mapping (issue #1196)
+
+| Acceptance bullet | Met by |
+|-------------------|--------|
+| Design doc with chosen option + paths-ignore flip mechanism | This document (Option C, config-file split). |
+| Synthetic probe file at appropriate location with comments | `Probes/Sanitized.cs` + `Probes/Unsanitized.cs` with header comments referencing ADR-058 §5 and #1196. |
+| Workflow `barrier-verification.yml` that runs probes and validates expected counts | New file, SARIF-based assertion logic above. |
+| Schedule: monthly cron | `cron: '0 4 1 * *'` — first day of month, 04:00 UTC. |
+| Failure case: probe file deleted → workflow fails | Step 2 (regression guard for the regression guard). |
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Future refactor "cleans up" the unsanitized probe (looks like a security bug) | Medium | Workflow turns green falsely | Header comment in file + regression-guard step that fails when file is missing |
+| Lowercase `tests/` collides with new directory containing real `Tests` content | Low | Probe accidentally scanned in default config | Exclude path is fully qualified `apps/api/tests/CodeqlBarrierSmoke/**`, not a glob |
+| MaD pack row count changes legitimately, breaking the rowCount gate | Low | Workflow fails | Bump `EXPECTED_PACK_ROWS` in this workflow when pack grows (same convention as `security-scan.yml`) |
+| Probe project builds break Api solution build | Low | Solution-wide build red | Project is standalone — only `ProjectReference` is to `Api.csproj`. Not added to default `dotnet test` discovery (no test classes). |
+| CodeQL CLI rule ID changes between versions | Low | Assertion silently misses | jq `select(.ruleId == "cs/exposure-of-sensitive-information")` is explicit; CodeQL CLI version is pinned via `codeql-action/init@v4` |
+
+## Out of scope
+
+- **`cs/log-forging` probes**: deferred to a follow-up. The MaD pack registers both `log-injection` and `file-content-store` barriers; the latter is the empirically validated kind (PR #1191). A `log-injection` probe can be added later as a 3rd/4th file under `Probes/`.
+- **Option D — Roslyn analyzer**: tracked separately in #1197 (marked Optional).
+- **Replacing the Monday `security-scan.yml`**: the barrier verification is a complement, not a replacement.
+
+## Implementation plan
+
+1. Spec doc (this file).
+2. `apps/api/tests/CodeqlBarrierSmoke/CodeqlBarrierSmoke.csproj` — minimal compile-only project.
+3. `Probes/Sanitized.cs` + `Probes/Unsanitized.cs`.
+4. Update `.github/codeql/codeql-config.yml` (add probe exclude).
+5. Add `.github/codeql/codeql-config-with-probes.yml` (clone without exclude).
+6. Add `.github/workflows/barrier-verification.yml`.
+7. Manual `workflow_dispatch` run on the PR branch to validate end-to-end before merge.
+8. Update ADR-058 references + `pii-safe-logging.md` with link to the new workflow.
+
+## References
+
+- [ADR-058](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md) — canonical log sanitizer strategy
+- [Issue #1196](https://github.com/meepleAi-app/meepleai-monorepo/issues/1196) — this work item
+- [Issue #1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) — closed parent (CodeQL high alerts cluster)
+- [PR #1189](https://github.com/meepleAi-app/meepleai-monorepo/pull/1189) — empirical MaD pack-load fix (8 iterations)
+- [PR #1191](https://github.com/meepleAi-app/meepleai-monorepo/pull/1191) — `file-content-store` barriers extended
+- `.github/workflows/security-scan.yml` — reference workflow for MaD pack load + SARIF gating patterns
+- `.github/codeql/meepleai/sanitizers-extensions/models/sanitizers.model.yml` — 14 barrier registrations


### PR DESCRIPTION
## Summary
- Implements ADR-058 §Acceptance bullet 5 via Option C (spec-panel 2026-05-16): two synthetic probes (`Sanitized.cs` + `Unsanitized.cs`) in a standalone test project, exercised by a new monthly workflow with a regression-guard for the probes themselves.
- Probe project is excluded from the default CodeQL config (the existing `**/Tests/**` glob is case-sensitive on Linux and does not match the lowercase `tests/` directory); a sibling `codeql-config-with-probes.yml` is used only by the new workflow to opt-in.
- ADR-058 + `pii-safe-logging.md` cross-referenced with the new spec doc and workflow.

## Acceptance criteria (#1196)
- Design doc: [`docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md`](docs/for-developers/specs/2026-05-17-codeql-barrier-probes.md)
- Synthetic probes with header comments explaining synthetic nature
- Workflow `.github/workflows/barrier-verification.yml` with SARIF-based assertion: sanitized=0, unsanitized≥1
- Schedule: `cron: '0 4 1 * *'` (first day of month 04:00 UTC) + `workflow_dispatch` + `pull_request` on probe/config changes
- Probe-file-deleted → workflow fails loudly via dedicated regression-guard step (regression guard for the regression guard)

## Test plan
- [ ] PR trigger fires `barrier-verification.yml` (paths-match — workflow itself is in the matched paths)
- [ ] `Sanitized.cs` raises 0 `cs/exposure-of-sensitive-information` alerts
- [ ] `Unsanitized.cs` raises ≥1 alert
- [x] Build of `CodeqlBarrierSmoke.csproj` is green (local: 0 errors, 1 benign EF Relational version-conflict warning)

## Out of scope
- `cs/log-forging` probes (deferred — current scope is `cs/exposure-of-sensitive-information` only per #1196 body)
- Roslyn analyzer alternative (#1197 — separate Optional issue)
- Replacing the Monday `security-scan.yml` cron — this is a complement, not a replacement

Closes #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)