### PR TITLE
fix(a11y): Real-C-F — --c-kb-text token + 2 swaps (closes 10 catastrophic 1.75 nodes, refs #1094)

### DIFF
--- a/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
+++ b/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
@@ -317,7 +317,7 @@ export function AdminSideDrawer({ open, onClose }: AdminSideDrawerProps) {
               href="/dashboard"
               onClick={onClose}
               className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors mb-2"
-              style={{ color: '#4ecdc4' }}
+              style={{ color: 'hsl(var(--c-kb-text))' }}
             >
               <ChevronLeft className="h-4 w-4 shrink-0" />
               <span>Torna all&apos;app</span>

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -50,7 +50,7 @@ export function PageHeader({
           <Link
             href={parentHref!}
             className="inline-flex items-center gap-1 text-sm font-medium"
-            style={{ color: '#4ecdc4' }}
+            style={{ color: 'hsl(var(--c-kb-text))' }}
           >
             <span aria-hidden="true">←</span>
             <span>{parentLabel}</span>

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -43,6 +43,7 @@
    * demand as violations surface for them.
    */
   --c-game-text: 25 95% 32%;
+  --c-kb-text:   174 60% 28%; /* Real-C-F: hsl(174 60% 28%) ≈ #1d7268 vs #f7f3ee = 4.95:1 ✅ — replaces hardcoded #4ecdc4 (1.75:1 fail) */
 
   /* ─── Semantic Colors ─── */
   --c-success: 142 70% 45%;
@@ -188,11 +189,15 @@
   --c-toolkit: 142 60% 58%;
   --c-tool:    195 75% 62%;
 
-  /* TEXT variant for dark theme: lighter to clear AA on dark bg.
+  /* TEXT variants for dark theme: lighter to clear AA on dark bg.
    *   --c-game-text  hsl(28 95% 70%) ≈ #fdb775 vs #14100a = 11.2:1 ✅
-   *   Refs: #1094 Real-C-B, audit doc §2.5 v3
+   *   --c-kb-text    hsl(174 60% 55%) ≈ #4ecdc4 vs #14100a = 9.87:1 ✅
+   *     (= --c-kb dark value; already AA-safe on dark — the violation
+   *      was solely the light-theme rendering of this dark-shade hex)
+   *   Refs: #1094 Real-C-B + Real-C-F
    */
   --c-game-text: 28 95% 70%;
+  --c-kb-text:   174 60% 55%;
 
   color-scheme: dark;
 }


### PR DESCRIPTION
## Summary

Phase C Real-Cluster F (newly discovered post #1226 v4 analysis): introduces `--c-kb-text` token + swaps the 2 inline `style={{ color: '#4ecdc4' }}` occurrences that produced **10 catastrophic axe nodes (ratio 1.75:1)** across sessions-index + session-summary routes.

**Risk**: minimal (1 token + 2 inline-style swaps; theme-aware via canonical scope).
**Effort**: ~30 min (incl. math verification + cross-component analysis).

## Root cause

Inline `style={{ color: '#4ecdc4' }}` hardcoded the DARK theme variant of `--c-kb`. Renders correctly on dark theme (~9.87:1 vs `#14100a`) but catastrophically on light theme (1.75:1 vs `#f7f3ee` cream). Theme mismatch, not color choice per se.

## Math

Light: `--c-kb-text: hsl(174 60% 28%)` ≈ `#1d7268` vs `#f7f3ee` = **4.95:1** ✅
Dark:  `--c-kb-text: hsl(174 60% 55%)` ≈ `#4ecdc4` vs `#14100a` = **9.87:1** ✅

Dark intentionally reuses the original hex (already AA-safe on dark). The bug was using it on light.

## Files (3)

- `design-tokens-canonical.css` — +`--c-kb-text` in both `:root` and `[data-theme="dark"]` scopes
- `AdminSideDrawer.tsx:320` — "Torna all'app" Link inline style swap
- `PageHeader.tsx:53` — parent-href Link arrow inline style swap

## Expected impact on v5 baseline

| | v4 | v5 (post this PR) |
|---|---:|---:|
| Total nodes | 103 | ~93 (-10) |
| Catastrophic (<2:1) | 12 | ~2 (-10, leaves `bg-emerald-700` 1.08 + `focus-visible:ring-slate-400` 1.06 from #1223) |

## Test plan

- [x] lint clean
- [x] typecheck clean
- [x] Diff: 3 files / 9 insertions / 4 deletions

## Out of scope

- 4 token-based `text-[hsl(var(--c-kb))]` consumers (CitationChip, CitationModal, LibroGameDetailView, HubGameCard) — re-run ext2 confirms if any surface AA failures; if so, swap to `--c-kb-text` follow-up
- 5 hardcoded `text-[hsl(174,60%,40%)]` (RuleSourceCard etc.) — separate analysis needed

## Refs

- Refs #1094 (Phase C Real-C-F)
- Refs PR #1224 (precedent pattern --c-game-text)
- Refs PR #1226 (ext2 baseline that surfaced the 10 nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)