### PR TITLE
test(web): finalize MockedApiClient pattern + 3 follow-ups (refs #1233)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -289,6 +289,16 @@ export default [
     plugins: {
       react: react,
       "react-hooks": reactHooks,
+      // PR #1230 review #2 follow-up: register the `local` plugin in the
+      // JS/JSX block too so any future *.{js,jsx} API client cannot
+      // silently bypass the /api/v1/ proxy guard. Today no JS API
+      // consumer exists, but the gate must be uniform across file
+      // extensions to remain meaningful.
+      "local": {
+        rules: {
+          "api-client-v1-prefix": apiClientV1Prefix,
+        },
+      },
     },
     rules: {
       "no-console": ["warn", { allow: ["warn", "error"] }],
@@ -299,6 +309,9 @@ export default [
       "react/prop-types": "off",
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
+      // Same gate as the TS block (line 263); see rule docstring at
+      // eslint-rules/api-client-v1-prefix.js for the rationale.
+      "local/api-client-v1-prefix": "error",
     },
     settings: {
       react: {

--- a/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useInstallToolkit.test.tsx
@@ -21,15 +21,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toolkitDetailKeys } from '../useToolkitDetail';
 import { useInstallToolkit } from '../useInstallToolkit';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    post: vi.fn(),
-  },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockPost = apiClient.post as ReturnType<typeof vi.fn>;
+const mockPost = mockApi.post;
 
 const TOOLKIT_ID = '11111111-1111-1111-1111-111111111111';
 
@@ -60,7 +65,7 @@ describe('useInstallToolkit — request shape', () => {
     await result.current.mutateAsync({ toolkitId: TOOLKIT_ID });
 
     expect(mockPost).toHaveBeenCalledWith(
-      `/toolkits/${TOOLKIT_ID}/install`,
+      `/api/v1/toolkits/${TOOLKIT_ID}/install`,
       undefined,
       expect.anything()
     );

--- a/apps/web/src/hooks/queries/__tests__/useKbChunkDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbChunkDetail.test.tsx
@@ -19,13 +19,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { KB_CHUNK_DETAIL_STALE_TIME_MS, useKbChunkDetail } from '../useKbChunkDetail';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: { get: vi.fn() },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -73,7 +80,7 @@ describe('useKbChunkDetail — happy path', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockGet).toHaveBeenCalledWith(
-      `/kb-docs/${DOC_ID}/chunks/${CHUNK_ID}`,
+      `/api/v1/kb-docs/${DOC_ID}/chunks/${CHUNK_ID}`,
       expect.anything()
     );
     expect(result.current.data?.position).toBe(5);

--- a/apps/web/src/hooks/queries/__tests__/useKbChunksList.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbChunksList.test.tsx
@@ -19,13 +19,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { KB_CHUNKS_LIST_STALE_TIME_MS, useKbChunksList } from '../useKbChunksList';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: { get: vi.fn() },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -74,7 +81,7 @@ describe('useKbChunksList — first page', () => {
 
     expect(mockGet).toHaveBeenCalledTimes(1);
     const calledPath = mockGet.mock.calls[0][0] as string;
-    expect(calledPath).toBe(`/kb-docs/${DOC_ID}/chunks?limit=50`);
+    expect(calledPath).toBe(`/api/v1/kb-docs/${DOC_ID}/chunks?limit=50`);
   });
 
   it('reflects custom limit in URL', async () => {

--- a/apps/web/src/hooks/queries/__tests__/useKbDocDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbDocDetail.test.tsx
@@ -22,13 +22,20 @@ import { ApiError } from '@/lib/api/core/errors';
 
 import { KB_DOC_DETAIL_STALE_TIME_MS, useKbDocDetail } from '../useKbDocDetail';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: { get: vi.fn() },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -76,7 +83,7 @@ describe('useKbDocDetail — happy path', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith(`/kb-docs/${DOC_ID}`, expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(`/api/v1/kb-docs/${DOC_ID}`, expect.anything());
     expect(result.current.data?.status).toBe('ready');
     if (result.current.data?.status === 'ready') {
       expect(result.current.data.doc.title).toBe('Catan rulebook');
@@ -93,7 +100,7 @@ describe('useKbDocDetail — 423 Locked', () => {
     const lockedError = new ApiError({
       message: "KB document xxx is in processing state 'processing' — not yet ready.",
       statusCode: 423,
-      endpoint: `/kb-docs/${DOC_ID}`,
+      endpoint: `/api/v1/kb-docs/${DOC_ID}`,
     });
     mockGet.mockRejectedValue(lockedError);
 

--- a/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitDetail.test.tsx
@@ -4,7 +4,7 @@
  * useToolkitDetail unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.1).
  *
  * Coverage:
- *   - Stable URL shape `/toolkits/{id}` and 10min staleTime mirror.
+ *   - Stable URL shape `/api/v1/toolkits/{id}` and 10min staleTime mirror.
  *   - Schema validation forwards typed envelope.
  *   - 404 / 401 / null fallback (apiClient returns null) → null result.
  *   - `enabled: false` defers the request.
@@ -22,15 +22,20 @@ import { TOOLKIT_DETAIL_STALE_TIME_MS, useToolkitDetail } from '../useToolkitDet
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -97,7 +102,7 @@ describe('useToolkitDetail — request shape', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}`, expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(`/api/v1/toolkits/${TOOLKIT_ID}`, expect.anything());
   });
 
   it('does not fire when toolkitId is null', () => {

--- a/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitRatings.test.tsx
@@ -25,13 +25,20 @@ import {
   useToolkitRatings,
 } from '../useToolkitRatings';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: { get: vi.fn() },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -88,7 +95,7 @@ describe('useToolkitRatings', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockGet).toHaveBeenCalledTimes(1);
-    expect(mockGet.mock.calls[0]![0]).toBe(`/toolkits/${TOOLKIT_ID}/ratings?limit=20`);
+    expect(mockGet.mock.calls[0]![0]).toBe(`/api/v1/toolkits/${TOOLKIT_ID}/ratings?limit=20`);
   });
 
   it('returns the v1 empty stub envelope unchanged', async () => {

--- a/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useToolkitVersions.test.tsx
@@ -4,7 +4,7 @@
  * useToolkitVersions unit tests — Wave 3 Phase 2 (Issue #805 / PR #732 §5.3.2).
  *
  * Coverage:
- *   - Stable URL `/toolkits/{id}/versions` and 10min staleTime mirror.
+ *   - Stable URL `/api/v1/toolkits/{id}/versions` and 10min staleTime mirror.
  *   - Schema validation forwards typed array (items unwrapped).
  *   - Empty / null fallback returns empty array.
  *   - `enabled: false` and missing toolkitId defer the request.
@@ -19,15 +19,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { TOOLKIT_VERSIONS_STALE_TIME_MS, useToolkitVersions } from '../useToolkitVersions';
 
-vi.mock('@/lib/api/client', () => ({
-  apiClient: {
-    get: vi.fn(),
-  },
+import type { MockedApiClient } from '@/test-utils/api-client-mock';
+
+const mockApi = vi.hoisted<MockedApiClient>(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
 }));
+vi.mock('@/lib/api/client', () => ({ apiClient: mockApi }));
 
-import { apiClient } from '@/lib/api/client';
-
-const mockGet = apiClient.get as ReturnType<typeof vi.fn>;
+const mockGet = mockApi.get;
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -71,7 +76,10 @@ describe('useToolkitVersions — request shape', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockGet).toHaveBeenCalledWith(`/toolkits/${TOOLKIT_ID}/versions`, expect.anything());
+    expect(mockGet).toHaveBeenCalledWith(
+      `/api/v1/toolkits/${TOOLKIT_ID}/versions`,
+      expect.anything()
+    );
   });
 
   it('does not fire when toolkitId is null', () => {

--- a/apps/web/src/hooks/queries/useKbChunksList.ts
+++ b/apps/web/src/hooks/queries/useKbChunksList.ts
@@ -68,7 +68,7 @@ export function useKbChunksList(
       const params = new URLSearchParams();
       params.set('limit', String(limit));
       if (pageParam) params.set('cursor', pageParam);
-      const path = `/kb-docs/${safeDocId}/chunks?${params.toString()}`;
+      const path = `/api/v1/kb-docs/${safeDocId}/chunks?${params.toString()}`;
       const response = await apiClient.get<KbChunksListResponse>(path, KbChunksListResponseSchema);
       // apiClient may return null on 401 — translate to an empty page so the
       // infinite query terminates cleanly without leaking a non-throwing null.

--- a/apps/web/src/test-utils/api-client-mock.ts
+++ b/apps/web/src/test-utils/api-client-mock.ts
@@ -78,4 +78,12 @@ export type MockedApiClient = {
   readonly delete: Mock;
   readonly head: Mock;
   readonly options: Mock;
+  /**
+   * `HttpClient` exposes a `postFile` download/upload helper with a
+   * distinct (non-REST-verb) signature. Optional so the 7 verb defaults
+   * do not need to change for the common case. Declare it inline in your
+   * `vi.hoisted<MockedApiClient>(() => ({ ..., postFile: vi.fn() }))`
+   * factory when a test exercises file flows.
+   */
+  readonly postFile?: Mock;
 };


### PR DESCRIPTION
## Summary

Closes the 3 non-blocking follow-ups surfaced by the code review of PR #1233. Also fixes a **bonus 404 bug** that the migration exposed.

## Follow-up #1: migrate the 7 remaining test files

All 7 files that still used `apiClient.X as ReturnType<typeof vi.fn>` are now on the canonical `vi.hoisted<MockedApiClient>(...)` + `vi.mock(...)` pattern. 13 of 13 apiClient-consuming test files now share the same typing/mock contract.

- `useToolkitVersions.test.tsx`
- `useToolkitRatings.test.tsx`
- `useToolkitDetail.test.tsx`
- `useKbChunkDetail.test.tsx`
- `useKbChunksList.test.tsx`
- `useKbDocDetail.test.tsx`
- `useInstallToolkit.test.tsx`

## Follow-up #2: `postFile?: Mock` in `MockedApiClient`

Adds the optional `readonly postFile?: Mock` field. `HttpClient.postFile` is the only non-REST-verb method on the production client — keeping it optional avoids forcing the 7-verb factory inline in every test that does not exercise upload/download flows.

## Follow-up #3: register `local/api-client-v1-prefix` in the `*.{js,jsx}` ESLint block

`eslint.config.mjs` lines 269-308 now declare the `local` plugin and activate `api-client-v1-prefix: error` for `.js`/`.jsx` files. No JS API consumer exists today, but the gate must be uniform across file extensions to remain meaningful as a regression preventer.

## Bonus bug fix surfaced by migration

`useKbChunksList.ts:71` constructed the path string in a local variable (`const path = \`/kb-docs/...\`; apiClient.get(path, ...)`), so it escaped the `api-client-v1-prefix` rule's static analysis (the rule conservatively skips Identifier callees to avoid false positives). The migrated test asserted the expected `/api/v1/kb-docs/...` shape, exposing the missing prefix — same 404 class as #1229/#1230. Path now corrected to `/api/v1/kb-docs/${docId}/chunks?...`. The rule extension (variable-path tracking) is a separate concern; the rule's docstring already documents this skip rationale.

## Validation

| Check | Result |
|---|---|
| `pnpm typecheck` | 0 errors |
| `pnpm exec eslint src/ --no-inline-config` | 0 `api-client-v1-prefix` violations |
| `pnpm test --run` on the 13 affected test files | **101/101 pass** |

## Risk

Low. Test-only refactor + one 1-line production fix to a path literal. ESLint extension scope is additive (no current JS files affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)