### PR TITLE
feat(mockups): SP7 K/L/M — game-night live + transition + summary (closes #487)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -6,7 +6,7 @@
 >
 > **Audience**: developers looking for "which mockup file do I need for route X?".
 >
-> **Last updated**: 2026-05-12. Keep in sync with
+> **Last updated**: 2026-05-18. Keep in sync with
 > [`docs/for-developers/frontend/v2-migration-matrix.md`](../docs/for-developers/frontend/v2-migration-matrix.md)
 > Route Index section.
 
@@ -105,6 +105,9 @@
 |------|------|---------------|
 | `sp7-game-night-create.html` | page-mock | `/game-nights/new` |
 | `sp7-game-night-detail-rsvp.html` | page-mock | `/game-nights/[id]`, `/game-nights/[id]/edit` |
+| `sp7-game-night-live.html` | page-mock | `/game-nights/[id]/live` (issue #487 screen #4+#7) |
+| `sp7-game-night-transition.html` | component-mock | Modal opened from `/game-nights/[id]/live` (issue #487 screen #5) |
+| `sp7-game-night-summary.html` | page-mock | `/game-nights/[id]/summary` (issue #487 screen #6) |
 
 ## Nanolith — Runthrough storyboard (Aaron Iter 1)
 
@@ -132,10 +135,10 @@
 
 | Type | Count |
 |------|------:|
-| page-mock | 46 |
-| component-mock | 15 |
+| page-mock | 48 |
+| component-mock | 16 |
 | dev-fixture | 10 |
-| **Total** | **71** |
+| **Total** | **74** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/briefs/SP7-game-night-agent-builder.md
+++ b/admin-mockups/briefs/SP7-game-night-agent-builder.md
@@ -394,6 +394,135 @@ US-31: G31.4 (host edit), G31.8 (cancel + notify), G31.9 (reschedule conflicts).
 
 ---
 
+# WAVE 1+ — Estensione issue #487 (game-night runtime)
+
+Tre mockup aggiunti 2026-05-18 per chiudere lo scope residuo della issue [#487](https://github.com/meepleAi-app/meepleai-monorepo/issues/487) (`[Design v1 · B3] Mockup Game Nights`). Gli screen #1-#3 del brief originale sono già coperti da `sp4-game-nights-index` (list desktop+mobile) e `sp7-game-night-create` (planning wizard). I 4 screen residui (#4 Night Live, #5 Transition, #6 Summary, #7 Diary widget) sono distribuiti in 3 file SP7, con il Diary widget embedded come sub-component esportato dentro `sp7-game-night-live.jsx`.
+
+## K — Game Night Live Hub (`sp7-game-night-live`)
+
+**File**: `sp7-game-night-live.{html,jsx}`
+**Route**: `/game-nights/[id]/live`
+**Persona**: Marco (host) durante la serata, desktop al tavolo o tablet. Mobile per quick-jump tra session.
+**Pattern**: 3-pane desktop (sidebar sx games planned 280px | center current game 1fr | sidebar dx diary stream 320px) / Mobile fullscreen swipeable tabs
+
+### Sezioni richieste
+
+- **Top bar live**: title serata + status pulsing `entityHsl('session')` + counter mono kicker "Game 2/3 · 23min elapsed"
+- **Toolbar fissa**: [Pause ⏸] [Transition ➡️] [End night 🛑] con confirmation modal per End
+- **Center pane — Current game card**: cover game + session live link + quick-jump CTA "Apri sessione live →" (link a `/sessions/[id]/live`)
+- **Left pane — Planned games list**: stato per game (✅ completed / 🔴 in-progress pulsing / ⏳ upcoming), tempo stimato vs reale, ordine PlayOrder draggable disabled in live mode
+- **Right pane — Cross-game diary**: stream timeline (riusa pattern `SessionDiaryTimeline` da `sp4-session-live-parts.jsx`, aggregato multi-session)
+- **Diary inline widget** (componente esportato, copre screen #7 brief originale): versione compatta 320×400 embeddable in altri contesti (es. `/game-nights/[id]` detail o sidebar `/sessions/[id]/live`)
+
+### Stati richiesti
+
+| Stato | Descrizione |
+|---|---|
+| `state-01-game-1-in-progress` | Prima session live, diary 5 eventi, 2 game planned upcoming |
+| `state-02-mid-night-game-2` | Game 1 completed (winner banner), Game 2 in-progress, diary 18 eventi |
+| `state-03-transition-pending` | Tra Game 1 e Game 2, current pane mostra "In attesa transition" |
+| `state-04-paused` | Serata in pausa (overlay `entityHsl('agent', 0.1)` = warning), toolbar pause attiva |
+| `state-05-diary-empty` | Inizio serata, diary "Nessun evento ancora · Inizia a giocare!" |
+| `state-06-diary-widget-embedded` | Diary widget 320×400 versione compatta isolata (standalone preview per riuso) |
+| `state-07-mobile-tab-current` | Mobile tab "Current" attivo |
+| `state-08-mobile-tab-planned` | Mobile tab "Planned" attivo |
+| `state-09-mobile-tab-diary` | Mobile tab "Diary" attivo |
+| `state-10-auto-save-toast` | Toast "✓ Auto-salvato" `entityHsl('toolkit', 0.1)` ogni 60s, posizione bottom-right (acceptance criterion #487) |
+
+Desktop variant: 3-pane fisso 280+1fr+320. Mobile variant: tabs swipeable (Current / Planned / Diary).
+
+### Componenti / primitive da riusare
+
+- `ConnectionBar` con pip `[event=1, game=3, session={current_id}, player={confirmed_count}]`
+- `SessionDiaryTimeline` pattern da `sp4-session-live-parts.jsx` (aggregato multi-session)
+- `Drawer` per game-jump bottom sheet mobile
+- `MeepleCard` variant `compact` per planned games list
+- `entityHsl('event')` accent serata, `entityHsl('session')` pulsing per game corrente
+
+### Coverage Gherkin
+
+US-31: G31.11 (live hub navigation), G31.12 (cross-game diary aggregation), G31.13 (auto-save indicator 60s)
+
+---
+
+## L — Game Transition Dialog (`sp7-game-night-transition`)
+
+**File**: `sp7-game-night-transition.{html,jsx}`
+**Route**: modal/overlay aperto da K — no standalone route
+**Persona**: Marco (host) tra game e game, decisione 30-90 sec.
+**Pattern**: Modal centered 600×500 desktop / fullscreen mobile, 2-column split (recap last | preview next)
+
+### Sezioni richieste
+
+- **Header**: "Pronti per il prossimo gioco?" + close X
+- **Left col — Ultimo gioco**: cover small + title + winner banner `entityHsl('event')` + durata effettiva + score finale top-3
+- **Right col — Prossimo gioco**: cover + title + rules quick-glance da KB (3 bullet) + tempo stimato + setup checklist con icone
+- **CTA primary**: "Avvia prossima session →" `entityHsl('session')`
+- **Secondary**: "Salta gioco" / "Termina serata qui"
+
+### Stati richiesti
+
+| Stato | Descrizione |
+|---|---|
+| `state-01-transition-default` | Default 2-col split, recap + preview entrambi popolati |
+| `state-02-rules-loading-skeleton` | KB quick-glance ancora in loading (skeleton 3 righe) |
+| `state-03-rules-load-error` | KB fetch failed, fallback "Rules non disponibili offline" |
+| `state-04-skip-confirm` | Submodal "Saltare? Verrà rimosso dai planned" |
+| `state-05-end-night-confirm` | Submodal "Terminare serata? Andrai al Summary" |
+| `state-06-mobile-fullscreen` | Mobile vertical stack invece di 2-col |
+
+### Componenti / primitive da riusare
+
+- `Drawer` variant `modal` da `03-drawer-variants.html`
+- `ConfirmModal` per submodal skip/end (pattern SP6-B)
+- `MeepleCard` variant `compact` per game preview entrambi i pannelli
+- `entityHsl('event')` winner banner, `entityHsl('session')` CTA primary
+
+### Coverage Gherkin
+
+US-31: G31.14 (transition flow), G31.15 (KB rules preview fallback)
+
+---
+
+## M — Night Summary (`sp7-game-night-summary`)
+
+**File**: `sp7-game-night-summary.{html,jsx}`
+**Route**: `/game-nights/[id]/summary` (post-end final state)
+**Persona**: tutti i partecipanti, post-serata. Mobile primario per share, desktop per archiviazione/review.
+**Pattern**: Full-screen single column scrollable, hero + sections stack
+
+### Sezioni richieste
+
+- **Hero**: title serata + date + total durata + winner banner globale "🏆 MVP della serata: Davide" `entityHsl('event')`
+- **Stats grid**: 4 KPI card mono kicker (totale sessioni, durata, n° eventi diary, winner per gioco)
+- **Cross-game timeline**: `SessionDiaryTimeline` filtered, collapsed by game (expand per dettaglio)
+- **Per-game recap**: 1 row per game con winner + durata + CTA "Vai a session →" link a `/sessions/[id]`
+- **Foto gallery** (placeholder): grid 3×N con add-photo CTA `entityHsl('event', 0.1)` placeholder card
+- **Footer CTA**: [Condividi riepilogo 📤] [Archivia ✓]
+
+### Stati richiesti
+
+| Stato | Descrizione |
+|---|---|
+| `state-01-summary-full` | 3 games completati, 28 diary events, foto 6 |
+| `state-02-summary-no-photos` | Stesso ma foto gallery empty con CTA placeholder "Aggiungi foto" |
+| `state-03-summary-single-game` | Serata 1 game (no transition history, no per-game recap multipli) |
+| `state-04-share-success-toast` | Post-share toast "Link copiato" `entityHsl('toolkit', 0.1)` |
+| `state-05-archived` | Post-archive banner muted `var(--text-muted)` + CTA "Torna alla lista" |
+| `state-06-mobile-single-col` | Mobile vertical stack (default già single col, ma con padding ridotto) |
+
+### Componenti / primitive da riusare
+
+- `SessionDiaryTimeline` mode `collapsed` (filtra per game header expandable)
+- `MeepleCard` variant `compact` per per-game recap rows
+- `entityHsl('event')` hero accent, `entityHsl('toolkit')` per success states (share/archive)
+
+### Coverage Gherkin
+
+US-31: G31.16 (summary aggregation), G31.17 (share riepilogo), G31.18 (archive flow)
+
+---
+
 # WAVE 2 — Agent Builder Flow (US-33)
 
 ## D — Agent Proposals List (`sp7-agent-proposals-list`)
@@ -860,6 +989,9 @@ Buon lavoro. SP7 attiva 3 user story P1 dormant — post-merge si passa allo spr
 | 1 | A `sp7-game-night-create` | ⏳ pending | First della wave |
 | 1 | B `sp7-game-night-detail-rsvp` | ⏳ pending | After A |
 | 1 | C `sp7-game-night-edit` | ⏳ pending | After B |
+| 1+ | K `sp7-game-night-live` | ⏳ pending | Issue #487 — central hub durante serata, embed Diary widget (#7) |
+| 1+ | L `sp7-game-night-transition` | ⏳ pending | Issue #487 — modal recap+preview tra game e game |
+| 1+ | M `sp7-game-night-summary` | ⏳ pending | Issue #487 — recap full-screen post-end |
 | 2 | D `sp7-agent-proposals-list` | ⏳ pending | First della wave 2 |
 | 2 | E `sp7-agent-builder-create` | ⏳ pending | After D |
 | 2 | F `sp7-agent-builder-test` | ⏳ pending | After E |

--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -266,6 +266,30 @@
     <p>4 stati extra wizard upload: source picker 4 card (file/BGG/riusa/URL coming-soon), pre-upload dedup check con hash SHA256, cost preview con 3 provider option (OpenAI/Cohere/local), indexing async progress 5-step timeline + failed variant retry. Consumer SG1 #902 + SG2 #903.</p>
     <div class="tags"><span class="tag">4 stati</span><span class="tag">Cost preview</span><span class="tag">Async progress</span></div>
   </a>
+
+  <a class="hub-card e-event" href="sp7-game-night-live.html">
+    <div class="arrow">→</div>
+    <div class="num">SP7 · K · #487</div>
+    <h3>Game Night Live Hub</h3>
+    <p>10 stati per l'hub centrale durante la serata: 3-pane desktop (planned games | current game | cross-game diary) / mobile swipeable tabs. Auto-save toast ogni 60s, diary widget esportato come sub-component embeddable. Acceptance criterion issue #487.</p>
+    <div class="tags"><span class="tag">10 stati</span><span class="tag">3-pane</span><span class="tag">Auto-save 60s</span></div>
+  </a>
+
+  <a class="hub-card e-event" href="sp7-game-night-transition.html">
+    <div class="arrow">→</div>
+    <div class="num">SP7 · L · #487</div>
+    <h3>Game Transition Dialog</h3>
+    <p>6 stati per il modal tra game e game: 2-col split recap (winner top-3) + preview prossimo (KB rules quick-glance + setup checklist). Fallback graceful KB offline, submodal nested per skip/end. Aperto dalla toolbar di K.</p>
+    <div class="tags"><span class="tag">6 stati</span><span class="tag">Modal 600×500</span><span class="tag">KB fallback</span></div>
+  </a>
+
+  <a class="hub-card e-event" href="sp7-game-night-summary.html">
+    <div class="arrow">→</div>
+    <div class="num">SP7 · M · #487</div>
+    <h3>Night Summary post-end</h3>
+    <p>6 stati per il recap full-screen post-serata: hero MVP + KPI grid 4 stat + cross-game timeline collapsed + per-game recap (co-op variant) + foto gallery (empty state) + share/archive CTA. MVP heuristic da definire backend-side.</p>
+    <div class="tags"><span class="tag">6 stati</span><span class="tag">MVP banner</span><span class="tag">Co-op variant</span></div>
+  </a>
 </div>
 
 <section class="palette-row">

--- a/admin-mockups/design_files/sp7-game-night-live.html
+++ b/admin-mockups/design_files/sp7-game-night-live.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>SP7-K · Game Night Live Hub — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700;800&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+  <style>
+    /* ─── Harness · sections ─── */
+    .section-header {
+      display: flex; align-items: center; gap: 12px;
+      padding-bottom: 12px; margin-bottom: 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .section-marker {
+      width: 6px; height: 28px; border-radius: 3px;
+    }
+    .section-title {
+      font-family: var(--f-display); font-size: 18px; font-weight: 800;
+      color: var(--text); margin: 0; flex: 1; letter-spacing: -.01em;
+    }
+    .section-meta {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em;
+    }
+
+    /* ─── State caption header (above every frame) ─── */
+    .state-caption {
+      display: flex; align-items: center; gap: 8px;
+      margin-bottom: 10px; flex-wrap: wrap;
+    }
+    .state-id {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 800;
+      color: hsl(var(--c-event));
+      background: hsl(var(--c-event) / .12);
+      border: 1px solid hsl(var(--c-event) / .25);
+      padding: 3px 8px; border-radius: var(--r-pill);
+      letter-spacing: .04em;
+    }
+    .state-label {
+      font-family: var(--f-display); font-size: 12.5px; font-weight: 800;
+      color: var(--text);
+    }
+    .gherkin {
+      font-family: var(--f-mono); font-size: 9.5px; font-weight: 800;
+      color: hsl(var(--c-toolkit));
+      background: hsl(var(--c-toolkit) / .1);
+      border: 1px solid hsl(var(--c-toolkit) / .3);
+      padding: 2px 7px; border-radius: var(--r-pill);
+      text-transform: uppercase; letter-spacing: .06em;
+    }
+    .state-desc {
+      font-size: 11.5px; color: var(--text-sec); margin: 12px 0 0;
+      line-height: 1.55; max-width: 1180px;
+    }
+
+    /* ─── Desktop frame ─── */
+    .desktop-shell {
+      display: flex; flex-direction: column; width: 100%;
+    }
+    .desktop-frame {
+      width: 100%; max-width: 1280px;
+      border-radius: var(--r-xl);
+      border: 1px solid var(--border);
+      background: var(--bg);
+      overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 9px 14px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    }
+    .desktop-bar .traffic {
+      width: 11px; height: 11px; border-radius: 50%;
+      background: hsl(var(--c-event));
+    }
+    .desktop-bar .traffic:nth-child(2) { background: hsl(var(--c-warning)); }
+    .desktop-bar .traffic:nth-child(3) { background: hsl(var(--c-toolkit)); }
+    .desktop-bar .url {
+      flex: 1; text-align: center; letter-spacing: .04em;
+    }
+
+    /* ─── Phone frame override (slightly taller for content) ─── */
+    .phone-shell {
+      display: flex; flex-direction: column; align-items: center;
+    }
+    .phone-shell .phone {
+      width: 390px; height: 800px;
+    }
+    .mobile-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(390px, 1fr));
+      gap: var(--s-7);
+      align-items: start;
+    }
+
+    /* ─── Widget shell ─── */
+    .widget-shell {
+      display: flex; flex-direction: column;
+    }
+    .widget-shell .widget-callout {
+      flex: 1; min-width: 0; max-width: 480px;
+      padding: 14px 16px;
+      background: var(--bg-card);
+      border: 1px dashed hsl(var(--c-event) / .35);
+      border-radius: var(--r-lg);
+    }
+    .widget-callout ul {
+      margin: 8px 0 0; padding-left: 18px;
+      font-size: 12px; color: var(--text-sec); line-height: 1.65;
+    }
+    .widget-callout code {
+      background: var(--bg-muted);
+      padding: 1px 5px; border-radius: var(--r-xs);
+      font-size: 11px;
+    }
+
+    /* ─── Animations ─── */
+    @keyframes sp7Pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50%      { transform: scale(1.45); opacity: .55; }
+    }
+    @keyframes sp7PulseRing {
+      0%   { transform: scale(.7); opacity: .55; }
+      100% { transform: scale(1.35); opacity: 0; }
+    }
+    @keyframes sp7ToastIn {
+      from { transform: translateY(12px) scale(.96); opacity: 0; }
+      to   { transform: translateY(0) scale(1);     opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+      }
+    }
+
+    /* ─── Misc resets for inner scroll ─── */
+    .phone > div::-webkit-scrollbar,
+    .desktop-frame ::-webkit-scrollbar {
+      width: 6px; height: 6px;
+    }
+    .desktop-frame ::-webkit-scrollbar-thumb {
+      background: var(--border-strong); border-radius: 3px;
+    }
+    button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible {
+      outline: 2px solid hsl(var(--c-event));
+      outline-offset: 2px;
+    }
+    code {
+      background: var(--bg-muted);
+      padding: 1px 5px; border-radius: var(--r-xs);
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- Global DS palette (mimics apps/web/src/lib/theme/entity-hsl.ts) -->
+  <script>
+    window.DS = {
+      EC: {
+        game:    { h: 25,  s: 95, l: 45, em: '🎲' },
+        player:  { h: 262, s: 83, l: 58, em: '👤' },
+        session: { h: 240, s: 60, l: 55, em: '🎯' },
+        agent:   { h: 38,  s: 92, l: 50, em: '🤖' },
+        kb:      { h: 174, s: 60, l: 40, em: '📄' },
+        chat:    { h: 220, s: 80, l: 55, em: '💬' },
+        event:   { h: 350, s: 89, l: 60, em: '🎉' },
+        toolkit: { h: 142, s: 70, l: 45, em: '🧰' },
+        tool:    { h: 195, s: 80, l: 50, em: '🔧' },
+      },
+      byId: {},
+    };
+    // Light/dark theme — entityHsl helper auto-bumps via DS.EC override
+    const _applyTheme = (t) => {
+      if (t === 'dark') {
+        Object.assign(window.DS.EC, {
+          game:    { h: 28,  s: 95, l: 58, em:'🎲' },
+          player:  { h: 262, s: 75, l: 70, em:'👤' },
+          session: { h: 235, s: 70, l: 70, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 62, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 55, em:'📄' },
+          chat:    { h: 218, s: 80, l: 68, em:'💬' },
+          event:   { h: 350, s: 85, l: 70, em:'🎉' },
+          toolkit: { h: 142, s: 60, l: 58, em:'🧰' },
+          tool:    { h: 195, s: 75, l: 62, em:'🔧' },
+        });
+      } else {
+        Object.assign(window.DS.EC, {
+          game:    { h: 25,  s: 95, l: 45, em:'🎲' },
+          player:  { h: 262, s: 83, l: 58, em:'👤' },
+          session: { h: 240, s: 60, l: 55, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 50, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 40, em:'📄' },
+          chat:    { h: 220, s: 80, l: 55, em:'💬' },
+          event:   { h: 350, s: 89, l: 60, em:'🎉' },
+          toolkit: { h: 142, s: 70, l: 45, em:'🧰' },
+          tool:    { h: 195, s: 80, l: 50, em:'🔧' },
+        });
+      }
+    };
+    // observe theme changes
+    new MutationObserver(() => {
+      _applyTheme(document.documentElement.getAttribute('data-theme'));
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    _applyTheme(document.documentElement.getAttribute('data-theme') || 'light');
+  </script>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="sp7-game-night-live.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp7-game-night-live.jsx
+++ b/admin-mockups/design_files/sp7-game-night-live.jsx
@@ -29,19 +29,19 @@
    - auto-save toast bg       = entityHsl('toolkit', 0.1) green tint
    - pause overlay accent     = var(--c-warning)     amber
 
-   Componenti v2 emersi (per impl post-merge)
-   - GameNightLiveHub          → apps/web/src/components/ui/v2/game-night-live-hub/
-   - LiveHubTopBar             → ui/v2/live-hub-top-bar/
-   - LiveHubToolbar            → ui/v2/live-hub-toolbar/      (Pausa · Transition · End)
-   - PlannedGamesPane          → ui/v2/planned-games-pane/
-   - PlannedGameRow            → ui/v2/planned-game-row/      (status ✅ / 🔴 / ⏳)
-   - CurrentGameCard           → ui/v2/current-game-card/
-   - CrossGameDiaryTimeline    → ui/v2/cross-game-diary-timeline/  (aggregato multi-session)
-   - DiaryInlineWidget         → ui/v2/diary-inline-widget/         (320×400 export riusabile)
-   - AutoSaveToast             → ui/v2/auto-save-toast/             (60s tick, bottom-right)
-   - LiveHubMobileTabs         → ui/v2/live-hub-mobile-tabs/
-   - PauseOverlay              → ui/v2/pause-overlay/               (riuso da sp4-session-live)
-   - TransitionPendingPane     → ui/v2/transition-pending-pane/
+   Componenti emersi (per impl post-merge — paths canonical Stage 2 PR #1025)
+   - GameNightLiveHub          → apps/web/src/components/features/game-nights/game-night-live-hub/
+   - LiveHubTopBar             → features/game-nights/live-hub-top-bar/
+   - LiveHubToolbar            → features/game-nights/live-hub-toolbar/      (Pausa · Transition · End)
+   - PlannedGamesPane          → features/game-nights/planned-games-pane/
+   - PlannedGameRow            → features/game-nights/planned-game-row/      (status ✅ / 🔴 / ⏳)
+   - CurrentGameCard           → features/game-nights/current-game-card/
+   - CrossGameDiaryTimeline    → features/game-nights/cross-game-diary-timeline/  (aggregato multi-session)
+   - DiaryInlineWidget         → features/game-nights/diary-inline-widget/         (320×400 export riusabile)
+   - AutoSaveToast             → components/ui/auto-save-toast/                    (primitive riusabile · 60s tick, bottom-right)
+   - LiveHubMobileTabs         → features/game-nights/live-hub-mobile-tabs/
+   - PauseOverlay              → features/sessions/pause-overlay/                  (riuso da sp4-session-live, già esistente)
+   - TransitionPendingPane     → features/game-nights/transition-pending-pane/
 
    Riusi pattern
    - ConnectionBar / ConnectionPip   — wave 1 (rendering 1:1 PR #568)
@@ -86,7 +86,7 @@ const byPid = Object.fromEntries(PLAYERS.map(p => [p.id, p]));
 const GAMES = [
   { id:'gs-brass-1',   gameId:'g-brass',    title:'Brass: Birmingham', publisher:'Roxley',
     emoji:'🏭', cover:['hsl(220 35% 28%)','hsl(28 60% 38%)'],
-    estimated:'120m', actual:'113m', winnerId:'p-marco', score:'142–128',
+    estimated:'120m', actual:'113m', winnerId:'p-davide', score:'178–142',
     sessionId:'s-brass-may17', status:'completed', order: 1, startedAt:'21:02', endedAt:'22:55' },
   { id:'gs-spirit-1',  gameId:'g-spirit',   title:'Spirit Island', publisher:'GMT',
     emoji:'🌋', cover:['hsl(210 50% 30%)','hsl(150 50% 38%)'],
@@ -117,8 +117,8 @@ const DIARY = [
     text:'Aaron pesca 4 carte (mano era 2)' },
   { id:'d08', t:'22:48', game:'gs-brass-1',  kind:'score',  icon:'📊', actors:['p-marco'],
     text:'Marco completa rete Birmingham (+12 link points)' },
-  { id:'d09', t:'22:55', game:'gs-brass-1',  kind:'end',    icon:'🏆', actors:['p-marco'],
-    text:'🏆 Marco vince Brass Birmingham 142–128' },
+  { id:'d09', t:'22:55', game:'gs-brass-1',  kind:'end',    icon:'🏆', actors:['p-davide'],
+    text:'🏆 Davide vince Brass Birmingham 178–142' },
   // ── Transition ───────────────────────────────────────
   { id:'d10', t:'23:00', game:null,           kind:'system', icon:'↻', actors:[],
     text:'Setup Spirit Island · 4 spiriti scelti random' },

--- a/admin-mockups/design_files/sp7-game-night-live.jsx
+++ b/admin-mockups/design_files/sp7-game-night-live.jsx
@@ -1,0 +1,1614 @@
+/* ===================================================================
+   SP7 Game Night — Live Hub (sp7-game-night-live.jsx)
+   Route: /game-nights/[id]/live
+   Persona: Marco (host) durante la serata, desktop al tavolo / tablet.
+            Mobile per quick-jump tra session.
+   Coverage: US-31 G31.11 / G31.12 / G31.13 — Sprint N+1 P1 backbone
+   Pattern desktop: 3-pane (sidebar planned 280px | center current 1fr | sidebar diary 320px)
+   Pattern mobile : fullscreen swipeable tabs (Current / Planned / Diary)
+
+   Stati (anchor id state-NN-…)
+   - state-01-game-1-in-progress     Game 1 live, diary 5 eventi, 2 planned upcoming
+   - state-02-mid-night-game-2       Game 1 completed (winner), Game 2 in-progress, diary 18 eventi
+   - state-03-transition-pending     Tra Game 1 e Game 2, current pane "In attesa transition"
+   - state-04-paused                 Serata in pausa (overlay entityHsl('agent', 0.1) warning)
+   - state-05-diary-empty            Inizio serata · diary "Nessun evento ancora"
+   - state-06-diary-widget-embedded  Diary widget 320×400 isolato (riuso standalone)
+   - state-07-mobile-tab-current     Mobile tab "Current" attivo
+   - state-08-mobile-tab-planned     Mobile tab "Planned" attivo
+   - state-09-mobile-tab-diary       Mobile tab "Diary" attivo
+   - state-10-auto-save-toast        Toast bottom-right entityHsl('toolkit', 0.1) ogni 60s
+                                     (acceptance criterion issue #487)
+
+   Entity color mapping
+   - serata event accent      = entityHsl('event')   rose
+   - session live current     = entityHsl('session') indigo pulsing
+   - games planned cards      = entityHsl('game')    orange
+   - players confermati       = entityHsl('player')  violet
+   - diary chat events        = entityHsl('chat')    blue
+   - auto-save toast bg       = entityHsl('toolkit', 0.1) green tint
+   - pause overlay accent     = var(--c-warning)     amber
+
+   Componenti v2 emersi (per impl post-merge)
+   - GameNightLiveHub          → apps/web/src/components/ui/v2/game-night-live-hub/
+   - LiveHubTopBar             → ui/v2/live-hub-top-bar/
+   - LiveHubToolbar            → ui/v2/live-hub-toolbar/      (Pausa · Transition · End)
+   - PlannedGamesPane          → ui/v2/planned-games-pane/
+   - PlannedGameRow            → ui/v2/planned-game-row/      (status ✅ / 🔴 / ⏳)
+   - CurrentGameCard           → ui/v2/current-game-card/
+   - CrossGameDiaryTimeline    → ui/v2/cross-game-diary-timeline/  (aggregato multi-session)
+   - DiaryInlineWidget         → ui/v2/diary-inline-widget/         (320×400 export riusabile)
+   - AutoSaveToast             → ui/v2/auto-save-toast/             (60s tick, bottom-right)
+   - LiveHubMobileTabs         → ui/v2/live-hub-mobile-tabs/
+   - PauseOverlay              → ui/v2/pause-overlay/               (riuso da sp4-session-live)
+   - TransitionPendingPane     → ui/v2/transition-pending-pane/
+
+   Riusi pattern
+   - ConnectionBar / ConnectionPip   — wave 1 (rendering 1:1 PR #568)
+   - SessionDiaryTimeline             — sp4-session-live-parts.jsx (CrossGame deriva da qui)
+   - StatusBadge lifecycle             — sp7-game-night-detail-rsvp.jsx
+   - Tabs animated underline           — wave 1
+   =================================================================== */
+
+const { useState, useEffect, useMemo, useRef } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.event;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ═══════════════════════════════════════════════════════
+// FIXTURE — Sabato boardgame con i Padovani · 17 mag 2026
+// ═══════════════════════════════════════════════════════
+
+const NIGHT = {
+  id: 'gn-padovani-may17',
+  title: 'Sabato boardgame con i Padovani',
+  dateLine: 'sab 17 maggio · 21:00',
+  startedAt: '21:00',
+  host: 'p-marco',
+  location: 'Casa Marco',
+};
+
+const PLAYERS = [
+  { id:'p-marco',   initials:'MR', name:'Marco',   color: 262, role:'host' },
+  { id:'p-giulia',  initials:'GM', name:'Giulia',  color: 10,  role:'invitee' },
+  { id:'p-davide',  initials:'DC', name:'Davide',  color: 200, role:'invitee' },
+  { id:'p-luca',    initials:'LB', name:'Luca',    color: 180, role:'invitee' },
+  { id:'p-sara',    initials:'ST', name:'Sara',    color: 320, role:'invitee' },
+  { id:'p-aaron',   initials:'AK', name:'Aaron',   color: 140, role:'invitee' },
+];
+const byPid = Object.fromEntries(PLAYERS.map(p => [p.id, p]));
+
+const GAMES = [
+  { id:'gs-brass-1',   gameId:'g-brass',    title:'Brass: Birmingham', publisher:'Roxley',
+    emoji:'🏭', cover:['hsl(220 35% 28%)','hsl(28 60% 38%)'],
+    estimated:'120m', actual:'113m', winnerId:'p-marco', score:'142–128',
+    sessionId:'s-brass-may17', status:'completed', order: 1, startedAt:'21:02', endedAt:'22:55' },
+  { id:'gs-spirit-1',  gameId:'g-spirit',   title:'Spirit Island', publisher:'GMT',
+    emoji:'🌋', cover:['hsl(210 50% 30%)','hsl(150 50% 38%)'],
+    estimated:'90m',  actual:'35m elapsed', winnerId:null, score:'round 2 · in corso',
+    sessionId:'s-spirit-may17', status:'inprogress', order: 2, startedAt:'23:00', endedAt:null },
+  { id:'gs-wing-1',    gameId:'g-wingspan', title:'Wingspan', publisher:'Stonemaier',
+    emoji:'🦜', cover:['hsl(85 40% 45%)','hsl(35 60% 50%)'],
+    estimated:'60m',  actual:null, winnerId:null, score:'in attesa',
+    sessionId:'s-wing-may17', status:'upcoming', order: 3, startedAt:null, endedAt:null },
+];
+
+// 18 eventi cross-game (Brass completed → transition → Spirit in-progress)
+const DIARY = [
+  // ── Brass Birmingham ─────────────────────────────────
+  { id:'d01', t:'21:02', game:'gs-brass-1',  kind:'turn',   icon:'🎯', actors:['p-marco'],
+    text:'Marco apre il Canal Era — porto a Stoke-on-Trent' },
+  { id:'d02', t:'21:15', game:'gs-brass-1',  kind:'score',  icon:'📊', actors:['p-giulia'],
+    text:'Giulia: +5 punti (Industria carbone)' },
+  { id:'d03', t:'21:34', game:'gs-brass-1',  kind:'turn',   icon:'🎯', actors:['p-davide'],
+    text:'Davide costruisce ferrovia Birmingham → Coventry' },
+  { id:'d04', t:'21:52', game:'gs-brass-1',  kind:'custom', icon:'💡', actors:['p-sara'],
+    text:'Sara passa il turno · scoop +10£' },
+  { id:'d05', t:'22:08', game:'gs-brass-1',  kind:'score',  icon:'📊', actors:['p-luca'],
+    text:'Luca: −2 income (debito loan)' },
+  { id:'d06', t:'22:20', game:'gs-brass-1',  kind:'turn',   icon:'🎯', actors:[],
+    text:'Inizia l\'era ferroviaria · scarto canali' },
+  { id:'d07', t:'22:36', game:'gs-brass-1',  kind:'custom', icon:'🎲', actors:['p-aaron'],
+    text:'Aaron pesca 4 carte (mano era 2)' },
+  { id:'d08', t:'22:48', game:'gs-brass-1',  kind:'score',  icon:'📊', actors:['p-marco'],
+    text:'Marco completa rete Birmingham (+12 link points)' },
+  { id:'d09', t:'22:55', game:'gs-brass-1',  kind:'end',    icon:'🏆', actors:['p-marco'],
+    text:'🏆 Marco vince Brass Birmingham 142–128' },
+  // ── Transition ───────────────────────────────────────
+  { id:'d10', t:'23:00', game:null,           kind:'system', icon:'↻', actors:[],
+    text:'Setup Spirit Island · 4 spiriti scelti random' },
+  // ── Spirit Island ────────────────────────────────────
+  { id:'d11', t:'23:08', game:'gs-spirit-1', kind:'turn',   icon:'🎯', actors:[],
+    text:'Round 1 · Esplora — invaders Mountain' },
+  { id:'d12', t:'23:14', game:'gs-spirit-1', kind:'score',  icon:'📊', actors:['p-davide'],
+    text:'Spirito "River Surges" +3 Fear · livello 1' },
+  { id:'d13', t:'23:19', game:'gs-spirit-1', kind:'custom', icon:'💡', actors:['p-aaron'],
+    text:'Aaron usa innate Lightning Strike (2 danno)' },
+  { id:'d14', t:'23:23', game:'gs-spirit-1', kind:'score',  icon:'📊', actors:['p-davide'],
+    text:'Blight su Powerwala — Davide perde 1 presenza' },
+  { id:'d15', t:'23:27', game:'gs-spirit-1', kind:'turn',   icon:'🎯', actors:[],
+    text:'Round 2 · Crescita · pesca 6 carte minor' },
+  { id:'d16', t:'23:30', game:'gs-spirit-1', kind:'chat',   icon:'💬', actors:['p-luca'],
+    text:'Luca: "Posso supportare il tuo spirito questo turno?"' },
+  { id:'d17', t:'23:33', game:'gs-spirit-1', kind:'score',  icon:'📊', actors:['p-giulia'],
+    text:'Giulia raccoglie 3 carte minor (Sacred Site)' },
+  { id:'d18', t:'23:35', game:'gs-spirit-1', kind:'custom', icon:'⏳', actors:['p-aaron'],
+    text:'Aaron sta decidendo le sue azioni…' },
+];
+
+// Mapping diary kind → entity color
+const DIARY_COLOR = {
+  turn:   'session',
+  score:  'session',
+  custom: 'tool',
+  chat:   'chat',
+  end:    'event',
+  system: 'toolkit',
+};
+
+// ═══════════════════════════════════════════════════════
+// PRIMITIVES
+// ═══════════════════════════════════════════════════════
+
+const Avatar = ({ player, size = 22, ring }) => (
+  <span style={{
+    width: size, height: size, borderRadius:'50%',
+    background:`hsl(${player.color}, 60%, 55%)`, color:'#fff',
+    fontFamily:'var(--f-display)',
+    fontWeight: 800, fontSize: size <= 18 ? 8 : size <= 24 ? 9 : 11,
+    display:'inline-flex', alignItems:'center', justifyContent:'center',
+    border:`2px solid ${ring || 'var(--bg-card)'}`,
+    flexShrink: 0,
+  }}>{player.initials}</span>
+);
+
+const MonoKicker = ({ children, color = 'var(--text-muted)', size = 10 }) => (
+  <span style={{
+    fontFamily:'var(--f-mono)', fontSize: size, fontWeight: 800,
+    color, textTransform:'uppercase', letterSpacing:'.08em',
+  }}>{children}</span>
+);
+
+// Pulsing dot — sp7Pulse animation defined in HTML
+const PulsingDot = ({ color, size = 8 }) => (
+  <span aria-hidden="true" style={{
+    width: size, height: size, borderRadius:'50%',
+    background: color, flexShrink: 0,
+    animation:'sp7Pulse 1.6s var(--ease-out) infinite',
+  }}/>
+);
+
+// /* v2: ConnectionPip (riuso da wave 1, rendering 1:1 PR #568) */
+const ConnectionPip = ({ type, count, label }) => {
+  const empty = !count || count === 0;
+  return (
+    <span aria-label={empty ? label : `${label}: ${count}`}
+      style={{
+        display:'inline-flex', alignItems:'center', gap: 5,
+        padding:'3px 9px 3px 6px',
+        borderRadius: 999,
+        background: empty ? 'transparent' : entityHsl(type, 0.1),
+        border: empty
+          ? `1px dashed ${entityHsl(type, 0.3)}`
+          : `1px solid ${entityHsl(type, 0.28)}`,
+        opacity: empty ? 0.6 : 1,
+        color: entityHsl(type),
+        fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.06em',
+        fontVariantNumeric:'tabular-nums',
+      }}>
+      <span aria-hidden="true" style={{
+        width: 14, height: 14, borderRadius:'50%',
+        background: entityHsl(type, empty ? 0.18 : 0.3),
+        color: entityHsl(type),
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        fontSize: 9, fontWeight: 800, flexShrink: 0,
+      }}>{empty ? '+' : DS.EC[type].em}</span>
+      <span style={{ color: empty ? 'var(--text-muted)' : 'inherit' }}>{label}</span>
+      {!empty && <strong style={{ marginLeft: 2 }}>{count}</strong>}
+    </span>
+  );
+};
+
+// /* v2: ConnectionBar — riga di pip sotto hero */
+const ConnectionBar = ({ pips }) => (
+  <div role="navigation" aria-label="Entità collegate" style={{
+    display:'flex', gap: 6, flexWrap:'wrap', alignItems:'center',
+    padding:'8px 16px',
+    background:'var(--bg-card)',
+    borderBottom:'1px solid var(--border)',
+  }}>
+    <MonoKicker size={9}>Collegate ·</MonoKicker>
+    {pips.map((p, i) => <ConnectionPip key={i} {...p}/>)}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// LIVE TOP BAR (title + status + counter + toolbar)
+// /* v2: LiveHubTopBar */
+// ═══════════════════════════════════════════════════════
+
+const LiveHubTopBar = ({ paused, compact, current = 2, total = 3, elapsed = '23m', confirmed = 6, nightStatus = 'live' }) => {
+  const accent = paused ? 'hsl(var(--c-warning))' : entityHsl('session');
+  const statusLabel = paused ? 'In pausa'
+                    : nightStatus === 'transition' ? 'Transition'
+                    : 'Live';
+  return (
+    <header style={{
+      display:'flex', flexDirection:'column',
+      background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+      borderBottom:`1px solid ${entityHsl('event', 0.25)}`,
+      position:'sticky', top: 0, zIndex: 20,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: compact ? 8 : 12,
+        padding: compact ? '10px 12px' : '12px 18px',
+        minHeight: compact ? 56 : 64,
+      }}>
+        {/* Left: back + title */}
+        <button type="button" aria-label="Indietro" style={{
+          width: compact ? 32 : 34, height: compact ? 32 : 34,
+          borderRadius:'var(--r-md)',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          color:'var(--text-sec)', cursor:'pointer',
+          fontSize: 16, fontWeight: 800, flexShrink: 0,
+        }}>←</button>
+
+        <div style={{ display:'flex', flexDirection:'column', gap: 2, minWidth: 0, flex: 1 }}>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 7, flexWrap:'wrap',
+          }}>
+            {/* Status pip */}
+            <span style={{
+              display:'inline-flex', alignItems:'center', gap: 5,
+              padding:'2px 8px 2px 6px',
+              borderRadius:'var(--r-pill)',
+              background: paused
+                ? 'hsl(var(--c-warning) / .14)'
+                : nightStatus === 'transition' ? entityHsl('event', 0.14)
+                : entityHsl('session', 0.14),
+              border: `1px solid ${paused ? 'hsl(var(--c-warning) / .3)' : entityHsl(nightStatus === 'transition' ? 'event' : 'session', 0.3)}`,
+              color: accent,
+              fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.08em',
+            }}>
+              {!paused && <PulsingDot color={accent} size={6}/>}
+              {paused && <span aria-hidden="true">⏸</span>}
+              {statusLabel}
+            </span>
+            <MonoKicker size={9.5}>#GN-042</MonoKicker>
+          </div>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 8,
+            fontFamily:'var(--f-display)', fontSize: compact ? 13 : 14.5, fontWeight: 800,
+            color:'var(--text)',
+            whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+            minWidth: 0,
+          }}>
+            <span aria-hidden="true">🎉</span>
+            <span style={{ overflow:'hidden', textOverflow:'ellipsis' }}>
+              {compact ? 'Padovani · 17 mag' : NIGHT.title}
+            </span>
+          </div>
+        </div>
+
+        {/* Center counter: Game X/Y · elapsed (desktop only) */}
+        {!compact && (
+          <div style={{
+            display:'flex', alignItems:'center', gap: 12,
+            padding:'6px 14px', borderRadius:'var(--r-md)',
+            background: entityHsl('event', 0.08),
+            border:`1px solid ${entityHsl('event', 0.22)}`,
+            flexShrink: 0,
+          }}>
+            <div style={{ textAlign:'center', minWidth: 0 }}>
+              <MonoKicker size={9}>Game</MonoKicker>
+              <div style={{
+                fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+                color: entityHsl('event'), fontVariantNumeric:'tabular-nums', lineHeight: 1,
+              }}>{current}<span style={{ color:'var(--text-muted)' }}>/{total}</span></div>
+            </div>
+            <span style={{ width: 1, height: 22, background:'var(--border)' }}/>
+            <div style={{ textAlign:'center', minWidth: 0 }}>
+              <MonoKicker size={9}>Elapsed</MonoKicker>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 13.5, fontWeight: 800,
+                color:'var(--text)', fontVariantNumeric:'tabular-nums', lineHeight: 1.1,
+              }}>{elapsed}</div>
+            </div>
+            <span style={{ width: 1, height: 22, background:'var(--border)' }}/>
+            <div style={{ textAlign:'center', minWidth: 0 }}>
+              <MonoKicker size={9}>Player</MonoKicker>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 13.5, fontWeight: 800,
+                color: entityHsl('player'), fontVariantNumeric:'tabular-nums', lineHeight: 1.1,
+              }}>{confirmed}/6</div>
+            </div>
+          </div>
+        )}
+
+        {/* Right: toolbar */}
+        <div style={{
+          display:'flex', alignItems:'center', gap: 6,
+          flexShrink: 0, marginLeft:'auto',
+        }}>
+          <ToolbarBtn icon={paused ? '▶' : '⏸'} label={compact ? null : (paused ? 'Riprendi' : 'Pausa')}
+            tone={paused ? 'session' : null}/>
+          <ToolbarBtn icon="➡️" label={compact ? null : 'Transition'} tone="event"/>
+          <ToolbarBtn icon="🛑" label={compact ? null : 'End'} tone="danger"/>
+        </div>
+      </div>
+
+      {/* Compact counter row mobile */}
+      {compact && (
+        <div style={{
+          display:'flex', gap: 10, padding:'6px 12px 8px',
+          borderTop:'1px solid var(--border-light)',
+          background:'var(--bg-card)',
+          fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+          color:'var(--text-sec)', alignItems:'center',
+        }}>
+          <span><strong style={{
+            color: entityHsl('event'), fontVariantNumeric:'tabular-nums',
+          }}>Game {current}/{total}</strong></span>
+          <span style={{ color:'var(--text-muted)' }}>·</span>
+          <span>Elapsed <strong style={{
+            color:'var(--text)', fontVariantNumeric:'tabular-nums',
+          }}>{elapsed}</strong></span>
+          <span style={{ color:'var(--text-muted)' }}>·</span>
+          <span><strong style={{
+            color: entityHsl('player'), fontVariantNumeric:'tabular-nums',
+          }}>{confirmed}/6</strong> player</span>
+        </div>
+      )}
+    </header>
+  );
+};
+
+const ToolbarBtn = ({ icon, label, tone }) => {
+  const isDanger = tone === 'danger';
+  const fg = isDanger ? 'hsl(var(--c-danger))'
+           : tone ? entityHsl(tone) : 'var(--text-sec)';
+  const bg = tone
+    ? (isDanger ? 'hsl(var(--c-danger) / .1)' : entityHsl(tone, 0.1))
+    : 'var(--bg-card)';
+  const bd = tone
+    ? (isDanger ? 'hsl(var(--c-danger) / .28)' : entityHsl(tone, 0.28))
+    : 'var(--border)';
+  return (
+    <button type="button" aria-label={label || icon} style={{
+      padding: label ? '7px 12px' : '7px 9px',
+      borderRadius:'var(--r-md)',
+      background: bg, color: fg, border:`1px solid ${bd}`,
+      cursor:'pointer',
+      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+      display:'inline-flex', alignItems:'center', gap: 5,
+    }}>
+      <span aria-hidden="true">{icon}</span>{label}
+    </button>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// PLANNED GAMES PANE (left sidebar 280)
+// /* v2: PlannedGamesPane + PlannedGameRow */
+// ═══════════════════════════════════════════════════════
+
+const PlannedGameRow = ({ game, current }) => {
+  const isCompleted = game.status === 'completed';
+  const isInProgress = game.status === 'inprogress';
+  const isUpcoming = game.status === 'upcoming';
+  const accent = isCompleted ? entityHsl('toolkit')
+               : isInProgress ? entityHsl('session')
+               : entityHsl('game');
+  const winner = isCompleted && game.winnerId ? byPid[game.winnerId] : null;
+  return (
+    <div style={{
+      position:'relative',
+      padding:'10px 12px',
+      borderRadius:'var(--r-md)',
+      background: isInProgress ? entityHsl('session', 0.08) : 'var(--bg-card)',
+      border: isInProgress
+        ? `1px solid ${entityHsl('session', 0.35)}`
+        : '1px solid var(--border)',
+      borderLeft: `4px solid ${accent}`,
+      opacity: isCompleted ? 0.82 : 1,
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 9, marginBottom: 7 }}>
+        <span style={{
+          width: 30, height: 30, borderRadius:'var(--r-sm)',
+          background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          fontSize: 16, flexShrink: 0,
+        }} aria-hidden="true">{game.emoji}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+            color:'var(--text)',
+            whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+            textDecoration: isCompleted ? 'none' : 'none',
+          }}>{game.title}</div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+            color:'var(--text-muted)',
+          }}>#{game.order} · {game.publisher}</div>
+        </div>
+        <span aria-hidden="true" style={{
+          width: 22, height: 22, borderRadius:'50%',
+          background: accent,
+          color:'#fff', flexShrink: 0,
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          fontSize: 11, fontWeight: 800, fontFamily:'var(--f-display)',
+          position:'relative',
+        }}>
+          {isCompleted && '✓'}
+          {isInProgress && (
+            <>
+              <span style={{ fontSize: 10 }}>●</span>
+              <span style={{
+                position:'absolute', inset:-3, borderRadius:'50%',
+                border:`2px solid ${accent}`, opacity: .4,
+                animation:'sp7PulseRing 1.6s var(--ease-out) infinite',
+              }}/>
+            </>
+          )}
+          {isUpcoming && <span style={{ fontSize: 10 }}>⏳</span>}
+        </span>
+      </div>
+
+      {/* Status line */}
+      <div style={{
+        display:'flex', alignItems:'center', gap: 6,
+        fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        color: accent,
+      }}>
+        {isCompleted && (
+          <>
+            <span>FINITO</span>
+            <span style={{ color:'var(--text-muted)' }}>·</span>
+            <span style={{ color:'var(--text-sec)' }}>{game.actual}</span>
+          </>
+        )}
+        {isInProgress && (
+          <>
+            <PulsingDot color={accent} size={6}/>
+            <span>LIVE</span>
+            <span style={{ color:'var(--text-muted)' }}>·</span>
+            <span style={{ color:'var(--text-sec)' }}>{game.actual}</span>
+          </>
+        )}
+        {isUpcoming && (
+          <>
+            <span>UPCOMING</span>
+            <span style={{ color:'var(--text-muted)' }}>·</span>
+            <span style={{ color:'var(--text-sec)' }}>est. {game.estimated}</span>
+          </>
+        )}
+      </div>
+
+      {/* Winner banner */}
+      {winner && (
+        <div style={{
+          marginTop: 7,
+          padding:'5px 8px', borderRadius:'var(--r-sm)',
+          background: entityHsl('event', 0.1),
+          border:`1px solid ${entityHsl('event', 0.25)}`,
+          display:'flex', alignItems:'center', gap: 6,
+        }}>
+          <Avatar player={winner} size={20}/>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800,
+              color: entityHsl('event'),
+              whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+            }}>🏆 {winner.name} ha vinto</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+              color:'var(--text-muted)', fontVariantNumeric:'tabular-nums',
+            }}>{game.score}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const PlannedGamesPane = ({ compact, games = GAMES }) => (
+  <aside style={{
+    width: compact ? '100%' : 280,
+    background:'var(--bg-card)',
+    borderRight: compact ? 'none' : '1px solid var(--border)',
+    display:'flex', flexDirection:'column', flexShrink: 0, minWidth: 0,
+  }}>
+    <div style={{
+      padding:'11px 14px', borderBottom:'1px solid var(--border-light)',
+      display:'flex', alignItems:'center', justifyContent:'space-between',
+    }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+        <span aria-hidden="true">🎲</span>
+        <MonoKicker size={10.5}>Planned ({games.length})</MonoKicker>
+      </div>
+      <span title="Riordino disabilitato in live mode" style={{
+        fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+        color:'var(--text-muted)',
+        padding:'2px 6px', borderRadius:'var(--r-pill)',
+        background:'var(--bg-muted)',
+        border:'1px solid var(--border)',
+      }}>🔒 PlayOrder</span>
+    </div>
+    <div style={{
+      flex: 1, overflowY:'auto', minHeight: 0,
+      padding: 10, display:'flex', flexDirection:'column', gap: 8,
+    }}>
+      {games.map(g => <PlannedGameRow key={g.id} game={g}/>)}
+    </div>
+    <div style={{
+      padding:'10px 12px', borderTop:'1px solid var(--border-light)',
+    }}>
+      <button type="button" disabled title="Aggiungi disponibile fuori live"
+        style={{
+          width:'100%', padding:'8px',
+          borderRadius:'var(--r-md)',
+          background:'transparent', color:'var(--text-muted)',
+          border:'1px dashed var(--border-strong)',
+          fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700,
+          cursor:'not-allowed', opacity: 0.7,
+        }}>+ Aggiungi gioco</button>
+    </div>
+  </aside>
+);
+
+// ═══════════════════════════════════════════════════════
+// CURRENT GAME CARD (center 1fr)
+// /* v2: CurrentGameCard */
+// ═══════════════════════════════════════════════════════
+
+const CurrentGameCard = ({ game, compact }) => {
+  if (!game) return null;
+  return (
+    <div style={{
+      flex: 1, padding: compact ? '14px' : '20px 24px',
+      display:'flex', flexDirection:'column', gap: 16,
+      minHeight: 0, overflowY:'auto', minWidth: 0,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap',
+      }}>
+        <MonoKicker size={10}>Current game</MonoKicker>
+        <span style={{
+          display:'inline-flex', alignItems:'center', gap: 5,
+          padding:'2px 8px', borderRadius:'var(--r-pill)',
+          background: entityHsl('session', 0.12),
+          border:`1px solid ${entityHsl('session', 0.28)}`,
+          color: entityHsl('session'),
+          fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.08em',
+        }}>
+          <PulsingDot color={entityHsl('session')} size={6}/>
+          {game.score}
+        </span>
+      </div>
+
+      {/* Cover hero */}
+      <div style={{
+        borderRadius:'var(--r-xl)',
+        border:`1px solid ${entityHsl('session', 0.25)}`,
+        overflow:'hidden',
+        boxShadow: `var(--shadow-md), 0 0 0 4px ${entityHsl('session', 0.08)}`,
+      }}>
+        <div style={{
+          height: compact ? 140 : 200,
+          background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+          position:'relative', display:'flex',
+          alignItems:'flex-end', padding: 16,
+        }} aria-hidden="true">
+          <div style={{
+            position:'absolute', top: 12, right: 12,
+            padding:'3px 8px', borderRadius:'var(--r-pill)',
+            background:'rgba(0,0,0,0.55)', color:'#fff',
+            fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.08em',
+            display:'inline-flex', alignItems:'center', gap: 5,
+          }}>
+            <span style={{
+              width: 6, height: 6, borderRadius:'50%',
+              background:'#fff',
+              animation:'sp7Pulse 1.6s var(--ease-out) infinite',
+            }}/>
+            Live · session
+          </div>
+          <div style={{
+            position:'absolute', inset: 0,
+            background:'linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.55) 100%)',
+            pointerEvents:'none',
+          }}/>
+          <div style={{ position:'relative', display:'flex', alignItems:'flex-end', gap: 14, color:'#fff' }}>
+            <span style={{
+              fontSize: compact ? 56 : 72, lineHeight: 1,
+              filter:'drop-shadow(0 4px 14px rgba(0,0,0,.5))',
+            }}>{game.emoji}</span>
+            <div>
+              <div style={{
+                fontFamily:'var(--f-display)', fontSize: compact ? 22 : 30,
+                fontWeight: 800, letterSpacing:'-.01em', lineHeight: 1.1,
+                textShadow:'0 2px 8px rgba(0,0,0,.4)',
+              }}>{game.title}</div>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700,
+                opacity: .85, marginTop: 4,
+              }}>#{game.order} · {game.publisher} · iniziato {game.startedAt}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div style={{
+          display:'grid',
+          gridTemplateColumns: compact ? '1fr 1fr' : 'repeat(4, 1fr)',
+          background:'var(--bg-card)',
+        }}>
+          {[
+            { lb:'Round', vl:'2', sub:'di stima 4', tone: 'session' },
+            { lb:'Elapsed', vl:'35m', sub:'su 90m est', tone:'event' },
+            { lb:'Player attivi', vl:'4', sub:'co-op', tone:'player' },
+            { lb:'Fear / Blight', vl:'+3/1', sub:'livello 1', tone:'tool' },
+          ].map((s, i) => (
+            <div key={i} style={{
+              padding:'12px 14px',
+              borderRight: i < 3 ? '1px solid var(--border-light)' : 'none',
+              borderTop:'1px solid var(--border-light)',
+            }}>
+              <MonoKicker size={9}>{s.lb}</MonoKicker>
+              <div style={{
+                fontFamily:'var(--f-display)', fontSize: 22, fontWeight: 800,
+                color: entityHsl(s.tone), fontVariantNumeric:'tabular-nums',
+                lineHeight: 1.1, marginTop: 2,
+              }}>{s.vl}</div>
+              <div style={{
+                fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+                color:'var(--text-muted)', marginTop: 1,
+              }}>{s.sub}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Player roster strip */}
+      <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+        <div style={{
+          display:'flex', alignItems:'center', justifyContent:'space-between',
+        }}>
+          <MonoKicker>👥 Player · 6 confermati</MonoKicker>
+          <button type="button" style={{
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            color: entityHsl('player'), background:'transparent', border:'none',
+            cursor:'pointer', padding: 0,
+          }}>Apri roster →</button>
+        </div>
+        <div style={{ display:'flex', gap: 6, flexWrap:'wrap' }}>
+          {PLAYERS.map(p => (
+            <div key={p.id} style={{
+              display:'inline-flex', alignItems:'center', gap: 6,
+              padding:'3px 8px 3px 3px', borderRadius:'var(--r-pill)',
+              background: entityHsl('player', 0.1),
+              border:`1px solid ${entityHsl('player', 0.25)}`,
+            }}>
+              <Avatar player={p} size={20} ring={entityHsl('player', 0.2)}/>
+              <span style={{
+                fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800,
+                color: entityHsl('player'),
+              }}>{p.name}</span>
+              {p.id === game.winnerId && <span aria-hidden="true">🏆</span>}
+              {p.role === 'host' && (
+                <span style={{
+                  fontFamily:'var(--f-mono)', fontSize: 8, fontWeight: 800,
+                  textTransform:'uppercase', letterSpacing:'.06em',
+                  background: entityHsl('player', 0.18),
+                  padding:'1px 4px', borderRadius:'var(--r-sm)',
+                }}>HOST</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* CTA */}
+      <a href="#" style={{
+        display:'flex', alignItems:'center', justifyContent:'space-between',
+        padding:'14px 18px', borderRadius:'var(--r-lg)',
+        background:`linear-gradient(135deg, ${entityHsl('session')}, ${entityHsl('chat')})`,
+        color:'#fff', textDecoration:'none',
+        boxShadow:`0 8px 24px ${entityHsl('session', 0.4)}`,
+      }}>
+        <div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+            textTransform:'uppercase', letterSpacing:'.1em', opacity:.85,
+          }}>Quick jump</div>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, marginTop: 2,
+          }}>Apri sessione live → /sessions/{game.sessionId}</div>
+        </div>
+        <span aria-hidden="true" style={{ fontSize: 22, fontWeight: 800 }}>↗</span>
+      </a>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// TRANSITION PENDING PANE (state-03)
+// /* v2: TransitionPendingPane */
+// ═══════════════════════════════════════════════════════
+
+const TransitionPendingPane = ({ from = GAMES[0], to = GAMES[1] }) => (
+  <div style={{
+    flex: 1, padding: 24, overflowY:'auto',
+    display:'flex', flexDirection:'column', gap: 16, minWidth: 0,
+  }}>
+    <div style={{
+      display:'flex', alignItems:'center', gap: 8,
+    }}>
+      <PulsingDot color={entityHsl('event')} size={9}/>
+      <MonoKicker color={entityHsl('event')}>In attesa transition</MonoKicker>
+    </div>
+    <h2 style={{
+      fontFamily:'var(--f-display)', fontSize: 26, fontWeight: 800,
+      color:'var(--text)', letterSpacing:'-.01em', margin: 0,
+    }}>Pronti per il prossimo gioco?</h2>
+    <p style={{
+      fontSize: 13.5, color:'var(--text-sec)', lineHeight: 1.6, margin: 0, maxWidth: 540,
+    }}>
+      <strong>{from.title}</strong> è finito. Conferma per avviare la session di <strong>{to.title}</strong>.
+      Tutti i giocatori (6) ricevono notifica e il timer parte automaticamente.
+    </p>
+
+    <div style={{
+      display:'grid', gridTemplateColumns:'1fr auto 1fr', gap: 16, alignItems:'stretch',
+    }}>
+      <TransitionMiniCard game={from} variant="completed"/>
+      <div style={{
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 28, color: entityHsl('event'),
+      }} aria-hidden="true">→</div>
+      <TransitionMiniCard game={to} variant="upcoming"/>
+    </div>
+
+    <div style={{ display:'flex', gap: 10, marginTop: 4 }}>
+      <button type="button" style={{
+        flex: 1, padding:'13px',
+        borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${entityHsl('session')}, ${entityHsl('chat')})`,
+        color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+        cursor:'pointer',
+        boxShadow:`0 6px 20px ${entityHsl('session', 0.35)}`,
+      }}>▶ Avvia Spirit Island</button>
+      <button type="button" style={{
+        padding:'13px 18px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid var(--border-strong)',
+        color:'var(--text-sec)',
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, cursor:'pointer',
+      }}>Salta gioco</button>
+      <button type="button" style={{
+        padding:'13px 18px', borderRadius:'var(--r-md)',
+        background:'transparent', border:'1px solid hsl(var(--c-danger) / 0.4)',
+        color:'hsl(var(--c-danger))',
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, cursor:'pointer',
+      }}>Termina serata</button>
+    </div>
+  </div>
+);
+
+const TransitionMiniCard = ({ game, variant }) => {
+  const isCompleted = variant === 'completed';
+  const accent = isCompleted ? entityHsl('toolkit') : entityHsl('event');
+  return (
+    <div style={{
+      padding: 12,
+      borderRadius:'var(--r-lg)',
+      background:'var(--bg-card)',
+      border:`1px solid ${accent}`,
+      boxShadow: `0 0 0 3px ${isCompleted ? entityHsl('toolkit', 0.08) : entityHsl('event', 0.08)}`,
+      display:'flex', flexDirection:'column', gap: 8,
+    }}>
+      <div style={{
+        height: 90, borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 36,
+      }} aria-hidden="true">{game.emoji}</div>
+      <MonoKicker size={9} color={accent}>{isCompleted ? '✓ Appena finito' : '⏳ Prossimo'}</MonoKicker>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800,
+        color:'var(--text)', lineHeight: 1.2,
+      }}>{game.title}</div>
+      <div style={{
+        fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+        color:'var(--text-muted)',
+      }}>
+        {isCompleted ? `${game.actual} · ${game.score}` : `Durata est. ${game.estimated} · co-op`}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// CROSS-GAME DIARY TIMELINE  (right sidebar 320)
+// + DIARY INLINE WIDGET (320×400 export riusabile)
+// /* v2: CrossGameDiaryTimeline + DiaryInlineWidget */
+// ═══════════════════════════════════════════════════════
+
+const DIARY_FILTERS = [
+  { id:'all',    label:'Tutti' },
+  { id:'turn',   label:'Turn' },
+  { id:'score',  label:'Score' },
+  { id:'custom', label:'Custom' },
+];
+
+const DiaryEvent = ({ e, prevGame, compact }) => {
+  const ec = DIARY_COLOR[e.kind] || 'session';
+  const game = e.game ? GAMES.find(g => g.id === e.game) : null;
+  const gameChanged = game && prevGame && prevGame.id !== game.id;
+  return (
+    <>
+      {/* Cross-game divider — quando cambio session */}
+      {(gameChanged || (game && !prevGame)) && (
+        <div aria-hidden="true" style={{
+          display:'flex', alignItems:'center', gap: 6,
+          padding: compact ? '4px 0 2px' : '6px 0 2px',
+        }}>
+          <span style={{
+            flex: 1, height: 1,
+            background: `linear-gradient(90deg, transparent, ${entityHsl('event', 0.4)}, transparent)`,
+          }}/>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            color: entityHsl('event'), textTransform:'uppercase', letterSpacing:'.1em',
+            display:'inline-flex', alignItems:'center', gap: 4,
+          }}>
+            <span aria-hidden="true">{game.emoji}</span>
+            {game.title}
+          </span>
+          <span style={{
+            flex: 1, height: 1,
+            background: `linear-gradient(90deg, transparent, ${entityHsl('event', 0.4)}, transparent)`,
+          }}/>
+        </div>
+      )}
+      <div style={{
+        position:'relative', display:'flex', gap: 9, paddingLeft: 4,
+      }}>
+        <div style={{
+          width: 22, height: 22, borderRadius:'50%',
+          background: entityHsl(ec, 0.14),
+          border:`2px solid ${entityHsl(ec, 0.4)}`,
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 10, flexShrink: 0, zIndex: 1,
+        }}>
+          <span aria-hidden="true">{e.icon}</span>
+        </div>
+        <div style={{
+          flex: 1, minWidth: 0,
+          padding:'5px 9px',
+          background: e.kind === 'end' ? entityHsl('event', 0.08)
+                    : e.kind === 'system' ? entityHsl('toolkit', 0.06)
+                    : 'var(--bg-muted)',
+          borderRadius:'var(--r-sm)',
+          borderLeft: e.kind === 'end' ? `2px solid ${entityHsl('event')}`
+                    : e.kind === 'system' ? `2px solid ${entityHsl('toolkit')}`
+                    : '2px solid transparent',
+        }}>
+          <div style={{
+            display:'flex', alignItems:'center', gap: 6, marginBottom: 1, flexWrap:'wrap',
+          }}>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+              color: entityHsl(ec), textTransform:'uppercase', letterSpacing:'.06em',
+              fontVariantNumeric:'tabular-nums',
+            }}>{e.t}</span>
+            {e.actors.length > 0 && (
+              <div style={{ display:'flex', gap: 1 }}>
+                {e.actors.map(a => {
+                  const p = byPid[a];
+                  if (!p) return null;
+                  return <Avatar key={a} player={p} size={14} ring="var(--bg-muted)"/>;
+                })}
+              </div>
+            )}
+          </div>
+          <div style={{
+            fontFamily:'var(--f-body)', fontSize: 11.5, fontWeight: 600,
+            color:'var(--text)', lineHeight: 1.4,
+          }}>{e.text}</div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// /* v2: DiaryInlineWidget — 320×400 export riusabile (state-06)
+//    Usato anche dentro /game-nights/[id] detail sidebar e /sessions/[id]/live */
+const DiaryInlineWidget = ({ events = DIARY, width = 320, height = 400, embedded }) => {
+  const visible = events.slice(-7);
+  return (
+    <div style={{
+      width: embedded ? width : '100%',
+      height: embedded ? height : '100%',
+      maxWidth: width,
+      display:'flex', flexDirection:'column',
+      background:'var(--bg-card)',
+      border:`1px solid ${entityHsl('event', 0.3)}`,
+      borderRadius:'var(--r-lg)',
+      boxShadow: embedded ? `var(--shadow-md), 0 0 0 3px ${entityHsl('event', 0.06)}` : 'none',
+      overflow:'hidden',
+    }}>
+      <div style={{
+        padding:'9px 12px',
+        background: entityHsl('event', 0.06),
+        borderBottom:`1px solid ${entityHsl('event', 0.2)}`,
+        display:'flex', alignItems:'center', gap: 7,
+      }}>
+        <span aria-hidden="true" style={{ fontSize: 13 }}>📜</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <MonoKicker size={9.5} color={entityHsl('event')}>Diary cross-game</MonoKicker>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+            color:'var(--text-muted)', marginTop: 1,
+          }}>{events.length} eventi · 2 session</div>
+        </div>
+        <span style={{
+          padding:'2px 6px', borderRadius:'var(--r-pill)',
+          background: entityHsl('session', 0.12),
+          color: entityHsl('session'),
+          fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          display:'inline-flex', alignItems:'center', gap: 3,
+        }}>
+          <PulsingDot color={entityHsl('session')} size={5}/>
+          Live
+        </span>
+      </div>
+      <div style={{
+        flex: 1, overflowY:'auto', padding:'10px 12px',
+        display:'flex', flexDirection:'column', gap: 7, position:'relative',
+      }}>
+        <div aria-hidden="true" style={{
+          position:'absolute', left: 17, top: 10, bottom: 10, width: 2,
+          background: `linear-gradient(180deg, ${entityHsl('event', 0.3)}, ${entityHsl('event', 0.05)})`,
+        }}/>
+        {visible.length === 0 && <DiaryEmptyState compact/>}
+        {visible.map((e, i) => (
+          <DiaryEvent key={e.id} e={e} prevGame={i > 0 ? GAMES.find(g => g.id === visible[i-1].game) : null} compact/>
+        ))}
+      </div>
+      <div style={{
+        padding:'7px 10px',
+        borderTop:'1px solid var(--border-light)',
+        display:'flex', alignItems:'center', justifyContent:'space-between',
+      }}>
+        <button type="button" style={{
+          padding:'3px 8px', borderRadius:'var(--r-pill)',
+          background: entityHsl('event', 0.1),
+          border:`1px solid ${entityHsl('event', 0.3)}`,
+          color: entityHsl('event'),
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          cursor:'pointer', textTransform:'uppercase', letterSpacing:'.06em',
+        }}>+ Annota</button>
+        <span style={{
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+          color:'var(--text-muted)',
+        }}>Apri timeline ↗</span>
+      </div>
+    </div>
+  );
+};
+
+const CrossGameDiaryTimeline = ({ events = DIARY, compact }) => {
+  const [filter, setFilter] = useState('all');
+  const filtered = useMemo(() => {
+    if (filter === 'all') return events;
+    return events.filter(e => e.kind === filter);
+  }, [filter, events]);
+
+  return (
+    <aside style={{
+      width: compact ? '100%' : 320,
+      background:'var(--bg-card)',
+      borderLeft: compact ? 'none' : '1px solid var(--border)',
+      display:'flex', flexDirection:'column', flexShrink: 0, minWidth: 0,
+    }}>
+      <div style={{
+        padding:'10px 14px', borderBottom:'1px solid var(--border-light)',
+        display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap',
+      }}>
+        <span aria-hidden="true">📜</span>
+        <MonoKicker size={10.5}>Diary cross-game</MonoKicker>
+        <div style={{ flex: 1 }}/>
+        <span style={{
+          padding:'2px 7px', borderRadius:'var(--r-pill)',
+          background: entityHsl('event', 0.12),
+          color: entityHsl('event'),
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          textTransform:'uppercase', letterSpacing:'.06em',
+          fontVariantNumeric:'tabular-nums',
+        }}>{events.length} eventi</span>
+      </div>
+
+      {/* Filters */}
+      <div style={{
+        padding:'7px 12px', display:'flex', gap: 4, flexWrap:'wrap',
+        borderBottom:'1px solid var(--border-light)',
+      }}>
+        {DIARY_FILTERS.map(f => (
+          <button key={f.id} type="button" onClick={() => setFilter(f.id)}
+            aria-pressed={filter === f.id}
+            style={{
+              padding:'3px 9px', borderRadius:'var(--r-pill)',
+              background: filter===f.id ? entityHsl('event', 0.14) : 'transparent',
+              border: filter===f.id ? `1px solid ${entityHsl('event', 0.4)}` : '1px solid var(--border)',
+              color: filter===f.id ? entityHsl('event') : 'var(--text-sec)',
+              fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 700,
+              cursor:'pointer',
+            }}>{f.label}</button>
+        ))}
+      </div>
+
+      <div style={{
+        flex: 1, overflowY:'auto', minHeight: 0,
+        padding:'10px 14px', position:'relative',
+      }}>
+        <div aria-hidden="true" style={{
+          position:'absolute', left: 24, top: 0, bottom: 0, width: 2,
+          background:`linear-gradient(180deg, ${entityHsl('event', 0.3)}, ${entityHsl('event', 0.05)})`,
+        }}/>
+        <div style={{ display:'flex', flexDirection:'column', gap: 9 }}>
+          {filtered.map((e, i) => (
+            <DiaryEvent key={e.id} e={e}
+              prevGame={i > 0 ? GAMES.find(g => g.id === filtered[i-1].game) : null}/>
+          ))}
+        </div>
+      </div>
+      <div style={{
+        padding:'9px 12px', borderTop:'1px solid var(--border-light)',
+        display:'flex', gap: 6,
+      }}>
+        <button type="button" style={{
+          flex: 1, padding:'7px 10px', borderRadius:'var(--r-md)',
+          background: entityHsl('event', 0.1),
+          border:`1px solid ${entityHsl('event', 0.3)}`,
+          color: entityHsl('event'),
+          fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 800,
+          cursor:'pointer',
+        }}>+ Annota evento</button>
+        <button type="button" aria-label="Esporta" style={{
+          width: 34, height: 34, borderRadius:'var(--r-md)',
+          background:'var(--bg-card)', border:'1px solid var(--border)',
+          color:'var(--text-sec)', fontSize: 13, cursor:'pointer',
+        }}>↗</button>
+      </div>
+    </aside>
+  );
+};
+
+const DiaryEmptyState = ({ compact }) => (
+  <div style={{
+    flex: 1, padding: compact ? 12 : 24,
+    display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center',
+    gap: 8, textAlign:'center',
+  }}>
+    <div style={{
+      width: compact ? 36 : 48, height: compact ? 36 : 48, borderRadius:'50%',
+      background: entityHsl('event', 0.1),
+      color: entityHsl('event'),
+      display:'flex', alignItems:'center', justifyContent:'center',
+      fontSize: compact ? 18 : 22,
+    }} aria-hidden="true">📜</div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: compact ? 12 : 14, fontWeight: 800,
+      color:'var(--text)',
+    }}>Nessun evento ancora</div>
+    <p style={{
+      margin: 0, fontSize: compact ? 10.5 : 12, color:'var(--text-sec)',
+      maxWidth: 220, lineHeight: 1.5,
+    }}>
+      Inizia a giocare! Score, turn change, e annotazioni appariranno qui in tempo reale.
+    </p>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// AUTO-SAVE TOAST (bottom-right · 60s tick)
+// /* v2: AutoSaveToast — acceptance criterion issue #487 */
+// ═══════════════════════════════════════════════════════
+
+const AutoSaveToast = ({ visible }) => {
+  if (!visible) return null;
+  return (
+    <div role="status" aria-live="polite" style={{
+      position:'absolute', bottom: 18, right: 18, zIndex: 40,
+      display:'flex', alignItems:'center', gap: 10,
+      padding:'10px 14px 10px 12px',
+      borderRadius:'var(--r-pill)',
+      background: entityHsl('toolkit', 0.1),
+      border:`1px solid ${entityHsl('toolkit', 0.32)}`,
+      backdropFilter:'blur(8px)',
+      boxShadow:`var(--shadow-lg), 0 0 0 4px ${entityHsl('toolkit', 0.06)}`,
+      animation:'sp7ToastIn .35s var(--ease-spring)',
+    }}>
+      <span aria-hidden="true" style={{
+        width: 22, height: 22, borderRadius:'50%',
+        background: entityHsl('toolkit'), color:'#fff',
+        display:'inline-flex', alignItems:'center', justifyContent:'center',
+        fontSize: 12, fontWeight: 800,
+      }}>✓</span>
+      <div style={{ display:'flex', flexDirection:'column', gap: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+          color: entityHsl('toolkit'),
+        }}>Auto-salvato</div>
+        <MonoKicker size={9}>23:35:42 · prossimo tra 60s</MonoKicker>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// PAUSE OVERLAY (state-04)
+// ═══════════════════════════════════════════════════════
+
+const PauseOverlay = () => (
+  <div style={{
+    position:'absolute', inset: 0, zIndex: 30,
+    background:'hsl(var(--c-warning) / 0.1)',
+    backdropFilter:'blur(8px)',
+    display:'flex', alignItems:'center', justifyContent:'center',
+    flexDirection:'column', gap: 22, padding: 24,
+  }}>
+    <div style={{
+      padding:'10px 20px', borderRadius:'var(--r-pill)',
+      background:'hsl(var(--c-warning) / 0.18)',
+      border:'1px solid hsl(var(--c-warning) / 0.4)',
+      color:'hsl(var(--c-warning))',
+      fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+      textTransform:'uppercase', letterSpacing:'.16em',
+      display:'inline-flex', alignItems:'center', gap: 10,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 14 }}>⏸</span>
+      Serata in pausa
+    </div>
+    <div style={{ textAlign:'center' }}>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 56, fontWeight: 800,
+        color:'var(--text)', fontVariantNumeric:'tabular-nums',
+        letterSpacing:'-.02em', lineHeight: 1,
+      }}>04:18</div>
+      <div style={{
+        fontFamily:'var(--f-body)', fontSize: 13, color:'var(--text-sec)', marginTop: 8,
+      }}>Tempo di pausa · auto-save attivo · diary congelato</div>
+    </div>
+    <div style={{
+      display:'flex', flexDirection:'column', gap: 8, width:'100%', maxWidth: 280,
+    }}>
+      <button type="button" style={{
+        padding:'12px 20px', borderRadius:'var(--r-md)',
+        background:'hsl(var(--c-warning))', color:'#fff', border:'none',
+        fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800, cursor:'pointer',
+        boxShadow:`0 6px 22px hsl(var(--c-warning) / 0.4)`,
+        display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 6,
+      }}><span aria-hidden="true">▶</span>Riprendi serata</button>
+      <button type="button" style={{
+        padding:'10px 16px', borderRadius:'var(--r-md)',
+        background:'transparent', color:'var(--text-sec)',
+        border:'1px solid var(--border-strong)',
+        fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700, cursor:'pointer',
+      }}>Pausa lunga · salva e chiudi</button>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// DESKTOP LAYOUT (3-pane: 280 / 1fr / 320)
+// ═══════════════════════════════════════════════════════
+
+const DesktopBody = ({ centerVariant = 'current', currentGame = GAMES[1], plannedGames = GAMES, diaryEvents = DIARY }) => (
+  <div style={{ display:'flex', flex: 1, minHeight: 0 }}>
+    <PlannedGamesPane games={plannedGames}/>
+    {centerVariant === 'transition'
+      ? <TransitionPendingPane from={GAMES[0]} to={GAMES[1]}/>
+      : <CurrentGameCard game={currentGame}/>
+    }
+    <CrossGameDiaryTimeline events={diaryEvents}/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// MOBILE LAYOUT (tabs swipeable)
+// ═══════════════════════════════════════════════════════
+
+const MobileBody = ({ initialTab = 'current', currentGame = GAMES[1], diaryEvents = DIARY }) => {
+  const [tab, setTab] = useState(initialTab);
+  const tabs = [
+    { id:'current', icon:'🎯', label:'Current', entity:'session' },
+    { id:'planned', icon:'🎲', label:'Planned', entity:'game' },
+    { id:'diary',   icon:'📜', label:'Diary',   entity:'event' },
+  ];
+  return (
+    <>
+      <div style={{
+        flex: 1, overflowY:'auto', minHeight: 0,
+        background:'var(--bg)',
+      }}>
+        {tab === 'current' && <CurrentGameCard game={currentGame} compact/>}
+        {tab === 'planned' && <PlannedGamesPane games={GAMES} compact/>}
+        {tab === 'diary'   && <CrossGameDiaryTimeline events={diaryEvents} compact/>}
+      </div>
+      <nav style={{
+        display:'flex', flexShrink: 0,
+        background:'var(--glass-bg)', backdropFilter:'blur(14px)',
+        borderTop:'1px solid var(--border)',
+      }}>
+        {tabs.map(t => {
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              aria-pressed={active}
+              style={{
+                flex: 1, padding:'9px 4px 10px',
+                background: active ? entityHsl(t.entity, 0.08) : 'transparent',
+                border:'none',
+                borderTop: active ? `2px solid ${entityHsl(t.entity)}` : '2px solid transparent',
+                color: active ? entityHsl(t.entity) : 'var(--text-muted)',
+                cursor:'pointer',
+                display:'flex', flexDirection:'column', alignItems:'center', gap: 1,
+                fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800,
+              }}>
+              <span aria-hidden="true" style={{ fontSize: 16 }}>{t.icon}</span>
+              {t.label}
+            </button>
+          );
+        })}
+      </nav>
+    </>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// FRAMES + HARNESS
+// ═══════════════════════════════════════════════════════
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>23:35</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+const DesktopFrame = ({ id, label, desc, gherkin, children }) => (
+  <section id={id} data-screen-label={`SP7-K · ${label}`} className="desktop-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">🖥️ {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="desktop-frame">
+      <div className="desktop-bar">
+        <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+        <span className="url">meepleai.app/game-nights/gn-padovani-may17/live</span>
+      </div>
+      <div style={{ background:'var(--bg)', position:'relative', overflow:'hidden', minHeight: 660 }}>
+        {children}
+      </div>
+    </div>
+    {desc && <p className="state-desc">{desc}</p>}
+  </section>
+);
+
+const PhoneShell = ({ id, label, desc, gherkin, children }) => (
+  <section id={id} data-screen-label={`SP7-K · ${label}`} className="phone-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">📱 {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="phone">
+      <PhoneSbar/>
+      <div style={{
+        flex: 1, display:'flex', flexDirection:'column',
+        background:'var(--bg)', position:'relative', overflow:'hidden', minHeight: 0,
+      }}>
+        {children}
+      </div>
+    </div>
+    {desc && <p className="state-desc" style={{ maxWidth: 360 }}>{desc}</p>}
+  </section>
+);
+
+const WidgetShell = ({ id, label, desc, gherkin }) => (
+  <section id={id} data-screen-label={`SP7-K · ${label}`} className="widget-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">🧩 {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div style={{ display:'flex', alignItems:'flex-start', gap: 14 }}>
+      <DiaryInlineWidget embedded width={320} height={400}/>
+      <div className="widget-callout">
+        <MonoKicker color={entityHsl('event')}>DiaryInlineWidget · export</MonoKicker>
+        <ul>
+          <li><strong>Riusabile</strong> in <code>/game-nights/[id]</code> detail sidebar</li>
+          <li><strong>Embedded</strong> in <code>/sessions/[id]/live</code> right rail</li>
+          <li>320×400 · scroll interno · cross-game divider visibile</li>
+          <li>Stesso pattern di <code>SessionDiaryTimeline</code> (sp4) ma multi-session</li>
+        </ul>
+      </div>
+    </div>
+    {desc && <p className="state-desc" style={{ maxWidth: 720 }}>{desc}</p>}
+  </section>
+);
+
+const DesktopScene = ({ stateVariant, paused, currentGame = GAMES[1], plannedGames = GAMES, diaryEvents = DIARY, showToast, ...topBarProps }) => (
+  <div style={{
+    display:'flex', flexDirection:'column',
+    minHeight: 660, height: 660,
+    background:'var(--bg)', position:'relative', overflow:'hidden',
+  }}>
+    <LiveHubTopBar paused={paused} nightStatus={stateVariant === 'transition' ? 'transition' : 'live'} {...topBarProps}/>
+    <ConnectionBar pips={[
+      { type:'event',   count: 1, label:'event' },
+      { type:'game',    count: 3, label:'game' },
+      { type:'session', count: currentGame ? 1 : 0, label: currentGame ? currentGame.sessionId.replace('s-','') : 'session' },
+      { type:'player',  count: 6, label:'player' },
+    ]}/>
+    <DesktopBody centerVariant={stateVariant === 'transition' ? 'transition' : 'current'}
+      currentGame={currentGame} plannedGames={plannedGames} diaryEvents={diaryEvents}/>
+    {paused && <PauseOverlay/>}
+    <AutoSaveToast visible={showToast}/>
+  </div>
+);
+
+const MobileScene = ({ initialTab, currentGame = GAMES[1], diaryEvents = DIARY }) => (
+  <>
+    <LiveHubTopBar compact currentGame={currentGame}/>
+    <MobileBody initialTab={initialTab} currentGame={currentGame} diaryEvents={diaryEvents}/>
+  </>
+);
+
+// ═══════════════════════════════════════════════════════
+// APP
+// ═══════════════════════════════════════════════════════
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "showStateAnchors": true,
+  "theme": "light"
+}/*EDITMODE-END*/;
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    return saved || document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      {/* Header */}
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'flex-start', gap: 16, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 12, flex: 1, minWidth: 0 }}>
+          <div style={{
+            width: 40, height: 40, borderRadius: 10,
+            background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)', fontSize: 18,
+          }}>K</div>
+          <div>
+            <div style={{
+              display:'flex', alignItems:'center', gap: 8, marginBottom: 2, flexWrap:'wrap',
+            }}>
+              <span style={{
+                padding:'2px 8px', borderRadius:'var(--r-pill)',
+                background: entityHsl('event', 0.12),
+                color: entityHsl('event'),
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+                border:`1px solid ${entityHsl('event', 0.22)}`,
+              }}>SP7 · Mockup K · Wave 1+</span>
+              <MonoKicker size={10}>US-31.K · Issue #487 · P1</MonoKicker>
+            </div>
+            <div style={{
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 22,
+              color:'var(--text)', letterSpacing:'-.01em',
+            }}>Game Night · Live Hub</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              fontWeight: 600, marginTop: 2,
+            }}>
+              <code>/game-nights/[id]/live</code> · 3-pane desktop (280 / 1fr / 320) · mobile tabs swipeable · diary cross-game multi-session
+            </div>
+          </div>
+        </div>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+            display:'inline-flex', alignItems:'center', gap: 6,
+          }}>
+          <span aria-hidden="true">🌗</span>
+          {theme === 'light' ? 'Light' : 'Dark'}
+        </button>
+      </header>
+
+      <main style={{
+        maxWidth: 1440, margin:'0 auto',
+        display:'flex', flexDirection:'column', gap: 56,
+      }}>
+        {/* Desktop section */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('event') }}/>
+            <h2 className="section-title">Desktop · 1280 — 3-pane (280 / 1fr / 320) — 5 stati</h2>
+            <span className="section-meta">Marco al tavolo · tablet/laptop</span>
+          </div>
+          <div style={{ display:'flex', flexDirection:'column', gap: 32 }}>
+            <DesktopFrame
+              id="state-01-game-1-in-progress"
+              label="01 · Game 1 in progress · diary 5 eventi · 2 planned upcoming"
+              gherkin="G31.11 / G31.12"
+              desc="Inizio serata: Brass Birmingham in corso (session indigo pulsing nel pane sx), Spirit Island + Wingspan upcoming. Diary mostra i primi 5 eventi del Brass run. Current pane focus su Brass cover + 4 KPI stats + roster 6 player + quick-jump CTA.">
+              <DesktopScene
+                currentGame={{ ...GAMES[0], status:'inprogress', score:'round 1 · in corso', actual:'13m elapsed' }}
+                plannedGames={[
+                  { ...GAMES[0], status:'inprogress', actual:'13m elapsed', score:'round 1 · in corso' },
+                  { ...GAMES[1], status:'upcoming' },
+                  { ...GAMES[2], status:'upcoming' },
+                ]}
+                diaryEvents={DIARY.slice(0, 5)}
+                current={1} total={3} elapsed="13m"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-02-mid-night-game-2"
+              label="02 · Mid-night · Game 1 completed + winner banner · Game 2 in-progress · diary 18 eventi"
+              gherkin="G31.11 / G31.12"
+              desc="Stato canonical: Brass finito (winner Marco banner nel pane sx) · Spirit Island in corso al centro con 4 KPI · diary aggregato cross-game con divider 'Spirit Island' a separazione visiva delle 2 session.">
+              <DesktopScene
+                current={2} total={3} elapsed="2h 35m"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-03-transition-pending"
+              label="03 · Transition pending tra Game 1 e Game 2 · Avvia / Salta / Termina"
+              gherkin="G31.12"
+              desc="Center pane sostituito da TransitionPendingPane: recap Brass (completed toolkit) → preview Spirit Island (upcoming event) · 3 CTA Avvia / Salta / Termina. Sidebar sx mostra entrambi i game con stati distinti, diary già con event 'Marco vince' + transition.">
+              <DesktopScene stateVariant="transition"
+                plannedGames={[
+                  GAMES[0],
+                  { ...GAMES[1], status:'upcoming', actual: null },
+                  GAMES[2],
+                ]}
+                diaryEvents={DIARY.slice(0, 10)}
+                current={2} total={3} elapsed="1h 53m"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-04-paused"
+              label="04 · Serata in pausa · overlay amber + timer pausa + auto-save attivo"
+              gherkin="G31.13 (acceptance #487)"
+              desc="Overlay full-area entityHsl('agent' alias warning) · timer pausa 56 Quicksand · 2 CTA Riprendi / Pausa lunga. Top bar pulsing dot diventa ⏸ amber. Auto-save continua sotto, diary congelato.">
+              <DesktopScene paused current={2} total={3} elapsed="2h 35m"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-05-diary-empty"
+              label="05 · Inizio serata · diary empty + sidebar sx tutti upcoming"
+              gherkin="G31.11"
+              desc="Pre-game: serata appena iniziata (#GN-042), nessuna session avviata, diary empty con CTA 'Inizia a giocare!' + sidebar sx 3 game tutti upcoming + center pane mostra Game 1 in attesa di start.">
+              <DesktopScene
+                currentGame={{ ...GAMES[0], status:'upcoming', score:'in attesa di start', actual:'non iniziato', startedAt:'—' }}
+                plannedGames={GAMES.map(g => ({ ...g, status:'upcoming', actual:null, winnerId:null, score:'in attesa', startedAt:null }))}
+                diaryEvents={[]}
+                current={0} total={3} elapsed="0m"/>
+            </DesktopFrame>
+          </div>
+        </div>
+
+        {/* Widget standalone state-06 */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('event') }}/>
+            <h2 className="section-title">Widget standalone · 320×400 — riuso embedded</h2>
+            <span className="section-meta">DiaryInlineWidget export</span>
+          </div>
+          <WidgetShell
+            id="state-06-diary-widget-embedded"
+            label="06 · DiaryInlineWidget · 320×400 standalone preview"
+            gherkin="G31.12 (riuso)"
+            desc="Versione compatta export-ready del CrossGameDiaryTimeline. 7 eventi più recenti, divider cross-game, header + footer azioni. Si embedda in altri context (game-night detail, session live sidebar) con stesso codice — solo width/height + flag embedded."/>
+        </div>
+
+        {/* Mobile section */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('session') }}/>
+            <h2 className="section-title">Mobile · 390 — fullscreen swipeable tabs · 3 stati</h2>
+            <span className="section-meta">Quick-jump al tavolo · iPhone 15 viewport</span>
+          </div>
+          <div className="mobile-grid">
+            <PhoneShell id="state-07-mobile-tab-current"
+              label="07 · Tab Current · Spirit Island in-progress"
+              gherkin="G31.11"
+              desc="Tab di default. Top bar compatta 56 con counter row sotto (Game 2/3 · 2h35m · 6/6 player). Cover hero Spirit + 4 KPI 2-col + roster strip + quick-jump CTA.">
+              <MobileScene initialTab="current"/>
+            </PhoneShell>
+            <PhoneShell id="state-08-mobile-tab-planned"
+              label="08 · Tab Planned · 3 game (✓ + 🔴 live + ⏳)"
+              gherkin="G31.11"
+              desc="3 PlannedGameRow stack verticale: Brass completed con winner banner Marco, Spirit Island in-progress pulsing, Wingspan upcoming. PlayOrder locked durante live.">
+              <MobileScene initialTab="planned"/>
+            </PhoneShell>
+            <PhoneShell id="state-09-mobile-tab-diary"
+              label="09 · Tab Diary · cross-game timeline · 18 eventi"
+              gherkin="G31.12"
+              desc="Timeline cross-game completa con divider 'Spirit Island' tra le 2 session. Filter pills Tutti/Turn/Score/Custom. Annota event CTA bottom sticky.">
+              <MobileScene initialTab="diary"/>
+            </PhoneShell>
+          </div>
+        </div>
+
+        {/* Auto-save toast state-10 */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('toolkit') }}/>
+            <h2 className="section-title">Auto-save toast · acceptance criterion #487</h2>
+            <span className="section-meta">60s tick · bottom-right · entityHsl('toolkit', 0.1)</span>
+          </div>
+          <DesktopFrame
+            id="state-10-auto-save-toast"
+            label="10 · Auto-save toast 'Auto-salvato' bottom-right · ogni 60s"
+            gherkin="G31.13 (acceptance #487)"
+            desc="Toast pill in bottom-right con bg entityHsl('toolkit', 0.1) + border 0.32 + check icon. Mostra timestamp HH:MM:SS + countdown prossimo tick. Non blocca interazione, sparisce dopo 4s. Stessa scene di state-02 con toast visibile.">
+            <DesktopScene showToast current={2} total={3} elapsed="2h 35m"/>
+          </DesktopFrame>
+        </div>
+
+        {/* Pattern note */}
+        <footer style={{
+          padding:'24px 0', borderTop:'1px solid var(--border)',
+          display:'flex', flexDirection:'column', gap: 10, maxWidth: 880,
+        }}>
+          <MonoKicker>Pattern note</MonoKicker>
+          <ul style={{
+            margin: 0, paddingLeft: 18,
+            fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.7,
+          }}>
+            <li>3-pane desktop fisso: 280 PlannedGamesPane | 1fr CurrentGameCard (o TransitionPendingPane) | 320 CrossGameDiaryTimeline. Mobile fullscreen + bottom tabs Current/Planned/Diary entity-aware.</li>
+            <li>ConnectionBar inline con pip <code>{'[event=1, game=3, session={current_id}, player={confirmed_count}]'}</code>. Rendering 1:1 prod (PR #568): borderRadius pill, bg pieno entityHsl @ 0.1 non-empty, dashed + opacity 0.6 + Plus icon empty, aria-label corretto.</li>
+            <li>CrossGameDiaryTimeline è la versione multi-session del SessionDiaryTimeline di sp4: stesso event row pattern (icon medallion + timestamp mono + avatar attori + bubble) ma con divider visibile a separazione cross-session.</li>
+            <li>DiaryInlineWidget esportato 320×400: ri-usato dentro game-night detail sidebar e session live rail. Stesso codice, flag embedded + width/height.</li>
+            <li>Auto-save toast (#487 acceptance): bg <code>entityHsl('toolkit', 0.1)</code>, border 0.32, position absolute bottom-right 18/18, animation spring in. Ogni 60s con timestamp HH:MM:SS.</li>
+            <li>Pause overlay accent <code>var(--c-warning)</code> (alias agent in <code>tokens.css</code>): respect del brief "entityHsl('agent', 0.1) = warning". Diary congelato durante pause, top bar status switch da Live a In pausa.</li>
+            <li>Light + dark via <code>[data-theme="dark"]</code>. Solo <code>entityHsl()</code> helper + <code>var(--c-*)</code> semantic token. Zero <code>hsl(num, ...)</code> hardcoded fuori dalle utility.</li>
+            <li>Anchor id <code>state-NN-...</code> standard SP6/SP7 su wrapper top-level + <code>data-screen-label</code> per review meeting.</li>
+          </ul>
+        </footer>
+      </main>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp7-game-night-summary.html
+++ b/admin-mockups/design_files/sp7-game-night-summary.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>SP7-M · Night Summary — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700;800&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+  <style>
+    /* ─── Harness · sections ─── */
+    .section-header {
+      display: flex; align-items: center; gap: 12px;
+      padding-bottom: 12px; margin-bottom: 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .section-marker { width: 6px; height: 28px; border-radius: 3px; }
+    .section-title {
+      font-family: var(--f-display); font-size: 18px; font-weight: 800;
+      color: var(--text); margin: 0; flex: 1; letter-spacing: -.01em;
+    }
+    .section-meta {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em;
+    }
+
+    /* ─── State caption ─── */
+    .state-caption {
+      display: flex; align-items: center; gap: 8px;
+      margin-bottom: 10px; flex-wrap: wrap;
+    }
+    .state-id {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 800;
+      color: hsl(var(--c-event));
+      background: hsl(var(--c-event) / .12);
+      border: 1px solid hsl(var(--c-event) / .25);
+      padding: 3px 8px; border-radius: var(--r-pill);
+      letter-spacing: .04em;
+    }
+    .state-label {
+      font-family: var(--f-display); font-size: 12.5px; font-weight: 800;
+      color: var(--text);
+    }
+    .gherkin {
+      font-family: var(--f-mono); font-size: 9.5px; font-weight: 800;
+      color: hsl(var(--c-toolkit));
+      background: hsl(var(--c-toolkit) / .1);
+      border: 1px solid hsl(var(--c-toolkit) / .3);
+      padding: 2px 7px; border-radius: var(--r-pill);
+      text-transform: uppercase; letter-spacing: .06em;
+    }
+    .state-desc {
+      font-size: 11.5px; color: var(--text-sec); margin: 12px 0 0;
+      line-height: 1.55; max-width: 1180px;
+    }
+
+    /* ─── Desktop frame ─── */
+    .desktop-shell { display: flex; flex-direction: column; width: 100%; }
+    .desktop-frame {
+      width: 100%; max-width: 1280px;
+      border-radius: var(--r-xl);
+      border: 1px solid var(--border);
+      background: var(--bg);
+      overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 9px 14px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    }
+    .desktop-bar .traffic { width: 11px; height: 11px; border-radius: 50%; background: hsl(var(--c-event)); }
+    .desktop-bar .traffic:nth-child(2) { background: hsl(var(--c-warning)); }
+    .desktop-bar .traffic:nth-child(3) { background: hsl(var(--c-toolkit)); }
+    .desktop-bar .url { flex: 1; text-align: center; letter-spacing: .04em; }
+
+    /* ─── Phone ─── */
+    .phone-shell { display: flex; flex-direction: column; align-items: center; }
+    .phone-shell .phone { width: 390px; height: 820px; }
+    .mobile-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(390px, 1fr));
+      gap: var(--s-7);
+      align-items: start;
+    }
+
+    /* ─── Animations ─── */
+    @keyframes sp7Pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50%      { transform: scale(1.45); opacity: .55; }
+    }
+    @keyframes sp7ToastIn {
+      from { transform: translateY(12px) scale(.96); opacity: 0; }
+      to   { transform: translateY(0) scale(1);     opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+      }
+    }
+
+    .phone > div::-webkit-scrollbar,
+    .desktop-frame ::-webkit-scrollbar { width: 6px; height: 6px; }
+    .desktop-frame ::-webkit-scrollbar-thumb {
+      background: var(--border-strong); border-radius: 3px;
+    }
+    .phone ::-webkit-scrollbar { width: 4px; }
+    .phone ::-webkit-scrollbar-thumb {
+      background: var(--border); border-radius: 2px;
+    }
+    button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible {
+      outline: 2px solid hsl(var(--c-event));
+      outline-offset: 2px;
+    }
+    code {
+      background: var(--bg-muted);
+      padding: 1px 5px; border-radius: var(--r-xs);
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script>
+    window.DS = {
+      EC: {
+        game:    { h: 25,  s: 95, l: 45, em: '🎲' },
+        player:  { h: 262, s: 83, l: 58, em: '👤' },
+        session: { h: 240, s: 60, l: 55, em: '🎯' },
+        agent:   { h: 38,  s: 92, l: 50, em: '🤖' },
+        kb:      { h: 174, s: 60, l: 40, em: '📄' },
+        chat:    { h: 220, s: 80, l: 55, em: '💬' },
+        event:   { h: 350, s: 89, l: 60, em: '🎉' },
+        toolkit: { h: 142, s: 70, l: 45, em: '🧰' },
+        tool:    { h: 195, s: 80, l: 50, em: '🔧' },
+      },
+      byId: {},
+    };
+    const _applyTheme = (t) => {
+      if (t === 'dark') {
+        Object.assign(window.DS.EC, {
+          game:    { h: 28,  s: 95, l: 58, em:'🎲' },
+          player:  { h: 262, s: 75, l: 70, em:'👤' },
+          session: { h: 235, s: 70, l: 70, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 62, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 55, em:'📄' },
+          chat:    { h: 218, s: 80, l: 68, em:'💬' },
+          event:   { h: 350, s: 85, l: 70, em:'🎉' },
+          toolkit: { h: 142, s: 60, l: 58, em:'🧰' },
+          tool:    { h: 195, s: 75, l: 62, em:'🔧' },
+        });
+      } else {
+        Object.assign(window.DS.EC, {
+          game:    { h: 25,  s: 95, l: 45, em:'🎲' },
+          player:  { h: 262, s: 83, l: 58, em:'👤' },
+          session: { h: 240, s: 60, l: 55, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 50, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 40, em:'📄' },
+          chat:    { h: 220, s: 80, l: 55, em:'💬' },
+          event:   { h: 350, s: 89, l: 60, em:'🎉' },
+          toolkit: { h: 142, s: 70, l: 45, em:'🧰' },
+          tool:    { h: 195, s: 80, l: 50, em:'🔧' },
+        });
+      }
+    };
+    new MutationObserver(() => {
+      _applyTheme(document.documentElement.getAttribute('data-theme'));
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    _applyTheme(document.documentElement.getAttribute('data-theme') || 'light');
+  </script>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="sp7-game-night-summary.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp7-game-night-summary.jsx
+++ b/admin-mockups/design_files/sp7-game-night-summary.jsx
@@ -1,0 +1,1134 @@
+/* ===================================================================
+   SP7 Game Night — Night Summary (sp7-game-night-summary.jsx)
+   Route: /game-nights/[id]/summary  (post-end final state)
+   Persona: tutti i partecipanti, post-serata. Mobile primario per share,
+            desktop per archiviazione/review.
+   Coverage: US-31 G31.16 / G31.17 / G31.18 — Sprint N+1 P1
+   Pattern: Full-screen single column scrollable · hero + sections stack
+
+   Stati (6 totali)
+   - state-01-summary-full           3 games completed · 28 diary events · 6 foto
+   - state-02-summary-no-photos      Stesso recap · gallery empty con placeholder CTA "Aggiungi foto"
+   - state-03-summary-single-game    Serata 1 game (no transition · no per-game multipli · stats ridotte)
+   - state-04-share-success-toast    Post-share toast "Link copiato" entityHsl('toolkit', 0.1)
+   - state-05-archived               Post-archive banner muted + CTA "Torna alla lista"
+   - state-06-mobile-single-col      Mobile vertical stack (390 fullscreen · padding ridotto)
+
+   Continuità dati con K + L
+   - Serata: "Sabato boardgame con i Padovani" · sab 17 mag 21:00 · Casa Marco
+   - 3 games completati:
+       Brass Birmingham   · winner Davide 178pt   · 2h 45m · top-3 (Davide/Marco/Giulia)
+       Spirit Island      · coop · winner team   · 1h 50m · round 5/6
+       Wingspan           · winner Giulia 92pt    · 1h 25m · top-3 (Giulia/Sara/Aaron)
+   - Total: 28 diary events · 6h 15m totale · 6 foto placeholder
+   - MVP serata: Davide (1 win + most events generated)
+   - 6 player: Marco (host), Giulia, Davide, Luca, Sara, Aaron
+
+   Entity color mapping
+   - hero MVP banner              = entityHsl('event')   rose
+   - KPI grid (totale sessioni)   = entityHsl('session') indigo
+   - KPI grid (durata)            = entityHsl('event')   rose
+   - KPI grid (diary events)      = entityHsl('chat')    blue
+   - KPI grid (winner per gioco)  = entityHsl('player')  violet
+   - per-game recap CTA           = entityHsl('session') (link a /sessions/[id])
+   - foto gallery placeholder     = entityHsl('event', 0.1) tint
+   - share success toast          = entityHsl('toolkit') green
+   - archived banner              = var(--text-muted)
+
+   Componenti v2 emersi
+   - NightSummaryHero            → apps/web/src/components/ui/v2/night-summary-hero/
+   - MVPBanner                   → ui/v2/mvp-banner/
+   - KPIStatGrid + KPIStatCard   → ui/v2/kpi-stat-grid/
+   - PerGameRecapRow             → ui/v2/per-game-recap-row/
+   - CollapsedDiaryByGame        → ui/v2/collapsed-diary-by-game/ (CrossGame collapsed mode)
+   - NightPhotoGallery           → ui/v2/night-photo-gallery/
+   - ShareSuccessToast           → ui/v2/share-success-toast/ (varianti per archive/copy/x)
+   - ArchivedBanner              → ui/v2/archived-banner/
+
+   Riusi pattern
+   - CrossGameDiaryTimeline (sp7-k) — qui in mode collapsed-by-game
+   - MeepleCard variant compact     — per-game recap rows
+   - StatusBadge lifecycle           — "Completata" badge da SP7-B
+   - AutoSaveToast pattern (sp7-k) — share toast riuso bottom-right
+   =================================================================== */
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.event;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ═══════════════════════════════════════════════════════
+// FIXTURE — Sabato Padovani · serata completata
+// ═══════════════════════════════════════════════════════
+
+const NIGHT = {
+  id: 'gn-padovani-may17',
+  title: 'Sabato boardgame con i Padovani',
+  dateLine: 'sabato 17 maggio 2026',
+  startedAt: '21:00',
+  endedAt: '03:15',
+  duration: '6h 15m',
+  location: 'Casa Marco · Padova',
+  hostId: 'p-marco',
+};
+
+const PLAYERS = [
+  { id:'p-marco',   initials:'MR', name:'Marco',   color: 262, role:'host' },
+  { id:'p-giulia',  initials:'GM', name:'Giulia',  color: 10  },
+  { id:'p-davide',  initials:'DC', name:'Davide',  color: 200 },
+  { id:'p-luca',    initials:'LB', name:'Luca',    color: 180 },
+  { id:'p-sara',    initials:'ST', name:'Sara',    color: 320 },
+  { id:'p-aaron',   initials:'AK', name:'Aaron',   color: 140 },
+];
+const byPid = Object.fromEntries(PLAYERS.map(p => [p.id, p]));
+
+const GAMES = [
+  { id:'gs-brass-1',  gameId:'g-brass',    title:'Brass: Birmingham', publisher:'Roxley',
+    emoji:'🏭', cover:['hsl(220 35% 28%)','hsl(28 60% 38%)'],
+    duration:'2h 45m', startedAt:'21:00', endedAt:'22:45',
+    coopMode: false, winnerId:'p-davide',
+    topThree: [
+      { id:'p-davide', score: 178 },
+      { id:'p-marco',  score: 142 },
+      { id:'p-giulia', score: 128 },
+    ],
+    sessionId: 's-brass-may17', eventsCount: 11, order: 1,
+  },
+  { id:'gs-spirit-1', gameId:'g-spirit',   title:'Spirit Island', publisher:'GMT',
+    emoji:'🌋', cover:['hsl(210 50% 30%)','hsl(150 50% 38%)'],
+    duration:'1h 50m', startedAt:'23:05', endedAt:'00:55',
+    coopMode: true, winnerId:null,
+    coopOutcome: 'Team coop ha vinto · round 5 di 6 · Adversary England 1',
+    sessionId: 's-spirit-may17', eventsCount: 8, order: 2,
+  },
+  { id:'gs-wing-1',   gameId:'g-wingspan', title:'Wingspan', publisher:'Stonemaier',
+    emoji:'🦜', cover:['hsl(85 40% 45%)','hsl(35 60% 50%)'],
+    duration:'1h 25m', startedAt:'01:30', endedAt:'02:55',
+    coopMode: false, winnerId:'p-giulia',
+    topThree: [
+      { id:'p-giulia', score: 92 },
+      { id:'p-sara',   score: 78 },
+      { id:'p-aaron',  score: 71 },
+    ],
+    sessionId: 's-wing-may17', eventsCount: 9, order: 3,
+  },
+];
+
+const MVP = byPid['p-davide'];
+
+// Diary events condensed (per game). Collapsed mode mostra solo count + breakdown.
+// L'expanded di Spirit Island mostra 3 eventi-chiave (highlights, non full list).
+const DIARY_HIGHLIGHTS = {
+  'gs-brass-1': [
+    { t:'22:48', kind:'score',  icon:'📊', actors:['p-marco'],  text:'Marco completa rete Birmingham (+12 link points)' },
+    { t:'22:55', kind:'end',    icon:'🏆', actors:['p-davide'], text:'🏆 Davide vince Brass Birmingham 178–142' },
+  ],
+  'gs-spirit-1': [
+    { t:'23:30', kind:'custom', icon:'💡', actors:['p-aaron'],  text:'Aaron usa innate Lightning Strike (2 danno)' },
+    { t:'00:42', kind:'score',  icon:'📊', actors:[],           text:'Fear deck stage III · 3 Earthquake' },
+    { t:'00:55', kind:'end',    icon:'🏆', actors:[],           text:'🏆 Team coop wins · England 1 sconfitto al round 5/6' },
+  ],
+  'gs-wing-1': [
+    { t:'02:38', kind:'score',  icon:'📊', actors:['p-giulia'], text:'Giulia +15 (Eggs bonus end-game)' },
+    { t:'02:55', kind:'end',    icon:'🏆', actors:['p-giulia'], text:'🏆 Giulia vince Wingspan 92–78' },
+  ],
+};
+
+const KIND_COLOR = {
+  turn:   'session',
+  score:  'session',
+  custom: 'tool',
+  chat:   'chat',
+  end:    'event',
+  system: 'toolkit',
+};
+
+const PHOTOS = [
+  { id:'ph-1', label:'Setup Brass',       g:'linear-gradient(135deg, hsl(220 35% 30%), hsl(28 60% 40%))' },
+  { id:'ph-2', label:'Davide vince',      g:'linear-gradient(135deg, hsl(350 70% 55%), hsl(28 60% 50%))' },
+  { id:'ph-3', label:'Tabellone Spirit',  g:'linear-gradient(135deg, hsl(210 50% 30%), hsl(150 50% 40%))' },
+  { id:'ph-4', label:'Foto di gruppo',    g:'linear-gradient(135deg, hsl(262 50% 50%), hsl(320 60% 55%))' },
+  { id:'ph-5', label:'Tableau Wingspan',  g:'linear-gradient(135deg, hsl(85 50% 50%), hsl(35 60% 55%))' },
+  { id:'ph-6', label:'Brindisi finale',   g:'linear-gradient(135deg, hsl(38 80% 55%), hsl(10 70% 50%))' },
+];
+
+// ═══════════════════════════════════════════════════════
+// PRIMITIVES
+// ═══════════════════════════════════════════════════════
+
+const Avatar = ({ player, size = 22, ring }) => (
+  <span style={{
+    width: size, height: size, borderRadius:'50%',
+    background:`hsl(${player.color}, 60%, 55%)`, color:'#fff',
+    fontFamily:'var(--f-display)', fontWeight: 800,
+    fontSize: size <= 18 ? 8 : size <= 24 ? 9 : size <= 36 ? 12 : 16,
+    display:'inline-flex', alignItems:'center', justifyContent:'center',
+    border:`2px solid ${ring || 'var(--bg-card)'}`,
+    flexShrink: 0,
+  }}>{player.initials}</span>
+);
+
+const MonoKicker = ({ children, color = 'var(--text-muted)', size = 10 }) => (
+  <span style={{
+    fontFamily:'var(--f-mono)', fontSize: size, fontWeight: 800,
+    color, textTransform:'uppercase', letterSpacing:'.08em',
+  }}>{children}</span>
+);
+
+// ═══════════════════════════════════════════════════════
+// HERO — NightSummaryHero
+// /* v2: NightSummaryHero + MVPBanner */
+// ═══════════════════════════════════════════════════════
+
+const NightSummaryHero = ({ mobile, mvp = MVP, gamesCount = 3 }) => (
+  <header style={{
+    position:'relative',
+    padding: mobile ? '20px 18px 22px' : '32px 32px 28px',
+    background: `linear-gradient(160deg, ${entityHsl('event', 0.18)} 0%, ${entityHsl('event', 0.03)} 100%)`,
+    borderBottom: `1px solid ${entityHsl('event', 0.2)}`,
+    overflow:'hidden',
+  }}>
+    {/* Decorative confetti shapes */}
+    <div aria-hidden="true" style={{
+      position:'absolute', top:-40, right:-40,
+      width: 220, height: 220, borderRadius:'50%',
+      background: `radial-gradient(circle at 30% 30%, ${entityHsl('event', 0.4)}, transparent 70%)`,
+      opacity: .4, pointerEvents:'none',
+    }}/>
+    <div aria-hidden="true" style={{
+      position:'absolute', bottom:-30, left:-30,
+      width: 160, height: 160, borderRadius:'50%',
+      background: `radial-gradient(circle at 40% 40%, ${entityHsl('toolkit', 0.4)}, transparent 70%)`,
+      opacity: .25, pointerEvents:'none',
+    }}/>
+
+    {/* Status badge */}
+    <div style={{
+      display:'flex', alignItems:'center', gap: 8, marginBottom: 12,
+      position:'relative',
+    }}>
+      <span style={{
+        display:'inline-flex', alignItems:'center', gap: 6,
+        padding:'4px 10px', borderRadius:'var(--r-pill)',
+        background: 'var(--bg-card)',
+        border:'1px solid var(--border-strong)',
+        color:'var(--text-muted)',
+        fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+        textTransform:'uppercase', letterSpacing:'.08em',
+      }}>
+        <span aria-hidden="true">✓</span>
+        Serata completata
+      </span>
+      <MonoKicker size={10}>#GN-042 · 17 mag 2026</MonoKicker>
+    </div>
+
+    {/* Title */}
+    <h1 style={{
+      position:'relative',
+      fontFamily:'var(--f-display)', fontSize: mobile ? 26 : 36, fontWeight: 800,
+      color:'var(--text)', letterSpacing:'-.02em',
+      margin:'0 0 6px', lineHeight: 1.1,
+    }}>{NIGHT.title}</h1>
+
+    {/* Date + location */}
+    <div style={{
+      position:'relative',
+      display:'flex', flexWrap:'wrap', gap:'4px 14px', alignItems:'center',
+      fontFamily:'var(--f-mono)', fontSize: 12, fontWeight: 700,
+      color:'var(--text-sec)', marginBottom: mobile ? 16 : 22,
+    }}>
+      <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+        <span aria-hidden="true">📅</span>{NIGHT.dateLine}
+      </span>
+      <span style={{ color:'var(--text-muted)' }}>·</span>
+      <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+        <span aria-hidden="true">⏱</span>
+        {NIGHT.startedAt} → {NIGHT.endedAt} · <strong style={{ color:'var(--text)' }}>{NIGHT.duration}</strong>
+      </span>
+      <span style={{ color:'var(--text-muted)' }}>·</span>
+      <span style={{ display:'inline-flex', alignItems:'center', gap: 5 }}>
+        <span aria-hidden="true">📍</span>{NIGHT.location}
+      </span>
+    </div>
+
+    {/* MVP banner */}
+    {mvp && (
+      <div style={{
+        position:'relative',
+        display:'flex', alignItems:'center', gap: mobile ? 12 : 16,
+        padding: mobile ? '12px 14px' : '16px 20px',
+        borderRadius:'var(--r-xl)',
+        background: entityHsl('event', 0.12),
+        border:`1.5px solid ${entityHsl('event', 0.4)}`,
+        boxShadow: `0 0 0 4px ${entityHsl('event', 0.08)}, var(--shadow-md)`,
+        maxWidth: mobile ? '100%' : 540,
+      }}>
+        <div style={{ position:'relative', flexShrink: 0 }}>
+          <Avatar player={mvp} size={mobile ? 48 : 60}
+            ring={`${entityHsl('event', 0.5)}`}/>
+          <span aria-hidden="true" style={{
+            position:'absolute', top: -6, right: -8,
+            fontSize: mobile ? 20 : 26,
+            filter:'drop-shadow(0 2px 4px rgba(0,0,0,.25))',
+          }}>🏆</span>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <MonoKicker size={mobile ? 9 : 10} color={entityHsl('event')}>
+            MVP della serata
+          </MonoKicker>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: mobile ? 19 : 24, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.01em', lineHeight: 1.15,
+            marginTop: 2,
+          }}>{mvp.name}</div>
+          <div style={{
+            fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+            color:'var(--text-sec)', marginTop: 3,
+          }}>1 vittoria · 11 eventi diary · top scorer Brass</div>
+        </div>
+        <span aria-hidden="true" style={{
+          fontSize: mobile ? 28 : 36, opacity: .35, color: entityHsl('event'),
+          flexShrink: 0, marginRight: -4,
+        }}>✨</span>
+      </div>
+    )}
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// KPI STAT GRID — KPIStatGrid + KPIStatCard
+// /* v2: KPIStatGrid */
+// ═══════════════════════════════════════════════════════
+
+const KPIStatCard = ({ label, value, sub, tone = 'session', icon }) => (
+  <div style={{
+    padding:'14px 16px',
+    borderRadius:'var(--r-lg)',
+    background:'var(--bg-card)',
+    border:'1px solid var(--border)',
+    borderTop: `3px solid ${entityHsl(tone)}`,
+    display:'flex', flexDirection:'column', gap: 4, minWidth: 0,
+  }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+      <span aria-hidden="true" style={{ fontSize: 13 }}>{icon}</span>
+      <MonoKicker size={9.5}>{label}</MonoKicker>
+    </div>
+    <div style={{
+      fontFamily:'var(--f-display)', fontSize: 28, fontWeight: 800,
+      color: entityHsl(tone), fontVariantNumeric:'tabular-nums',
+      letterSpacing:'-.02em', lineHeight: 1,
+    }}>{value}</div>
+    <div style={{
+      fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+      color:'var(--text-muted)',
+    }}>{sub}</div>
+  </div>
+);
+
+const KPIStatGrid = ({ mobile, games = GAMES, eventsCount = 28 }) => {
+  const winners = games.filter(g => g.coopMode || g.winnerId).length;
+  return (
+    <div style={{
+      padding: mobile ? '18px 14px 4px' : '24px 32px 8px',
+      display:'grid',
+      gridTemplateColumns: mobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)',
+      gap: mobile ? 10 : 14,
+    }}>
+      <KPIStatCard icon="🎯" tone="session" label="Sessioni totali"
+        value={games.length} sub={games.length === 1 ? '1 game · serata breve' : `${games.length} game completati`}/>
+      <KPIStatCard icon="⏱" tone="event" label="Durata totale"
+        value={NIGHT.duration} sub={`${NIGHT.startedAt} → ${NIGHT.endedAt}`}/>
+      <KPIStatCard icon="📜" tone="chat" label="Eventi diary"
+        value={eventsCount} sub={`${(eventsCount / Math.max(games.length, 1)).toFixed(1)} avg per session`}/>
+      <KPIStatCard icon="🏆" tone="player" label="Winner per gioco"
+        value={`${winners}/${games.length}`} sub={games.some(g => g.coopMode) ? '1 coop · 2 competitive' : 'tutti competitive'}/>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// PER-GAME RECAP ROW
+// /* v2: PerGameRecapRow */
+// ═══════════════════════════════════════════════════════
+
+const PerGameRecapRow = ({ game, mobile }) => {
+  const winner = game.winnerId ? byPid[game.winnerId] : null;
+  const isCoop = game.coopMode;
+  return (
+    <div style={{
+      display:'grid',
+      gridTemplateColumns: mobile ? '1fr' : '90px 1fr auto',
+      gap: mobile ? 10 : 16,
+      alignItems:'center',
+      padding: mobile ? 12 : '14px 16px',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border)',
+      borderLeft: `4px solid ${entityHsl(isCoop ? 'toolkit' : 'event')}`,
+      borderRadius:'var(--r-lg)',
+    }}>
+      {/* Cover */}
+      <div style={{
+        height: mobile ? 110 : 70,
+        borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: mobile ? 44 : 30, position:'relative',
+      }} aria-hidden="true">
+        <span style={{
+          position:'absolute', top: 6, left: 6,
+          padding:'2px 7px', borderRadius:'var(--r-pill)',
+          background:'rgba(0,0,0,0.55)', color:'#fff',
+          fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+          letterSpacing:'.06em',
+        }}>#{game.order}</span>
+        <span style={{ filter:'drop-shadow(0 3px 8px rgba(0,0,0,.4))' }}>{game.emoji}</span>
+      </div>
+
+      {/* Info */}
+      <div style={{ minWidth: 0, display:'flex', flexDirection:'column', gap: 6 }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap' }}>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.01em',
+          }}>{game.title}</div>
+          {isCoop && (
+            <span style={{
+              padding:'2px 7px', borderRadius:'var(--r-pill)',
+              background: entityHsl('toolkit', 0.12),
+              border:`1px solid ${entityHsl('toolkit', 0.3)}`,
+              color: entityHsl('toolkit'),
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              textTransform:'uppercase', letterSpacing:'.06em',
+            }}>🤝 Co-op</span>
+          )}
+          <MonoKicker size={9.5}>
+            ⏱ {game.duration} · {game.eventsCount} eventi
+          </MonoKicker>
+        </div>
+
+        {/* Winner line */}
+        <div style={{
+          display:'flex', alignItems:'center', gap: 8, flexWrap:'wrap',
+        }}>
+          {isCoop ? (
+            <>
+              <span style={{
+                display:'inline-flex', alignItems:'center', gap: 5,
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background: entityHsl('toolkit', 0.12),
+                border:`1px solid ${entityHsl('toolkit', 0.3)}`,
+                color: entityHsl('toolkit'),
+                fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800,
+              }}>
+                <span aria-hidden="true">🏆</span>
+                Team coop ha vinto
+              </span>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 10.5, fontWeight: 700,
+                color:'var(--text-sec)',
+              }}>{game.coopOutcome}</span>
+            </>
+          ) : winner && (
+            <>
+              <Avatar player={winner} size={22} ring={entityHsl('event', 0.4)}/>
+              <span style={{
+                fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+                color:'var(--text)',
+              }}>🏆 {winner.name}</span>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+                color: entityHsl('event'), fontVariantNumeric:'tabular-nums',
+              }}>{game.topThree[0].score}pt</span>
+              {/* Mini score chips */}
+              <div style={{ display:'flex', gap: 4, marginLeft: 4 }}>
+                {game.topThree.slice(1).map((t, i) => {
+                  const p = byPid[t.id];
+                  return (
+                    <span key={t.id} style={{
+                      display:'inline-flex', alignItems:'center', gap: 4,
+                      padding:'2px 6px 2px 2px',
+                      borderRadius:'var(--r-pill)',
+                      background:'var(--bg-muted)',
+                      border:'1px solid var(--border)',
+                      fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+                      color:'var(--text-sec)',
+                      fontVariantNumeric:'tabular-nums',
+                    }}>
+                      <Avatar player={p} size={16}/>
+                      {p.name} {t.score}
+                    </span>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* CTA */}
+      <a href={`/sessions/${game.sessionId}`} style={{
+        padding:'10px 14px', borderRadius:'var(--r-md)',
+        background: entityHsl('session', 0.1),
+        border:`1px solid ${entityHsl('session', 0.3)}`,
+        color: entityHsl('session'),
+        textDecoration:'none',
+        fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+        display:'inline-flex', alignItems:'center', gap: 6,
+        flexShrink: 0,
+        whiteSpace:'nowrap',
+        justifyContent: mobile ? 'center' : 'flex-start',
+      }}>Vai a session <span aria-hidden="true">→</span></a>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// COLLAPSED CROSS-GAME DIARY TIMELINE
+// /* v2: CollapsedDiaryByGame */
+// ═══════════════════════════════════════════════════════
+
+const DiaryHighlightRow = ({ e }) => {
+  const ec = KIND_COLOR[e.kind] || 'session';
+  return (
+    <div style={{ display:'flex', gap: 9, alignItems:'flex-start', paddingLeft: 4 }}>
+      <div style={{
+        width: 22, height: 22, borderRadius:'50%',
+        background: entityHsl(ec, 0.14),
+        border:`2px solid ${entityHsl(ec, 0.4)}`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 10, flexShrink: 0,
+      }}><span aria-hidden="true">{e.icon}</span></div>
+      <div style={{
+        flex: 1, minWidth: 0,
+        padding:'5px 9px',
+        background: e.kind === 'end' ? entityHsl('event', 0.08) : 'var(--bg-muted)',
+        borderRadius:'var(--r-sm)',
+        borderLeft: e.kind === 'end' ? `2px solid ${entityHsl('event')}` : '2px solid transparent',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 6, marginBottom: 1, flexWrap:'wrap' }}>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+            color: entityHsl(ec), letterSpacing:'.06em',
+            fontVariantNumeric:'tabular-nums',
+          }}>{e.t}</span>
+          {e.actors.length > 0 && (
+            <div style={{ display:'flex', gap: 1 }}>
+              {e.actors.map(a => {
+                const p = byPid[a];
+                if (!p) return null;
+                return <Avatar key={a} player={p} size={14} ring="var(--bg-muted)"/>;
+              })}
+            </div>
+          )}
+        </div>
+        <div style={{
+          fontFamily:'var(--f-body)', fontSize: 11.5, fontWeight: 600,
+          color:'var(--text)', lineHeight: 1.4,
+        }}>{e.text}</div>
+      </div>
+    </div>
+  );
+};
+
+const CollapsedDiaryByGame = ({ mobile, games = GAMES, initialExpanded = ['gs-spirit-1'] }) => {
+  const [expanded, setExpanded] = useState(initialExpanded);
+  const toggle = (id) => setExpanded(prev =>
+    prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+  );
+  const total = games.reduce((s, g) => s + g.eventsCount, 0);
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
+      <div style={{
+        display:'flex', alignItems:'center', justifyContent:'space-between',
+        flexWrap:'wrap', gap: 8,
+      }}>
+        <div>
+          <MonoKicker color={entityHsl('event')}>Diary cross-game · collapsed</MonoKicker>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.01em', marginTop: 2,
+          }}>{total} eventi su {games.length} session</div>
+        </div>
+        <button type="button" style={{
+          padding:'7px 12px', borderRadius:'var(--r-md)',
+          background:'transparent', color: entityHsl('event'),
+          border:`1px solid ${entityHsl('event', 0.32)}`,
+          fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer',
+          display:'inline-flex', alignItems:'center', gap: 5,
+        }}>
+          <span aria-hidden="true">📜</span>Apri timeline completa →
+        </button>
+      </div>
+
+      <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+        {games.map(g => {
+          const isOpen = expanded.includes(g.id);
+          const highlights = DIARY_HIGHLIGHTS[g.id] || [];
+          return (
+            <div key={g.id} style={{
+              background:'var(--bg-card)',
+              border:`1px solid var(--border)`,
+              borderRadius:'var(--r-lg)',
+              overflow:'hidden',
+            }}>
+              <button type="button" onClick={() => toggle(g.id)}
+                aria-expanded={isOpen}
+                style={{
+                  width:'100%',
+                  display:'flex', alignItems:'center', gap: 12,
+                  padding:'10px 14px',
+                  background: isOpen ? entityHsl('event', 0.05) : 'transparent',
+                  border:'none', cursor:'pointer',
+                  textAlign:'left', minWidth: 0,
+                }}>
+                <span style={{
+                  width: 36, height: 36, borderRadius:'var(--r-sm)',
+                  background:`linear-gradient(135deg, ${g.cover[0]}, ${g.cover[1]})`,
+                  display:'inline-flex', alignItems:'center', justifyContent:'center',
+                  fontSize: 18, flexShrink: 0,
+                }} aria-hidden="true">{g.emoji}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{
+                    fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+                    color:'var(--text)',
+                  }}>{g.title}</div>
+                  <MonoKicker size={9.5}>
+                    {g.startedAt} → {g.endedAt} · {g.duration} · {g.eventsCount} eventi
+                  </MonoKicker>
+                </div>
+                <span style={{
+                  padding:'3px 8px', borderRadius:'var(--r-pill)',
+                  background: entityHsl('event', 0.1),
+                  border:`1px solid ${entityHsl('event', 0.28)}`,
+                  color: entityHsl('event'),
+                  fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+                  textTransform:'uppercase', letterSpacing:'.06em',
+                  flexShrink: 0,
+                  fontVariantNumeric:'tabular-nums',
+                }}>{g.eventsCount}</span>
+                <span aria-hidden="true" style={{
+                  fontSize: 14, color:'var(--text-muted)', flexShrink: 0,
+                  transform: isOpen ? 'rotate(180deg)' : 'none',
+                  transition:'transform var(--dur-sm) var(--ease-out)',
+                }}>▾</span>
+              </button>
+              {isOpen && (
+                <div style={{
+                  padding:'4px 14px 14px',
+                  borderTop:'1px solid var(--border-light)',
+                  display:'flex', flexDirection:'column', gap: 8,
+                  position:'relative',
+                }}>
+                  <MonoKicker size={9} color={entityHsl('event')}>Highlights · {highlights.length}</MonoKicker>
+                  <div style={{ position:'relative' }}>
+                    <div aria-hidden="true" style={{
+                      position:'absolute', left: 14, top: 0, bottom: 0, width: 2,
+                      background:`linear-gradient(180deg, ${entityHsl('event', 0.3)}, ${entityHsl('event', 0.05)})`,
+                    }}/>
+                    <div style={{ display:'flex', flexDirection:'column', gap: 7 }}>
+                      {highlights.map((e, i) => <DiaryHighlightRow key={i} e={e}/>)}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// NIGHT PHOTO GALLERY
+// /* v2: NightPhotoGallery */
+// ═══════════════════════════════════════════════════════
+
+const NightPhotoGallery = ({ photos = PHOTOS, empty, mobile }) => {
+  const cols = mobile ? 3 : 4;
+  if (empty) {
+    return (
+      <div style={{
+        display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center',
+        padding: mobile ? '24px 16px' : '36px 24px', gap: 10, textAlign:'center',
+        background: entityHsl('event', 0.05),
+        border:`1.5px dashed ${entityHsl('event', 0.35)}`,
+        borderRadius:'var(--r-xl)',
+      }}>
+        <div style={{
+          width: 60, height: 60, borderRadius:'50%',
+          background: entityHsl('event', 0.12),
+          color: entityHsl('event'),
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 26,
+        }} aria-hidden="true">📷</div>
+        <h3 style={{
+          margin: 0, fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', letterSpacing:'-.01em',
+        }}>Nessuna foto ancora</h3>
+        <p style={{
+          margin: 0, fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.55,
+          maxWidth: 380,
+        }}>Aggiungi una foto della serata: setup tavolo, foto di gruppo, tableau finali — resteranno legate al play record.</p>
+        <button type="button" style={{
+          marginTop: 4,
+          padding:'10px 18px', borderRadius:'var(--r-md)',
+          background: entityHsl('event'), color:'#fff', border:'none',
+          fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+          cursor:'pointer',
+          boxShadow:`0 4px 14px ${entityHsl('event', 0.35)}`,
+          display:'inline-flex', alignItems:'center', gap: 6,
+        }}>+ Aggiungi prima foto</button>
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display:'grid',
+      gridTemplateColumns: `repeat(${cols}, 1fr)`,
+      gap: mobile ? 6 : 10,
+    }}>
+      {photos.map(p => (
+        <div key={p.id} style={{
+          aspectRatio:'1', borderRadius:'var(--r-md)',
+          background: p.g,
+          display:'flex', alignItems:'flex-end',
+          padding: 8, position:'relative', overflow:'hidden',
+          cursor:'pointer',
+        }}>
+          <span style={{
+            fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+            color:'#fff', background:'rgba(0,0,0,.5)',
+            padding:'2px 6px', borderRadius:'var(--r-pill)',
+            whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+            maxWidth:'100%',
+          }}>{p.label}</span>
+        </div>
+      ))}
+      {/* Add CTA tile */}
+      <button type="button" style={{
+        aspectRatio:'1', borderRadius:'var(--r-md)',
+        background: entityHsl('event', 0.08),
+        border:`1.5px dashed ${entityHsl('event', 0.4)}`,
+        color: entityHsl('event'),
+        cursor:'pointer',
+        display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center',
+        gap: 4,
+      }}>
+        <span aria-hidden="true" style={{ fontSize: 24 }}>+</span>
+        <span style={{
+          fontFamily:'var(--f-display)', fontSize: 10.5, fontWeight: 800,
+        }}>Aggiungi</span>
+      </button>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// FOOTER CTA + SHARE TOAST + ARCHIVED BANNER
+// ═══════════════════════════════════════════════════════
+
+const FooterCTAs = ({ mobile }) => (
+  <div style={{
+    display:'flex', gap: 10, flexDirection: mobile ? 'column' : 'row',
+    padding: mobile ? '20px 14px 24px' : '28px 32px 36px',
+    borderTop:'1px solid var(--border)',
+    background:'var(--bg-muted)',
+  }}>
+    <button type="button" style={{
+      flex: mobile ? 'unset' : 1,
+      padding:'13px 20px', borderRadius:'var(--r-md)',
+      background:`linear-gradient(135deg, ${entityHsl('toolkit')}, hsl(142 60% 38%))`,
+      color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      cursor:'pointer',
+      boxShadow:`0 6px 18px ${entityHsl('toolkit', 0.4)}`,
+      display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 16 }}>📤</span>
+      Condividi riepilogo
+    </button>
+    <button type="button" style={{
+      flex: mobile ? 'unset' : 1,
+      padding:'13px 20px', borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border-strong)',
+      color:'var(--text)',
+      fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+      cursor:'pointer',
+      display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 8,
+    }}>
+      <span aria-hidden="true">✓</span>
+      Archivia serata
+    </button>
+  </div>
+);
+
+const ShareSuccessToast = () => (
+  <div role="status" aria-live="polite" style={{
+    position:'absolute', bottom: 20, right: 20, zIndex: 40,
+    display:'flex', alignItems:'center', gap: 10,
+    padding:'10px 14px 10px 12px',
+    borderRadius:'var(--r-pill)',
+    background: entityHsl('toolkit', 0.1),
+    border:`1px solid ${entityHsl('toolkit', 0.32)}`,
+    backdropFilter:'blur(8px)',
+    boxShadow:`var(--shadow-lg), 0 0 0 4px ${entityHsl('toolkit', 0.06)}`,
+    animation:'sp7ToastIn .35s var(--ease-spring)',
+    maxWidth: 280,
+  }}>
+    <span aria-hidden="true" style={{
+      width: 26, height: 26, borderRadius:'50%',
+      background: entityHsl('toolkit'), color:'#fff',
+      display:'inline-flex', alignItems:'center', justifyContent:'center',
+      fontSize: 13, fontWeight: 800, flexShrink: 0,
+    }}>🔗</span>
+    <div style={{ display:'flex', flexDirection:'column', gap: 1, minWidth: 0 }}>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+        color: entityHsl('toolkit'),
+      }}>Link copiato</div>
+      <MonoKicker size={9}>meepleai.app/s/gn-042 · sparisce in 3s</MonoKicker>
+    </div>
+  </div>
+);
+
+const ArchivedBanner = ({ mobile }) => (
+  <div role="status" style={{
+    margin: mobile ? '0 14px' : '0 32px',
+    padding:'14px 16px',
+    background:'var(--bg-muted)',
+    border:'1px solid var(--border)',
+    borderRadius:'var(--r-lg)',
+    display:'flex', alignItems:'center', gap: 12,
+    flexWrap:'wrap',
+  }}>
+    <span aria-hidden="true" style={{
+      width: 36, height: 36, borderRadius:'50%',
+      background:'var(--bg-card)',
+      border:'1px solid var(--border-strong)',
+      color:'var(--text-muted)',
+      display:'inline-flex', alignItems:'center', justifyContent:'center',
+      fontSize: 16, flexShrink: 0,
+    }}>📦</span>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <MonoKicker>Serata archiviata</MonoKicker>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+        color:'var(--text)', marginTop: 1,
+      }}>Riepilogo salvato · accessibile da /game-nights/archived</div>
+    </div>
+    <a href="/game-nights" style={{
+      padding:'8px 14px', borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border-strong)',
+      color:'var(--text)', textDecoration:'none',
+      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800,
+      display:'inline-flex', alignItems:'center', gap: 5, whiteSpace:'nowrap',
+    }}>← Torna alla lista</a>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// MAIN SUMMARY PAGE
+// /* v2: NightSummaryPage */
+// ═══════════════════════════════════════════════════════
+
+const NightSummaryPage = ({ mobile, games = GAMES, photos = PHOTOS, eventsCount = 28, archived, photosEmpty }) => (
+  <div style={{
+    background:'var(--bg)', minWidth: 0,
+    display:'flex', flexDirection:'column',
+  }}>
+    <NightSummaryHero mobile={mobile} mvp={MVP} gamesCount={games.length}/>
+    {archived && <ArchivedBanner mobile={mobile}/>}
+    <KPIStatGrid mobile={mobile} games={games} eventsCount={eventsCount}/>
+    <section style={{
+      padding: mobile ? '16px 14px' : '20px 32px',
+      display:'flex', flexDirection:'column', gap: 12,
+    }}>
+      <div>
+        <MonoKicker color={entityHsl('event')}>Per-game recap</MonoKicker>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800,
+          color:'var(--text)', letterSpacing:'-.01em', marginTop: 2,
+        }}>{games.length === 1 ? '1 gioco completato' : `${games.length} giochi completati · in ordine cronologico`}</div>
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', gap: 8 }}>
+        {games.map(g => <PerGameRecapRow key={g.id} game={g} mobile={mobile}/>)}
+      </div>
+    </section>
+    <section style={{
+      padding: mobile ? '8px 14px 16px' : '12px 32px 20px',
+    }}>
+      <CollapsedDiaryByGame mobile={mobile} games={games}/>
+    </section>
+    <section style={{
+      padding: mobile ? '8px 14px 16px' : '12px 32px 20px',
+      display:'flex', flexDirection:'column', gap: 10,
+    }}>
+      <div style={{
+        display:'flex', alignItems:'center', justifyContent:'space-between',
+        flexWrap:'wrap', gap: 6,
+      }}>
+        <div>
+          <MonoKicker color={entityHsl('event')}>Foto della serata</MonoKicker>
+          <div style={{
+            fontFamily:'var(--f-display)', fontSize: 18, fontWeight: 800,
+            color:'var(--text)', letterSpacing:'-.01em', marginTop: 2,
+          }}>{photosEmpty ? 'Gallery vuota' : `${photos.length} foto caricate`}</div>
+        </div>
+        {!photosEmpty && (
+          <button type="button" style={{
+            padding:'6px 11px', borderRadius:'var(--r-pill)',
+            background: entityHsl('event', 0.1),
+            border:`1px solid ${entityHsl('event', 0.3)}`,
+            color: entityHsl('event'),
+            fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800,
+            cursor:'pointer', textTransform:'uppercase', letterSpacing:'.06em',
+          }}>+ Aggiungi foto</button>
+        )}
+      </div>
+      <NightPhotoGallery photos={photos} empty={photosEmpty} mobile={mobile}/>
+    </section>
+    <FooterCTAs mobile={mobile}/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// FRAMES + HARNESS
+// ═══════════════════════════════════════════════════════
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>03:18</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">92%</span></div>
+  </div>
+);
+
+const DesktopFrame = ({ id, label, desc, gherkin, children, height = 1180, showToast }) => (
+  <section id={id} data-screen-label={`SP7-M · ${label}`} className="desktop-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">🖥️ {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="desktop-frame">
+      <div className="desktop-bar">
+        <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+        <span className="url">meepleai.app/game-nights/gn-padovani-may17/summary</span>
+      </div>
+      <div style={{
+        background:'var(--bg)', position:'relative', overflow:'hidden',
+        height,
+      }}>
+        <div style={{ height:'100%', overflowY:'auto' }}>
+          {children}
+        </div>
+        {showToast && <ShareSuccessToast/>}
+      </div>
+    </div>
+    {desc && <p className="state-desc">{desc}</p>}
+  </section>
+);
+
+const PhoneShell = ({ id, label, desc, gherkin, children }) => (
+  <section id={id} data-screen-label={`SP7-M · ${label}`} className="phone-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">📱 {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="phone">
+      <PhoneSbar/>
+      <div style={{
+        flex: 1, display:'flex', flexDirection:'column',
+        background:'var(--bg)', position:'relative', overflow:'hidden', minHeight: 0,
+      }}>
+        <div style={{ flex: 1, overflowY:'auto', minHeight: 0 }}>
+          {children}
+        </div>
+      </div>
+    </div>
+    {desc && <p className="state-desc" style={{ maxWidth: 360 }}>{desc}</p>}
+  </section>
+);
+
+// ═══════════════════════════════════════════════════════
+// APP
+// ═══════════════════════════════════════════════════════
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "showStateAnchors": true,
+  "theme": "light"
+}/*EDITMODE-END*/;
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    return saved || document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'flex-start', gap: 16, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 12, flex: 1, minWidth: 0 }}>
+          <div style={{
+            width: 40, height: 40, borderRadius: 10,
+            background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('toolkit')})`,
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)', fontSize: 18,
+          }}>M</div>
+          <div>
+            <div style={{
+              display:'flex', alignItems:'center', gap: 8, marginBottom: 2, flexWrap:'wrap',
+            }}>
+              <span style={{
+                padding:'2px 8px', borderRadius:'var(--r-pill)',
+                background: entityHsl('event', 0.12),
+                color: entityHsl('event'),
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+                border:`1px solid ${entityHsl('event', 0.22)}`,
+              }}>SP7 · Mockup M · Wave 1+</span>
+              <MonoKicker size={10}>US-31.M · Issue #487 · P1</MonoKicker>
+            </div>
+            <div style={{
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 22,
+              color:'var(--text)', letterSpacing:'-.01em',
+            }}>Game Night · Summary</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              fontWeight: 600, marginTop: 2,
+            }}>
+              <code>/game-nights/[id]/summary</code> · full-screen scrollable · hero MVP + 4 KPI + per-game recap + diary collapsed + foto gallery + share/archive
+            </div>
+          </div>
+        </div>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+            display:'inline-flex', alignItems:'center', gap: 6,
+          }}>
+          <span aria-hidden="true">🌗</span>
+          {theme === 'light' ? 'Light' : 'Dark'}
+        </button>
+      </header>
+
+      <main style={{
+        maxWidth: 1440, margin:'0 auto',
+        display:'flex', flexDirection:'column', gap: 56,
+      }}>
+        {/* Desktop section — 5 states */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('event') }}/>
+            <h2 className="section-title">Desktop · 1280 full-screen scrollable — 5 stati</h2>
+            <span className="section-meta">hero + sections stack</span>
+          </div>
+          <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
+            <DesktopFrame
+              id="state-01-summary-full"
+              label="01 · Summary full · 3 games · 28 eventi · 6 foto"
+              gherkin="G31.16"
+              desc="Canonical post-end: hero rosa con MVP banner Davide 1 win + 11 eventi, 4 KPI stat card (3 session · 6h15m · 28 eventi · 3/3 winner), per-game recap 3 row (Brass winner Davide 178, Spirit coop team won, Wingspan winner Giulia 92), diary collapsed con Spirit expanded di default (3 highlights), foto gallery 6 + add CTA, footer toolkit share + archive.">
+              <NightSummaryPage/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-02-summary-no-photos"
+              label="02 · Gallery empty · placeholder CTA 'Aggiungi prima foto'"
+              gherkin="G31.16 (no photos)"
+              desc="Identico a state-01 ma section foto mostra empty state: card dashed rose con icon 📷 + heading + body + CTA primary 'Aggiungi prima foto'. Tutto il resto invariato.">
+              <NightSummaryPage photosEmpty/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-03-summary-single-game"
+              label="03 · Single game · serata 1 game · stats ridotte"
+              gherkin="G31.16 (single)"
+              desc="Edge case: serata con 1 solo game (Brass). KPI mostra '1 game · serata breve', '1/1 winner', no per-game multipli, diary collapsed con 1 sola row, recap conciso."
+              height={1050}>
+              <NightSummaryPage games={[GAMES[0]]} eventsCount={11}/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-04-share-success-toast"
+              label="04 · Post-share · toast 'Link copiato' bottom-right · toolkit success"
+              gherkin="G31.17"
+              desc="Toast pill bottom-right entityHsl('toolkit', 0.1) con icon 🔗 + label 'Link copiato' + sublabel 'meepleai.app/s/gn-042 · sparisce in 3s'. Stessa scene di state-01 con toast visibile."
+              showToast>
+              <NightSummaryPage/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-05-archived"
+              label="05 · Archiviata · banner muted + 'Torna alla lista'"
+              gherkin="G31.18"
+              desc="Banner archived inserito subito sotto l'hero (sopra le KPI). Icon 📦 in card muted · MonoKicker 'Serata archiviata' · sublabel '/game-nights/archived' · CTA right 'Torna alla lista' che porta a /game-nights. Footer CTA share/archive restano (archivia è no-op se già archiviata).">
+              <NightSummaryPage archived/>
+            </DesktopFrame>
+          </div>
+        </div>
+
+        {/* Mobile section — state-06 */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('session') }}/>
+            <h2 className="section-title">Mobile · 390 single-col — 1 stato</h2>
+            <span className="section-meta">padding ridotto · stack vertical</span>
+          </div>
+          <div className="mobile-grid">
+            <PhoneShell
+              id="state-06-mobile-single-col"
+              label="06 · Mobile single col · stessa pagina · padding ridotto"
+              gherkin="G31.16 (mobile)"
+              desc="Stessa pagina di state-01 ma con mobile=true: hero font ridotto, KPI 2x2 invece di 4x1, per-game recap stack 1-col con cover 110px height, photo gallery 3 col, footer CTA stack column. Scroll-y interno al phone frame.">
+              <NightSummaryPage mobile/>
+            </PhoneShell>
+          </div>
+        </div>
+
+        {/* Pattern note */}
+        <footer style={{
+          padding:'24px 0', borderTop:'1px solid var(--border)',
+          display:'flex', flexDirection:'column', gap: 10, maxWidth: 880,
+        }}>
+          <MonoKicker>Pattern note</MonoKicker>
+          <ul style={{
+            margin: 0, paddingLeft: 18,
+            fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.7,
+          }}>
+            <li>Full-screen single column scrollable: hero rose tint → archived banner (opzionale) → KPI grid 4-col → per-game recap stack → diary collapsed-by-game → foto gallery → footer CTA. Tutto verticale, no split.</li>
+            <li>MVPBanner globale nell'hero entityHsl('event'): avatar 60 + 🏆 emoji floating + nome Quicksand 24 + sublabel mono "1 vittoria · 11 eventi · top scorer Brass". Box-shadow + ring entity-event per dare presenza.</li>
+            <li>KPIStatCard pattern: border-top 3px entity color, value Quicksand 28 tabular-nums, label mono kicker, sub mono micro. Border-top tone-aware (session/event/chat/player) anziché bg pieno per minor visual weight.</li>
+            <li>PerGameRecapRow grid 90 / 1fr / auto: cover 90×70 con #order badge top-left + emoji centered, info 1fr con winner banner inline (avatar + score + top-2 chip), CTA right "Vai a session →" link a /sessions/[id]. Co-op variant con badge 🤝 toolkit invece di winner avatar.</li>
+            <li>CollapsedDiaryByGame: 3 row click-to-expand. Spirit di default expanded (showcase). Highlights = 2-3 eventi chiave per game (non full list di 28 — quella si apre con "Apri timeline completa →" che porta al CrossGameDiaryTimeline full di K).</li>
+            <li>NightPhotoGallery grid 4-col desktop / 3-col mobile + add-tile dashed rose. Empty state full card con CTA primary "+ Aggiungi prima foto". Match brief "add-photo CTA entityHsl('event', 0.1) placeholder card".</li>
+            <li>Share toast riusa pattern AutoSaveToast di K (bottom-right + spring-in) ma con tone toolkit + icon 🔗 + sublabel timestamp/sparizione. Match brief "Foto gallery (placeholder)" + acceptance G31.17.</li>
+            <li>ArchivedBanner: muted neutral · NO entity color (brief "banner muted var(--text-muted)"). Posizionato sopra le KPI (subito dopo hero) come notice non-destructive.</li>
+            <li>Light + dark via <code>[data-theme="dark"]</code> + MutationObserver (pattern K/L). Solo <code>entityHsl()</code> + <code>var(--c-*)</code> semantici. Game cover gradients restano fixture decorativi.</li>
+            <li>Anchor id <code>state-NN-...</code> standard SP7 + <code>data-screen-label</code>.</li>
+          </ul>
+        </footer>
+      </main>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp7-game-night-summary.jsx
+++ b/admin-mockups/design_files/sp7-game-night-summary.jsx
@@ -35,15 +35,15 @@
    - share success toast          = entityHsl('toolkit') green
    - archived banner              = var(--text-muted)
 
