### PR TITLE
fix(web): add /api/v1 prefix to 6 discover hooks (refs #1160)

### DIFF
--- a/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
@@ -93,7 +93,7 @@ describe('useDiscoverNewGames — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/catalog/games/new?limit=10', expect.anything());
   });
 
   it('clamps a limit > 50 to the validator ceiling', async () => {
@@ -103,7 +103,7 @@ describe('useDiscoverNewGames — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=50', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/catalog/games/new?limit=50', expect.anything());
   });
 
   it('clamps a non-positive limit to the default', async () => {
@@ -113,7 +113,7 @@ describe('useDiscoverNewGames — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/catalog/games/new?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/catalog/games/new?limit=10', expect.anything());
   });
 });
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
@@ -94,7 +94,7 @@ describe('useDiscoverPopularAgents — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/agents/popular?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/agents/popular?limit=10', expect.anything());
   });
 
   it('clamps an oversize limit to 50', async () => {
@@ -104,7 +104,7 @@ describe('useDiscoverPopularAgents — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/agents/popular?limit=50', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/agents/popular?limit=50', expect.anything());
   });
 });
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
@@ -95,7 +95,7 @@ describe('useDiscoverRecentKbDocs — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/kb-docs/recent?limit=10', expect.anything());
   });
 
   it('clamps a fractional limit downward to integer', async () => {
@@ -106,7 +106,7 @@ describe('useDiscoverRecentKbDocs — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=7', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/kb-docs/recent?limit=7', expect.anything());
   });
 
   it('clamps a NaN limit to the default', async () => {
@@ -116,7 +116,7 @@ describe('useDiscoverRecentKbDocs — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/kb-docs/recent?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/kb-docs/recent?limit=10', expect.anything());
   });
 });
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
@@ -91,7 +91,10 @@ describe('useDiscoverRecommendedToolkits — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/toolkits/recommended?limit=10',
+      expect.anything()
+    );
   });
 
   it('clamps an oversize limit to 50', async () => {
@@ -101,7 +104,10 @@ describe('useDiscoverRecommendedToolkits — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=50', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/toolkits/recommended?limit=50',
+      expect.anything()
+    );
   });
 
   it('clamps a sub-1 limit to default 10', async () => {
@@ -111,7 +117,10 @@ describe('useDiscoverRecommendedToolkits — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/toolkits/recommended?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/toolkits/recommended?limit=10',
+      expect.anything()
+    );
   });
 });
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
@@ -95,7 +95,10 @@ describe('useDiscoverTopContributors — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/users/top-contributors?limit=10',
+      expect.anything()
+    );
   });
 
   it('clamps an oversize limit to 50', async () => {
@@ -105,7 +108,10 @@ describe('useDiscoverTopContributors — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=50', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/users/top-contributors?limit=50',
+      expect.anything()
+    );
   });
 
   it('clamps a sub-1 limit to default 10', async () => {
@@ -115,7 +121,10 @@ describe('useDiscoverTopContributors — limit handling', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith('/users/top-contributors?limit=10', expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      '/api/v1/users/top-contributors?limit=10',
+      expect.anything()
+    );
   });
 });
 

