### PR TITLE
feat(security): NoPiiInLogAnalyzer Phase 2 — Tier 1 (MAI002) + Tier 2 (MAI003) detection (refs #1197)

### DIFF
--- a/apps/api/src/Api.Analyzers/NoPiiInLogAnalyzer.cs
+++ b/apps/api/src/Api.Analyzers/NoPiiInLogAnalyzer.cs
@@ -10,49 +10,77 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Api.Analyzers;
 
 /// <summary>
-/// MAI001 — flags <c>ILogger.Log*</c> calls whose message template contains a
-/// PII-suggesting placeholder (e.g. <c>{Email}</c>, <c>{Token}</c>) and whose
-/// corresponding argument is NOT wrapped via the canonical PII masking sanitizer
-/// <c>Api.Infrastructure.Security.DataMasking.Mask*</c>.
+/// Flags <c>ILogger.Log*</c> calls whose argument is PII-suggesting and is NOT wrapped via
+/// the canonical PII masking sanitizer <c>Api.Infrastructure.Security.DataMasking.Mask*</c>.
+///
+/// Three tiers of detection (in priority order; one diagnostic per argument):
+///   - <b>Tier 3 — MAI001</b>: log template placeholder name matches a curated PII set
+///     (e.g. <c>{Email}</c>, <c>{Token}</c>). Phase 1.
+///   - <b>Tier 1 — MAI002</b>: argument type fully-qualified name matches a known PII
+///     value-object list (Email / PasswordHash / SessionToken / TotpSecret / BackupCode).
+///     Phase 2a.
+///   - <b>Tier 2 — MAI003</b>: argument is an identifier reference (parameter / local /
+///     field / property) whose name matches a heuristic PII name set (email, password,
+///     token, phone, ssn, ipAddress, …). Phase 2b — highest false-positive risk; severity
+///     stays Warning + WarningsNotAsErrors so it does not fail builds.
 ///
 /// ADR-058 distinguishes two orthogonal concerns:
 ///   - Integrity (log-forging, CWE-117) → <c>Api.Helpers.LogSanitizer.Sanitize</c>
 ///   - Confidentiality (PII exposure, CWE-359) → <c>Api.Infrastructure.Security.DataMasking.Mask*</c>
 ///
-/// Phase 1 (this PR) implements Tier 3 detection (placeholder name match). Tiers 1 (typed VOs)
-/// and 2 (parameter name heuristic) are deferred to future PRs per issue #1197.
+/// CodeFixProvider auto-wrap (Phase 3) and NuGet packaging (Phase 4) are deferred per #1197.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class NoPiiInLogAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "MAI001";
+    public const string TypedVoDiagnosticId = "MAI002";
+    public const string HeuristicNameDiagnosticId = "MAI003";
 
-    private const string Title = "PII argument logged without canonical masking";
-    private const string MessageFormat = "Log placeholder '{{{0}}}' suggests PII content; wrap argument with DataMasking.Mask* (ADR-058)";
     private const string Category = "Security";
-    private const string Description =
+    private const string HelpLinkUri = "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/security/pii-safe-logging.md";
+    private const string SharedDescription =
         "Per ADR-058 / docs/for-developers/security/pii-safe-logging.md, PII fields " +
         "(email, password, token, phone, SSN, IP address) must be masked via " +
         "Api.Infrastructure.Security.DataMasking.Mask* before being logged. " +
         "Note: Api.Helpers.LogSanitizer.Sanitize is for log-forging integrity (CWE-117) " +
         "and is NOT a valid PII masker (CWE-359).";
-    private const string HelpLinkUri = "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/security/pii-safe-logging.md";
 
-    private static readonly DiagnosticDescriptor Rule = new(
+    private static readonly DiagnosticDescriptor Mai001Rule = new(
         DiagnosticId,
-        Title,
-        MessageFormat,
+        title: "PII argument logged without canonical masking (placeholder match)",
+        messageFormat: "Log placeholder '{{{0}}}' suggests PII content; wrap argument with DataMasking.Mask* (ADR-058)",
         Category,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: Description,
+        description: SharedDescription,
+        helpLinkUri: HelpLinkUri);
+
+    private static readonly DiagnosticDescriptor Mai002Rule = new(
+        TypedVoDiagnosticId,
+        title: "PII typed value object logged without canonical masking",
+        messageFormat: "Argument of type '{0}' is a PII value object; wrap with DataMasking.Mask* before logging (ADR-058)",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: SharedDescription,
+        helpLinkUri: HelpLinkUri);
+
+    private static readonly DiagnosticDescriptor Mai003Rule = new(
+        HeuristicNameDiagnosticId,
+        title: "Likely PII argument logged without canonical masking (name heuristic)",
+        messageFormat: "Argument identifier '{0}' likely contains PII; wrap with DataMasking.Mask* (heuristic; if false-positive, rename arg or [SuppressMessage] with justification) (ADR-058)",
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: SharedDescription,
         helpLinkUri: HelpLinkUri);
 
     /// <summary>
-    /// Placeholder names that suggest the corresponding argument is PII.
+    /// Tier 3 — Placeholder names that suggest the corresponding argument is PII.
     /// Match is case-insensitive. Extending this list is allowed without an ADR
     /// change as long as the new placeholder is unambiguously PII (no false-positive
-    /// risk from non-PII semantics). For ambiguous names see Tier 2 (Phase 2+).
+    /// risk from non-PII semantics).
     /// </summary>
     private static readonly ImmutableHashSet<string> PiiPlaceholderNames =
         ImmutableHashSet.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
@@ -67,6 +95,40 @@ public sealed class NoPiiInLogAnalyzer : DiagnosticAnalyzer
             "PhoneNumber",
             "Ssn",
             "IpAddress",
+        });
+
+    /// <summary>
+    /// Tier 1 — Fully-qualified type names whose runtime instances are known PII.
+    /// Curated against <c>Api.BoundedContexts.Authentication.Domain.ValueObjects/</c>.
+    /// Extending this list requires explicit review (add a new VO only if it
+    /// represents PII content, not arbitrary identifiers).
+    /// </summary>
+    private static readonly ImmutableHashSet<string> Tier1PiiTypes =
+        ImmutableHashSet.CreateRange(StringComparer.Ordinal, new[]
+        {
+            "Api.BoundedContexts.Authentication.Domain.ValueObjects.Email",
+            "Api.BoundedContexts.Authentication.Domain.ValueObjects.PasswordHash",
+            "Api.BoundedContexts.Authentication.Domain.ValueObjects.SessionToken",
+            "Api.BoundedContexts.Authentication.Domain.ValueObjects.TotpSecret",
+            "Api.BoundedContexts.Authentication.Domain.ValueObjects.BackupCode",
+        });
+
+    /// <summary>
+    /// Tier 2 — Identifier names (parameter / local / field / property) that the
+    /// heuristic treats as PII. Curated to keep false-positive rate low; if a real
+    /// name should match (e.g. <c>jwtSignature</c>) we add it explicitly rather than
+    /// loosening the regex. <c>OrdinalIgnoreCase</c> covers both camelCase and PascalCase.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> Tier2PiiNames =
+        ImmutableHashSet.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
+        {
+            "email", "emailAddress", "userEmail", "user_email",
+            "password", "userPassword", "newPassword", "oldPassword", "currentPassword",
+            "token", "accessToken", "refreshToken", "apiToken", "authToken",
+            "jwt", "jwtToken", "bearerToken",
+            "phone", "phoneNumber", "userPhone",
+            "ssn",
+            "ipAddress", "remoteIp", "clientIp",
         });
 
     private const string DataMaskingTypeName = "Api.Infrastructure.Security.DataMasking";
