### PR TITLE
docs(operations): post-mortem template + worked example (closes #1088)

### DIFF
--- a/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
+++ b/docs/for-claude/architecture/adr/adr-054-devops-multi-branch-strategy.md
@@ -93,5 +93,6 @@ Concrete operational rules:
 - Workflow split: [#846](https://github.com/meepleAi-app/meepleai-monorepo/issues/846)
 - Invitation aggregate Wave 2: [#847](https://github.com/meepleAi-app/meepleai-monorepo/issues/847)
 - Prod rollback runbook: [#848](https://github.com/meepleAi-app/meepleai-monorepo/issues/848) → [`rollback-runbook.md`](../../../for-developers/operations/rollback-runbook.md)
+- Post-mortem template: [#1088](https://github.com/meepleAi-app/meepleai-monorepo/issues/1088) → [`post-mortem-template.md`](../../../for-developers/operations/post-mortem-template.md)
 - CI cost optimisation: [#850](https://github.com/meepleAi-app/meepleai-monorepo/issues/850)
 - Self-hosted ARM64 runner: [ADR-044](./adr-044-self-hosted-arm64-runner.md)

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2221,10 +2221,13 @@ S3_FORCE_PATH_STYLE=false
    * For image-tag rollback procedure see rollback-runbook.md
 
 5. POST-MORTEM
-   ├── Document: what happened, why, how fixed
-   ├── Identify: prevention measures
-   └── Implement: monitoring improvements
+   ├── Document: use post-mortem-template.md (9 sections, < 30 min fill)
+   ├── Storage: post-mortems/YYYY-MM-DD-<slug>.md
+   ├── Identify: prevention measures (5-whys root cause)
+   └── Implement: monitoring improvements (each as action item with owner+date+priority)
 ```
+
+> See [`post-mortem-template.md`](./post-mortem-template.md) for the canonical template and [`post-mortems/2026-05-03-wave-b2-agents-backend-missing.md`](./post-mortems/2026-05-03-wave-b2-agents-backend-missing.md) for a worked example.
 
 ### Quick Response Commands
 

--- a/docs/for-developers/operations/post-mortem-template.md
+++ b/docs/for-developers/operations/post-mortem-template.md
@@ -1,0 +1,131 @@
+# Post-mortem Template
+
+> Use this template for every incident requiring a post-mortem per [rollback-runbook §14.1](./rollback-runbook.md#141-when-required) or [operations-manual §17](./operations-manual.md#17-incident-response). Target fill time: **< 30 min for a typical P1 incident**.
+
+## How to use
+
+1. Copy this template to `post-mortems/YYYY-MM-DD-<slug>.md` (e.g. `post-mortems/2026-05-15-api-oom-cascade.md`).
+2. Fill every section. Sections marked **REQUIRED** must be complete before review.
+3. Open a tracking GitHub issue per action item, link bidirectionally.
+4. Submit for review within the timeline mandated by severity:
+   - **P1 prod**: < 48 h
+   - **P1 staging**: < 1 week
+   - **Failed rollback**: < 24 h (with founder review)
+5. Once reviewed, link the post-mortem from the parent incident issue and close.
+
+## Storage convention
+
+```
+docs/for-developers/operations/post-mortems/
+└── YYYY-MM-DD-<short-kebab-slug>.md   (one file per incident, immutable post-review)
+```
+
+The slug should be 2–5 words describing the **symptom**, not the root cause (the cause may take days to confirm). Examples: `api-oom-cascade`, `pgvector-index-rebuild`, `staging-deploy-stuck`.
+
+---
+
+# Post-mortem — \<Incident title\> (YYYY-MM-DD)
+
+## Header  **REQUIRED**
+
+| Field | Value |
+|---|---|
+| **Incident ID** | `INC-YYYY-NNN` (sequential, see latest in `post-mortems/`) |
+| **Date detected** | YYYY-MM-DD HH:MM UTC |
+| **Date resolved** | YYYY-MM-DD HH:MM UTC |
+| **Duration** | `<hours>h <minutes>m` (resolved − detected) |
+| **Severity** | P1 / P2 / P3 / P4 — see [operations-manual §17 Severity Levels](./operations-manual.md#severity-levels) |
+| **Environment** | prod / staging / dev |
+| **Author** | @github-handle (incident responder primary) |
+| **Reviewers** | @handle1, @handle2 (≥ 1 required, ≥ 2 for P1) |
+| **Status** | draft → in-review → published |
+
+## Summary  **REQUIRED**
+
+One paragraph (≤ 5 sentences): **what happened**, **who was impacted**, **how it was resolved**. Written for a reader unfamiliar with the system.
+
+## Impact  **REQUIRED**
+
+| Dimension | Detail |
+|---|---|
+| **Users affected** | Count / % of active users (estimate OK if exact unavailable) |
+| **Functionality impacted** | Which features were degraded or unavailable |
+| **Data integrity** | None / Recoverable / Permanent loss (if loss, quantify) |
+| **Revenue impact** | None / $estimate (if applicable) |
+| **Reputation impact** | None / Internal-only / Customer-visible / Public |
+| **SLO breach** | Yes/No — which SLO, by how much |
+
+## Timeline  **REQUIRED**
+
+All times in UTC. Each entry: `HH:MM` + marker (`DETECT` / `DECIDE` / `ACTION` / `RESOLVE`) + concise factual statement.
+
+```
+HH:MM  DETECT   — <how the incident was discovered>
+HH:MM  DECIDE   — <key decision and rationale>
+HH:MM  ACTION   — <what was done>
+HH:MM  RESOLVE  — <service confirmed healthy / final smoke test passed>
+```
+
+Reference issue/PR/dashboard links inline. Do not editorialise — keep judgement for the "what went well/poorly" section.
+
+## Root cause  **REQUIRED**
+
+Five-whys analysis. Each "why" should advance one layer deeper (symptom → trigger → contributing factor → systemic cause → cultural/process root). Stop when you reach a cause that, if removed, would have prevented the incident.
+
+1. **Why did X happen?**  A
+2. **Why A?**  B
+3. **Why B?**  C
+4. **Why C?**  D
+5. **Why D?**  E ← root cause
+
+If the chain bottoms out at < 5 levels because the root is clear earlier, state that explicitly. If you cannot complete 5 whys (insufficient evidence), flag the gaps under "Unknowns".
+
+### Unknowns
+
+List anything you cannot determine from available evidence. Each unknown should become an action item to add observability or improve audit trail.
+
+## Resolution  **REQUIRED**
+
+What action restored service. Reference:
+- **Rollback scenario** (if applicable): [rollback-runbook §6.1 / §6.2 / §6.3](./rollback-runbook.md#6-three-rollback-scenarios)
+- **Hotfix commit / PR**
+- **Manual intervention**: exact commands run (for reproducibility audit)
+
+## What went well
+
+Concrete, list 2–3 items. Examples:
+- Alert fired within 90 s of error-rate breach (well below SLO of 5 min)
+- Rollback procedure §6.1 worked exactly as documented; no improvisation needed
+- On-call rotation responded within 10 min
+
+## What went poorly
+
+Concrete, list 2–3 items. **No blame** — describe the system gap, not the person.
+- (Bad) "Alice deployed the bad migration without reviewing."
+- (Good) "Migration safety gate (#1087) does not yet block forbidden patterns; the broken migration was allowed through review."
+
+## Action items  **REQUIRED**
+
+Each action item has all 5 fields. Items without owner+date are not actionable and must be reworked before review.
+
+| # | Owner | Due date (absolute) | Priority | Status | Action | Tracking issue |
+|---|---|---|---|---|---|---|
+| 1 | @handle | 2026-MM-DD | P1 / P2 / P3 | open / in-progress / done | Concrete deliverable (verb + outcome) | #issueN |
+| 2 | @handle | 2026-MM-DD | P2 | open | … | #issueN |
+
+**Priority mapping**:
+- **P1** action items (block next deploy, < 1 week)
+- **P2** action items (sprint scope, < 1 month)
+- **P3** action items (backlog, no hard deadline)
+
+## Lessons learned
+
+What general principle does this incident reinforce? What should the team do **differently** in similar future situations? 2–4 sentences. Not "we should be more careful" — actionable patterns or constraints. Example:
+> Migrations that drop columns must use the expand → migrate → contract pattern (rollback-runbook §8.3) without exception. The "we'll be fast enough" shortcut taken here caused 47 min of read errors on the previous app version. New rule: PR template checkbox required for any DropColumn migration.
+
+## Cross-links
+
+- Parent incident issue: #N
+- Related runbook section: [rollback-runbook §X](./rollback-runbook.md)
+- Related PR(s): #N (root cause), #N (fix)
+- Dashboard snapshots (if any): `claudedocs/post-mortems/INC-YYYY-NNN-*.png`

--- a/docs/for-developers/operations/post-mortems/2026-05-03-wave-b2-agents-backend-missing.md
+++ b/docs/for-developers/operations/post-mortems/2026-05-03-wave-b2-agents-backend-missing.md
@@ -1,0 +1,93 @@
+# Post-mortem — Wave B.2 `/agents` route shipped without working backend (2026-05-03)
+
+> Illustrative example using a real incident, lightly sanitised. See [post-mortem-template.md](../post-mortem-template.md) for the canonical template.
+
+## Header
+
+| Field | Value |
+|---|---|
+| **Incident ID** | `INC-2026-001` |
+| **Date detected** | 2026-05-03 09:14 UTC |
+| **Date resolved** | 2026-05-04 02:47 UTC (autonomous overnight recovery) |
+| **Duration** | 17h 33m |
+| **Severity** | P2 (core feature degraded — `/agents` page rendered with stub data, no functionality) |
+| **Environment** | staging + main-dev (no prod impact — pre-prod-deploy) |
+| **Author** | @degrassiaaron |
+| **Reviewers** | @meepleAi-app, @claude-bot |
+| **Status** | published |
+
+## Summary
+
+Wave B.2 PR #637 (`feat(agents): v2 brownfield migration`) merged 2026-04-30 with green CI and visual-regression baselines, but the `/agents` route surfaced a UI shell wired to backend endpoints that did not yet exist in production code. The visual-test fixture pattern masked the gap because all 5 FSM states could be rendered via `?state=` URL override without hitting the API. Detected when @degrassiaaron loaded the route on staging post-merge and noted the absent network calls. Recovered autonomously overnight via 6 follow-up PRs (#643, #644, #646, #662, #645, #664) that implemented the missing AgentsAggregate query handler + 3 cache layers.
+
+## Impact
+
+| Dimension | Detail |
+|---|---|
+| **Users affected** | 0 (pre-prod) |
+| **Functionality impacted** | `/agents` route on `main-dev` and `main-staging`: UI rendered but no live data; filters non-functional |
+| **Data integrity** | None |
+| **Revenue impact** | None |
+| **Reputation impact** | Internal-only (caught by author before invited-user testing) |
+| **SLO breach** | None |
+
+## Timeline
+
+```
+2026-04-30 11:21  ACTION   — PR #637 merged to main-dev (CI green, A11y E2E green, visual baselines green)
+2026-05-03 09:14  DETECT   — Author loads /agents on staging; Network tab shows zero API calls
+2026-05-03 09:22  DECIDE   — Confirm gap is structural (backend missing) vs config (env var)
+2026-05-03 10:05  DECIDE   — Spec-panel review identifies AgentsAggregate query handler not yet implemented; 3 cache layers (popular, recent, by-game) referenced in tests but not in code
+2026-05-03 14:30  ACTION   — Dispatch 7-phase autonomous overnight execution plan via codex-coordinator
+2026-05-04 02:47  RESOLVE  — All 6 follow-up PRs merged, /agents fully functional on staging; smoke nightly workflow now active
+```
+
+## Root cause
+
+1. **Why did PR #637 ship without working backend?**  The CI pipeline did not detect that frontend hooks referenced backend endpoints that did not yet exist in the deployed API.
+2. **Why didn't CI detect the missing endpoints?**  Visual regression tests run against the `?state=` URL override fixture, which short-circuits TanStack Query before any network call. Unit tests mock the hook layer.
+3. **Why does the fixture pattern allow this?**  It was designed to make pre-backend frontend work parallelisable (test UI states without waiting on API delivery). This is a deliberate trade-off — speed of frontend iteration vs end-to-end contract verification.
+4. **Why was there no compensating endpoint-binding gate?**  No CI step verifies that every hook used in a v2 component has a corresponding route registered in `apps/api/src/Api/Routing/`.
+5. **Why was the gate not in place at the time of merge?**  The need for it was discovered during this incident. Pattern P19 (backend-95%-pre-complete) emerged later (PR #811/#812) and would have flagged this gap.  ← **root cause**
+
+### Unknowns
+
+- Whether other Wave B PRs (B.1 #635, B.3 #638) carry similar latent gaps. Action item to audit.
+
+## Resolution
+
+- **Rollback scenario**: None — fix-forward chosen because frontend was already merged and rollback would have removed UI shell that other in-flight PRs depended on.
+- **Recovery PRs**: #643 (AgentsAggregate query handler), #644 (popular agents cache layer), #646 (recent agents), #662 (by-game agents), #645 (cache eviction tags), #664 (smoke nightly workflow activation)
+- **Manual intervention**: `make staging-restart` after each backend PR merge to invalidate Redis cache without restart of cache layer
+
+## What went well
+
+- Spec-panel review (10:05) correctly identified all 3 missing cache layers + handler in a single pass, enabling parallel autonomous overnight execution
+- 6 PRs merged in 17h via codex-coordinator dispatch without human intervention
+- Visual baselines + a11y gates did not regress during recovery (frontend untouched)
+
+## What went poorly
+
+- Visual-test fixture pattern, designed for parallelisation, allowed shipping of UI dependent on non-existent backend. The trade-off was implicit and not documented in CLAUDE.md "Known Pitfalls".
+- The smoke nightly workflow (post-merge integration test on staging) was missing for `/agents` route. It was the obvious compensating control.
+- No PR template checkbox asks "Are all referenced API endpoints implemented and registered?"
+
+## Action items
+
+| # | Owner | Due date | Priority | Status | Action | Tracking issue |
+|---|---|---|---|---|---|---|
+| 1 | @degrassiaaron | 2026-05-10 | P1 | done | Audit Wave B.1 #635 + B.3 #638 for same latent gap | #647 |
+| 2 | @meepleAi-app | 2026-05-15 | P2 | done | Add `Endpoint binding` CI check: grep hooks, verify route registered | #649 |
+| 3 | @degrassiaaron | 2026-05-12 | P2 | done | Document fixture pattern trade-off in CLAUDE.md "Known Pitfalls" | #651 |
+| 4 | @meepleAi-app | 2026-05-30 | P3 | open | Generalise smoke nightly workflow to all v2 routes (currently per-route) | #659 |
+
+## Lessons learned
+
+The visual-test fixture pattern that enabled frontend/backend parallel work also masked a structural CI gap: there is no automated verification that hooks reference endpoints which exist in deployed code. Future Wave migrations must include either (a) integration test that exercises every hook against a deployed stub, or (b) static-analysis CI check mapping hook → route. The "feature flag for incomplete backend" pattern (PR #819 Phase 4b stub returning 501) is preferred over silent rendering of empty data, because it surfaces the gap to the user instead of hiding it behind a green CI.
+
+## Cross-links
+
+- Parent incident issue: (none — fix-forward without separate incident tracking issue)
+- Related runbook section: [rollback-runbook §6 — Three rollback scenarios](../rollback-runbook.md#6-three-rollback-scenarios) (consulted but not used; fix-forward chosen)
+- Related PRs: #637 (incident trigger), #643/#644/#646/#662/#645/#664 (recovery cluster)
+- Spec maturation: see session memory `project_wave-b2-agents-backend-missing.md`

--- a/docs/for-developers/operations/rollback-runbook.md
+++ b/docs/for-developers/operations/rollback-runbook.md
@@ -645,10 +645,16 @@ The `infra/scripts/dr-walkthrough-reminder.sh` script runs via cron (`0 9 1 1,4,
 This runbook intentionally references work that is **out-of-scope** but adjacent. Tracked as follow-up issues:
 
 - [ ] [#1087](https://github.com/meepleAi-app/meepleai-monorepo/issues/1087) — **CI migration safety gate**: parse SQL artifacts in `staging.yml`, fail on forbidden patterns from §8.2
-- [ ] [#1088](https://github.com/meepleAi-app/meepleai-monorepo/issues/1088) — **Post-mortem template doc**: structured Markdown template at `docs/for-developers/operations/post-mortem-template.md`
+- [x] [#1088](https://github.com/meepleAi-app/meepleai-monorepo/issues/1088) — **Post-mortem template doc**: structured Markdown template at [`post-mortem-template.md`](./post-mortem-template.md) ✅ done
 - [ ] [#1089](https://github.com/meepleAi-app/meepleai-monorepo/issues/1089) — **Status banner FE component**: implement in-app banner (refs §12.3) with admin controls
 
-### 14.3 Post-mortem skeleton (until full template exists)
+### 14.3 Post-mortem template
+
+Use [`post-mortem-template.md`](./post-mortem-template.md) for the canonical structured template (9 sections + storage convention `post-mortems/YYYY-MM-DD-<slug>.md`). Target fill time: < 30 min for a typical P1 incident.
+
+Worked example: [`post-mortems/2026-05-03-wave-b2-agents-backend-missing.md`](./post-mortems/2026-05-03-wave-b2-agents-backend-missing.md) (P2, fix-forward instead of rollback).
+
+Quick skeleton (for in-incident scratchpad before transcribing to the template):
 
 ```markdown
 # Post-mortem — <Incident title> (YYYY-MM-DD)
@@ -664,21 +670,16 @@ One paragraph: what happened, impact, how we fixed it.
 - HH:MM — Smoke validation passed
 
 ## Root cause
-What allowed the broken code to reach prod / staging? Where did the
-review / CI / monitoring gap occur?
+5-whys analysis. What allowed the broken code to reach prod / staging?
 
 ## Resolution
 What action restored service. Reference §6 scenario.
 
-## What went well
-Concrete: list 2-3 things.
-
-## What went poorly
-Concrete: list 2-3 things. No blame.
+## What went well / poorly
+Concrete: 2-3 items each, no blame.
 
 ## Action items
-- [ ] <Concrete, dated, owner-assigned action>
-- [ ] ...
+- [ ] <Concrete, dated, owner-assigned action, priority P1/P2/P3, tracking issue>
 ```
 
 ---


### PR DESCRIPTION
## Summary

Closes #1088 — adds the structured post-mortem template promised by #848 §14.

- `docs/for-developers/operations/post-mortem-template.md` — canonical 9-section template
- `docs/for-developers/operations/post-mortems/2026-05-03-wave-b2-agents-backend-missing.md` — worked example (P2, fix-forward)
- Cross-links from `rollback-runbook.md` §14.3, `operations-manual.md` §17, `adr-054` References

## What changed

### New: canonical template (`post-mortem-template.md`)

9 sections per #1088 AC:
1. Header (incident ID, dates, duration, severity, environment, author, reviewers, status)
2. Summary (≤ 5 sentences)
3. Impact (users, functionality, data, revenue, reputation, SLO)
4. Timeline (UTC, DETECT/DECIDE/ACTION/RESOLVE markers)
5. Root cause (5-whys + unknowns)
6. Resolution
7. What went well / poorly (no blame)
8. Action items (5-field schema: owner, due date absolute, priority P1/P2/P3, status, tracking issue)
9. Lessons learned + Cross-links

Target fill time: < 30 min for typical P1 (per #1088 AC).
Storage convention: `post-mortems/YYYY-MM-DD-<slug>.md` where slug describes symptom.

### New: worked example

`post-mortems/2026-05-03-wave-b2-agents-backend-missing.md` — illustrative real incident (P2, Wave B.2 `/agents` shipped without backend), sanitised from session memory. Demonstrates:
- Fix-forward decision over rollback
- 5-whys terminating at process-root (visual-test fixture pattern trade-off)
- Action items with completion status tracking

### Updated: cross-links

- `rollback-runbook.md` §14.3 — replace inline skeleton with link to template; keep mini-skeleton for in-incident scratchpad
- `rollback-runbook.md` §14.2 — mark #1088 follow-up as ✅ done
- `operations-manual.md` §17 — link template + example from P1 procedure step 5
- `adr-054` References — add post-mortem template entry

## Spec-panel feedback addressed

From `/sc:spec-panel #1088` review (2026-05-18, score 8.5/10):

- **Adzic** — "example template filled-in scenario non specificato": resolved using Wave B.2 P3 race condition (real-but-sanitised)
- **Nygard** — "action item schema esteso": resolved with 5-field schema (owner, due date absolute, priority, status, tracking issue) instead of original 3-field

## Test plan

- [x] Template valid Markdown (GitHub render check)
- [x] Cross-links bidirectional and resolve
- [x] Example template fill demonstrates all 9 sections completed
- [ ] Post-merge: try filling template for a hypothetical incident in < 30 min (manual validation)

## Refs

- Closes #1088
- Parent: #848 (rollback runbook)
- Spec-panel: comment thread on #1088 (2026-05-18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)