### PR TITLE
fix(a11y): scrollable carousel keyboard focusable (closes #1094 Phase C)

### DIFF
--- a/apps/web/src/components/features/session-summary/AchievementsCarousel.tsx
+++ b/apps/web/src/components/features/session-summary/AchievementsCarousel.tsx
@@ -105,12 +105,18 @@ export function AchievementsCarousel({
           {labels.unlockedCount}
         </span>
       </div>
+      {/* tabIndex={0} required for axe scrollable-region-focusable: keyboard
+          users must be able to focus the scrollable container to use arrow keys.
+          aria-label provides accessible name (#1094 ARIA fix). */}
       <ul
         role="list"
+        tabIndex={0}
+        aria-label={labels.title}
         className={clsx(
           'flex gap-2 overflow-x-auto pb-1',
           '[scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-          '[scroll-snap-type:x_mandatory]'
+          '[scroll-snap-type:x_mandatory]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm'
         )}
       >
         {achievements.map(a => {


### PR DESCRIPTION
## Summary

Phase A.live v7 (post #1252) showed last remaining residual: AchievementsCarousel \`<ul>\` lacked \`tabIndex\` → axe \`scrollable-region-focusable\`.

**Fix**: \`tabIndex={0}\` + \`aria-label\` + focus ring on the scrollable container.

## Cumulative reduction (Phase A.live trajectory)

| Run | Color-contrast | ARIA | Total | Tests fail |
|---|---:|---:|---:|---:|
| v4 baseline | 103 | ~11 | ~114 | 36 |
| v5 (#1237) | 8 | ~11 | ~19 | 22 |
| v6 (#1249) | 0 | ~11 | ~11 | 15 |
| v7 (#1252) | 0 | 0 | 1 | 10 |
| **v8 (this PR — expected)** | **0** | **0** | **0** | **0** |

**Phase D ready** post-merge: gate flip can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)