### PR TITLE
fix(a11y): ARIA defects cleanup — final Phase C step before D gate flip (refs #1094)

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -436,10 +436,13 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
     comingSoon: t('pages.playerDetail.tabs.toolkits.comingSoon'),
   };
 
-  let tabPanel: ReactElement;
+  // #1094 ARIA fix: wrap tabPanel in role="tabpanel" + matching id so that
+  // PlayerTabs' aria-controls="tabpanel-player-detail-{key}" resolves to a
+  // real element (was firing axe aria-valid-attr-value otherwise).
+  let tabPanelInner: ReactElement;
   switch (tab) {
     case 'games':
-      tabPanel = (
+      tabPanelInner = (
         <GamesTabPanel
           playerId={safePlayerId}
           gamePlayCounts={gamePlayCounts}
@@ -448,10 +451,10 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
       );
       break;
     case 'toolkits':
-      tabPanel = <ToolkitsTabPanel labels={toolkitsLabels} />;
+      tabPanelInner = <ToolkitsTabPanel labels={toolkitsLabels} />;
       break;
     case 'achievements':
-      tabPanel = (
+      tabPanelInner = (
         <AchievementBadgeGrid
           count={safeProfile.achievementCount}
           viewAllHref={`/players/${safePlayerId}/achievements`}
@@ -461,9 +464,19 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
       break;
     case 'sessions':
     default:
-      tabPanel = <SessionsTabPanel stats={safeProfile} labels={sessionsLabels} />;
+      tabPanelInner = <SessionsTabPanel stats={safeProfile} labels={sessionsLabels} />;
       break;
   }
+  const tabPanel: ReactElement = (
+    <div
+      role="tabpanel"
+      id={`tabpanel-player-detail-${tab}`}
+      aria-labelledby={`tab-player-detail-${tab}`}
+      tabIndex={0}
+    >
+      {tabPanelInner}
+    </div>
+  );
 
   return (
     <div data-slot="player-detail-view">

--- a/apps/web/src/components/features/session-live/PlayerRosterLive.tsx
+++ b/apps/web/src/components/features/session-live/PlayerRosterLive.tsx
@@ -95,7 +95,10 @@ export function PlayerRosterLive({
             >
               {/* Left: online dot + name */}
               <div className="flex min-w-0 items-center gap-2">
+                {/* role="img" is required for aria-label on generic span (#1094 ARIA fix).
+                    Without role, axe flags aria-prohibited-attr on the default 'generic' role. */}
                 <span
+                  role="img"
                   title={player.isOnline ? labels.onlineLabel : labels.offlineLabel}
                   aria-label={player.isOnline ? labels.onlineLabel : labels.offlineLabel}
                   className={[

--- a/apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx
+++ b/apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx
@@ -16,8 +16,9 @@
  *
  * A11y:
  *   - Filter pills use `useTablistKeyboardNav` (Wave A.6 reusable hook). The
- *     active filter has `tabIndex=0` + `aria-pressed=true`; siblings
- *     `tabIndex=-1` and `aria-pressed=false`.
+ *     active filter has `tabIndex=0` + `aria-selected=true`; siblings
+ *     `tabIndex=-1` and `aria-selected=false`. aria-pressed was removed
+ *     because it is prohibited on role="tab" per WCAG (#1094 ARIA fix).
  *   - Each turn collapsible: `<button aria-expanded={open} aria-controls={id}>`
  *     + sibling `<div id={id}>` (when open).
  *
@@ -147,7 +148,6 @@ export function SessionDiaryTimeline({
                 else tabRefs.current.delete(filter);
               }}
               tabIndex={active ? 0 : -1}
-              aria-pressed={active}
               aria-selected={active}
               onKeyDown={e => handleKeyDown(e, filter)}
               onClick={() => onFilterChange(filter)}

--- a/apps/web/src/components/features/session-summary/__tests__/SessionDiaryTimeline.test.tsx
+++ b/apps/web/src/components/features/session-summary/__tests__/SessionDiaryTimeline.test.tsx
@@ -80,10 +80,12 @@ describe('SessionDiaryTimeline', () => {
     expect(chatPill.getAttribute('data-active')).toBe('true');
   });
 
-  it('aria-pressed mirrors active state', () => {
+  it('aria-selected mirrors active state — #1094 ARIA fix: role="tab" prohibits aria-pressed', () => {
     render(<SessionDiaryTimeline {...DEFAULT_PROPS} activeFilter="all" />);
     const allPill = document.querySelector('[data-filter="all"]')!;
-    expect(allPill.getAttribute('aria-pressed')).toBe('true');
+    expect(allPill.getAttribute('aria-selected')).toBe('true');
+    // aria-pressed must NOT be present (prohibited on role="tab" per WCAG)
+    expect(allPill.getAttribute('aria-pressed')).toBeNull();
   });
 
   it('fires onFilterChange when a filter pill is clicked', () => {


### PR DESCRIPTION
## Summary

Post-#1249 Phase A.live v6 confirmed **0 color-contrast violations** (down from 103 in v4, -100%). However ~11 ARIA defects remained — pre-existing #1094 scope (audit body: "159 nodes incl. entity alpha-blend contrast + **ARIA defects**") never addressed by Real-C-A→Real-C-misc clusters (all color-contrast focused).

This PR closes the ARIA gap. Expected v7: **0 violations across ALL axe rules**.

## Fixes

### 1. aria-prohibited-attr (5 nodi) — `PlayerRosterLive.tsx:98`

`<span title="Online" aria-label="Online" class="...rounded-full bg-emerald-400">` — status dot indicator. axe flags `aria-label` on default `generic` role spans.

**Fix**: add `role="img"` to satisfy WCAG ARIA spec (canonical pattern for decorative-but-labeled spans).

### 2. aria-allowed-attr (5 nodi) — `SessionDiaryTimeline.tsx:150`

`<button role="tab" aria-pressed={active} aria-selected={active}>` — diary filter pill. `aria-pressed` is prohibited on `role="tab"` (only `aria-selected` is canonical per ARIA APG tablist).

**Fix**: remove `aria-pressed`, retain `aria-selected`. JSDoc updated. Unit test rewritten to assert `aria-selected=true` AND absence of `aria-pressed`.

### 3. aria-valid-attr-value (1 nodo) — `PlayerDetailView.tsx` tabPanel missing wrapper

`PlayerTabs.tsx:79` declares `aria-controls="tabpanel-player-detail-{key}"` but NO element with matching id existed in the DOM (axe fired `aria-valid-attr-value` because the controlled element couldn't be resolved).

**Fix**: wrap the `tabPanel` ReactElement in `<div role="tabpanel" id={`tabpanel-player-detail-${tab}`} aria-labelledby={`tab-player-detail-${tab}`} tabIndex={0}>`. Completes the ARIA APG tablist contract.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] SessionDiaryTimeline.test.tsx test 9 rewritten (asserts aria-selected, NOT aria-pressed)
- [ ] CI a11y E2E v7 will confirm 0 ARIA violations
- [ ] Phase D ready: gate flip (N+5) can proceed post-merge with clean baseline

## Phase D readiness

| Metric | v4 baseline | v5 | v6 | **v7 (expected)** |
|---|---:|---:|---:|---:|
| Color-contrast | 103 | 8 | 0 | **0** ✅ |
| ARIA defects | ~11 | ~11 | ~11 | **0** ✅ |
| **Total** | **~114** | **~19** | **~11** | **0** ✅ |

Phase C **COMPLETE** post-merge. N+5 (gate flip) can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)