### PR TITLE
feat(ui): 6 primitives per game-nights runtime (PR 1/2 refs #1255)

### DIFF
--- a/apps/web/src/components/ui/archived-banner/archived-banner.test.tsx
+++ b/apps/web/src/components/ui/archived-banner/archived-banner.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ArchivedBanner } from './index';
+
+describe('ArchivedBanner', () => {
+  it('renders title (kicker)', () => {
+    render(<ArchivedBanner title="Serata archiviata" />);
+    expect(screen.getByText('Serata archiviata')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(
+      <ArchivedBanner
+        title="Serata archiviata"
+        subtitle="Riepilogo salvato · accessibile da /game-nights/archived"
+      />
+    );
+    expect(
+      screen.getByText('Riepilogo salvato · accessibile da /game-nights/archived')
+    ).toBeInTheDocument();
+  });
+
+  it('omits subtitle div when not provided', () => {
+    const { container } = render(<ArchivedBanner title="OK" />);
+    expect(container.querySelector('.font-display')).toBeNull();
+  });
+
+  it('uses default 📦 icon', () => {
+    render(<ArchivedBanner title="OK" />);
+    expect(screen.getByText('📦')).toBeInTheDocument();
+  });
+
+  it('accepts custom icon override', () => {
+    render(<ArchivedBanner title="OK" icon="📁" />);
+    expect(screen.getByText('📁')).toBeInTheDocument();
+    expect(screen.queryByText('📦')).toBeNull();
+  });
+
+  it('icon is aria-hidden (decorative)', () => {
+    render(<ArchivedBanner title="OK" />);
+    expect(screen.getByText('📦')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders action slot when provided', () => {
+    render(<ArchivedBanner title="OK" action={<a href="/game-nights">← Torna alla lista</a>} />);
+    expect(screen.getByRole('link', { name: '← Torna alla lista' })).toBeInTheDocument();
+  });
+
+  it('omits action wrapper when not provided', () => {
+    const { container } = render(<ArchivedBanner title="OK" />);
+    // expect only 2 top-level children: icon span + content div (no action div)
+    expect(container.firstChild?.childNodes.length).toBe(2);
+  });
+
+  it('has role="status" (non-critical announcement)', () => {
+    render(<ArchivedBanner title="OK" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('uses muted neutral (no entity color) as per brief', () => {
+    const { container } = render(<ArchivedBanner title="OK" />);
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.className).toContain('bg-muted');
+    expect(banner.className).not.toContain('entity-event');
+    expect(banner.className).not.toContain('entity-toolkit');
+  });
+
+  it('accepts custom className override', () => {
+    render(<ArchivedBanner title="OK" className="custom-class" />);
+    expect(screen.getByRole('status').className).toContain('custom-class');
+  });
+});

--- a/apps/web/src/components/ui/archived-banner/archived-banner.tsx
+++ b/apps/web/src/components/ui/archived-banner/archived-banner.tsx
@@ -1,0 +1,53 @@
+import type { JSX, ReactNode } from 'react';
+
+export interface ArchivedBannerProps {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly icon?: string;
+  readonly action?: ReactNode;
+  readonly className?: string;
+}
+
+export function ArchivedBanner({
+  title,
+  subtitle,
+  icon = '📦',
+  action,
+  className,
+}: ArchivedBannerProps): JSX.Element {
+  return (
+    <div
+      role="status"
+      className={[
+        'flex flex-wrap items-center gap-3',
+        'rounded-lg border border-border bg-muted',
+        'px-4 py-3.5',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <span
+        aria-hidden="true"
+        className={[
+          'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          'border border-border-strong bg-card',
+          'text-base text-muted-foreground',
+        ].join(' ')}
+      >
+        {icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+          {title}
+        </span>
+        {subtitle ? (
+          <div className="mt-px font-display text-[13px] font-extrabold text-foreground">
+            {subtitle}
+          </div>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/archived-banner/index.ts
+++ b/apps/web/src/components/ui/archived-banner/index.ts
@@ -1,0 +1,2 @@
+export { ArchivedBanner } from '@/components/ui/archived-banner/archived-banner';
+export type { ArchivedBannerProps } from '@/components/ui/archived-banner/archived-banner';

--- a/apps/web/src/components/ui/auto-save-toast/auto-save-toast.test.tsx
+++ b/apps/web/src/components/ui/auto-save-toast/auto-save-toast.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AutoSaveToast } from './auto-save-toast';
+
+describe('AutoSaveToast', () => {
+  it('renders nothing when visible=false', () => {
+    const { container } = render(<AutoSaveToast visible={false} timestamp="23:35:42" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders default label "Auto-salvato" when visible', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" />);
+    expect(screen.getByText('Auto-salvato')).toBeInTheDocument();
+  });
+
+  it('renders timestamp + default 60s next-save in subline', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" />);
+    expect(screen.getByText('23:35:42 · prossimo tra 60s')).toBeInTheDocument();
+  });
+
+  it('renders custom nextInSeconds in subline', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" nextInSeconds={30} />);
+    expect(screen.getByText('23:35:42 · prossimo tra 30s')).toBeInTheDocument();
+  });
+
+  it('renders custom label override', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" label="Salvataggio…" />);
+    expect(screen.getByText('Salvataggio…')).toBeInTheDocument();
+  });
+
+  it('has role="status" and aria-live="polite" for screen reader announcements', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" />);
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(toast).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('check icon is aria-hidden (decorative)', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" />);
+    const checkIcon = screen.getByText('✓');
+    expect(checkIcon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('accepts custom className override', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" className="custom-class" />);
+    const toast = screen.getByRole('status');
+    expect(toast.className).toContain('custom-class');
+  });
+
+  it('uses entity-toolkit color tokens (no hardcoded green)', () => {
+    render(<AutoSaveToast visible timestamp="23:35:42" />);
+    const toast = screen.getByRole('status');
+    expect(toast.className).toContain('bg-entity-toolkit/10');
+    expect(toast.className).toContain('border-entity-toolkit/30');
+  });
+});

--- a/apps/web/src/components/ui/auto-save-toast/auto-save-toast.tsx
+++ b/apps/web/src/components/ui/auto-save-toast/auto-save-toast.tsx
@@ -1,0 +1,57 @@
+import type { JSX } from 'react';
+
+export interface AutoSaveToastProps {
+  readonly visible: boolean;
+  readonly timestamp: string;
+  readonly nextInSeconds?: number;
+  readonly label?: string;
+  readonly className?: string;
+}
+
+export function AutoSaveToast({
+  visible,
+  timestamp,
+  nextInSeconds = 60,
+  label = 'Auto-salvato',
+  className,
+}: AutoSaveToastProps): JSX.Element | null {
+  if (!visible) return null;
+
+  const subline = `${timestamp} · prossimo tra ${nextInSeconds}s`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={[
+        'fixed bottom-[18px] right-[18px] z-40',
+        'flex items-center gap-2.5',
+        'px-3.5 py-2.5 pl-3',
+        'rounded-pill',
+        'bg-entity-toolkit/10 border border-entity-toolkit/30',
+        'backdrop-blur-md shadow-lg',
+        'motion-safe:animate-in motion-safe:slide-in-from-bottom-2 motion-safe:fade-in-0 motion-safe:duration-300',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{ boxShadow: 'var(--shadow-lg), 0 0 0 4px hsl(var(--c-toolkit) / 0.06)' }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex h-[22px] w-[22px] items-center justify-center rounded-full bg-entity-toolkit text-white text-xs font-extrabold"
+      >
+        ✓
+      </span>
+      <div className="flex min-w-0 flex-col gap-px">
+        <span className="font-display text-xs font-extrabold text-entity-toolkit-text">
+          {label}
+        </span>
+        <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
+          {subline}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/auto-save-toast/index.ts
+++ b/apps/web/src/components/ui/auto-save-toast/index.ts
@@ -1,0 +1,2 @@
+export { AutoSaveToast } from '@/components/ui/auto-save-toast/auto-save-toast';
+export type { AutoSaveToastProps } from '@/components/ui/auto-save-toast/auto-save-toast';

--- a/apps/web/src/components/ui/kb-rules-quick-glance/index.ts
+++ b/apps/web/src/components/ui/kb-rules-quick-glance/index.ts
@@ -1,0 +1,6 @@
+export { KBRulesQuickGlance } from '@/components/ui/kb-rules-quick-glance/kb-rules-quick-glance';
+export type {
+  KBRulesQuickGlanceProps,
+  KBRulesQuickGlanceStatus,
+  KBRule,
+} from '@/components/ui/kb-rules-quick-glance/kb-rules-quick-glance';

--- a/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.test.tsx
+++ b/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { KBRulesQuickGlance, type KBRule } from './index';
+
+const SAMPLE_RULES: ReadonlyArray<KBRule> = [
+  { icon: '🔁', text: 'Phase order · Growth → Fast → Slow', src: '§ 4.2' },
+  { icon: '😱', text: 'Fear deck · 9 carte iniziali', src: '§ 5.1' },
+  { icon: '⚡', text: 'Power growth · 1 minor + 1 major', src: '§ 6.3' },
+];
+
+describe('KBRulesQuickGlance', () => {
+  describe('status="ok" (default)', () => {
+    it('renders rules count in title', () => {
+      render(<KBRulesQuickGlance rules={SAMPLE_RULES} />);
+      expect(screen.getByText(/Rules quick-glance · 3 bullet/)).toBeInTheDocument();
+    });
+
+    it('renders all rule texts', () => {
+      render(<KBRulesQuickGlance rules={SAMPLE_RULES} />);
+      SAMPLE_RULES.forEach(r => {
+        expect(screen.getByText(r.text)).toBeInTheDocument();
+      });
+    });
+
+    it('renders src reference pills when provided', () => {
+      render(<KBRulesQuickGlance rules={SAMPLE_RULES} />);
+      expect(screen.getByText('§ 4.2')).toBeInTheDocument();
+      expect(screen.getByText('§ 5.1')).toBeInTheDocument();
+    });
+
+    it('omits src element when rule.src missing', () => {
+      const rules: ReadonlyArray<KBRule> = [{ text: 'rule without src' }];
+      render(<KBRulesQuickGlance rules={rules} />);
+      expect(screen.getByText('rule without src')).toBeInTheDocument();
+      expect(screen.queryByText('§')).toBeNull();
+    });
+
+    it('icon spans are aria-hidden (decorative)', () => {
+      render(<KBRulesQuickGlance rules={SAMPLE_RULES} />);
+      const icons = screen.getAllByText('🔁');
+      expect(icons[0]).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('renders 0 bullet title with empty rules array', () => {
+      render(<KBRulesQuickGlance rules={[]} />);
+      expect(screen.getByText(/Rules quick-glance · 0 bullet/)).toBeInTheDocument();
+    });
+
+    it('accepts custom title override', () => {
+      render(<KBRulesQuickGlance rules={SAMPLE_RULES} title="Custom title" />);
+      expect(screen.getByText(/Custom title · 3 bullet/)).toBeInTheDocument();
+    });
+  });
+
+  describe('status="loading"', () => {
+    it('renders skeleton placeholders with aria-busy', () => {
+      const { container } = render(<KBRulesQuickGlance status="loading" />);
+      expect(container.firstChild).toHaveAttribute('aria-busy', 'true');
+      const skeletons = container.querySelectorAll('.animate-pulse');
+      expect(skeletons.length).toBe(3);
+    });
+
+    it('appends "loading…" suffix to title', () => {
+      render(<KBRulesQuickGlance status="loading" />);
+      expect(screen.getByText(/Rules quick-glance · loading…/)).toBeInTheDocument();
+    });
+
+    it('renders loadingHint when provided', () => {
+      render(<KBRulesQuickGlance status="loading" loadingHint="Fetching KB…" />);
+      expect(screen.getByText('Fetching KB…')).toBeInTheDocument();
+    });
+  });
+
+  describe('status="error"', () => {
+    it('renders alert role with default error copy', () => {
+      render(<KBRulesQuickGlance status="error" />);
+      const alert = screen.getByRole('alert');
+      expect(alert).toBeInTheDocument();
+      expect(screen.getByText('Rules non disponibili offline')).toBeInTheDocument();
+    });
+
+    it('renders custom errorTitle + errorMessage', () => {
+      render(
+        <KBRulesQuickGlance
+          status="error"
+          errorTitle="Custom error"
+          errorMessage="Custom message"
+        />
+      );
+      expect(screen.getByText('Custom error')).toBeInTheDocument();
+      expect(screen.getByText('Custom message')).toBeInTheDocument();
+    });
+
+    it('invokes onRetry when Riprova button clicked', async () => {
+      const onRetry = vi.fn();
+      render(<KBRulesQuickGlance status="error" onRetry={onRetry} />);
+      await userEvent.click(screen.getByRole('button', { name: /Riprova/ }));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onProceed when "Procedi senza" button clicked', async () => {
+      const onProceed = vi.fn();
+      render(<KBRulesQuickGlance status="error" onProceed={onProceed} />);
+      await userEvent.click(screen.getByRole('button', { name: /Procedi senza/ }));
+      expect(onProceed).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
+++ b/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
@@ -1,0 +1,163 @@
+import type { JSX } from 'react';
+
+export type KBRulesQuickGlanceStatus = 'ok' | 'loading' | 'error';
+
+export interface KBRule {
+  readonly icon?: string;
+  readonly text: string;
+  readonly src?: string;
+}
+
+export interface KBRulesQuickGlanceProps {
+  readonly status?: KBRulesQuickGlanceStatus;
+  readonly rules?: ReadonlyArray<KBRule>;
+  readonly title?: string;
+  readonly loadingHint?: string;
+  readonly errorTitle?: string;
+  readonly errorMessage?: string;
+  readonly onRetry?: () => void;
+  readonly onProceed?: () => void;
+  readonly className?: string;
+}
+
+export function KBRulesQuickGlance({
+  status = 'ok',
+  rules = [],
+  title = 'Rules quick-glance',
+  loadingHint,
+  errorTitle = 'Rules non disponibili offline',
+  errorMessage = 'Tu sei offline o la KB non è ancora indicizzata. Procedi senza quick-glance, oppure riprova.',
+  onRetry,
+  onProceed,
+  className,
+}: KBRulesQuickGlanceProps): JSX.Element {
+  const wrapperClass = ['flex flex-col gap-1.5', className ?? ''].filter(Boolean).join(' ');
+
+  if (status === 'loading') {
+    return (
+      <div className={wrapperClass} aria-busy="true" aria-live="polite">
+        <div className="flex items-center gap-1.5">
+          <span aria-hidden="true" className="text-[13px] leading-none">
+            📄
+          </span>
+          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+            {title} · loading…
+          </span>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {[0, 1, 2].map(i => (
+            <div key={i} aria-hidden="true" className="h-7 rounded-sm bg-muted animate-pulse" />
+          ))}
+        </div>
+        {loadingHint ? (
+          <span className="font-mono text-[9px] font-bold text-muted-foreground">
+            {loadingHint}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className={wrapperClass}>
+        <div className="flex items-center gap-1.5">
+          <span aria-hidden="true" className="text-[13px] leading-none">
+            📄
+          </span>
+          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+            {title}
+          </span>
+        </div>
+        <div
+          role="alert"
+          className={[
+            'flex items-start gap-2.5 rounded-md px-3 py-2.5',
+            'bg-[hsl(var(--c-danger)/0.06)]',
+            'border border-dashed border-[hsl(var(--c-danger)/0.35)]',
+          ].join(' ')}
+        >
+          <span
+            aria-hidden="true"
+            className="mt-px text-base leading-none text-[hsl(var(--c-danger))]"
+          >
+            ⚠
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="font-display text-xs font-extrabold text-foreground">{errorTitle}</div>
+            <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{errorMessage}</p>
+            <div className="mt-1.5 flex gap-1.5">
+              <button
+                type="button"
+                onClick={onRetry}
+                className={[
+                  'rounded-pill px-2.5 py-0.5 border-0 cursor-pointer',
+                  'font-mono text-[9.5px] font-extrabold uppercase tracking-wider',
+                  'bg-[hsl(var(--c-danger))] text-white',
+                ].join(' ')}
+              >
+                ↻ Riprova
+              </button>
+              <button
+                type="button"
+                onClick={onProceed}
+                className={[
+                  'rounded-pill px-2.5 py-0.5 border border-border bg-transparent cursor-pointer',
+                  'font-mono text-[9.5px] font-bold uppercase tracking-wider',
+                  'text-muted-foreground',
+                ].join(' ')}
+              >
+                Procedi senza
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // status === 'ok'
+  return (
+    <div className={wrapperClass}>
+      <div className="flex items-center gap-1.5">
+        <span aria-hidden="true" className="text-[13px] leading-none">
+          📄
+        </span>
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+          {title} · {rules.length} bullet
+        </span>
+      </div>
+      <ul className="flex flex-col gap-1.5 m-0 p-0 list-none">
+        {rules.map((rule, i) => (
+          <li
+            key={i}
+            className={[
+              'flex items-center gap-2 rounded-sm px-2.5 py-1.5',
+              'bg-[hsl(var(--c-kb)/0.06)] border border-[hsl(var(--c-kb)/0.22)]',
+            ].join(' ')}
+          >
+            {rule.icon ? (
+              <span aria-hidden="true" className="shrink-0 text-[13px] leading-none">
+                {rule.icon}
+              </span>
+            ) : null}
+            <span className="min-w-0 flex-1 font-body text-xs font-semibold leading-snug text-foreground">
+              {rule.text}
+            </span>
+            {rule.src ? (
+              <span
+                className={[
+                  'shrink-0 rounded-pill px-1.5 py-px',
+                  'font-mono text-[9px] font-extrabold tracking-wider',
+                  'bg-[hsl(var(--c-kb)/0.12)] text-entity-document',
+                ].join(' ')}
+              >
+                {rule.src}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
+++ b/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'react';
 export type KBRulesQuickGlanceStatus = 'ok' | 'loading' | 'error';
 
 export interface KBRule {
+  readonly id?: string;
   readonly icon?: string;
   readonly text: string;
   readonly src?: string;
@@ -128,9 +129,9 @@ export function KBRulesQuickGlance({
         </span>
       </div>
       <ul className="flex flex-col gap-1.5 m-0 p-0 list-none">
-        {rules.map((rule, i) => (
+        {rules.map(rule => (
           <li
-            key={i}
+            key={rule.id ?? rule.text}
             className={[
               'flex items-center gap-2 rounded-sm px-2.5 py-1.5',
               'bg-[hsl(var(--c-kb)/0.06)] border border-[hsl(var(--c-kb)/0.22)]',

--- a/apps/web/src/components/ui/kpi-stat-grid/index.ts
+++ b/apps/web/src/components/ui/kpi-stat-grid/index.ts
@@ -1,0 +1,4 @@
+export { KPIStatGrid } from '@/components/ui/kpi-stat-grid/kpi-stat-grid';
+export type { KPIStatGridProps } from '@/components/ui/kpi-stat-grid/kpi-stat-grid';
+export { KPIStatCard } from '@/components/ui/kpi-stat-grid/kpi-stat-card';
+export type { KPIStatCardProps } from '@/components/ui/kpi-stat-grid/kpi-stat-card';

--- a/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-card.tsx
+++ b/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-card.tsx
@@ -31,7 +31,7 @@ const TONE_VALUE_TEXT: Record<EntityType, string> = {
   kb: 'text-entity-document',
   chat: 'text-entity-chat',
   event: 'text-entity-event',
-  toolkit: 'text-entity-toolkit-text',
+  toolkit: 'text-entity-toolkit',
   tool: 'text-entity-tool',
 };
 

--- a/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-card.tsx
+++ b/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-card.tsx
@@ -1,0 +1,81 @@
+import type { JSX, ReactNode } from 'react';
+
+import type { EntityType } from '@/components/ui/entity-tokens';
+
+export interface KPIStatCardProps {
+  readonly label: string;
+  readonly value: ReactNode;
+  readonly sub?: string;
+  readonly tone?: EntityType;
+  readonly icon?: ReactNode;
+  readonly className?: string;
+}
+
+const TONE_BORDER: Record<EntityType, string> = {
+  game: 'border-t-entity-game',
+  player: 'border-t-entity-player',
+  session: 'border-t-entity-session',
+  agent: 'border-t-entity-agent',
+  kb: 'border-t-entity-document',
+  chat: 'border-t-entity-chat',
+  event: 'border-t-entity-event',
+  toolkit: 'border-t-entity-toolkit',
+  tool: 'border-t-entity-tool',
+};
+
+const TONE_VALUE_TEXT: Record<EntityType, string> = {
+  game: 'text-entity-game',
+  player: 'text-entity-player',
+  session: 'text-entity-session',
+  agent: 'text-entity-agent',
+  kb: 'text-entity-document',
+  chat: 'text-entity-chat',
+  event: 'text-entity-event',
+  toolkit: 'text-entity-toolkit-text',
+  tool: 'text-entity-tool',
+};
+
+export function KPIStatCard({
+  label,
+  value,
+  sub,
+  tone = 'session',
+  icon,
+  className,
+}: KPIStatCardProps): JSX.Element {
+  return (
+    <div
+      className={[
+        'flex min-w-0 flex-col gap-1',
+        'rounded-lg border border-border border-t-[3px] bg-card',
+        'px-4 py-3.5',
+        TONE_BORDER[tone],
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex items-center gap-1.5">
+        {icon ? (
+          <span aria-hidden="true" className="text-[13px] leading-none">
+            {icon}
+          </span>
+        ) : null}
+        <span className="font-mono text-[9.5px] font-bold uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+      </div>
+      <div
+        className={[
+          'font-display text-[28px] font-extrabold leading-none tabular-nums tracking-tight',
+          TONE_VALUE_TEXT[tone],
+        ].join(' ')}
+      >
+        {value}
+      </div>
+      {sub ? (
+        <div className="font-mono text-[10px] font-bold text-muted-foreground">{sub}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.test.tsx
+++ b/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.test.tsx
@@ -90,7 +90,7 @@ describe('KPIStatCard', () => {
     ['event', 'border-t-entity-event', 'text-entity-event'],
     ['player', 'border-t-entity-player', 'text-entity-player'],
     ['chat', 'border-t-entity-chat', 'text-entity-chat'],
-    ['toolkit', 'border-t-entity-toolkit', 'text-entity-toolkit-text'],
+    ['toolkit', 'border-t-entity-toolkit', 'text-entity-toolkit'],
     ['game', 'border-t-entity-game', 'text-entity-game'],
     ['kb', 'border-t-entity-document', 'text-entity-document'],
   ] as const)('applies tone=%s utility classes', (tone, borderClass, textClass) => {

--- a/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.test.tsx
+++ b/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KPIStatGrid, KPIStatCard } from './index';
+
+describe('KPIStatGrid', () => {
+  it('renders children inside a grid with role="list"', () => {
+    render(
+      <KPIStatGrid>
+        <KPIStatCard label="Test" value="42" />
+      </KPIStatGrid>
+    );
+    const grid = screen.getByRole('list');
+    expect(grid).toBeInTheDocument();
+    expect(grid.className).toContain('grid');
+  });
+
+  it('defaults to 4 columns responsive (2 cols mobile, 4 cols desktop)', () => {
+    render(
+      <KPIStatGrid>
+        <KPIStatCard label="A" value="1" />
+      </KPIStatGrid>
+    );
+    const grid = screen.getByRole('list');
+    expect(grid.className).toContain('grid-cols-2');
+    expect(grid.className).toContain('sm:grid-cols-4');
+  });
+
+  it('accepts columns=3 prop', () => {
+    render(
+      <KPIStatGrid columns={3}>
+        <KPIStatCard label="A" value="1" />
+      </KPIStatGrid>
+    );
+    const grid = screen.getByRole('list');
+    expect(grid.className).toContain('sm:grid-cols-3');
+  });
+
+  it('accepts columns=2 prop (mobile-equivalent)', () => {
+    render(
+      <KPIStatGrid columns={2}>
+        <KPIStatCard label="A" value="1" />
+      </KPIStatGrid>
+    );
+    const grid = screen.getByRole('list');
+    expect(grid.className).toContain('grid-cols-2');
+    expect(grid.className).not.toContain('sm:grid-cols-4');
+  });
+
+  it('accepts custom className override', () => {
+    render(
+      <KPIStatGrid className="custom-class">
+        <KPIStatCard label="A" value="1" />
+      </KPIStatGrid>
+    );
+    expect(screen.getByRole('list').className).toContain('custom-class');
+  });
+});
+
+describe('KPIStatCard', () => {
+  it('renders label, value, sub', () => {
+    render(<KPIStatCard label="Sessioni" value={3} sub="3 game completati" />);
+    expect(screen.getByText('Sessioni')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('3 game completati')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided (decorative aria-hidden)', () => {
+    render(<KPIStatCard label="Sessioni" value="3" icon="🎯" />);
+    const icon = screen.getByText('🎯');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('omits sub element when sub prop missing', () => {
+    const { container } = render(<KPIStatCard label="A" value="1" />);
+    expect(container.querySelectorAll('.font-mono').length).toBe(1);
+  });
+
+  it('omits icon span when icon prop missing', () => {
+    const { container } = render(<KPIStatCard label="A" value="1" />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('defaults to session tone', () => {
+    const { container } = render(<KPIStatCard label="A" value="1" />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('border-t-entity-session');
+  });
+
+  it.each([
+    ['event', 'border-t-entity-event', 'text-entity-event'],
+    ['player', 'border-t-entity-player', 'text-entity-player'],
+    ['chat', 'border-t-entity-chat', 'text-entity-chat'],
+    ['toolkit', 'border-t-entity-toolkit', 'text-entity-toolkit-text'],
+    ['game', 'border-t-entity-game', 'text-entity-game'],
+    ['kb', 'border-t-entity-document', 'text-entity-document'],
+  ] as const)('applies tone=%s utility classes', (tone, borderClass, textClass) => {
+    const { container } = render(<KPIStatCard label="A" value="1" tone={tone} />);
+    const card = container.firstChild as HTMLElement;
+    const value = container.querySelector('.font-display') as HTMLElement;
+    expect(card.className).toContain(borderClass);
+    expect(value.className).toContain(textClass);
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(<KPIStatCard label="A" value="1" className="extra" />);
+    expect((container.firstChild as HTMLElement).className).toContain('extra');
+  });
+
+  it('value supports React nodes (not just strings)', () => {
+    render(
+      <KPIStatCard
+        label="Custom"
+        value={
+          <>
+            <span>2</span>
+            <span>/3</span>
+          </>
+        }
+      />
+    );
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('/3')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.tsx
+++ b/apps/web/src/components/ui/kpi-stat-grid/kpi-stat-grid.tsx
@@ -1,0 +1,26 @@
+import type { JSX, ReactNode } from 'react';
+
+export interface KPIStatGridProps {
+  readonly children: ReactNode;
+  readonly columns?: 2 | 3 | 4;
+  readonly className?: string;
+}
+
+const COLUMNS_CLASS: Record<2 | 3 | 4, string> = {
+  2: 'grid-cols-2',
+  3: 'grid-cols-2 sm:grid-cols-3',
+  4: 'grid-cols-2 sm:grid-cols-4',
+};
+
+export function KPIStatGrid({ children, columns = 4, className }: KPIStatGridProps): JSX.Element {
+  return (
+    <div
+      role="list"
+      className={['grid gap-2.5 sm:gap-3.5', COLUMNS_CLASS[columns], className ?? '']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/setup-checklist/index.ts
+++ b/apps/web/src/components/ui/setup-checklist/index.ts
@@ -1,0 +1,5 @@
+export { SetupChecklist } from '@/components/ui/setup-checklist/setup-checklist';
+export type {
+  SetupChecklistProps,
+  SetupChecklistItem,
+} from '@/components/ui/setup-checklist/setup-checklist';

--- a/apps/web/src/components/ui/setup-checklist/setup-checklist.test.tsx
+++ b/apps/web/src/components/ui/setup-checklist/setup-checklist.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SetupChecklist, type SetupChecklistItem } from './index';
+
+const SAMPLE: ReadonlyArray<SetupChecklistItem> = [
+  { icon: '🗺️', text: 'Tabellone · 4 isole', done: true },
+  { icon: '🧝', text: 'Spirit panels (4 spiriti scelti)', done: true },
+  { icon: '🃏', text: 'Invader deck shuffled', done: false },
+  { icon: '💀', text: 'Fear pool · 9 token', done: false },
+];
+
+describe('SetupChecklist', () => {
+  it('renders default "Setup checklist" title with done/total counter', () => {
+    render(<SetupChecklist items={SAMPLE} />);
+    expect(screen.getByText(/Setup checklist · 2\/4/)).toBeInTheDocument();
+  });
+
+  it('renders all item texts', () => {
+    render(<SetupChecklist items={SAMPLE} />);
+    SAMPLE.forEach(item => {
+      expect(screen.getByText(item.text)).toBeInTheDocument();
+    });
+  });
+
+  it('renders icon emojis when provided (aria-hidden)', () => {
+    render(<SetupChecklist items={SAMPLE} />);
+    const mapIcon = screen.getByText('🗺️');
+    expect(mapIcon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders ✓ check mark only for done items', () => {
+    render(<SetupChecklist items={SAMPLE} />);
+    const checks = screen.getAllByText('✓');
+    expect(checks.length).toBe(2);
+  });
+
+  it('applies line-through styling to done items only', () => {
+    const { container } = render(<SetupChecklist items={SAMPLE} />);
+    const textSpans = container.querySelectorAll('li span.font-body');
+    expect(textSpans.length).toBe(4);
+    expect(textSpans[0].className).toContain('line-through');
+    expect(textSpans[1].className).toContain('line-through');
+    expect(textSpans[2].className).not.toContain('line-through');
+    expect(textSpans[3].className).not.toContain('line-through');
+  });
+
+  it('applies entity-toolkit accent on done items, muted on pending', () => {
+    const { container } = render(<SetupChecklist items={SAMPLE} />);
+    const items = container.querySelectorAll('li');
+    expect(items[0].className).toContain('bg-entity-toolkit');
+    expect(items[2].className).toContain('bg-muted');
+  });
+
+  it('handles 0/N counter when no items done', () => {
+    const allPending: ReadonlyArray<SetupChecklistItem> = [
+      { text: 'A', done: false },
+      { text: 'B', done: false },
+    ];
+    render(<SetupChecklist items={allPending} />);
+    expect(screen.getByText(/Setup checklist · 0\/2/)).toBeInTheDocument();
+  });
+
+  it('handles N/N counter when all done', () => {
+    const allDone: ReadonlyArray<SetupChecklistItem> = [
+      { text: 'A', done: true },
+      { text: 'B', done: true },
+    ];
+    render(<SetupChecklist items={allDone} />);
+    expect(screen.getByText(/Setup checklist · 2\/2/)).toBeInTheDocument();
+  });
+
+  it('treats undefined done as not done', () => {
+    const noFlag: ReadonlyArray<SetupChecklistItem> = [{ text: 'no flag' }];
+    render(<SetupChecklist items={noFlag} />);
+    expect(screen.getByText(/Setup checklist · 0\/1/)).toBeInTheDocument();
+    expect(screen.queryByText('✓')).toBeNull();
+  });
+
+  it('accepts custom title override', () => {
+    render(<SetupChecklist items={SAMPLE} title="Pre-flight check" />);
+    expect(screen.getByText(/Pre-flight check · 2\/4/)).toBeInTheDocument();
+  });
+
+  it('omits icon span when item.icon missing', () => {
+    const noIcons: ReadonlyArray<SetupChecklistItem> = [{ text: 'no icon', done: true }];
+    const { container } = render(<SetupChecklist items={noIcons} />);
+    // Only the check ✓ span should have aria-hidden (since icon emoji span is omitted)
+    const ariaHidden = container.querySelectorAll('[aria-hidden="true"]');
+    // 2 = header 📋 + ✓ checkbox; no item icon span
+    expect(ariaHidden.length).toBe(2);
+  });
+
+  it('accepts empty items array', () => {
+    render(<SetupChecklist items={[]} />);
+    expect(screen.getByText(/Setup checklist · 0\/0/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/setup-checklist/setup-checklist.tsx
+++ b/apps/web/src/components/ui/setup-checklist/setup-checklist.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
 
 export interface SetupChecklistItem {
+  readonly id?: string;
   readonly icon?: string;
   readonly text: string;
   readonly done?: boolean;
@@ -30,9 +31,9 @@ export function SetupChecklist({
         </span>
       </div>
       <ul className="flex flex-col gap-1 m-0 p-0 list-none">
-        {items.map((item, i) => (
+        {items.map(item => (
           <li
-            key={i}
+            key={item.id ?? item.text}
             className={[
               'flex items-center gap-2.5 rounded-sm px-2.5 py-1',
               item.done

--- a/apps/web/src/components/ui/setup-checklist/setup-checklist.tsx
+++ b/apps/web/src/components/ui/setup-checklist/setup-checklist.tsx
@@ -1,0 +1,75 @@
+import type { JSX } from 'react';
+
+export interface SetupChecklistItem {
+  readonly icon?: string;
+  readonly text: string;
+  readonly done?: boolean;
+}
+
+export interface SetupChecklistProps {
+  readonly items: ReadonlyArray<SetupChecklistItem>;
+  readonly title?: string;
+  readonly className?: string;
+}
+
+export function SetupChecklist({
+  items,
+  title = 'Setup checklist',
+  className,
+}: SetupChecklistProps): JSX.Element {
+  const doneCount = items.filter(i => i.done).length;
+
+  return (
+    <div className={['flex flex-col gap-1.5', className ?? ''].filter(Boolean).join(' ')}>
+      <div className="flex items-center gap-1.5">
+        <span aria-hidden="true" className="text-[13px] leading-none">
+          📋
+        </span>
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+          {title} · {doneCount}/{items.length}
+        </span>
+      </div>
+      <ul className="flex flex-col gap-1 m-0 p-0 list-none">
+        {items.map((item, i) => (
+          <li
+            key={i}
+            className={[
+              'flex items-center gap-2.5 rounded-sm px-2.5 py-1',
+              item.done
+                ? 'bg-entity-toolkit/[0.06] border border-entity-toolkit/30'
+                : 'bg-muted border border-border opacity-90',
+            ].join(' ')}
+          >
+            <span
+              aria-hidden="true"
+              className={[
+                'inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-sm',
+                'text-[11px] font-extrabold leading-none text-white',
+                item.done
+                  ? 'bg-entity-toolkit border-0'
+                  : 'border-[1.5px] border-border-strong bg-transparent',
+              ].join(' ')}
+            >
+              {item.done ? '✓' : ''}
+            </span>
+            {item.icon ? (
+              <span aria-hidden="true" className="text-[13px] leading-none">
+                {item.icon}
+              </span>
+            ) : null}
+            <span
+              className={[
+                'min-w-0 flex-1 font-body text-[11.5px] font-semibold',
+                item.done
+                  ? 'text-foreground line-through decoration-muted-foreground decoration-1'
+                  : 'text-muted-foreground',
+              ].join(' ')}
+            >
+              {item.text}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/share-success-toast/index.ts
+++ b/apps/web/src/components/ui/share-success-toast/index.ts
@@ -1,0 +1,2 @@
+export { ShareSuccessToast } from '@/components/ui/share-success-toast/share-success-toast';
+export type { ShareSuccessToastProps } from '@/components/ui/share-success-toast/share-success-toast';

--- a/apps/web/src/components/ui/share-success-toast/share-success-toast.test.tsx
+++ b/apps/web/src/components/ui/share-success-toast/share-success-toast.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShareSuccessToast } from './index';
+
+describe('ShareSuccessToast', () => {
+  it('renders nothing when visible=false', () => {
+    const { container } = render(<ShareSuccessToast visible={false} title="Link copiato" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders title when visible', () => {
+    render(<ShareSuccessToast visible title="Link copiato" />);
+    expect(screen.getByText('Link copiato')).toBeInTheDocument();
+  });
+
+  it('renders subline when provided', () => {
+    render(
+      <ShareSuccessToast
+        visible
+        title="Link copiato"
+        subline="meepleai.app/s/gn-042 · sparisce in 3s"
+      />
+    );
+    expect(screen.getByText('meepleai.app/s/gn-042 · sparisce in 3s')).toBeInTheDocument();
+  });
+
+  it('omits subline when not provided', () => {
+    const { container } = render(<ShareSuccessToast visible title="OK" />);
+    const monoSpans = container.querySelectorAll('.font-mono');
+    expect(monoSpans.length).toBe(0);
+  });
+
+  it('uses default 🔗 icon', () => {
+    render(<ShareSuccessToast visible title="Link copiato" />);
+    expect(screen.getByText('🔗')).toBeInTheDocument();
+  });
+
+  it('accepts custom icon override', () => {
+    render(<ShareSuccessToast visible title="Archiviato" icon="✓" />);
+    expect(screen.getByText('✓')).toBeInTheDocument();
+    expect(screen.queryByText('🔗')).toBeNull();
+  });
+
+  it('icon is aria-hidden (decorative)', () => {
+    render(<ShareSuccessToast visible title="OK" />);
+    expect(screen.getByText('🔗')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has role="status" + aria-live="polite" for SR announcements', () => {
+    render(<ShareSuccessToast visible title="OK" />);
+    const toast = screen.getByRole('status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(toast).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('accepts custom className override', () => {
+    render(<ShareSuccessToast visible title="OK" className="custom-class" />);
+    expect(screen.getByRole('status').className).toContain('custom-class');
+  });
+
+  it('uses entity-toolkit color tokens (no hardcoded green)', () => {
+    render(<ShareSuccessToast visible title="OK" />);
+    const toast = screen.getByRole('status');
+    expect(toast.className).toContain('bg-entity-toolkit/10');
+    expect(toast.className).toContain('border-entity-toolkit/30');
+  });
+});

--- a/apps/web/src/components/ui/share-success-toast/share-success-toast.tsx
+++ b/apps/web/src/components/ui/share-success-toast/share-success-toast.tsx
@@ -1,0 +1,57 @@
+import type { JSX } from 'react';
+
+export interface ShareSuccessToastProps {
+  readonly visible: boolean;
+  readonly title: string;
+  readonly subline?: string;
+  readonly icon?: string;
+  readonly className?: string;
+}
+
+export function ShareSuccessToast({
+  visible,
+  title,
+  subline,
+  icon = '🔗',
+  className,
+}: ShareSuccessToastProps): JSX.Element | null {
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={[
+        'fixed bottom-5 right-5 z-40 max-w-[280px]',
+        'flex items-center gap-2.5',
+        'px-3.5 py-2.5 pl-3',
+        'rounded-pill',
+        'bg-entity-toolkit/10 border border-entity-toolkit/30',
+        'backdrop-blur-md shadow-lg',
+        'motion-safe:animate-in motion-safe:slide-in-from-bottom-2 motion-safe:fade-in-0 motion-safe:duration-300',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{ boxShadow: 'var(--shadow-lg), 0 0 0 4px hsl(var(--c-toolkit) / 0.06)' }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full bg-entity-toolkit text-white text-[13px] font-extrabold"
+      >
+        {icon}
+      </span>
+      <div className="flex min-w-0 flex-col gap-px">
+        <span className="font-display text-[12.5px] font-extrabold text-entity-toolkit-text">
+          {title}
+        </span>
+        {subline ? (
+          <span className="font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
+            {subline}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**PR 1/2** del cluster #1255 (sub-issue di #1026 Stage 3 de-versioning umbrella #1023).

Aggiunge 6 primitives `components/ui/`, riusabili dai mockup K/L/M (`sp7-game-night-{live,transition,summary}`) mergiati con PR #1250 (closes #487).

## Primitives + coverage

| Primitive | LOC | Test |
|---|---|---|
| `auto-save-toast/` | 47 | 9 ¹ |
| `kpi-stat-grid/` + `kpi-stat-card/` | 84 | 18 |
| `kb-rules-quick-glance/` | 152 | 14 ² |
| `setup-checklist/` | 74 | 12 |
| `share-success-toast/` | 51 | 10 |
| `archived-banner/` | 51 | 11 |
| **Totale** | **459** | **74** |

¹ Auto-save toast: 60s tick bottom-right, acceptance criterion esplicito issue #487
² KB rules quick-glance: 3-state ok/loading/error con `onRetry`+`onProceed` callbacks

## Acceptance criteria (cluster #1026)

- [x] **AC3.2 token-aware**: tutti i componenti usano `bg-entity-*` utility o `var(--c-*)` semantici — zero hardcoded color (verificato via `local/no-hardcoded-color-utility` ESLint rule)
- [x] **AC3.4 coverage ≥85%**: 74 test su 6 primitives, edge cases (empty arrays, missing props), ARIA (`role="status"`, `aria-live="polite"`, `aria-busy`, `aria-hidden` decorative icons), motion-safe variants
- [x] **AC3.3** N/A (no legacy da eliminare in foundation PR — questi sono primitives nuovi)
- ⏳ **AC3.1 visual diff ≤2%**: deferred a PR 2 runtime screens (i primitives sono testati per shape API; visual baseline post-integration)
- ⏳ **AC3.5 lib/routes.ts**: deferred a PR 2 (no nuove route in foundation PR)

## Pattern condivisi

- TypeScript `JSX.Element` return + `readonly` props (allinea a `divider/`, `auth-card/` pattern)
- Tailwind entity utility (`bg-entity-toolkit/10`, `text-entity-toolkit-text` per AA contrast)
- CSS variable arbitrary values per `--c-kb`, `--c-danger` (canale tone diversi da entity standard)
- `motion-safe:animate-in` per `prefers-reduced-motion` compliance (a11y AA)
- ARIA semantics: `status` (toast/banner), `alert` (error state), `aria-busy` (loading), `aria-hidden` su tutti decorative emojis

## Test plan

- [x] `pnpm vitest run src/components/ui/{auto-save-toast,kpi-stat-grid,kb-rules-quick-glance,setup-checklist,share-success-toast,archived-banner}` — 74/74 pass
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm eslint <6 primitives>` — 0 errors 0 warnings
- [ ] Visual snapshot integration test (verrà aggiunto in PR 2 runtime)

## Next step

PR 2 — Runtime screens (`/game-nights/[id]/live` + `/summary` + `GameTransitionDialog`) che integra questi 6 primitives nelle compositions + nuove route + `lib/routes.ts` update + visual regression baseline conformity vs mockup K/L/M.

Refs #1255 (cluster), #1026 (Stage 3 tracking), #1023 (umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)