-   Componenti v2 emersi
-   - NightSummaryHero            → apps/web/src/components/ui/v2/night-summary-hero/
-   - MVPBanner                   → ui/v2/mvp-banner/
-   - KPIStatGrid + KPIStatCard   → ui/v2/kpi-stat-grid/
-   - PerGameRecapRow             → ui/v2/per-game-recap-row/
-   - CollapsedDiaryByGame        → ui/v2/collapsed-diary-by-game/ (CrossGame collapsed mode)
-   - NightPhotoGallery           → ui/v2/night-photo-gallery/
-   - ShareSuccessToast           → ui/v2/share-success-toast/ (varianti per archive/copy/x)
-   - ArchivedBanner              → ui/v2/archived-banner/
+   Componenti emersi (paths canonical Stage 2 PR #1025)
+   - NightSummaryHero            → apps/web/src/components/features/game-nights/night-summary-hero/
+   - MVPBanner                   → features/game-nights/mvp-banner/
+   - KPIStatGrid + KPIStatCard   → components/ui/kpi-stat-grid/                     (primitive riusabile)
+   - PerGameRecapRow             → features/game-nights/per-game-recap-row/
+   - CollapsedDiaryByGame        → features/game-nights/collapsed-diary-by-game/    (CrossGame collapsed mode)
+   - NightPhotoGallery           → features/game-nights/night-photo-gallery/
+   - ShareSuccessToast           → components/ui/share-success-toast/               (primitive riusabile · varianti per archive/copy/x)
+   - ArchivedBanner              → components/ui/archived-banner/                   (primitive riusabile)
 
    Riusi pattern
    - CrossGameDiaryTimeline (sp7-k) — qui in mode collapsed-by-game

--- a/admin-mockups/design_files/sp7-game-night-transition.html
+++ b/admin-mockups/design_files/sp7-game-night-transition.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>SP7-L · Game Transition Dialog — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700;800&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="tokens.css"/>
+  <link rel="stylesheet" href="components.css"/>
+  <style>
+    /* ─── Harness · sections ─── */
+    .section-header {
+      display: flex; align-items: center; gap: 12px;
+      padding-bottom: 12px; margin-bottom: 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .section-marker { width: 6px; height: 28px; border-radius: 3px; }
+    .section-title {
+      font-family: var(--f-display); font-size: 18px; font-weight: 800;
+      color: var(--text); margin: 0; flex: 1; letter-spacing: -.01em;
+    }
+    .section-meta {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em;
+    }
+
+    /* ─── State caption ─── */
+    .state-caption {
+      display: flex; align-items: center; gap: 8px;
+      margin-bottom: 10px; flex-wrap: wrap;
+    }
+    .state-id {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 800;
+      color: hsl(var(--c-event));
+      background: hsl(var(--c-event) / .12);
+      border: 1px solid hsl(var(--c-event) / .25);
+      padding: 3px 8px; border-radius: var(--r-pill);
+      letter-spacing: .04em;
+    }
+    .state-label {
+      font-family: var(--f-display); font-size: 12.5px; font-weight: 800;
+      color: var(--text);
+    }
+    .gherkin {
+      font-family: var(--f-mono); font-size: 9.5px; font-weight: 800;
+      color: hsl(var(--c-toolkit));
+      background: hsl(var(--c-toolkit) / .1);
+      border: 1px solid hsl(var(--c-toolkit) / .3);
+      padding: 2px 7px; border-radius: var(--r-pill);
+      text-transform: uppercase; letter-spacing: .06em;
+    }
+    .state-desc {
+      font-size: 11.5px; color: var(--text-sec); margin: 12px 0 0;
+      line-height: 1.55; max-width: 1180px;
+    }
+
+    /* ─── Desktop frame ─── */
+    .desktop-shell { display: flex; flex-direction: column; width: 100%; }
+    .desktop-frame {
+      width: 100%; max-width: 1280px;
+      border-radius: var(--r-xl);
+      border: 1px solid var(--border);
+      background: var(--bg);
+      overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 9px 14px;
+      background: var(--bg-muted);
+      border-bottom: 1px solid var(--border);
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    }
+    .desktop-bar .traffic { width: 11px; height: 11px; border-radius: 50%; background: hsl(var(--c-event)); }
+    .desktop-bar .traffic:nth-child(2) { background: hsl(var(--c-warning)); }
+    .desktop-bar .traffic:nth-child(3) { background: hsl(var(--c-toolkit)); }
+    .desktop-bar .url { flex: 1; text-align: center; letter-spacing: .04em; }
+
+    /* ─── Phone ─── */
+    .phone-shell { display: flex; flex-direction: column; align-items: center; }
+    .phone-shell .phone { width: 390px; height: 800px; }
+    .mobile-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(390px, 1fr));
+      gap: var(--s-7);
+      align-items: start;
+    }
+
+    /* ─── Animations ─── */
+    @keyframes sp7Pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50%      { transform: scale(1.45); opacity: .55; }
+    }
+    @keyframes sp7Shimmer {
+      0%   { background-position: -200% 0; }
+      100% { background-position:  200% 0; }
+    }
+    .sp7-shimmer {
+      background-image: linear-gradient(90deg,
+        var(--bg-muted) 0%,
+        var(--bg-hover) 50%,
+        var(--bg-muted) 100%) !important;
+      background-size: 200% 100% !important;
+      animation: sp7Shimmer 1.5s linear infinite;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+      }
+    }
+
+    .phone > div::-webkit-scrollbar,
+    .desktop-frame ::-webkit-scrollbar { width: 6px; height: 6px; }
+    .desktop-frame ::-webkit-scrollbar-thumb {
+      background: var(--border-strong); border-radius: 3px;
+    }
+    button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible {
+      outline: 2px solid hsl(var(--c-event));
+      outline-offset: 2px;
+    }
+    code {
+      background: var(--bg-muted);
+      padding: 1px 5px; border-radius: var(--r-xs);
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script>
+    window.DS = {
+      EC: {
+        game:    { h: 25,  s: 95, l: 45, em: '🎲' },
+        player:  { h: 262, s: 83, l: 58, em: '👤' },
+        session: { h: 240, s: 60, l: 55, em: '🎯' },
+        agent:   { h: 38,  s: 92, l: 50, em: '🤖' },
+        kb:      { h: 174, s: 60, l: 40, em: '📄' },
+        chat:    { h: 220, s: 80, l: 55, em: '💬' },
+        event:   { h: 350, s: 89, l: 60, em: '🎉' },
+        toolkit: { h: 142, s: 70, l: 45, em: '🧰' },
+        tool:    { h: 195, s: 80, l: 50, em: '🔧' },
+      },
+      byId: {},
+    };
+    const _applyTheme = (t) => {
+      if (t === 'dark') {
+        Object.assign(window.DS.EC, {
+          game:    { h: 28,  s: 95, l: 58, em:'🎲' },
+          player:  { h: 262, s: 75, l: 70, em:'👤' },
+          session: { h: 235, s: 70, l: 70, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 62, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 55, em:'📄' },
+          chat:    { h: 218, s: 80, l: 68, em:'💬' },
+          event:   { h: 350, s: 85, l: 70, em:'🎉' },
+          toolkit: { h: 142, s: 60, l: 58, em:'🧰' },
+          tool:    { h: 195, s: 75, l: 62, em:'🔧' },
+        });
+      } else {
+        Object.assign(window.DS.EC, {
+          game:    { h: 25,  s: 95, l: 45, em:'🎲' },
+          player:  { h: 262, s: 83, l: 58, em:'👤' },
+          session: { h: 240, s: 60, l: 55, em:'🎯' },
+          agent:   { h: 38,  s: 92, l: 50, em:'🤖' },
+          kb:      { h: 174, s: 60, l: 40, em:'📄' },
+          chat:    { h: 220, s: 80, l: 55, em:'💬' },
+          event:   { h: 350, s: 89, l: 60, em:'🎉' },
+          toolkit: { h: 142, s: 70, l: 45, em:'🧰' },
+          tool:    { h: 195, s: 80, l: 50, em:'🔧' },
+        });
+      }
+    };
+    new MutationObserver(() => {
+      _applyTheme(document.documentElement.getAttribute('data-theme'));
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    _applyTheme(document.documentElement.getAttribute('data-theme') || 'light');
+  </script>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="sp7-game-night-transition.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp7-game-night-transition.jsx
+++ b/admin-mockups/design_files/sp7-game-night-transition.jsx
@@ -1,0 +1,953 @@
+/* ===================================================================
+   SP7 Game Night — Transition Dialog (sp7-game-night-transition.jsx)
+   Opened from: /game-nights/[id]/live  (mockup K, toolbar "Transition ➡️")
+   Persona: Marco (host) tra game e game, decisione 30–90 sec.
+   Coverage: US-31 G31.14 / G31.15 — Sprint N+1 P1
+   Pattern desktop: Modal centered 600×500, 2-column split (recap last | preview next)
+   Pattern mobile : fullscreen vertical stack (recap stack-top, preview stack-bottom)
+
+   Stati (6 totali)
+   - state-01-transition-default      Default 2-col split (recap Brass + preview Spirit popolati)
+   - state-02-rules-loading-skeleton  KB quick-glance ancora in loading (skeleton 3 righe)
+   - state-03-rules-load-error        KB fetch failed — fallback "Rules non disponibili offline"
+   - state-04-skip-confirm            Submodal nested "Saltare Spirit Island?"
+   - state-05-end-night-confirm       Submodal nested "Terminare serata? → Summary"
+   - state-06-mobile-fullscreen       Mobile vertical stack invece di 2-col
+
+   Continuità dati con K
+   - Ultimo gioco completato: Brass: Birmingham
+     winner Davide 178pt · durata 2h 45m · top-3 (Davide 178 · Marco 142 · Giulia 128)
+   - Prossimo gioco: Spirit Island · est 90m
+   - 3 rules bullet: Phase order Growth→Fast→Slow · Fear deck 9 carte · Power growth 1 minor + 1 major
+   - Setup checklist: tabellone · 4 spirit panels · invader deck shuffled · fear pool 9
+
+   Entity color mapping
+   - winner banner          = entityHsl('event')   rose
+   - score top-3            = entityHsl('player')  violet
+   - KB rules quick-glance  = entityHsl('kb')      teal
+   - CTA Avvia              = entityHsl('session') indigo
+   - Skip submodal          = var(--c-warning)
+   - End night submodal     = var(--c-danger)
+
+   Componenti v2 emersi
+   - GameTransitionDialog       → apps/web/src/components/ui/v2/game-transition-dialog/
+   - TransitionRecapPanel       → ui/v2/transition-recap-panel/    (left col)
+   - TransitionPreviewPanel     → ui/v2/transition-preview-panel/  (right col)
+   - KBRulesQuickGlance         → ui/v2/kb-rules-quick-glance/     (3 bullet · skeleton · offline fallback)
+   - SetupChecklist             → ui/v2/setup-checklist/           (icone + check)
+   - TopThreeScoreList          → ui/v2/top-three-score-list/      (rank + avatar + score)
+   - TransitionConfirmSubmodal  → ui/v2/transition-confirm-submodal/
+
+   Riusi pattern
+   - PauseOverlay / EndgameDialog (sp4) — backdrop + bottom-sheet mobile
+   - ConfirmModal                  — pattern SP6-B
+   - MeepleCard variant compact     — game cover preview
+   =================================================================== */
+
+const { useState, useEffect, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.event;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ═══════════════════════════════════════════════════════
+// FIXTURE — continuità SP7-K (Sabato Padovani · 17 mag)
+// ═══════════════════════════════════════════════════════
+
+const LAST_GAME = {
+  id:'gs-brass-1',
+  title:'Brass: Birmingham',
+  publisher:'Roxley',
+  emoji:'🏭',
+  cover:['hsl(220 35% 28%)','hsl(28 60% 38%)'],
+  duration:'2h 45m',
+  endedAt:'22:55',
+  winner: { id:'p-davide', initials:'DC', name:'Davide',  color: 200, score: 178 },
+  topThree: [
+    { id:'p-davide', initials:'DC', name:'Davide', color: 200, score: 178, delta: '+50 industria' },
+    { id:'p-marco',  initials:'MR', name:'Marco',  color: 262, score: 142, delta: '+12 network' },
+    { id:'p-giulia', initials:'GM', name:'Giulia', color: 10,  score: 128, delta: '+8 carbone' },
+  ],
+};
+
+const NEXT_GAME = {
+  id:'gs-spirit-1',
+  title:'Spirit Island',
+  publisher:'GMT · co-op',
+  emoji:'🌋',
+  cover:['hsl(210 50% 30%)','hsl(150 50% 38%)'],
+  estimated:'90m',
+  weight: 4.08,
+  rules: [
+    { icon:'🔁', text:'Phase order · Growth → Fast → Slow', src:'§ 4.2' },
+    { icon:'😱', text:'Fear deck · 9 carte iniziali (level 1/2/3)', src:'§ 5.1' },
+    { icon:'⚡', text:'Power growth · 1 minor + 1 major per round', src:'§ 6.3' },
+  ],
+  setup: [
+    { icon:'🗺️', text:'Tabellone · 4 isole', done: true },
+    { icon:'🧝', text:'Spirit panels (4 spiriti scelti)', done: true },
+    { icon:'🃏', text:'Invader deck shuffled · stage I', done: false },
+    { icon:'💀', text:'Fear pool · 9 token', done: false },
+  ],
+};
+
+// ═══════════════════════════════════════════════════════
+// PRIMITIVES
+// ═══════════════════════════════════════════════════════
+
+const Avatar = ({ player, size = 22, ring }) => (
+  <span style={{
+    width: size, height: size, borderRadius:'50%',
+    background:`hsl(${player.color}, 60%, 55%)`, color:'#fff',
+    fontFamily:'var(--f-display)', fontWeight: 800,
+    fontSize: size <= 18 ? 8 : size <= 24 ? 9 : 11,
+    display:'inline-flex', alignItems:'center', justifyContent:'center',
+    border:`2px solid ${ring || 'var(--bg-card)'}`,
+    flexShrink: 0,
+  }}>{player.initials}</span>
+);
+
+const MonoKicker = ({ children, color = 'var(--text-muted)', size = 10 }) => (
+  <span style={{
+    fontFamily:'var(--f-mono)', fontSize: size, fontWeight: 800,
+    color, textTransform:'uppercase', letterSpacing:'.08em',
+  }}>{children}</span>
+);
+
+const PulsingDot = ({ color, size = 8 }) => (
+  <span aria-hidden="true" style={{
+    width: size, height: size, borderRadius:'50%',
+    background: color, flexShrink: 0,
+    animation:'sp7Pulse 1.6s var(--ease-out) infinite',
+  }}/>
+);
+
+// ═══════════════════════════════════════════════════════
+// LEFT COL — TransitionRecapPanel (Ultimo gioco)
+// /* v2: TransitionRecapPanel */
+// ═══════════════════════════════════════════════════════
+
+const RecapPanel = ({ game = LAST_GAME, mobile }) => (
+  <div style={{
+    display:'flex', flexDirection:'column',
+    background: entityHsl('event', 0.04),
+    borderRight: mobile ? 'none' : `1px solid var(--border)`,
+    borderBottom: mobile ? `1px solid var(--border)` : 'none',
+    padding: mobile ? '16px 18px 14px' : '18px 18px 16px',
+    gap: 12, minWidth: 0,
+  }}>
+    {/* Section header */}
+    <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
+      <span aria-hidden="true" style={{ fontSize: 14 }}>⏪</span>
+      <MonoKicker color={entityHsl('event')}>Ultimo gioco</MonoKicker>
+    </div>
+
+    {/* Cover + title */}
+    <div style={{
+      display:'flex', gap: 12, alignItems:'center',
+    }}>
+      <div style={{
+        width: 56, height: 56, borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 26, flexShrink: 0,
+        boxShadow:'var(--shadow-sm)',
+      }} aria-hidden="true">{game.emoji}</div>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1.2,
+          whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+        }}>{game.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color:'var(--text-muted)', marginTop: 2,
+        }}>{game.publisher} · finito {game.endedAt}</div>
+      </div>
+    </div>
+
+    {/* Winner banner — entityHsl('event') */}
+    <div style={{
+      padding:'10px 12px', borderRadius:'var(--r-md)',
+      background: entityHsl('event', 0.1),
+      border:`1px solid ${entityHsl('event', 0.32)}`,
+      display:'flex', alignItems:'center', gap: 10,
+      boxShadow:`0 0 0 3px ${entityHsl('event', 0.06)}`,
+    }}>
+      <span aria-hidden="true" style={{ fontSize: 22 }}>🏆</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <MonoKicker size={9} color={entityHsl('event')}>Winner · {game.duration}</MonoKicker>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 800,
+          color:'var(--text)', marginTop: 1,
+        }}>{game.winner.name}{' '}
+          <span style={{
+            color: entityHsl('event'),
+            fontVariantNumeric:'tabular-nums',
+          }}>{game.winner.score}pt</span>
+        </div>
+      </div>
+      <Avatar player={game.winner} size={32} ring={entityHsl('event', 0.4)}/>
+    </div>
+
+    {/* Top-3 score list */}
+    <div style={{ display:'flex', flexDirection:'column', gap: 4 }}>
+      <MonoKicker size={9.5}>Classifica · Top 3</MonoKicker>
+      <div style={{ display:'flex', flexDirection:'column', gap: 4 }}>
+        {game.topThree.map((p, i) => {
+          const isWinner = i === 0;
+          return (
+            <div key={p.id} style={{
+              display:'flex', alignItems:'center', gap: 9,
+              padding:'7px 10px',
+              borderRadius:'var(--r-sm)',
+              background: isWinner ? entityHsl('event', 0.08) : 'var(--bg-card)',
+              border: isWinner
+                ? `1px solid ${entityHsl('event', 0.28)}`
+                : '1px solid var(--border)',
+            }}>
+              <span style={{
+                width: 18, height: 18, borderRadius:'50%',
+                background: isWinner
+                  ? entityHsl('event')
+                  : 'var(--bg-muted)',
+                color: isWinner ? '#fff' : 'var(--text-sec)',
+                display:'inline-flex', alignItems:'center', justifyContent:'center',
+                fontFamily:'var(--f-display)', fontSize: 10, fontWeight: 800,
+                flexShrink: 0,
+              }}>{i + 1}</span>
+              <Avatar player={p} size={22}/>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+                  color:'var(--text)',
+                }}>{p.name}</div>
+                <div style={{
+                  fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 700,
+                  color:'var(--text-muted)',
+                  whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+                }}>{p.delta}</div>
+              </div>
+              <span style={{
+                fontFamily:'var(--f-mono)', fontSize: 14, fontWeight: 800,
+                color: isWinner ? entityHsl('event') : 'var(--text)',
+                fontVariantNumeric:'tabular-nums',
+              }}>{p.score}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// RIGHT COL — TransitionPreviewPanel (Prossimo gioco)
+// /* v2: TransitionPreviewPanel + KBRulesQuickGlance + SetupChecklist */
+// ═══════════════════════════════════════════════════════
+
+const RulesQuickGlance = ({ game = NEXT_GAME, status = 'ok' }) => {
+  if (status === 'loading') {
+    return (
+      <div style={{ display:'flex', flexDirection:'column', gap: 4 }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+          <span aria-hidden="true" style={{ fontSize: 13 }}>📄</span>
+          <MonoKicker color={entityHsl('kb')}>Rules quick-glance · loading…</MonoKicker>
+        </div>
+        <div style={{ display:'flex', flexDirection:'column', gap: 5 }}>
+          {[0,1,2].map(i => (
+            <div key={i} className="sp7-shimmer" style={{
+              height: 28, borderRadius:'var(--r-sm)',
+              background:'var(--bg-muted)',
+            }}/>
+          ))}
+        </div>
+        <MonoKicker size={9}>Fetching from KB · spirit-island-rules-v2</MonoKicker>
+      </div>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <div style={{ display:'flex', flexDirection:'column', gap: 6 }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+          <span aria-hidden="true" style={{ fontSize: 13 }}>📄</span>
+          <MonoKicker color={entityHsl('kb')}>Rules quick-glance</MonoKicker>
+        </div>
+        <div role="alert" style={{
+          padding:'10px 12px',
+          borderRadius:'var(--r-md)',
+          background:'hsl(var(--c-danger) / 0.06)',
+          border:'1px dashed hsl(var(--c-danger) / 0.35)',
+          display:'flex', gap: 9, alignItems:'flex-start',
+        }}>
+          <span aria-hidden="true" style={{
+            fontSize: 16, color:'hsl(var(--c-danger))', marginTop: 1,
+          }}>⚠</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800,
+              color:'var(--text)',
+            }}>Rules non disponibili offline</div>
+            <div style={{
+              fontSize: 11, color:'var(--text-sec)', lineHeight: 1.45, marginTop: 2,
+            }}>Tu sei offline o la KB non è ancora indicizzata. Procedi senza quick-glance, oppure riprova.</div>
+            <div style={{ display:'flex', gap: 6, marginTop: 6 }}>
+              <button type="button" style={{
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background:'hsl(var(--c-danger))', color:'#fff', border:'none',
+                fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800,
+                cursor:'pointer', textTransform:'uppercase', letterSpacing:'.06em',
+              }}>↻ Riprova</button>
+              <button type="button" style={{
+                padding:'3px 9px', borderRadius:'var(--r-pill)',
+                background:'transparent', border:'1px solid var(--border)',
+                color:'var(--text-sec)',
+                fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+                cursor:'pointer', textTransform:'uppercase', letterSpacing:'.06em',
+              }}>Procedi senza</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap: 5 }}>
+      <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+        <span aria-hidden="true" style={{ fontSize: 13 }}>📄</span>
+        <MonoKicker color={entityHsl('kb')}>Rules quick-glance · 3 bullet</MonoKicker>
+      </div>
+      <ul style={{ margin: 0, padding: 0, listStyle:'none', display:'flex', flexDirection:'column', gap: 5 }}>
+        {game.rules.map((r, i) => (
+          <li key={i} style={{
+            display:'flex', alignItems:'center', gap: 8,
+            padding:'7px 10px',
+            borderRadius:'var(--r-sm)',
+            background: entityHsl('kb', 0.06),
+            border:`1px solid ${entityHsl('kb', 0.22)}`,
+          }}>
+            <span aria-hidden="true" style={{ fontSize: 13, flexShrink: 0 }}>{r.icon}</span>
+            <span style={{
+              flex: 1, minWidth: 0,
+              fontFamily:'var(--f-body)', fontSize: 12, fontWeight: 600,
+              color:'var(--text)', lineHeight: 1.35,
+            }}>{r.text}</span>
+            <span style={{
+              fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+              color: entityHsl('kb'), letterSpacing:'.05em',
+              padding:'1px 6px', borderRadius:'var(--r-pill)',
+              background: entityHsl('kb', 0.12),
+              flexShrink: 0,
+            }}>{r.src}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const SetupChecklist = ({ items = NEXT_GAME.setup }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 5 }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 6 }}>
+      <span aria-hidden="true" style={{ fontSize: 13 }}>📋</span>
+      <MonoKicker>Setup checklist · {items.filter(i => i.done).length}/{items.length}</MonoKicker>
+    </div>
+    <ul style={{ margin: 0, padding: 0, listStyle:'none', display:'flex', flexDirection:'column', gap: 4 }}>
+      {items.map((it, i) => (
+        <li key={i} style={{
+          display:'flex', alignItems:'center', gap: 9,
+          padding:'5px 10px',
+          borderRadius:'var(--r-sm)',
+          background: it.done ? entityHsl('toolkit', 0.06) : 'var(--bg-muted)',
+          border: it.done
+            ? `1px solid ${entityHsl('toolkit', 0.25)}`
+            : '1px solid var(--border)',
+          opacity: it.done ? 1 : 0.92,
+        }}>
+          <span aria-hidden="true" style={{
+            width: 18, height: 18, borderRadius:'var(--r-sm)',
+            background: it.done ? entityHsl('toolkit') : 'transparent',
+            border: it.done ? 'none' : '1.5px solid var(--border-strong)',
+            color:'#fff',
+            display:'inline-flex', alignItems:'center', justifyContent:'center',
+            fontSize: 11, fontWeight: 800, flexShrink: 0,
+          }}>{it.done ? '✓' : ''}</span>
+          <span aria-hidden="true" style={{ fontSize: 13 }}>{it.icon}</span>
+          <span style={{
+            flex: 1, minWidth: 0,
+            fontFamily:'var(--f-body)', fontSize: 11.5, fontWeight: 600,
+            color: it.done ? 'var(--text)' : 'var(--text-sec)',
+            textDecoration: it.done ? 'line-through' : 'none',
+            textDecorationColor: 'var(--text-muted)',
+            textDecorationThickness: '1px',
+          }}>{it.text}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+const PreviewPanel = ({ game = NEXT_GAME, rulesStatus = 'ok', mobile }) => (
+  <div style={{
+    flex: 1, display:'flex', flexDirection:'column',
+    padding: mobile ? '16px 18px 14px' : '18px 18px 16px',
+    gap: 12, minWidth: 0,
+    background:'var(--bg-card)',
+  }}>
+    {/* Section header */}
+    <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
+      <span aria-hidden="true" style={{ fontSize: 14 }}>⏩</span>
+      <MonoKicker color={entityHsl('session')}>Prossimo gioco</MonoKicker>
+    </div>
+
+    {/* Cover + title */}
+    <div style={{ display:'flex', gap: 12, alignItems:'center' }}>
+      <div style={{
+        width: 56, height: 56, borderRadius:'var(--r-md)',
+        background:`linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+        display:'flex', alignItems:'center', justifyContent:'center',
+        fontSize: 26, flexShrink: 0,
+        boxShadow:'var(--shadow-sm)',
+      }} aria-hidden="true">{game.emoji}</div>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{
+          fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800,
+          color:'var(--text)', lineHeight: 1.2,
+          whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+        }}>{game.title}</div>
+        <div style={{
+          fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 700,
+          color:'var(--text-muted)', marginTop: 2,
+        }}>{game.publisher} · weight {game.weight.toFixed(2)}</div>
+      </div>
+      <div style={{
+        padding:'4px 9px', borderRadius:'var(--r-pill)',
+        background: entityHsl('session', 0.12),
+        border:`1px solid ${entityHsl('session', 0.3)}`,
+        color: entityHsl('session'),
+        fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800,
+        fontVariantNumeric:'tabular-nums',
+        display:'inline-flex', alignItems:'center', gap: 4,
+        flexShrink: 0,
+      }}>
+        <span aria-hidden="true">⏱</span>
+        ~{game.estimated}
+      </div>
+    </div>
+
+    <RulesQuickGlance game={game} status={rulesStatus}/>
+    <SetupChecklist items={game.setup}/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// SUBMODAL — Skip / End night confirm
+// /* v2: TransitionConfirmSubmodal */
+// ═══════════════════════════════════════════════════════
+
+const ConfirmSubmodal = ({ tone = 'warning', icon, title, body, primaryLabel, primaryIcon }) => {
+  const fg = tone === 'danger' ? 'hsl(var(--c-danger))' : 'hsl(var(--c-warning))';
+  const bg = tone === 'danger' ? 'hsl(var(--c-danger) / 0.12)' : 'hsl(var(--c-warning) / 0.12)';
+  const bd = tone === 'danger' ? 'hsl(var(--c-danger) / 0.32)' : 'hsl(var(--c-warning) / 0.32)';
+  return (
+    <div style={{
+      position:'absolute', inset: 0, zIndex: 60,
+      display:'flex', alignItems:'center', justifyContent:'center',
+      background:'rgba(0,0,0,0.45)',
+      backdropFilter:'blur(6px)',
+      padding: 16,
+    }}>
+      <div role="alertdialog" aria-modal="true" style={{
+        width:'100%', maxWidth: 380,
+        background:'var(--bg-card)',
+        border:`1px solid ${bd}`,
+        borderRadius:'var(--r-xl)',
+        boxShadow:'var(--shadow-lg)',
+        padding: 18,
+        display:'flex', flexDirection:'column', gap: 12,
+      }}>
+        <div style={{
+          width: 44, height: 44, borderRadius:'50%',
+          background: bg, color: fg,
+          display:'flex', alignItems:'center', justifyContent:'center',
+          fontSize: 22, flexShrink: 0,
+        }} aria-hidden="true">{icon}</div>
+        <div>
+          <h3 style={{
+            margin: 0, fontFamily:'var(--f-display)', fontSize: 16,
+            fontWeight: 800, color:'var(--text)', letterSpacing:'-.01em',
+          }}>{title}</h3>
+          <p style={{
+            margin:'6px 0 0', fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.55,
+          }}>{body}</p>
+        </div>
+        <div style={{ display:'flex', gap: 8 }}>
+          <button type="button" style={{
+            flex: 2, padding:'11px',
+            borderRadius:'var(--r-md)',
+            background: fg, color:'#fff', border:'none',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800,
+            cursor:'pointer',
+            boxShadow:`0 4px 14px ${tone === 'danger' ? 'hsl(var(--c-danger) / 0.35)' : 'hsl(var(--c-warning) / 0.35)'}`,
+            display:'inline-flex', alignItems:'center', justifyContent:'center', gap: 6,
+          }}><span aria-hidden="true">{primaryIcon}</span>{primaryLabel}</button>
+          <button type="button" style={{
+            flex: 1, padding:'11px',
+            borderRadius:'var(--r-md)',
+            background:'transparent', color:'var(--text-sec)',
+            border:'1px solid var(--border-strong)',
+            fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, cursor:'pointer',
+          }}>Annulla</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// MAIN DIALOG — GameTransitionDialog
+// /* v2: GameTransitionDialog */
+// ═══════════════════════════════════════════════════════
+
+const DialogHeader = ({ mobile, onClose }) => (
+  <div style={{
+    display:'flex', alignItems:'center', gap: 10,
+    padding: mobile ? '14px 16px' : '14px 18px',
+    borderBottom:'1px solid var(--border)',
+    background:'var(--glass-bg)',
+    backdropFilter:'blur(10px)',
+    flexShrink: 0,
+  }}>
+    <div style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+      color:'#fff', display:'inline-flex', alignItems:'center', justifyContent:'center',
+      fontSize: 16, flexShrink: 0,
+    }} aria-hidden="true">➡️</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <MonoKicker size={9.5} color={entityHsl('event')}>Game transition · #GN-042</MonoKicker>
+      <div style={{
+        fontFamily:'var(--f-display)', fontSize: 14.5, fontWeight: 800,
+        color:'var(--text)', letterSpacing:'-.01em',
+      }}>Pronti per il prossimo gioco?</div>
+    </div>
+    <button type="button" aria-label="Chiudi" onClick={onClose} style={{
+      width: 32, height: 32, borderRadius:'var(--r-md)',
+      background:'var(--bg-card)', border:'1px solid var(--border)',
+      color:'var(--text-sec)', fontSize: 16, cursor:'pointer',
+      flexShrink: 0,
+    }}>×</button>
+  </div>
+);
+
+const DialogFooter = ({ mobile }) => (
+  <div style={{
+    display:'flex', gap: 8, alignItems:'center', flexWrap: mobile ? 'wrap' : 'nowrap',
+    padding: mobile ? '12px 16px' : '12px 18px',
+    borderTop:'1px solid var(--border)',
+    background:'var(--bg-muted)',
+    flexShrink: 0,
+  }}>
+    <button type="button" style={{
+      padding:'9px 13px', borderRadius:'var(--r-md)',
+      background:'transparent', color:'hsl(var(--c-warning))',
+      border:'1px solid hsl(var(--c-warning) / 0.4)',
+      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700, cursor:'pointer',
+      display:'inline-flex', alignItems:'center', gap: 5,
+    }}><span aria-hidden="true">⏭</span>Salta gioco</button>
+    <button type="button" style={{
+      padding:'9px 13px', borderRadius:'var(--r-md)',
+      background:'transparent', color:'hsl(var(--c-danger))',
+      border:'1px solid hsl(var(--c-danger) / 0.4)',
+      fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700, cursor:'pointer',
+      display:'inline-flex', alignItems:'center', gap: 5,
+    }}><span aria-hidden="true">🛑</span>Termina serata qui</button>
+    <div style={{ flex: 1 }}/>
+    <button type="button" style={{
+      padding:'11px 16px', borderRadius:'var(--r-md)',
+      background:`linear-gradient(135deg, ${entityHsl('session')}, ${entityHsl('chat')})`,
+      color:'#fff', border:'none',
+      fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, cursor:'pointer',
+      boxShadow:`0 6px 18px ${entityHsl('session', 0.4)}`,
+      display:'inline-flex', alignItems:'center', gap: 6,
+      flexShrink: 0,
+    }}>▶ Avvia prossima session
+      <span aria-hidden="true" style={{ fontSize: 14 }}>→</span>
+    </button>
+  </div>
+);
+
+const GameTransitionDialog = ({ rulesStatus = 'ok', mobile, submodal }) => (
+  <div role="dialog" aria-modal="true" aria-labelledby="sp7-l-dialog-title"
+    style={{
+      width: mobile ? '100%' : 600,
+      height: mobile ? '100%' : 500,
+      maxHeight: '100%',
+      background:'var(--bg-card)',
+      borderRadius: mobile ? 0 : 'var(--r-xl)',
+      border: mobile ? 'none' : '1px solid var(--border)',
+      boxShadow: mobile ? 'none' : 'var(--shadow-lg)',
+      overflow:'hidden', position:'relative',
+      display:'flex', flexDirection:'column',
+    }}>
+    <DialogHeader mobile={mobile}/>
+    <div style={{
+      flex: 1, minHeight: 0, overflowY:'auto',
+      display: mobile ? 'flex' : 'grid',
+      flexDirection: mobile ? 'column' : undefined,
+      gridTemplateColumns: mobile ? undefined : '1fr 1fr',
+    }}>
+      <RecapPanel mobile={mobile}/>
+      <PreviewPanel rulesStatus={rulesStatus} mobile={mobile}/>
+    </div>
+    <DialogFooter mobile={mobile}/>
+
+    {submodal === 'skip' && (
+      <ConfirmSubmodal
+        tone="warning"
+        icon="⏭"
+        title="Saltare Spirit Island?"
+        body="Verrà rimosso dai planned games di questa serata. Resterà in libreria ma il diary non avrà entries per questa session."
+        primaryLabel="Salta e prossimo"
+        primaryIcon="⏭"
+      />
+    )}
+    {submodal === 'end' && (
+      <ConfirmSubmodal
+        tone="danger"
+        icon="🛑"
+        title="Terminare la serata qui?"
+        body="Andrai al Summary con i 2 game registrati. Gli upcoming games verranno archiviati come 'non giocati'. Il diary sarà finalizzato."
+        primaryLabel="Termina · vai a Summary"
+        primaryIcon="🛑"
+      />
+    )}
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// BLURRED LIVE HUB BACKDROP (preview only)
+// — restituisce un mini live-hub semi-trasparente sotto al dialog
+// ═══════════════════════════════════════════════════════
+
+const LiveHubBackdrop = () => (
+  <div aria-hidden="true" style={{
+    position:'absolute', inset: 0,
+    background:'var(--bg)',
+    overflow:'hidden',
+  }}>
+    {/* Mock top bar */}
+    <div style={{
+      display:'flex', alignItems:'center', gap: 10,
+      padding:'10px 16px',
+      background:'var(--bg-card)',
+      borderBottom:`1px solid ${entityHsl('event', 0.25)}`,
+    }}>
+      <div style={{
+        width: 30, height: 30, borderRadius:'var(--r-md)',
+        background:'var(--bg-muted)',
+      }}/>
+      <div style={{ flex: 1 }}>
+        <div style={{
+          height: 8, width: 100, borderRadius: 4,
+          background: entityHsl('event', 0.2), marginBottom: 5,
+        }}/>
+        <div style={{
+          height: 10, width: 200, borderRadius: 4,
+          background:'var(--bg-muted)',
+        }}/>
+      </div>
+      <div style={{ display:'flex', gap: 4 }}>
+        {[0,1,2].map(i => (
+          <div key={i} style={{
+            width: 34, height: 30, borderRadius:'var(--r-md)',
+            background:'var(--bg-muted)',
+          }}/>
+        ))}
+      </div>
+    </div>
+    {/* Mock 3-pane */}
+    <div style={{ display:'flex', height:'calc(100% - 50px)' }}>
+      <div style={{
+        width: 200, padding: 10, borderRight:'1px solid var(--border)',
+        display:'flex', flexDirection:'column', gap: 8,
+      }}>
+        {[0,1,2].map(i => (
+          <div key={i} style={{
+            height: 56, borderRadius:'var(--r-md)',
+            background: i === 1 ? entityHsl('event', 0.06) : 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            borderLeft: `4px solid ${i===0 ? entityHsl('toolkit') : i===1 ? entityHsl('event') : entityHsl('game')}`,
+          }}/>
+        ))}
+      </div>
+      <div style={{ flex: 1, padding: 14 }}>
+        <div style={{
+          height:'70%', borderRadius:'var(--r-lg)',
+          background:`linear-gradient(135deg, ${entityHsl('event', 0.18)}, ${entityHsl('session', 0.1)})`,
+          border:`1px solid ${entityHsl('event', 0.3)}`,
+        }}/>
+      </div>
+      <div style={{
+        width: 220, padding: 10, borderLeft:'1px solid var(--border)',
+      }}>
+        <div style={{
+          height: 12, width: 100, borderRadius: 4,
+          background: entityHsl('event', 0.18), marginBottom: 10,
+        }}/>
+        {[0,1,2,3].map(i => (
+          <div key={i} style={{
+            height: 36, marginBottom: 5,
+            borderRadius:'var(--r-sm)',
+            background:'var(--bg-muted)',
+            borderLeft: `2px solid ${entityHsl('session', 0.3)}`,
+          }}/>
+        ))}
+      </div>
+    </div>
+    {/* Dim overlay above backdrop */}
+    <div style={{
+      position:'absolute', inset: 0,
+      background:'rgba(0,0,0,0.4)',
+      backdropFilter:'blur(8px)',
+    }}/>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// FRAMES + HARNESS
+// ═══════════════════════════════════════════════════════
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span style={{ fontFamily:'var(--f-mono)' }}>22:55</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div>
+  </div>
+);
+
+const DesktopFrame = ({ id, label, desc, gherkin, children }) => (
+  <section id={id} data-screen-label={`SP7-L · ${label}`} className="desktop-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">🖥️ {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="desktop-frame">
+      <div className="desktop-bar">
+        <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+        <span className="url">meepleai.app/game-nights/gn-padovani-may17/live · transition</span>
+      </div>
+      <div style={{
+        background:'var(--bg)', position:'relative', overflow:'hidden',
+        height: 600,
+      }}>
+        <LiveHubBackdrop/>
+        <div style={{
+          position:'absolute', inset: 0, zIndex: 30,
+          display:'flex', alignItems:'center', justifyContent:'center',
+          padding: 24,
+        }}>
+          {children}
+        </div>
+      </div>
+    </div>
+    {desc && <p className="state-desc">{desc}</p>}
+  </section>
+);
+
+const PhoneShell = ({ id, label, desc, gherkin, children }) => (
+  <section id={id} data-screen-label={`SP7-L · ${label}`} className="phone-shell">
+    <div className="state-caption">
+      <span className="state-id">{id.replace('state-', '#')}</span>
+      <span className="state-label">📱 {label}</span>
+      {gherkin && <span className="gherkin">{gherkin}</span>}
+    </div>
+    <div className="phone">
+      <PhoneSbar/>
+      <div style={{
+        flex: 1, display:'flex', flexDirection:'column',
+        background:'var(--bg)', position:'relative', overflow:'hidden', minHeight: 0,
+      }}>
+        {children}
+      </div>
+    </div>
+    {desc && <p className="state-desc" style={{ maxWidth: 360 }}>{desc}</p>}
+  </section>
+);
+
+// ═══════════════════════════════════════════════════════
+// APP
+// ═══════════════════════════════════════════════════════
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "showStateAnchors": true,
+  "theme": "light"
+}/*EDITMODE-END*/;
+
+const App = () => {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('mai-theme');
+    return saved || document.documentElement.getAttribute('data-theme') || 'light';
+  });
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div style={{
+      minHeight:'100vh', background:'var(--bg)', color:'var(--text)',
+      padding:'24px 24px 80px',
+    }}>
+      <header style={{
+        maxWidth: 1440, margin:'0 auto 32px',
+        display:'flex', alignItems:'flex-start', gap: 16, flexWrap:'wrap',
+      }}>
+        <div style={{ display:'flex', alignItems:'center', gap: 12, flex: 1, minWidth: 0 }}>
+          <div style={{
+            width: 40, height: 40, borderRadius: 10,
+            background:`linear-gradient(135deg, ${entityHsl('event')}, ${entityHsl('session')})`,
+            color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+            fontWeight: 800, fontFamily:'var(--f-display)', fontSize: 18,
+          }}>L</div>
+          <div>
+            <div style={{
+              display:'flex', alignItems:'center', gap: 8, marginBottom: 2, flexWrap:'wrap',
+            }}>
+              <span style={{
+                padding:'2px 8px', borderRadius:'var(--r-pill)',
+                background: entityHsl('event', 0.12),
+                color: entityHsl('event'),
+                fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800,
+                textTransform:'uppercase', letterSpacing:'.08em',
+                border:`1px solid ${entityHsl('event', 0.22)}`,
+              }}>SP7 · Mockup L · Wave 1+</span>
+              <MonoKicker size={10}>US-31.L · Issue #487 · P1</MonoKicker>
+            </div>
+            <div style={{
+              fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 22,
+              color:'var(--text)', letterSpacing:'-.01em',
+            }}>Game Transition · Dialog</div>
+            <div style={{
+              fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)',
+              fontWeight: 600, marginTop: 2,
+            }}>
+              opened-from <code>/game-nights/[id]/live</code> (toolbar Transition) · modal 600×500 desktop / fullscreen mobile · 2-col split (recap | preview)
+            </div>
+          </div>
+        </div>
+        <button type="button" onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}
+          style={{
+            padding:'8px 14px', borderRadius:'var(--r-md)',
+            background:'var(--bg-card)', border:'1px solid var(--border)',
+            color:'var(--text)', fontFamily:'var(--f-display)',
+            fontSize: 12, fontWeight: 800, cursor:'pointer',
+            display:'inline-flex', alignItems:'center', gap: 6,
+          }}>
+          <span aria-hidden="true">🌗</span>
+          {theme === 'light' ? 'Light' : 'Dark'}
+        </button>
+      </header>
+
+      <main style={{
+        maxWidth: 1440, margin:'0 auto',
+        display:'flex', flexDirection:'column', gap: 56,
+      }}>
+        {/* Desktop section · 5 states */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('event') }}/>
+            <h2 className="section-title">Desktop · modal 600×500 — 5 stati</h2>
+            <span className="section-meta">centered su backdrop live-hub blurred</span>
+          </div>
+          <div style={{ display:'flex', flexDirection:'column', gap: 32 }}>
+            <DesktopFrame
+              id="state-01-transition-default"
+              label="01 · Default 2-col split · recap Brass + preview Spirit popolati"
+              gherkin="G31.14"
+              desc="Recap left (winner Davide 178pt rose banner + top-3 score + durata 2h45m) | Preview right (cover Spirit + weight 4.08 + 3 bullet rules teal + setup checklist 2/4 done). Footer 3 CTA (Salta · Termina · Avvia primary).">
+              <GameTransitionDialog/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-02-rules-loading-skeleton"
+              label="02 · KB rules quick-glance in loading · skeleton 3 righe"
+              gherkin="G31.15 (loading)"
+              desc="Stato transitorio mentre KB index fetcha le rules. 3 shimmer bar al posto dei bullet · subtitle 'Fetching from KB · spirit-island-rules-v2'. Tutto il resto del dialog resta funzionante (setup checklist + CTA).">
+              <GameTransitionDialog rulesStatus="loading"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-03-rules-load-error"
+              label="03 · KB fetch failed · fallback 'Rules non disponibili offline' + retry"
+              gherkin="G31.15 (fallback)"
+              desc="Banner dashed danger con icon ⚠ + body + 2 micro-CTA (Riprova · Procedi senza). Setup checklist e CTA primary restano abilitati: si può iniziare anche senza quick-glance.">
+              <GameTransitionDialog rulesStatus="error"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-04-skip-confirm"
+              label="04 · Submodal nested · 'Saltare Spirit Island?' (warning amber)"
+              gherkin="G31.14 (skip)"
+              desc="ConfirmModal centered sopra il dialog principale. Icon ⏭ amber · 'Verrà rimosso dai planned · resterà in libreria'. 2 CTA (Salta e prossimo · Annulla).">
+              <GameTransitionDialog submodal="skip"/>
+            </DesktopFrame>
+
+            <DesktopFrame
+              id="state-05-end-night-confirm"
+              label="05 · Submodal nested · 'Terminare serata qui?' (danger rosso)"
+              gherkin="G31.14 (end)"
+              desc="ConfirmModal centered sopra il dialog principale. Icon 🛑 danger · 'Andrai al Summary · gli upcoming verranno archiviati'. 2 CTA (Termina · vai a Summary · Annulla).">
+              <GameTransitionDialog submodal="end"/>
+            </DesktopFrame>
+          </div>
+        </div>
+
+        {/* Mobile section · state-06 */}
+        <div>
+          <div className="section-header">
+            <span className="section-marker" style={{ background: entityHsl('session') }}/>
+            <h2 className="section-title">Mobile · 390 fullscreen — 1 stato</h2>
+            <span className="section-meta">vertical stack: recap-top, preview-bottom</span>
+          </div>
+          <div className="mobile-grid">
+            <PhoneShell
+              id="state-06-mobile-fullscreen"
+              label="06 · Mobile fullscreen · vertical stack invece di 2-col"
+              gherkin="G31.14 (mobile)"
+              desc="Dialog fullscreen senza border-radius. Recap panel stack-top (con border-bottom invece di border-right), Preview panel stack-bottom. Footer wrap su 2 righe: top [Salta · Termina], bottom CTA Avvia full-width.">
+              <GameTransitionDialog mobile/>
+            </PhoneShell>
+          </div>
+        </div>
+
+        {/* Pattern note */}
+        <footer style={{
+          padding:'24px 0', borderTop:'1px solid var(--border)',
+          display:'flex', flexDirection:'column', gap: 10, maxWidth: 880,
+        }}>
+          <MonoKicker>Pattern note</MonoKicker>
+          <ul style={{
+            margin: 0, paddingLeft: 18,
+            fontSize: 12.5, color:'var(--text-sec)', lineHeight: 1.7,
+          }}>
+            <li>Modal 600×500 centered desktop con backdrop di anteprima live-hub blurred (continuità visiva con K · mostra che la transition NON sostituisce la pagina, è un overlay).</li>
+            <li>Mobile fullscreen: dialog occupa 100% del viewport (no border-radius, no shadow). Layout cambia da grid 2-col a flex column con border-bottom invece di border-right tra recap/preview.</li>
+            <li>RulesQuickGlance ha 3 stati: <code>ok</code> (3 bullet teal con § page reference), <code>loading</code> (3 shimmer + subtitle), <code>error</code> (banner dashed danger + 2 micro-CTA). CTA primary "Avvia" SEMPRE abilitata anche con KB error (fallback graceful).</li>
+            <li>SetupChecklist: 2/4 done di default (tabellone + spirit panels), restanti 2 (invader deck + fear pool) sono "da fare" — non bloccano la transition ma sono visivamente in muted/dashed.</li>
+            <li>Submodal nested (z-index 60) sopra il dialog principale (z-index 30): backdrop dim aggiuntivo. ConfirmModal pattern SP6-B con tone warning (skip) o danger (end). 2 CTA primary+annulla.</li>
+            <li>Top-3 score list: winner highlighted entityHsl('event') 8% bg + 28% border + numero rank pieno. Resto in card neutro. Tabular-nums per allineamento score.</li>
+            <li>Light + dark via <code>[data-theme="dark"]</code> + MutationObserver pattern (stesso K). Solo <code>entityHsl()</code> + <code>var(--c-*)</code> semantici · game cover gradients sono fixture decorativi (pattern accettato come K).</li>
+            <li>Anchor id <code>state-NN-...</code> standard SP7 + <code>data-screen-label</code> per review meeting.</li>
+          </ul>
+        </footer>
+      </main>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);

--- a/admin-mockups/design_files/sp7-game-night-transition.jsx
+++ b/admin-mockups/design_files/sp7-game-night-transition.jsx
@@ -29,14 +29,14 @@
    - Skip submodal          = var(--c-warning)
    - End night submodal     = var(--c-danger)
 
-   Componenti v2 emersi
-   - GameTransitionDialog       → apps/web/src/components/ui/v2/game-transition-dialog/
-   - TransitionRecapPanel       → ui/v2/transition-recap-panel/    (left col)
-   - TransitionPreviewPanel     → ui/v2/transition-preview-panel/  (right col)
-   - KBRulesQuickGlance         → ui/v2/kb-rules-quick-glance/     (3 bullet · skeleton · offline fallback)
-   - SetupChecklist             → ui/v2/setup-checklist/           (icone + check)
-   - TopThreeScoreList          → ui/v2/top-three-score-list/      (rank + avatar + score)
-   - TransitionConfirmSubmodal  → ui/v2/transition-confirm-submodal/
+   Componenti emersi (paths canonical Stage 2 PR #1025)
+   - GameTransitionDialog       → apps/web/src/components/features/game-nights/game-transition-dialog/
+   - TransitionRecapPanel       → features/game-nights/transition-recap-panel/    (left col)
+   - TransitionPreviewPanel     → features/game-nights/transition-preview-panel/  (right col)
+   - KBRulesQuickGlance         → components/ui/kb-rules-quick-glance/            (primitive riusabile · 3 bullet · skeleton · offline fallback)
+   - SetupChecklist             → components/ui/setup-checklist/                  (primitive riusabile · icone + check)
+   - TopThreeScoreList          → features/game-nights/top-three-score-list/      (rank + avatar + score, specifico session/night-recap)
+   - TransitionConfirmSubmodal  → features/game-nights/transition-confirm-submodal/
 
    Riusi pattern
    - PauseOverlay / EndgameDialog (sp4) — backdrop + bottom-sheet mobile
@@ -530,7 +530,7 @@ const DialogHeader = ({ mobile, onClose }) => (
     }} aria-hidden="true">➡️</div>
     <div style={{ flex: 1, minWidth: 0 }}>
       <MonoKicker size={9.5} color={entityHsl('event')}>Game transition · #GN-042</MonoKicker>
-      <div style={{
+      <div id="sp7-l-dialog-title" style={{
         fontFamily:'var(--f-display)', fontSize: 14.5, fontWeight: 800,
         color:'var(--text)', letterSpacing:'-.01em',
       }}>Pronti per il prossimo gioco?</div>

--- a/apps/web/e2e/state-coverage/state-matrix.json
+++ b/apps/web/e2e/state-coverage/state-matrix.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./state-matrix.schema.json",
-  "generated_at": "2026-05-15T09:22:09.817Z",
-  "total_mockups": 65,
+  "generated_at": "2026-05-18T06:43:09.489Z",
+  "total_mockups": 68,
   "enforced_count": 1,
   "entries": [
     {
@@ -618,6 +618,30 @@
         "not-found",
         "loading"
       ],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp7-game-night-live.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp7-game-night-summary.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
+      "enforced": false
+    },
+    {
+      "mockup_path": "admin-mockups/design_files/sp7-game-night-transition.html",
+      "route": null,
+      "declared_states": [],
+      "covered_states": [],
+      "missing": [],
       "enforced": false
     }
   ]


### PR DESCRIPTION
## Summary

Aggiunge 3 mockup mancanti dalla issue [#487](https://github.com/meepleAi-app/meepleai-monorepo/issues/487) (`Design v1 · B3 Mockup Game Nights`) distribuiti come file SP7 separati, coerenti con la naming convention `sp7-game-night-{create,detail-rsvp}` già mergiata.

- **`sp7-game-night-live`** (screen brief #4 + #7) — central hub durante la serata. 3-pane desktop (planned games | current game | cross-game diary) / mobile swipeable tabs. **10 stati**. Diary widget esportato come sub-component riutilizzabile. **Auto-save toast ogni 60s** `entityHsl('toolkit', 0.1)` bottom-right (acceptance criterion #487)
- **`sp7-game-night-transition`** (screen brief #5) — modal centered 600×500 / fullscreen mobile. **6 stati**. 2-col split recap+preview con KB rules quick-glance + fallback graceful offline + submodal nested skip/end
- **`sp7-game-night-summary`** (screen brief #6) — full-screen post-end recap. **6 stati**. MVP banner globale, KPI grid 4 stat, cross-game timeline collapsed, per-game recap con **co-op variant** (Spirit Island pattern), foto gallery placeholder, share/archive CTA

Screen #1-3 del brief #487 erano già coperti da `sp4-game-nights-index` (list desktop+mobile) e `sp7-game-night-create` (planning wizard) mergiati nelle wave precedenti — audit dettagliato nel [commento di status sulla issue](https://github.com/meepleAi-app/meepleai-monorepo/issues/487#issuecomment-4474634589).

## Brief extension

Estende `admin-mockups/briefs/SP7-game-night-agent-builder.md` con la sezione `WAVE 1+ — Estensione issue #487` (specs complete K/L/M + wave checklist aggiornata). Single source of truth preservata.

## Integration

- `00-hub.html` — 3 card nuove entity-event coerenti col pattern esistente
- `MOCKUPS_INDEX.md` — sezione SP7 estesa +3 righe (K/M page-mock, L component-mock), count totale 71→74, last-updated 2026-05-18

## Pattern condivisi (K + L + M)

- `entityHsl()` helper + `var(--c-*)` tokens semantici (zero rgba hardcoded)
- `MutationObserver` per light+dark theme switching
- Anchor id `state-NN-*` su tutti i wrapper top-level per review meeting
- Game cover gradient `hsl(...)` decorativi (pattern accettato come già usato in 6 file SP6/SP7 esistenti)

## Test plan

- [x] Gate 1 grep no-hardcoded-color: zero match (eccetto cover gradients pattern accettato) su tutti 3 mockup
- [x] Gate 2 anchor `state-NN-*` completi (live=10, transition=6, summary=6)
- [x] Gate 3 acceptance #487: auto-save toast presente in `sp7-game-night-live` con copy "Auto-salvato · prossimo tra 60s" + entityHsl toolkit
- [x] Gate 4 entity colors: `--c-event` + `entityHsl('event')` come primario (47/38/63 occorrenze per K/L/M)
- [x] Gate 5 light + dark: MutationObserver su entrambi html + theme picker JSX con localStorage
- [x] Pre-push frontend build OK, backend build 0 errori
- [ ] Verifica visuale finale light+dark in browser (revisore)

## Follow-up minori (non-blocker, fuori scope #487)

- Continuità fixture K vs L: in K state-02 il winner di Brass è Marco, in L è Davide. Sono scenari illustrativi diversi (`gn-padovani-may17-A` vs `B`). Da consolidare quando i fixture migrano in `data.js` per impl reale.
- MVP heuristic in M (`1 win + most events generated`): fixture statica nel mockup. La regola va definita in `GameNightSummary` service backend.
- Co-op session result: nuovo edge case `coopMode: true` + `coopOutcome` string — `PerGameRecapRow` swappa il rendering. Impl deve gestire in `RSVPRow`/`SessionResult`.
- Gap pre-esistente: `sp7-game-night-create` e `sp7-game-night-detail-rsvp` (PR storiche) NON sono indicizzati in `00-hub.html`. Decisione separata se aggiungerli — non in scope #487.

Sblocca [#497](https://github.com/meepleAi-app/meepleai-monorepo/issues/497) (Migrate Game Nights pages) e [#951](https://github.com/meepleAi-app/meepleai-monorepo/issues/951) (`/game-nights/[id]` detail v2) per [#1023](https://github.com/meepleAi-app/meepleai-monorepo/issues/1023) Stage 3 cluster Game Nights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)