### PR TITLE
fix(ci): unbreak ci-minutes-digest.yml — gh api --slurp/--jq regression (refs #850 AC-5)

### DIFF
--- a/.github/workflows/ci-minutes-digest.yml
+++ b/.github/workflows/ci-minutes-digest.yml
@@ -53,11 +53,16 @@ jobs:
           # at 10 pages (1000 runs) to avoid runaway API consumption on busy
           # weeks. The default branch is main; the same query covers all
           # branches/events.
+          #
+          # Note: `gh api --slurp --jq` was deprecated and now errors out
+          # ("the --slurp option is not supported with --jq or --template").
+          # Workaround: pipe --paginate output through `jq -s` (slurp client-side)
+          # then apply the projection in a second jq pass. See issue #850 AC-5
+          # (this workflow was failing since 2026-04-13 due to this regression).
           gh api \
             "repos/$REPO/actions/runs?per_page=100&created=>$CUTOFF" \
             --paginate \
-            --slurp \
-            --jq '[.[].workflow_runs[] | select(.run_started_at != null and .updated_at != null) | {
+          | jq -s '[.[].workflow_runs[] | select(.run_started_at != null and .updated_at != null) | {
               name: .name,
               workflow_id: .workflow_id,
               conclusion: (.conclusion // "in_progress"),


### PR DESCRIPTION
## Summary

Unblocks **#850 AC-5** (Day-14 monthly CI minutes measurement) by fixing the `ci-minutes-digest.yml` workflow, which has been failing every Monday since 2026-04-13 due to a `gh` CLI regression.

## Problem

The script invoked:
```bash
gh api ... --paginate --slurp --jq '...'
```

A recent `gh` CLI release made `--slurp` incompatible with `--jq` / `--template`, returning:
```
the --slurp option is not supported with --jq or --template
Usage: gh api <endpoint> [flags]
...
##[error]Process completed with exit code 1.
```

Result: **5+ consecutive Monday scheduled runs failed** (25669180746, and 4 priors back to 2026-04-13). The digest never posted to GitHub step summary or Slack.

This blocks AC-5 verification of issue #850 (CI cost optimization): we cannot measure whether the 3-PR series (#1121 concurrency + paths-ignore, #1124 cache keys, #1125 paths-filter — all merged 2026-05-13) achieved the ≥ 30 % monthly minute reduction target.

## Fix

Replace `--slurp --jq '<projection>'` with `| jq -s '<projection>'` (client-side slurp). Functionally equivalent — `jq -s` reads stdin pages and treats them as an array, same as `--slurp` did server-side.

```diff
  gh api \
    "repos/$REPO/actions/runs?per_page=100&created=>$CUTOFF" \
-   --paginate \
-   --slurp \
-   --jq '[.[].workflow_runs[] | ...]' > runs.json
+   --paginate \
+ | jq -s '[.[].workflow_runs[] | ...]' > runs.json
```

Added inline comment explaining the workaround for future maintainers.

## Test plan

- [x] Inline comment explains the deprecation and workaround
- [x] jq filter unchanged — output shape identical
- [ ] Post-merge: trigger `workflow_dispatch` on `ci-minutes-digest.yml` manually
- [ ] Verify GitHub step summary populates with weekly digest table
- [ ] Verify Slack post if `SLACK_GITNOTIFY_WEBHOOK_URL` secret is set
- [ ] Wait for next scheduled Monday run (2026-05-25) to confirm cron path works

## Why now

PR #1121 / #1124 / #1125 (#850 3-PR series) were merged 2026-05-13 with the expectation that AC-5 would be measured via Day-14 digest. Without this fix, that verification never happens and #850 cannot be closed.

## Refs

- Refs #850 (parent epic)
- PR #1121, #1124, #1125 (3-PR series awaiting AC-5 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)