### PR TITLE
fix(security): wrap 10 MAI001 first-run positives with DataMasking (closes #1202)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SendUserEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/SendUserEmailCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Administration.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure.Security;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
@@ -50,7 +51,7 @@ internal sealed class SendUserEmailCommandHandler : IRequestHandler<SendUserEmai
         // NOTE: Email service integration pending - email infrastructure not yet available
         // Placeholder implementation: logs action for audit trail
         _logger.LogInformation("Email would be sent to {Email}: Subject='{Subject}'",
-            user.Email.Value, command.Subject);
+            DataMasking.MaskEmail(user.Email.Value), command.Subject);
 
         // Create audit log for the action
         var auditLog = new Api.BoundedContexts.Administration.Domain.Entities.AuditLog(

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/StagingAllowlistCacheInvalidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/StagingAllowlistCacheInvalidator.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Administration.Domain.Events;
 using Api.BoundedContexts.Authentication.Application.Services;
+using Api.Infrastructure.Security;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -28,14 +29,14 @@ internal sealed class StagingAllowlistCacheInvalidator
     public Task Handle(StagingAllowlistEntryAddedEvent notification, CancellationToken cancellationToken)
     {
         _guard.InvalidateCache();
-        _logger.LogDebug("Staging allowlist cache invalidated after add of {Email}", notification.Email);
+        _logger.LogDebug("Staging allowlist cache invalidated after add of {Email}", DataMasking.MaskEmail(notification.Email));
         return Task.CompletedTask;
     }
 
     public Task Handle(StagingAllowlistEntryRemovedEvent notification, CancellationToken cancellationToken)
     {
         _guard.InvalidateCache();
-        _logger.LogDebug("Staging allowlist cache invalidated after removal of {Email}", notification.Email);
+        _logger.LogDebug("Staging allowlist cache invalidated after removal of {Email}", DataMasking.MaskEmail(notification.Email));
         return Task.CompletedTask;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Api.BoundedContexts.Authentication.Application.Attributes;
 using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.Infrastructure.Security;
 using MediatR;
 
 namespace Api.BoundedContexts.Authentication.Application.Behaviors;
@@ -81,7 +82,7 @@ internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipel
             _logger.LogWarning(
                 "TwoFactorEnforcementBehavior[shadow]: user {UserId} ({Email}) invoked 2FA-required command "
                 + "{CommandType} WITHOUT 2FA enabled. Reason: {Reason}. MaxAge: {MaxAgeMinutes}min",
-                user.Id, user.Email, typeof(TRequest).Name, attr.Reason ?? "(unspecified)", attr.MaxAgeMinutes);
+                user.Id, DataMasking.MaskEmail(user.Email), typeof(TRequest).Name, attr.Reason ?? "(unspecified)", attr.MaxAgeMinutes);
         }
         else
         {

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/OAuth/InitiateOAuthLoginCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/OAuth/InitiateOAuthLoginCommandHandler.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Api.Infrastructure.Security;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using MediatR;
@@ -44,7 +45,7 @@ internal sealed class InitiateOAuthLoginCommandHandler : ICommandHandler<Initiat
 
             _logger.LogInformation("OAuth login initiated for provider {Provider}, IP: {IpAddress}",
                 provider,
-                command.IpAddress ?? "unknown");
+                DataMasking.MaskIpAddress(command.IpAddress ?? "unknown"));
 
             return new InitiateOAuthLoginResult
             {

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
 using Api.BoundedContexts.Authentication.Domain.Events;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Security;
 using Api.SharedKernel.Application.EventHandlers;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -49,7 +50,7 @@ internal sealed class AccessRequestApprovedEventHandler : DomainEventHandlerBase
         {
             Logger.LogError(ex,
                 "Failed to create invitation for approved access request {AccessRequestId}, email {Email}",
-                domainEvent.AccessRequestId, domainEvent.Email);
+                domainEvent.AccessRequestId, DataMasking.MaskEmail(domainEvent.Email));
             // Approval stands. Admin can resend via invitation UI.
         }
     }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
