### PR TITLE
fix(a11y): Real-C-D partial — session-live violet 70%→75% (refs #1223)

### DIFF
--- a/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
+++ b/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
@@ -60,7 +60,7 @@ function typeColor(type: ActionLogEntry['type']): string {
   const map: Record<ActionLogEntry['type'], string> = {
     score: 'text-emerald-400',
     // eslint-disable-next-line meepleai/no-inline-hsl-v2 -- TODO #807-followup: session hue in Tailwind arbitrary class; no `text-entity-session/light` token exists for dark-bg variant
-    tool: 'text-[hsl(240,60%,70%)]',
+    tool: 'text-[hsl(240,60%,75%)]',
     agent: 'text-amber-400',
     chat: 'text-sky-400',
     photo: 'text-rose-400',

--- a/apps/web/src/components/features/session-live/LiveScoringPanel.tsx
+++ b/apps/web/src/components/features/session-live/LiveScoringPanel.tsx
@@ -110,7 +110,7 @@ export function LiveScoringPanel({
                   {entry.playerName}
                   {isViewer && (
                     // eslint-disable-next-line meepleai/no-inline-hsl-v2 -- TODO #807-followup: session light-text variant in Tailwind arbitrary class; no light-text entity token exists
-                    <span className="ml-1 text-xs text-[hsl(240,60%,70%)]">
+                    <span className="ml-1 text-xs text-[hsl(240,60%,75%)]">
                       ({labels.myScoreLabel})
                     </span>
                   )}

--- a/apps/web/src/components/features/session-live/MobileBody.tsx
+++ b/apps/web/src/components/features/session-live/MobileBody.tsx
@@ -93,7 +93,7 @@ export function MobileBody({
                   'focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[hsl(240,60%,70%)]',
                   isActive
                     ? // eslint-disable-next-line meepleai/no-inline-hsl-v2 -- TODO #807-followup: session hue in Tailwind arbitrary classes (active state); no dark-bg light-text entity token exists
-                      'text-[hsl(240,60%,70%)] border-t-2 border-[hsl(240,60%,70%)] -mt-0.5'
+                      'text-[hsl(240,60%,75%)] border-t-2 border-[hsl(240,60%,70%)] -mt-0.5'
                     : 'text-muted-foreground hover:text-slate-300 border-t-2 border-transparent -mt-0.5',
                 ].join(' ')}
               >


### PR DESCRIPTION
## Summary

Partial fix for Real-C-D session-live violet pattern (refs #1094 Phase C). The 3 inline `text-[hsl(240,60%,70%)]` occurrences flagged by Phase A.live v3 axe data on session-live dark backdrop are bumped to `text-[hsl(240,60%,75%)]`.

**Risk**: minimal (3 single-line changes, dark theme only).
**Effort**: ~15 min.

## Math

bg `#2e2e2e` L = 0.026; fg target ≥ 0.34 for AA 4.5:1.

- `hsl(240,60%,70%)` (`#8585e0`) ratio **4.15** (axe measured) — fail
- `hsl(240,60%,75%)` (`#9d9deb`) ratio **5.58** ✅ pass

## Diff (3 single-line changes)

```diff
- ActionLogTimeline.tsx:63    'text-[hsl(240,60%,70%)]'
+                              'text-[hsl(240,60%,75%)]'

- LiveScoringPanel.tsx:113     'text-xs text-[hsl(240,60%,70%)]'
+                              'text-xs text-[hsl(240,60%,75%)]'

- MobileBody.tsx:96            'text-[hsl(240,60%,70%)] border-t-2 border-[hsl(240,60%,70%)]'
+                              'text-[hsl(240,60%,75%)] border-t-2 border-[hsl(240,60%,70%)]'
```

Border at 70% kept (passes 3:1 non-text against `#2e2e2e`).

## Out of scope (remain in #1223)

| Item | Nodes | Why deferred |
|---|---:|---|
| `text-blue-600` | 3 | 10 source files; per-site analysis needed |
| `--c-kb` cyan as text (`a[href$="sessions"] > span`) | 10 (catastrophic 1.75) | Needs `--c-kb-text` token (DS-15 coordination) |
| `.bg-emerald-700` disabled | 1 (1.08) | Per-surface investigation needed |
| `.focus-visible:ring-slate-400` | 1 (1.06) | Per-surface investigation needed |

The 15 deferred nodes will be addressed in follow-up sessions. The 3 nodes addressed here validate the per-surface fix path (c) on session-live dark theme.

## Test plan

- [x] lint clean
- [x] typecheck clean
- [x] Diff: 3 files / 3 insertions / 3 deletions

## Refs

- Refs #1223 (partial — 3 of ~18 nodes)
- Refs #1094 (Phase C Real-C-D session-live violet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)