### PR TITLE
feat(security): NoPiiInLogAnalyzer Phase 1 — MAI001 in-IDE PII feedback (refs #1197)

### DIFF
--- a/apps/api/MeepleAI.Api.sln
+++ b/apps/api/MeepleAI.Api.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34322.80
@@ -6,23 +7,77 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api", "src\Api\Api.csproj",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Tests", "tests\Api.Tests\Api.Tests.csproj", "{A36CE4F0-92C2-4566-9465-130CA35D2B5A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Analyzers", "src\Api.Analyzers\Api.Analyzers.csproj", "{E500A089-70B9-47D9-BF19-0D66C045C142}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Analyzers.Tests", "tests\Api.Analyzers.Tests\Api.Analyzers.Tests.csproj", "{E35B86E4-99C9-49FC-B88F-7A55B5894216}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|x64.Build.0 = Debug|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Debug|x86.Build.0 = Debug|Any CPU
 		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|x64.ActiveCfg = Release|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|x64.Build.0 = Release|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|x86.ActiveCfg = Release|Any CPU
+		{28449411-3901-4969-B5B4-C4E20A837CB7}.Release|x86.Build.0 = Release|Any CPU
 		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Debug|x86.Build.0 = Debug|Any CPU
 		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|x64.Build.0 = Release|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A36CE4F0-92C2-4566-9465-130CA35D2B5A}.Release|x86.Build.0 = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|x64.Build.0 = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Debug|x86.Build.0 = Debug|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|x64.ActiveCfg = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|x64.Build.0 = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|x86.ActiveCfg = Release|Any CPU
+		{E500A089-70B9-47D9-BF19-0D66C045C142}.Release|x86.Build.0 = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|x64.Build.0 = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Debug|x86.Build.0 = Debug|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|x64.ActiveCfg = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|x64.Build.0 = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|x86.ActiveCfg = Release|Any CPU
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E500A089-70B9-47D9-BF19-0D66C045C142} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{E35B86E4-99C9-49FC-B88F-7A55B5894216} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0EAD6C43-6C9B-4CAD-8647-C95F3F8EAB74}