@@ -25,7 +25,7 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
     {
         Logger.LogInformation(
             "New access request {AccessRequestId} created for email {Email}",
-            domainEvent.AccessRequestId, domainEvent.Email);
+            domainEvent.AccessRequestId, DataMasking.MaskEmail(domainEvent.Email));
 
         try
         {

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetSharedLibraryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetSharedLibraryQueryHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.UserLibrary.Application.DTOs;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
+using Api.Infrastructure.Security;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -42,7 +43,7 @@ internal class GetSharedLibraryQueryHandler : IQueryHandler<GetSharedLibraryQuer
 
         if (shareLink == null)
         {
-            _logger.LogDebug("Share link not found for token: {Token}", query.ShareToken);
+            _logger.LogDebug("Share link not found for token: {Token}", DataMasking.MaskString(query.ShareToken, 8));
             return null;
         }
 

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InvitationCleanupService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InvitationCleanupService.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.Infrastructure;
+using Api.Infrastructure.Security;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -122,7 +123,7 @@ internal sealed class InvitationCleanupService : BackgroundService
 
                 _logger.LogInformation(
                     "Cleaned up expired pending user {UserId} ({Email})",
-                    expiredUser.Id, expiredUser.Email);
+                    expiredUser.Id, DataMasking.MaskEmail(expiredUser.Email));
             }
             catch (Exception ex)
             {

--- a/apps/api/src/Api/Middleware/EmailVerificationMiddleware.cs
+++ b/apps/api/src/Api/Middleware/EmailVerificationMiddleware.cs
@@ -1,4 +1,5 @@
 using Api.Extensions;
+using Api.Infrastructure.Security;
 using System.Text.Json;
 
 namespace Api.Middleware;
@@ -116,7 +117,7 @@ internal class EmailVerificationMiddleware
             _logger.LogWarning(
                 "Blocking request for unverified user {UserId} (email: {Email}, grace period ended: {GracePeriodEnded})",
                 user.Id,
-                user.Email,
+                DataMasking.MaskEmail(user.Email),
                 gracePeriodEndsAt?.ToString("O") ?? "never set");
 
             return new


### PR DESCRIPTION
## Closes #1202

PR #1201 introduced the `NoPiiInLogAnalyzer` (MAI001) in advisory mode. On the first build of `Api.csproj` with the analyzer wired, **10 production log statements** were flagged for PII placeholders (`{Email}` / `{IpAddress}` / `{Token}`) whose arguments were NOT wrapped via `Api.Infrastructure.Security.DataMasking`.

Each site was individually reviewed against the **ADR-058 decision tree**. All 10 are legitimate operational/diagnostic log statements where the PII context is informational (not the audit-record subject), so the canonical remediation is a per-site `DataMasking.Mask*` wrap.

## Sites wrapped

| # | File:line | Mask method | Rationale |
|---|-----------|-------------|-----------|
| 1 | `SendUserEmailCommandHandler.cs:53` | `MaskEmail(user.Email.Value)` | Admin email-send placeholder log |
| 2 | `StagingAllowlistCacheInvalidator.cs:31` | `MaskEmail(notification.Email)` | Cache invalidation on allowlist-add event |
| 3 | `StagingAllowlistCacheInvalidator.cs:38` | `MaskEmail(notification.Email)` | Same handler, allowlist-remove path |
| 4 | `EmailVerificationMiddleware.cs:119` | `MaskEmail(user.Email)` | Per-request gate log for unverified-user denial |
| 5 | `InvitationCleanupService.cs:125` | `MaskEmail(expiredUser.Email)` | Background cleanup of expired invitation |
| 6 | `TwoFactorEnforcementBehavior.cs:84` | `MaskEmail(user.Email)` | Shadow-mode 2FA telemetry |
| 7 | `AccessRequestCreatedEventHandler.cs:28` | `MaskEmail(domainEvent.Email)` | Access request creation log |
| 8 | `AccessRequestApprovedEventHandler.cs:52` | `MaskEmail(domainEvent.Email)` | Approval failure-path error log |
| 9 | `InitiateOAuthLoginCommandHandler.cs:47` | `MaskIpAddress(command.IpAddress ?? \"unknown\")` | OAuth initiation telemetry |
| 10 | `GetSharedLibraryQueryHandler.cs:45` | `MaskString(query.ShareToken, 8)` | Share-link not-found debug log (truncates to first 8 chars) |

## Pattern applied

- **8 files** received a new `using Api.Infrastructure.Security;` directive
  - `AccessRequestCreatedEventHandler.cs` already had it (so no import change)
- Each log call has **exactly one** argument expression wrapped — the one MAI001 identified as the tainted PII path. Other arguments (`Guid` Ids, `CommandType` typeof strings, etc.) remain unwrapped because they were not flagged.
- `MaskEmail` handles `null` gracefully (returns empty string), so no NRE risk introduced for entity properties exposing nullable email strings.

## Validation

- ✅ `dotnet build src/Api/Api.csproj` → **0 errors, 0 warnings** (was 10 MAI001 warnings before this PR)
- ✅ Pre-commit hooks: frontend lint + typecheck passed
- ✅ No behavioral change in log message templates (placeholders unchanged); only the substituted value is masked at log-emit time

## Why not refactor to `AuditService`?

ADR-058 decision tree distinguishes:
- **Operational logs** (debug/info/warn/error for ops consumption) → mask in place via `DataMasking.Mask*`
- **Audit events** (compliance event records) → route to dedicated `AuditService.LogAsync` pipeline

All 10 sites are operational: they describe a system event in which the email/IP/token is informational *context*, not the audit-record subject. Refactoring them to `AuditService` would lose per-request diagnostic value with no compliance gain.

## Acceptance

- [x] All 10 MAI001 warnings closed (build evidence above)
- [x] Each wrap matches the placeholder semantics (`MaskEmail` for `{Email}`, `MaskIpAddress` for `{IpAddress}`, `MaskString` for opaque `{Token}`)
- [x] No behavioral change to log message templates or log levels
- [ ] Post-merge CodeQL re-run on `main-dev` confirms no new `cs/log-forging` or `cs/exposure-of-sensitive-information` alerts surface

## Refs

- Issue #1202 — parent (this PR closes it)
- PR #1201 — introduced MAI001, surfaced these 10 sites
- ADR-058 — Canonical Log Sanitizers
- `docs/for-developers/security/pii-safe-logging.md` — decision tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)