### PR TITLE
test(web): extract MockedApiClient type for apiClient unit tests (refs #1229)

### DIFF
--- a/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx
@@ -18,6 +18,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
 import {
   DISCOVER_NEW_GAMES_DEFAULT_LIMIT,
   DISCOVER_NEW_GAMES_STALE_TIME_MS,
@@ -26,15 +28,18 @@ import {
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx
@@ -24,17 +24,22 @@ import {
   useDiscoverPopularAgents,
 } from '../useDiscoverPopularAgents';
 
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx
@@ -24,17 +24,22 @@ import {
   useDiscoverRecentKbDocs,
 } from '../useDiscoverRecentKbDocs';
 
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx
@@ -24,16 +24,21 @@ import {
   useDiscoverRecommendedToolkits,
 } from '../useDiscoverRecommendedToolkits';
 
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
 // Mocks
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({

--- a/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx
@@ -25,15 +25,20 @@ import {
   useDiscoverTopContributors,
 } from '../useDiscoverTopContributors';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({

--- a/apps/web/src/lib/api/__tests__/my-hand.api.test.ts
+++ b/apps/web/src/lib/api/__tests__/my-hand.api.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
 import { getMyHand, updateHandSlot, clearHandSlot } from '../my-hand';
 
-vi.mock('../client', () => ({
-  apiClient: {
-    get: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
-  },
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
-
-import { apiClient } from '../client';
+vi.mock('../client', () => ({ apiClient: mockApi }));
 
 describe('my-hand API client', () => {
   beforeEach(() => {
@@ -17,7 +21,7 @@ describe('my-hand API client', () => {
   });
 
   it('getMyHand calls GET /api/v1/users/me/hand', async () => {
-    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue([
+    mockApi.get.mockResolvedValue([
       {
         slotType: 'toolkit',
         entityId: null,
@@ -29,7 +33,7 @@ describe('my-hand API client', () => {
     ]);
 
     const result = await getMyHand();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users/me/hand');
+    expect(mockApi.get).toHaveBeenCalledWith('/api/v1/users/me/hand');
     expect(result).toHaveLength(1);
   });
 
@@ -42,7 +46,7 @@ describe('my-hand API client', () => {
       entityImageUrl: null,
       pinnedAt: '2026-04-09T00:00:00Z',
     };
-    (apiClient.put as ReturnType<typeof vi.fn>).mockResolvedValue(dto);
+    mockApi.put.mockResolvedValue(dto);
 
     const result = await updateHandSlot('game', {
       entityId: 'g-1',
@@ -50,7 +54,7 @@ describe('my-hand API client', () => {
       entityLabel: 'Catan',
       entityImageUrl: null,
     });
-    expect(apiClient.put).toHaveBeenCalledWith('/api/v1/users/me/hand/game', {
+    expect(mockApi.put).toHaveBeenCalledWith('/api/v1/users/me/hand/game', {
       entityId: 'g-1',
       entityType: 'game',
       entityLabel: 'Catan',
@@ -60,14 +64,14 @@ describe('my-hand API client', () => {
   });
 
   it('clearHandSlot calls DELETE /api/v1/users/me/hand/{slotType}', async () => {
-    (apiClient.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    mockApi.delete.mockResolvedValue(undefined);
 
     await clearHandSlot('toolkit');
-    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/users/me/hand/toolkit');
+    expect(mockApi.delete).toHaveBeenCalledWith('/api/v1/users/me/hand/toolkit');
   });
 
   it('getMyHand returns empty array on null response', async () => {
-    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    mockApi.get.mockResolvedValue(null);
     const result = await getMyHand();
     expect(result).toEqual([]);
   });

--- a/apps/web/src/test-utils/api-client-mock.ts
+++ b/apps/web/src/test-utils/api-client-mock.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared type for mocking `@/lib/api/client` in unit tests.
+ *
+ * Pre-existing tests boilerplate looked like:
+ *
+ *   vi.mock('@/lib/api/client', () => ({
+ *     apiClient: { get: vi.fn() },
+ *   }));
+ *
+ *   import { apiClient } from '@/lib/api/client';
+ *   const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+ *
+ * Two problems with that:
+ *   1. Untyped cast on every method access (`as ReturnType<typeof vi.fn>`).
+ *   2. Each test enumerates only the verbs it happens to need, so adding
+ *      a `.post(...)` call site to the hook requires updating the mock
+ *      factory in the test too.
+ *
+ * Note on Vitest hoisting: `vi.mock` is hoisted ABOVE all static imports,
+ * so its factory cannot reference imported identifiers (would throw
+ * `Cannot access __vi_import_X__ before initialization`). `vi.hoisted`
+ * has the same constraint — its body cannot reference imports. That's
+ * why the supported pattern centralizes only the TYPE here and keeps the
+ * mock-instance construction inline in each test file.
+ *
+ * Canonical usage:
+ *
+ *   import { vi } from 'vitest';
+ *   import type { MockedApiClient } from '@/test-utils/api-client-mock';
+ *
+ *   const mockApi = vi.hoisted<MockedApiClient>(() => ({
+ *     get: vi.fn(),
+ *     post: vi.fn(),
+ *     put: vi.fn(),
+ *     patch: vi.fn(),
+ *     delete: vi.fn(),
+ *     head: vi.fn(),
+ *     options: vi.fn(),
+ *   }));
+ *   vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
+ *
+ *   beforeEach(() => {
+ *     vi.clearAllMocks();
+ *     mockApi.get.mockResolvedValue(SAMPLE);
+ *   });
+ *
+ *   it('...', () => {
+ *     expect(mockApi.get).toHaveBeenCalledWith('/api/v1/foo', expect.anything());
+ *   });
+ *
+ * Benefits vs the prior boilerplate:
+ *   - Strong typing end-to-end (no `as ReturnType<typeof vi.fn>` casts).
+ *   - All 7 HTTP verbs pre-mocked, so adding a verb call site to the
+ *     production hook doesn't require touching the mock factory.
+ *   - `mockApi.get` is a typed `Mock` instance directly (callable as
+ *     `mockApi.get.mockResolvedValue(...)` without intermediate variables).
+ *
+ * Refs:
+ *   - PR #1229 / PR #1230 follow-up #2 (review of #1229 surfaced the
+ *     mock-boilerplate gap across 6 test files).
+ *   - Vitest docs on hoisting: https://vitest.dev/api/vi.html#vi-hoisted
+ */
+
+import type { Mock } from 'vitest';
+
+/**
+ * Strongly-typed shape of the mocked `apiClient` instance. Each HTTP verb
+ * is a `vi.fn()` Mock callable as the production method, e.g.
+ * `mockApi.get.mockResolvedValue(...)`.
+ *
+ * The 7 verbs mirror `HttpClient` in `apps/web/src/lib/api/core/httpClient.ts`.
+ */
+export type MockedApiClient = {
+  readonly get: Mock;
+  readonly post: Mock;
+  readonly put: Mock;
+  readonly patch: Mock;
+  readonly delete: Mock;
+  readonly head: Mock;
+  readonly options: Mock;
+};


### PR DESCRIPTION
## Summary

Implements **follow-up #2** from the code review of PR #1229: a shared test utility to reduce `vi.mock('@/lib/api/client', ...)` boilerplate across 6 test files.

After investigation, only the **TYPE** can be centralized (the `MockedApiClient` shape). A `buildMockedApiClient()` function helper turned out to be incompatible with Vitest's hoisting: both `vi.mock` and `vi.hoisted` are hoisted ABOVE all static imports, so their factory bodies cannot reference imported identifiers (throws `Cannot access __vi_import_X__ before initialization`).

The type-only approach plus the documented `vi.hoisted` recipe is what's shareable today. See `apps/web/src/test-utils/api-client-mock.ts` docstring for the full Vitest hoisting rationale.

## Diff per test (canonical pattern)

**Before** (6 files, ~7 lines each):
```ts
vi.mock('@/lib/api/client', () => ({
  apiClient: { get: vi.fn() },
}));

import { apiClient } from '@/lib/api/client';
const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
```

**After** (6 files, ~11 lines each):
```ts
import type { MockedApiClient } from '@/test-utils/api-client-mock';

const mockApi = vi.hoisted<MockedApiClient>(() => ({
  get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(),
  delete: vi.fn(), head: vi.fn(), options: vi.fn(),
}));
vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));

const mockGet = mockApi.get;
```

## Trade-off

Two more lines per file (all 7 verbs are listed inline), but in exchange every test gets:
- **Zero `as ReturnType<typeof vi.fn>` casts** — the explicit ask from the original review.
- **All 7 verbs pre-mocked** — adding a new verb call site to the production hook no longer requires touching the mock factory.
- **Greppable type** — `MockedApiClient` signals "this is an apiClient mock" and ties usage to the canonical docstring.

## Files changed (7 = 1 new utility + 6 refactored tests)

| File | Type |
|---|---|
| `apps/web/src/test-utils/api-client-mock.ts` | **NEW** — type + docstring |
| `apps/web/src/hooks/queries/__tests__/useDiscoverNewGames.test.tsx` | refactor |
| `apps/web/src/hooks/queries/__tests__/useDiscoverPopularAgents.test.tsx` | refactor |
| `apps/web/src/hooks/queries/__tests__/useDiscoverRecentKbDocs.test.tsx` | refactor |
| `apps/web/src/hooks/queries/__tests__/useDiscoverRecommendedToolkits.test.tsx` | refactor |
| `apps/web/src/hooks/queries/__tests__/useDiscoverTopContributors.test.tsx` | refactor |
| `apps/web/src/lib/api/__tests__/my-hand.api.test.ts` | refactor (incl. `apiClient.x` → `mockApi.x` in 3 assertions) |

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck` | 0 errors |
| `pnpm test --run` on the 6 affected files | **49/49 pass** |
| `local/api-client-v1-prefix` ESLint rule (PR #1230) | still clean — refactor is test-only |

## Risk

Low. Test-only refactor with no production behavior change. ESLint API guard from PR #1230 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)