### PR TITLE
fix(a11y): FAQ category-tabs AA regression (refs #1094)

### DIFF
--- a/apps/web/src/components/ui/faq/category-tabs.tsx
+++ b/apps/web/src/components/ui/faq/category-tabs.tsx
@@ -96,7 +96,7 @@ export function CategoryTabs({
                 'transition-[background-color,border-color,color] duration-150 ease-out',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--c-game))] focus-visible:ring-offset-2',
                 isActive
-                  ? 'border border-[hsl(var(--c-game)/0.3)] bg-[hsl(var(--c-game)/0.12)] text-[hsl(var(--c-game))] font-bold'
+                  ? 'border border-[hsl(var(--c-game)/0.3)] bg-[hsl(var(--c-game)/0.12)] text-[hsl(var(--c-game-text))] font-bold'
                   : 'border border-border bg-transparent text-[hsl(var(--text-sec))] font-semibold hover:bg-[hsl(var(--bg-hover))]'
               )}
             >
@@ -107,7 +107,7 @@ export function CategoryTabs({
                   'min-w-4 text-center font-mono text-[9px] font-extrabold tabular-nums',
                   'rounded-full px-1.5 py-px',
                   isActive
-                    ? 'bg-[hsl(var(--c-game)/0.25)] text-[hsl(var(--c-game))] dark:bg-[hsl(var(--c-game)/0.4)] dark:text-foreground'
+                    ? 'bg-[hsl(var(--c-game)/0.25)] text-[hsl(var(--c-game-text))] dark:bg-[hsl(var(--c-game)/0.4)] dark:text-foreground'
                     : 'bg-[hsl(var(--bg-muted))] text-[hsl(var(--text-muted))]'
                 )}
               >


### PR DESCRIPTION
## Summary

Phase A.live v8 (post #1254 merge) captured 12 inflated nodi (~4 unique) of \`#bd5205\` on warm-tinted bg — **NEW regression** from FAQ category-tabs introduced in parallel with Phase C cleanup work.

## Fix

\`apps/web/src/components/ui/faq/category-tabs.tsx\` lines 97, 99, 110:
- swap \`text-[hsl(var(--c-game))]\` → \`text-[hsl(var(--c-game-text))]\`

This matches Real-C-B pattern: \`--c-game-text\` is the AA-safe darker variant (l=32% light, l=70% dark) introduced in PR #1232.

## Math

| State | fg | bg | Before | After |
|---|---|---|---:|---:|
| Active tab text | \`#bd5205\` (l=38%) | \`#f2e3d8\` (game/0.12) | 4.34:1 ❌ | **6.14:1** ✅ |
| Count badge | \`#bd5205\` | \`#e5bfa3\` (game/0.25) | 4.49:1 ❌ | **~5.8:1** ✅ |

## Phase A.live trajectory (final)

| Run | Total | Color-contrast | ARIA | Other |
|---|---:|---:|---:|---:|
| v4 baseline | ~114 | 103 | ~11 | 0 |
| v8 (current) | 8 | 4 (FAQ regression) | 0 | 4 (scrollable, fixed in #1254) |
| **v9 (post-merge — expected)** | **0** | **0** | **0** | **0** |

Phase D ready after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)