@@ -85,7 +147,7 @@ public sealed class NoPiiInLogAnalyzer : DiagnosticAnalyzer
         @"\{[@$]?(?<name>[A-Za-z_][A-Za-z0-9_]*)(?:[,:][^}]*)?\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Mai001Rule, Mai002Rule, Mai003Rule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -109,40 +171,91 @@ public sealed class NoPiiInLogAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var templateLiteral = ExtractMessageTemplateLiteral(invocation);
-        if (templateLiteral is null)
-        {
-            return;
-        }
-
-        var piiPositions = FindPiiPlaceholderPositions(templateLiteral);
-        if (piiPositions.Count == 0)
-        {
-            return;
-        }
-
         var argValues = ExtractParamsArgumentValues(invocation);
         if (argValues.IsDefaultOrEmpty)
         {
             return;
         }
 
-        foreach (var (name, index) in piiPositions)
-        {
-            if (index >= argValues.Length)
-            {
-                continue;
-            }
+        var templateLiteral = ExtractMessageTemplateLiteral(invocation);
+        var piiPositions = templateLiteral is null
+            ? null
+            : FindPiiPlaceholderPositions(templateLiteral);
 
-            var argOp = argValues[index];
+        for (var i = 0; i < argValues.Length; i++)
+        {
+            var argOp = argValues[i];
             if (IsWrappedByDataMasking(argOp))
             {
                 continue;
             }
 
-            var location = argOp.Syntax?.GetLocation() ?? invocation.Syntax.GetLocation();
-            context.ReportDiagnostic(Diagnostic.Create(Rule, location, name));
+            // Tier 3 — placeholder name match. Highest priority: when both the
+            // template and the argument are PII-suggesting, the template signal is
+            // the most actionable for the user.
+            var placeholderName = ResolvePiiPlaceholderAt(piiPositions, i);
+            if (placeholderName is not null)
+            {
+                ReportDiagnostic(context, Mai001Rule, argOp, placeholderName);
+                continue;
+            }
+
+            // Tier 1 — typed PII value object as argument.
+            var unwrapped = UnwrapConversions(argOp);
+            var typeFqn = unwrapped.Type?.ToDisplayString();
+            if (typeFqn is not null && Tier1PiiTypes.Contains(typeFqn))
+            {
+                ReportDiagnostic(context, Mai002Rule, argOp, typeFqn);
+                continue;
+            }
+
+            // Tier 2 — identifier name heuristic.
+            var identifierName = GetReferencedIdentifierName(unwrapped);
+            if (identifierName is not null && Tier2PiiNames.Contains(identifierName))
+            {
+                ReportDiagnostic(context, Mai003Rule, argOp, identifierName);
+            }
         }
+    }
+
+    private static void ReportDiagnostic(
+        OperationAnalysisContext context,
+        DiagnosticDescriptor rule,
+        IOperation argOp,
+        string messageArg)
+    {
+        var location = argOp.Syntax?.GetLocation() ?? context.Operation.Syntax.GetLocation();
+        context.ReportDiagnostic(Diagnostic.Create(rule, location, messageArg));
+    }
+
+    private static string? GetReferencedIdentifierName(IOperation operation)
+    {
+        return operation switch
+        {
+            IParameterReferenceOperation parameter => parameter.Parameter.Name,
+            ILocalReferenceOperation local => local.Local.Name,
+            IFieldReferenceOperation field => field.Field.Name,
+            IPropertyReferenceOperation property => property.Property.Name,
+            _ => null,
+        };
+    }
+
+    private static string? ResolvePiiPlaceholderAt(List<(string Name, int Index)>? positions, int argIndex)
+    {
+        if (positions is null)
+        {
+            return null;
+        }
+
+        foreach (var (name, index) in positions)
+        {
+            if (index == argIndex)
+            {
+                return string.IsNullOrEmpty(name) ? null : name;
+            }
+        }
+
+        return null;
     }
 
     private static bool IsLoggerLogCall(IMethodSymbol method)