--- a/apps/api/src/Api.Analyzers/Api.Analyzers.csproj
+++ b/apps/api/src/Api.Analyzers/Api.Analyzers.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      Roslyn analyzers must target netstandard2.0 because they are loaded into the
+      MSBuild process (which runs on .NET Framework or the .NET runtime that ships
+      with the .NET SDK) and netstandard2.0 is the lowest-common-denominator that
+      both runtimes can load.
+    -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>Api.Analyzers</RootNamespace>
+    <AssemblyName>Api.Analyzers</AssemblyName>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!--
+      Suppress missing-XML-doc warnings (1591) and analyzer release tracking
+      (RS2008). Release tracking is opt-in; we document MAI001 in
+      docs/for-developers/security/pii-safe-logging.md and ADR-058 instead.
+      Reconsider RS2008 if the analyzer accumulates 3+ rules.
+    -->
+    <NoWarn>$(NoWarn);1591;RS2008</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Microsoft.CodeAnalysis.CSharp.Workspaces 4.8.0 is the latest stable release
+      that ships with the .NET 9 SDK toolchain (Roslyn 4.8.x). Pinning explicitly
+      so future .NET SDK upgrades surface incompatibilities via build errors
+      rather than silent ABI drift. Update only when the .NET SDK version bumps.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/apps/api/src/Api.Analyzers/NoPiiInLogAnalyzer.cs
+++ b/apps/api/src/Api.Analyzers/NoPiiInLogAnalyzer.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Api.Analyzers;
+
+/// <summary>
+/// MAI001 — flags <c>ILogger.Log*</c> calls whose message template contains a
+/// PII-suggesting placeholder (e.g. <c>{Email}</c>, <c>{Token}</c>) and whose
+/// corresponding argument is NOT wrapped via the canonical PII masking sanitizer
+/// <c>Api.Infrastructure.Security.DataMasking.Mask*</c>.
+///
+/// ADR-058 distinguishes two orthogonal concerns:
+///   - Integrity (log-forging, CWE-117) → <c>Api.Helpers.LogSanitizer.Sanitize</c>
+///   - Confidentiality (PII exposure, CWE-359) → <c>Api.Infrastructure.Security.DataMasking.Mask*</c>
+///
+/// Phase 1 (this PR) implements Tier 3 detection (placeholder name match). Tiers 1 (typed VOs)
+/// and 2 (parameter name heuristic) are deferred to future PRs per issue #1197.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoPiiInLogAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "MAI001";
+
+    private const string Title = "PII argument logged without canonical masking";
+    private const string MessageFormat = "Log placeholder '{{{0}}}' suggests PII content; wrap argument with DataMasking.Mask* (ADR-058)";
+    private const string Category = "Security";
+    private const string Description =
+        "Per ADR-058 / docs/for-developers/security/pii-safe-logging.md, PII fields " +
+        "(email, password, token, phone, SSN, IP address) must be masked via " +
+        "Api.Infrastructure.Security.DataMasking.Mask* before being logged. " +
+        "Note: Api.Helpers.LogSanitizer.Sanitize is for log-forging integrity (CWE-117) " +
+        "and is NOT a valid PII masker (CWE-359).";
+    private const string HelpLinkUri = "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/security/pii-safe-logging.md";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description,
+        helpLinkUri: HelpLinkUri);
+
+    /// <summary>
+    /// Placeholder names that suggest the corresponding argument is PII.
+    /// Match is case-insensitive. Extending this list is allowed without an ADR
+    /// change as long as the new placeholder is unambiguously PII (no false-positive
+    /// risk from non-PII semantics). For ambiguous names see Tier 2 (Phase 2+).
+    /// </summary>
+    private static readonly ImmutableHashSet<string> PiiPlaceholderNames =
+        ImmutableHashSet.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
+        {
+            "Email",
+            "EmailAddress",
+            "Password",
+            "Token",
+            "Jwt",
+            "JwtToken",
+            "Phone",
+            "PhoneNumber",
+            "Ssn",
+            "IpAddress",
+        });
+
+    private const string DataMaskingTypeName = "Api.Infrastructure.Security.DataMasking";
+    private const string MaskMethodPrefix = "Mask";
+
+    private const string LoggerExtensionsTypeName = "Microsoft.Extensions.Logging.LoggerExtensions";
+    private const string LoggerInterfaceTypeName = "Microsoft.Extensions.Logging.ILogger";
+
+    /// <summary>
+    /// Matches log message template placeholders. Microsoft.Extensions.Logging uses
+    /// Serilog-style brace placeholders; we accept the same grammar (alphanumeric +
+    /// underscore identifier, optionally prefixed by <c>@</c> or <c>$</c> for
+    /// destructured / stringified hints which we ignore for matching).
+    /// </summary>
+    private static readonly Regex PlaceholderRegex = new(
+        @"\{[@$]?(?<name>[A-Za-z_][A-Za-z0-9_]*)(?:[,:][^}]*)?\}",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+
+        if (!IsLoggerLogCall(method))
+        {
+            return;
+        }
+
+        var templateLiteral = ExtractMessageTemplateLiteral(invocation);
+        if (templateLiteral is null)
+        {
+            return;
+        }
+
+        var piiPositions = FindPiiPlaceholderPositions(templateLiteral);
+        if (piiPositions.Count == 0)
+        {
+            return;
+        }
+
+        var argValues = ExtractParamsArgumentValues(invocation);
+        if (argValues.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var (name, index) in piiPositions)
+        {
+            if (index >= argValues.Length)
+            {
+                continue;
+            }
+
+            var argOp = argValues[index];
+            if (IsWrappedByDataMasking(argOp))
+            {
+                continue;
+            }
+
+            var location = argOp.Syntax?.GetLocation() ?? invocation.Syntax.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(Rule, location, name));
+        }
+    }
+
+    private static bool IsLoggerLogCall(IMethodSymbol method)
+    {
+        if (method.Name.Length < 4 || !method.Name.StartsWith("Log", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var containingType = method.ContainingType;
+        if (containingType is null)
+        {
+            return false;
+        }
+
+        var containingDisplay = containingType.ToDisplayString();
+        if (string.Equals(containingDisplay, LoggerExtensionsTypeName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Direct ILogger.Log(...) calls (less common but valid).
+        if (string.Equals(containingDisplay, LoggerInterfaceTypeName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string? ExtractMessageTemplateLiteral(IInvocationOperation invocation)
+    {
+        // LoggerExtensions.Log* signatures consistently expose the template as the
+        // parameter named "message". Falling back to any constant-string argument
+        // would risk false positives on overloads that take a non-template string.
+        foreach (var arg in invocation.Arguments)
+        {
+            if (arg.Parameter is null)
+            {
+                continue;
+            }
+
+            if (!string.Equals(arg.Parameter.Name, "message", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // The argument value may be wrapped in implicit conversions.
+            var value = UnwrapConversions(arg.Value);
+            if (value.ConstantValue.HasValue && value.ConstantValue.Value is string template)
+            {
+                return template;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<(string Name, int Index)> FindPiiPlaceholderPositions(string template)
+    {
+        var result = new List<(string, int)>();
+        var matches = PlaceholderRegex.Matches(template);
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var name = matches[i].Groups["name"].Value;
+            if (PiiPlaceholderNames.Contains(name))
+            {
+                result.Add((name, i));
+            }
+        }
+
+        return result;
+    }
+
+    private static ImmutableArray<IOperation> ExtractParamsArgumentValues(IInvocationOperation invocation)
+    {
+        foreach (var arg in invocation.Arguments)
+        {
+            if (arg.Parameter is null || !arg.Parameter.IsParams)
+            {
+                continue;
+            }
+
+            var value = UnwrapConversions(arg.Value);
+            if (value is IArrayCreationOperation array)
+            {
+                return array.Initializer?.ElementValues ?? ImmutableArray<IOperation>.Empty;
+            }
+        }
+
+        return ImmutableArray<IOperation>.Empty;
+    }
+
+    private static bool IsWrappedByDataMasking(IOperation operation)
+    {
+        var unwrapped = UnwrapConversions(operation);
+        if (unwrapped is not IInvocationOperation invocation)
+        {
+            return false;
+        }
+
+        var method = invocation.TargetMethod;
+        if (!method.Name.StartsWith(MaskMethodPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var containingType = method.ContainingType?.ToDisplayString();
+        return string.Equals(containingType, DataMaskingTypeName, StringComparison.Ordinal);
+    }
+
+    private static IOperation UnwrapConversions(IOperation operation)
+    {
+        var current = operation;
+        while (current is IConversionOperation conversion)
+        {
+            current = conversion.Operand;
+        }
+
+        return current;
+    }
+}

--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -8,6 +8,15 @@
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--
+      Issue #1197 (ADR-058 DX): MAI001 from the in-house NoPiiInLogAnalyzer is
+      a developer-experience signal, not an enforcement gate. CodeQL on PR/push
+      is the authoritative enforcement (issue #1195 FU#1 gate, threshold 0).
+      Keep MAI001 as a build warning so it shows in IDE / PR check logs but
+      does NOT fail builds (Roslyn analyzer is meant to be advisory; CodeQL
+      stays authoritative).
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);MAI001</WarningsNotAsErrors>
     <!-- Living Documentation: Generate XML documentation file for API -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Suppress warnings: 1591=missing XML comments, code quality warnings temporarily disabled for build -->
@@ -32,6 +41,18 @@
     <InternalsVisibleTo Include="Api.Tests" />
     <!-- Required for Moq to create proxies of internal types in generic contexts (e.g., ILogger<InternalService>) -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <!--
+    Issue #1197 — wire the in-house NoPiiInLogAnalyzer (MAI001) as a build-time
+    analyzer. ADR-058 + docs/for-developers/security/pii-safe-logging.md.
+    OutputItemType="Analyzer" + ReferenceOutputAssembly="false" attaches the
+    project as an analyzer without pulling its assembly into Api's output.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Api.Analyzers\Api.Analyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.413" />

--- a/apps/api/tests/Api.Analyzers.Tests/Api.Analyzers.Tests.csproj
+++ b/apps/api/tests/Api.Analyzers.Tests/Api.Analyzers.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Api.Analyzers.Tests</RootNamespace>
+    <!--
+      Tests are isolated from the Api.csproj analyzer suite (Sonar/Net/Meziantou)
+      to keep the analyzer focus on what THIS project tests, not on test-suite
+      cleanliness. Mirror the codebase NoWarn list for the analyzers that DO
+      run by default.
+    -->
+    <NoWarn>$(NoWarn);1591;xUnit1000;xUnit1051;CA1707;CA1711;CA2007;CA2000;CS0060;MA0048</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!--
+      Roslyn analyzer testing uses the same packages the analyzer itself
+      depends on (Microsoft.CodeAnalysis.CSharp 4.8.0). We assert diagnostics
+      directly via CSharpCompilation.WithAnalyzers, without an external
+      verifier framework — Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit
+      1.1.2 (latest stable) pins Roslyn 1.0.1 transitively which conflicts
+      with the analyzer's 4.8.0 binding. Direct API usage avoids the conflict.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Api.Analyzers\Api.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/api/tests/Api.Analyzers.Tests/NoPiiInLogAnalyzerTests.cs
+++ b/apps/api/tests/Api.Analyzers.Tests/NoPiiInLogAnalyzerTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Api.Analyzers.Tests;
+
+/// <summary>
+/// Snapshot tests for <see cref="NoPiiInLogAnalyzer"/> (MAI001).
+///
+/// Each test inlines a self-contained mock of <c>Microsoft.Extensions.Logging</c> and
+/// <c>Api.Infrastructure.Security.DataMasking</c> so the suite does not depend on the
+/// production assembly. The analyzer matches by fully-qualified type name, so the
+/// inline types must use the same FQN as the real ones.
+///
+/// We invoke the analyzer through <see cref="CompilationWithAnalyzers"/> directly to
+/// avoid pulling in the Microsoft.CodeAnalysis.Testing.* packages, whose 1.1.x branch
+/// pins Roslyn 1.0.1 and conflicts with our 4.8.0 binding.
+/// </summary>
+public sealed class NoPiiInLogAnalyzerTests
+{
+    private const string SharedShimSource = """
+        namespace Microsoft.Extensions.Logging
+        {
+            public interface ILogger { }
+            public static class LoggerExtensions
+            {
+                public static void LogInformation(this ILogger logger, string message, params object[] args) { }
+                public static void LogWarning(this ILogger logger, string message, params object[] args) { }
+                public static void LogError(this ILogger logger, string message, params object[] args) { }
+                public static void LogDebug(this ILogger logger, string message, params object[] args) { }
+            }
+        }
+        namespace Api.Infrastructure.Security
+        {
+            public static class DataMasking
+            {
+                public static string MaskEmail(string? value) => string.Empty;
+                public static string MaskString(string? value, int maxLength = 4) => string.Empty;
+                public static string MaskJwt(string? value) => string.Empty;
+                public static string MaskIpAddress(string? value) => string.Empty;
+            }
+        }
+        namespace Api.Helpers
+        {
+            public static class LogSanitizer
+            {
+                public static string Sanitize(string? value) => string.Empty;
+            }
+        }
+        """;
+
+    /// <summary>Positive case: unwrapped Email placeholder must flag MAI001.</summary>
+    [Fact]
+    public async Task EmailPlaceholder_UnwrappedString_ReportsMAI001()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string userEmail)
+                    {
+                        logger.LogInformation("User logged in: {Email}", userEmail);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleMaiDiagnostic(diagnostics, expectedPlaceholderName: "Email");
+    }
+
+    /// <summary>Positive case: unwrapped Token placeholder must flag MAI001.</summary>
+    [Fact]
+    public async Task TokenPlaceholder_UnwrappedString_ReportsMAI001()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string accessToken)
+                    {
+                        logger.LogDebug("Issued JWT: {Token}", accessToken);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleMaiDiagnostic(diagnostics, expectedPlaceholderName: "Token");
+    }
+
+    /// <summary>Positive case: unwrapped Phone placeholder must flag MAI001.</summary>
+    [Fact]
+    public async Task PhonePlaceholder_UnwrappedString_ReportsMAI001()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string callerPhone)
+                    {
+                        logger.LogWarning("Verification SMS sent to {Phone}", callerPhone);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleMaiDiagnostic(diagnostics, expectedPlaceholderName: "Phone");
+    }
+
+    /// <summary>Negative case: DataMasking.MaskEmail wrap must NOT flag.</summary>
+    [Fact]
+    public async Task EmailPlaceholder_WrappedWithMaskEmail_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.Infrastructure.Security;
+                public class C
+                {
+                    public void M(ILogger logger, string userEmail)
+                    {
+                        logger.LogInformation("User logged in: {Email}", DataMasking.MaskEmail(userEmail));
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    /// <summary>Negative case: DataMasking.MaskJwt wrap on Token placeholder must NOT flag.</summary>
+    [Fact]
+    public async Task TokenPlaceholder_WrappedWithMaskJwt_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.Infrastructure.Security;
+                public class C
+                {
+                    public void M(ILogger logger, string accessToken)
+                    {
+                        logger.LogDebug("Issued JWT: {Token}", DataMasking.MaskJwt(accessToken));
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    /// <summary>
+    /// Negative case: a non-PII placeholder (e.g. {SessionId}) must NOT flag even when
+    /// the argument is unwrapped. Phase 1 only watches the curated PII list; SessionId
+    /// is intentionally NOT on it (Tier 2/3 will revisit identifier handling).
+    /// </summary>
+    [Fact]
+    public async Task NonPiiPlaceholder_UnwrappedString_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string sessionId)
+                    {
+                        logger.LogInformation("Session {SessionId} created", sessionId);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Runtime.CompilerServices.RuntimeHelpers).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var compileDiagnostics = compilation.GetDiagnostics();
+        var compileErrors = compileDiagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToImmutableArray();
+        if (!compileErrors.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                "Inline test source did not compile cleanly. Errors:\n  " +
+                string.Join("\n  ", compileErrors.Select(d => d.ToString())));
+        }
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new NoPiiInLogAnalyzer());
+        var withAnalyzers = compilation.WithAnalyzers(analyzers);
+        return await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+    }
+
+    private static void AssertSingleMaiDiagnostic(ImmutableArray<Diagnostic> diagnostics, string expectedPlaceholderName)
+    {
+        var maiDiagnostics = diagnostics
+            .Where(d => string.Equals(d.Id, NoPiiInLogAnalyzer.DiagnosticId, StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        Assert.Single(maiDiagnostics);
+        Assert.Contains($"'{{{expectedPlaceholderName}}}'", maiDiagnostics[0].GetMessage());
+    }
+
+    private static void AssertNoMaiDiagnostics(ImmutableArray<Diagnostic> diagnostics)
+    {
+        var maiDiagnostics = diagnostics
+            .Where(d => string.Equals(d.Id, NoPiiInLogAnalyzer.DiagnosticId, StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        Assert.Empty(maiDiagnostics);
+    }
+}

--- a/docs/for-developers/security/pii-safe-logging.md
+++ b/docs/for-developers/security/pii-safe-logging.md
@@ -1,8 +1,18 @@
 # PII-Safe Logging Conventions
 
-**Status**: active — enforced by CodeQL Models-as-Data pack + `Security Scan` workflow on every PR to `main-dev`/`main-staging`/`main`
+**Status**: active — enforced by CodeQL Models-as-Data pack + `Security Scan` workflow on every PR/push to `main-dev`/`main-staging`/`main`, with in-IDE feedback via the `Api.Analyzers.NoPiiInLogAnalyzer` Roslyn analyzer (MAI001).
 
-**See also**: [ADR-058 — Canonical Log Sanitizers](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md), issue [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181)
+**See also**: [ADR-058 — Canonical Log Sanitizers](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md), issues [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) (sanitizer infrastructure), [#1195](https://github.com/meepleAi-app/meepleai-monorepo/issues/1195) (CI hardening), [#1197](https://github.com/meepleAi-app/meepleai-monorepo/issues/1197) (Roslyn analyzer).
+
+## In-IDE feedback (MAI001)
+
+`Api.Analyzers.NoPiiInLogAnalyzer` runs at build time and emits diagnostic **MAI001** when it detects an `ILogger.Log*` call whose message template contains a PII-suggesting placeholder name (e.g. `{Email}`, `{Password}`, `{Token}`, `{Phone}`, `{Ssn}`, `{IpAddress}`) and the corresponding positional argument is NOT wrapped via the canonical `Api.Infrastructure.Security.DataMasking.Mask*` family.
+
+The analyzer is **advisory only** — the warning is mapped via `<WarningsNotAsErrors>MAI001</WarningsNotAsErrors>` in `Api.csproj` so it never fails a build. The authoritative gate stays the CodeQL `cs/log-forging` threshold check in `security-scan.yml` (issue #1195 FU#1). Treat the IDE warning as a developer convenience: fix at write-time, do not rely on it for security enforcement.
+
+**Phase 1 scope (current)**: Tier 3 detection — placeholder name match only, exact placeholder list above. Tier 1 (typed value objects: `Email`, `JwtToken`, etc.) and Tier 2 (parameter-name heuristic) and the auto-fix CodeFixProvider are tracked as Phase 2/3/4 follow-ups on issue #1197.
+
+**Important — `LogSanitizer.Sanitize` is NOT a PII barrier**: it strips `\r\n\t` for log-forging (CWE-117 integrity), not PII content (CWE-359 confidentiality). The analyzer correctly flags a call wrapped via `LogSanitizer.Sanitize` if the placeholder name suggests PII. Use `DataMasking.Mask*` for PII.
 
 ---
 


### PR DESCRIPTION
## Phase 1 of #1197

Implements the **skeleton + Tier 3 detection** phase of the Roslyn analyzer from the spec-panel review on issue #1197. Phase 2 (typed VO + heuristic), Phase 3 (CodeFixProvider auto-wrap), and Phase 4 (NuGet packaging) are deferred to separate PRs on the same issue.

The analyzer is **advisory-only** — `WarningsNotAsErrors=MAI001` in `Api.csproj` keeps the diagnostic out of the build-failure path. The authoritative enforcement remains the CodeQL `cs/log-forging` threshold gate delivered in PR #1198 (issue #1195 FU#1). Roslyn analyzer = developer-experience feedback before commit; CodeQL = post-PR security enforcement.

## What's delivered

### New project: `Api.Analyzers`
- `apps/api/src/Api.Analyzers/Api.Analyzers.csproj` — netstandard2.0, `IsRoslynComponent=true`, pinned to `Microsoft.CodeAnalysis.CSharp.Workspaces` **4.8.0** (matching the Roslyn that ships with the .NET 9 SDK).
- `NoPiiInLogAnalyzer.cs` — `DiagnosticAnalyzer` registering **MAI001** (severity: Warning). Tier 3 detection: matches `ILogger.Log*` calls whose message template contains a PII-suggesting placeholder name and whose corresponding positional argument is NOT a call to `Api.Infrastructure.Security.DataMasking.Mask*`.

**Placeholder set (case-insensitive)**: `Email`, `EmailAddress`, `Password`, `Token`, `Jwt`, `JwtToken`, `Phone`, `PhoneNumber`, `Ssn`, `IpAddress`.

### New test project: `Api.Analyzers.Tests`
- 6 snapshot scenarios:
  - 3 **positive** (must flag): `{Email}` / `{Token}` / `{Phone}` with unwrapped argument
  - 3 **negative** (must NOT flag): `DataMasking.MaskEmail` / `DataMasking.MaskJwt` wrap + non-PII placeholder
- Uses `CSharpCompilation.WithAnalyzers` directly (no `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` — its 1.1.2 release pins Roslyn 1.0.1 and conflicts with the analyzer's 4.8.0 binding; rationale documented inline in the csproj).
- **6/6 tests pass in 1.04s**.

### Build integration
- `Api.csproj` references `Api.Analyzers` via `<ProjectReference OutputItemType=\"Analyzer\" ReferenceOutputAssembly=\"false\" />` so the analyzer attaches at build time without polluting the runtime assembly.
- `<WarningsNotAsErrors>$(WarningsNotAsErrors);MAI001</WarningsNotAsErrors>` ensures the warning surfaces in IDE / build output without failing CI builds. Rationale documented inline.

### Documentation
- `docs/for-developers/security/pii-safe-logging.md`: new \"In-IDE feedback (MAI001)\" section explaining scope, advisory nature, and the critical distinction that `LogSanitizer.Sanitize` is an integrity sanitizer for log-forging (CWE-117), NOT a confidentiality sanitizer for PII (CWE-359) — the analyzer correctly flags `LogSanitizer.Sanitize(user.Email)` because it's the wrong tool for the job.

## Out of scope (Phase 2+)

| Phase | Scope | Tracked |
|---|---|---|
| 2 | Tier 1 (typed VO detection: `Email`, `JwtToken`, etc.) + Tier 2 (parameter-name heuristic) | #1197 follow-up |
| 3 | `CodeFixProvider` auto-wrap suggestions | #1197 follow-up |
| 4 | NuGet packaging + `Directory.Build.targets` integration | #1197 follow-up |
| edge | `using static` form recognition + method-group invocation barrier | #1197 follow-up |

## First-run findings (NOT fixed in this PR)

On the first build of `Api.csproj` with the analyzer wired, the warning list surfaces **10 real positives** in production code — log statements with PII-suggesting placeholders whose argument is not wrapped via `DataMasking`:

| File | Line | Placeholder |
|---|---|---|
| `SendUserEmailCommandHandler.cs` | 53 | `{Email}` |
| `StagingAllowlistCacheInvalidator.cs` | 31, 38 | `{Email}` |
| `EmailVerificationMiddleware.cs` | 119 | `{Email}` |
| `InvitationCleanupService.cs` | 125 | `{Email}` |
| `TwoFactorEnforcementBehavior.cs` | 84 | `{Email}` |
| `AccessRequestCreatedEventHandler.cs` | 28 | `{Email}` |
| `AccessRequestApprovedEventHandler.cs` | 52 | `{Email}` |
| `InitiateOAuthLoginCommandHandler.cs` | 47 | `{IpAddress}` |
| `GetSharedLibraryQueryHandler.cs` | 45 | `{Token}` |

None block the build (`WarningsNotAsErrors=MAI001`). I'll open a separate tracking issue for the remediation PR — they look like genuine candidates for `DataMasking.Mask*` wraps but each deserves a per-site decision (some are admin-context audit log lines where the email is the subject, see ADR-058 decision tree).

## Validation

- ✅ `dotnet build src/Api.Analyzers/` → 0 errors, 0 warnings (RS2008 suppressed inline with rationale)
- ✅ `dotnet build src/Api/` → 0 errors, 10 MAI001 warnings (advisory, expected)
- ✅ `dotnet test tests/Api.Analyzers.Tests/` → **6/6 passed in 1.04s**
- ✅ YAML syntax of unchanged workflows verified
- ✅ Pre-commit hooks passed (frontend lint + typecheck)

## Acceptance

- [ ] Phase 1 PR merged (this PR)
- [ ] Follow-up issue opened for the 10 first-run positives (separate remediation PR)
- [ ] Phase 2/3/4 left open on #1197 for future iteration

## Refs

- Issue #1197 — parent (Roslyn analyzer plan, deferred per ADR-058 OR-semantics, now Phase 1 delivered)
- Issue #1181 — sanitizer infrastructure parent epic
- ADR-058 — Canonical Log Sanitizers
- PR #1198 — CodeQL gate (authoritative enforcement; this analyzer is advisory)
- PR #1199 — wrapped pre-existing call sites under the CodeQL gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)