--- a/apps/web/src/hooks/queries/useDiscoverNewGames.ts
+++ b/apps/web/src/hooks/queries/useDiscoverNewGames.ts
@@ -57,7 +57,7 @@ export function useDiscoverNewGames(
     queryKey: discoverNewGamesKeys.list(safeLimit),
     queryFn: async () => {
       const response = await apiClient.get<NewGamesResponse>(
-        `/catalog/games/new?limit=${safeLimit}`,
+        `/api/v1/catalog/games/new?limit=${safeLimit}`,
         NewGamesResponseSchema
       );
       return response?.items ?? [];

--- a/apps/web/src/hooks/queries/useDiscoverPopularAgents.ts
+++ b/apps/web/src/hooks/queries/useDiscoverPopularAgents.ts
@@ -57,7 +57,7 @@ export function useDiscoverPopularAgents(
     queryKey: discoverPopularAgentsKeys.list(safeLimit),
     queryFn: async () => {
       const response = await apiClient.get<PopularAgentsResponse>(
-        `/agents/popular?limit=${safeLimit}`,
+        `/api/v1/agents/popular?limit=${safeLimit}`,
         PopularAgentsResponseSchema
       );
       return response?.items ?? [];

--- a/apps/web/src/hooks/queries/useDiscoverRecentKbDocs.ts
+++ b/apps/web/src/hooks/queries/useDiscoverRecentKbDocs.ts
@@ -59,7 +59,7 @@ export function useDiscoverRecentKbDocs(
     queryKey: discoverRecentKbDocsKeys.list(safeLimit),
     queryFn: async () => {
       const response = await apiClient.get<RecentKbDocsResponse>(
-        `/kb-docs/recent?limit=${safeLimit}`,
+        `/api/v1/kb-docs/recent?limit=${safeLimit}`,
         RecentKbDocsResponseSchema
       );
       return response?.items ?? [];

--- a/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
+++ b/apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts
@@ -58,7 +58,7 @@ export function useDiscoverRecommendedToolkits(
     queryKey: discoverRecommendedToolkitsKeys.list(safeLimit),
     queryFn: async () => {
       const response = await apiClient.get<RecommendedToolkitsResponse>(
-        `/toolkits/recommended?limit=${safeLimit}`,
+        `/api/v1/toolkits/recommended?limit=${safeLimit}`,
         RecommendedToolkitsResponseSchema
       );
       return response?.items ?? [];

--- a/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
+++ b/apps/web/src/hooks/queries/useDiscoverTopContributors.ts
@@ -64,7 +64,7 @@ export function useDiscoverTopContributors(
     queryKey: discoverTopContributorsKeys.list(safeLimit),
     queryFn: async () => {
       const response = await apiClient.get<TopUserContributorsResponse>(
-        `/users/top-contributors?limit=${safeLimit}`,
+        `/api/v1/users/top-contributors?limit=${safeLimit}`,
         TopUserContributorsResponseSchema
       );
       return response?.items ?? [];

--- a/apps/web/src/lib/api/catalog.ts
+++ b/apps/web/src/lib/api/catalog.ts
@@ -13,7 +13,7 @@ export interface TrendingGame {
 }
 
 export async function getTrendingGames(limit = 10): Promise<TrendingGame[]> {
-  const response = await apiClient.get<TrendingGame[]>(`/catalog/trending?limit=${limit}`);
+  const response = await apiClient.get<TrendingGame[]>(`/api/v1/catalog/trending?limit=${limit}`);
   return response ?? [];
 }
 


### PR DESCRIPTION
## Summary

Fixes pre-existing bug introduced by PR #1160 (Stage 3 /discover catalog, 2026-05-14): six TanStack Query hooks called `apiClient` with relative paths missing the `/api/v1` prefix. Browser-side `HttpClient.baseUrl = ''` (see `apps/web/src/lib/api/core/httpClient.ts:54-56`) — the empty base relies on the Next.js `/api/v1/[...path]/route.ts` proxy, which only matches paths starting with `/api/v1/`. Missing prefix → request served by Next.js itself → 404 on every `/discover` data rail.

## Root cause discovery

Discovered during the post-#979 release Playwright validation of the `/discover` code-split refactor (#1213). Stack was fully healthy, backend endpoints existed (`docker exec meepleai-web wget http://api:8080/api/v1/catalog/games/new` returned 401, confirming presence), but browser-side requests went to `http://localhost:3000/catalog/games/new` (no proxy match → Next.js 404).

The 5 hook unit test files **masked the bug** because their assertions verified the path passed to `apiClient.get`, not the resolved fetch URL. They still pass — just against the wrong contract. Tests updated alongside the source change.

## Files changed (11)

**Source (6):**
- `apps/web/src/lib/api/catalog.ts` — `getTrendingGames` (consumed by `useCatalogTrending`)
- `apps/web/src/hooks/queries/useDiscoverNewGames.ts`
- `apps/web/src/hooks/queries/useDiscoverPopularAgents.ts`
- `apps/web/src/hooks/queries/useDiscoverRecentKbDocs.ts`
- `apps/web/src/hooks/queries/useDiscoverRecommendedToolkits.ts`
- `apps/web/src/hooks/queries/useDiscoverTopContributors.ts`

**Tests (5):** the corresponding `__tests__/*.test.tsx`, mock expectation updated to new paths.

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck` | 0 errors |
| `pnpm test --run src/hooks/queries/__tests__/useDiscover` | 5 files / **45 tests pass** |
| Docker rebuild + Playwright on `/discover` | Confirmed end-to-end |

**Endpoint status after fix (validated via Playwright network tab on rebuilt `meepleai-web:3a7e0b88`):**

| Endpoint | Before | After |
|---|---|---|
| `/api/v1/catalog/trending` | 404 (path `/catalog/trending`) | **200 OK** (real data, `.AllowAnonymous()`) |
| `/api/v1/catalog/games/new` | 404 | **401** (RequireAuthorization, endpoint reached) |
| `/api/v1/agents/popular` | 404 | **401** |
| `/api/v1/kb-docs/recent` | 404 | **401** |
| `/api/v1/toolkits/recommended` | 404 | **401** |
| `/api/v1/users/top-contributors` | 404 | **401** |

All 404s gone. The 401s confirm endpoints exist and the proxy is honored — login flow not in scope here.

## Risk

Low. String-literal swap only, no behavior change, no API contract change, no bundle size impact. Test coverage updated to match.

## Test plan

- [x] Typecheck + lint pass
- [x] 45/45 hook tests pass
- [x] Playwright validation on rebuilt Docker stack
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)