--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -9,14 +9,20 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--
-      Issue #1197 (ADR-058 DX): MAI001 from the in-house NoPiiInLogAnalyzer is
-      a developer-experience signal, not an enforcement gate. CodeQL on PR/push
-      is the authoritative enforcement (issue #1195 FU#1 gate, threshold 0).
-      Keep MAI001 as a build warning so it shows in IDE / PR check logs but
-      does NOT fail builds (Roslyn analyzer is meant to be advisory; CodeQL
-      stays authoritative).
+      Issue #1197 (ADR-058 DX): MAI001/MAI002/MAI003 from the in-house
+      NoPiiInLogAnalyzer are developer-experience signals, not enforcement
+      gates. CodeQL on PR/push is the authoritative enforcement (issue #1195
+      FU#1 gate, threshold 0). Keep the analyzer diagnostics as build warnings
+      so they show in IDE / PR check logs but do NOT fail builds. Roslyn
+      analyzer is meant to be advisory; CodeQL stays authoritative.
+
+      Tier mapping (Phase 1 + 2):
+        - MAI001 (Tier 3): placeholder name match — Phase 1.
+        - MAI002 (Tier 1): argument is a typed PII value object — Phase 2a.
+        - MAI003 (Tier 2): argument identifier name heuristic — Phase 2b
+          (highest false-positive risk; reduce or [SuppressMessage] per-site).
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);MAI001</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);MAI001;MAI002;MAI003</WarningsNotAsErrors>
     <!-- Living Documentation: Generate XML documentation file for API -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Suppress warnings: 1591=missing XML comments, code quality warnings temporarily disabled for build -->

