### PR TITLE
fix(docs): repair broken fragment in ADR-054 (#disk-space → #docker-maintenance)

### DIFF
--- a/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
@@ -61,7 +61,7 @@ Concrete operational rules:
 
 ### Negative
 
-- **Co-tenancy fragility**: the dev workstation hosting both `make dev` and `make staging` can race for ports / RAM if pruning discipline lapses (see [Staging disk space memory](../../../../docs/for-developers/operations/operations-manual.md#disk-space) and the related ops notes about cleaning images before rebuilds). Accepted for beta scale.
+- **Co-tenancy fragility**: the dev workstation hosting both `make dev` and `make staging` can race for ports / RAM if pruning discipline lapses (see [Docker Maintenance](../../../../docs/for-developers/operations/operations-manual.md#docker-maintenance) and the related ops notes about cleaning images before rebuilds). Accepted for beta scale.
 - **CI complexity**: four workflow files instead of one is more to maintain. Mitigation: each file has a clear scope (fast PR, async post-merge, staging deploy, prod deploy) and shared steps live in reusable workflows.
 - **Three branches to keep in sync**: drift between `main-staging` and `main` is possible if hotfixes land directly on `main`. Mitigation: hotfixes also fast-forward back into `main-staging` and `main-dev` in the same PR series.
 


### PR DESCRIPTION
## Summary
Lychee Docs Link Check has been failing on main-dev since at least 07:08 UTC ([run id 25985982996](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/25985982996) and earlier), all reporting the same broken fragment:

\`\`\`
docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
  → docs/for-developers/operations/operations-manual.md#disk-space
Cannot find fragment: #disk-space not found in document
\`\`\`

## Root cause
The \`#disk-space\` anchor never existed in \`operations-manual.md\`. The reference in ADR-054 was likely written speculatively or against a renamed section.

## Fix
Repoint the link to \`#docker-maintenance\` — the \`### Docker Maintenance\` section at line 230 of \`operations-manual.md\` contains the \`docker system prune\` commands relevant to the ADR's "pruning discipline lapses" context. No other reasonable target exists in the document.

## Test plan
- [ ] Lychee link check passes on this PR
- [ ] Link is clickable from rendered ADR

## Refs
- ADR-054 (epic #842 — DevOps Multi-Branch Strategy)
- Discovered while sweeping post-merge state after PR #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)