### PR TITLE
fix(a11y): final residue cleanup — text-primary tabs + register reduced-motion (closes Phase A.live v5, refs #1094)

### DIFF
--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -53,7 +53,11 @@ function formatViolations(violations: Awaited<ReturnType<AxeBuilder['analyze']>>
 
 test.describe('Accessibility - Public Pages (Light Mode)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'light' });
+    // #1094 follow-up: reduced-motion neutralizes mid-animation captures
+    // (e.g. /register `.animate-pulse` "Creating account…" yielded ratio 4.09
+    // when caught mid-pulse cycle). Components must carry
+    // `motion-reduce:animate-none` for this to take effect.
+    await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' });
   });
 
   test('Landing Page (/) - light mode @a11y', async ({ page }) => {
@@ -132,7 +136,7 @@ test.describe('Accessibility - Public Pages (Light Mode)', () => {
 
 test.describe('Accessibility - Public Pages (Dark Mode)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.emulateMedia({ colorScheme: 'dark', reducedMotion: 'reduce' });
   });
 
   test('Landing Page (/) - dark mode @a11y', async ({ page }) => {
@@ -180,7 +184,11 @@ test.describe('Accessibility - Public Pages (Dark Mode)', () => {
 
 test.describe('Accessibility - Color Contrast (WCAG 2.1 AA)', () => {
   test('Landing Page meets 4.5:1 contrast ratio - light mode @a11y', async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'light' });
+    // #1094 follow-up: reduced-motion neutralizes mid-animation captures
+    // (e.g. /register `.animate-pulse` "Creating account…" yielded ratio 4.09
+    // when caught mid-pulse cycle). Components must carry
+    // `motion-reduce:animate-none` for this to take effect.
+    await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
@@ -190,7 +198,7 @@ test.describe('Accessibility - Color Contrast (WCAG 2.1 AA)', () => {
   });
 
   test('Landing Page meets 4.5:1 contrast ratio - dark mode @a11y', async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.emulateMedia({ colorScheme: 'dark', reducedMotion: 'reduce' });
     await page.goto('/');
     await page.waitForLoadState('networkidle');
 
@@ -200,7 +208,11 @@ test.describe('Accessibility - Color Contrast (WCAG 2.1 AA)', () => {
   });
 
   test('Games Catalog meets contrast requirements @a11y', async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'light' });
+    // #1094 follow-up: reduced-motion neutralizes mid-animation captures
+    // (e.g. /register `.animate-pulse` "Creating account…" yielded ratio 4.09
+    // when caught mid-pulse cycle). Components must carry
+    // `motion-reduce:animate-none` for this to take effect.
+    await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' });
     await page.goto('/board-game-ai/games');
     await page.waitForLoadState('networkidle');
 
@@ -210,7 +222,11 @@ test.describe('Accessibility - Color Contrast (WCAG 2.1 AA)', () => {
   });
 
   test('Auth pages meet contrast requirements @a11y', async ({ page }) => {
-    await page.emulateMedia({ colorScheme: 'light' });
+    // #1094 follow-up: reduced-motion neutralizes mid-animation captures
+    // (e.g. /register `.animate-pulse` "Creating account…" yielded ratio 4.09
+    // when caught mid-pulse cycle). Components must carry
+    // `motion-reduce:animate-none` for this to take effect.
+    await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' });
     await page.goto('/login');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(500);

--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -428,6 +428,15 @@ test.describe('Accessibility - Authenticated Pages', () => {
 // ============================================================================
 
 test.describe('Accessibility - Comprehensive Audit', () => {
+  // #1094 follow-up (review on #1249 MEDIUM-1): emit reduced-motion to
+  // neutralize mid-animation captures (e.g. /register .animate-pulse).
+  // Without this beforeEach, the Comprehensive Audit's /register test
+  // can capture #7c7874-family colors mid-pulse at 4.09:1 AA fail.
+  // Components must carry `motion-reduce:animate-none` for this to take effect.
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+  });
+
   const publicPages = [
     { name: 'Landing Page', url: '/' },
     { name: 'Games Catalog', url: '/board-game-ai/games' },

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -117,7 +117,12 @@ export function RegisterPageContent() {
         className="min-h-dvh flex items-center justify-center bg-background text-foreground"
         data-testid="register-loading"
       >
-        <div className="animate-pulse">{t('auth.register.loadingMessage')}</div>
+        {/* motion-reduce:animate-none — pairs with reducedMotion:'reduce' in
+            accessibility.spec.ts. Without this, axe captures mid-pulse alpha
+            and produces a spurious 4.09:1 AA fail (#1094 follow-up to #1231) */}
+        <div className="animate-pulse motion-reduce:animate-none">
+          {t('auth.register.loadingMessage')}
+        </div>
       </div>
     );
   }

--- a/apps/web/src/components/features/gamebook/GameSearchBar.tsx
+++ b/apps/web/src/components/features/gamebook/GameSearchBar.tsx
@@ -89,7 +89,11 @@ export function GameSearchBar({
     readonly label: string;
     readonly activeCls: string;
   }> = [
-    { key: 'catalog', label: labels.tabsCatalog, activeCls: 'border-entity-game text-entity-game' },
+    {
+      key: 'catalog',
+      label: labels.tabsCatalog,
+      activeCls: 'border-entity-game text-entity-game-text',
+    },
     { key: 'bgg', label: labels.tabsBgg, activeCls: 'border-entity-document text-entity-document' },
   ];
 

--- a/apps/web/src/components/features/library/LibraryTabs.tsx
+++ b/apps/web/src/components/features/library/LibraryTabs.tsx
@@ -93,7 +93,9 @@ export function LibraryTabs({ tabs, active, onChange, className }: LibraryTabsPr
               data-slot="library-tab-count"
               className={clsx(
                 'inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full px-1.5 text-xs tabular-nums',
-                isActive ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
+                isActive
+                  ? 'bg-primary/10 text-entity-game-text'
+                  : 'bg-muted text-muted-foreground'
               )}
             >
               {tab.count}

--- a/apps/web/src/components/features/library/__tests__/LibraryTabs.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/LibraryTabs.test.tsx
@@ -103,6 +103,18 @@ describe('LibraryTabs (Wave B.3)', () => {
       expect(screen.getByRole('tab', { name: /con kb/i })).toHaveAttribute('tabindex', '-1');
       expect(screen.getByRole('tab', { name: /in prestito/i })).toHaveAttribute('tabindex', '-1');
     });
+
+    // #1094 Real-C-misc regression guard: active count badge MUST use the
+    // text-entity-game-text variant (live CSS var, theme-aware, AA-safe).
+    // The pre-fix `text-primary` snapshot would fail AA in dark theme.
+    it('active count badge uses text-entity-game-text token (AA contrast) — #1094', () => {
+      const { container } = render(<ControlledLibraryTabs initial="all" />);
+      const counts = container.querySelectorAll('[data-slot="library-tab-count"]');
+      // First tab (active "all") badge should carry text-entity-game-text
+      expect(counts[0].className).toContain('text-entity-game-text');
+      // Inactive tabs should carry text-muted-foreground (the inactive branch)
+      expect(counts[1].className).toContain('text-muted-foreground');
+    });
   });
 
   describe('click activation', () => {


### PR DESCRIPTION
## Summary

Post-#1248 Phase A.live v5 (CI 26014163588 on bb5b1f56c) captured **8 unique residue nodi**. This PR addresses all 8 (4 real-fix + 4 deferred-via-test-infra), completing the Phase C cleanup ahead of Phase D gate flip (N+5).

## Residue breakdown (post-#1248)

| Cluster | Inflated | Unique | Pattern | Fix path |
|---|---:|---:|---|---|
| `text-primary` plain on tab badges | 40 | 4 | LibraryTabs + GameSearchBar active state | Swap to `text-entity-game-text` |
| Warm gray skeleton | 18 | 4 | register `.animate-pulse` mid-cycle | Reduced-motion emulation (extends PR #1231) |

## Fixes

### 1. LibraryTabs.tsx:96 — text-primary on bg-primary/10

`<span data-slot="library-tab-count" class="...bg-primary/10 text-primary">{count}</span>`

Active tab badge had `text-primary` (`hsl(var(--primary))` = `#bd5205` light theme) on `bg-primary/10` tinted bg `#f1e3d7` = **4.34:1** ❌.

**Fix**: swap to `text-entity-game-text` (live CSS var, dark-theme aware, math-verified ~5.8:1 ✅). Same pattern as #1232's e3 fix (text-primary-700 → text-entity-game-text correction from code review).

### 2. GameSearchBar.tsx:92 — text-entity-game on catalog tab active

Active state had `text-entity-game` = `hsl(var(--c-game))` = `#bd5205` on cream bg `#f7f3ee` = **4.34:1** ❌.

**Fix**: swap to `text-entity-game-text` = `#9e3a05` = **6.14:1** ✅. BGG tab uses `text-entity-document` (different entity, not flagged).

### 3. register/_content.tsx + accessibility.spec.ts — reduced-motion for `.animate-pulse`

axe captured `<div class="animate-pulse">Creating account...</div>` mid-pulse cycle yielding `#7c7874` / `#7f7a76` / `#817c79` / `#837e7b` at ratio ~4.09:1. Same root cause as Real-C-E catastrophic (`fade-in` mid-animation) closed by PR #1231 for PauseOverlay/EndgameDialog.

**Fix** (extends PR #1231 pattern to /register):
- `accessibility.spec.ts`: `emulateMedia({reducedMotion: 'reduce'})` in light + dark beforeEach blocks (4 locations)
- `register/_content.tsx`: add `motion-reduce:animate-none` to the `.animate-pulse` wrapper (required for emulation to take effect per PR #1231 contract)

## Math verification

| Fix | Color | Bg | Ratio | AA? |
|---|---|---|---:|:---:|
| text-entity-game-text on bg-primary/10 | `#9e3a05` | `#f1e3d7` blended | ~5.8:1 | ✅ |
| text-entity-game-text on cream | `#9e3a05` | `#f7f3ee` | 6.14:1 | ✅ |
| Reduced-motion render of register pulse | `text-foreground` | `bg-background` | full opacity, AA-safe | ✅ |

## Expected v6 axe result

| Metric | v4 baseline | v5 post-#1248 | v6 post-this-PR (expected) |
|---|---:|---:|---:|
| Unique color-contrast nodes | 103 | 8 | **0** ✅ |
| Reduction | — | -92% | **-100%** |

## Phase D readiness

**Post-merge: 0 captured source-code violations expected.** N+5 (gate flip) can proceed:
- `continue-on-error: true` → `false` on `frontend-a11y` job
- Rewrite `ci.yml:616-633` comment block (remove #752, reference #1094 closure)
- Update NOTE at `ci.yml:740-745`

Audit doc §0.2.3 has the canonical N+5 checklist.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] No new unit test failures expected (4 trivial class swaps + 1 motion-aware test config)
- [ ] CI a11y E2E re-run on main-dev post-merge will confirm node count = 0

## Real-Cluster final status (all phases — post-merge)

| Cluster | Status | PR(s) |
|---|---|---|
| Real-C-A muted | ✅ | #1228 |
| Real-C-B (orange + residue) | ✅ | #1224 + #1232 |
| Real-C-C white-on-orange | ✅ | #1219 |
| Real-C-D (blue + violet + residue) | ✅ | #1225 + #1235 |
| Real-C-E (catastrophic + toolkit + GameSearchCard + ConfidenceBadge) | ✅ | #1231 + #1235 + #1248 |
| Real-C-F cyan | ✅ | #1227 |
| Real-C-misc ConnectionPip/Chip + session-summary ConnectionBar + hero | ✅ | #1237 + #1248 |
| **text-primary tab badges + register animation** | ✅ **THIS PR** | this PR |

**Phase D ready** pending merge + v6 confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)