--- a/apps/api/tests/Api.Analyzers.Tests/NoPiiInLogAnalyzerTests.cs
+++ b/apps/api/tests/Api.Analyzers.Tests/NoPiiInLogAnalyzerTests.cs
@@ -52,6 +52,21 @@ public sealed class NoPiiInLogAnalyzerTests
                 public static string Sanitize(string? value) => string.Empty;
             }
         }
+        // Tier 1 — typed PII value objects. FQN must match the Tier1PiiTypes
+        // hashset in NoPiiInLogAnalyzer.
+        namespace Api.BoundedContexts.Authentication.Domain.ValueObjects
+        {
+            public sealed class Email { public string Value => string.Empty; }
+            public sealed class PasswordHash { public string Value => string.Empty; }
+            public sealed class SessionToken { public string Value => string.Empty; }
+            public sealed class TotpSecret { public string Value => string.Empty; }
+            public sealed class BackupCode { public string Value => string.Empty; }
+        }
+        // A non-PII VO used to assert MAI002 does not fire on unrelated types.
+        namespace Api.SharedKernel.Domain.ValueObjects
+        {
+            public sealed class Role { public string Value => string.Empty; }
+        }
         """;
 
     /// <summary>Positive case: unwrapped Email placeholder must flag MAI001.</summary>
@@ -198,6 +213,265 @@ public sealed class NoPiiInLogAnalyzerTests
         AssertNoMaiDiagnostics(diagnostics);
     }
 
+    // -------------------------------------------------------------------------
+    // Phase 2a — Tier 1 (typed PII value object detection, MAI002)
+    // -------------------------------------------------------------------------
+
+    /// <summary>Positive: Email VO logged unwrapped → MAI002.</summary>
+    [Fact]
+    public async Task TypedVo_Email_UnwrappedArg_ReportsMAI002()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+                public class C
+                {
+                    public void M(ILogger logger, Email email)
+                    {
+                        logger.LogInformation("Sign-in attempt: {Subject}", email);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleTypedVoDiagnostic(diagnostics, "Api.BoundedContexts.Authentication.Domain.ValueObjects.Email");
+    }
+
+    /// <summary>Positive: PasswordHash VO logged unwrapped → MAI002.</summary>
+    [Fact]
+    public async Task TypedVo_PasswordHash_UnwrappedArg_ReportsMAI002()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+                public class C
+                {
+                    public void M(ILogger logger, PasswordHash hash)
+                    {
+                        logger.LogError("Auth failed for hash {HashRepr}", hash);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleTypedVoDiagnostic(diagnostics, "Api.BoundedContexts.Authentication.Domain.ValueObjects.PasswordHash");
+    }
+
+    /// <summary>Positive: SessionToken VO logged unwrapped → MAI002.</summary>
+    [Fact]
+    public async Task TypedVo_SessionToken_UnwrappedArg_ReportsMAI002()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+                public class C
+                {
+                    public void M(ILogger logger, SessionToken token)
+                    {
+                        logger.LogDebug("Issued session {Subject}", token);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleTypedVoDiagnostic(diagnostics, "Api.BoundedContexts.Authentication.Domain.ValueObjects.SessionToken");
+    }
+
+    /// <summary>Negative: Email VO wrapped via DataMasking.MaskEmail(email.Value) does NOT flag.</summary>
+    [Fact]
+    public async Task TypedVo_Email_WrappedViaValueAccess_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+                using Api.Infrastructure.Security;
+                public class C
+                {
+                    public void M(ILogger logger, Email email)
+                    {
+                        logger.LogInformation("Sign-in attempt: {Subject}", DataMasking.MaskEmail(email.Value));
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    /// <summary>Negative: non-PII VO (Role) logged unwrapped does NOT flag MAI002.</summary>
+    [Fact]
+    public async Task TypedVo_NonPiiRole_UnwrappedArg_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.SharedKernel.Domain.ValueObjects;
+                public class C
+                {
+                    public void M(ILogger logger, Role role)
+                    {
+                        logger.LogInformation("Role assigned: {Role}", role);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2b — Tier 2 (identifier name heuristic, MAI003)
+    // -------------------------------------------------------------------------
+
+    /// <summary>Positive: parameter named 'password' logged unwrapped → MAI003.</summary>
+    [Fact]
+    public async Task HeuristicName_Password_UnwrappedArg_ReportsMAI003()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string password)
+                    {
+                        logger.LogWarning("Validating credentials: {Credential}", password);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleHeuristicNameDiagnostic(diagnostics, "password");
+    }
+
+    /// <summary>Positive: parameter named 'accessToken' (camelCase) → MAI003.</summary>
+    [Fact]
+    public async Task HeuristicName_AccessToken_UnwrappedArg_ReportsMAI003()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string accessToken)
+                    {
+                        logger.LogDebug("Issued credential: {Credential}", accessToken);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertSingleHeuristicNameDiagnostic(diagnostics, "accessToken");
+    }
+
+    /// <summary>Negative: parameter named 'sessionId' (not in PII heuristic set) does NOT flag.</summary>
+    [Fact]
+    public async Task HeuristicName_SessionId_UnwrappedArg_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string sessionId)
+                    {
+                        logger.LogInformation("Session active: {SessionId}", sessionId);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    /// <summary>Negative: param 'phoneNumber' wrapped via DataMasking.MaskString does NOT flag.</summary>
+    [Fact]
+    public async Task HeuristicName_PhoneNumber_Wrapped_DoesNotFlag()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                using Api.Infrastructure.Security;
+                public class C
+                {
+                    public void M(ILogger logger, string phoneNumber)
+                    {
+                        logger.LogInformation("SMS target: {Subject}", DataMasking.MaskString(phoneNumber));
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        AssertNoMaiDiagnostics(diagnostics);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tier priority — Tier 3 (placeholder) wins over Tier 1 / Tier 2
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the placeholder is PII-suggesting AND the argument identifier name is also
+    /// PII-suggesting, only MAI001 (Tier 3) should fire — the placeholder signal is the
+    /// most actionable cue for the developer.
+    /// </summary>
+    [Fact]
+    public async Task TierPriority_PlaceholderAndIdentifierBothPii_ReportsMAI001Only()
+    {
+        var source = SharedShimSource + """
+
+            namespace SubjectUnderTest
+            {
+                using Microsoft.Extensions.Logging;
+                public class C
+                {
+                    public void M(ILogger logger, string email)
+                    {
+                        logger.LogInformation("Sign-in: {Email}", email);
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAnalyzerAsync(source).ConfigureAwait(false);
+        var mai001 = diagnostics.Where(d => d.Id == NoPiiInLogAnalyzer.DiagnosticId).ToImmutableArray();
+        var mai002 = diagnostics.Where(d => d.Id == NoPiiInLogAnalyzer.TypedVoDiagnosticId).ToImmutableArray();
+        var mai003 = diagnostics.Where(d => d.Id == NoPiiInLogAnalyzer.HeuristicNameDiagnosticId).ToImmutableArray();
+
+        Assert.Single(mai001);
+        Assert.Empty(mai002);
+        Assert.Empty(mai003);
+    }
+
     private static async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(string source)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
@@ -241,10 +515,32 @@ public sealed class NoPiiInLogAnalyzerTests
 
     private static void AssertNoMaiDiagnostics(ImmutableArray<Diagnostic> diagnostics)
     {
-        var maiDiagnostics = diagnostics
-            .Where(d => string.Equals(d.Id, NoPiiInLogAnalyzer.DiagnosticId, StringComparison.Ordinal))
+        var allMai = diagnostics
+            .Where(d => d.Id is NoPiiInLogAnalyzer.DiagnosticId
+                or NoPiiInLogAnalyzer.TypedVoDiagnosticId
+                or NoPiiInLogAnalyzer.HeuristicNameDiagnosticId)
             .ToImmutableArray();
 
-        Assert.Empty(maiDiagnostics);
+        Assert.Empty(allMai);
+    }
+
+    private static void AssertSingleTypedVoDiagnostic(ImmutableArray<Diagnostic> diagnostics, string expectedTypeFqn)
+    {
+        var hits = diagnostics
+            .Where(d => string.Equals(d.Id, NoPiiInLogAnalyzer.TypedVoDiagnosticId, StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        Assert.Single(hits);
+        Assert.Contains(expectedTypeFqn, hits[0].GetMessage());
+    }
+
+    private static void AssertSingleHeuristicNameDiagnostic(ImmutableArray<Diagnostic> diagnostics, string expectedIdentifier)
+    {
+        var hits = diagnostics
+            .Where(d => string.Equals(d.Id, NoPiiInLogAnalyzer.HeuristicNameDiagnosticId, StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        Assert.Single(hits);
+        Assert.Contains($"'{expectedIdentifier}'", hits[0].GetMessage());
     }
 }

--- a/docs/for-developers/security/pii-safe-logging.md
+++ b/docs/for-developers/security/pii-safe-logging.md
@@ -1,18 +1,24 @@
 # PII-Safe Logging Conventions
 
-**Status**: active — enforced by CodeQL Models-as-Data pack + `Security Scan` workflow on every PR/push to `main-dev`/`main-staging`/`main`, with in-IDE feedback via the `Api.Analyzers.NoPiiInLogAnalyzer` Roslyn analyzer (MAI001).
+**Status**: active — enforced by CodeQL Models-as-Data pack + `Security Scan` workflow on every PR/push to `main-dev`/`main-staging`/`main`, with in-IDE feedback via the `Api.Analyzers.NoPiiInLogAnalyzer` Roslyn analyzer (MAI001 / MAI002 / MAI003).
 
 **See also**: [ADR-058 — Canonical Log Sanitizers](../../for-claude/architecture/adr/adr-058-canonical-log-sanitizers.md), issues [#1181](https://github.com/meepleAi-app/meepleai-monorepo/issues/1181) (sanitizer infrastructure), [#1195](https://github.com/meepleAi-app/meepleai-monorepo/issues/1195) (CI hardening), [#1197](https://github.com/meepleAi-app/meepleai-monorepo/issues/1197) (Roslyn analyzer).
 
-## In-IDE feedback (MAI001)
+## In-IDE feedback (MAI001 / MAI002 / MAI003)
 
-`Api.Analyzers.NoPiiInLogAnalyzer` runs at build time and emits diagnostic **MAI001** when it detects an `ILogger.Log*` call whose message template contains a PII-suggesting placeholder name (e.g. `{Email}`, `{Password}`, `{Token}`, `{Phone}`, `{Ssn}`, `{IpAddress}`) and the corresponding positional argument is NOT wrapped via the canonical `Api.Infrastructure.Security.DataMasking.Mask*` family.
+`Api.Analyzers.NoPiiInLogAnalyzer` runs at build time and emits three diagnostics across complementary detection tiers. All three are **advisory only** — mapped via `<WarningsNotAsErrors>MAI001;MAI002;MAI003</WarningsNotAsErrors>` in `Api.csproj` so they never fail a build. The authoritative gate stays the CodeQL `cs/log-forging` threshold check in `security-scan.yml` (issue #1195 FU#1).
 
-The analyzer is **advisory only** — the warning is mapped via `<WarningsNotAsErrors>MAI001</WarningsNotAsErrors>` in `Api.csproj` so it never fails a build. The authoritative gate stays the CodeQL `cs/log-forging` threshold check in `security-scan.yml` (issue #1195 FU#1). Treat the IDE warning as a developer convenience: fix at write-time, do not rely on it for security enforcement.
+| Diagnostic | Tier | Detection rule | Phase |
+|---|---|---|---|
+| **MAI001** | Tier 3 | Log message template contains a PII-suggesting placeholder (`{Email}`, `{Password}`, `{Token}`, `{Phone}`, `{Ssn}`, `{IpAddress}`, …) and the corresponding positional argument is NOT wrapped via `DataMasking.Mask*`. | Phase 1 |
+| **MAI002** | Tier 1 | Argument is an instance of a known PII *value object* type (curated list: `Email`, `PasswordHash`, `SessionToken`, `TotpSecret`, `BackupCode`). | Phase 2a |
+| **MAI003** | Tier 2 | Argument is an identifier reference (parameter / local / field / property) whose name matches a PII heuristic set (`email`, `password`, `token`, `phone`, `ssn`, `ipAddress`, …). Highest false-positive risk; rename the variable or `[SuppressMessage]` with justification when the heuristic is wrong. | Phase 2b |
 
-**Phase 1 scope (current)**: Tier 3 detection — placeholder name match only, exact placeholder list above. Tier 1 (typed value objects: `Email`, `JwtToken`, etc.) and Tier 2 (parameter-name heuristic) and the auto-fix CodeFixProvider are tracked as Phase 2/3/4 follow-ups on issue #1197.
+When the same argument triggers multiple tiers, the analyzer emits only the highest-priority diagnostic: **Tier 3 > Tier 1 > Tier 2**. The placeholder signal is the most actionable cue for the developer, so we surface that first.
 
-**Important — `LogSanitizer.Sanitize` is NOT a PII barrier**: it strips `\r\n\t` for log-forging (CWE-117 integrity), not PII content (CWE-359 confidentiality). The analyzer correctly flags a call wrapped via `LogSanitizer.Sanitize` if the placeholder name suggests PII. Use `DataMasking.Mask*` for PII.
+**Important — `LogSanitizer.Sanitize` is NOT a PII barrier**: it strips `\r\n\t` for log-forging (CWE-117 integrity), not PII content (CWE-359 confidentiality). The analyzer correctly flags a call wrapped via `LogSanitizer.Sanitize` if the placeholder name (or argument type, or identifier) suggests PII. Use `DataMasking.Mask*` for PII.
+
+**Deferred (Phase 3+)**: `CodeFixProvider` auto-wrap (Phase 3), NuGet packaging (Phase 4), additional edge-case detection (using-static call form, method-group invocation) tracked on issue #1197.
 
 ---
 


### PR DESCRIPTION
## Phase 2 of #1197

Implements **Phase 2a (Tier 1 — typed PII value object detection, MAI002)** and **Phase 2b (Tier 2 — identifier name heuristic, MAI003)** of the Roslyn analyzer plan on #1197. Phase 1 (Tier 3 — placeholder name match, MAI001) was delivered by PR #1201; Phase 3 (CodeFixProvider auto-wrap) and Phase 4 (NuGet packaging) remain open.

Still **advisory-only** — `WarningsNotAsErrors=MAI001;MAI002;MAI003` in `Api.csproj` keeps all three diagnostics out of the build-failure path. CodeQL `cs/log-forging` threshold gate (#1195 FU#1) remains authoritative.

## What's added

### MAI002 — Typed PII value object detection (Tier 1)

Flags `ILogger.Log*` arguments whose CLR type matches one of:

| Type FQN | Source |
|---|---|
| `Api.BoundedContexts.Authentication.Domain.ValueObjects.Email` | Authentication BC |
| `Api.BoundedContexts.Authentication.Domain.ValueObjects.PasswordHash` | Authentication BC |
| `Api.BoundedContexts.Authentication.Domain.ValueObjects.SessionToken` | Authentication BC |
| `Api.BoundedContexts.Authentication.Domain.ValueObjects.TotpSecret` | Authentication BC |
| `Api.BoundedContexts.Authentication.Domain.ValueObjects.BackupCode` | Authentication BC |

Hardcoded curated list. Adding a new typed VO requires explicit code review — only add if it represents PII content (not arbitrary identifiers like `Role` or `UserTier`).

### MAI003 — Identifier name heuristic (Tier 2)

Flags `ILogger.Log*` arguments that are identifier references (parameter / local / field / property) whose name matches a curated set:

- `email` / `emailAddress` / `userEmail` / `user_email`
- `password` / `userPassword` / `newPassword` / `oldPassword` / `currentPassword`
- `token` / `accessToken` / `refreshToken` / `apiToken` / `authToken`
- `jwt` / `jwtToken` / `bearerToken`
- `phone` / `phoneNumber` / `userPhone`
- `ssn`
- `ipAddress` / `remoteIp` / `clientIp`

`OrdinalIgnoreCase` match. Curated names rather than a permissive regex to keep false-positive rate manageable. Highest false-positive risk among the three tiers — suppress per-site with `[SuppressMessage(\"Security\", \"MAI003\")]` and a comment when the heuristic is wrong.

### Tier priority

When the same argument satisfies multiple tier conditions, only the highest-priority diagnostic is emitted:

**Tier 3 (MAI001) > Tier 1 (MAI002) > Tier 2 (MAI003)**

The placeholder signal is the most actionable cue, so it surfaces first. This avoids dual-flagging the same site (e.g., a `string email` param logged via `{Email}` placeholder fires MAI001 only, not MAI003).

## Validation

| Check | Result |
|---|---|
| `dotnet build src/Api.Analyzers/` | ✅ 0 errors, 0 warnings |
| `dotnet build src/Api/` (with extended analyzer) | ✅ **0 errors, 0 warnings** (no new positives — PR #1204 already cleaned the codebase) |
| `dotnet test tests/Api.Analyzers.Tests/` | ✅ **16/16 passed** in 4.2s |
| Pre-commit hooks | ✅ frontend lint + typecheck passed |

### Test coverage (10 new + 6 existing = 16 total)

**Phase 2a (Tier 1, 4 tests)**:
- ✅ Email VO unwrapped → MAI002
- ✅ PasswordHash VO unwrapped → MAI002
- ✅ SessionToken VO unwrapped → MAI002
- ✅ Email VO wrapped via `DataMasking.MaskEmail(email.Value)` → no flag
- ✅ Non-PII VO (Role) → no flag

**Phase 2b (Tier 2, 4 tests)**:
- ✅ Param `password` unwrapped → MAI003
- ✅ Param `accessToken` (camelCase) → MAI003
- ✅ Param `sessionId` (non-PII) → no flag
- ✅ Param `phoneNumber` wrapped via `DataMasking.MaskString` → no flag

**Tier priority (1 test)**:
- ✅ `{Email}` placeholder + param named `email` → only MAI001 fires (NOT MAI002 + MAI003)

## Impact on current codebase

**Zero new positives.** PR #1204 (merged earlier today) wrapped the 10 first-run findings from Phase 1, and Phase 2 surfaces no additional candidates. The Tier 1/2 detection rules are now active for any future regression, with empirical baseline of zero.

## Out of scope (Phase 3+ tracking on #1197)

- **Phase 3** — `CodeFixProvider` auto-wrap (suggest `DataMasking.MaskEmail(x)` lightbulb fix)
- **Phase 4** — NuGet packaging + `Directory.Build.targets` integration
- **Edge cases** — `using static` form recognition + method-group invocation barrier

## Refs

- Issue #1197 — parent (Phase 1 → #1201, Phase 2 → this PR, Phase 3/4 still open)
- ADR-058 — Canonical Log Sanitizers
- `docs/for-developers/security/pii-safe-logging.md` — updated with three-tier table

🤖 Generated with [Claude Code](https://claude.com/claude-code)