### PR TITLE
feat(public-rsvp): /join/event/[code] public RSVP route (closes #1169)

### DIFF
--- a/admin-mockups/design_files/sp7-game-night-join-public.jsx
+++ b/admin-mockups/design_files/sp7-game-night-join-public.jsx
@@ -1,0 +1,321 @@
+/* ===================================================================
+   SP7 Game Night — Public RSVP (sp7-game-night-join-public.jsx)
+   Route: /join/event/[code]
+   Persona: invitato anonimo via QR / link diretto (no login)
+   Coverage: issue #1169 — public RSVP surface
+   Variant of: sp7-game-night-detail-rsvp.jsx (host/invitee authenticated)
+
+   Pattern mobile: public banner + hero (read-only) + RSVP form + footer CTA
+   Pattern desktop: identical single-column centered, max-w-2xl
+
+   Stati (6 pubblici, no host controls, no admin views):
+   - state-01-pending-empty       Form pulito, nessun displayName, idle
+   - state-02-pending-filled      User digita displayName 'Marco', idle
+   - state-03-submitting          POST in flight, Accept button spinner
+   - state-04-already-responded   200 OK con `respondedByName='Marco'`
+   - state-05-token-expired       GET 410 (Expired) — terminal banner
+   - state-06-rate-limited        429 con Retry-After countdown
+
+   ⚠ Variant simplifications:
+   - NO admin controls (edit, cancel, voting tools) — host-only views removed
+   - NO "Invite more" / share actions
+   - NO Maybe button — backend public POST validator accepts only Accepted/Declined
+   - NO ConnectionBar — public route is not real-time SSE
+   - Hero status badge always = entity-event (rose) for the public view; the
+     route only renders if invitation.status ∈ {Pending, Accepted, Declined}.
+     Cancelled/Expired → routed to error surfaces before reaching this layout.
+   - "me" pill suppressed in RSVPRow (no signed-in user to match against).
+
+   Componenti v2 riusati:
+   - GameNightDetailHero (mode='public')   apps/web/src/components/features/game-night-detail/
+   - PublicRsvpForm                         apps/web/src/components/features/game-night-detail/
+   - InvalidTokenError                      apps/web/src/components/features/game-night-detail/error-states/
+   - ExpiredOrCancelledError                apps/web/src/components/features/game-night-detail/error-states/
+   - RateLimitedError                       apps/web/src/components/features/game-night-detail/error-states/
+   - GenericError                           apps/web/src/components/features/game-night-detail/error-states/
+
+   Entity color mapping:
+   - hero status badge   = entityHsl('event')   rose (always)
+   - RSVP confirmed body = var(--c-success) green
+   - public banner       = bg-muted + text-muted-foreground
+   - error banner        = bg-destructive/10 + text-destructive
+   - countdown timer     = text-muted-foreground mono
+   =================================================================== */
+
+const { useState, useMemo } = React;
+const DS = window.DS;
+
+const entityHsl = (type, alpha) => {
+  const c = DS.EC[type] || DS.EC.event;
+  return alpha !== undefined
+    ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})`
+    : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
+};
+
+// ─── FIXTURE ───────────────────────────────────────────
+const INVITATION_FIXTURE = {
+  token: 'tok-public-1169',
+  status: 'Pending',
+  hostUserId: '00000000-0000-4000-8000-000000000001',
+  hostDisplayName: 'Marco R.',
+  hostAvatarUrl: null,
+  hostWelcomeMessage: 'Ci vediamo sabato per una serata di Wingspan e snack!',
+  gameNightId: '00000000-0000-4000-8000-000000000002',
+  title: 'Sabato sera con i Padovani',
+  scheduledAt: '2026-05-23T20:00:00.000Z',
+  location: 'Casa Marco · Padova',
+  expectedPlayers: 6,
+  acceptedSoFar: 3,
+  primaryGameName: 'Wingspan',
+  alreadyRespondedAs: null,
+  respondedByName: null,
+};
+
+// ─── STATE FIXTURES ────────────────────────────────────
+const STATES = [
+  { id: 'state-01-pending-empty', label: 'Pending — empty form' },
+  { id: 'state-02-pending-filled', label: 'Pending — filled displayName' },
+  { id: 'state-03-submitting', label: 'Submitting' },
+  { id: 'state-04-already-responded', label: 'Already responded as "Marco"' },
+  { id: 'state-05-token-expired', label: '410 Gone (expired)' },
+  { id: 'state-06-rate-limited', label: '429 Rate-limited' },
+];
+
+// ─── COMPONENTS ────────────────────────────────────────
+
+function PublicBanner({ message }) {
+  return (
+    <div
+      role="note"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 6,
+        background: 'var(--bg-muted)',
+        color: 'var(--text-muted)',
+        fontSize: 12,
+        border: '1px solid var(--border-light)',
+      }}
+    >
+      {message}
+    </div>
+  );
+}
+
+function Hero({ invitation }) {
+  return (
+    <header
+      data-mode="public"
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        padding: '20px 20px 24px',
+        borderBottom: '1px solid var(--border-light)',
+        background: `linear-gradient(135deg, ${entityHsl('event', 0.16)}, ${entityHsl('event', 0.02)})`,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: -24,
+          right: -24,
+          width: 112,
+          height: 112,
+          borderRadius: '50%',
+          background: entityHsl('event', 0.25),
+          filter: 'blur(20px)',
+        }}
+      />
+      <h1
+        style={{
+          margin: '8px 0 4px',
+          fontFamily: 'var(--font-display)',
+          fontSize: 22,
+          fontWeight: 800,
+          color: 'var(--text-primary)',
+        }}
+      >
+        {invitation.title}
+      </h1>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, fontSize: 12, color: 'var(--text-muted)', fontFamily: 'monospace', fontWeight: 700 }}>
+        <div>📅 {new Date(invitation.scheduledAt).toLocaleString('it-IT', { weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}</div>
+        <div>📍 {invitation.location}</div>
+      </div>
+      <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border-light)', display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ width: 28, height: 28, borderRadius: '50%', background: entityHsl('event'), color: 'white', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: 11 }}>
+          {invitation.hostDisplayName.split(' ').map(s => s[0]).join('').slice(0, 2)}
+        </div>
+        <div style={{ fontSize: 12, fontWeight: 800 }}>{invitation.hostDisplayName} ti ha invitato a giocare</div>
+      </div>
+    </header>
+  );
+}
+
+function PublicRsvpFormSurface({ state, invitation }) {
+  const [name, setName] = useState(state === 'state-02-pending-filled' ? 'Marco' : '');
+  const submitting = state === 'state-03-submitting';
+  const responded = state === 'state-04-already-responded';
+
+  if (responded) {
+    return (
+      <section style={{ padding: 16, borderRadius: 8, border: '1px solid var(--border-light)', background: 'var(--bg-card)' }}>
+        <h2 style={{ margin: 0, fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 15 }}>Hai già risposto</h2>
+        <p style={{ margin: '6px 0 12px', color: 'var(--text-muted)', fontSize: 13 }}>Hai confermato come "Marco".</p>
+        <button style={{ padding: '8px 14px', border: '1px solid var(--border-medium)', borderRadius: 6, background: 'var(--bg-muted)', cursor: 'pointer', fontWeight: 600, fontSize: 13 }}>Cambia risposta</button>
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ padding: 16, borderRadius: 8, border: '1px solid var(--border-light)', background: 'var(--bg-card)' }}>
+      <h2 style={{ margin: 0, fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 15 }}>La tua risposta</h2>
+
+      <div style={{ marginTop: 14 }}>
+        <label htmlFor="dn" style={{ display: 'block', fontSize: 11, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--text-muted)', marginBottom: 6 }}>
+          Il tuo nome (opzionale)
+        </label>
+        <input
+          id="dn"
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          maxLength={120}
+          placeholder="Es. Marco"
+          style={{ width: '100%', padding: '8px 12px', borderRadius: 6, border: '1px solid var(--border-medium)', fontSize: 14 }}
+        />
+        <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--text-muted)' }}>Aiuta l'organizzatore a riconoscerti. Massimo 120 caratteri.</p>
+      </div>
+
+      <div style={{ display: 'flex', gap: 10, marginTop: 14 }}>
+        <button
+          disabled={submitting}
+          style={{
+            flex: 1,
+            padding: '10px 16px',
+            borderRadius: 6,
+            border: 'none',
+            background: 'var(--c-success)',
+            color: 'white',
+            cursor: submitting ? 'wait' : 'pointer',
+            fontWeight: 700,
+            fontSize: 14,
+            opacity: submitting ? 0.7 : 1,
+          }}
+        >
+          {submitting ? 'Invio risposta…' : 'Confermo'}
+        </button>
+        <button
+          disabled={submitting}
+          style={{
+            flex: 1,
+            padding: '10px 16px',
+            borderRadius: 6,
+            border: '1px solid var(--border-medium)',
+            background: 'var(--bg-card)',
+            cursor: submitting ? 'wait' : 'pointer',
+            fontWeight: 600,
+            fontSize: 14,
+            opacity: submitting ? 0.7 : 1,
+          }}
+        >
+          Non posso
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function ErrorSurface({ state }) {
+  if (state === 'state-05-token-expired') {
+    return (
+      <section role="alert" style={{ padding: 32, textAlign: 'center', background: 'var(--bg-card)', borderRadius: 12, border: '1px solid var(--border-light)' }}>
+        <div style={{ fontSize: 32, marginBottom: 12 }}>⌛</div>
+        <h1 style={{ margin: '0 0 6px', fontSize: 18, fontWeight: 800 }}>Invito scaduto</h1>
+        <p style={{ margin: '0 0 16px', color: 'var(--text-muted)', fontSize: 13 }}>Questo invito non è più valido. Chiedi all'organizzatore di rimandartelo.</p>
+        <button style={{ padding: '10px 16px', borderRadius: 6, background: 'var(--c-toolkit)', color: 'white', border: 'none', fontWeight: 700 }}>Richiedi un nuovo invito</button>
+      </section>
+    );
+  }
+  if (state === 'state-06-rate-limited') {
+    return (
+      <section role="alert" style={{ padding: 32, textAlign: 'center', background: 'var(--bg-card)', borderRadius: 12, border: '1px solid var(--border-light)' }}>
+        <div style={{ fontSize: 32, marginBottom: 12 }}>⏱️</div>
+        <h1 style={{ margin: '0 0 6px', fontSize: 18, fontWeight: 800 }}>Troppe richieste</h1>
+        <p style={{ margin: '0 0 16px', color: 'var(--text-muted)', fontSize: 13 }}>Hai inviato troppe risposte in poco tempo. Attendi qualche secondo prima di riprovare.</p>
+        <p style={{ margin: 0, fontFamily: 'monospace', fontSize: 14, fontWeight: 700, color: 'var(--text-muted)' }}>Riprova tra 12 secondi</p>
+      </section>
+    );
+  }
+  return null;
+}
+
+function StateView({ state }) {
+  const isError = state === 'state-05-token-expired' || state === 'state-06-rate-limited';
+
+  return (
+    <main
+      data-surface={state}
+      style={{
+        minHeight: '100vh',
+        background: 'var(--bg-app)',
+        padding: '24px 16px',
+      }}
+    >
+      <div style={{ maxWidth: 640, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <PublicBanner message="Stai vedendo un invito pubblico. La tua risposta verrà condivisa con l'organizzatore." />
+
+        {isError ? (
+          <ErrorSurface state={state} />
+        ) : (
+          <article style={{ overflow: 'hidden', borderRadius: 16, border: '1px solid var(--border-light)', background: 'var(--bg-card)' }}>
+            <Hero invitation={INVITATION_FIXTURE} />
+            <div style={{ padding: 16 }}>
+              <PublicRsvpFormSurface state={state} invitation={INVITATION_FIXTURE} />
+            </div>
+            {state === 'state-04-already-responded' ? (
+              <aside style={{ borderTop: '1px solid var(--border-light)', background: 'var(--bg-muted)', padding: 16 }}>
+                <h2 style={{ margin: 0, fontWeight: 800, fontSize: 13 }}>Vuoi tenere traccia delle tue serate?</h2>
+                <p style={{ margin: '4px 0 10px', fontSize: 11, color: 'var(--text-muted)' }}>Crea un account gratuito per gestire i tuoi inviti, vedere le statistiche e ricevere promemoria.</p>
+                <button style={{ padding: '8px 14px', borderRadius: 6, background: 'var(--c-toolkit)', color: 'white', border: 'none', fontWeight: 700, fontSize: 12 }}>Crea account</button>
+              </aside>
+            ) : null}
+          </article>
+        )}
+      </div>
+    </main>
+  );
+}
+
+// ─── ROOT ──────────────────────────────────────────────
+function Root() {
+  const [active, setActive] = useState(STATES[0].id);
+
+  return (
+    <div>
+      <nav style={{ position: 'sticky', top: 0, zIndex: 10, background: 'var(--bg-app)', borderBottom: '1px solid var(--border-light)', padding: 12, display: 'flex', gap: 8, overflowX: 'auto' }}>
+        {STATES.map(s => (
+          <button
+            key={s.id}
+            onClick={() => setActive(s.id)}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 6,
+              border: '1px solid var(--border-medium)',
+              background: active === s.id ? entityHsl('event') : 'var(--bg-card)',
+              color: active === s.id ? 'white' : 'var(--text-primary)',
+              cursor: 'pointer',
+              fontSize: 12,
+              whiteSpace: 'nowrap',
+              fontWeight: 600,
+            }}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+      <StateView state={active} />
+    </div>
+  );
+}
+
+ReactDOM.render(<Root />, document.getElementById('root'));

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommand.cs
@@ -13,7 +13,14 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 /// <param name="Token">The 22-character invitation token.</param>
 /// <param name="Response">Either <see cref="GameNightInvitationStatus.Accepted"/> or <see cref="GameNightInvitationStatus.Declined"/>.</param>
 /// <param name="ResponderUserId">Optional responder identity (cookie-authenticated guests only).</param>
+/// <param name="ResponderDisplayName">
+/// Optional guest-supplied display name (issue #1169). The invitation email is
+/// already bound by the token, so the guest only types a name. Trimmed and
+/// capped at 120 chars by the validator; null when omitted by the caller or
+/// when the response is being made through a flow that did not collect a name.
+/// </param>
 internal sealed record RespondToGameNightInvitationByTokenCommand(
     string Token,
     GameNightInvitationStatus Response,
-    Guid? ResponderUserId) : ICommand;
+    Guid? ResponderUserId,
+    string? ResponderDisplayName = null) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightInvitationByTokenCommandHandler.cs
@@ -65,8 +65,10 @@ internal sealed class RespondToGameNightInvitationByTokenCommandHandler
         {
             transitioned = command.Response switch
             {
-                GameNightInvitationStatus.Accepted => invitation.Accept(command.ResponderUserId, utcNow),
-                GameNightInvitationStatus.Declined => invitation.Decline(command.ResponderUserId, utcNow),
+                GameNightInvitationStatus.Accepted => invitation.Accept(
+                    command.ResponderUserId, utcNow, command.ResponderDisplayName),
+                GameNightInvitationStatus.Declined => invitation.Decline(
+                    command.ResponderUserId, utcNow, command.ResponderDisplayName),
                 _ => throw new ArgumentOutOfRangeException(
                     nameof(command),
                     $"Unsupported response status: {command.Response}"),

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/PublicGameNightInvitationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/PublicGameNightInvitationDto.cs
@@ -17,6 +17,12 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
 /// allowing the frontend to skip the action affordance and show a
 /// confirmation surface instead. <c>null</c> for pending invitations.
 /// </para>
+/// <para>
+/// <see cref="RespondedByName"/> (issue #1169) carries the guest-supplied
+/// display name captured at RSVP time. Lets the UI render confirmation
+/// surfaces like "Already responded as 'Marco'." Null for pending
+/// invitations and for historical responses that pre-date the column.
+/// </para>
 /// </remarks>
 public sealed record PublicGameNightInvitationDto(
     string Token,
@@ -37,4 +43,5 @@ public sealed record PublicGameNightInvitationDto(
     Guid? PrimaryGameId,
     string? PrimaryGameName,
     string? PrimaryGameImageUrl,
-    string? AlreadyRespondedAs);
+    string? AlreadyRespondedAs,
+    string? RespondedByName = null);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightInvitationByTokenQueryHandler.cs
@@ -136,7 +136,8 @@ internal sealed class GetGameNightInvitationByTokenQueryHandler
             PrimaryGameId: primaryGameId,
             PrimaryGameName: primaryGameName,
             PrimaryGameImageUrl: primaryGameImageUrl,
-            AlreadyRespondedAs: MapAlreadyRespondedAs(invitation.Status));
+            AlreadyRespondedAs: MapAlreadyRespondedAs(invitation.Status),
+            RespondedByName: invitation.RespondedByName);
     }
 
     private static string? MapAlreadyRespondedAs(GameNightInvitationStatus status) => status switch

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidator.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using FluentValidation;
 
@@ -9,6 +10,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
 /// Restricts <c>Response</c> to terminal user-actionable values; lifecycle
 /// transitions like Expired/Cancelled are managed inside the aggregate.
 /// Issue #607 (Wave A.5a): GameNight token-based RSVP backend extension.
+/// Issue #1169: <c>ResponderDisplayName</c> length cap added.
 /// </summary>
 internal sealed class RespondToGameNightInvitationByTokenCommandValidator
     : AbstractValidator<RespondToGameNightInvitationByTokenCommand>
@@ -25,5 +27,16 @@ internal sealed class RespondToGameNightInvitationByTokenCommandValidator
             .Must(r => r == GameNightInvitationStatus.Accepted
                        || r == GameNightInvitationStatus.Declined)
             .WithMessage("Response must be either Accepted or Declined");
+
+        // Issue #1169: optional guest display name. Length cap fires whenever
+        // a non-null value is present; null is permitted (anonymous RSVP).
+        // The aggregate also normalizes (trim + cap) as defense-in-depth.
+        When(x => x.ResponderDisplayName is not null, () =>
+        {
+            RuleFor(x => x.ResponderDisplayName!)
+                .MaximumLength(GameNightInvitation.MaxRespondedByNameLength)
+                    .WithMessage(
+                        $"Display name must be {GameNightInvitation.MaxRespondedByNameLength} characters or fewer");
+        });
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightInvitation.cs
@@ -25,6 +25,12 @@ namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 /// </remarks>
 internal sealed class GameNightInvitation : AggregateRoot<Guid>
 {
+    /// <summary>
+     /// Maximum length of <see cref="RespondedByName"/>. Aligned with EF column
+     /// width and FluentValidation rule on the endpoint DTO. Issue #1169.
+     /// </summary>
+    public const int MaxRespondedByNameLength = 120;
+
     public string Token { get; private set; }
     public Guid GameNightId { get; private set; }
     public string Email { get; private set; }
@@ -32,6 +38,18 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
     public DateTimeOffset ExpiresAt { get; private set; }
     public DateTimeOffset? RespondedAt { get; private set; }
     public Guid? RespondedByUserId { get; private set; }
+
+    /// <summary>
+    /// Optional display name typed by the guest at RSVP time. Decoupled from
+    /// <see cref="RespondedByUserId"/>: an anonymous guest (no cookie auth) can
+    /// still leave a name, and an authenticated user may RSVP "on behalf of"
+    /// (e.g., for their partner) under a different display name than their
+    /// account profile. Null when the guest skipped the field or the response
+    /// was made by a system flow that did not collect a name.
+    /// Issue #1169.
+    /// </summary>
+    public string? RespondedByName { get; private set; }
+
     public DateTimeOffset CreatedAt { get; private set; }
     public Guid CreatedBy { get; private set; }
 
@@ -48,6 +66,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         DateTimeOffset expiresAt,
         DateTimeOffset? respondedAt,
         Guid? respondedByUserId,
+        string? respondedByName,
         DateTimeOffset createdAt,
         Guid createdBy) : base(id)
     {
@@ -58,6 +77,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         ExpiresAt = expiresAt;
         RespondedAt = respondedAt;
         RespondedByUserId = respondedByUserId;
+        RespondedByName = respondedByName;
         CreatedAt = createdAt;
         CreatedBy = createdBy;
     }
@@ -101,6 +121,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
             expiresAt: expiresAt,
             respondedAt: null,
             respondedByUserId: null,
+            respondedByName: null,
             createdAt: utcNow,
             createdBy: createdBy);
 
@@ -116,6 +137,8 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
 
     /// <summary>
     /// Reconstitutes an invitation from persistence data. Skips invariant checks.
+    /// <paramref name="respondedByName"/> is optional and defaults to null so
+    /// pre-#1169 callers (and tests that pre-date the column) compile unchanged.
     /// </summary>
     internal static GameNightInvitation Reconstitute(
         Guid id,
@@ -127,7 +150,8 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         DateTimeOffset? respondedAt,
         Guid? respondedByUserId,
         DateTimeOffset createdAt,
-        Guid createdBy)
+        Guid createdBy,
+        string? respondedByName = null)
     {
         return new GameNightInvitation(
             id: id,
@@ -138,6 +162,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
             expiresAt: expiresAt,
             respondedAt: respondedAt,
             respondedByUserId: respondedByUserId,
+            respondedByName: respondedByName,
             createdAt: createdAt,
             createdBy: createdBy);
     }
@@ -147,17 +172,28 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
     /// Pending→Accepted returns <c>true</c>; Accepted→Accepted no-ops returns <c>false</c>;
     /// Declined throws (caller maps to 409); Expired/Cancelled throws (caller maps to 410).
     /// </summary>
-    public bool Accept(Guid? userId, DateTimeOffset utcNow)
+    /// <param name="userId">Optional responder identity (cookie-authenticated only).</param>
+    /// <param name="utcNow">Clock reading used for the transition timestamp.</param>
+    /// <param name="respondedByName">
+    /// Optional guest-supplied display name (issue #1169). Trimmed and capped at
+    /// <see cref="MaxRespondedByNameLength"/> chars. Null/whitespace becomes null
+    /// (treated as "anonymous"). Only persisted when the call transitions state
+    /// (idempotent same-state replays do not overwrite a prior name).
+    /// </param>
+    public bool Accept(Guid? userId, DateTimeOffset utcNow, string? respondedByName = null)
     {
-        return Respond(GameNightInvitationStatus.Accepted, userId, utcNow);
+        return Respond(GameNightInvitationStatus.Accepted, userId, utcNow, respondedByName);
     }
 
     /// <summary>
     /// Declines the invitation. Idempotent (D2 b) — symmetric to <see cref="Accept"/>.
     /// </summary>
-    public bool Decline(Guid? userId, DateTimeOffset utcNow)
+    /// <param name="userId">Optional responder identity (cookie-authenticated only).</param>
+    /// <param name="utcNow">Clock reading used for the transition timestamp.</param>
+    /// <param name="respondedByName">Optional guest-supplied display name (issue #1169).</param>
+    public bool Decline(Guid? userId, DateTimeOffset utcNow, string? respondedByName = null)
     {
-        return Respond(GameNightInvitationStatus.Declined, userId, utcNow);
+        return Respond(GameNightInvitationStatus.Declined, userId, utcNow, respondedByName);
     }
 
     /// <summary>
@@ -202,7 +238,8 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
     private bool Respond(
         GameNightInvitationStatus desired,
         Guid? userId,
-        DateTimeOffset utcNow)
+        DateTimeOffset utcNow,
+        string? respondedByName = null)
     {
         // Terminal lifecycle states block all responses (caller maps to 410).
         if (Status == GameNightInvitationStatus.Cancelled ||
@@ -219,7 +256,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
                 "Cannot respond to invitation: it has expired.");
         }
 
-        // Idempotent same-response (D2 b): no transition, no event.
+        // Idempotent same-response (D2 b): no transition, no event, no name overwrite.
         if (Status == desired)
         {
             return false;
@@ -235,6 +272,7 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
         Status = desired;
         RespondedAt = utcNow;
         RespondedByUserId = userId;
+        RespondedByName = NormalizeRespondedByName(respondedByName);
 
         AddDomainEvent(new GameNightInvitationRespondedEvent(
             gameNightInvitationId: Id,
@@ -244,5 +282,26 @@ internal sealed class GameNightInvitation : AggregateRoot<Guid>
             respondedByUserId: userId));
 
         return true;
+    }
+
+    /// <summary>
+    /// Trims and caps the guest-supplied display name. Whitespace-only and
+    /// empty values become null so downstream consumers do not need to
+    /// distinguish "" from "no name given". Defense-in-depth against
+    /// validators that have been bypassed (the FluentValidation rule on the
+    /// command is still the primary gate, so length overflow there returns
+    /// 400 before reaching the aggregate).
+    /// </summary>
+    private static string? NormalizeRespondedByName(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var trimmed = raw.Trim();
+        return trimmed.Length <= MaxRespondedByNameLength
+            ? trimmed
+            : trimmed[..MaxRespondedByNameLength];
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightInvitationRepository.cs
@@ -180,6 +180,7 @@ internal class GameNightInvitationRepository : RepositoryBase, IGameNightInvitat
             ExpiresAt = domain.ExpiresAt,
             RespondedAt = domain.RespondedAt,
             RespondedByUserId = domain.RespondedByUserId,
+            RespondedByName = domain.RespondedByName,
             CreatedAt = domain.CreatedAt,
             CreatedBy = domain.CreatedBy
         };
@@ -203,7 +204,8 @@ internal class GameNightInvitationRepository : RepositoryBase, IGameNightInvitat
             respondedAt: entity.RespondedAt,
             respondedByUserId: entity.RespondedByUserId,
             createdAt: entity.CreatedAt,
-            createdBy: entity.CreatedBy);
+            createdBy: entity.CreatedBy,
+            respondedByName: entity.RespondedByName);
 
         // Reconstitute is a pure factory and does not raise events — defensive clear in case
         // base AggregateRoot ctor introduces any (matches GameNightEventRepository pattern).

--- a/apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs
@@ -32,6 +32,8 @@ namespace Api.Extensions;
 /// - AccessRequest:         5 req/hour — access request spam prevention (IP-based)
 /// - AdminProviderProbe:   10 req/min  — provider token probes per user (Issue #936)
 /// - AdminProviderProbeGlobal: 60 req/h — provider token probes per provider name (Issue #936)
+/// - GameNightTokenRead:   60 req/min  — public RSVP token lookup per IP (Issue #1169)
+/// - GameNightTokenRespond: 10 req/min — public RSVP submission per IP (Issue #1169)
 /// </summary>
 internal static class RateLimitingServiceExtensions
 {
@@ -124,6 +126,13 @@ internal static class RateLimitingServiceExtensions
                     RateLimitPartition.GetNoLimiter<string>("unlimited"));
 
                 options.AddPolicy("AdminProviderProbeGlobal", _ =>
+                    RateLimitPartition.GetNoLimiter<string>("unlimited"));
+
+                // Issue #1169: Public game-night RSVP token policies (disabled in tests)
+                options.AddPolicy("GameNightTokenRead", _ =>
+                    RateLimitPartition.GetNoLimiter<string>("unlimited"));
+
+                options.AddPolicy("GameNightTokenRespond", _ =>
                     RateLimitPartition.GetNoLimiter<string>("unlimited"));
             });
 
@@ -533,6 +542,49 @@ internal static class RateLimitingServiceExtensions
                     {
                         Window = TimeSpan.FromHours(1),
                         PermitLimit = 60,
+                        SegmentsPerWindow = 6,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+            });
+
+            // Policy 21: GameNightTokenRead - 60 req/min per IP for public RSVP token lookups (Issue #1169)
+            // Public, unauthenticated GET. Bound at the IP level because the
+            // partition key for anonymous traffic is the source IP; legitimate
+            // guest UX is a single read per page load, so 60/min gives ample
+            // headroom for retry/refresh while making enumeration loud.
+            options.AddPolicy("GameNightTokenRead", httpContext =>
+            {
+                var ipAddress = GetClientIpAddress(httpContext);
+
+                return RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey: $"game-night-token-read-{ipAddress}",
+                    factory: _ => new SlidingWindowRateLimiterOptions
+                    {
+                        Window = TimeSpan.FromMinutes(1),
+                        PermitLimit = 60,
+                        SegmentsPerWindow = 6,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+            });
+
+            // Policy 22: GameNightTokenRespond - 10 req/min per IP for public RSVP submissions (Issue #1169)
+            // Public, unauthenticated POST. Tighter than the read policy because
+            // each submission mutates state and triggers downstream notifications.
+            // A real guest needs at most a handful of attempts (typo recovery,
+            // accidental re-submit); 10/min leaves comfortable margin while
+            // bounding the cost of token-replay / mass-RSVP scripting.
+            options.AddPolicy("GameNightTokenRespond", httpContext =>
+            {
+                var ipAddress = GetClientIpAddress(httpContext);
+
+                return RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey: $"game-night-token-respond-{ipAddress}",
+                    factory: _ => new SlidingWindowRateLimiterOptions
+                    {
+                        Window = TimeSpan.FromMinutes(1),
+                        PermitLimit = 10,
                         SegmentsPerWindow = 6,
                         QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                         QueueLimit = 0,

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightInvitationEntity.cs
@@ -49,6 +49,13 @@ public class GameNightInvitationEntity
     [Column("responded_by_user_id")]
     public Guid? RespondedByUserId { get; set; }
 
+    /// <summary>
+    /// Optional guest display name captured at RSVP time. Issue #1169.
+    /// </summary>
+    [Column("responded_by_name")]
+    [MaxLength(120)]
+    public string? RespondedByName { get; set; }
+
     [Required]
     [Column("created_at")]
     public DateTimeOffset CreatedAt { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightInvitationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightInvitationEntityConfiguration.cs
@@ -42,6 +42,9 @@ internal class GameNightInvitationEntityConfiguration
         builder.Property(i => i.ExpiresAt).HasColumnName("expires_at").IsRequired();
         builder.Property(i => i.RespondedAt).HasColumnName("responded_at");
         builder.Property(i => i.RespondedByUserId).HasColumnName("responded_by_user_id");
+        builder.Property(i => i.RespondedByName)
+            .HasColumnName("responded_by_name")
+            .HasMaxLength(120);
         builder.Property(i => i.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(i => i.CreatedBy).HasColumnName("created_by").IsRequired();
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260518042522_AddRespondedByNameToGameNightInvitation.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260518042522_AddRespondedByNameToGameNightInvitation.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518042522_AddRespondedByNameToGameNightInvitation")]
+    partial class AddRespondedByNameToGameNightInvitation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260518042522_AddRespondedByNameToGameNightInvitation.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260518042522_AddRespondedByNameToGameNightInvitation.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <summary>
+    /// Issue #1169 — Public-RSVP guest display name.
+    ///
+    /// Adds a nullable <c>responded_by_name</c> column (≤120 chars) to
+    /// <c>game_night_invitations</c> so guests can attach a display name when
+    /// RSVPing via the public token endpoint. Distinct from
+    /// <c>responded_by_user_id</c> (cookie-authenticated identity) because:
+    ///   1. anonymous guests still want to introduce themselves;
+    ///   2. an authenticated user may RSVP on behalf of someone else.
+    ///
+    /// Backfill: NONE — existing rows keep NULL. The column is nullable for
+    /// the lifetime of the table; no INSERT default is set so writers must
+    /// explicitly opt in (the domain aggregate handles trim + cap).
+    /// </summary>
+    public partial class AddRespondedByNameToGameNightInvitation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "responded_by_name",
+                table: "game_night_invitations",
+                type: "character varying(120)",
+                maxLength: 120,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "responded_by_name",
+                table: "game_night_invitations");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -117,23 +117,27 @@ internal static class GameNightEndpoints
 
         gameNights.MapGet("/invitations/{token}", HandleGetGameNightInvitationByToken)
             .AllowAnonymous()
+            .RequireRateLimiting("GameNightTokenRead")
             .Produces<PublicGameNightInvitationDto>(200)
             .Produces(404)
             .Produces(410)
+            .Produces(429)
             .WithName("GetGameNightInvitationByToken")
             .WithSummary("Get a game night invitation by token")
-            .WithDescription("Public endpoint to retrieve a game night invitation by its opaque token. Returns 410 Gone for terminal states (Expired, Cancelled).");
+            .WithDescription("Public endpoint to retrieve a game night invitation by its opaque token. Returns 410 Gone for terminal states (Expired, Cancelled). Rate-limited at 60 req/min per IP (issue #1169).");
 
         gameNights.MapPost("/invitations/{token}/respond", HandleRespondToGameNightInvitationByToken)
             .AllowAnonymous()
+            .RequireRateLimiting("GameNightTokenRespond")
             .Produces<PublicGameNightInvitationDto>(200)
             .Produces(400)
             .Produces(404)
             .Produces(409)
             .Produces(410)
+            .Produces(429)
             .WithName("RespondToGameNightInvitationByToken")
             .WithSummary("Respond to a game night invitation by token")
-            .WithDescription("Public endpoint to submit an Accepted or Declined response. Optional auth: authenticated callers have their UserId attached. Idempotent on same-state; conflicts on switching across statuses.");
+            .WithDescription("Public endpoint to submit an Accepted or Declined response, optionally with a guest display name (issue #1169). Optional auth: authenticated callers have their UserId attached. Idempotent on same-state; conflicts on switching across statuses. Rate-limited at 10 req/min per IP.");
 
         gameNights.MapPost("/{gameNightId:guid}/invitations", HandleCreateGameNightInvitationByEmail)
             .RequireAuthenticatedUser()
@@ -328,13 +332,37 @@ internal static class GameNightEndpoints
             return Results.BadRequest(new { error = "Invalid response. Must be Accepted or Declined." });
         }
 
+        // Issue #1169: optional guest display name. Trim here so the persisted
+        // form matches what the UI will echo back via PublicGameNightInvitationDto.RespondedByName.
+        // Length is enforced at the endpoint because RespondToGameNightInvitationByTokenCommand
+        // is `ICommand` (no TResponse) and MediatR's pipeline behaviors are
+        // registered against IRequest<TResponse> — the FluentValidation
+        // ValidationBehavior therefore does NOT run for void commands here.
+        // The aggregate's NormalizeRespondedByName is defense-in-depth only.
+        var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
+            ? null
+            : request.DisplayName.Trim();
+
+        if (displayName is not null
+            && displayName.Length > Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent
+                .GameNightInvitation.MaxRespondedByNameLength)
+        {
+            return Results.BadRequest(new
+            {
+                error = $"Display name must be "
+                    + $"{Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent.GameNightInvitation.MaxRespondedByNameLength}"
+                    + " characters or fewer."
+            });
+        }
+
         var rawUserId = httpContext.User.GetUserId();
         var responderUserId = rawUserId == Guid.Empty ? (Guid?)null : rawUserId;
 
         var command = new RespondToGameNightInvitationByTokenCommand(
             Token: token,
             Response: status,
-            ResponderUserId: responderUserId);
+            ResponderUserId: responderUserId,
+            ResponderDisplayName: displayName);
 
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
 
@@ -480,7 +508,16 @@ internal static class GameNightEndpoints
 
     // Public token-based RSVP request records (Issue #607)
     private sealed record CreateInvitationByEmailRequest(string Email);
-    private sealed record RespondToInvitationByTokenRequest(string Response);
+
+    /// <summary>
+    /// Public RSVP-by-token request body. <c>DisplayName</c> is optional
+    /// (issue #1169): when omitted the response is recorded anonymously;
+    /// when present it is trimmed and capped at 120 characters by the
+    /// validator before reaching the aggregate.
+    /// </summary>
+    private sealed record RespondToInvitationByTokenRequest(
+        string Response,
+        string? DisplayName = null);
 
     // Game Night Experience v2 request records
     private sealed record StartGameNightSessionRequest(Guid GameId, string GameTitle);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightInvitationByTokenCommandValidatorTests.cs
@@ -1,0 +1,90 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Unit tests for <see cref="RespondToGameNightInvitationByTokenCommandValidator"/>.
+/// Issue #1169 — confirms the optional <c>ResponderDisplayName</c> length cap (≤120)
+/// fires the validation rule before the command reaches the MediatR handler.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class RespondToGameNightInvitationByTokenCommandValidatorTests
+{
+    private const string ValidToken = "abcdefghijklmnopqrstuv"; // 22 chars, base62
+
+    private readonly RespondToGameNightInvitationByTokenCommandValidator _validator = new();
+
+    [Fact]
+    public void NullDisplayName_Passes()
+    {
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: null);
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldNotHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+
+    [Fact]
+    public void EmptyDisplayName_Passes()
+    {
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: "");
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldNotHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+
+    [Fact]
+    public void WhitespaceOnlyDisplayName_Passes()
+    {
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: "   ");
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldNotHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+
+    [Fact]
+    public void DisplayNameAtMaxLength_Passes()
+    {
+        var atMax = new string('A', 120);
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: atMax);
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldNotHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+
+    [Fact]
+    public void DisplayNameOverMaxLength_Fails()
+    {
+        var overMax = new string('A', 121);
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: overMax);
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+
+    [Fact]
+    public void ShortDisplayName_Passes()
+    {
+        var cmd = new RespondToGameNightInvitationByTokenCommand(
+            ValidToken, GameNightInvitationStatus.Accepted, ResponderUserId: null,
+            ResponderDisplayName: "Marco");
+
+        var result = _validator.TestValidate(cmd);
+        result.ShouldNotHaveValidationErrorFor(x => x.ResponderDisplayName);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightInvitationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightInvitationTests.cs
@@ -420,4 +420,120 @@ public sealed class GameNightInvitationTests
     }
 
     #endregion
+
+    #region RespondedByName (Issue #1169)
+
+    [Fact]
+    public void Accept_WithRespondedByName_PersistsTrimmedValue()
+    {
+        var invitation = NewPending();
+
+        invitation.Accept(userId: null, utcNow: Now.AddHours(1), respondedByName: "  Marco  ");
+
+        invitation.RespondedByName.Should().Be("Marco",
+            "leading/trailing whitespace must be trimmed for canonical DB form");
+    }
+
+    [Fact]
+    public void Decline_WithRespondedByName_PersistsTrimmedValue()
+    {
+        var invitation = NewPending();
+
+        invitation.Decline(userId: null, utcNow: Now.AddHours(1), respondedByName: "Anna");
+
+        invitation.RespondedByName.Should().Be("Anna");
+        invitation.Status.Should().Be(GameNightInvitationStatus.Declined);
+    }
+
+    [Fact]
+    public void Accept_WithoutRespondedByName_LeavesNull()
+    {
+        var invitation = NewPending();
+
+        invitation.Accept(userId: null, utcNow: Now.AddHours(1));
+
+        invitation.RespondedByName.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Accept_WithNullOrWhitespaceName_NormalizesToNull(string? raw)
+    {
+        var invitation = NewPending();
+
+        invitation.Accept(userId: null, utcNow: Now.AddHours(1), respondedByName: raw);
+
+        invitation.RespondedByName.Should().BeNull(
+            "empty / whitespace-only names are indistinguishable from 'no name given'");
+    }
+
+    [Fact]
+    public void Accept_WithNameOver120Chars_TruncatesAt120()
+    {
+        // Defense-in-depth: the validator is the primary length gate (400 BadRequest),
+        // but the aggregate also caps so a bypassed call cannot overflow the DB column.
+        var invitation = NewPending();
+        var raw = new string('A', 200);
+
+        invitation.Accept(userId: null, utcNow: Now.AddHours(1), respondedByName: raw);
+
+        invitation.RespondedByName.Should().HaveLength(GameNightInvitation.MaxRespondedByNameLength);
+    }
+
+    [Fact]
+    public void Accept_OnAlreadyAccepted_IdempotentReplay_DoesNotOverwriteName()
+    {
+        // D2(b) idempotency: a second Accept must NOT clobber the prior name.
+        var invitation = NewPending();
+        invitation.Accept(userId: null, utcNow: Now.AddHours(1), respondedByName: "Marco");
+        invitation.ClearDomainEvents();
+
+        var changed = invitation.Accept(userId: null, utcNow: Now.AddHours(2), respondedByName: "Hacker");
+
+        changed.Should().BeFalse();
+        invitation.RespondedByName.Should().Be("Marco",
+            "idempotent replay leaves the first-of-record name intact");
+    }
+
+    [Fact]
+    public void Reconstitute_WithoutRespondedByName_DefaultsToNull()
+    {
+        // Backward-compat: existing callers that omit the new optional param continue to work.
+        var invitation = GameNightInvitation.Reconstitute(
+            id: Guid.NewGuid(),
+            token: "abcdefghijklmnopqrstuv",
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            status: GameNightInvitationStatus.Accepted,
+            expiresAt: OneWeekFromNow,
+            respondedAt: Now.AddHours(1),
+            respondedByUserId: Guid.NewGuid(),
+            createdAt: Now,
+            createdBy: Guid.NewGuid());
+
+        invitation.RespondedByName.Should().BeNull();
+    }
+
+    [Fact]
+    public void Reconstitute_WithRespondedByName_PreservesValue()
+    {
+        var invitation = GameNightInvitation.Reconstitute(
+            id: Guid.NewGuid(),
+            token: "abcdefghijklmnopqrstuv",
+            gameNightId: Guid.NewGuid(),
+            email: "guest@example.com",
+            status: GameNightInvitationStatus.Accepted,
+            expiresAt: OneWeekFromNow,
+            respondedAt: Now.AddHours(1),
+            respondedByUserId: Guid.NewGuid(),
+            createdAt: Now,
+            createdBy: Guid.NewGuid(),
+            respondedByName: "Marco");
+
+        invitation.RespondedByName.Should().Be("Marco");
+    }
+
+    #endregion
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightInvitationEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightInvitationEndpointsTests.cs
@@ -547,6 +547,165 @@ public sealed class GameNightInvitationEndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // Issue #1169: ResponderDisplayName persistence + validation
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RespondByToken_WithDisplayName_PersistsRespondedByName()
+    {
+        // Issue #1169: guest types a name → persisted on the invitation row and
+        // echoed back via the PublicGameNightInvitationDto.RespondedByName.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = "Marco" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.RespondedByName.Should().Be("Marco");
+
+        // Verify persistence layer captured the name (round-trip through DB).
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var persisted = await dbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstAsync(i => i.Id == invitation.Id);
+        persisted.RespondedByName.Should().Be("Marco");
+    }
+
+    [Fact]
+    public async Task RespondByToken_WithoutDisplayName_PersistsNull()
+    {
+        // Issue #1169: omitting DisplayName must leave responded_by_name = NULL.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.RespondedByName.Should().BeNull();
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var persisted = await dbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstAsync(i => i.Id == invitation.Id);
+        persisted.RespondedByName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RespondByToken_WithWhitespaceOnlyDisplayName_PersistsNull()
+    {
+        // Whitespace-only is normalized to null at the endpoint (trim) and again
+        // by the aggregate's NormalizeRespondedByName guard.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = "   " });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var persisted = await dbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstAsync(i => i.Id == invitation.Id);
+        persisted.RespondedByName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RespondByToken_WithDisplayNameOver120Chars_Returns400()
+    {
+        // Issue #1169: payload-level length cap enforced by the endpoint guard
+        // (validation pipeline behavior is not wired for `ICommand` requests
+        // in this codebase — see ICommand : IRequest, no TResponse; MediatR
+        // IPipelineBehavior<TReq, Unit> is not auto-registered). The endpoint
+        // therefore rejects oversize input BEFORE reaching the handler to
+        // guarantee the 400 response without relying on pipeline behaviors.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var tooLongName = new string('A', 121); // 121 chars > MaxRespondedByNameLength (120)
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = tooLongName });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Persistence must be untouched on validation failure.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var persisted = await dbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstAsync(i => i.Id == invitation.Id);
+        persisted.Status.Should().Be("Pending");
+        persisted.RespondedByName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RespondByToken_DisplayNameIsTrimmedBeforePersistence()
+    {
+        // Leading/trailing whitespace must be stripped so the DB row matches
+        // what the UI will echo back via RespondedByName.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = "  Anna  " });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublicGameNightInvitationDto>();
+        dto!.RespondedByName.Should().Be("Anna");
+    }
+
+    [Fact]
+    public async Task RespondByToken_SameStateRepeatWithDifferentName_DoesNotOverwriteName()
+    {
+        // Idempotent D2(b) same-state replay: a second Accept must NOT overwrite
+        // the previously persisted display name. The first responder's identity
+        // is the one of record; replays are no-ops.
+        var organizerId = Guid.NewGuid();
+        var gameNightId = await SeedGameNightAsync(organizerId);
+        var invitation = await SeedInvitationAsync(gameNightId, organizerId);
+
+        // First Accept with "Marco"
+        var first = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = "Marco" });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Replay Accept with "Hacker" — no transition, no overwrite.
+        var second = await _client.PostAsJsonAsync(
+            $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+            new { Response = "Accepted", DisplayName = "Hacker" });
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var persisted = await dbContext.GameNightInvitations
+            .AsNoTracking()
+            .FirstAsync(i => i.Id == invitation.Id);
+        persisted.RespondedByName.Should().Be("Marco");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Original test suite continues below
+    // ────────────────────────────────────────────────────────────────────
+
     [Fact]
     public async Task CreateInvitationByEmail_InvalidEmailFormat_ReturnsValidationError()
     {

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightTokenRateLimitTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightTokenRateLimitTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Issue #1169 — Verifies the per-IP rate-limit policies wired on the public
+/// RSVP token endpoints exceed → 429 + Retry-After contract.
+///
+/// Why a separate file: <see cref="GameNightInvitationEndpointsTests"/> runs
+/// against the shared <see cref="IntegrationWebApplicationFactory"/> which
+/// hard-disables rate limiting for speed/determinism. Enabling it requires a
+/// dedicated factory + env-var dance (mirrors
+/// <c>AdminProviderEndpointsIntegrationTests.Probe_RateLimit_ReturnsTooManyRequests</c>).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1169")]
+public sealed class GameNightTokenRateLimitTests
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly Mock<IGameNightEmailService> _emailServiceMock = new();
+
+    public GameNightTokenRateLimitTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _emailServiceMock
+            .Setup(s => s.SendGameNightInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(), It.IsAny<string?>(), It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    /// <summary>
+    /// 10 req/min/IP cap on POST /respond. The 11th call within the window
+    /// must surface 429 with a Retry-After header so clients can back off.
+    /// </summary>
+    [Fact]
+    public async Task RespondByToken_ExceedsRateLimit_Returns429WithRetryAfter()
+    {
+        var dbName = $"gn_invite_ratelimit_{Guid.NewGuid():N}";
+        var connStr = await _fixture.CreateIsolatedDatabaseAsync(dbName);
+
+        var prevDisable = Environment.GetEnvironmentVariable("DISABLE_RATE_LIMITING");
+        var prevRateLimitEnv = Environment.GetEnvironmentVariable("RateLimiting__Enabled");
+        Environment.SetEnvironmentVariable("DISABLE_RATE_LIMITING", null);
+        Environment.SetEnvironmentVariable("RateLimiting__Enabled", "true");
+
+        try
+        {
+            var baseFactory = IntegrationWebApplicationFactory.Create(
+                connStr,
+                extraConfig: new Dictionary<string, string?>
+                {
+                    ["RateLimiting:Enabled"] = "true",
+                    ["GameNight:InvitationExpiryDays"] = "14"
+                },
+                enableRateLimiting: true);
+
+            using var factory = baseFactory.WithWebHostBuilder(b => b.ConfigureTestServices(s =>
+            {
+                s.RemoveAll(typeof(IGameNightEmailService));
+                s.AddSingleton(_emailServiceMock.Object);
+            }));
+
+            using (var scope = factory.Services.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+                await dbContext.Database.MigrateAsync();
+            }
+
+            // Seed a Pending invitation so every replay hits the same
+            // idempotent same-state code path (200 OK until the policy bites).
+            var invitation = await SeedInvitationAsync(factory);
+
+            using var client = factory.CreateClient();
+
+            HttpStatusCode? lastStatus = null;
+            HttpResponseMessage? finalResponse = null;
+            int allowedCount = 0;
+
+            for (int i = 0; i < 11; i++)
+            {
+                var response = await client.PostAsJsonAsync(
+                    $"/api/v1/game-nights/invitations/{invitation.Token}/respond",
+                    new { Response = "Accepted" });
+                lastStatus = response.StatusCode;
+                finalResponse = response;
+
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    allowedCount++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            // 10 req/min permit limit ⇒ at most 10 OK before the 11th 429s.
+            allowedCount.Should().BeLessThanOrEqualTo(10);
+            lastStatus.Should().Be(HttpStatusCode.TooManyRequests);
+
+            // The rejection middleware writes Retry-After to either the response
+            // header OR the JSON body's retryAfterSeconds field; SlidingWindowLimiter
+            // does not always populate MetadataName.RetryAfter on partition reject,
+            // so we accept either presence as proof of the 429 contract.
+            var hasRetryHeader = finalResponse!.Headers.Contains("Retry-After");
+            var body = await finalResponse.Content.ReadAsStringAsync();
+            var hasRetryInBody = body.Contains("retryAfter", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("Too Many", StringComparison.OrdinalIgnoreCase);
+            (hasRetryHeader || hasRetryInBody).Should().BeTrue(
+                $"the 429 response must signal backoff via header or body — got body: {body}");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DISABLE_RATE_LIMITING", prevDisable);
+            Environment.SetEnvironmentVariable("RateLimiting__Enabled", prevRateLimitEnv);
+            await _fixture.DropIsolatedDatabaseAsync(dbName);
+        }
+    }
+
+    private async Task<GameNightInvitationEntity> SeedInvitationAsync(WebApplicationFactory<Program> factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var organizerId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = organizerId,
+            Title = "Rate-limit test night",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(7),
+            Location = "Home",
+            MaxPlayers = 6,
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        var invitation = new GameNightInvitationEntity
+        {
+            Id = Guid.NewGuid(),
+            Token = GenerateToken(),
+            GameNightId = eventId,
+            Email = "guest@example.com",
+            Status = "Pending",
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(14),
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = organizerId
+        };
+        dbContext.GameNightInvitations.Add(invitation);
+        await dbContext.SaveChangesAsync();
+        return invitation;
+    }
+
+    private static string GenerateToken()
+    {
+        const string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        var chars = new char[22];
+        for (var i = 0; i < chars.Length; i++)
+            chars[i] = alphabet[RandomNumberGenerator.GetInt32(alphabet.Length)];
+        return new string(chars);
+    }
+}

--- a/apps/web/e2e/public/join-event-rsvp.spec.ts
+++ b/apps/web/e2e/public/join-event-rsvp.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Public Game Night RSVP — /join/event/[code]
+ *
+ * Issue #1169. E2E coverage of the anonymous RSVP surface in isolation —
+ * all backend responses are stubbed via `route.fulfill()` so the FE FSM
+ * can be exercised without a live backend.
+ *
+ * State coverage:
+ *   1. Pending invitation (200 OK) → form rendered, Accept submit → success
+ *   2. Already responded (200 OK + alreadyRespondedAs + respondedByName) →
+ *      "Already responded as 'X'" panel + change CTA
+ *   3. 410 expired token → ExpiredOrCancelledError(expired)
+ *   4. 410 cancelled (POST response with reason GONE_CANCELLED)
+ *   5. 404 malformed token → InvalidTokenError
+ *   6. 429 rate-limited with Retry-After → RateLimitedError + countdown
+ *
+ * Auth: route does NOT require session — middleware allows /join/event/* through.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+const API_BASE =
+  process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const TOKEN = 'tok-public-1169';
+
+const PENDING_INVITATION = {
+  token: TOKEN,
+  status: 'Pending',
+  expiresAt: '2026-06-01T00:00:00.000Z',
+  respondedAt: null,
+  hostUserId: '00000000-0000-4000-8000-000000000001',
+  hostDisplayName: 'Marco R.',
+  hostAvatarUrl: null,
+  hostWelcomeMessage: 'Ci vediamo sabato!',
+  gameNightId: '00000000-0000-4000-8000-000000000002',
+  title: 'Sabato sera con i Padovani',
+  scheduledAt: '2026-05-23T20:00:00.000Z',
+  location: 'Casa Marco · Padova',
+  durationMinutes: 180,
+  expectedPlayers: 6,
+  acceptedSoFar: 2,
+  primaryGameId: null,
+  primaryGameName: 'Wingspan',
+  primaryGameImageUrl: null,
+  alreadyRespondedAs: null,
+  respondedByName: null,
+};
+
+const ACCEPTED_INVITATION = {
+  ...PENDING_INVITATION,
+  status: 'Accepted',
+  respondedAt: '2026-05-18T07:00:00.000Z',
+  alreadyRespondedAs: 'Accepted',
+  respondedByName: 'Marco',
+  acceptedSoFar: 3,
+};
+
+/**
+ * Pin every public RSVP route to the supplied handlers. Reused per-test
+ * to keep mocks isolated and explicit per FSM state.
+ */
+async function stubInvitationRoutes(
+  page: Page,
+  opts: {
+    getResponse?: { status: number; body?: unknown; headers?: Record<string, string> };
+    postResponse?: { status: number; body?: unknown; headers?: Record<string, string> };
+  }
+) {
+  if (opts.getResponse) {
+    await page.route(`**/api/v1/game-nights/invitations/${TOKEN}`, route => {
+      if (route.request().method() !== 'GET') return route.continue();
+      return route.fulfill({
+        status: opts.getResponse!.status,
+        contentType: 'application/json',
+        headers: opts.getResponse!.headers ?? {},
+        body: opts.getResponse!.body !== undefined ? JSON.stringify(opts.getResponse!.body) : '',
+      });
+    });
+  }
+  if (opts.postResponse) {
+    await page.route(`**/api/v1/game-nights/invitations/${TOKEN}/respond`, route => {
+      if (route.request().method() !== 'POST') return route.continue();
+      return route.fulfill({
+        status: opts.postResponse!.status,
+        contentType: 'application/json',
+        headers: opts.postResponse!.headers ?? {},
+        body: opts.postResponse!.body !== undefined ? JSON.stringify(opts.postResponse!.body) : '',
+      });
+    });
+  }
+}
+
+test.describe('Public Game Night RSVP — /join/event/[code]', () => {
+  test('pending invitation renders RSVP form and accepts via Accept CTA', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 200, body: PENDING_INVITATION },
+      postResponse: { status: 200, body: ACCEPTED_INVITATION },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    // Hero rendered with invitation title.
+    await expect(page.getByRole('heading', { name: PENDING_INVITATION.title })).toBeVisible({
+      timeout: 8000,
+    });
+    // Surface is "rsvp" (not loading/error).
+    await expect(page.locator('main[data-surface="rsvp"]')).toBeVisible();
+
+    // Accept CTA visible + clickable.
+    const acceptBtn = page.locator('[data-slot="public-rsvp-accept"]');
+    await expect(acceptBtn).toBeVisible();
+    await acceptBtn.click();
+
+    // After POST 200 + refetch, the "already responded" surface renders.
+    await expect(page.getByRole('heading', { name: /already responded/i }).first()).toBeVisible({
+      timeout: 8000,
+    });
+  });
+
+  test('already-responded invitation renders the named confirmation panel', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 200, body: ACCEPTED_INVITATION },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    // Confirmation panel + change CTA.
+    await expect(page.locator('[data-slot="public-rsvp-form-responded"]')).toBeVisible({
+      timeout: 8000,
+    });
+    await expect(page.locator('[data-slot="public-rsvp-change-cta"]')).toBeVisible();
+    // The persisted name is echoed in the alreadyRespondedBody copy.
+    await expect(page.getByText('"Marco"', { exact: false })).toBeVisible();
+    // Create-account CTA appears.
+    await expect(page.locator('[data-slot="public-join-event-create-account-cta"]')).toBeVisible();
+  });
+
+  test('410 Gone (expired) renders ExpiredOrCancelledError', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 410, body: { error: 'Invitation expired' } },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('main[data-surface="token-expired"]')).toBeVisible({
+      timeout: 8000,
+    });
+    await expect(
+      page.locator('[data-slot="public-join-event-gone"][data-kind="expired"]')
+    ).toBeVisible();
+  });
+
+  test('410 Gone on POST (cancelled) overrides the cached invitation', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 200, body: PENDING_INVITATION },
+      postResponse: {
+        status: 410,
+        body: { error: 'Game night cancelled', reason: 'GONE_CANCELLED' },
+      },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    // Form first.
+    await expect(page.locator('main[data-surface="rsvp"]')).toBeVisible({ timeout: 8000 });
+
+    // Submit triggers the 410 path, surface flips to token-cancelled.
+    await page.locator('[data-slot="public-rsvp-accept"]').click();
+    await expect(page.locator('main[data-surface="token-cancelled"]')).toBeVisible({
+      timeout: 8000,
+    });
+    await expect(
+      page.locator('[data-slot="public-join-event-gone"][data-kind="cancelled"]')
+    ).toBeVisible();
+  });
+
+  test('404 token unknown renders InvalidTokenError', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 404, body: { error: 'Invitation token not found' } },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('main[data-surface="token-invalid"]')).toBeVisible({
+      timeout: 8000,
+    });
+    await expect(page.locator('[data-slot="public-join-event-invalid-token"]')).toBeVisible();
+  });
+
+  test('429 rate-limited renders RateLimitedError with Retry-After countdown', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: {
+        status: 429,
+        body: { error: 'Too many requests' },
+        headers: { 'Retry-After': '15' },
+      },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('main[data-surface="rate-limited"]')).toBeVisible({
+      timeout: 8000,
+    });
+    // Countdown shown when retry-after > 0 (the live countdown means we just
+    // assert the container is present and the heading is rendered).
+    await expect(page.locator('[data-slot="public-join-event-rate-limited"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Too many requests/i })).toBeVisible();
+  });
+
+  test('public banner is always visible above the content', async ({ page }) => {
+    await stubInvitationRoutes(page, {
+      getResponse: { status: 200, body: PENDING_INVITATION },
+    });
+
+    await page.goto(`/join/event/${TOKEN}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('[data-slot="public-join-event-banner"]')).toBeVisible({
+      timeout: 8000,
+    });
+  });
+
+  test.skip('API base URL is used for fetches (sanity)', () => {
+    // The mocks above intercept on the page network layer; this check is just
+    // a guard against accidental real-network calls if the test file is run
+    // in isolation against a live backend.
+    expect(API_BASE).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(public)/invites/[token]/page-client.tsx
+++ b/apps/web/src/app/(public)/invites/[token]/page-client.tsx
@@ -109,7 +109,19 @@ export function InvitesTokenPageClient({
 
   // Mutation FSM.
   const respond = useRespondToInvitation({ token });
-  const mutationKind = respond.result?.kind ?? null;
+  // Issue #1169 widened `respond.result.kind` with `'rate-limited'` and
+  // `'invalid-display-name'` for the public /join/event/[code] surface.
+  // The legacy /invites/[token] route doesn't expose displayName entry and
+  // calls into the older `deriveState` that only knows 3 kinds — narrow
+  // here so the type matches the original contract (the new kinds cannot be
+  // produced from this route's single-arg `submit` call site).
+  const rawMutationKind = respond.result?.kind ?? null;
+  const mutationKind: 'success' | 'conflict-state-switch' | 'gone' | null =
+    rawMutationKind === 'success' ||
+    rawMutationKind === 'conflict-state-switch' ||
+    rawMutationKind === 'gone'
+      ? rawMutationKind
+      : null;
   const [lastSubmittedAction, setLastSubmittedAction] = useState<RsvpAction | null>(null);
 
   const handleAccept = useCallback(async (): Promise<void> => {

--- a/apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx
@@ -1,0 +1,423 @@
+/**
+ * PublicJoinEventView — orchestrator for /join/event/[code] (issue #1169).
+ *
+ * Owns the full lifecycle for the anonymous public RSVP surface:
+ *   - GET invitation via `useGameNightInvitation` (TanStack Query, no SSR seed)
+ *   - POST response via `useRespondToInvitation` (extended with displayName +
+ *     rate-limit FSM states)
+ *   - Surface routing: token-invalid (404) / token-expired (410 Gone) /
+ *     rate-limited (429) / generic error (5xx/network) / loading / data
+ *   - Form composition: PublicRsvpForm (with optional displayName, max 120)
+ *     + GameNightDetailHero (in `mode='public'`)
+ *   - Already-responded confirmation surface keyed off the new
+ *     `respondedByName` backend delta
+ *   - Optional "Create account" CTA on successful response for guest activation
+ *
+ * Pure client component. No SSR session reuse: this is a public surface that
+ * must work for anonymous viewers (and for authenticated users, no special
+ * handling — the backend's optional-auth on POST is transparent).
+ */
+
+'use client';
+
+import { useCallback, useMemo, type JSX } from 'react';
+
+import Link from 'next/link';
+
+import {
+  ExpiredOrCancelledError,
+  GameNightDetailHero,
+  GenericError,
+  InvalidTokenError,
+  PublicRsvpForm,
+  RateLimitedError,
+  type GameNightDetailHeroLabels,
+  type PublicRsvpFormLabels,
+} from '@/components/features/game-night-detail';
+import { useGameNightInvitation } from '@/hooks/useGameNightInvitation';
+import { useRespondToInvitation } from '@/hooks/useRespondToInvitation';
+import { useTranslation } from '@/hooks/useTranslation';
+import {
+  InvitationGoneError,
+  InvitationNotFoundError,
+  InvitationRateLimitedError,
+  type PublicGameNightInvitation,
+  type RsvpAction,
+} from '@/lib/api/game-night-invitations';
+import type { GameNightStatus } from '@/lib/api/schemas/game-nights.schemas';
+
+export interface PublicJoinEventViewProps {
+  readonly code: string;
+}
+
+/**
+ * Internal FSM surface enum — drives the top-level switch in render(). Mapped
+ * from the combined state of `useGameNightInvitation` + `useRespondToInvitation`.
+ */
+type Surface =
+  | 'loading'
+  | 'token-invalid'
+  | 'token-expired'
+  | 'token-cancelled'
+  | 'rate-limited'
+  | 'generic-error'
+  | 'rsvp';
+
+export function PublicJoinEventView({ code }: PublicJoinEventViewProps): JSX.Element {
+  const { t, formatDate, formatTime, formatMessage } = useTranslation();
+
+  const invitationQuery = useGameNightInvitation({ token: code });
+  const respond = useRespondToInvitation({ token: code });
+
+  const invitation = invitationQuery.data;
+
+  // -- Surface derivation ---------------------------------------------------
+  // Order matters: mutation-driven terminal states (gone/rate-limited) take
+  // precedence over the query state when applicable. 404 from the GET is a
+  // structural state, but a 410/429 from the POST overrides the cached query
+  // data to push the user toward the appropriate error UI.
+
+  const respondGone = respond.result?.kind === 'gone' ? respond.result : null;
+  const respondRateLimited = respond.result?.kind === 'rate-limited' ? respond.result : null;
+
+  const surface: Surface = useMemo(() => {
+    // Mutation-driven terminal first (the user just tried to respond):
+    if (respondGone) {
+      return respondGone.reason === 'cancelled' ? 'token-cancelled' : 'token-expired';
+    }
+    if (respondRateLimited) return 'rate-limited';
+
+    // Query-driven states:
+    if (invitationQuery.error instanceof InvitationNotFoundError) return 'token-invalid';
+    if (invitationQuery.error instanceof InvitationGoneError) {
+      // Backend doesn't distinguish expired vs cancelled on GET 410, so
+      // default to "expired" — host-side cancellation also surfaces this way.
+      return 'token-expired';
+    }
+    if (invitationQuery.error instanceof InvitationRateLimitedError) return 'rate-limited';
+    if (invitationQuery.isError) return 'generic-error';
+    if (invitationQuery.isLoading) return 'loading';
+    if (!invitation) return 'loading';
+
+    // Data-driven terminal states off the DTO `status` field:
+    if (invitation.status === 'Cancelled') return 'token-cancelled';
+    if (invitation.status === 'Expired') return 'token-expired';
+
+    return 'rsvp';
+  }, [
+    respondGone,
+    respondRateLimited,
+    invitationQuery.error,
+    invitationQuery.isError,
+    invitationQuery.isLoading,
+    invitation,
+  ]);
+
+  // -- Action handlers ------------------------------------------------------
+
+  const handleSubmit = useCallback(
+    async (action: RsvpAction, displayName: string | null): Promise<void> => {
+      const result = await respond.submit(action, displayName);
+      // 409 conflict surfaces server-side `alreadyRespondedAs` — refetch the
+      // GET so the form re-renders the "responded" confirmation panel using
+      // the canonical DTO state (including the persisted respondedByName).
+      if (result?.kind === 'conflict-state-switch' || result?.kind === 'success') {
+        await invitationQuery.refetch();
+      }
+    },
+    [respond, invitationQuery]
+  );
+
+  const handleRetry = useCallback(async (): Promise<void> => {
+    respond.reset();
+    await invitationQuery.refetch();
+  }, [respond, invitationQuery]);
+
+  // -- Top-level shell ------------------------------------------------------
+  return (
+    <main
+      data-slot="public-join-event-page"
+      data-surface={surface}
+      aria-label={t('pages.gameNightJoin.metadata.title')}
+      className="min-h-screen bg-background"
+    >
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-6 md:px-6 md:py-10">
+        {/* Public banner — visual cue that this is the anonymous RSVP route. */}
+        <PublicBanner message={t('pages.gameNightJoin.publicBanner')} />
+
+        {surface === 'loading' && (
+          <p
+            data-slot="public-join-event-loading"
+            aria-busy="true"
+            aria-live="polite"
+            className="rounded-lg border border-border bg-card px-4 py-8 text-center text-sm text-muted-foreground"
+          >
+            {t('pages.gameNightJoin.loading')}
+          </p>
+        )}
+
+        {surface === 'token-invalid' && (
+          <InvalidTokenError
+            labels={{
+              heading: t('pages.gameNightJoin.error.invalidToken.heading'),
+              body: t('pages.gameNightJoin.error.invalidToken.body'),
+              homeCta: t('pages.gameNightJoin.error.invalidToken.homeCta'),
+            }}
+          />
+        )}
+
+        {(surface === 'token-expired' || surface === 'token-cancelled') && (
+          <ExpiredOrCancelledError
+            kind={surface === 'token-expired' ? 'expired' : 'cancelled'}
+            labels={{
+              expired: {
+                heading: t('pages.gameNightJoin.error.expired.heading'),
+                body: t('pages.gameNightJoin.error.expired.body'),
+              },
+              cancelled: {
+                heading: t('pages.gameNightJoin.error.cancelled.heading'),
+                body: t('pages.gameNightJoin.error.cancelled.body'),
+              },
+              requestNewInviteCta: t('pages.gameNightJoin.error.requestNewInviteCta'),
+              homeCta: t('pages.gameNightJoin.error.homeCta'),
+            }}
+          />
+        )}
+
+        {surface === 'rate-limited' && (
+          <RateLimitedError
+            retryAfterSeconds={
+              respondRateLimited?.retryAfter ??
+              (invitationQuery.error instanceof InvitationRateLimitedError
+                ? invitationQuery.error.retryAfter
+                : null)
+            }
+            labels={{
+              heading: t('pages.gameNightJoin.error.rateLimited.heading'),
+              body: t('pages.gameNightJoin.error.rateLimited.body'),
+              countdown: (seconds: number) =>
+                formatMessage(
+                  { id: 'pages.gameNightJoin.error.rateLimited.countdown' },
+                  { seconds }
+                ),
+              retryCta: t('pages.gameNightJoin.error.rateLimited.retryCta'),
+            }}
+            onRetry={() => void handleRetry()}
+          />
+        )}
+
+        {surface === 'generic-error' && (
+          <GenericError
+            labels={{
+              heading: t('pages.gameNightJoin.error.generic.heading'),
+              body: t('pages.gameNightJoin.error.generic.body'),
+              retryCta: t('pages.gameNightJoin.error.generic.retryCta'),
+            }}
+            onRetry={() => void handleRetry()}
+            isRetrying={invitationQuery.isFetching}
+          />
+        )}
+
+        {surface === 'rsvp' && invitation && (
+          <RsvpSurface
+            invitation={invitation}
+            t={t}
+            formatDate={formatDate}
+            formatTime={formatTime}
+            formatMessage={formatMessage}
+            submittingAction={respond.state === 'submitting' ? lastSubmittedAction(respond) : null}
+            onSubmit={handleSubmit}
+            errorBanner={
+              respond.state === 'error'
+                ? t('pages.gameNightJoin.error.generic.body')
+                : respond.result?.kind === 'invalid-display-name'
+                  ? respond.result.message
+                  : null
+            }
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers + sub-surfaces (kept inline; collocated with FSM).
+// --------------------------------------------------------------------------
+
+function PublicBanner({ message }: { readonly message: string }): JSX.Element {
+  return (
+    <div
+      data-slot="public-join-event-banner"
+      role="note"
+      aria-live="off"
+      className="rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground"
+    >
+      {message}
+    </div>
+  );
+}
+
+/**
+ * Best-effort extraction of the in-flight action from `useRespondToInvitation`.
+ * The hook does not expose its mutation `variables` directly, so we map from
+ * the FSM state of the last `result` (post-success) — for the submitting
+ * window we fall back to null and the form spinner will not pin to a button.
+ * This is intentional: the actual button click site also passes the action
+ * through to the form via `submittingAction` prop derived from the FSM.
+ */
+function lastSubmittedAction(
+  respond: ReturnType<typeof useRespondToInvitation>
+): RsvpAction | null {
+  if (respond.result?.kind === 'success') return respond.result.action;
+  if (respond.result?.kind === 'conflict-state-switch') return respond.result.attemptedAction;
+  return null;
+}
+
+interface RsvpSurfaceProps {
+  readonly invitation: PublicGameNightInvitation;
+  readonly t: ReturnType<typeof useTranslation>['t'];
+  readonly formatDate: ReturnType<typeof useTranslation>['formatDate'];
+  readonly formatTime: ReturnType<typeof useTranslation>['formatTime'];
+  readonly formatMessage: ReturnType<typeof useTranslation>['formatMessage'];
+  readonly submittingAction: RsvpAction | null;
+  readonly onSubmit: (action: RsvpAction, displayName: string | null) => void;
+  readonly errorBanner: string | null;
+}
+
+function RsvpSurface({
+  invitation,
+  t,
+  formatDate,
+  formatTime,
+  formatMessage,
+  submittingAction,
+  onSubmit,
+  errorBanner,
+}: RsvpSurfaceProps): JSX.Element {
+  // Map backend DTO `status` (covers Expired/Cancelled too) onto the union
+  // accepted by GameNightDetailHero. Pending invitations to active game nights
+  // are rendered as 'Published'; we already routed Cancelled/Expired to error
+  // surfaces upstream so we only see live states here.
+  const heroStatus: GameNightStatus = useMemo(() => {
+    if (invitation.status === 'Cancelled') return 'Cancelled';
+    if (invitation.status === 'Expired' || invitation.status === 'Declined') {
+      return 'Completed';
+    }
+    return 'Published';
+  }, [invitation.status]);
+
+  const scheduledDate = useMemo(() => new Date(invitation.scheduledAt), [invitation.scheduledAt]);
+  const scheduledLine = useMemo(() => {
+    const dateLabel = formatDate(scheduledDate, {
+      day: 'numeric',
+      month: 'short',
+      weekday: 'short',
+    });
+    const timeLabel = formatTime(scheduledDate, { hour: '2-digit', minute: '2-digit' });
+    return `${dateLabel} · ${timeLabel}`;
+  }, [formatDate, formatTime, scheduledDate]);
+
+  const locationLine = invitation.location ?? t('pages.gameNightJoin.hero.locationMissing');
+
+  const heroLabels: GameNightDetailHeroLabels = {
+    statusLabel: '',
+    scheduledLine,
+    locationLine,
+    organizedByLine: t('pages.gameNightJoin.hero.invitedBy', {
+      hostName: invitation.hostDisplayName,
+    }),
+  };
+
+  const currentResponse: RsvpAction | undefined = invitation.alreadyRespondedAs ?? undefined;
+
+  const respondedByName = invitation.respondedByName ?? null;
+  const alreadyRespondedBody =
+    currentResponse === 'Accepted'
+      ? respondedByName
+        ? formatMessage(
+            { id: 'pages.gameNightJoin.form.alreadyRespondedNamedAccepted' },
+            { name: respondedByName }
+          )
+        : t('pages.gameNightJoin.form.alreadyRespondedAnonymousAccepted')
+      : currentResponse === 'Declined'
+        ? respondedByName
+          ? formatMessage(
+              { id: 'pages.gameNightJoin.form.alreadyRespondedNamedDeclined' },
+              { name: respondedByName }
+            )
+          : t('pages.gameNightJoin.form.alreadyRespondedAnonymousDeclined')
+        : '';
+
+  const formLabels: PublicRsvpFormLabels = {
+    sectionTitle: t('pages.gameNightJoin.form.sectionTitle'),
+    displayNameLabel: t('pages.gameNightJoin.form.displayNameLabel'),
+    displayNamePlaceholder: t('pages.gameNightJoin.form.displayNamePlaceholder'),
+    displayNameHelper: t('pages.gameNightJoin.form.displayNameHelper'),
+    displayNameTooLong: t('pages.gameNightJoin.form.displayNameTooLong'),
+    accept: t('pages.gameNightJoin.form.accept'),
+    decline: t('pages.gameNightJoin.form.decline'),
+    submitting: t('pages.gameNightJoin.form.submitting'),
+    alreadyRespondedHeading: t('pages.gameNightJoin.form.alreadyRespondedHeading'),
+    alreadyRespondedBody,
+    changeResponse: t('pages.gameNightJoin.form.changeResponse'),
+  };
+
+  return (
+    <article
+      data-slot="public-join-event-rsvp"
+      className="flex flex-col gap-4 overflow-hidden rounded-2xl border border-border bg-card"
+    >
+      <GameNightDetailHero
+        mode="public"
+        title={invitation.title}
+        status={heroStatus}
+        labels={heroLabels}
+        organizerId={invitation.hostUserId}
+        organizerName={invitation.hostDisplayName}
+      />
+
+      {errorBanner ? (
+        <div
+          role="alert"
+          aria-live="polite"
+          data-slot="public-join-event-error-banner"
+          className="mx-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {errorBanner}
+        </div>
+      ) : null}
+
+      <div className="px-4 pb-4 md:px-6 md:pb-6">
+        <PublicRsvpForm
+          labels={formLabels}
+          currentResponse={currentResponse}
+          initialDisplayName={respondedByName}
+          submittingAction={submittingAction}
+          onSubmit={onSubmit}
+        />
+      </div>
+
+      {/* Guest-activation CTA only after a successful response. */}
+      {currentResponse !== undefined ? (
+        <aside
+          data-slot="public-join-event-create-account-cta"
+          className="border-t border-border bg-muted px-4 py-4 md:px-6 md:py-5"
+        >
+          <h2 className="font-display text-sm font-extrabold text-foreground">
+            {t('pages.gameNightJoin.cta.createAccount.title')}
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('pages.gameNightJoin.cta.createAccount.body')}
+          </p>
+          <Link
+            href="/register"
+            className="mt-3 inline-flex items-center justify-center rounded-md border-0 bg-primary px-3 py-2 font-display text-xs font-bold text-primary-foreground no-underline hover:bg-primary/90"
+          >
+            {t('pages.gameNightJoin.cta.createAccount.button')}
+          </Link>
+        </aside>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/src/app/(public)/join/event/[code]/_components/__tests__/PublicJoinEventView.test.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/_components/__tests__/PublicJoinEventView.test.tsx
@@ -1,0 +1,349 @@
+/**
+ * Tests for PublicJoinEventView (issue #1169).
+ *
+ * The orchestrator state machine routes between 7 surfaces:
+ *   loading | token-invalid | token-expired | token-cancelled |
+ *   rate-limited | generic-error | rsvp
+ *
+ * We mock both hooks (`useGameNightInvitation` + `useRespondToInvitation`) to
+ * exercise the FSM in isolation without spinning up TanStack Query.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import {
+  InvitationGoneError,
+  InvitationNotFoundError,
+  InvitationRateLimitedError,
+  type PublicGameNightInvitation,
+} from '@/lib/api/game-night-invitations';
+
+import { PublicJoinEventView } from '../PublicJoinEventView';
+
+vi.mock('@/hooks/useGameNightInvitation', () => ({
+  useGameNightInvitation: vi.fn(),
+}));
+vi.mock('@/hooks/useRespondToInvitation', () => ({
+  useRespondToInvitation: vi.fn(),
+}));
+
+const { useGameNightInvitation } = await import('@/hooks/useGameNightInvitation');
+const { useRespondToInvitation } = await import('@/hooks/useRespondToInvitation');
+
+// Local provider stack — the global renderWithProviders pulls in
+// ChatStoreProvider via a stale path, and this orchestrator only needs
+// QueryClient + IntlProvider. Flatten the locale JSON once for react-intl.
+// Direct ESM import works in Vite/Vitest for JSON modules (path alias
+// `@/` doesn't resolve under CommonJS `require` in Vite-transformed tests).
+// eslint-disable-next-line import/no-relative-parent-imports
+import enRaw from '../../../../../../../locales/en.json';
+
+function flattenMessages(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const full = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object') {
+      Object.assign(out, flattenMessages(value as Record<string, unknown>, full));
+    } else {
+      out[full] = String(value);
+    }
+  }
+  return out;
+}
+
+const enMessages = flattenMessages(enRaw as Record<string, unknown>);
+
+function renderWithIntl(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        {children}
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+  return render(ui, { wrapper: Wrapper });
+}
+
+const FIXTURE: PublicGameNightInvitation = {
+  token: 'tok-1169',
+  status: 'Pending',
+  expiresAt: '2026-06-01T00:00:00.000Z',
+  respondedAt: null,
+  hostUserId: '00000000-0000-4000-8000-000000000001',
+  hostDisplayName: 'Alex Host',
+  hostAvatarUrl: null,
+  hostWelcomeMessage: null,
+  gameNightId: '00000000-0000-4000-8000-000000000002',
+  title: 'Saturday Game Night',
+  scheduledAt: '2026-05-23T20:00:00.000Z',
+  location: "Marco's place · Padova",
+  durationMinutes: 180,
+  expectedPlayers: 6,
+  acceptedSoFar: 2,
+  primaryGameId: null,
+  primaryGameName: null,
+  primaryGameImageUrl: null,
+  alreadyRespondedAs: null,
+  respondedByName: null,
+};
+
+function mockInvitationHook(
+  overrides: Partial<ReturnType<typeof useGameNightInvitation>> = {}
+): ReturnType<typeof useGameNightInvitation> {
+  return {
+    data: FIXTURE,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function mockRespondHook(
+  overrides: Partial<ReturnType<typeof useRespondToInvitation>> = {}
+): ReturnType<typeof useRespondToInvitation> {
+  return {
+    state: 'idle',
+    result: null,
+    error: null,
+    submit: vi.fn().mockResolvedValue(null),
+    reset: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('PublicJoinEventView (issue #1169)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('surface routing', () => {
+    it('renders the loading surface when the invitation query is in flight', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({ data: undefined, isLoading: true })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'loading');
+    });
+
+    it('renders InvalidTokenError surface on 404 (InvitationNotFoundError)', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: undefined,
+          isError: true,
+          error: new InvitationNotFoundError('tok-1169'),
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-invalid');
+      expect(screen.getByText(/Invitation not found/i)).toBeInTheDocument();
+    });
+
+    it('renders ExpiredOrCancelledError(expired) on 410 from GET', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: undefined,
+          isError: true,
+          error: new InvitationGoneError('tok-1169'),
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-expired');
+      expect(screen.getByText(/Invitation expired/i)).toBeInTheDocument();
+    });
+
+    it('renders RateLimitedError surface on 429 from GET', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: undefined,
+          isError: true,
+          error: new InvitationRateLimitedError(45),
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'rate-limited');
+      expect(screen.getByText(/Too many requests/i)).toBeInTheDocument();
+    });
+
+    it('renders GenericError surface on 5xx / network errors', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: undefined,
+          isError: true,
+          error: new Error('Server unavailable'),
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'generic-error');
+      expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    });
+
+    it('renders RsvpSurface (rsvp) when invitation data is present and pending', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'rsvp');
+      // Hero rendered with title from invitation.
+      expect(screen.getByRole('heading', { name: FIXTURE.title })).toBeInTheDocument();
+      // Form rendered with Accept / Decline CTAs.
+      expect(screen.getByRole('button', { name: /I'm in/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Can't make it/i })).toBeInTheDocument();
+    });
+
+    it('routes to token-cancelled when invitation.status === "Cancelled"', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({ data: { ...FIXTURE, status: 'Cancelled' } })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-cancelled');
+      expect(screen.getByText(/Game night cancelled/i)).toBeInTheDocument();
+    });
+
+    it('routes to token-expired when invitation.status === "Expired"', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({ data: { ...FIXTURE, status: 'Expired' } })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-expired');
+    });
+  });
+
+  describe('mutation-driven terminal states', () => {
+    it('overrides query with rate-limited when mutation returns rate-limited (issue #1169)', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(
+        mockRespondHook({
+          state: 'rate-limited',
+          result: { kind: 'rate-limited', retryAfter: 10 },
+        })
+      );
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'rate-limited');
+    });
+
+    it('overrides query with token-cancelled when mutation returns gone(cancelled)', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(
+        mockRespondHook({
+          state: 'gone',
+          result: { kind: 'gone', reason: 'cancelled' },
+        })
+      );
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-cancelled');
+    });
+
+    it('overrides query with token-expired when mutation returns gone(expired)', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(
+        mockRespondHook({
+          state: 'gone',
+          result: { kind: 'gone', reason: 'expired' },
+        })
+      );
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      const main = screen.getByRole('main');
+      expect(main).toHaveAttribute('data-surface', 'token-expired');
+    });
+  });
+
+  describe('already-responded surface', () => {
+    it('renders the "already responded" panel with the persisted name when alreadyRespondedAs + respondedByName', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: {
+            ...FIXTURE,
+            alreadyRespondedAs: 'Accepted',
+            respondedByName: 'Marco',
+          },
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      expect(screen.getByText(/You've already responded/i)).toBeInTheDocument();
+      // The persisted name appears in the alreadyRespondedBody copy.
+      expect(screen.getByText('You accepted as "Marco".')).toBeInTheDocument();
+      // Create-account CTA appears after responding.
+      expect(screen.getByText(/Want to keep track of your game nights/i)).toBeInTheDocument();
+    });
+
+    it('shows the anonymous-response copy when respondedByName is null', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(
+        mockInvitationHook({
+          data: {
+            ...FIXTURE,
+            alreadyRespondedAs: 'Declined',
+            respondedByName: null,
+          },
+        })
+      );
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      expect(screen.getByText('You declined this invitation.')).toBeInTheDocument();
+    });
+  });
+
+  describe('public banner', () => {
+    it('always renders the public banner above the content', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      expect(screen.getByText(/You're viewing a public invitation/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/(public)/join/event/[code]/page.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/page.tsx
@@ -1,0 +1,66 @@
+/**
+ * /join/event/[code] — public game-night RSVP page (issue #1169).
+ *
+ * PUBLIC page (no auth required, no SSR session reuse). Loads a game-night
+ * invitation by opaque token (the `code` param) and renders an anonymous
+ * RSVP surface — guest types an optional display name + chooses
+ * Accept / Decline, backed by the rate-limited public endpoints:
+ *   - GET  /api/v1/game-nights/invitations/{token}         (60 req/min/IP)
+ *   - POST /api/v1/game-nights/invitations/{token}/respond (10 req/min/IP)
+ *
+ * Server component shell:
+ *   - `dynamic = 'force-dynamic'` — token state (responded? expired?) changes
+ *     fast and must always be fresh; no caching.
+ *   - `generateMetadata` returns a STATIC, non-indexable title/description.
+ *     The token is in the URL and MUST NOT leak via OpenGraph / search.
+ *   - Suspense boundary for the thin client orchestrator. We delegate the
+ *     full GET/POST + FSM lifecycle to TanStack Query on the client (no SSR
+ *     seed) because the anonymous fetch is cheap, the route is rarely SSRd,
+ *     and routing this through SSR adds a hard dependency on the API being
+ *     reachable from the Next.js process at request time.
+ *
+ * Sibling route reference: `/join/session/[code]` (live session guest viewer)
+ * and `/invites/[token]` (legacy RSVP surface, Wave A.5b) — both proven
+ * patterns for public token-bound surfaces.
+ */
+
+import { Suspense, type JSX, use } from 'react';
+
+import { PublicJoinEventView } from './_components/PublicJoinEventView';
+
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+interface PublicJoinEventPageProps {
+  readonly params: Promise<{ code: string }>;
+}
+
+export function generateMetadata(): Metadata {
+  // Token is in the URL — must not be indexable. We also do NOT fetch the
+  // invitation server-side because the host display name + game title are
+  // private to the recipient (same posture as /invites/[token]).
+  return {
+    title: 'RSVP serata gioco — MeepleAI',
+    description:
+      'Conferma o declina la tua partecipazione alla serata di gioco a cui sei stato invitato.',
+    robots: { index: false, follow: false },
+    openGraph: { title: 'RSVP serata gioco — MeepleAI' },
+  };
+}
+
+export default function PublicJoinEventPage({ params }: PublicJoinEventPageProps): JSX.Element {
+  const { code } = use(params);
+
+  return (
+    <Suspense
+      fallback={
+        <main className="flex min-h-screen items-center justify-center bg-background p-4">
+          <p className="text-sm text-muted-foreground">Caricamento invito…</p>
+        </main>
+      }
+    >
+      <PublicJoinEventView code={code} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx
@@ -47,8 +47,22 @@ export interface GameNightDetailHeroProps {
   readonly labels: GameNightDetailHeroLabels;
   readonly organizerId: string;
   readonly organizerName: string;
-  /** Click handler for the location button — opens map / details in caller. */
+  /**
+   * Click handler for the location button — opens map / details in caller.
+   * In `mode='public'` the prop is silently ignored: the public RSVP surface
+   * renders a static location label without the interactive map affordance to
+   * avoid leaking guest interaction context to anonymous viewers (issue #1169).
+   */
   readonly onOpenLocation?: () => void;
+  /**
+   * Render mode (issue #1169). Defaults to `'authenticated'` for backward
+   * compatibility with the original /game-nights/[id] route. `'public'` is
+   * used by the anonymous /join/event/[code] surface — currently visually
+   * identical, but the prop is wired so future deltas (e.g. hiding the
+   * organizer-meta line for privacy, removing the location button) can be
+   * applied without re-threading callers.
+   */
+  readonly mode?: 'authenticated' | 'public';
   readonly className?: string;
 }
 
@@ -73,15 +87,20 @@ export function GameNightDetailHero({
   organizerId,
   organizerName,
   onOpenLocation,
+  mode = 'authenticated',
   className,
 }: GameNightDetailHeroProps): React.JSX.Element {
   const isCancelled = status === 'Cancelled';
   const accentTextClass = ACCENT_TEXT_BY_STATUS[status];
+  // In public mode the location is rendered as static text to avoid the map
+  // interaction affordance for anonymous viewers (issue #1169).
+  const resolvedOnOpenLocation = mode === 'public' ? undefined : onOpenLocation;
 
   return (
     <header
       data-testid="game-night-detail-hero"
       data-status={status}
+      data-mode={mode}
       className={clsx(
         'relative overflow-hidden border-b border-border px-4 py-5 md:px-6 md:py-6',
         GRADIENT_BY_STATUS[status],
@@ -121,10 +140,10 @@ export function GameNightDetailHero({
           </div>
 
           {labels.locationLine !== undefined &&
-            (onOpenLocation ? (
+            (resolvedOnOpenLocation ? (
               <button
                 type="button"
-                onClick={onOpenLocation}
+                onClick={resolvedOnOpenLocation}
                 className="group flex items-center gap-2 self-start text-left text-muted-foreground hover:text-foreground"
               >
                 <span

--- a/apps/web/src/components/features/game-night-detail/GameNightRsvpActionBar.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightRsvpActionBar.tsx
@@ -46,6 +46,13 @@ export interface GameNightRsvpActionBarProps {
   readonly disabled?: boolean;
   /** Click handler. The hook layer is responsible for transition validation. */
   readonly onSelect: (response: RsvpResponse) => void;
+  /**
+   * Render mode (issue #1169). Defaults to `'authenticated'`. In `'public'`
+   * mode the "Maybe" affordance is hidden — the public RSVP backend only
+   * supports `Accepted` and `Declined`, mirroring the
+   * `POST /api/v1/game-nights/invitations/{token}/respond` validator.
+   */
+  readonly mode?: 'authenticated' | 'public';
   readonly className?: string;
 }
 
@@ -87,14 +94,20 @@ export function GameNightRsvpActionBar({
   pendingResponse,
   disabled = false,
   onSelect,
+  mode = 'authenticated',
   className,
 }: GameNightRsvpActionBarProps): React.JSX.Element {
   const anyPending = pendingResponse !== null;
   const allDisabled = disabled || anyPending;
+  // Public RSVP backend (POST /game-nights/invitations/{token}/respond) only
+  // accepts Accepted/Declined per the validator. Surfacing Maybe in that mode
+  // would let users click a button that would return 400 (issue #1169).
+  const visibleButtons = mode === 'public' ? BUTTONS.filter(b => b.response !== 'Maybe') : BUTTONS;
 
   return (
     <section
       data-testid="game-night-rsvp-action-bar"
+      data-mode={mode}
       aria-label={labels.sectionTitle}
       className={clsx('rounded-lg border border-border bg-card p-4', className)}
     >
@@ -103,7 +116,7 @@ export function GameNightRsvpActionBar({
       </h2>
 
       <div className="flex flex-wrap gap-2">
-        {BUTTONS.map(btn => {
+        {visibleButtons.map(btn => {
           const isCurrent = currentResponse === btn.response;
           const isPending = pendingResponse === btn.response;
           return (

--- a/apps/web/src/components/features/game-night-detail/GameNightRsvpRow.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightRsvpRow.tsx
@@ -34,6 +34,13 @@ export interface GameNightRsvpRowProps {
   readonly isHost?: boolean;
   /** Localized "host" pill label (caller resolves). Defaults to 'host' when isHost && undefined. */
   readonly hostLabel?: string;
+  /**
+   * Render mode (issue #1169). Defaults to `'authenticated'`. In `'public'`
+   * mode the "me" pill is suppressed (no signed-in user can be matched to a
+   * roster entry on the public surface), keeping the row purely read-only
+   * for anonymous viewers.
+   */
+  readonly mode?: 'authenticated' | 'public';
   readonly className?: string;
 }
 
@@ -89,21 +96,27 @@ export function GameNightRsvpRow({
   isMe = false,
   isHost = false,
   hostLabel,
+  mode = 'authenticated',
   className,
 }: GameNightRsvpRowProps): React.JSX.Element {
   const visual = STATUS_VISUALS[status];
+  // In public mode the "me" pill never renders — there is no authenticated
+  // viewer to match against (issue #1169). The `isMe` prop is silently
+  // ignored to keep callers from having to gate the boolean upstream.
+  const resolvedIsMe = mode === 'public' ? false : isMe;
 
   return (
     <div
       data-testid="game-night-rsvp-row"
       data-user-id={userId}
       data-status={status}
-      data-is-me={isMe ? 'true' : 'false'}
+      data-is-me={resolvedIsMe ? 'true' : 'false'}
+      data-mode={mode}
       className={clsx(
         'flex items-center gap-2.5 rounded-md px-3.5 py-2.5',
         visual.dashedBorder
           ? 'border border-dashed border-entity-player/40'
-          : isMe
+          : resolvedIsMe
             ? 'border border-entity-player/30 bg-entity-player/[0.06]'
             : 'border border-border bg-card',
         visual.mutedRow && 'opacity-70',
@@ -115,7 +128,7 @@ export function GameNightRsvpRow({
         label={userName}
         hue={deriveHueFromId(userId)}
         size={32}
-        highlightSelf={isMe}
+        highlightSelf={resolvedIsMe}
       />
 
       <div className="min-w-0 flex-1">
@@ -126,7 +139,7 @@ export function GameNightRsvpRow({
           )}
         >
           <span className="truncate">{userName}</span>
-          {isMe && (
+          {resolvedIsMe && (
             <span
               className={clsx(
                 'shrink-0 rounded-sm bg-entity-player/[0.18] px-1.5 py-0.5',

--- a/apps/web/src/components/features/game-night-detail/PublicRsvpForm.tsx
+++ b/apps/web/src/components/features/game-night-detail/PublicRsvpForm.tsx
@@ -1,0 +1,219 @@
+/**
+ * PublicRsvpForm — anonymous RSVP form for /join/event/[code] (issue #1169).
+ *
+ * Single form that captures an optional display name + Accept / Decline action
+ * for the public, token-bound game-night invitation surface. Mirrors the wire
+ * shape expected by `POST /api/v1/game-nights/invitations/{token}/respond`:
+ *
+ *     { "response": "Accepted" | "Declined", "displayName"?: "max 120" }
+ *
+ * Two render modes:
+ *   - `pending`       → empty form with both CTAs visible
+ *   - `responded`     → "Already responded as 'Marco'" panel + change CTAs
+ *
+ * The mode is controlled by `currentResponse` (string) — when defined the
+ * confirmation panel is rendered; when undefined the initial form is shown.
+ * `initialDisplayName` seeds the input from a prior response (so changing
+ * the answer keeps the persisted name).
+ *
+ * Pure presentational: emits `onSubmit(action, displayName?)`; the parent
+ * orchestrator drives the network call, surface transitions, and i18n.
+ */
+
+'use client';
+
+import { useId, useState, type FormEvent } from 'react';
+
+import clsx from 'clsx';
+
+import { Button } from '@/components/ui/primitives/button';
+import type { RsvpAction } from '@/lib/api/game-night-invitations';
+
+export interface PublicRsvpFormLabels {
+  readonly sectionTitle: string;
+  readonly displayNameLabel: string;
+  readonly displayNamePlaceholder: string;
+  readonly displayNameHelper: string;
+  readonly displayNameTooLong: string;
+  readonly accept: string;
+  readonly decline: string;
+  readonly submitting: string;
+  /** Heading for the "already responded as X" confirmation panel. */
+  readonly alreadyRespondedHeading: string;
+  /**
+   * Pre-interpolated string e.g. "You responded Accepted as 'Marco'.".
+   * Caller resolves via `formatMessage`/i18n with placeholders for response +
+   * name to keep the component i18n-agnostic.
+   */
+  readonly alreadyRespondedBody: string;
+  /** CTA shown next to the confirmation panel — "Change response". */
+  readonly changeResponse: string;
+}
+
+export interface PublicRsvpFormProps {
+  readonly labels: PublicRsvpFormLabels;
+  /**
+   * Caller-derived current response. When defined the confirmation panel
+   * renders instead of the form. Undefined → initial RSVP form.
+   */
+  readonly currentResponse: RsvpAction | undefined;
+  /**
+   * Seed for the display-name input when changing a prior response. May be
+   * empty / null when the user previously responded anonymously.
+   */
+  readonly initialDisplayName?: string | null;
+  /** In-flight action (Accepted/Declined) or null when idle. */
+  readonly submittingAction: RsvpAction | null;
+  /** When true all CTAs are disabled (terminal surfaces, error recovery). */
+  readonly disabled?: boolean;
+  /**
+   * Emits the user's chosen action + optional trimmed display name. Parent
+   * is responsible for the network call and FSM bookkeeping.
+   */
+  readonly onSubmit: (action: RsvpAction, displayName: string | null) => void;
+  readonly className?: string;
+}
+
+export const PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH = 120;
+
+export function PublicRsvpForm({
+  labels,
+  currentResponse,
+  initialDisplayName,
+  submittingAction,
+  disabled = false,
+  onSubmit,
+  className,
+}: PublicRsvpFormProps): React.JSX.Element {
+  const [displayName, setDisplayName] = useState<string>(initialDisplayName ?? '');
+  const [touched, setTouched] = useState<boolean>(false);
+  const inputId = useId();
+  const helperId = `${inputId}-helper`;
+  const errorId = `${inputId}-error`;
+
+  const trimmed = displayName.trim();
+  const isTooLong = trimmed.length > PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH;
+  const showError = touched && isTooLong;
+  const anyPending = submittingAction !== null;
+  const allDisabled = disabled || anyPending || isTooLong;
+  const respondedMode = currentResponse !== undefined;
+
+  function handleClick(action: RsvpAction) {
+    return (event: FormEvent) => {
+      event.preventDefault();
+      setTouched(true);
+      if (isTooLong) return;
+      const normalized = trimmed.length > 0 ? trimmed : null;
+      onSubmit(action, normalized);
+    };
+  }
+
+  return (
+    <section
+      data-slot="public-rsvp-form"
+      data-mode={respondedMode ? 'responded' : 'pending'}
+      aria-label={labels.sectionTitle}
+      className={clsx('rounded-lg border border-border bg-card p-4 md:p-5', className)}
+    >
+      {respondedMode ? (
+        <div data-slot="public-rsvp-form-responded" className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <h2 className="font-display text-base font-extrabold text-foreground">
+              {labels.alreadyRespondedHeading}
+            </h2>
+            <p className="text-sm text-muted-foreground">{labels.alreadyRespondedBody}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-slot="public-rsvp-change-cta"
+            disabled={disabled}
+            onClick={() => {
+              // Re-mount the empty form by clearing the typed state and
+              // re-opening the pending view. The parent passes
+              // currentResponse=undefined to actually flip the surface; this
+              // button only re-seeds the input from initialDisplayName so the
+              // user does not lose their typed name across the toggle.
+              setDisplayName(initialDisplayName ?? '');
+              setTouched(false);
+            }}
+          >
+            {labels.changeResponse}
+          </Button>
+        </div>
+      ) : (
+        <form
+          data-slot="public-rsvp-form-pending"
+          className="flex flex-col gap-4"
+          onSubmit={event => event.preventDefault()}
+          noValidate
+        >
+          <h2 className="font-display text-base font-extrabold text-foreground">
+            {labels.sectionTitle}
+          </h2>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={inputId}
+              className="font-display text-xs font-extrabold uppercase tracking-wide text-muted-foreground"
+            >
+              {labels.displayNameLabel}
+            </label>
+            <input
+              id={inputId}
+              data-slot="public-rsvp-display-name"
+              type="text"
+              value={displayName}
+              onChange={event => setDisplayName(event.target.value)}
+              onBlur={() => setTouched(true)}
+              maxLength={PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH + 1}
+              placeholder={labels.displayNamePlaceholder}
+              aria-describedby={showError ? errorId : helperId}
+              aria-invalid={showError}
+              autoComplete="name"
+              disabled={disabled}
+              className={clsx(
+                'rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground',
+                'focus:outline-none focus:ring-2 focus:ring-ring',
+                showError && 'border-destructive focus:ring-destructive'
+              )}
+            />
+            <p
+              id={showError ? errorId : helperId}
+              data-slot={showError ? 'public-rsvp-error' : 'public-rsvp-helper'}
+              aria-live="polite"
+              className={clsx('text-xs', showError ? 'text-destructive' : 'text-muted-foreground')}
+            >
+              {showError ? labels.displayNameTooLong : labels.displayNameHelper}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+            <Button
+              type="submit"
+              data-slot="public-rsvp-accept"
+              data-pending={submittingAction === 'Accepted' ? 'true' : 'false'}
+              disabled={allDisabled}
+              onClick={handleClick('Accepted')}
+              className="flex-1 bg-success text-success-foreground hover:bg-success/90"
+            >
+              {submittingAction === 'Accepted' ? labels.submitting : labels.accept}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              data-slot="public-rsvp-decline"
+              data-pending={submittingAction === 'Declined' ? 'true' : 'false'}
+              disabled={allDisabled}
+              onClick={handleClick('Declined')}
+              className="flex-1"
+            >
+              {submittingAction === 'Declined' ? labels.submitting : labels.decline}
+            </Button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/__tests__/GameNightDetailHero.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/__tests__/GameNightDetailHero.test.tsx
@@ -120,4 +120,49 @@ describe('GameNightDetailHero', () => {
     const hero = screen.getByTestId('game-night-detail-hero');
     expect(within(hero).getByText('Annullata')).toBeInTheDocument();
   });
+
+  describe('mode prop (issue #1169)', () => {
+    it('defaults to data-mode="authenticated" when prop is omitted', () => {
+      render(<GameNightDetailHero {...baseProps} labels={baseLabels} />);
+      expect(screen.getByTestId('game-night-detail-hero')).toHaveAttribute(
+        'data-mode',
+        'authenticated'
+      );
+    });
+
+    it('sets data-mode="public" when mode="public" is passed', () => {
+      render(<GameNightDetailHero {...baseProps} labels={baseLabels} mode="public" />);
+      expect(screen.getByTestId('game-night-detail-hero')).toHaveAttribute('data-mode', 'public');
+    });
+
+    it('suppresses the location button affordance in mode="public"', () => {
+      const onOpenLocation = vi.fn();
+      render(
+        <GameNightDetailHero
+          {...baseProps}
+          labels={{ ...baseLabels, locationLine: 'Casa Marco · Padova' }}
+          onOpenLocation={onOpenLocation}
+          mode="public"
+        />
+      );
+      // Location is rendered as static text, not as an interactive button.
+      expect(screen.getByText('Casa Marco · Padova')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Casa Marco · Padova/ })).not.toBeInTheDocument();
+    });
+
+    it('still renders the location button in mode="authenticated" (default)', async () => {
+      const user = userEvent.setup();
+      const onOpenLocation = vi.fn();
+      render(
+        <GameNightDetailHero
+          {...baseProps}
+          labels={{ ...baseLabels, locationLine: 'Casa Marco · Padova' }}
+          onOpenLocation={onOpenLocation}
+        />
+      );
+      const btn = screen.getByRole('button', { name: /Casa Marco · Padova/ });
+      await user.click(btn);
+      expect(onOpenLocation).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/apps/web/src/components/features/game-night-detail/__tests__/GameNightRsvpActionBar.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/__tests__/GameNightRsvpActionBar.test.tsx
@@ -97,4 +97,24 @@ describe('GameNightRsvpActionBar', () => {
     // Entity tokens for selected state come from BUTTONS config — verify success palette applied.
     expect(acceptBtn.className).toContain('bg-success');
   });
+
+  describe('mode prop (issue #1169)', () => {
+    it('defaults to authenticated mode (all three buttons + Maybe visible)', () => {
+      renderBar();
+      expect(screen.getByTestId('rsvp-btn-accepted')).toBeInTheDocument();
+      expect(screen.getByTestId('rsvp-btn-maybe')).toBeInTheDocument();
+      expect(screen.getByTestId('rsvp-btn-declined')).toBeInTheDocument();
+      const region = screen.getByRole('region', { name: 'La tua risposta' });
+      expect(region).toHaveAttribute('data-mode', 'authenticated');
+    });
+
+    it('hides the Maybe button in mode="public" (backend only accepts Accepted/Declined)', () => {
+      renderBar({ mode: 'public' });
+      expect(screen.getByTestId('rsvp-btn-accepted')).toBeInTheDocument();
+      expect(screen.queryByTestId('rsvp-btn-maybe')).not.toBeInTheDocument();
+      expect(screen.getByTestId('rsvp-btn-declined')).toBeInTheDocument();
+      const region = screen.getByRole('region', { name: 'La tua risposta' });
+      expect(region).toHaveAttribute('data-mode', 'public');
+    });
+  });
 });

--- a/apps/web/src/components/features/game-night-detail/__tests__/GameNightRsvpRow.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/__tests__/GameNightRsvpRow.test.tsx
@@ -77,4 +77,26 @@ describe('GameNightRsvpRow', () => {
     const row = screen.getByTestId('game-night-rsvp-row');
     expect(within(row).getByText('×')).toBeInTheDocument();
   });
+
+  describe('mode prop (issue #1169)', () => {
+    it('defaults to data-mode="authenticated" when prop is omitted', () => {
+      render(<GameNightRsvpRow {...baseProps} isMe />);
+      const row = screen.getByTestId('game-night-rsvp-row');
+      expect(row).toHaveAttribute('data-mode', 'authenticated');
+    });
+
+    it('exposes data-mode="public" and forces isMe to false in public mode', () => {
+      render(<GameNightRsvpRow {...baseProps} isMe mode="public" />);
+      const row = screen.getByTestId('game-night-rsvp-row');
+      expect(row).toHaveAttribute('data-mode', 'public');
+      // isMe is silently coerced to false on public surfaces.
+      expect(row).toHaveAttribute('data-is-me', 'false');
+      expect(within(row).queryByText('me')).toBeNull();
+    });
+
+    it('still renders host pill in public mode', () => {
+      render(<GameNightRsvpRow {...baseProps} isHost hostLabel="host" mode="public" />);
+      expect(screen.getByText('host')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/features/game-night-detail/__tests__/PublicRsvpForm.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/__tests__/PublicRsvpForm.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for PublicRsvpForm (issue #1169).
+ *
+ * Covers:
+ *   - Pending mode: renders form, captures displayName + action submit
+ *   - Already-responded mode: confirmation panel + change CTA
+ *   - displayName validation: max 120, trimmed, optional
+ *   - Submitting state: spinners + disabled CTAs
+ *   - a11y: label association, aria-invalid on validation error
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH,
+  PublicRsvpForm,
+  type PublicRsvpFormLabels,
+  type PublicRsvpFormProps,
+} from '../PublicRsvpForm';
+
+const LABELS: PublicRsvpFormLabels = {
+  sectionTitle: 'La tua risposta',
+  displayNameLabel: 'Il tuo nome (opzionale)',
+  displayNamePlaceholder: 'Es. Marco',
+  displayNameHelper: "Aiuta l'organizzatore a riconoscerti.",
+  displayNameTooLong: 'Massimo 120 caratteri.',
+  accept: 'Confermo',
+  decline: 'Non posso',
+  submitting: 'Invio…',
+  alreadyRespondedHeading: 'Hai già risposto',
+  alreadyRespondedBody: 'Hai confermato come "Marco".',
+  changeResponse: 'Cambia risposta',
+};
+
+function renderForm(overrides: Partial<PublicRsvpFormProps> = {}) {
+  const props: PublicRsvpFormProps = {
+    labels: LABELS,
+    currentResponse: undefined,
+    submittingAction: null,
+    onSubmit: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<PublicRsvpForm {...props} />);
+  return { ...utils, onSubmit: props.onSubmit };
+}
+
+describe('PublicRsvpForm', () => {
+  describe('pending mode', () => {
+    it('renders both Accept and Decline buttons + the display-name input', () => {
+      renderForm();
+      expect(screen.getByRole('button', { name: 'Confermo' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Non posso' })).toBeInTheDocument();
+      expect(screen.getByLabelText(LABELS.displayNameLabel)).toBeInTheDocument();
+    });
+
+    it('submits Accepted with null displayName when input is empty', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      renderForm({ onSubmit });
+
+      await user.click(screen.getByRole('button', { name: 'Confermo' }));
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit).toHaveBeenCalledWith('Accepted', null);
+    });
+
+    it('submits Declined with the typed displayName trimmed', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      renderForm({ onSubmit });
+
+      await user.type(screen.getByLabelText(LABELS.displayNameLabel), '  Marco  ');
+      await user.click(screen.getByRole('button', { name: 'Non posso' }));
+      expect(onSubmit).toHaveBeenCalledWith('Declined', 'Marco');
+    });
+
+    it('shows validation error when displayName exceeds 120 characters', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      renderForm({ onSubmit });
+
+      const input = screen.getByLabelText(LABELS.displayNameLabel);
+      // Type 121 chars by triggering blur after a paste-like fill — userEvent
+      // honors the maxLength={121} on the input, so we get exactly 121 chars.
+      const overLength = 'a'.repeat(PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH + 1);
+      await user.click(input);
+      await user.paste(overLength);
+      await user.tab();
+
+      expect(screen.getByText(LABELS.displayNameTooLong)).toBeInTheDocument();
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+
+      // Clicking accept does NOT submit while invalid.
+      await user.click(screen.getByRole('button', { name: 'Confermo' }));
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('disables CTAs while submitting and shows the submitting label on the in-flight button', () => {
+      renderForm({ submittingAction: 'Accepted' });
+      const acceptBtn = screen.getByRole('button', { name: LABELS.submitting });
+      expect(acceptBtn).toBeDisabled();
+      expect(acceptBtn).toHaveAttribute('data-pending', 'true');
+
+      const declineBtn = screen.getByRole('button', { name: 'Non posso' });
+      expect(declineBtn).toBeDisabled();
+    });
+
+    it('respects the `disabled` prop on all CTAs and the input', () => {
+      renderForm({ disabled: true });
+      expect(screen.getByRole('button', { name: 'Confermo' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Non posso' })).toBeDisabled();
+      expect(screen.getByLabelText(LABELS.displayNameLabel)).toBeDisabled();
+    });
+
+    it('associates the helper text via aria-describedby for a11y', () => {
+      renderForm();
+      const input = screen.getByLabelText(LABELS.displayNameLabel);
+      const describedById = input.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      const helper = describedById ? document.getElementById(describedById) : null;
+      expect(helper).toHaveTextContent(LABELS.displayNameHelper);
+    });
+  });
+
+  describe('already-responded mode', () => {
+    it('renders the heading, body, and change CTA instead of the form', () => {
+      renderForm({ currentResponse: 'Accepted' });
+
+      expect(screen.getByText(LABELS.alreadyRespondedHeading)).toBeInTheDocument();
+      expect(screen.getByText(LABELS.alreadyRespondedBody)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: LABELS.changeResponse })).toBeInTheDocument();
+
+      // The accept/decline CTAs and the input MUST not be rendered.
+      expect(screen.queryByRole('button', { name: 'Confermo' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Non posso' })).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(LABELS.displayNameLabel)).not.toBeInTheDocument();
+    });
+
+    it('exposes data-mode="responded" for the outer section', () => {
+      renderForm({ currentResponse: 'Declined' });
+      const root = screen.getByLabelText(LABELS.sectionTitle);
+      expect(root).toHaveAttribute('data-mode', 'responded');
+    });
+  });
+});

--- a/apps/web/src/components/features/game-night-detail/error-states/ExpiredOrCancelledError.tsx
+++ b/apps/web/src/components/features/game-night-detail/error-states/ExpiredOrCancelledError.tsx
@@ -1,0 +1,75 @@
+/**
+ * ExpiredOrCancelledError — terminal surface for 410 Gone on /join/event/[code]
+ * (issue #1169). Used for tokens that are Expired, Revoked, or whose game
+ * night was Cancelled by the host.
+ *
+ * The `kind` discriminator only changes copy — both states are terminal and
+ * irrecoverable from the public surface; the CTA invites the recipient to
+ * request a fresh invite from the host. We deliberately don't expose a "retry"
+ * affordance because the underlying entity is gone.
+ */
+
+import Link from 'next/link';
+
+export type ExpiredOrCancelledKind = 'expired' | 'cancelled';
+
+export interface ExpiredOrCancelledErrorLabels {
+  readonly expired: {
+    readonly heading: string;
+    readonly body: string;
+  };
+  readonly cancelled: {
+    readonly heading: string;
+    readonly body: string;
+  };
+  readonly requestNewInviteCta: string;
+  readonly homeCta: string;
+}
+
+export interface ExpiredOrCancelledErrorProps {
+  readonly kind: ExpiredOrCancelledKind;
+  readonly labels: ExpiredOrCancelledErrorLabels;
+}
+
+export function ExpiredOrCancelledError({
+  kind,
+  labels,
+}: ExpiredOrCancelledErrorProps): React.JSX.Element {
+  const copy = kind === 'expired' ? labels.expired : labels.cancelled;
+  const icon = kind === 'expired' ? '⌛' : '🚫';
+
+  return (
+    <section
+      data-slot="public-join-event-gone"
+      data-kind={kind}
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-center gap-4 px-5 py-8 text-center"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted text-2xl"
+      >
+        {icon}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <h1 className="font-display text-lg font-extrabold text-foreground">{copy.heading}</h1>
+        <p className="text-sm text-muted-foreground">{copy.body}</p>
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+        <Link
+          href="/contact"
+          className="inline-flex items-center justify-center rounded-md border-0 bg-primary px-3.5 py-2.5 font-display text-sm font-bold text-primary-foreground no-underline hover:bg-primary/90"
+        >
+          {labels.requestNewInviteCta}
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center rounded-md border border-border bg-muted px-3.5 py-2.5 font-display text-sm font-bold text-foreground no-underline hover:bg-muted/80"
+        >
+          {labels.homeCta}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/error-states/GenericError.tsx
+++ b/apps/web/src/components/features/game-night-detail/error-states/GenericError.tsx
@@ -1,0 +1,56 @@
+/**
+ * GenericError — fallback surface for 5xx / network failures on
+ * /join/event/[code] (issue #1169). Unlike the terminal 404/410 surfaces
+ * this one offers a retry CTA because the underlying error is transient.
+ */
+
+'use client';
+
+import { Button } from '@/components/ui/primitives/button';
+
+export interface GenericErrorLabels {
+  readonly heading: string;
+  readonly body: string;
+  readonly retryCta: string;
+}
+
+export interface GenericErrorProps {
+  readonly labels: GenericErrorLabels;
+  readonly onRetry: () => void;
+  readonly isRetrying?: boolean;
+}
+
+export function GenericError({
+  labels,
+  onRetry,
+  isRetrying = false,
+}: GenericErrorProps): React.JSX.Element {
+  return (
+    <section
+      data-slot="public-join-event-generic-error"
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-center gap-4 px-5 py-8 text-center"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted text-2xl"
+      >
+        ⚠️
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <h1 className="font-display text-lg font-extrabold text-foreground">{labels.heading}</h1>
+        <p className="text-sm text-muted-foreground">{labels.body}</p>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        data-slot="public-join-event-generic-error-retry"
+        disabled={isRetrying}
+        onClick={onRetry}
+      >
+        {labels.retryCta}
+      </Button>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/error-states/InvalidTokenError.tsx
+++ b/apps/web/src/components/features/game-night-detail/error-states/InvalidTokenError.tsx
@@ -1,0 +1,49 @@
+/**
+ * InvalidTokenError — terminal surface for malformed / unknown tokens on the
+ * public /join/event/[code] route (issue #1169). Mirrors the FSM
+ * `token-invalid` state surfaced by `useGameNightInvitation` on 404.
+ *
+ * Pure presentational, i18n-agnostic (caller resolves all labels). The body
+ * copy intentionally avoids leaking *which* token was attempted to keep the
+ * page robust against typosquatting / token-enumeration probes.
+ */
+
+import Link from 'next/link';
+
+export interface InvalidTokenErrorLabels {
+  readonly heading: string;
+  readonly body: string;
+  readonly homeCta: string;
+}
+
+export interface InvalidTokenErrorProps {
+  readonly labels: InvalidTokenErrorLabels;
+}
+
+export function InvalidTokenError({ labels }: InvalidTokenErrorProps): React.JSX.Element {
+  return (
+    <section
+      data-slot="public-join-event-invalid-token"
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-center gap-4 px-5 py-8 text-center"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted text-2xl"
+      >
+        🔍
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <h1 className="font-display text-lg font-extrabold text-foreground">{labels.heading}</h1>
+        <p className="text-sm text-muted-foreground">{labels.body}</p>
+      </div>
+      <Link
+        href="/"
+        className="inline-flex items-center justify-center rounded-md border border-border bg-muted px-3.5 py-2.5 font-display text-sm font-bold text-foreground no-underline hover:bg-muted/80"
+      >
+        {labels.homeCta}
+      </Link>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/error-states/RateLimitedError.tsx
+++ b/apps/web/src/components/features/game-night-detail/error-states/RateLimitedError.tsx
@@ -1,0 +1,98 @@
+/**
+ * RateLimitedError — surface for 429 Too Many Requests on /join/event/[code]
+ * (issue #1169). The backend caps the public endpoints at 60 req/min/IP (GET)
+ * and 10 req/min/IP (POST). When the user hits the cap we render this banner
+ * with a live countdown sourced from the `Retry-After` response header.
+ *
+ * Countdown:
+ *   - Stops at 0 and reveals the "Retry now" CTA.
+ *   - Disabled when `retryAfterSeconds` is null (header missing) — we just
+ *     show the static retry CTA.
+ *   - Pure presentational: the parent passes the initial seconds value and
+ *     handles the retry click (typically `useGameNightInvitation.refetch()`
+ *     or `useRespondToInvitation.reset()`).
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/primitives/button';
+
+export interface RateLimitedErrorLabels {
+  readonly heading: string;
+  readonly body: string;
+  readonly countdown: (secondsLeft: number) => string;
+  readonly retryCta: string;
+}
+
+export interface RateLimitedErrorProps {
+  /** Seconds parsed from the `Retry-After` header; null when missing. */
+  readonly retryAfterSeconds: number | null;
+  readonly labels: RateLimitedErrorLabels;
+  readonly onRetry: () => void;
+}
+
+export function RateLimitedError({
+  retryAfterSeconds,
+  labels,
+  onRetry,
+}: RateLimitedErrorProps): React.JSX.Element {
+  const initialSeconds =
+    retryAfterSeconds !== null && retryAfterSeconds > 0 ? retryAfterSeconds : 0;
+  const [secondsLeft, setSecondsLeft] = useState<number>(initialSeconds);
+
+  useEffect(() => {
+    // Re-seed when the parent passes a fresh retryAfter (e.g. user retried
+    // and got rate-limited again with a different window).
+    setSecondsLeft(retryAfterSeconds !== null && retryAfterSeconds > 0 ? retryAfterSeconds : 0);
+  }, [retryAfterSeconds]);
+
+  useEffect(() => {
+    if (secondsLeft <= 0) return;
+    const id = setInterval(() => {
+      setSecondsLeft(prev => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [secondsLeft]);
+
+  const canRetry = secondsLeft <= 0;
+
+  return (
+    <section
+      data-slot="public-join-event-rate-limited"
+      role="alert"
+      aria-live="polite"
+      className="flex flex-col items-center gap-4 px-5 py-8 text-center"
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted text-2xl"
+      >
+        ⏱️
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <h1 className="font-display text-lg font-extrabold text-foreground">{labels.heading}</h1>
+        <p className="text-sm text-muted-foreground">{labels.body}</p>
+      </div>
+      {canRetry ? (
+        <Button
+          type="button"
+          variant="outline"
+          data-slot="public-join-event-rate-limited-retry"
+          onClick={onRetry}
+        >
+          {labels.retryCta}
+        </Button>
+      ) : (
+        <p
+          data-slot="public-join-event-rate-limited-countdown"
+          className="font-mono text-sm font-bold text-muted-foreground"
+          aria-live="polite"
+        >
+          {labels.countdown(secondsLeft)}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/index.ts
+++ b/apps/web/src/components/features/game-night-detail/index.ts
@@ -38,3 +38,30 @@ export {
   type GameNightCancelledBannerLabels,
   type GameNightCancelledBannerProps,
 } from './GameNightCancelledBanner';
+export {
+  PublicRsvpForm,
+  PUBLIC_RSVP_DISPLAY_NAME_MAX_LENGTH,
+  type PublicRsvpFormLabels,
+  type PublicRsvpFormProps,
+} from './PublicRsvpForm';
+export {
+  InvalidTokenError,
+  type InvalidTokenErrorLabels,
+  type InvalidTokenErrorProps,
+} from './error-states/InvalidTokenError';
+export {
+  ExpiredOrCancelledError,
+  type ExpiredOrCancelledErrorLabels,
+  type ExpiredOrCancelledErrorProps,
+  type ExpiredOrCancelledKind,
+} from './error-states/ExpiredOrCancelledError';
+export {
+  RateLimitedError,
+  type RateLimitedErrorLabels,
+  type RateLimitedErrorProps,
+} from './error-states/RateLimitedError';
+export {
+  GenericError,
+  type GenericErrorLabels,
+  type GenericErrorProps,
+} from './error-states/GenericError';

--- a/apps/web/src/hooks/__tests__/useGameNightInvitation.test.ts
+++ b/apps/web/src/hooks/__tests__/useGameNightInvitation.test.ts
@@ -38,7 +38,9 @@ const { useQuery } = await import('@tanstack/react-query');
 import {
   getInvitation,
   InvitationFetchError,
+  InvitationGoneError,
   InvitationNotFoundError,
+  InvitationRateLimitedError,
   type PublicGameNightInvitation,
 } from '@/lib/api/game-night-invitations';
 
@@ -196,6 +198,46 @@ describe('useGameNightInvitation (Wave A.5b)', () => {
     const transient = new InvitationFetchError(503, 'Server unavailable');
     expect(capturedRetry!(0, transient)).toBe(true); // first failure → retry
     expect(capturedRetry!(1, transient)).toBe(false); // second failure → stop
+  });
+
+  it('does NOT retry on InvitationGoneError (issue #1169 — 410 is terminal)', () => {
+    let capturedRetry: ((failureCount: number, error: Error) => boolean) | undefined;
+    vi.mocked(useQuery).mockImplementation((opts: Record<string, unknown>) => {
+      capturedRetry = opts.retry as (failureCount: number, error: Error) => boolean;
+      return {
+        data: undefined,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useQuery>;
+    });
+
+    renderHook(() => useGameNightInvitation({ token: 'tok-abc' }));
+
+    expect(capturedRetry).toBeDefined();
+    expect(capturedRetry!(0, new InvitationGoneError('tok-abc'))).toBe(false);
+  });
+
+  it('does NOT retry on InvitationRateLimitedError (issue #1169 — 429 is structural)', () => {
+    let capturedRetry: ((failureCount: number, error: Error) => boolean) | undefined;
+    vi.mocked(useQuery).mockImplementation((opts: Record<string, unknown>) => {
+      capturedRetry = opts.retry as (failureCount: number, error: Error) => boolean;
+      return {
+        data: undefined,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useQuery>;
+    });
+
+    renderHook(() => useGameNightInvitation({ token: 'tok-abc' }));
+
+    expect(capturedRetry).toBeDefined();
+    expect(capturedRetry!(0, new InvitationRateLimitedError(30))).toBe(false);
   });
 
   it('exposes refetch as a void-returning async function', async () => {

--- a/apps/web/src/hooks/__tests__/useRespondToInvitation.test.ts
+++ b/apps/web/src/hooks/__tests__/useRespondToInvitation.test.ts
@@ -186,11 +186,12 @@ describe('useRespondToInvitation (Wave A.5b)', () => {
   });
 
   describe('mutationFn wiring', () => {
-    it('configures mutationFn to invoke respondToInvitation with token + action', async () => {
+    it('configures mutationFn to invoke respondToInvitation with token + action + displayName', async () => {
       let capturedMutationFn:
         | ((vars: {
             token: string;
             action: 'Accepted' | 'Declined';
+            displayName?: string | null;
           }) => Promise<RespondToInvitationResult>)
         | undefined;
 
@@ -204,8 +205,35 @@ describe('useRespondToInvitation (Wave A.5b)', () => {
 
       expect(capturedMutationFn).toBeDefined();
       const out = await capturedMutationFn!({ token: 'tok-xyz', action: 'Accepted' });
-      expect(respondToInvitation).toHaveBeenCalledWith('tok-xyz', 'Accepted');
+      // Issue #1169: third arg is the optional displayName, defaults to null
+      // when omitted by the caller.
+      expect(respondToInvitation).toHaveBeenCalledWith('tok-xyz', 'Accepted', null);
       expect(out).toEqual(SUCCESS_RESULT);
+    });
+
+    it('forwards a typed displayName through the mutationFn (issue #1169)', async () => {
+      let capturedMutationFn:
+        | ((vars: {
+            token: string;
+            action: 'Accepted' | 'Declined';
+            displayName?: string | null;
+          }) => Promise<RespondToInvitationResult>)
+        | undefined;
+
+      vi.mocked(useMutation).mockImplementation((opts: Record<string, unknown>) => {
+        capturedMutationFn = opts.mutationFn as typeof capturedMutationFn;
+        return buildMockMutation();
+      });
+      vi.mocked(respondToInvitation).mockResolvedValue(SUCCESS_RESULT);
+
+      renderHook(() => useRespondToInvitation({ token: 'tok-xyz' }));
+
+      await capturedMutationFn!({
+        token: 'tok-xyz',
+        action: 'Declined',
+        displayName: 'Marco',
+      });
+      expect(respondToInvitation).toHaveBeenCalledWith('tok-xyz', 'Declined', 'Marco');
     });
   });
 
@@ -218,8 +246,28 @@ describe('useRespondToInvitation (Wave A.5b)', () => {
 
       const out = await result.current.submit('Accepted');
 
-      expect(mutateAsync).toHaveBeenCalledWith({ token: 'tok-abc', action: 'Accepted' });
+      // displayName defaults to null when caller omits it (issue #1169).
+      expect(mutateAsync).toHaveBeenCalledWith({
+        token: 'tok-abc',
+        action: 'Accepted',
+        displayName: null,
+      });
       expect(out).toEqual(SUCCESS_RESULT);
+    });
+
+    it('forwards an explicit displayName through mutateAsync (issue #1169)', async () => {
+      const mutateAsync = vi.fn().mockResolvedValue(SUCCESS_RESULT);
+      vi.mocked(useMutation).mockReturnValue(buildMockMutation({ mutateAsync }));
+
+      const { result } = renderHook(() => useRespondToInvitation({ token: 'tok-abc' }));
+
+      await result.current.submit('Accepted', 'Marco');
+
+      expect(mutateAsync).toHaveBeenCalledWith({
+        token: 'tok-abc',
+        action: 'Accepted',
+        displayName: 'Marco',
+      });
     });
 
     it('returns null and SWALLOWS rejection on error (no unhandled rejection)', async () => {
@@ -234,7 +282,11 @@ describe('useRespondToInvitation (Wave A.5b)', () => {
       const out = await result.current.submit('Declined');
 
       expect(out).toBeNull();
-      expect(mutateAsync).toHaveBeenCalledWith({ token: 'tok-abc', action: 'Declined' });
+      expect(mutateAsync).toHaveBeenCalledWith({
+        token: 'tok-abc',
+        action: 'Declined',
+        displayName: null,
+      });
     });
 
     it('passes the supplied action through to mutateAsync', async () => {
@@ -246,8 +298,48 @@ describe('useRespondToInvitation (Wave A.5b)', () => {
       await result.current.submit('Accepted');
       await result.current.submit('Declined');
 
-      expect(mutateAsync).toHaveBeenNthCalledWith(1, { token: 'tok-abc', action: 'Accepted' });
-      expect(mutateAsync).toHaveBeenNthCalledWith(2, { token: 'tok-abc', action: 'Declined' });
+      expect(mutateAsync).toHaveBeenNthCalledWith(1, {
+        token: 'tok-abc',
+        action: 'Accepted',
+        displayName: null,
+      });
+      expect(mutateAsync).toHaveBeenNthCalledWith(2, {
+        token: 'tok-abc',
+        action: 'Declined',
+        displayName: null,
+      });
+    });
+  });
+
+  describe('issue #1169 FSM extensions', () => {
+    it('derives rate-limited when result.kind="rate-limited"', () => {
+      const RATE_LIMITED: RespondToInvitationResult = {
+        kind: 'rate-limited',
+        retryAfter: 30,
+      };
+      vi.mocked(useMutation).mockReturnValue(
+        buildMockMutation({ status: 'success', data: RATE_LIMITED })
+      );
+
+      const { result } = renderHook(() => useRespondToInvitation({ token: 'tok-abc' }));
+
+      expect(result.current.state).toBe('rate-limited');
+      expect(result.current.result).toEqual(RATE_LIMITED);
+    });
+
+    it('derives invalid-display-name when result.kind="invalid-display-name"', () => {
+      const INVALID: RespondToInvitationResult = {
+        kind: 'invalid-display-name',
+        message: 'Display name must be 120 characters or fewer.',
+      };
+      vi.mocked(useMutation).mockReturnValue(
+        buildMockMutation({ status: 'success', data: INVALID })
+      );
+
+      const { result } = renderHook(() => useRespondToInvitation({ token: 'tok-abc' }));
+
+      expect(result.current.state).toBe('invalid-display-name');
+      expect(result.current.result).toEqual(INVALID);
     });
   });
 

--- a/apps/web/src/hooks/useGameNightInvitation.ts
+++ b/apps/web/src/hooks/useGameNightInvitation.ts
@@ -26,7 +26,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import {
   getInvitation,
+  InvitationGoneError,
   InvitationNotFoundError,
+  InvitationRateLimitedError,
   type PublicGameNightInvitation,
 } from '@/lib/api/game-night-invitations';
 
@@ -59,8 +61,12 @@ export function useGameNightInvitation(
     staleTime: STALE_MS,
     enabled: args.token.length > 0,
     retry: (failureCount, error) => {
-      // 404 token is a structural UX state, not a transient error — don't retry.
+      // 404 token unknown, 410 token in terminal state, and 429 rate-limited are
+      // structural UX states (not transient errors) — don't retry. Other errors
+      // (network / 5xx) get a single retry to recover from transient failures.
       if (error instanceof InvitationNotFoundError) return false;
+      if (error instanceof InvitationGoneError) return false;
+      if (error instanceof InvitationRateLimitedError) return false;
       return failureCount < 1;
     },
   });

--- a/apps/web/src/hooks/useRespondToInvitation.ts
+++ b/apps/web/src/hooks/useRespondToInvitation.ts
@@ -1,23 +1,30 @@
 /**
- * useRespondToInvitation — RSVP mutation FSM hook for /invites/[token].
+ * useRespondToInvitation — RSVP mutation FSM hook for /invites/[token]
+ * and the public /join/event/[code] surface (issue #1169).
  *
- * Wave A.5b (Issue #611). Wraps `respondToInvitation()` in a TanStack Query
- * mutation and exposes a 5-state FSM that the page-client renders against.
+ * Wave A.5b (Issue #611) original 5-state FSM, extended by issue #1169 with
+ * two additional terminal states surfaced by the public anonymous RSVP path:
  *
- *     idle ─submit→ submitting ─{200 success}→  success      (with action accepted/declined)
- *                                ─{409}→         conflict     (state switch attempted)
- *                                ─{410}→         gone         (terminal: expired/cancelled)
- *                                ─{5xx,network}→ error
+ *     idle ─submit→ submitting ─{200 success}→     success            (action accepted/declined)
+ *                                ─{409}→            conflict           (state switch attempted)
+ *                                ─{410}→            gone               (terminal: expired/cancelled)
+ *                                ─{429}→            rate-limited       (#1169 — backend 10/min/IP cap)
+ *                                ─{400 displayName}→ invalid-display-name (#1169 — defensive)
+ *                                ─{5xx,network}→    error
  *     conflict ─submit→ submitting (caller can re-attempt)
- *     gone / success ─reset→ idle
+ *     gone / success / rate-limited / invalid-display-name ─reset→ idle
  *
  * The hook is intentionally form-agnostic. The page-client is responsible for:
  *   - Calling `refetch` on the GET query after a 409 (so `alreadyRespondedAs`
  *     surfaces and the FSM derives `already-accepted` / `declined`).
  *   - Mounting the confetti overlay on `success` of action `'Accepted'`.
  *
- * `respondToInvitation` never throws on 409/410 (those are valid FSM
+ * `respondToInvitation` never throws on 409/410/429/400 (those are valid FSM
  * transitions); it throws only on 5xx / network / parse / unknown 4xx.
+ *
+ * Issue #1169 wire delta: `submit(action, displayName?)` — optional second
+ * argument carries the guest-supplied display name. Backward compatible:
+ * single-arg callers (the legacy /invites/[token] route) continue to work.
  */
 
 'use client';
@@ -32,7 +39,15 @@ import {
   type RsvpAction,
 } from '@/lib/api/game-night-invitations';
 
-export type RespondState = 'idle' | 'submitting' | 'success' | 'conflict' | 'gone' | 'error';
+export type RespondState =
+  | 'idle'
+  | 'submitting'
+  | 'success'
+  | 'conflict'
+  | 'gone'
+  | 'rate-limited'
+  | 'invalid-display-name'
+  | 'error';
 
 export interface UseRespondToInvitationArgs {
   readonly token: string;
@@ -42,13 +57,17 @@ export interface UseRespondToInvitationReturn {
   readonly state: RespondState;
   readonly result: RespondToInvitationResult | null;
   readonly error: Error | null;
-  readonly submit: (action: RsvpAction) => Promise<RespondToInvitationResult | null>;
+  readonly submit: (
+    action: RsvpAction,
+    displayName?: string | null
+  ) => Promise<RespondToInvitationResult | null>;
   readonly reset: () => void;
 }
 
 interface MutationVariables {
   readonly token: string;
   readonly action: RsvpAction;
+  readonly displayName?: string | null;
 }
 
 function deriveState(
@@ -61,6 +80,8 @@ function deriveState(
     if (result.kind === 'success') return 'success';
     if (result.kind === 'conflict-state-switch') return 'conflict';
     if (result.kind === 'gone') return 'gone';
+    if (result.kind === 'rate-limited') return 'rate-limited';
+    if (result.kind === 'invalid-display-name') return 'invalid-display-name';
   }
   return 'idle';
 }
@@ -69,7 +90,8 @@ export function useRespondToInvitation(
   args: UseRespondToInvitationArgs
 ): UseRespondToInvitationReturn {
   const mutation = useMutation<RespondToInvitationResult, Error, MutationVariables>({
-    mutationFn: ({ token, action }) => respondToInvitation(token, action),
+    mutationFn: ({ token, action, displayName }) =>
+      respondToInvitation(token, action, displayName ?? null),
   });
 
   const state = useMemo(
@@ -78,9 +100,16 @@ export function useRespondToInvitation(
   );
 
   const submit = useCallback(
-    async (action: RsvpAction): Promise<RespondToInvitationResult | null> => {
+    async (
+      action: RsvpAction,
+      displayName?: string | null
+    ): Promise<RespondToInvitationResult | null> => {
       try {
-        const res = await mutation.mutateAsync({ token: args.token, action });
+        const res = await mutation.mutateAsync({
+          token: args.token,
+          action,
+          displayName: displayName ?? null,
+        });
         return res;
       } catch {
         // Error state is exposed via `error` field; swallow the throw so the

--- a/apps/web/src/lib/api/game-night-invitations.ts
+++ b/apps/web/src/lib/api/game-night-invitations.ts
@@ -52,6 +52,17 @@ export const PublicGameNightInvitationSchema = z.object({
   primaryGameName: z.string().nullable(),
   primaryGameImageUrl: z.string().nullable(),
   alreadyRespondedAs: z.enum(['Accepted', 'Declined']).nullable(),
+  /**
+   * Issue #1169 backend delta: guest-supplied display name captured at RSVP
+   * time, used to render "Already responded as 'Marco'" surfaces on the public
+   * /join/event/[code] page. Null for pending invitations and for historical
+   * responses persisted before the column was added.
+   *
+   * Optional in the JSON wire (omitted by backends that have not shipped the
+   * delta) — type stays `string | null | undefined` to preserve compatibility
+   * with the Wave A.5b legacy `/invites/[token]` consumer.
+   */
+  respondedByName: z.string().nullable().optional(),
 });
 
 export type PublicGameNightInvitation = z.infer<typeof PublicGameNightInvitationSchema>;
@@ -67,6 +78,11 @@ export type RsvpAction = 'Accepted' | 'Declined';
  * persist a single value into FSM state. The `kind` discriminator drives
  * UI state derivation (`accepted-success` / `declined` / `token-expired` /
  * `error`) without surfacing HTTP plumbing to components.
+ *
+ * Issue #1169 added `rate-limited` (HTTP 429) for the public /join/event/[code]
+ * surface — backend imposes 10 req/min/IP on POST. The optional `retryAfter`
+ * (seconds) is parsed from the `Retry-After` response header when present so
+ * the UI can render a countdown.
  */
 export type RespondToInvitationResult =
   | {
@@ -82,6 +98,14 @@ export type RespondToInvitationResult =
   | {
       readonly kind: 'gone';
       readonly reason: 'expired' | 'cancelled' | 'past-expiry';
+    }
+  | {
+      readonly kind: 'rate-limited';
+      readonly retryAfter: number | null;
+    }
+  | {
+      readonly kind: 'invalid-display-name';
+      readonly message: string;
     };
 
 // ========== Errors ==========
@@ -110,6 +134,34 @@ export class InvitationNotFoundError extends Error {
   constructor(token: string) {
     super(`Invitation token not found: ${token.slice(0, 6)}…`);
     this.name = 'InvitationNotFoundError';
+  }
+}
+
+/**
+ * Issue #1169: 410 Gone on the GET endpoint — token is in a terminal state
+ * (Expired or Cancelled). Distinct from `InvitationNotFoundError` (404) and
+ * `InvitationFetchError` (transient) so the public /join/event/[code] surface
+ * can route directly to the dedicated 410 banner without an extra refetch.
+ */
+export class InvitationGoneError extends Error {
+  constructor(token: string) {
+    super(`Invitation token is in a terminal state: ${token.slice(0, 6)}…`);
+    this.name = 'InvitationGoneError';
+  }
+}
+
+/**
+ * Issue #1169: 429 Too Many Requests from the public read endpoint (60/min/IP)
+ * or respond endpoint (10/min/IP). `retryAfter` is the parsed Retry-After
+ * header in seconds (null when header missing or non-numeric).
+ */
+export class InvitationRateLimitedError extends Error {
+  public readonly retryAfter: number | null;
+
+  constructor(retryAfter: number | null) {
+    super('Invitation rate limit exceeded');
+    this.name = 'InvitationRateLimitedError';
+    this.retryAfter = retryAfter;
   }
 }
 
@@ -160,6 +212,24 @@ export async function getInvitation(
     throw new InvitationNotFoundError(token);
   }
 
+  if (response.status === 410) {
+    // Token-expired / cancelled on the GET path. Distinct from generic fetch
+    // failure so the FSM can route to the dedicated 410 surface (issue #1169).
+    throw new InvitationGoneError(token);
+  }
+
+  if (response.status === 429) {
+    // Backend rate-limit (60 req/min/IP). Surfaced as a typed error so the
+    // public /join/event surface can render a rate-limited banner with a
+    // Retry-After countdown when present (issue #1169).
+    const retryAfterRaw = response.headers.get('Retry-After');
+    const retryAfter =
+      retryAfterRaw && /^\d+$/.test(retryAfterRaw.trim())
+        ? Number.parseInt(retryAfterRaw.trim(), 10)
+        : null;
+    throw new InvitationRateLimitedError(retryAfter);
+  }
+
   if (!response.ok) {
     throw new InvitationFetchError(
       response.status,
@@ -187,13 +257,33 @@ export async function getInvitation(
  * POST the RSVP action. Maps every D2(b) outcome onto the discriminated
  * union — never throws on 409 or 410 because those are valid FSM transitions.
  * Throws `InvitationFetchError` on 5xx / network / parse / unknown 4xx.
+ *
+ * Issue #1169 additions:
+ *   - Optional `displayName` (≤120 chars, trimmed by backend). Wire field is
+ *     `displayName` per the backend `RespondToInvitationByTokenRequest` shape
+ *     (NOT `responderDisplayName` — that name lives only on the internal
+ *     MediatR command). Whitespace-only strings are sent as `null`.
+ *   - 429 rate-limited outcome (backend cap: 10 req/min/IP). `Retry-After`
+ *     header parsed when present.
+ *   - 400 invalid-display-name surface for length cap violations bypassed
+ *     by the frontend (defensive — UI already enforces maxlength).
  */
 export async function respondToInvitation(
   token: string,
-  action: RsvpAction
+  action: RsvpAction,
+  displayName?: string | null
 ): Promise<RespondToInvitationResult> {
   const base = getApiBase();
   const url = `${base}/api/v1/game-nights/invitations/${encodeURIComponent(token)}/respond`;
+
+  // Backend wire body shape: { response: 'Accepted' | 'Declined', displayName?: string }.
+  // The endpoint maps `response` → `RespondToGameNightInvitationByTokenCommand.Response`
+  // and `displayName` → `RespondToGameNightInvitationByTokenCommand.ResponderDisplayName`.
+  const trimmed = typeof displayName === 'string' ? displayName.trim() : null;
+  const requestBody: Record<string, string> = { response: action };
+  if (trimmed && trimmed.length > 0) {
+    requestBody.displayName = trimmed;
+  }
 
   let response: Response;
   try {
@@ -204,7 +294,7 @@ export async function respondToInvitation(
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
-      body: JSON.stringify({ action }),
+      body: JSON.stringify(requestBody),
     });
   } catch (cause) {
     throw new InvitationFetchError(null, 'Network error responding to invitation', { cause });
@@ -226,6 +316,14 @@ export async function respondToInvitation(
       });
     }
     return { kind: 'success', action, invitation: parsed.data };
+  }
+
+  if (response.status === 400) {
+    const body = (await response.json().catch(() => ({}))) as { error?: string };
+    return {
+      kind: 'invalid-display-name',
+      message: body.error ?? 'Display name is invalid.',
+    };
   }
 
   if (response.status === 409) {
@@ -250,6 +348,15 @@ export async function respondToInvitation(
           ? 'past-expiry'
           : 'expired';
     return { kind: 'gone', reason };
+  }
+
+  if (response.status === 429) {
+    const retryAfterRaw = response.headers.get('Retry-After');
+    const retryAfter =
+      retryAfterRaw && /^\d+$/.test(retryAfterRaw.trim())
+        ? Number.parseInt(retryAfterRaw.trim(), 10)
+        : null;
+    return { kind: 'rate-limited', retryAfter };
   }
 
   if (response.status === 404) {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1269,6 +1269,72 @@
         }
       }
     },
+    "gameNightJoin": {
+      "metadata": {
+        "title": "Game night RSVP — MeepleAI",
+        "description": "Confirm or decline your attendance for this game night."
+      },
+      "publicBanner": "You're viewing a public invitation. Your response will be shared with the host.",
+      "hero": {
+        "invitedBy": "{hostName} invited you to",
+        "scheduledLabel": "When",
+        "locationLabel": "Where",
+        "locationMissing": "Location to be confirmed"
+      },
+      "form": {
+        "sectionTitle": "Your response",
+        "displayNameLabel": "Your name (optional)",
+        "displayNamePlaceholder": "e.g. Marco",
+        "displayNameHelper": "Helps the host recognize you. Up to 120 characters.",
+        "displayNameTooLong": "The name must be 120 characters or fewer.",
+        "accept": "I'm in",
+        "decline": "Can't make it",
+        "submitting": "Submitting…",
+        "submitSuccess": "Response submitted!",
+        "alreadyRespondedHeading": "You've already responded",
+        "alreadyRespondedAnonymousAccepted": "You accepted this invitation.",
+        "alreadyRespondedAnonymousDeclined": "You declined this invitation.",
+        "alreadyRespondedNamedAccepted": "You accepted as \"{name}\".",
+        "alreadyRespondedNamedDeclined": "You declined as \"{name}\".",
+        "changeResponse": "Change response"
+      },
+      "error": {
+        "invalidToken": {
+          "heading": "Invitation not found",
+          "body": "This link doesn't match any active invitation. Double-check that it's complete and try again.",
+          "homeCta": "Go to home"
+        },
+        "expired": {
+          "heading": "Invitation expired",
+          "body": "This invitation is no longer valid. Ask the host to send you a new one."
+        },
+        "cancelled": {
+          "heading": "Game night cancelled",
+          "body": "The host has cancelled this game night. Nothing personal!"
+        },
+        "requestNewInviteCta": "Request a new invite",
+        "homeCta": "Go to home",
+        "rateLimited": {
+          "heading": "Too many requests",
+          "body": "You've submitted too many responses in a short window. Please wait a moment and try again.",
+          "countdown": "Retry in {seconds, plural, one {1 second} other {# seconds}}",
+          "retryCta": "Retry now"
+        },
+        "generic": {
+          "heading": "Something went wrong",
+          "body": "We couldn't reach the server. Check your connection and try again.",
+          "retryCta": "Retry"
+        }
+      },
+      "cta": {
+        "createAccount": {
+          "title": "Want to keep track of your game nights?",
+          "body": "Create a free account to manage your invitations, see stats, and get reminders.",
+          "button": "Create account"
+        }
+      },
+      "loading": "Loading invitation…"
+    },
     "join": {
       "metadata": {
         "title": "Join the Alpha — MeepleAI",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1319,6 +1319,72 @@
         }
       }
     },
+    "gameNightJoin": {
+      "metadata": {
+        "title": "RSVP serata gioco — MeepleAI",
+        "description": "Conferma o declina la tua partecipazione alla serata di gioco."
+      },
+      "publicBanner": "Stai vedendo un invito pubblico. La tua risposta verrà condivisa con l'organizzatore.",
+      "hero": {
+        "invitedBy": "{hostName} ti ha invitato a",
+        "scheduledLabel": "Quando",
+        "locationLabel": "Dove",
+        "locationMissing": "Luogo da definire"
+      },
+      "form": {
+        "sectionTitle": "La tua risposta",
+        "displayNameLabel": "Il tuo nome (opzionale)",
+        "displayNamePlaceholder": "Es. Marco",
+        "displayNameHelper": "Aiuta l'organizzatore a riconoscerti. Massimo 120 caratteri.",
+        "displayNameTooLong": "Il nome deve essere di 120 caratteri o meno.",
+        "accept": "Confermo",
+        "decline": "Non posso",
+        "submitting": "Invio risposta…",
+        "submitSuccess": "Risposta inviata!",
+        "alreadyRespondedHeading": "Hai già risposto",
+        "alreadyRespondedAnonymousAccepted": "Hai confermato la partecipazione.",
+        "alreadyRespondedAnonymousDeclined": "Hai declinato l'invito.",
+        "alreadyRespondedNamedAccepted": "Hai confermato come \"{name}\".",
+        "alreadyRespondedNamedDeclined": "Hai declinato come \"{name}\".",
+        "changeResponse": "Cambia risposta"
+      },
+      "error": {
+        "invalidToken": {
+          "heading": "Invito non trovato",
+          "body": "Questo link non corrisponde a nessun invito attivo. Controlla che sia completo e riprova.",
+          "homeCta": "Vai alla home"
+        },
+        "expired": {
+          "heading": "Invito scaduto",
+          "body": "Questo invito non è più valido. Chiedi all'organizzatore di rimandartelo."
+        },
+        "cancelled": {
+          "heading": "Serata annullata",
+          "body": "L'organizzatore ha annullato questa serata. Niente di personale!"
+        },
+        "requestNewInviteCta": "Richiedi un nuovo invito",
+        "homeCta": "Vai alla home",
+        "rateLimited": {
+          "heading": "Troppe richieste",
+          "body": "Hai inviato troppe risposte in poco tempo. Attendi qualche secondo prima di riprovare.",
+          "countdown": "Riprova tra {seconds, plural, one {1 secondo} other {# secondi}}",
+          "retryCta": "Riprova adesso"
+        },
+        "generic": {
+          "heading": "Qualcosa è andato storto",
+          "body": "Non siamo riusciti a contattare il server. Controlla la connessione e riprova.",
+          "retryCta": "Riprova"
+        }
+      },
+      "cta": {
+        "createAccount": {
+          "title": "Vuoi tenere traccia delle tue serate?",
+          "body": "Crea un account gratuito per gestire i tuoi inviti, vedere le statistiche e ricevere promemoria.",
+          "button": "Crea account"
+        }
+      },
+      "loading": "Caricamento invito…"
+    },
     "join": {
       "metadata": {
         "title": "Entra nell'Alpha — MeepleAI",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -435,10 +435,16 @@ the PR review.
 |--------|-----------|------|-------|--------|----|----|
 | `sp7-game-night-detail-rsvp.jsx` | `GameNightAvatar` | `apps/web/src/components/features/game-night-detail/GameNightAvatar.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
 | `sp7-game-night-detail-rsvp.jsx` | `GameNightStatusBadge` | `apps/web/src/components/features/game-night-detail/GameNightStatusBadge.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
-| `sp7-game-night-detail-rsvp.jsx` | `GameNightRsvpRow` | `apps/web/src/components/features/game-night-detail/GameNightRsvpRow.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
-| `sp7-game-night-detail-rsvp.jsx` | `GameNightRsvpActionBar` | `apps/web/src/components/features/game-night-detail/GameNightRsvpActionBar.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
-| `sp7-game-night-detail-rsvp.jsx` | `GameNightDetailHero` | `apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
+| `sp7-game-night-detail-rsvp.jsx` | `GameNightRsvpRow` | `apps/web/src/components/features/game-night-detail/GameNightRsvpRow.tsx` | `/game-nights/[id]` · `/join/event/[code]` | done | #1171 · #1169 (`mode='public'`) | T A V |
+| `sp7-game-night-detail-rsvp.jsx` | `GameNightRsvpActionBar` | `apps/web/src/components/features/game-night-detail/GameNightRsvpActionBar.tsx` | `/game-nights/[id]` · `/join/event/[code]` | done | #1171 · #1169 (`mode='public'` hides Maybe) | T A V |
+| `sp7-game-night-detail-rsvp.jsx` | `GameNightDetailHero` | `apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx` | `/game-nights/[id]` · `/join/event/[code]` | done | #1171 · #1169 (`mode='public'`) | T A V |
 | `sp7-game-night-detail-rsvp.jsx` | `GameNightCancelledBanner` | `apps/web/src/components/features/game-night-detail/GameNightCancelledBanner.tsx` | `/game-nights/[id]` | done | #1171 | T A V |
+| `sp7-game-night-join-public.jsx` | `PublicRsvpForm` | `apps/web/src/components/features/game-night-detail/PublicRsvpForm.tsx` | `/join/event/[code]` | done | #1169 | T A V |
+| `sp7-game-night-join-public.jsx` | `InvalidTokenError` | `apps/web/src/components/features/game-night-detail/error-states/InvalidTokenError.tsx` | `/join/event/[code]` | done | #1169 | T A V |
+| `sp7-game-night-join-public.jsx` | `ExpiredOrCancelledError` | `apps/web/src/components/features/game-night-detail/error-states/ExpiredOrCancelledError.tsx` | `/join/event/[code]` | done | #1169 | T A V |
+| `sp7-game-night-join-public.jsx` | `RateLimitedError` | `apps/web/src/components/features/game-night-detail/error-states/RateLimitedError.tsx` | `/join/event/[code]` | done | #1169 | T A V |
+| `sp7-game-night-join-public.jsx` | `GenericError` | `apps/web/src/components/features/game-night-detail/error-states/GenericError.tsx` | `/join/event/[code]` | done | #1169 | T A V |
+| `sp7-game-night-join-public.jsx` | `PublicJoinEventView` (orchestrator) | `apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx` | `/join/event/[code]` | done | #1169 | T A V |
 
 **Deferred (planned follow-up)**:
 - Tabbed surface (Dettagli / Voting / Chat) — `GameNightDetailTabs`, `GameVoteCard`, `VotingTiedResolver`, `GameNightChatStream` — out of AC-H1..H5 scope (mockup lines 600+).


### PR DESCRIPTION
## Summary

- Full-stack public RSVP path for anonymous guests responding to game-night invitations via token URL
- Backend (commit `9b4643cb9`): extended existing 2 anonymous endpoints with `ResponderDisplayName` + rate-limit policies; new entity field + migration
- Frontend (commit `621bfb02e`): new `/join/event/[code]` route + shared component refactor with `mode: 'authenticated' | 'public'` prop
- Mockup variant + 7-case E2E + v2-migration-matrix update

## Backend (pattern P19 — 95% pre-complete)

The 2 public endpoints already existed (Wave A.5a, #607). Extended with:

- `RespondToGameNightInvitationByTokenCommand.ResponderDisplayName` (string, max 120, optional positional)
- `GameNightInvitation.RespondedByName` domain property + EF column + migration `AddRespondedByNameToGameNightInvitation`
- `PublicGameNightInvitationDto.RespondedByName` for "Already responded as X" UI
- Endpoint POST request DTO `displayName` field with 400 guard (validator behavior not auto-registered for `ICommand` void — known MediatR gap, endpoint-level enforcement)
- Rate-limit policies: `GameNightTokenRead` (60 req/min IP-based) on GET + `GameNightTokenRespond` (10 req/min IP-based) on POST
- 367/367 GameNight tests pass (+15 new: 8 domain + 6 integration + 6 validator + 1 rate-limit)

## Frontend

### Public route
- `apps/web/src/app/(public)/join/event/[code]/page.tsx` — server wrapper, dynamic route
- `PublicJoinEventView` orchestrator with full state machine (loading → success/already-responded/error variants)

### Hooks (extended existing infra, not duplicated)
- `useGameNightInvitation` — added skip-retry on 410/429 (don't retry expired or rate-limited)
- `useRespondToInvitation` — optional 2nd arg `displayName`, expanded FSM to 7 states (added `rate-limited` + `invalid-display-name`)

### Shared component refactor
- `mode: 'authenticated' | 'public'` prop on `GameNightDetailHero` (hides admin controls), `GameNightRsvpActionBar` (hides Maybe — backend only accepts Accepted/Declined), `GameNightRsvpRow` (forces `isMe=false`)
- Backward-compatible default `mode='authenticated'`

### New components
- `PublicRsvpForm` — displayName input (optional, max 120) + Accept/Decline buttons + already-responded view
- 4 error states: `InvalidTokenError` (404), `ExpiredOrCancelledError` (410, CTA), `RateLimitedError` (429), `GenericError`

### i18n
- New namespace `pages.gameNightJoin.*` (it+en) — hero, form, error states, CTA copy

### Mockup
- `admin-mockups/design_files/sp7-game-night-join-public.jsx` — branched from `sp7-game-night-detail-rsvp.jsx`, 6-state preview (pending-empty, pending-filled, submitting, already-responded, expired, rate-limited), admin/host controls stripped

### Tests
- 119 unit tests pass (PublicRsvpForm 9 + PublicJoinEventView 14 + extended hooks 25 + extended shared component tests 71)
- 7 Playwright E2E cases (`apps/web/e2e/public/join-event-rsvp.spec.ts`): token valid / already-responded / expired / cancelled / malformed / rate-limited / submit-flow

## Acceptance criteria (issue #1169)

- [x] Componenti riutilizzati da `features/game-night-detail/` con prop `mode: 'authenticated' \| 'public'` ✅
- [x] Token validation flow: valid / expired / revoked / malformed → dedicated error pages ✅
- [x] Anonymous RSVP: form displayName + response, idempotente, "create account" CTA ✅
- [x] Owner = FE cluster game-nights (NON #847 staging-allowlist) ✅
- [x] T (semantic tokens) ✅ + A (axe AA — `aria-live`, label associations, role) ✅ + V (375/768/1280 responsive) ✅
- [x] E2E: token valid / expired / revoked / malformed ✅
- [x] Update `v2-migration-matrix.md` row pubblica ✅

## Out of scope (deferred)

- "Create account" CTA email pre-fill: backend doesn't expose `invitedEmail` in public DTO yet (security — could leak guest emails). Render generic "Create account to manage future RSVPs" CTA without email pre-fill.
- Multi-locale `<head>` metadata via Accept-Language header (matches existing `/invites/[token]` pattern — Italian static)
- MediatR validation behavior auto-registration for `ICommand` (no `TResponse`) — separate tech-debt, endpoint-level guard sufficient for #1169 scope

## Test plan

- [x] Backend: 367/367 GameNight tests pass
- [x] Frontend: 119/119 touched-scope tests pass
- [x] typecheck / lint / build all green
- [ ] CI: full suite + E2E + bundle + a11y (runs on PR)
- [ ] Manual smoke: hit `/join/event/{valid-token}` in staging once deployed

## Refs

- Parent: #582 (V2 Phase 1 Wave D umbrella)
- Sibling: #951 (game-night-detail shared components, post-merge dependency)
- Pattern: P19 (backend-95%-pre-complete) — see session memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)