### PR TITLE
feat(game-nights): live sub-components + runtime screens (WIP PR 2/2 refs #1255)

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  NightLiveHub,
+  type NightLiveHubCurrentGame,
+  type NightLiveHubNight,
+  type NightLiveStatus,
+} from '@/components/features/game-nights/live';
+import type {
+  DiaryEvent,
+  DiaryGameRef,
+  DiaryPlayerRef,
+} from '@/components/features/game-nights/live';
+import type { PlannedGame } from '@/components/features/game-nights/live';
+import {
+  GameTransitionDialog,
+  type TransitionLastGame,
+  type TransitionNextGame,
+  type TransitionSubmodal,
+} from '@/components/features/game-nights/transition';
+
+// ─── Fixture data (TODO: replace with backend hook `useGameNightLive(id)`)
+// Continuità con mockup K/L mergiati nel PR #1250 — issue #487
+// ─────────────────────────────────────────────────────────────────────────
+
+const NIGHT: NightLiveHubNight = {
+  title: 'Sabato boardgame con i Padovani',
+  shortTitle: 'Padovani · 17 mag',
+  nightCode: '#GN-042',
+};
+
+const DIARY_PLAYERS: ReadonlyArray<DiaryPlayerRef> = [
+  { id: 'p-marco', initials: 'MR', color: 262 },
+  { id: 'p-giulia', initials: 'GM', color: 10 },
+  { id: 'p-davide', initials: 'DC', color: 200 },
+  { id: 'p-luca', initials: 'LB', color: 180 },
+  { id: 'p-sara', initials: 'ST', color: 320 },
+  { id: 'p-aaron', initials: 'AK', color: 140 },
+];
+
+const DIARY_GAMES: ReadonlyArray<DiaryGameRef> = [
+  { id: 'gs-brass-1', title: 'Brass: Birmingham', emoji: '🏭' },
+  { id: 'gs-spirit-1', title: 'Spirit Island', emoji: '🌋' },
+];
+
+const PLANNED_GAMES: ReadonlyArray<PlannedGame> = [
+  {
+    id: 'gs-brass-1',
+    title: 'Brass: Birmingham',
+    publisher: 'Roxley',
+    emoji: '🏭',
+    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+    status: 'completed',
+    order: 1,
+    actual: '113m',
+    estimated: '120m',
+    score: '178–142',
+    winner: { name: 'Davide', initials: 'DC', color: 200 },
+  },
+  {
+    id: 'gs-spirit-1',
+    title: 'Spirit Island',
+    publisher: 'GMT · co-op',
+    emoji: '🌋',
+    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+    status: 'inprogress',
+    order: 2,
+    actual: '35m elapsed',
+    estimated: '90m',
+    score: 'round 2 · in corso',
+  },
+  {
+    id: 'gs-wing-1',
+    title: 'Wingspan',
+    publisher: 'Stonemaier',
+    emoji: '🦜',
+    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
+    status: 'upcoming',
+    order: 3,
+    estimated: '60m',
+  },
+];
+
+const CURRENT_GAME: NightLiveHubCurrentGame = {
+  id: 'gs-spirit-1',
+  sessionId: 's-spirit-may17',
+  title: 'Spirit Island',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  score: 'round 2 · in corso',
+};
+
+const DIARY_EVENTS: ReadonlyArray<DiaryEvent> = [
+  {
+    id: 'd01',
+    time: '21:02',
+    gameId: 'gs-brass-1',
+    kind: 'turn',
+    icon: '🎯',
+    actors: ['p-marco'],
+    text: 'Marco apre il Canal Era — porto a Stoke-on-Trent',
+  },
+  {
+    id: 'd08',
+    time: '22:48',
+    gameId: 'gs-brass-1',
+    kind: 'score',
+    icon: '📊',
+    actors: ['p-marco'],
+    text: 'Marco completa rete Birmingham (+12 link points)',
+  },
+  {
+    id: 'd09',
+    time: '22:55',
+    gameId: 'gs-brass-1',
+    kind: 'end',
+    icon: '🏆',
+    actors: ['p-davide'],
+    text: '🏆 Davide vince Brass Birmingham 178–142',
+  },
+  {
+    id: 'd10',
+    time: '23:00',
+    gameId: null,
+    kind: 'system',
+    icon: '↻',
+    actors: [],
+    text: 'Setup Spirit Island · 4 spiriti scelti random',
+  },
+  {
+    id: 'd14',
+    time: '23:23',
+    gameId: 'gs-spirit-1',
+    kind: 'score',
+    icon: '📊',
+    actors: ['p-davide'],
+    text: 'Blight su Powerwala — Davide perde 1 presenza',
+  },
+];
+
+// Transition data (last game = Brass completed, next game = Spirit Island)
+const LAST_GAME: TransitionLastGame = {
+  id: 'gs-brass-1',
+  title: 'Brass: Birmingham',
+  publisher: 'Roxley',
+  emoji: '🏭',
+  cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+  duration: '2h 45m',
+  endedAt: '22:55',
+  winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
+  topThree: [
+    {
+      id: 'p-davide',
+      name: 'Davide',
+      initials: 'DC',
+      color: 200,
+      score: 178,
+      delta: '+50 industria',
+    },
+    { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142, delta: '+12 network' },
+    {
+      id: 'p-giulia',
+      name: 'Giulia',
+      initials: 'GM',
+      color: 10,
+      score: 128,
+      delta: '+8 carbone',
+    },
+  ],
+};
+
+const NEXT_GAME: TransitionNextGame = {
+  id: 'gs-spirit-1',
+  title: 'Spirit Island',
+  publisher: 'GMT · co-op',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  estimated: '90m',
+  weight: 4.08,
+  rules: [
+    { icon: '🔁', text: 'Phase order · Growth → Fast → Slow', src: '§ 4.2' },
+    { icon: '😱', text: 'Fear deck · 9 carte iniziali (level 1/2/3)', src: '§ 5.1' },
+    { icon: '⚡', text: 'Power growth · 1 minor + 1 major per round', src: '§ 6.3' },
+  ],
+  setup: [
+    { icon: '🗺️', text: 'Tabellone · 4 isole', done: true },
+    { icon: '🧝', text: 'Spirit panels (4 spiriti scelti)', done: true },
+    { icon: '🃏', text: 'Invader deck shuffled · stage I', done: false },
+    { icon: '💀', text: 'Fear pool · 9 token', done: false },
+  ],
+};
+
+// ─── View component ─────────────────────────────────────────────────────
+
+export interface NightLiveClientViewProps {
+  readonly nightId: string;
+}
+
+export function NightLiveClientView({ nightId: _nightId }: NightLiveClientViewProps) {
+  const router = useRouter();
+  const [status, setStatus] = useState<NightLiveStatus>('live');
+  const [transitionOpen, setTransitionOpen] = useState(false);
+  const [submodal, setSubmodal] = useState<TransitionSubmodal>(null);
+
+  const handlePauseToggle = useCallback(() => {
+    setStatus(current => (current === 'paused' ? 'live' : 'paused'));
+  }, []);
+
+  const handleTransitionOpen = useCallback(() => {
+    setStatus('transition');
+    setTransitionOpen(true);
+  }, []);
+
+  const handleTransitionClose = useCallback(() => {
+    setTransitionOpen(false);
+    setSubmodal(null);
+    setStatus('live');
+  }, []);
+
+  const handlePlayNext = useCallback(() => {
+    setTransitionOpen(false);
+    setSubmodal(null);
+    setStatus('live');
+  }, []);
+
+  const handleSkipConfirmed = useCallback(() => {
+    setSubmodal(null);
+    setTransitionOpen(false);
+    setStatus('live');
+  }, []);
+
+  const handleEndNight = useCallback(() => {
+    router.push(`/game-nights/${_nightId}/summary`);
+  }, [router, _nightId]);
+
+  const handleOpenSubmodal = useCallback((which: 'skip' | 'end') => {
+    setSubmodal(which);
+  }, []);
+
+  const handleConfirmSubmodal = useCallback(() => {
+    if (submodal === 'skip') {
+      handleSkipConfirmed();
+    } else if (submodal === 'end') {
+      handleEndNight();
+    }
+  }, [submodal, handleSkipConfirmed, handleEndNight]);
+
+  const handleCancelSubmodal = useCallback(() => {
+    setSubmodal(null);
+  }, []);
+
+  const handleJumpToSession = useCallback(
+    (sessionId: string) => {
+      router.push(`/sessions/${sessionId}`);
+    },
+    [router]
+  );
+
+  const handleBack = useCallback(() => {
+    router.push(`/game-nights/${_nightId}`);
+  }, [router, _nightId]);
+
+  return (
+    <>
+      <NightLiveHub
+        night={NIGHT}
+        status={status}
+        current={2}
+        total={3}
+        elapsed="2h 35m"
+        confirmedPlayers={6}
+        totalPlayers={6}
+        plannedGames={PLANNED_GAMES}
+        currentGame={status === 'transition' ? null : CURRENT_GAME}
+        diaryEvents={DIARY_EVENTS}
+        diaryGames={DIARY_GAMES}
+        diaryPlayers={DIARY_PLAYERS}
+        onBack={handleBack}
+        onPauseToggle={handlePauseToggle}
+        onTransition={handleTransitionOpen}
+        onEnd={handleEndNight}
+        onJumpToSession={handleJumpToSession}
+      />
+
+      {transitionOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+          style={{ background: 'rgba(0,0,0,0.45)' }}
+          onClick={handleTransitionClose}
+          onKeyDown={e => {
+            if (e.key === 'Escape') handleTransitionClose();
+          }}
+          role="presentation"
+        >
+          <div onClick={e => e.stopPropagation()} role="presentation">
+            <GameTransitionDialog
+              open
+              lastGame={LAST_GAME}
+              nextGame={NEXT_GAME}
+              nightCode={NIGHT.nightCode}
+              submodal={submodal}
+              onClose={handleTransitionClose}
+              onPlayNext={handlePlayNext}
+              onOpenSubmodal={handleOpenSubmodal}
+              onConfirmSubmodal={handleConfirmSubmodal}
+              onCancelSubmodal={handleCancelSubmodal}
+            />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -263,6 +263,23 @@ export function NightLiveClientView({ nightId: _nightId }: NightLiveClientViewPr
   const handleBack = useCallback(() => {
     router.push(`/game-nights/${_nightId}`);
   }, [router, _nightId]);
+
+  // Global Escape listener: closes the transition modal regardless of focus.
+  // The backdrop's local onKeyDown only fires when focus is on the backdrop,
+  // which never happens via keyboard nav. This effect ensures Escape works
+  // even when focus is inside the dialog content.
+  useEffect(() => {
+    if (!transitionOpen) return undefined;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleTransitionClose();
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [transitionOpen, handleTransitionClose]);
 
   return (
     <>

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Game Night Live Hub Page (Issue #1255 cluster game-nights PR 2).
+ *
+ * Thin wrapper: resolves the dynamic `id` param and delegates rendering
+ * to `NightLiveClientView` which integrates `NightLiveHub` (Screen K) +
+ * `GameTransitionDialog` (Screen L) from `components/features/game-nights/`.
+ *
+ * Source mockup: admin-mockups/design_files/sp7-game-night-live.{html,jsx}
+ * (mergiato con PR #1250 chiudendo issue #487).
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { NightLiveClientView } from './_components/NightLiveClientView';
+
+export default function GameNightLivePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  return <NightLiveClientView nightId={id} />;
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  NightSummaryView,
+  type NightSummaryMVP,
+  type NightSummaryNight,
+  type NightSummaryPhoto,
+} from '@/components/features/game-nights/summary';
+import type { PerGameRecapGame } from '@/components/features/game-nights/summary';
+
+// ─── Fixture data (TODO: replace with backend hook `useGameNightSummary(id)`)
+// Continuità con mockup M mergiato nel PR #1250 — issue #487
+// ─────────────────────────────────────────────────────────────────────────
+
+const NIGHT: NightSummaryNight = {
+  title: 'Sabato boardgame con i Padovani',
+  dateLine: 'sabato 17 maggio 2026',
+  location: 'Casa Marco · Padova',
+  startedAt: '21:00',
+  endedAt: '03:15',
+  duration: '6h 15m',
+  nightCode: '#GN-042',
+};
+
+const MVP: NightSummaryMVP = {
+  id: 'p-davide',
+  name: 'Davide',
+  initials: 'DC',
+  color: 200,
+  achievements: '1 vittoria · 11 eventi diary · top scorer Brass',
+};
+
+const GAMES: ReadonlyArray<PerGameRecapGame> = [
+  {
+    id: 'gs-brass-1',
+    sessionId: 's-brass-may17',
+    title: 'Brass: Birmingham',
+    emoji: '🏭',
+    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+    order: 1,
+    duration: '2h 45m',
+    eventsCount: 11,
+    winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
+    topScores: [
+      { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142 },
+      { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 128 },
+    ],
+  },
+  {
+    id: 'gs-spirit-1',
+    sessionId: 's-spirit-may17',
+    title: 'Spirit Island',
+    emoji: '🌋',
+    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+    order: 2,
+    duration: '1h 50m',
+    eventsCount: 9,
+    coopMode: true,
+    coopOutcome: 'team coop vinto · round 5/6 · adversary England 1',
+  },
+  {
+    id: 'gs-wing-1',
+    sessionId: 's-wing-may17',
+    title: 'Wingspan',
+    emoji: '🦜',
+    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
+    order: 3,
+    duration: '1h 25m',
+    eventsCount: 8,
+    winner: { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 92 },
+    topScores: [
+      { id: 'p-sara', name: 'Sara', initials: 'ST', color: 320, score: 88 },
+      { id: 'p-aaron', name: 'Aaron', initials: 'AK', color: 140, score: 81 },
+    ],
+  },
+];
+
+const PHOTOS: ReadonlyArray<NightSummaryPhoto> = [
+  { id: 'ph-1', label: 'Setup Brass', gradient: ['hsl(220 35% 30%)', 'hsl(28 60% 40%)'] },
+  { id: 'ph-2', label: 'Davide vince', gradient: ['hsl(350 70% 55%)', 'hsl(28 60% 50%)'] },
+  { id: 'ph-3', label: 'Tabellone Spirit', gradient: ['hsl(210 50% 30%)', 'hsl(150 50% 40%)'] },
+  { id: 'ph-4', label: 'Foto di gruppo', gradient: ['hsl(262 50% 50%)', 'hsl(320 60% 55%)'] },
+  { id: 'ph-5', label: 'Tableau Wingspan', gradient: ['hsl(85 50% 50%)', 'hsl(35 60% 55%)'] },
+  { id: 'ph-6', label: 'Brindisi finale', gradient: ['hsl(38 80% 55%)', 'hsl(10 70% 50%)'] },
+];
+
+// ─── View component ─────────────────────────────────────────────────────
+
+export interface NightSummaryClientViewProps {
+  readonly nightId: string;
+}
+
+export function NightSummaryClientView({ nightId: _nightId }: NightSummaryClientViewProps) {
+  const router = useRouter();
+  const [archived, setArchived] = useState(false);
+  const [shareSuccess, setShareSuccess] = useState<{
+    visible: boolean;
+    subline?: string;
+  }>({ visible: false });
+
+  const handleShare = useCallback(() => {
+    const url = `meepleai.app/s/${_nightId.slice(0, 12)}`;
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(`https://${url}`).catch(() => undefined);
+    }
+    setShareSuccess({
+      visible: true,
+      subline: `${url} · sparisce in 3s`,
+    });
+    window.setTimeout(() => {
+      setShareSuccess({ visible: false });
+    }, 3000);
+  }, [_nightId]);
+
+  const handleArchive = useCallback(() => {
+    setArchived(true);
+  }, []);
+
+  const handleUnarchive = useCallback(() => {
+    setArchived(false);
+  }, []);
+
+  const handleGoToList = useCallback(() => {
+    router.push('/game-nights');
+  }, [router]);
+
+  const handleJumpToSession = useCallback(
+    (sessionId: string) => {
+      router.push(`/sessions/${sessionId}`);
+    },
+    [router]
+  );
+
+  return (
+    <NightSummaryView
+      night={NIGHT}
+      mvp={MVP}
+      games={GAMES}
+      eventsCount={28}
+      photos={PHOTOS}
+      archived={archived}
+      shareSuccess={shareSuccess}
+      onShare={handleShare}
+      onArchive={handleArchive}
+      onUnarchive={handleUnarchive}
+      onGoToList={handleGoToList}
+      onJumpToSession={handleJumpToSession}
+    />
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -101,6 +101,16 @@ export function NightSummaryClientView({ nightId: _nightId }: NightSummaryClient
     visible: boolean;
     subline?: string;
   }>({ visible: false });
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup pending toast timer on unmount to avoid setState on unmounted component
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleShare = useCallback(() => {
     const url = `meepleai.app/s/${_nightId.slice(0, 12)}`;
@@ -111,8 +121,13 @@ export function NightSummaryClientView({ nightId: _nightId }: NightSummaryClient
       visible: true,
       subline: `${url} · sparisce in 3s`,
     });
-    window.setTimeout(() => {
+    // Replace any previous pending timer so rapid re-shares don't race
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+    }
+    toastTimerRef.current = setTimeout(() => {
       setShareSuccess({ visible: false });
+      toastTimerRef.current = null;
     }, 3000);
   }, [_nightId]);
 

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Game Night Summary Page (Issue #1255 cluster game-nights PR 2).
+ *
+ * Thin wrapper: resolves the dynamic `id` param and delegates rendering
+ * to `NightSummaryClientView` which integrates `NightSummaryView` (Screen M)
+ * from `components/features/game-nights/summary/`.
+ *
+ * Source mockup: admin-mockups/design_files/sp7-game-night-summary.{html,jsx}
+ * (mergiato con PR #1250 chiudendo issue #487).
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { NightSummaryClientView } from './_components/NightSummaryClientView';
+
+export default function GameNightSummaryPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  return <NightSummaryClientView nightId={id} />;
+}

--- a/apps/web/src/components/features/game-nights/live/CrossGameDiaryTimeline.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/CrossGameDiaryTimeline.test.tsx
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  CrossGameDiaryTimeline,
+  type DiaryEvent,
+  type DiaryGameRef,
+  type DiaryPlayerRef,
+} from './CrossGameDiaryTimeline';
+
+const GAMES: ReadonlyArray<DiaryGameRef> = [
+  { id: 'g1', title: 'Brass: Birmingham', emoji: '🏭' },
+  { id: 'g2', title: 'Spirit Island', emoji: '🌋' },
+];
+
+const PLAYERS: ReadonlyArray<DiaryPlayerRef> = [
+  { id: 'p1', initials: 'MR', color: 262 },
+  { id: 'p2', initials: 'DC', color: 200 },
+];
+
+const SAMPLE_EVENTS: ReadonlyArray<DiaryEvent> = [
+  {
+    id: 'e1',
+    time: '21:02',
+    gameId: 'g1',
+    kind: 'turn',
+    icon: '🎯',
+    actors: ['p1'],
+    text: 'Marco apre il Canal Era',
+  },
+  {
+    id: 'e2',
+    time: '22:55',
+    gameId: 'g1',
+    kind: 'end',
+    icon: '🏆',
+    actors: ['p2'],
+    text: '🏆 Davide vince Brass Birmingham 178–142',
+  },
+  {
+    id: 'e3',
+    time: '23:00',
+    gameId: null,
+    kind: 'system',
+    icon: '↻',
+    actors: [],
+    text: 'Setup Spirit Island',
+  },
+  {
+    id: 'e4',
+    time: '23:08',
+    gameId: 'g2',
+    kind: 'score',
+    icon: '📊',
+    actors: ['p2'],
+    text: 'Spirito River Surges +3 Fear',
+  },
+];
+
+describe('CrossGameDiaryTimeline', () => {
+  it('renders all events when filter="all"', () => {
+    render(<CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />);
+    expect(screen.getByText('Marco apre il Canal Era')).toBeInTheDocument();
+    expect(screen.getByText('🏆 Davide vince Brass Birmingham 178–142')).toBeInTheDocument();
+    expect(screen.getByText('Setup Spirit Island')).toBeInTheDocument();
+    expect(screen.getByText('Spirito River Surges +3 Fear')).toBeInTheDocument();
+  });
+
+  it('filters events by kind when filter !== "all"', () => {
+    render(
+      <CrossGameDiaryTimeline
+        events={SAMPLE_EVENTS}
+        games={GAMES}
+        players={PLAYERS}
+        filter="score"
+      />
+    );
+    expect(screen.queryByText('Marco apre il Canal Era')).toBeNull();
+    expect(screen.getByText('Spirito River Surges +3 Fear')).toBeInTheDocument();
+  });
+
+  it('renders timestamps in tabular-nums', () => {
+    const { container } = render(
+      <CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />
+    );
+    const timestamps = container.querySelectorAll('.tabular-nums');
+    expect(timestamps.length).toBeGreaterThan(0);
+    expect(timestamps[0].textContent).toBe('21:02');
+  });
+
+  it('renders cross-game divider when gameId changes', () => {
+    render(<CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />);
+    // first game shows divider (no previous), second game (Spirit Island) shows another
+    const spiritIsland = screen.getAllByText('Spirit Island');
+    expect(spiritIsland.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders empty state message when filter yields zero events', () => {
+    render(<CrossGameDiaryTimeline events={[]} games={GAMES} players={PLAYERS} />);
+    expect(screen.getByText(/Nessun evento ancora/)).toBeInTheDocument();
+  });
+
+  it('renders filter chips only when onFilterChange provided', () => {
+    const { rerender } = render(
+      <CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />
+    );
+    expect(screen.queryByRole('tablist')).toBeNull();
+
+    rerender(
+      <CrossGameDiaryTimeline
+        events={SAMPLE_EVENTS}
+        games={GAMES}
+        players={PLAYERS}
+        onFilterChange={() => undefined}
+      />
+    );
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('calls onFilterChange with selected filter id', async () => {
+    const onFilterChange = vi.fn();
+    render(
+      <CrossGameDiaryTimeline
+        events={SAMPLE_EVENTS}
+        games={GAMES}
+        players={PLAYERS}
+        onFilterChange={onFilterChange}
+      />
+    );
+    await userEvent.click(screen.getByRole('tab', { name: 'Score' }));
+    expect(onFilterChange).toHaveBeenCalledWith('score');
+  });
+
+  it('marks active filter tab via aria-selected', () => {
+    render(
+      <CrossGameDiaryTimeline
+        events={SAMPLE_EVENTS}
+        games={GAMES}
+        players={PLAYERS}
+        filter="turn"
+        onFilterChange={() => undefined}
+      />
+    );
+    const turnTab = screen.getByRole('tab', { name: 'Turn' });
+    expect(turnTab).toHaveAttribute('aria-selected', 'true');
+    const scoreTab = screen.getByRole('tab', { name: 'Score' });
+    expect(scoreTab).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('renders player avatars when actors present', () => {
+    render(<CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />);
+    // MR appears once (e1), DC appears twice (e2 end-event + e4 score-event)
+    expect(screen.getByLabelText('Player MR')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Player DC')).toHaveLength(2);
+  });
+
+  it('skips unknown actor ids gracefully', () => {
+    const eventWithUnknownActor: DiaryEvent = {
+      id: 'eX',
+      time: '00:00',
+      gameId: 'g1',
+      kind: 'turn',
+      icon: '🎯',
+      actors: ['unknown-player', 'p1'],
+      text: 'Unknown actor test',
+    };
+    render(
+      <CrossGameDiaryTimeline events={[eventWithUnknownActor]} games={GAMES} players={PLAYERS} />
+    );
+    expect(screen.getByLabelText('Player MR')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Player unknown-player')).toBeNull();
+  });
+
+  it('has role="log" with aria-live="polite" for live updates', () => {
+    render(<CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />);
+    const log = screen.getByRole('log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+    expect(log).toHaveAttribute('aria-label', 'Timeline diary cross-game');
+  });
+
+  it('compact mode reduces gap spacing', () => {
+    const { container, rerender } = render(
+      <CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} />
+    );
+    const logDefault = container.querySelector('[role="log"]');
+    expect(logDefault?.className).toContain('gap-2');
+
+    rerender(
+      <CrossGameDiaryTimeline events={SAMPLE_EVENTS} games={GAMES} players={PLAYERS} compact />
+    );
+    const logCompact = container.querySelector('[role="log"]');
+    expect(logCompact?.className).toContain('gap-1.5');
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <CrossGameDiaryTimeline
+        events={SAMPLE_EVENTS}
+        games={GAMES}
+        players={PLAYERS}
+        className="custom-class"
+      />
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('custom-class');
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/CrossGameDiaryTimeline.tsx
+++ b/apps/web/src/components/features/game-nights/live/CrossGameDiaryTimeline.tsx
@@ -1,0 +1,234 @@
+import type { JSX } from 'react';
+import { useMemo } from 'react';
+
+export type DiaryEventKind = 'turn' | 'score' | 'custom' | 'end' | 'system';
+
+export interface DiaryEvent {
+  readonly id: string;
+  readonly time: string;
+  readonly gameId: string | null;
+  readonly kind: DiaryEventKind;
+  readonly icon: string;
+  readonly actors: ReadonlyArray<string>;
+  readonly text: string;
+}
+
+export interface DiaryGameRef {
+  readonly id: string;
+  readonly title: string;
+  readonly emoji: string;
+}
+
+export interface DiaryPlayerRef {
+  readonly id: string;
+  readonly initials: string;
+  readonly color: number;
+}
+
+export type DiaryFilter = 'all' | 'turn' | 'score' | 'custom';
+
+export interface CrossGameDiaryTimelineProps {
+  readonly events: ReadonlyArray<DiaryEvent>;
+  readonly games: ReadonlyArray<DiaryGameRef>;
+  readonly players: ReadonlyArray<DiaryPlayerRef>;
+  readonly filter?: DiaryFilter;
+  readonly onFilterChange?: (filter: DiaryFilter) => void;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+const FILTERS: ReadonlyArray<{ id: DiaryFilter; label: string }> = [
+  { id: 'all', label: 'Tutti' },
+  { id: 'turn', label: 'Turn' },
+  { id: 'score', label: 'Score' },
+  { id: 'custom', label: 'Custom' },
+];
+
+const KIND_TO_ENTITY: Record<DiaryEventKind, string> = {
+  turn: 'session',
+  score: 'player',
+  custom: 'chat',
+  end: 'event',
+  system: 'toolkit',
+};
+
+export function CrossGameDiaryTimeline({
+  events,
+  games,
+  players,
+  filter = 'all',
+  onFilterChange,
+  compact = false,
+  className,
+}: CrossGameDiaryTimelineProps): JSX.Element {
+  const gamesById = useMemo(() => Object.fromEntries(games.map(g => [g.id, g])), [games]);
+  const playersById = useMemo(() => Object.fromEntries(players.map(p => [p.id, p])), [players]);
+
+  const filtered = useMemo(
+    () => (filter === 'all' ? events : events.filter(e => e.kind === filter)),
+    [events, filter]
+  );
+
+  return (
+    <div className={['flex flex-col gap-2', className ?? ''].filter(Boolean).join(' ')}>
+      {onFilterChange ? (
+        <div role="tablist" aria-label="Filtro eventi diary" className="flex gap-1.5">
+          {FILTERS.map(f => {
+            const active = filter === f.id;
+            return (
+              <button
+                key={f.id}
+                role="tab"
+                aria-selected={active}
+                type="button"
+                onClick={() => onFilterChange(f.id)}
+                className={[
+                  'rounded-pill px-2.5 py-1 font-mono text-[9.5px] font-extrabold uppercase tracking-wider cursor-pointer',
+                  active
+                    ? 'bg-entity-event/15 text-entity-event border border-entity-event/40'
+                    : 'bg-transparent text-muted-foreground border border-border',
+                ].join(' ')}
+              >
+                {f.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <div
+        role="log"
+        aria-live="polite"
+        aria-label="Timeline diary cross-game"
+        className={['relative flex flex-col', compact ? 'gap-1.5' : 'gap-2'].join(' ')}
+      >
+        {filtered.length === 0 ? (
+          <div className="font-mono text-xs text-muted-foreground py-4 text-center">
+            Nessun evento ancora · Inizia a giocare!
+          </div>
+        ) : (
+          filtered.map((event, i) => {
+            const prevEvent = i > 0 ? filtered[i - 1] : null;
+            const currentGame = event.gameId ? (gamesById[event.gameId] ?? null) : null;
+            const prevGame = prevEvent?.gameId ? (gamesById[prevEvent.gameId] ?? null) : null;
+            const gameChanged = currentGame !== null && currentGame.id !== prevGame?.id;
+            return (
+              <DiaryEventRow
+                key={event.id}
+                event={event}
+                gameTitle={gameChanged ? currentGame.title : null}
+                gameEmoji={gameChanged ? currentGame.emoji : null}
+                actorPlayers={event.actors
+                  .map(a => playersById[a])
+                  .filter((p): p is DiaryPlayerRef => Boolean(p))}
+                compact={compact}
+              />
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface DiaryEventRowProps {
+  readonly event: DiaryEvent;
+  readonly gameTitle: string | null;
+  readonly gameEmoji: string | null;
+  readonly actorPlayers: ReadonlyArray<DiaryPlayerRef>;
+  readonly compact: boolean;
+}
+
+function DiaryEventRow({
+  event,
+  gameTitle,
+  gameEmoji,
+  actorPlayers,
+  compact,
+}: DiaryEventRowProps): JSX.Element {
+  const entityKey = KIND_TO_ENTITY[event.kind];
+  const isEnd = event.kind === 'end';
+  const isSystem = event.kind === 'system';
+
+  return (
+    <>
+      {gameTitle ? (
+        <div
+          aria-hidden="true"
+          className={['flex items-center gap-1.5', compact ? 'py-0.5' : 'py-1'].join(' ')}
+        >
+          <span
+            className="flex-1 h-px"
+            style={{
+              background:
+                'linear-gradient(90deg, transparent, hsl(var(--c-event) / 0.4), transparent)',
+            }}
+          />
+          <span className="font-mono text-[9px] font-extrabold uppercase tracking-wider text-entity-event inline-flex items-center gap-1">
+            <span>{gameEmoji}</span>
+            {gameTitle}
+          </span>
+          <span
+            className="flex-1 h-px"
+            style={{
+              background:
+                'linear-gradient(90deg, transparent, hsl(var(--c-event) / 0.4), transparent)',
+            }}
+          />
+        </div>
+      ) : null}
+      <div className="relative flex gap-2.5 pl-1">
+        <div
+          aria-hidden="true"
+          className="z-10 flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[10px]"
+          style={{
+            background: `hsl(var(--c-${entityKey}) / 0.14)`,
+            border: `2px solid hsl(var(--c-${entityKey}) / 0.4)`,
+          }}
+        >
+          <span aria-hidden="true">{event.icon}</span>
+        </div>
+        <div
+          className={[
+            'min-w-0 flex-1 rounded-sm px-2.5 py-1.5',
+            isEnd
+              ? 'bg-entity-event/10 border-l-2 border-l-entity-event'
+              : isSystem
+                ? 'bg-entity-toolkit/[0.06] border-l-2 border-l-entity-toolkit'
+                : 'bg-muted border-l-2 border-l-transparent',
+          ].join(' ')}
+        >
+          <div className="flex flex-wrap items-center gap-1.5 mb-px">
+            <span
+              className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider tabular-nums"
+              style={{ color: `hsl(var(--c-${entityKey}))` }}
+            >
+              {event.time}
+            </span>
+            {actorPlayers.length > 0 ? (
+              <div className="flex gap-px">
+                {actorPlayers.map(player => (
+                  <span
+                    key={player.id}
+                    aria-label={`Player ${player.initials}`}
+                    className="inline-flex h-[14px] w-[14px] items-center justify-center rounded-full border-2 font-display text-[7px] font-extrabold"
+                    style={{
+                      background: `hsl(${player.color}, 60%, 55%)`,
+                      borderColor: 'var(--bg-muted)' as string,
+                      color: '#fff',
+                    }}
+                  >
+                    {player.initials}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div className="font-body text-[11.5px] font-semibold leading-snug text-foreground">
+            {event.text}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/DiaryInlineWidget.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/DiaryInlineWidget.test.tsx
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DiaryInlineWidget } from './DiaryInlineWidget';
+import type { DiaryEvent, DiaryGameRef, DiaryPlayerRef } from './CrossGameDiaryTimeline';
+
+const GAMES: ReadonlyArray<DiaryGameRef> = [
+  { id: 'g1', title: 'Brass', emoji: '🏭' },
+  { id: 'g2', title: 'Spirit Island', emoji: '🌋' },
+];
+const PLAYERS: ReadonlyArray<DiaryPlayerRef> = [{ id: 'p1', initials: 'MR', color: 262 }];
+
+const makeEvents = (count: number, gameId: string | null = 'g1'): DiaryEvent[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `e${i + 1}`,
+    time: `${20 + i}:00`,
+    gameId,
+    kind: 'turn' as const,
+    icon: '🎯',
+    actors: ['p1'],
+    text: `Evento ${i + 1}`,
+  }));
+
+describe('DiaryInlineWidget', () => {
+  it('renders header with default "Diary cross-game" kicker', () => {
+    render(<DiaryInlineWidget events={makeEvents(3)} games={GAMES} players={PLAYERS} />);
+    expect(screen.getByText('Diary cross-game')).toBeInTheDocument();
+  });
+
+  it('renders event count + sessions count in subheader', () => {
+    const mixedGameEvents = [...makeEvents(3, 'g1'), ...makeEvents(2, 'g2')];
+    render(<DiaryInlineWidget events={mixedGameEvents} games={GAMES} players={PLAYERS} />);
+    expect(screen.getByText('5 eventi · 2 session')).toBeInTheDocument();
+  });
+
+  it('uses singular "evento" when count is 1', () => {
+    render(<DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} />);
+    expect(screen.getByText(/1 evento ·/)).toBeInTheDocument();
+  });
+
+  it('overrides sessionsCount when prop provided', () => {
+    render(
+      <DiaryInlineWidget
+        events={makeEvents(3)}
+        games={GAMES}
+        players={PLAYERS}
+        sessionsCount={42}
+      />
+    );
+    expect(screen.getByText('3 eventi · 42 session')).toBeInTheDocument();
+  });
+
+  it('slices to last maxEvents (default 7)', () => {
+    render(<DiaryInlineWidget events={makeEvents(10)} games={GAMES} players={PLAYERS} />);
+    // Events 1-3 hidden (only last 7 shown)
+    expect(screen.queryByText('Evento 1')).toBeNull();
+    expect(screen.queryByText('Evento 3')).toBeNull();
+    expect(screen.getByText('Evento 4')).toBeInTheDocument();
+    expect(screen.getByText('Evento 10')).toBeInTheDocument();
+  });
+
+  it('respects custom maxEvents', () => {
+    render(
+      <DiaryInlineWidget events={makeEvents(10)} games={GAMES} players={PLAYERS} maxEvents={3} />
+    );
+    expect(screen.queryByText('Evento 7')).toBeNull();
+    expect(screen.getByText('Evento 8')).toBeInTheDocument();
+    expect(screen.getByText('Evento 10')).toBeInTheDocument();
+  });
+
+  it('maxEvents=0 disables slicing (shows all)', () => {
+    render(
+      <DiaryInlineWidget events={makeEvents(10)} games={GAMES} players={PLAYERS} maxEvents={0} />
+    );
+    expect(screen.getByText('Evento 1')).toBeInTheDocument();
+    expect(screen.getByText('Evento 10')).toBeInTheDocument();
+  });
+
+  it('renders Live badge with pulsing dot when isLive', () => {
+    render(<DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} isLive />);
+    expect(screen.getByLabelText('Live')).toBeInTheDocument();
+  });
+
+  it('omits Live badge when isLive=false (default)', () => {
+    render(<DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} />);
+    expect(screen.queryByLabelText('Live')).toBeNull();
+  });
+
+  it('renders Annota button when onAddNote provided + invokes callback', async () => {
+    const onAddNote = vi.fn();
+    render(
+      <DiaryInlineWidget
+        events={makeEvents(1)}
+        games={GAMES}
+        players={PLAYERS}
+        onAddNote={onAddNote}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /\+ Annota/ }));
+    expect(onAddNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Apri timeline as button when onOpenFullTimeline provided', async () => {
+    const onOpen = vi.fn();
+    render(
+      <DiaryInlineWidget
+        events={makeEvents(1)}
+        games={GAMES}
+        players={PLAYERS}
+        onOpenFullTimeline={onOpen}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /Apri timeline/ }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Apri timeline as static span when no callback (read-only)', () => {
+    render(<DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} />);
+    expect(screen.queryByRole('button', { name: /Apri timeline/ })).toBeNull();
+    expect(screen.getByText(/Apri timeline/)).toBeInTheDocument();
+  });
+
+  it('embedded=true applies fixed size + shadow', () => {
+    const { container } = render(
+      <DiaryInlineWidget
+        events={makeEvents(1)}
+        games={GAMES}
+        players={PLAYERS}
+        embedded
+        width={320}
+        height={400}
+      />
+    );
+    const widget = container.firstChild as HTMLElement;
+    expect(widget.className).toContain('shadow-md');
+    expect(widget.style.width).toBe('320px');
+    expect(widget.style.height).toBe('400px');
+  });
+
+  it('embedded=false (default) uses 100% size, no shadow', () => {
+    const { container } = render(
+      <DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} />
+    );
+    const widget = container.firstChild as HTMLElement;
+    expect(widget.className).not.toContain('shadow-md');
+    expect(widget.style.width).toBe('100%');
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <DiaryInlineWidget
+        events={makeEvents(1)}
+        games={GAMES}
+        players={PLAYERS}
+        className="custom-class"
+      />
+    );
+    expect((container.firstChild as HTMLElement).className).toContain('custom-class');
+  });
+
+  it('does not show Annota button when onAddNote missing', () => {
+    render(<DiaryInlineWidget events={makeEvents(1)} games={GAMES} players={PLAYERS} />);
+    expect(screen.queryByRole('button', { name: /\+ Annota/ })).toBeNull();
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/DiaryInlineWidget.tsx
+++ b/apps/web/src/components/features/game-nights/live/DiaryInlineWidget.tsx
@@ -1,0 +1,138 @@
+import type { JSX } from 'react';
+
+import { CrossGameDiaryTimeline } from '@/components/features/game-nights/live/CrossGameDiaryTimeline';
+import type {
+  DiaryEvent,
+  DiaryGameRef,
+  DiaryPlayerRef,
+} from '@/components/features/game-nights/live/CrossGameDiaryTimeline';
+
+export interface DiaryInlineWidgetProps {
+  readonly events: ReadonlyArray<DiaryEvent>;
+  readonly games: ReadonlyArray<DiaryGameRef>;
+  readonly players: ReadonlyArray<DiaryPlayerRef>;
+  readonly width?: number;
+  readonly height?: number;
+  readonly embedded?: boolean;
+  readonly sessionsCount?: number;
+  readonly isLive?: boolean;
+  readonly maxEvents?: number;
+  readonly onAddNote?: () => void;
+  readonly onOpenFullTimeline?: () => void;
+  readonly className?: string;
+}
+
+export function DiaryInlineWidget({
+  events,
+  games,
+  players,
+  width = 320,
+  height = 400,
+  embedded = false,
+  sessionsCount,
+  isLive = false,
+  maxEvents = 7,
+  onAddNote,
+  onOpenFullTimeline,
+  className,
+}: DiaryInlineWidgetProps): JSX.Element {
+  const visibleEvents = maxEvents > 0 ? events.slice(-maxEvents) : events;
+  const derivedSessionsCount =
+    sessionsCount ??
+    new Set(events.map(e => e.gameId).filter((id): id is string => id !== null)).size;
+
+  return (
+    <div
+      className={[
+        'flex flex-col overflow-hidden',
+        'rounded-lg border bg-card border-entity-event/30',
+        embedded ? 'shadow-md ring-4 ring-entity-event/[0.06]' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={
+        embedded
+          ? { width, height, maxWidth: width }
+          : { width: '100%', height: '100%', maxWidth: width }
+      }
+    >
+      {/* Header */}
+      <div className="flex items-center gap-1.5 px-3 py-2 bg-entity-event/[0.06] border-b border-entity-event/20">
+        <span aria-hidden="true" className="text-[13px] leading-none">
+          📜
+        </span>
+        <div className="min-w-0 flex-1">
+          <span className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-entity-event block">
+            Diary cross-game
+          </span>
+          <span className="font-mono text-[9.5px] font-bold text-muted-foreground mt-px block">
+            {events.length} {events.length === 1 ? 'evento' : 'eventi'} · {derivedSessionsCount}{' '}
+            {derivedSessionsCount === 1 ? 'session' : 'session'}
+          </span>
+        </div>
+        {isLive ? (
+          <span
+            aria-label="Live"
+            className={[
+              'inline-flex items-center gap-1 rounded-pill px-1.5 py-0.5',
+              'bg-entity-session/15 text-entity-session',
+              'font-mono text-[8.5px] font-extrabold uppercase tracking-wider',
+            ].join(' ')}
+          >
+            <span
+              aria-hidden="true"
+              className="motion-safe:animate-pulse inline-block h-1.5 w-1.5 rounded-full bg-entity-session"
+            />
+            Live
+          </span>
+        ) : null}
+      </div>
+
+      {/* Body — scrollable timeline */}
+      <div className="relative flex-1 overflow-y-auto px-3 py-2.5">
+        <div
+          aria-hidden="true"
+          className="absolute left-4 top-2.5 bottom-2.5 w-0.5"
+          style={{
+            background:
+              'linear-gradient(180deg, hsl(var(--c-event) / 0.3), hsl(var(--c-event) / 0.05))',
+          }}
+        />
+        <CrossGameDiaryTimeline events={visibleEvents} games={games} players={players} compact />
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-border px-2.5 py-1.5">
+        {onAddNote ? (
+          <button
+            type="button"
+            onClick={onAddNote}
+            className={[
+              'rounded-pill px-2 py-0.5 cursor-pointer',
+              'bg-entity-event/10 text-entity-event border border-entity-event/30',
+              'font-mono text-[9px] font-extrabold uppercase tracking-wider',
+            ].join(' ')}
+          >
+            + Annota
+          </button>
+        ) : (
+          <span />
+        )}
+        {onOpenFullTimeline ? (
+          <button
+            type="button"
+            onClick={onOpenFullTimeline}
+            className="font-mono text-[9px] font-bold text-muted-foreground cursor-pointer bg-transparent border-0"
+          >
+            Apri timeline ↗
+          </button>
+        ) : (
+          <span className="font-mono text-[9px] font-bold text-muted-foreground">
+            Apri timeline ↗
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  NightLiveHub,
+  type NightLiveHubProps,
+  type NightLiveHubNight,
+  type NightLiveHubCurrentGame,
+} from './NightLiveHub';
+import type { PlannedGame } from './PlannedGamesPane';
+import type { DiaryEvent, DiaryGameRef, DiaryPlayerRef } from './CrossGameDiaryTimeline';
+
+const NIGHT: NightLiveHubNight = {
+  title: 'Sabato boardgame con i Padovani',
+  shortTitle: 'Padovani · 17 mag',
+  nightCode: '#GN-042',
+};
+
+const CURRENT_GAME: NightLiveHubCurrentGame = {
+  id: 'gs-spirit-1',
+  sessionId: 's-spirit-may17',
+  title: 'Spirit Island',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  score: 'round 2',
+};
+
+const PLANNED_GAMES: ReadonlyArray<PlannedGame> = [
+  {
+    id: 'gs-brass-1',
+    title: 'Brass: Birmingham',
+    emoji: '🏭',
+    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+    status: 'completed',
+    order: 1,
+    actual: '113m',
+    winner: { name: 'Davide', initials: 'DC', color: 200 },
+  },
+  {
+    id: 'gs-spirit-1',
+    title: 'Spirit Island',
+    emoji: '🌋',
+    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+    status: 'inprogress',
+    order: 2,
+    actual: '35m',
+  },
+  {
+    id: 'gs-wing-1',
+    title: 'Wingspan',
+    emoji: '🦜',
+    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
+    status: 'upcoming',
+    order: 3,
+    estimated: '60m',
+  },
+];
+
+const DIARY_GAMES: ReadonlyArray<DiaryGameRef> = [
+  { id: 'gs-brass-1', title: 'Brass', emoji: '🏭' },
+];
+
+const DIARY_PLAYERS: ReadonlyArray<DiaryPlayerRef> = [{ id: 'p1', initials: 'MR', color: 262 }];
+
+const DIARY_EVENTS: ReadonlyArray<DiaryEvent> = [
+  {
+    id: 'd01',
+    time: '21:02',
+    gameId: 'gs-brass-1',
+    kind: 'turn',
+    icon: '🎯',
+    actors: ['p1'],
+    text: 'Marco apre il Canal Era',
+  },
+];
+
+const baseProps: NightLiveHubProps = {
+  night: NIGHT,
+  current: 2,
+  total: 3,
+  elapsed: '23m',
+  plannedGames: PLANNED_GAMES,
+  currentGame: CURRENT_GAME,
+  diaryEvents: DIARY_EVENTS,
+  diaryGames: DIARY_GAMES,
+  diaryPlayers: DIARY_PLAYERS,
+};
+
+describe('NightLiveHub', () => {
+  describe('desktop layout (default)', () => {
+    it('renders night title in top bar', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByText('Sabato boardgame con i Padovani')).toBeInTheDocument();
+    });
+
+    it('renders nightCode badge when provided', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByText('#GN-042')).toBeInTheDocument();
+    });
+
+    it('renders 3-pane layout (planned + current + diary)', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByLabelText('Planned games')).toBeInTheDocument();
+      expect(screen.getByLabelText('Current game')).toBeInTheDocument();
+      expect(screen.getByLabelText('Cross-game diary')).toBeInTheDocument();
+    });
+
+    it('renders desktop counter Game X/Y · elapsed', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('/3')).toBeInTheDocument();
+      expect(screen.getByText('23m')).toBeInTheDocument();
+    });
+
+    it('renders player counter when both props provided', () => {
+      render(<NightLiveHub {...baseProps} confirmedPlayers={5} totalPlayers={6} />);
+      expect(screen.getByText('5/6')).toBeInTheDocument();
+      // "Player" label appears in both desktop counter and mobile compact strip
+      expect(screen.getAllByText('Player').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('omits player counter when totalPlayers missing', () => {
+      render(<NightLiveHub {...baseProps} confirmedPlayers={5} />);
+      expect(screen.queryByText('5/6')).toBeNull();
+    });
+
+    it('does NOT render mobile bottom tabs', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.queryByRole('tablist', { name: 'Hub mobile tabs' })).toBeNull();
+    });
+  });
+
+  describe('mobile layout', () => {
+    it('renders bottom tab navigation (3 tabs)', () => {
+      render(<NightLiveHub {...baseProps} mobile />);
+      const tablist = screen.getByRole('tablist', { name: 'Hub mobile tabs' });
+      expect(tablist).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Current/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Planned/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Diary/ })).toBeInTheDocument();
+    });
+
+    it('starts with current tab active by default', () => {
+      render(<NightLiveHub {...baseProps} mobile />);
+      expect(screen.getByRole('tab', { name: /Current/ })).toHaveAttribute('aria-selected', 'true');
+      // Current game card visible
+      expect(screen.getByLabelText('Current game')).toBeInTheDocument();
+    });
+
+    it('respects initialMobileTab prop', () => {
+      render(<NightLiveHub {...baseProps} mobile initialMobileTab="planned" />);
+      expect(screen.getByRole('tab', { name: /Planned/ })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByLabelText('Planned games')).toBeInTheDocument();
+    });
+
+    it('switches tabs on click', async () => {
+      render(<NightLiveHub {...baseProps} mobile />);
+      // initially "Current" is active
+      expect(screen.getByLabelText('Current game')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('tab', { name: /Diary/ }));
+      // diary text visible
+      expect(screen.getByText('Marco apre il Canal Era')).toBeInTheDocument();
+      // current game card no longer rendered
+      expect(screen.queryByLabelText('Current game')).toBeNull();
+    });
+
+    it('renders short title in compact mode', () => {
+      render(<NightLiveHub {...baseProps} mobile />);
+      expect(screen.getByText('Padovani · 17 mag')).toBeInTheDocument();
+    });
+
+    it('falls back to full title in compact when shortTitle missing', () => {
+      const nightNoShort: NightLiveHubNight = { title: 'Full title only' };
+      render(<NightLiveHub {...baseProps} night={nightNoShort} mobile />);
+      expect(screen.getByText('Full title only')).toBeInTheDocument();
+    });
+  });
+
+  describe('status variants', () => {
+    it('shows "Live" badge by default with pulsing dot', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByLabelText('Status: Live')).toBeInTheDocument();
+    });
+
+    it('shows "In pausa" badge with ⏸ icon when status=paused', () => {
+      render(<NightLiveHub {...baseProps} status="paused" />);
+      expect(screen.getByLabelText('Status: In pausa')).toBeInTheDocument();
+      // pause icon span ⏸ is decorative
+      expect(screen.getByText('⏸')).toBeInTheDocument();
+    });
+
+    it('shows "Transition" badge when status=transition', () => {
+      render(<NightLiveHub {...baseProps} status="transition" />);
+      expect(screen.getByLabelText('Status: Transition')).toBeInTheDocument();
+    });
+
+    it('toolbar button shows "Pausa" when status=live', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByRole('button', { name: /Pausa/ })).toBeInTheDocument();
+    });
+
+    it('toolbar button shows "Riprendi" when status=paused', () => {
+      render(<NightLiveHub {...baseProps} status="paused" />);
+      expect(screen.getByRole('button', { name: /Riprendi/ })).toBeInTheDocument();
+    });
+
+    it('top-level data-night-status reflects current status', () => {
+      const { container, rerender } = render(<NightLiveHub {...baseProps} />);
+      expect(container.firstChild).toHaveAttribute('data-night-status', 'live');
+      rerender(<NightLiveHub {...baseProps} status="paused" />);
+      expect(container.firstChild).toHaveAttribute('data-night-status', 'paused');
+    });
+  });
+
+  describe('toolbar callbacks', () => {
+    it('invokes onPauseToggle on Pausa click', async () => {
+      const onPauseToggle = vi.fn();
+      render(<NightLiveHub {...baseProps} onPauseToggle={onPauseToggle} />);
+      await userEvent.click(screen.getByRole('button', { name: /Pausa/ }));
+      expect(onPauseToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onTransition on Transition click', async () => {
+      const onTransition = vi.fn();
+      render(<NightLiveHub {...baseProps} onTransition={onTransition} />);
+      await userEvent.click(screen.getByRole('button', { name: /Transition/ }));
+      expect(onTransition).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onEnd on End click', async () => {
+      const onEnd = vi.fn();
+      render(<NightLiveHub {...baseProps} onEnd={onEnd} />);
+      await userEvent.click(screen.getByRole('button', { name: /^End$/ }));
+      expect(onEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders back button only when onBack provided', () => {
+      const { rerender } = render(<NightLiveHub {...baseProps} />);
+      expect(screen.queryByRole('button', { name: 'Indietro' })).toBeNull();
+
+      rerender(<NightLiveHub {...baseProps} onBack={() => undefined} />);
+      expect(screen.getByRole('button', { name: 'Indietro' })).toBeInTheDocument();
+    });
+  });
+
+  describe('CurrentGameCard', () => {
+    it('renders current game title + sessionId', () => {
+      render(<NightLiveHub {...baseProps} />);
+      const currentGameSection = screen.getByLabelText('Current game');
+      // Spirit Island title and sessionId rendered inside CurrentGameCard region
+      // (Spirit Island also appears in PlannedGamesPane row, so we scope to the region)
+      expect(within(currentGameSection).getByText('Spirit Island')).toBeInTheDocument();
+      expect(within(currentGameSection).getByText('s-spirit-may17')).toBeInTheDocument();
+    });
+
+    it('renders score pill when score provided', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByText('round 2')).toBeInTheDocument();
+    });
+
+    it('invokes onJumpToSession with sessionId', async () => {
+      const onJumpToSession = vi.fn();
+      render(<NightLiveHub {...baseProps} onJumpToSession={onJumpToSession} />);
+      await userEvent.click(screen.getByRole('button', { name: /Apri sessione live/ }));
+      expect(onJumpToSession).toHaveBeenCalledWith('s-spirit-may17');
+    });
+
+    it('renders empty state when currentGame=null', () => {
+      render(<NightLiveHub {...baseProps} currentGame={null} />);
+      expect(screen.getByText('Nessun gioco corrente · in attesa transition')).toBeInTheDocument();
+    });
+  });
+
+  describe('AutoSaveToast integration', () => {
+    it('renders toast when autoSaveToast.visible=true', () => {
+      render(
+        <NightLiveHub {...baseProps} autoSaveToast={{ visible: true, timestamp: '23:35:42' }} />
+      );
+      expect(screen.getByText('Auto-salvato')).toBeInTheDocument();
+      expect(screen.getByText('23:35:42 · prossimo tra 60s')).toBeInTheDocument();
+    });
+
+    it('does not render toast when autoSaveToast.visible=false', () => {
+      render(
+        <NightLiveHub {...baseProps} autoSaveToast={{ visible: false, timestamp: '23:35:42' }} />
+      );
+      expect(screen.queryByText('Auto-salvato')).toBeNull();
+    });
+
+    it('does not render toast when autoSaveToast prop missing', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.queryByText('Auto-salvato')).toBeNull();
+    });
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(<NightLiveHub {...baseProps} className="custom-hub-class" />);
+    expect(container.firstChild).toHaveClass('custom-hub-class');
+  });
+
+  it('forwards onAddGame to PlannedGamesPane', async () => {
+    const onAddGame = vi.fn();
+    render(<NightLiveHub {...baseProps} onAddGame={onAddGame} />);
+    await userEvent.click(screen.getByRole('button', { name: /Aggiungi gioco/ }));
+    expect(onAddGame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
@@ -1,0 +1,573 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+
+import {
+  CrossGameDiaryTimeline,
+  type DiaryEvent,
+  type DiaryGameRef,
+  type DiaryPlayerRef,
+} from '@/components/features/game-nights/live/CrossGameDiaryTimeline';
+import {
+  PlannedGamesPane,
+  type PlannedGame,
+} from '@/components/features/game-nights/live/PlannedGamesPane';
+import { AutoSaveToast } from '@/components/ui/auto-save-toast';
+
+export type NightLiveStatus = 'live' | 'paused' | 'transition';
+export type MobileTab = 'current' | 'planned' | 'diary';
+
+export interface NightLiveHubNight {
+  readonly title: string;
+  readonly shortTitle?: string;
+  readonly nightCode?: string;
+}
+
+export interface NightLiveHubCurrentGame {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly title: string;
+  readonly emoji?: string;
+  readonly cover?: readonly [string, string];
+  readonly score?: string;
+}
+
+export interface NightLiveHubProps {
+  readonly night: NightLiveHubNight;
+  readonly status?: NightLiveStatus;
+  readonly current: number;
+  readonly total: number;
+  readonly elapsed: string;
+  readonly confirmedPlayers?: number;
+  readonly totalPlayers?: number;
+  readonly plannedGames: ReadonlyArray<PlannedGame>;
+  readonly currentGame: NightLiveHubCurrentGame | null;
+  readonly diaryEvents: ReadonlyArray<DiaryEvent>;
+  readonly diaryGames: ReadonlyArray<DiaryGameRef>;
+  readonly diaryPlayers: ReadonlyArray<DiaryPlayerRef>;
+  readonly autoSaveToast?: { readonly visible: boolean; readonly timestamp: string };
+  readonly mobile?: boolean;
+  readonly initialMobileTab?: MobileTab;
+  readonly onBack?: () => void;
+  readonly onPauseToggle?: () => void;
+  readonly onTransition?: () => void;
+  readonly onEnd?: () => void;
+  readonly onJumpToSession?: (sessionId: string) => void;
+  readonly onAddGame?: () => void;
+  readonly className?: string;
+}
+
+const STATUS_LABEL: Record<NightLiveStatus, string> = {
+  live: 'Live',
+  paused: 'In pausa',
+  transition: 'Transition',
+};
+
+const STATUS_TONE: Record<NightLiveStatus, 'session' | 'warning' | 'event'> = {
+  live: 'session',
+  paused: 'warning',
+  transition: 'event',
+};
+
+export function NightLiveHub({
+  night,
+  status = 'live',
+  current,
+  total,
+  elapsed,
+  confirmedPlayers,
+  totalPlayers,
+  plannedGames,
+  currentGame,
+  diaryEvents,
+  diaryGames,
+  diaryPlayers,
+  autoSaveToast,
+  mobile = false,
+  initialMobileTab = 'current',
+  onBack,
+  onPauseToggle,
+  onTransition,
+  onEnd,
+  onJumpToSession,
+  onAddGame,
+  className,
+}: NightLiveHubProps): JSX.Element {
+  const isPaused = status === 'paused';
+
+  return (
+    <div
+      data-night-status={status}
+      data-mobile={mobile ? 'true' : 'false'}
+      className={[
+        'relative flex h-full min-h-0 flex-col overflow-hidden bg-background',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <NightLiveTopBar
+        night={night}
+        status={status}
+        current={current}
+        total={total}
+        elapsed={elapsed}
+        confirmedPlayers={confirmedPlayers}
+        totalPlayers={totalPlayers}
+        compact={mobile}
+        isPaused={isPaused}
+        onBack={onBack}
+        onPauseToggle={onPauseToggle}
+        onTransition={onTransition}
+        onEnd={onEnd}
+      />
+
+      {mobile ? (
+        <MobileBody
+          initialTab={initialMobileTab}
+          plannedGames={plannedGames}
+          currentGame={currentGame}
+          diaryEvents={diaryEvents}
+          diaryGames={diaryGames}
+          diaryPlayers={diaryPlayers}
+          onJumpToSession={onJumpToSession}
+          onAddGame={onAddGame}
+        />
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <PlannedGamesPane games={plannedGames} onAddGame={onAddGame} />
+          <CurrentGameCard
+            game={currentGame}
+            score={currentGame?.score}
+            onJumpToSession={onJumpToSession}
+          />
+          <aside
+            aria-label="Cross-game diary"
+            className="flex w-[320px] shrink-0 flex-col border-l border-border bg-card p-3 overflow-y-auto"
+          >
+            <CrossGameDiaryTimeline
+              events={diaryEvents}
+              games={diaryGames}
+              players={diaryPlayers}
+            />
+          </aside>
+        </div>
+      )}
+
+      {autoSaveToast?.visible ? (
+        <AutoSaveToast visible timestamp={autoSaveToast.timestamp} />
+      ) : null}
+    </div>
+  );
+}
+
+interface NightLiveTopBarProps {
+  readonly night: NightLiveHubNight;
+  readonly status: NightLiveStatus;
+  readonly current: number;
+  readonly total: number;
+  readonly elapsed: string;
+  readonly confirmedPlayers?: number;
+  readonly totalPlayers?: number;
+  readonly compact: boolean;
+  readonly isPaused: boolean;
+  readonly onBack?: () => void;
+  readonly onPauseToggle?: () => void;
+  readonly onTransition?: () => void;
+  readonly onEnd?: () => void;
+}
+
+function NightLiveTopBar({
+  night,
+  status,
+  current,
+  total,
+  elapsed,
+  confirmedPlayers,
+  totalPlayers,
+  compact,
+  isPaused,
+  onBack,
+  onPauseToggle,
+  onTransition,
+  onEnd,
+}: NightLiveTopBarProps): JSX.Element {
+  const tone = STATUS_TONE[status];
+  const toneBgClass =
+    tone === 'session'
+      ? 'bg-entity-session/15 border-entity-session/30 text-entity-session'
+      : tone === 'event'
+        ? 'bg-entity-event/15 border-entity-event/30 text-entity-event'
+        : 'bg-[hsl(var(--c-warning)/0.14)] border-[hsl(var(--c-warning)/0.3)] text-[hsl(var(--c-warning))]';
+
+  return (
+    <header
+      className={[
+        'sticky top-0 z-20 flex flex-col bg-card/80 backdrop-blur-md',
+        'border-b border-entity-event/25',
+      ].join(' ')}
+    >
+      <div
+        className={[
+          'flex items-center gap-2',
+          compact ? 'px-3 py-2.5 min-h-[56px]' : 'px-4 py-3 gap-3 min-h-[64px]',
+        ].join(' ')}
+      >
+        {onBack ? (
+          <button
+            type="button"
+            aria-label="Indietro"
+            onClick={onBack}
+            className="shrink-0 rounded-md border border-border bg-card font-display text-base font-extrabold text-muted-foreground cursor-pointer h-[34px] w-[34px]"
+          >
+            ←
+          </button>
+        ) : null}
+
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span
+              aria-label={`Status: ${STATUS_LABEL[status]}`}
+              className={[
+                'inline-flex items-center gap-1 rounded-pill border px-2 py-0.5',
+                'font-mono text-[9.5px] font-extrabold uppercase tracking-wider',
+                toneBgClass,
+              ].join(' ')}
+            >
+              {isPaused ? (
+                <span aria-hidden="true">⏸</span>
+              ) : (
+                <span
+                  aria-hidden="true"
+                  className="motion-safe:animate-pulse inline-block h-1.5 w-1.5 rounded-full"
+                  style={{
+                    background:
+                      tone === 'session' ? 'hsl(var(--c-session))' : 'hsl(var(--c-event))',
+                  }}
+                />
+              )}
+              {STATUS_LABEL[status]}
+            </span>
+            {night.nightCode ? (
+              <span className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-muted-foreground">
+                {night.nightCode}
+              </span>
+            ) : null}
+          </div>
+          <div
+            className={[
+              'flex items-center gap-1.5 truncate font-display font-extrabold text-foreground',
+              compact ? 'text-[13px]' : 'text-[14.5px]',
+            ].join(' ')}
+          >
+            <span aria-hidden="true">🎉</span>
+            <span className="truncate">
+              {compact && night.shortTitle ? night.shortTitle : night.title}
+            </span>
+          </div>
+        </div>
+
+        {!compact ? (
+          <div className="flex shrink-0 items-center gap-3 rounded-md border border-entity-event/20 bg-entity-event/[0.08] px-3.5 py-1.5">
+            <div className="text-center">
+              <span className="block font-mono text-[9px] font-extrabold uppercase tracking-wider text-muted-foreground">
+                Game
+              </span>
+              <span className="font-display text-base font-extrabold leading-none tabular-nums text-entity-event">
+                {current}
+                <span className="text-muted-foreground">/{total}</span>
+              </span>
+            </div>
+            <span className="h-[22px] w-px bg-border" />
+            <div className="text-center">
+              <span className="block font-mono text-[9px] font-extrabold uppercase tracking-wider text-muted-foreground">
+                Elapsed
+              </span>
+              <span className="font-mono text-[13.5px] font-extrabold leading-tight tabular-nums text-foreground">
+                {elapsed}
+              </span>
+            </div>
+            {confirmedPlayers !== undefined && totalPlayers !== undefined ? (
+              <>
+                <span className="h-[22px] w-px bg-border" />
+                <div className="text-center">
+                  <span className="block font-mono text-[9px] font-extrabold uppercase tracking-wider text-muted-foreground">
+                    Player
+                  </span>
+                  <span className="font-mono text-[13.5px] font-extrabold leading-tight tabular-nums text-entity-player">
+                    {confirmedPlayers}/{totalPlayers}
+                  </span>
+                </div>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="flex shrink-0 items-center gap-1.5">
+          <ToolbarButton
+            icon={isPaused ? '▶' : '⏸'}
+            label={compact ? null : isPaused ? 'Riprendi' : 'Pausa'}
+            tone={isPaused ? 'session' : null}
+            onClick={onPauseToggle}
+          />
+          <ToolbarButton
+            icon="➡️"
+            label={compact ? null : 'Transition'}
+            tone="event"
+            onClick={onTransition}
+          />
+          <ToolbarButton icon="🛑" label={compact ? null : 'End'} tone="danger" onClick={onEnd} />
+        </div>
+      </div>
+
+      {compact ? (
+        <div className="flex items-center gap-2 border-t border-border-light bg-card px-3 py-1.5 font-mono text-[10.5px] font-bold text-foreground/70">
+          <span>
+            <strong className="tabular-nums text-entity-event">
+              Game {current}/{total}
+            </strong>
+          </span>
+          <span className="text-muted-foreground">·</span>
+          <span>
+            Elapsed <strong className="tabular-nums text-foreground">{elapsed}</strong>
+          </span>
+          {confirmedPlayers !== undefined && totalPlayers !== undefined ? (
+            <>
+              <span className="text-muted-foreground">·</span>
+              <span>
+                <strong className="tabular-nums text-entity-player">
+                  {confirmedPlayers}/{totalPlayers}
+                </strong>{' '}
+                player
+              </span>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </header>
+  );
+}
+
+interface ToolbarButtonProps {
+  readonly icon: string;
+  readonly label: string | null;
+  readonly tone: 'session' | 'event' | 'danger' | null;
+  readonly onClick?: () => void;
+}
+
+function ToolbarButton({ icon, label, tone, onClick }: ToolbarButtonProps): JSX.Element {
+  const cls =
+    tone === 'session'
+      ? 'border-entity-session/30 bg-entity-session/10 text-entity-session'
+      : tone === 'event'
+        ? 'border-entity-event/30 bg-entity-event/10 text-entity-event'
+        : tone === 'danger'
+          ? 'border-[hsl(var(--c-danger)/0.3)] bg-[hsl(var(--c-danger)/0.1)] text-[hsl(var(--c-danger))]'
+          : 'border-border bg-card text-muted-foreground';
+
+  return (
+    <button
+      type="button"
+      aria-label={label ?? icon}
+      onClick={onClick}
+      className={[
+        'inline-flex items-center gap-1.5 rounded-md border cursor-pointer',
+        'font-display text-[12.5px] font-extrabold',
+        label ? 'px-3 py-1.5' : 'px-2 py-1.5',
+        cls,
+      ].join(' ')}
+    >
+      <span aria-hidden="true">{icon}</span>
+      {label}
+    </button>
+  );
+}
+
+interface CurrentGameCardProps {
+  readonly game: NightLiveHubCurrentGame | null;
+  readonly score?: string;
+  readonly onJumpToSession?: (sessionId: string) => void;
+  readonly compact?: boolean;
+}
+
+function CurrentGameCard({
+  game,
+  score,
+  onJumpToSession,
+  compact = false,
+}: CurrentGameCardProps): JSX.Element {
+  if (!game) {
+    return (
+      <section
+        aria-label="Current game"
+        className="flex flex-1 items-center justify-center bg-card font-mono text-xs text-muted-foreground p-6"
+      >
+        Nessun gioco corrente · in attesa transition
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Current game"
+      className={[
+        'flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto bg-card',
+        compact ? 'p-3.5' : 'px-6 py-5',
+      ].join(' ')}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+          Current game
+        </span>
+        {score ? (
+          <span className="inline-flex items-center gap-1.5 rounded-pill border border-entity-session/30 bg-entity-session/15 px-2 py-0.5 font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-entity-session">
+            <span
+              aria-hidden="true"
+              className="motion-safe:animate-pulse inline-block h-1.5 w-1.5 rounded-full bg-entity-session"
+            />
+            {score}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-entity-session/25 ring-4 ring-entity-session/[0.08] shadow-md">
+        <div
+          aria-hidden="true"
+          className={['flex items-end p-4', compact ? 'h-[140px]' : 'h-[200px]'].join(' ')}
+          style={
+            game.cover
+              ? {
+                  background: `linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})`,
+                }
+              : { background: 'var(--bg-muted)' }
+          }
+        >
+          <span
+            className="font-display text-3xl font-extrabold drop-shadow-lg"
+            style={{ color: '#fff' }}
+          >
+            {game.emoji ?? '🎲'}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate font-display text-lg font-extrabold text-foreground">
+              {game.title}
+            </h2>
+            <span className="font-mono text-[10px] font-bold text-muted-foreground">
+              {game.sessionId}
+            </span>
+          </div>
+          {onJumpToSession ? (
+            <button
+              type="button"
+              onClick={() => onJumpToSession(game.sessionId)}
+              className="shrink-0 rounded-md border border-entity-session/30 bg-entity-session/10 px-3 py-1.5 font-display text-[12.5px] font-extrabold text-entity-session cursor-pointer"
+            >
+              Apri sessione live →
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface MobileBodyProps {
+  readonly initialTab: MobileTab;
+  readonly plannedGames: ReadonlyArray<PlannedGame>;
+  readonly currentGame: NightLiveHubCurrentGame | null;
+  readonly diaryEvents: ReadonlyArray<DiaryEvent>;
+  readonly diaryGames: ReadonlyArray<DiaryGameRef>;
+  readonly diaryPlayers: ReadonlyArray<DiaryPlayerRef>;
+  readonly onJumpToSession?: (sessionId: string) => void;
+  readonly onAddGame?: () => void;
+}
+
+function MobileBody({
+  initialTab,
+  plannedGames,
+  currentGame,
+  diaryEvents,
+  diaryGames,
+  diaryPlayers,
+  onJumpToSession,
+  onAddGame,
+}: MobileBodyProps): JSX.Element {
+  const [tab, setTab] = useState<MobileTab>(initialTab);
+  const TABS: ReadonlyArray<{
+    id: MobileTab;
+    icon: string;
+    label: string;
+    tone: 'session' | 'game' | 'event';
+  }> = [
+    { id: 'current', icon: '🎯', label: 'Current', tone: 'session' },
+    { id: 'planned', icon: '🎲', label: 'Planned', tone: 'game' },
+    { id: 'diary', icon: '📜', label: 'Diary', tone: 'event' },
+  ];
+
+  return (
+    <>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-background">
+        {tab === 'current' ? (
+          <CurrentGameCard game={currentGame} onJumpToSession={onJumpToSession} compact />
+        ) : null}
+        {tab === 'planned' ? (
+          <PlannedGamesPane games={plannedGames} onAddGame={onAddGame} compact />
+        ) : null}
+        {tab === 'diary' ? (
+          <div className="p-3">
+            <CrossGameDiaryTimeline
+              events={diaryEvents}
+              games={diaryGames}
+              players={diaryPlayers}
+              compact
+            />
+          </div>
+        ) : null}
+      </div>
+      <nav
+        role="tablist"
+        aria-label="Hub mobile tabs"
+        className="flex shrink-0 border-t border-border bg-card/80 backdrop-blur-md"
+      >
+        {TABS.map(t => {
+          const active = tab === t.id;
+          const toneClass =
+            t.tone === 'session'
+              ? active
+                ? 'bg-entity-session/[0.08] border-t-entity-session text-entity-session'
+                : 'border-t-transparent text-muted-foreground'
+              : t.tone === 'game'
+                ? active
+                  ? 'bg-entity-game/[0.08] border-t-entity-game text-entity-game'
+                  : 'border-t-transparent text-muted-foreground'
+                : active
+                  ? 'bg-entity-event/[0.08] border-t-entity-event text-entity-event'
+                  : 'border-t-transparent text-muted-foreground';
+
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-controls={`night-live-pane-${t.id}`}
+              onClick={() => setTab(t.id)}
+              className={[
+                'flex flex-1 flex-col items-center gap-px py-2.5 px-1',
+                'border-t-2 bg-transparent cursor-pointer',
+                'font-display text-[11px] font-extrabold',
+                toneClass,
+              ].join(' ')}
+            >
+              <span aria-hidden="true" className="text-base">
+                {t.icon}
+              </span>
+              {t.label}
+            </button>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/PlannedGamesPane.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/PlannedGamesPane.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PlannedGamesPane, type PlannedGame } from './PlannedGamesPane';
+
+const SAMPLE_GAMES: ReadonlyArray<PlannedGame> = [
+  {
+    id: 'gs-brass-1',
+    title: 'Brass: Birmingham',
+    publisher: 'Roxley',
+    emoji: '🏭',
+    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+    status: 'completed',
+    order: 1,
+    actual: '113m',
+    estimated: '120m',
+    score: '178–142',
+    winner: { name: 'Davide', initials: 'DC', color: 200 },
+  },
+  {
+    id: 'gs-spirit-1',
+    title: 'Spirit Island',
+    publisher: 'GMT',
+    emoji: '🌋',
+    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+    status: 'inprogress',
+    order: 2,
+    actual: '35m elapsed',
+    estimated: '90m',
+    score: 'round 2',
+  },
+  {
+    id: 'gs-wing-1',
+    title: 'Wingspan',
+    publisher: 'Stonemaier',
+    emoji: '🦜',
+    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
+    status: 'upcoming',
+    order: 3,
+    estimated: '60m',
+  },
+];
+
+describe('PlannedGamesPane', () => {
+  it('renders default "Planned (N)" title', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText(/Planned \(3\)/)).toBeInTheDocument();
+  });
+
+  it('renders custom title override', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} title="Giochi" />);
+    expect(screen.getByText(/Giochi \(3\)/)).toBeInTheDocument();
+  });
+
+  it('renders all game titles', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('Brass: Birmingham')).toBeInTheDocument();
+    expect(screen.getByText('Spirit Island')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no games', () => {
+    render(<PlannedGamesPane games={[]} />);
+    expect(screen.getByText('Nessun gioco pianificato')).toBeInTheDocument();
+  });
+
+  it('shows PlayOrder lock badge by default', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText(/PlayOrder/)).toBeInTheDocument();
+  });
+
+  it('omits PlayOrder lock when playOrderLocked=false', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} playOrderLocked={false} />);
+    expect(screen.queryByText(/PlayOrder/)).toBeNull();
+  });
+
+  it('renders status badges per row (completed/inprogress/upcoming)', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByLabelText('Status: completed')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status: inprogress')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status: upcoming')).toBeInTheDocument();
+  });
+
+  it('renders FINITO + actual time for completed games', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('FINITO')).toBeInTheDocument();
+    expect(screen.getByText('113m')).toBeInTheDocument();
+  });
+
+  it('renders LIVE + actual for inprogress games', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('LIVE')).toBeInTheDocument();
+    expect(screen.getByText('35m elapsed')).toBeInTheDocument();
+  });
+
+  it('renders UPCOMING + estimated for upcoming games', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('UPCOMING')).toBeInTheDocument();
+    expect(screen.getByText('est. 60m')).toBeInTheDocument();
+  });
+
+  it('renders winner banner for completed game when winner present', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('🏆 Davide ha vinto')).toBeInTheDocument();
+    expect(screen.getByLabelText('Winner DC')).toBeInTheDocument();
+    expect(screen.getByText('178–142')).toBeInTheDocument();
+  });
+
+  it('omits winner banner when winner missing', () => {
+    const noWinnerGame: PlannedGame = {
+      id: 'g-x',
+      title: 'X',
+      status: 'completed',
+      order: 1,
+      actual: '60m',
+    };
+    render(<PlannedGamesPane games={[noWinnerGame]} />);
+    expect(screen.queryByText(/ha vinto/)).toBeNull();
+  });
+
+  it('compact=true removes right border + uses full width', () => {
+    const { container, rerender } = render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    const aside = container.querySelector('aside');
+    expect(aside?.className).toContain('w-[280px]');
+    expect(aside?.className).toContain('border-r');
+
+    rerender(<PlannedGamesPane games={SAMPLE_GAMES} compact />);
+    const asideCompact = container.querySelector('aside');
+    expect(asideCompact?.className).toContain('w-full');
+    expect(asideCompact?.className).not.toContain('border-r');
+  });
+
+  it('add game button disabled when onAddGame missing', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    const btn = screen.getByRole('button', { name: /Aggiungi gioco/ });
+    expect(btn).toBeDisabled();
+  });
+
+  it('add game button enabled + invokes callback when onAddGame provided', async () => {
+    const onAddGame = vi.fn();
+    render(<PlannedGamesPane games={SAMPLE_GAMES} onAddGame={onAddGame} />);
+    const btn = screen.getByRole('button', { name: /Aggiungi gioco/ });
+    expect(btn).not.toBeDisabled();
+    await userEvent.click(btn);
+    expect(onAddGame).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders #order · publisher in subline', () => {
+    render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    expect(screen.getByText('#1 · Roxley')).toBeInTheDocument();
+    expect(screen.getByText('#2 · GMT')).toBeInTheDocument();
+  });
+
+  it('falls back to #order only when publisher missing', () => {
+    const noPub: PlannedGame = {
+      id: 'g-x',
+      title: 'X',
+      status: 'upcoming',
+      order: 5,
+      estimated: '30m',
+    };
+    render(<PlannedGamesPane games={[noPub]} />);
+    expect(screen.getByText('#5')).toBeInTheDocument();
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <PlannedGamesPane games={SAMPLE_GAMES} className="custom-class" />
+    );
+    expect(container.querySelector('aside')?.className).toContain('custom-class');
+  });
+
+  it('inprogress row has session-tinted bg + border', () => {
+    const { container } = render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    const inprogressRow = container.querySelector('[data-status="inprogress"]');
+    expect(inprogressRow?.className).toContain('bg-entity-session');
+    expect(inprogressRow?.className).toContain('border-entity-session');
+  });
+
+  it('completed row has reduced opacity (.80)', () => {
+    const { container } = render(<PlannedGamesPane games={SAMPLE_GAMES} />);
+    const completedRow = container.querySelector('[data-status="completed"]');
+    expect(completedRow?.className).toContain('opacity-80');
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/PlannedGamesPane.tsx
+++ b/apps/web/src/components/features/game-nights/live/PlannedGamesPane.tsx
@@ -1,0 +1,244 @@
+import type { JSX } from 'react';
+
+export type PlannedGameStatus = 'completed' | 'inprogress' | 'upcoming';
+
+export interface PlannedGameWinner {
+  readonly name: string;
+  readonly initials: string;
+  readonly color: number;
+}
+
+export interface PlannedGame {
+  readonly id: string;
+  readonly title: string;
+  readonly publisher?: string;
+  readonly emoji?: string;
+  readonly cover?: readonly [string, string];
+  readonly status: PlannedGameStatus;
+  readonly order: number;
+  readonly actual?: string;
+  readonly estimated?: string;
+  readonly score?: string;
+  readonly winner?: PlannedGameWinner;
+}
+
+export interface PlannedGamesPaneProps {
+  readonly games: ReadonlyArray<PlannedGame>;
+  readonly compact?: boolean;
+  readonly title?: string;
+  readonly playOrderLocked?: boolean;
+  readonly onAddGame?: () => void;
+  readonly addGameDisabledLabel?: string;
+  readonly className?: string;
+}
+
+const STATUS_ACCENT: Record<PlannedGameStatus, string> = {
+  completed: 'hsl(var(--c-toolkit))',
+  inprogress: 'hsl(var(--c-session))',
+  upcoming: 'hsl(var(--c-game))',
+};
+
+export function PlannedGamesPane({
+  games,
+  compact = false,
+  title = 'Planned',
+  playOrderLocked = true,
+  onAddGame,
+  addGameDisabledLabel = 'Aggiungi disponibile fuori live',
+  className,
+}: PlannedGamesPaneProps): JSX.Element {
+  const canAdd = Boolean(onAddGame);
+
+  return (
+    <aside
+      aria-label="Planned games"
+      className={[
+        'flex flex-col bg-card min-w-0 shrink-0',
+        compact ? 'w-full' : 'w-[280px] border-r border-border',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex items-center justify-between border-b border-border-light px-3.5 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <span aria-hidden="true">🎲</span>
+          <span className="font-mono text-[10.5px] font-extrabold uppercase tracking-wider text-muted-foreground">
+            {title} ({games.length})
+          </span>
+        </div>
+        {playOrderLocked ? (
+          <span
+            title="Riordino disabilitato in live mode"
+            className="rounded-pill border border-border bg-muted px-1.5 py-0.5 font-mono text-[9px] font-bold text-muted-foreground"
+          >
+            🔒 PlayOrder
+          </span>
+        ) : null}
+      </div>
+
+      <ul className="flex flex-1 flex-col gap-2 overflow-y-auto p-2.5 m-0 list-none min-h-0">
+        {games.length === 0 ? (
+          <li className="font-mono text-xs text-muted-foreground text-center py-6">
+            Nessun gioco pianificato
+          </li>
+        ) : (
+          games.map(game => <PlannedGameRow key={game.id} game={game} />)
+        )}
+      </ul>
+
+      <div className="border-t border-border-light p-3">
+        <button
+          type="button"
+          onClick={onAddGame}
+          disabled={!canAdd}
+          title={canAdd ? undefined : addGameDisabledLabel}
+          className={[
+            'w-full rounded-md border border-dashed font-display text-[11.5px] font-bold py-2',
+            canAdd
+              ? 'cursor-pointer border-border-strong text-foreground hover:bg-muted'
+              : 'cursor-not-allowed border-border-strong text-muted-foreground opacity-70',
+          ].join(' ')}
+        >
+          + Aggiungi gioco
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function PlannedGameRow({ game }: { readonly game: PlannedGame }): JSX.Element {
+  const isCompleted = game.status === 'completed';
+  const isInProgress = game.status === 'inprogress';
+  const isUpcoming = game.status === 'upcoming';
+  const accent = STATUS_ACCENT[game.status];
+
+  return (
+    <li
+      data-status={game.status}
+      className={[
+        'relative rounded-md px-3 py-2.5 border-l-4',
+        isInProgress
+          ? 'bg-entity-session/[0.08] border border-entity-session/35'
+          : 'bg-card border border-border',
+        isCompleted ? 'opacity-80' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{ borderLeftColor: accent }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        <span
+          aria-hidden="true"
+          className="inline-flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-sm text-base"
+          style={
+            game.cover
+              ? { background: `linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})` }
+              : { background: 'var(--bg-muted)' }
+          }
+        >
+          {game.emoji ?? '🎲'}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-display text-[12.5px] font-extrabold text-foreground">
+            {game.title}
+          </div>
+          {game.publisher ? (
+            <div className="font-mono text-[9.5px] font-bold text-muted-foreground">
+              #{game.order} · {game.publisher}
+            </div>
+          ) : (
+            <div className="font-mono text-[9.5px] font-bold text-muted-foreground">
+              #{game.order}
+            </div>
+          )}
+        </div>
+        <span
+          aria-label={`Status: ${game.status}`}
+          className="relative inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full font-display text-[11px] font-extrabold"
+          style={{ background: accent, color: '#fff' }}
+        >
+          {isCompleted ? '✓' : null}
+          {isInProgress ? (
+            <>
+              <span className="text-[10px]">●</span>
+              <span
+                aria-hidden="true"
+                className="motion-safe:animate-ping absolute -inset-[3px] rounded-full border-2 opacity-40"
+                style={{ borderColor: accent }}
+              />
+            </>
+          ) : null}
+          {isUpcoming ? <span className="text-[10px]">⏳</span> : null}
+        </span>
+      </div>
+
+      {/* Status line */}
+      <div
+        className="flex items-center gap-1.5 font-mono text-[10px] font-bold tabular-nums"
+        style={{ color: accent }}
+      >
+        {isCompleted ? (
+          <>
+            <span>FINITO</span>
+            <span className="text-muted-foreground">·</span>
+            <span className="text-foreground/70">{game.actual ?? '—'}</span>
+          </>
+        ) : null}
+        {isInProgress ? (
+          <>
+            <span
+              aria-hidden="true"
+              className="motion-safe:animate-pulse inline-block h-1.5 w-1.5 rounded-full"
+              style={{ background: accent }}
+            />
+            <span>LIVE</span>
+            {game.actual ? (
+              <>
+                <span className="text-muted-foreground">·</span>
+                <span className="text-foreground/70">{game.actual}</span>
+              </>
+            ) : null}
+          </>
+        ) : null}
+        {isUpcoming ? (
+          <>
+            <span>UPCOMING</span>
+            {game.estimated ? (
+              <>
+                <span className="text-muted-foreground">·</span>
+                <span className="text-foreground/70">est. {game.estimated}</span>
+              </>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+
+      {/* Winner banner */}
+      {isCompleted && game.winner ? (
+        <div className="mt-1.5 flex items-center gap-1.5 rounded-sm border border-entity-event/30 bg-entity-event/10 px-2 py-1.5">
+          <span
+            aria-label={`Winner ${game.winner.initials}`}
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-display text-[9px] font-extrabold"
+            style={{
+              background: `hsl(${game.winner.color}, 60%, 55%)`,
+              color: '#fff',
+            }}
+          >
+            {game.winner.initials}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-display text-[11px] font-extrabold text-entity-event">
+              🏆 {game.winner.name} ha vinto
+            </div>
+            {game.score ? (
+              <div className="font-mono text-[9px] font-bold tabular-nums text-muted-foreground">
+                {game.score}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/index.ts
+++ b/apps/web/src/components/features/game-nights/live/index.ts
@@ -18,3 +18,12 @@ export type {
   PlannedGameStatus,
   PlannedGameWinner,
 } from '@/components/features/game-nights/live/PlannedGamesPane';
+
+export { NightLiveHub } from '@/components/features/game-nights/live/NightLiveHub';
+export type {
+  NightLiveHubProps,
+  NightLiveHubNight,
+  NightLiveHubCurrentGame,
+  NightLiveStatus,
+  MobileTab,
+} from '@/components/features/game-nights/live/NightLiveHub';

--- a/apps/web/src/components/features/game-nights/live/index.ts
+++ b/apps/web/src/components/features/game-nights/live/index.ts
@@ -1,0 +1,20 @@
+export { CrossGameDiaryTimeline } from '@/components/features/game-nights/live/CrossGameDiaryTimeline';
+export type {
+  CrossGameDiaryTimelineProps,
+  DiaryEvent,
+  DiaryEventKind,
+  DiaryGameRef,
+  DiaryPlayerRef,
+  DiaryFilter,
+} from '@/components/features/game-nights/live/CrossGameDiaryTimeline';
+
+export { DiaryInlineWidget } from '@/components/features/game-nights/live/DiaryInlineWidget';
+export type { DiaryInlineWidgetProps } from '@/components/features/game-nights/live/DiaryInlineWidget';
+
+export { PlannedGamesPane } from '@/components/features/game-nights/live/PlannedGamesPane';
+export type {
+  PlannedGamesPaneProps,
+  PlannedGame,
+  PlannedGameStatus,
+  PlannedGameWinner,
+} from '@/components/features/game-nights/live/PlannedGamesPane';

--- a/apps/web/src/components/features/game-nights/summary/NightSummaryView.test.tsx
+++ b/apps/web/src/components/features/game-nights/summary/NightSummaryView.test.tsx
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  NightSummaryView,
+  type NightSummaryViewProps,
+  type NightSummaryNight,
+  type NightSummaryMVP,
+  type NightSummaryPhoto,
+} from './NightSummaryView';
+import type { PerGameRecapGame } from './PerGameRecapRow';
+
+const NIGHT: NightSummaryNight = {
+  title: 'Sabato boardgame con i Padovani',
+  dateLine: 'sabato 17 maggio 2026',
+  location: 'Casa Marco · Padova',
+  startedAt: '21:00',
+  endedAt: '03:15',
+  duration: '6h 15m',
+  nightCode: '#GN-042',
+};
+
+const MVP: NightSummaryMVP = {
+  id: 'p-davide',
+  name: 'Davide',
+  initials: 'DC',
+  color: 200,
+  achievements: '1 vittoria · 11 eventi · top scorer Brass',
+};
+
+const GAMES: ReadonlyArray<PerGameRecapGame> = [
+  {
+    id: 'gs-brass-1',
+    sessionId: 's-brass-may17',
+    title: 'Brass: Birmingham',
+    emoji: '🏭',
+    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+    order: 1,
+    duration: '2h 45m',
+    eventsCount: 11,
+    winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
+  },
+  {
+    id: 'gs-spirit-1',
+    sessionId: 's-spirit-may17',
+    title: 'Spirit Island',
+    emoji: '🌋',
+    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+    order: 2,
+    duration: '1h 50m',
+    eventsCount: 9,
+    coopMode: true,
+    coopOutcome: 'round 5/6 · adversary England 1',
+  },
+  {
+    id: 'gs-wing-1',
+    sessionId: 's-wing-may17',
+    title: 'Wingspan',
+    emoji: '🦜',
+    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
+    order: 3,
+    duration: '1h 25m',
+    eventsCount: 8,
+    winner: { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 92 },
+  },
+];
+
+const PHOTOS: ReadonlyArray<NightSummaryPhoto> = [
+  { id: 'ph-1', label: 'Setup', gradient: ['hsl(220 35% 30%)', 'hsl(28 60% 40%)'] },
+  { id: 'ph-2', label: 'Brindisi', gradient: ['hsl(38 80% 55%)', 'hsl(10 70% 50%)'] },
+];
+
+const baseProps: NightSummaryViewProps = {
+  night: NIGHT,
+  mvp: MVP,
+  games: GAMES,
+  eventsCount: 28,
+  photos: PHOTOS,
+};
+
+describe('NightSummaryView', () => {
+  describe('hero', () => {
+    it('renders title + date + location', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('Sabato boardgame con i Padovani')).toBeInTheDocument();
+      expect(screen.getByText(/sabato 17 maggio 2026/)).toBeInTheDocument();
+      expect(screen.getByText(/Casa Marco · Padova/)).toBeInTheDocument();
+    });
+
+    it('renders night code and games count badge', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText(/#GN-042 · 3 giochi/)).toBeInTheDocument();
+    });
+
+    it('renders "Serata completata" status', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('Serata completata')).toBeInTheDocument();
+    });
+
+    it('renders MVP banner when mvp provided', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('MVP della serata')).toBeInTheDocument();
+      expect(screen.getByText('Davide')).toBeInTheDocument();
+      expect(screen.getByLabelText('MVP avatar DC')).toBeInTheDocument();
+      expect(screen.getByText('1 vittoria · 11 eventi · top scorer Brass')).toBeInTheDocument();
+    });
+
+    it('omits MVP banner when mvp=null', () => {
+      render(<NightSummaryView {...baseProps} mvp={null} />);
+      expect(screen.queryByText('MVP della serata')).toBeNull();
+    });
+  });
+
+  describe('KPI grid', () => {
+    it('renders 4 KPI cards', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('Sessioni totali')).toBeInTheDocument();
+      expect(screen.getByText('Durata totale')).toBeInTheDocument();
+      expect(screen.getByText('Eventi diary')).toBeInTheDocument();
+      expect(screen.getByText('Winner per gioco')).toBeInTheDocument();
+    });
+
+    it('renders games count as Sessioni totali value', () => {
+      const stats = render(<NightSummaryView {...baseProps} />);
+      const sessionsCard = stats.container.querySelector('.font-display.text-\\[28px\\]');
+      expect(sessionsCard?.textContent).toBe('3');
+    });
+
+    it('renders durata totale value (also appears in hero date line)', () => {
+      render(<NightSummaryView {...baseProps} />);
+      // "6h 15m" appears in 2 places: hero date row + KPI Durata totale card
+      expect(screen.getAllByText('6h 15m').length).toBe(2);
+    });
+
+    it('renders Winner per gioco with coop split sub', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('3/3')).toBeInTheDocument(); // all games have winner or coop
+      expect(screen.getByText('1 coop · 2 competitive')).toBeInTheDocument();
+    });
+
+    it('renders "tutti competitive" sub when no coop games', () => {
+      const noCoopGames: ReadonlyArray<PerGameRecapGame> = GAMES.filter(g => !g.coopMode);
+      render(<NightSummaryView {...baseProps} games={noCoopGames} />);
+      expect(screen.getByText('tutti competitive')).toBeInTheDocument();
+    });
+
+    it('renders eventi diary avg / session', () => {
+      render(<NightSummaryView {...baseProps} />);
+      // 28 / 3 = 9.3
+      expect(screen.getByText(/9\.3 avg \/ session/)).toBeInTheDocument();
+    });
+  });
+
+  describe('per-game recap', () => {
+    it('renders all games with title', () => {
+      render(<NightSummaryView {...baseProps} />);
+      const recapSection = screen.getByLabelText('Per-game recap');
+      expect(within(recapSection).getByText('Brass: Birmingham')).toBeInTheDocument();
+      expect(within(recapSection).getByText('Spirit Island')).toBeInTheDocument();
+      expect(within(recapSection).getByText('Wingspan')).toBeInTheDocument();
+    });
+
+    it('renders "3 giochi completati · in ordine cronologico" when multiple', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('3 giochi completati · in ordine cronologico')).toBeInTheDocument();
+    });
+
+    it('renders "1 gioco completato" when single', () => {
+      render(<NightSummaryView {...baseProps} games={[GAMES[0]]} />);
+      expect(screen.getByText('1 gioco completato')).toBeInTheDocument();
+    });
+
+    it('forwards onJumpToSession to PerGameRecapRow', async () => {
+      const onJumpToSession = vi.fn();
+      render(<NightSummaryView {...baseProps} onJumpToSession={onJumpToSession} />);
+      const btns = screen.getAllByRole('button', { name: /Vai a session/ });
+      await userEvent.click(btns[0]);
+      expect(onJumpToSession).toHaveBeenCalledWith('s-brass-may17');
+    });
+  });
+
+  describe('photo gallery', () => {
+    it('renders "N foto caricate" with N>0', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByText('2 foto caricate')).toBeInTheDocument();
+    });
+
+    it('renders + Aggiungi foto button when photos exist + onAddPhoto provided', () => {
+      render(<NightSummaryView {...baseProps} onAddPhoto={() => undefined} />);
+      expect(screen.getByRole('button', { name: /\+ Aggiungi foto/ })).toBeInTheDocument();
+    });
+
+    it('renders "Gallery vuota" + add-first-photo button when no photos', () => {
+      render(<NightSummaryView {...baseProps} photos={[]} onAddPhoto={() => undefined} />);
+      expect(screen.getByText('Gallery vuota')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /\+ Aggiungi prima foto/ })).toBeInTheDocument();
+    });
+
+    it('omits add-first-photo button when onAddPhoto missing', () => {
+      render(<NightSummaryView {...baseProps} photos={[]} />);
+      expect(screen.getByText('Gallery vuota')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /\+ Aggiungi prima foto/ })).toBeNull();
+    });
+  });
+
+  describe('archived banner', () => {
+    it('does not render banner when archived=false', () => {
+      render(<NightSummaryView {...baseProps} />);
+      expect(screen.queryByText('Serata archiviata')).toBeNull();
+    });
+
+    it('renders ArchivedBanner when archived=true', () => {
+      render(<NightSummaryView {...baseProps} archived />);
+      expect(screen.getByText('Serata archiviata')).toBeInTheDocument();
+    });
+
+    it('renders "Torna alla lista" CTA when archived + onGoToList', () => {
+      const onGoToList = vi.fn();
+      render(<NightSummaryView {...baseProps} archived onGoToList={onGoToList} />);
+      const btn = screen.getByRole('button', { name: /Torna alla lista/ });
+      expect(btn).toBeInTheDocument();
+    });
+
+    it('switches Archivia↔Disarchivia footer CTA based on archived state', () => {
+      const { rerender } = render(<NightSummaryView {...baseProps} />);
+      expect(screen.getByRole('button', { name: /Archivia/ })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Disarchivia/ })).toBeNull();
+
+      rerender(<NightSummaryView {...baseProps} archived />);
+      expect(screen.getByRole('button', { name: /Disarchivia/ })).toBeInTheDocument();
+    });
+
+    it('top-level data-archived reflects state', () => {
+      const { container, rerender } = render(<NightSummaryView {...baseProps} />);
+      expect(container.firstChild).toHaveAttribute('data-archived', 'false');
+      rerender(<NightSummaryView {...baseProps} archived />);
+      expect(container.firstChild).toHaveAttribute('data-archived', 'true');
+    });
+  });
+
+  describe('footer CTAs', () => {
+    it('invokes onShare on "Condividi riepilogo" click', async () => {
+      const onShare = vi.fn();
+      render(<NightSummaryView {...baseProps} onShare={onShare} />);
+      await userEvent.click(screen.getByRole('button', { name: /Condividi riepilogo/ }));
+      expect(onShare).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onArchive when not-archived + click Archivia', async () => {
+      const onArchive = vi.fn();
+      render(<NightSummaryView {...baseProps} onArchive={onArchive} />);
+      await userEvent.click(screen.getByRole('button', { name: /^Archivia$/ }));
+      expect(onArchive).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onUnarchive when archived + click Disarchivia', async () => {
+      const onUnarchive = vi.fn();
+      render(<NightSummaryView {...baseProps} archived onUnarchive={onUnarchive} />);
+      await userEvent.click(screen.getByRole('button', { name: /Disarchivia/ }));
+      expect(onUnarchive).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('share success toast', () => {
+    it('does not render toast when shareSuccess.visible=false', () => {
+      render(<NightSummaryView {...baseProps} shareSuccess={{ visible: false }} />);
+      expect(screen.queryByText('Link copiato')).toBeNull();
+    });
+
+    it('renders toast with custom subline when shareSuccess.visible=true', () => {
+      render(
+        <NightSummaryView
+          {...baseProps}
+          shareSuccess={{ visible: true, subline: 'meepleai.app/s/gn-042' }}
+        />
+      );
+      expect(screen.getByText('Link copiato')).toBeInTheDocument();
+      expect(screen.getByText('meepleai.app/s/gn-042')).toBeInTheDocument();
+    });
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <NightSummaryView {...baseProps} className="custom-summary-class" />
+    );
+    expect(container.firstChild).toHaveClass('custom-summary-class');
+  });
+
+  it('data-mobile reflects mobile prop', () => {
+    const { container, rerender } = render(<NightSummaryView {...baseProps} />);
+    expect(container.firstChild).toHaveAttribute('data-mobile', 'false');
+    rerender(<NightSummaryView {...baseProps} mobile />);
+    expect(container.firstChild).toHaveAttribute('data-mobile', 'true');
+  });
+});

--- a/apps/web/src/components/features/game-nights/summary/NightSummaryView.tsx
+++ b/apps/web/src/components/features/game-nights/summary/NightSummaryView.tsx
@@ -1,0 +1,461 @@
+import type { JSX } from 'react';
+
+import {
+  PerGameRecapRow,
+  type PerGameRecapGame,
+  type PerGameRecapPlayer,
+} from '@/components/features/game-nights/summary/PerGameRecapRow';
+import { ArchivedBanner } from '@/components/ui/archived-banner';
+import { KPIStatCard, KPIStatGrid } from '@/components/ui/kpi-stat-grid';
+import { ShareSuccessToast } from '@/components/ui/share-success-toast';
+
+export interface NightSummaryNight {
+  readonly title: string;
+  readonly dateLine: string;
+  readonly location?: string;
+  readonly startedAt: string;
+  readonly endedAt: string;
+  readonly duration: string;
+  readonly nightCode?: string;
+}
+
+export interface NightSummaryMVP extends PerGameRecapPlayer {
+  readonly achievements?: string;
+}
+
+export interface NightSummaryPhoto {
+  readonly id: string;
+  readonly label?: string;
+  readonly gradient: readonly [string, string];
+}
+
+export interface NightSummaryViewProps {
+  readonly night: NightSummaryNight;
+  readonly mvp?: NightSummaryMVP | null;
+  readonly games: ReadonlyArray<PerGameRecapGame>;
+  readonly eventsCount: number;
+  readonly photos?: ReadonlyArray<NightSummaryPhoto>;
+  readonly mobile?: boolean;
+  readonly archived?: boolean;
+  readonly shareSuccess?: {
+    readonly visible: boolean;
+    readonly url?: string;
+    readonly subline?: string;
+  };
+  readonly onShare?: () => void;
+  readonly onArchive?: () => void;
+  readonly onUnarchive?: () => void;
+  readonly onGoToList?: () => void;
+  readonly onJumpToSession?: (sessionId: string) => void;
+  readonly onAddPhoto?: () => void;
+  readonly className?: string;
+}
+
+export function NightSummaryView({
+  night,
+  mvp,
+  games,
+  eventsCount,
+  photos = [],
+  mobile = false,
+  archived = false,
+  shareSuccess,
+  onShare,
+  onArchive,
+  onUnarchive,
+  onGoToList,
+  onJumpToSession,
+  onAddPhoto,
+  className,
+}: NightSummaryViewProps): JSX.Element {
+  const winnersCount = games.filter(g => g.coopMode || g.winner).length;
+  const coopGamesCount = games.filter(g => g.coopMode).length;
+  const photosEmpty = photos.length === 0;
+  const sessionsLabel =
+    games.length === 1 ? '1 game · serata breve' : `${games.length} game completati`;
+
+  return (
+    <article
+      data-archived={archived ? 'true' : 'false'}
+      data-mobile={mobile ? 'true' : 'false'}
+      className={['relative flex flex-col bg-background min-h-full', className ?? '']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <NightSummaryHero night={night} mvp={mvp ?? null} gamesCount={games.length} mobile={mobile} />
+
+      {archived ? (
+        <div className={mobile ? 'px-3.5 pt-3.5' : 'px-8 pt-5'}>
+          <ArchivedBanner
+            title="Serata archiviata"
+            subtitle="Riepilogo salvato · accessibile da /game-nights/archived"
+            action={
+              onGoToList ? (
+                <button
+                  type="button"
+                  onClick={onGoToList}
+                  className="inline-flex items-center gap-1 rounded-md border border-border-strong bg-card px-3 py-2 font-display text-[12.5px] font-extrabold text-foreground cursor-pointer whitespace-nowrap"
+                >
+                  ← Torna alla lista
+                </button>
+              ) : undefined
+            }
+          />
+        </div>
+      ) : null}
+
+      {/* KPI grid */}
+      <section
+        aria-label="Stats della serata"
+        className={mobile ? 'px-3.5 pt-4 pb-1' : 'px-8 pt-6 pb-2'}
+      >
+        <KPIStatGrid columns={4}>
+          <KPIStatCard
+            icon="🎯"
+            tone="session"
+            label="Sessioni totali"
+            value={games.length}
+            sub={sessionsLabel}
+          />
+          <KPIStatCard
+            icon="⏱"
+            tone="event"
+            label="Durata totale"
+            value={night.duration}
+            sub={`${night.startedAt} → ${night.endedAt}`}
+          />
+          <KPIStatCard
+            icon="📜"
+            tone="chat"
+            label="Eventi diary"
+            value={eventsCount}
+            sub={`${(eventsCount / Math.max(games.length, 1)).toFixed(1)} avg / session`}
+          />
+          <KPIStatCard
+            icon="🏆"
+            tone="player"
+            label="Winner per gioco"
+            value={`${winnersCount}/${games.length}`}
+            sub={
+              coopGamesCount > 0
+                ? `${coopGamesCount} coop · ${games.length - coopGamesCount} competitive`
+                : 'tutti competitive'
+            }
+          />
+        </KPIStatGrid>
+      </section>
+
+      {/* Per-game recap */}
+      <section
+        aria-label="Per-game recap"
+        className={['flex flex-col gap-3', mobile ? 'px-3.5 py-4' : 'px-8 py-5'].join(' ')}
+      >
+        <div>
+          <span className="block font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event">
+            Per-game recap
+          </span>
+          <h2 className="mt-0.5 m-0 font-display text-lg font-extrabold tracking-tight text-foreground">
+            {games.length === 1
+              ? '1 gioco completato'
+              : `${games.length} giochi completati · in ordine cronologico`}
+          </h2>
+        </div>
+        <div className="flex flex-col gap-2">
+          {games.map(g => (
+            <PerGameRecapRow
+              key={g.id}
+              game={g}
+              mobile={mobile}
+              onJumpToSession={onJumpToSession}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Photo gallery */}
+      <section
+        aria-label="Foto della serata"
+        className={['flex flex-col gap-2.5', mobile ? 'px-3.5 pt-2 pb-4' : 'px-8 pt-3 pb-5'].join(
+          ' '
+        )}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-1.5">
+          <div>
+            <span className="block font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event">
+              Foto della serata
+            </span>
+            <h2 className="mt-0.5 m-0 font-display text-lg font-extrabold tracking-tight text-foreground">
+              {photosEmpty ? 'Gallery vuota' : `${photos.length} foto caricate`}
+            </h2>
+          </div>
+          {!photosEmpty && onAddPhoto ? (
+            <button
+              type="button"
+              onClick={onAddPhoto}
+              className="rounded-pill border border-entity-event/30 bg-entity-event/10 px-2.5 py-1 font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event cursor-pointer"
+            >
+              + Aggiungi foto
+            </button>
+          ) : null}
+        </div>
+        <PhotoGallery photos={photos} mobile={mobile} onAddFirstPhoto={onAddPhoto} />
+      </section>
+
+      {/* Footer CTAs */}
+      <footer
+        className={[
+          'flex shrink-0 flex-wrap items-center gap-2 border-t border-border bg-card',
+          mobile ? 'px-3.5 py-3' : 'px-8 py-4',
+        ].join(' ')}
+      >
+        <button
+          type="button"
+          onClick={onShare}
+          className="inline-flex items-center gap-1.5 rounded-md border border-entity-toolkit/30 bg-entity-toolkit/10 px-3 py-2 font-display text-[12.5px] font-extrabold text-entity-toolkit-text cursor-pointer"
+        >
+          <span aria-hidden="true">📤</span>
+          Condividi riepilogo
+        </button>
+        <button
+          type="button"
+          onClick={archived ? onUnarchive : onArchive}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border-strong bg-transparent px-3 py-2 font-display text-[12.5px] font-extrabold text-foreground cursor-pointer"
+        >
+          <span aria-hidden="true">{archived ? '↺' : '✓'}</span>
+          {archived ? 'Disarchivia' : 'Archivia'}
+        </button>
+      </footer>
+
+      {/* Share success toast */}
+      {shareSuccess?.visible ? (
+        <ShareSuccessToast
+          visible
+          title="Link copiato"
+          subline={shareSuccess.subline ?? shareSuccess.url}
+        />
+      ) : null}
+    </article>
+  );
+}
+
+interface NightSummaryHeroProps {
+  readonly night: NightSummaryNight;
+  readonly mvp: NightSummaryMVP | null;
+  readonly gamesCount: number;
+  readonly mobile: boolean;
+}
+
+function NightSummaryHero({ night, mvp, gamesCount, mobile }: NightSummaryHeroProps): JSX.Element {
+  return (
+    <header
+      className={[
+        'relative overflow-hidden border-b border-entity-event/20',
+        mobile ? 'px-4 pt-5 pb-5' : 'px-8 pt-8 pb-7',
+      ].join(' ')}
+      style={{
+        background:
+          'linear-gradient(160deg, hsl(var(--c-event) / 0.18) 0%, hsl(var(--c-event) / 0.03) 100%)',
+      }}
+    >
+      {/* Decorative confetti shapes */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute opacity-40"
+        style={{
+          top: -40,
+          right: -40,
+          width: 220,
+          height: 220,
+          borderRadius: '50%',
+          background:
+            'radial-gradient(circle at 30% 30%, hsl(var(--c-event) / 0.4), transparent 70%)',
+        }}
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute opacity-25"
+        style={{
+          bottom: -30,
+          left: -30,
+          width: 160,
+          height: 160,
+          borderRadius: '50%',
+          background:
+            'radial-gradient(circle at 40% 40%, hsl(var(--c-toolkit) / 0.4), transparent 70%)',
+        }}
+      />
+
+      {/* Status badge */}
+      <div className="relative mb-3 flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-pill border border-border-strong bg-card px-2.5 py-1 font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+          <span aria-hidden="true">✓</span>
+          Serata completata
+        </span>
+        {night.nightCode ? (
+          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-muted-foreground">
+            {night.nightCode} · {gamesCount} {gamesCount === 1 ? 'gioco' : 'giochi'}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Title */}
+      <h1
+        className={[
+          'relative m-0 mb-1.5 font-display font-extrabold leading-tight tracking-tight text-foreground',
+          mobile ? 'text-[26px]' : 'text-[36px]',
+        ].join(' ')}
+      >
+        {night.title}
+      </h1>
+
+      {/* Date + location */}
+      <div
+        className={[
+          'relative flex flex-wrap items-center gap-x-3.5 gap-y-1 font-mono text-xs font-bold text-muted-foreground',
+          mobile ? 'mb-4' : 'mb-5',
+        ].join(' ')}
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true">📅</span>
+          {night.dateLine}
+        </span>
+        <span aria-hidden="true">·</span>
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true">⏱</span>
+          {night.startedAt} → {night.endedAt} ·{' '}
+          <strong className="text-foreground">{night.duration}</strong>
+        </span>
+        {night.location ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <span className="inline-flex items-center gap-1.5">
+              <span aria-hidden="true">📍</span>
+              {night.location}
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      {/* MVP banner */}
+      {mvp ? (
+        <div
+          className={[
+            'relative flex items-center rounded-xl border-2 border-entity-event/40 bg-entity-event/15 shadow-md ring-4 ring-entity-event/[0.08]',
+            mobile ? 'gap-3 px-3.5 py-3' : 'gap-4 px-5 py-4 max-w-[540px]',
+          ].join(' ')}
+        >
+          <div className="relative shrink-0">
+            <span
+              aria-label={`MVP avatar ${mvp.initials}`}
+              className={[
+                'inline-flex items-center justify-center rounded-full border-2 font-display font-extrabold',
+                mobile ? 'h-12 w-12 text-[14px]' : 'h-[60px] w-[60px] text-[17px]',
+              ].join(' ')}
+              style={{
+                background: `hsl(${mvp.color}, 60%, 55%)`,
+                color: '#fff',
+                borderColor: 'hsl(var(--c-event) / 0.5)' as string,
+              }}
+            >
+              {mvp.initials}
+            </span>
+            <span
+              aria-hidden="true"
+              className="absolute -right-2 -top-1.5 drop-shadow"
+              style={{ fontSize: mobile ? 20 : 26 }}
+            >
+              🏆
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <span className="block font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event">
+              MVP della serata
+            </span>
+            <h2
+              className={[
+                'mt-px m-0 font-display font-extrabold leading-tight tracking-tight text-foreground',
+                mobile ? 'text-[19px]' : 'text-2xl',
+              ].join(' ')}
+            >
+              {mvp.name}
+            </h2>
+            {mvp.achievements ? (
+              <span className="mt-1 block font-mono text-[10.5px] font-bold text-muted-foreground">
+                {mvp.achievements}
+              </span>
+            ) : null}
+          </div>
+          <span
+            aria-hidden="true"
+            className="-mr-1 shrink-0 text-entity-event opacity-35"
+            style={{ fontSize: mobile ? 28 : 36 }}
+          >
+            ✨
+          </span>
+        </div>
+      ) : null}
+    </header>
+  );
+}
+
+interface PhotoGalleryProps {
+  readonly photos: ReadonlyArray<NightSummaryPhoto>;
+  readonly mobile: boolean;
+  readonly onAddFirstPhoto?: () => void;
+}
+
+function PhotoGallery({ photos, mobile, onAddFirstPhoto }: PhotoGalleryProps): JSX.Element {
+  if (photos.length === 0) {
+    return (
+      <div
+        className={[
+          'flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-entity-event/[0.04] py-8 px-4 text-center',
+          'border-entity-event/30',
+        ].join(' ')}
+      >
+        <span aria-hidden="true" className="text-3xl opacity-60">
+          📷
+        </span>
+        <span className="font-display text-sm font-extrabold text-foreground">
+          Nessuna foto ancora
+        </span>
+        {onAddFirstPhoto ? (
+          <button
+            type="button"
+            onClick={onAddFirstPhoto}
+            className="mt-1 rounded-md border-0 bg-entity-event px-3 py-2 font-display text-[12.5px] font-extrabold cursor-pointer"
+            style={{ color: '#fff' }}
+          >
+            + Aggiungi prima foto
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      role="list"
+      className={['grid gap-2 m-0 p-0 list-none', mobile ? 'grid-cols-3' : 'grid-cols-4'].join(' ')}
+    >
+      {photos.map(photo => (
+        <li
+          key={photo.id}
+          className="relative aspect-square overflow-hidden rounded-md shadow-sm"
+          style={{
+            background: `linear-gradient(135deg, ${photo.gradient[0]}, ${photo.gradient[1]})`,
+          }}
+        >
+          {photo.label ? (
+            <span
+              className="absolute bottom-1 left-1 right-1 truncate rounded-sm px-1.5 py-0.5 font-mono text-[9px] font-bold"
+              style={{ background: 'rgba(0,0,0,0.55)', color: '#fff' }}
+            >
+              {photo.label}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/features/game-nights/summary/PerGameRecapRow.test.tsx
+++ b/apps/web/src/components/features/game-nights/summary/PerGameRecapRow.test.tsx
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PerGameRecapRow, type PerGameRecapGame } from './PerGameRecapRow';
+
+const COMPETITIVE_GAME: PerGameRecapGame = {
+  id: 'gs-brass-1',
+  sessionId: 's-brass-may17',
+  title: 'Brass: Birmingham',
+  emoji: '🏭',
+  cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+  order: 1,
+  duration: '2h 45m',
+  eventsCount: 11,
+  winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
+  topScores: [
+    { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142 },
+    { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 128 },
+  ],
+};
+
+const COOP_GAME: PerGameRecapGame = {
+  id: 'gs-spirit-1',
+  sessionId: 's-spirit-may17',
+  title: 'Spirit Island',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  order: 2,
+  duration: '1h 50m',
+  eventsCount: 9,
+  coopMode: true,
+  coopOutcome: 'round 5/6 · adversary England 1',
+};
+
+describe('PerGameRecapRow', () => {
+  describe('competitive variant (default)', () => {
+    it('renders game title + order badge + duration + events', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.getByText('Brass: Birmingham')).toBeInTheDocument();
+      expect(screen.getByText('#1')).toBeInTheDocument();
+      expect(screen.getByText(/2h 45m · 11 eventi/)).toBeInTheDocument();
+    });
+
+    it('renders winner avatar with aria-label', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.getByLabelText('Winner DC')).toBeInTheDocument();
+    });
+
+    it('renders winner name + score with "pt" suffix', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.getByText(/Davide/)).toBeInTheDocument();
+      expect(screen.getByText('178pt')).toBeInTheDocument();
+    });
+
+    it('renders top scores chips when provided', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.getByLabelText('Top MR')).toBeInTheDocument();
+      expect(screen.getByLabelText('Top GM')).toBeInTheDocument();
+    });
+
+    it('does NOT render co-op badge', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.queryByText(/Co-op/)).toBeNull();
+      expect(screen.queryByText(/Team coop ha vinto/)).toBeNull();
+    });
+
+    it('data-coop="false"', () => {
+      const { container } = render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(container.firstChild).toHaveAttribute('data-coop', 'false');
+    });
+  });
+
+  describe('co-op variant', () => {
+    it('renders 🤝 Co-op badge', () => {
+      render(<PerGameRecapRow game={COOP_GAME} />);
+      expect(screen.getByText(/Co-op/)).toBeInTheDocument();
+    });
+
+    it('renders "Team coop ha vinto" instead of winner avatar', () => {
+      render(<PerGameRecapRow game={COOP_GAME} />);
+      expect(screen.getByText(/Team coop ha vinto/)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/^Winner /)).toBeNull();
+    });
+
+    it('renders coopOutcome text when provided', () => {
+      render(<PerGameRecapRow game={COOP_GAME} />);
+      expect(screen.getByText('round 5/6 · adversary England 1')).toBeInTheDocument();
+    });
+
+    it('data-coop="true"', () => {
+      const { container } = render(<PerGameRecapRow game={COOP_GAME} />);
+      expect(container.firstChild).toHaveAttribute('data-coop', 'true');
+    });
+
+    it('uses entity-toolkit border-left accent (vs entity-event for competitive)', () => {
+      const { container, rerender } = render(<PerGameRecapRow game={COOP_GAME} />);
+      const coopArticle = container.firstChild as HTMLElement;
+      expect(coopArticle.className).toContain('border-l-entity-toolkit');
+
+      rerender(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      const competitiveArticle = container.firstChild as HTMLElement;
+      expect(competitiveArticle.className).toContain('border-l-entity-event');
+    });
+  });
+
+  describe('no-winner edge case', () => {
+    it('renders "Nessun winner registrato" placeholder', () => {
+      const noWinner: PerGameRecapGame = {
+        id: 'gs-x',
+        title: 'X',
+        order: 1,
+        duration: '60m',
+        eventsCount: 0,
+      };
+      render(<PerGameRecapRow game={noWinner} />);
+      expect(screen.getByText('Nessun winner registrato')).toBeInTheDocument();
+    });
+  });
+
+  describe('singular/plural events', () => {
+    it('uses "evento" for count=1', () => {
+      const oneEvent: PerGameRecapGame = {
+        id: 'gs-x',
+        title: 'X',
+        order: 1,
+        duration: '60m',
+        eventsCount: 1,
+      };
+      render(<PerGameRecapRow game={oneEvent} />);
+      expect(screen.getByText(/60m · 1 evento/)).toBeInTheDocument();
+    });
+
+    it('uses "eventi" for count !== 1', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.getByText(/11 eventi/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Vai a session CTA', () => {
+    it('renders CTA when sessionId + onJumpToSession provided', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} onJumpToSession={() => undefined} />);
+      expect(screen.getByRole('button', { name: /Vai a session/ })).toBeInTheDocument();
+    });
+
+    it('invokes onJumpToSession with sessionId', async () => {
+      const onJumpToSession = vi.fn();
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} onJumpToSession={onJumpToSession} />);
+      await userEvent.click(screen.getByRole('button', { name: /Vai a session/ }));
+      expect(onJumpToSession).toHaveBeenCalledWith('s-brass-may17');
+    });
+
+    it('omits CTA when onJumpToSession missing', () => {
+      render(<PerGameRecapRow game={COMPETITIVE_GAME} />);
+      expect(screen.queryByRole('button', { name: /Vai a session/ })).toBeNull();
+    });
+
+    it('omits CTA when sessionId missing', () => {
+      const noSessionGame: PerGameRecapGame = { ...COMPETITIVE_GAME, sessionId: undefined };
+      render(<PerGameRecapRow game={noSessionGame} onJumpToSession={() => undefined} />);
+      expect(screen.queryByRole('button', { name: /Vai a session/ })).toBeNull();
+    });
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <PerGameRecapRow game={COMPETITIVE_GAME} className="custom-row-class" />
+    );
+    expect(container.firstChild).toHaveClass('custom-row-class');
+  });
+});

--- a/apps/web/src/components/features/game-nights/summary/PerGameRecapRow.tsx
+++ b/apps/web/src/components/features/game-nights/summary/PerGameRecapRow.tsx
@@ -1,0 +1,169 @@
+import type { JSX } from 'react';
+
+export interface PerGameRecapPlayer {
+  readonly id: string;
+  readonly name: string;
+  readonly initials: string;
+  readonly color: number;
+  readonly score?: number;
+}
+
+export interface PerGameRecapGame {
+  readonly id: string;
+  readonly sessionId?: string;
+  readonly title: string;
+  readonly emoji?: string;
+  readonly cover?: readonly [string, string];
+  readonly order: number;
+  readonly duration: string;
+  readonly eventsCount: number;
+  readonly coopMode?: boolean;
+  readonly coopOutcome?: string;
+  readonly winner?: PerGameRecapPlayer & { readonly score: number };
+  readonly topScores?: ReadonlyArray<PerGameRecapPlayer>;
+}
+
+export interface PerGameRecapRowProps {
+  readonly game: PerGameRecapGame;
+  readonly mobile?: boolean;
+  readonly onJumpToSession?: (sessionId: string) => void;
+  readonly className?: string;
+}
+
+export function PerGameRecapRow({
+  game,
+  mobile = false,
+  onJumpToSession,
+  className,
+}: PerGameRecapRowProps): JSX.Element {
+  const isCoop = Boolean(game.coopMode);
+  const accentClass = isCoop ? 'border-l-entity-toolkit' : 'border-l-entity-event';
+
+  return (
+    <article
+      data-coop={isCoop ? 'true' : 'false'}
+      className={[
+        'rounded-lg border border-border bg-card border-l-4',
+        accentClass,
+        mobile ? 'flex flex-col gap-2.5 p-3' : 'grid items-center gap-4 px-4 py-3.5',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={mobile ? undefined : { gridTemplateColumns: '90px 1fr auto' }}
+    >
+      {/* Cover */}
+      <div
+        aria-hidden="true"
+        className={[
+          'relative flex items-center justify-center rounded-md',
+          mobile ? 'h-[110px] text-[44px]' : 'h-[70px] text-3xl',
+        ].join(' ')}
+        style={
+          game.cover
+            ? { background: `linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})` }
+            : { background: 'var(--bg-muted)' }
+        }
+      >
+        <span
+          className="absolute left-1.5 top-1.5 rounded-pill px-1.5 py-px font-mono text-[9px] font-extrabold tracking-wider"
+          style={{ background: 'rgba(0,0,0,0.55)', color: '#fff' }}
+        >
+          #{game.order}
+        </span>
+        <span className="drop-shadow-lg">{game.emoji ?? '🎲'}</span>
+      </div>
+
+      {/* Info column */}
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="m-0 font-display text-base font-extrabold tracking-tight text-foreground">
+            {game.title}
+          </h3>
+          {isCoop ? (
+            <span className="inline-flex items-center gap-1 rounded-pill border border-entity-toolkit/30 bg-entity-toolkit/15 px-1.5 py-px font-mono text-[9px] font-extrabold uppercase tracking-wider text-entity-toolkit">
+              <span aria-hidden="true">🤝</span>
+              Co-op
+            </span>
+          ) : null}
+          <span className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-muted-foreground">
+            ⏱ {game.duration} · {game.eventsCount} {game.eventsCount === 1 ? 'evento' : 'eventi'}
+          </span>
+        </div>
+
+        {/* Winner line */}
+        <div className="flex flex-wrap items-center gap-2">
+          {isCoop ? (
+            <>
+              <span className="inline-flex items-center gap-1.5 rounded-pill border border-entity-toolkit/30 bg-entity-toolkit/15 px-2 py-0.5 font-display text-[11px] font-extrabold text-entity-toolkit">
+                <span aria-hidden="true">🏆</span>
+                Team coop ha vinto
+              </span>
+              {game.coopOutcome ? (
+                <span className="font-mono text-[10.5px] font-bold text-foreground/70">
+                  {game.coopOutcome}
+                </span>
+              ) : null}
+            </>
+          ) : game.winner ? (
+            <>
+              <span
+                aria-label={`Winner ${game.winner.initials}`}
+                className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full border-2 font-display text-[9px] font-extrabold"
+                style={{
+                  background: `hsl(${game.winner.color}, 60%, 55%)`,
+                  color: '#fff',
+                  borderColor: 'hsl(var(--c-event) / 0.4)' as string,
+                }}
+              >
+                {game.winner.initials}
+              </span>
+              <span className="font-display text-[12.5px] font-extrabold text-foreground">
+                🏆 {game.winner.name}
+              </span>
+              <span className="font-mono text-[11px] font-extrabold tabular-nums text-entity-event">
+                {game.winner.score}pt
+              </span>
+              {game.topScores && game.topScores.length > 0 ? (
+                <div className="ml-1 flex gap-1">
+                  {game.topScores.slice(0, 3).map(p => (
+                    <span
+                      key={p.id}
+                      aria-label={`Top ${p.initials}`}
+                      className="inline-flex h-[18px] items-center gap-1 rounded-pill border border-border bg-muted px-1.5 font-mono text-[9px] font-bold tabular-nums text-foreground/70"
+                    >
+                      {p.initials}
+                      {p.score !== undefined ? ` ${p.score}` : ''}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <span className="font-mono text-[10.5px] font-bold text-muted-foreground">
+              Nessun winner registrato
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* CTA */}
+      {(() => {
+        const sessionId = game.sessionId;
+        if (!sessionId || !onJumpToSession) return null;
+        return (
+          <button
+            type="button"
+            onClick={() => onJumpToSession(sessionId)}
+            className={[
+              'shrink-0 rounded-md border border-entity-session/30 bg-entity-session/10 font-display font-extrabold text-entity-session cursor-pointer',
+              mobile ? 'w-full px-3 py-2 text-[12px]' : 'px-3 py-2 text-[12.5px]',
+            ].join(' ')}
+          >
+            Vai a session →
+          </button>
+        );
+      })()}
+    </article>
+  );
+}

--- a/apps/web/src/components/features/game-nights/summary/index.ts
+++ b/apps/web/src/components/features/game-nights/summary/index.ts
@@ -1,0 +1,14 @@
+export { NightSummaryView } from '@/components/features/game-nights/summary/NightSummaryView';
+export type {
+  NightSummaryViewProps,
+  NightSummaryNight,
+  NightSummaryMVP,
+  NightSummaryPhoto,
+} from '@/components/features/game-nights/summary/NightSummaryView';
+
+export { PerGameRecapRow } from '@/components/features/game-nights/summary/PerGameRecapRow';
+export type {
+  PerGameRecapRowProps,
+  PerGameRecapGame,
+  PerGameRecapPlayer,
+} from '@/components/features/game-nights/summary/PerGameRecapRow';

--- a/apps/web/src/components/features/game-nights/transition/GameTransitionDialog.test.tsx
+++ b/apps/web/src/components/features/game-nights/transition/GameTransitionDialog.test.tsx
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  GameTransitionDialog,
+  type GameTransitionDialogProps,
+  type TransitionLastGame,
+  type TransitionNextGame,
+} from './GameTransitionDialog';
+
+const LAST_GAME: TransitionLastGame = {
+  id: 'gs-brass-1',
+  title: 'Brass: Birmingham',
+  publisher: 'Roxley',
+  emoji: '🏭',
+  cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
+  duration: '2h 45m',
+  endedAt: '22:55',
+  winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
+  topThree: [
+    {
+      id: 'p-davide',
+      name: 'Davide',
+      initials: 'DC',
+      color: 200,
+      score: 178,
+      delta: '+50 industria',
+    },
+    { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142, delta: '+12 network' },
+    { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 128, delta: '+8 carbone' },
+  ],
+};
+
+const NEXT_GAME: TransitionNextGame = {
+  id: 'gs-spirit-1',
+  title: 'Spirit Island',
+  publisher: 'GMT · co-op',
+  emoji: '🌋',
+  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
+  estimated: '90m',
+  weight: 4.08,
+  rules: [
+    { icon: '🔁', text: 'Phase order · Growth → Fast → Slow', src: '§ 4.2' },
+    { icon: '😱', text: 'Fear deck · 9 carte', src: '§ 5.1' },
+  ],
+  setup: [
+    { icon: '🗺️', text: 'Tabellone', done: true },
+    { icon: '🃏', text: 'Invader deck', done: false },
+  ],
+};
+
+const baseProps: GameTransitionDialogProps = {
+  open: true,
+  lastGame: LAST_GAME,
+  nextGame: NEXT_GAME,
+};
+
+describe('GameTransitionDialog', () => {
+  describe('open prop', () => {
+    it('returns null when open=false', () => {
+      const { container } = render(<GameTransitionDialog {...baseProps} open={false} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders dialog when open=true', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA + accessibility', () => {
+    it('has aria-modal="true" + aria-labelledby pointing to existing id', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      const titleId = dialog.getAttribute('aria-labelledby');
+      expect(titleId).toBeTruthy();
+      // The element with that id must exist (avoid screen-reader naming bug like PR #1250 review)
+      expect(document.getElementById(titleId!)).not.toBeNull();
+    });
+
+    it('renders Ultimo gioco + Prossimo gioco sections with aria-label', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.getByLabelText('Ultimo gioco')).toBeInTheDocument();
+      expect(screen.getByLabelText('Prossimo gioco')).toBeInTheDocument();
+    });
+
+    it('renders close button only when onClose provided', () => {
+      const { rerender } = render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.queryByRole('button', { name: 'Chiudi' })).toBeNull();
+
+      rerender(<GameTransitionDialog {...baseProps} onClose={() => undefined} />);
+      expect(screen.getByRole('button', { name: 'Chiudi' })).toBeInTheDocument();
+    });
+  });
+
+  describe('RecapPanel (left col)', () => {
+    it('renders last game title + publisher + endedAt', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      const recap = screen.getByLabelText('Ultimo gioco');
+      expect(within(recap).getByText('Brass: Birmingham')).toBeInTheDocument();
+      expect(within(recap).getByText(/Roxley/)).toBeInTheDocument();
+      expect(within(recap).getByText(/22:55/)).toBeInTheDocument();
+    });
+
+    it('renders winner banner with score + duration kicker + winner avatar', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      const recap = screen.getByLabelText('Ultimo gioco');
+      // "178pt" is unique to the winner banner (top-3 list shows just "178" without "pt")
+      expect(within(recap).getByText('178pt')).toBeInTheDocument();
+      expect(within(recap).getByText(/Winner · 2h 45m/)).toBeInTheDocument();
+      expect(within(recap).getByLabelText('Winner avatar DC')).toBeInTheDocument();
+    });
+
+    it('renders top-3 list with rank + name + score', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      const recap = screen.getByLabelText('Ultimo gioco');
+      expect(within(recap).getByLabelText('Rank 1')).toBeInTheDocument();
+      expect(within(recap).getByLabelText('Rank 2')).toBeInTheDocument();
+      expect(within(recap).getByLabelText('Rank 3')).toBeInTheDocument();
+      expect(within(recap).getByText('178')).toBeInTheDocument();
+      expect(within(recap).getByText('142')).toBeInTheDocument();
+      expect(within(recap).getByText('128')).toBeInTheDocument();
+    });
+
+    it('renders delta info when provided', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.getByText('+50 industria')).toBeInTheDocument();
+      expect(screen.getByText('+12 network')).toBeInTheDocument();
+    });
+
+    it('truncates to top-3 even when more players provided', () => {
+      const moreThanThree: TransitionLastGame = {
+        ...LAST_GAME,
+        topThree: [
+          ...LAST_GAME.topThree,
+          { id: 'p-extra', name: 'Extra', initials: 'EX', color: 50, score: 100 },
+        ],
+      };
+      render(<GameTransitionDialog {...baseProps} lastGame={moreThanThree} />);
+      expect(screen.queryByText('Extra')).toBeNull();
+    });
+
+    it('omits top-3 list when empty', () => {
+      const noTop: TransitionLastGame = { ...LAST_GAME, topThree: [] };
+      render(<GameTransitionDialog {...baseProps} lastGame={noTop} />);
+      expect(screen.queryByText('Classifica · Top 3')).toBeNull();
+    });
+  });
+
+  describe('PreviewPanel (right col)', () => {
+    it('renders next game title + publisher + weight', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      const preview = screen.getByLabelText('Prossimo gioco');
+      expect(within(preview).getByText('Spirit Island')).toBeInTheDocument();
+      expect(within(preview).getByText(/GMT · co-op/)).toBeInTheDocument();
+      expect(within(preview).getByText(/weight 4\.08/)).toBeInTheDocument();
+    });
+
+    it('renders duration pill', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.getByText(/~90m/)).toBeInTheDocument();
+    });
+
+    it('forwards rulesStatus to KBRulesQuickGlance', () => {
+      const { rerender } = render(<GameTransitionDialog {...baseProps} />);
+      // ok status: rules text visible
+      expect(screen.getByText('Phase order · Growth → Fast → Slow')).toBeInTheDocument();
+
+      rerender(<GameTransitionDialog {...baseProps} rulesStatus="error" />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('invokes onRetryRules when Riprova clicked (error state)', async () => {
+      const onRetryRules = vi.fn();
+      render(
+        <GameTransitionDialog {...baseProps} rulesStatus="error" onRetryRules={onRetryRules} />
+      );
+      await userEvent.click(screen.getByRole('button', { name: /Riprova/ }));
+      expect(onRetryRules).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders SetupChecklist with done/total counter', () => {
+      render(<GameTransitionDialog {...baseProps} />);
+      expect(screen.getByText(/Setup checklist · 1\/2/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Footer actions', () => {
+    it('invokes onPlayNext on "Avvia prossima session" click', async () => {
+      const onPlayNext = vi.fn();
+      render(<GameTransitionDialog {...baseProps} onPlayNext={onPlayNext} />);
+      await userEvent.click(screen.getByRole('button', { name: /Avvia prossima session/ }));
+      expect(onPlayNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onOpenSubmodal("skip") on "Salta gioco" click', async () => {
+      const onOpenSubmodal = vi.fn();
+      render(<GameTransitionDialog {...baseProps} onOpenSubmodal={onOpenSubmodal} />);
+      await userEvent.click(screen.getByRole('button', { name: /Salta gioco/ }));
+      expect(onOpenSubmodal).toHaveBeenCalledWith('skip');
+    });
+
+    it('invokes onOpenSubmodal("end") on "Termina serata qui" click', async () => {
+      const onOpenSubmodal = vi.fn();
+      render(<GameTransitionDialog {...baseProps} onOpenSubmodal={onOpenSubmodal} />);
+      await userEvent.click(screen.getByRole('button', { name: /Termina serata qui/ }));
+      expect(onOpenSubmodal).toHaveBeenCalledWith('end');
+    });
+  });
+
+  describe('ConfirmSubmodal', () => {
+    it('does not render when submodal=null', () => {
+      render(<GameTransitionDialog {...baseProps} submodal={null} />);
+      expect(screen.queryByRole('alertdialog')).toBeNull();
+    });
+
+    it('renders skip submodal with warning tone when submodal="skip"', () => {
+      render(<GameTransitionDialog {...baseProps} submodal="skip" />);
+      const alertdialog = screen.getByRole('alertdialog');
+      expect(alertdialog).toBeInTheDocument();
+      expect(within(alertdialog).getByText('Saltare Spirit Island?')).toBeInTheDocument();
+      expect(
+        within(alertdialog).getByRole('button', { name: /Salta e prossimo/ })
+      ).toBeInTheDocument();
+    });
+
+    it('renders end submodal with danger tone when submodal="end"', () => {
+      render(<GameTransitionDialog {...baseProps} submodal="end" />);
+      const alertdialog = screen.getByRole('alertdialog');
+      expect(within(alertdialog).getByText('Terminare la serata qui?')).toBeInTheDocument();
+      expect(
+        within(alertdialog).getByRole('button', { name: /Termina · vai a Summary/ })
+      ).toBeInTheDocument();
+    });
+
+    it('invokes onConfirmSubmodal on primary button click', async () => {
+      const onConfirmSubmodal = vi.fn();
+      render(
+        <GameTransitionDialog
+          {...baseProps}
+          submodal="skip"
+          onConfirmSubmodal={onConfirmSubmodal}
+        />
+      );
+      await userEvent.click(screen.getByRole('button', { name: /Salta e prossimo/ }));
+      expect(onConfirmSubmodal).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes onCancelSubmodal on Annulla click', async () => {
+      const onCancelSubmodal = vi.fn();
+      render(
+        <GameTransitionDialog {...baseProps} submodal="end" onCancelSubmodal={onCancelSubmodal} />
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+      expect(onCancelSubmodal).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mobile layout', () => {
+    it('renders fullscreen instead of fixed size when mobile=true', () => {
+      const { container } = render(<GameTransitionDialog {...baseProps} mobile />);
+      const dialog = container.firstChild as HTMLElement;
+      expect(dialog.className).toContain('w-full');
+      expect(dialog.className).toContain('h-full');
+      expect(dialog.className).not.toContain('rounded-xl');
+    });
+
+    it('uses flex column body when mobile=true (instead of 2-col grid)', () => {
+      const { container } = render(<GameTransitionDialog {...baseProps} mobile />);
+      const dialog = container.firstChild as HTMLElement;
+      expect(dialog.getAttribute('data-mobile')).toBe('true');
+    });
+  });
+
+  it('accepts custom nightCode in header', () => {
+    render(<GameTransitionDialog {...baseProps} nightCode="#GN-042" />);
+    expect(screen.getByText(/Game transition · #GN-042/)).toBeInTheDocument();
+  });
+
+  it('falls back to "Game transition" label when nightCode missing', () => {
+    render(<GameTransitionDialog {...baseProps} />);
+    expect(screen.getByText('Game transition')).toBeInTheDocument();
+  });
+
+  it('accepts custom className override', () => {
+    const { container } = render(
+      <GameTransitionDialog {...baseProps} className="custom-dialog-class" />
+    );
+    expect(container.firstChild).toHaveClass('custom-dialog-class');
+  });
+});

--- a/apps/web/src/components/features/game-nights/transition/GameTransitionDialog.tsx
+++ b/apps/web/src/components/features/game-nights/transition/GameTransitionDialog.tsx
@@ -1,0 +1,567 @@
+import type { JSX } from 'react';
+
+import { KBRulesQuickGlance } from '@/components/ui/kb-rules-quick-glance';
+import type { KBRule, KBRulesQuickGlanceStatus } from '@/components/ui/kb-rules-quick-glance';
+import { SetupChecklist } from '@/components/ui/setup-checklist';
+import type { SetupChecklistItem } from '@/components/ui/setup-checklist';
+
+export type TransitionSubmodal = 'skip' | 'end' | null;
+
+export interface TransitionPlayer {
+  readonly id: string;
+  readonly name: string;
+  readonly initials: string;
+  readonly color: number;
+  readonly score?: number;
+  readonly delta?: string;
+}
+
+export interface TransitionLastGame {
+  readonly id: string;
+  readonly title: string;
+  readonly publisher?: string;
+  readonly emoji?: string;
+  readonly cover?: readonly [string, string];
+  readonly duration: string;
+  readonly endedAt?: string;
+  readonly winner: TransitionPlayer & { readonly score: number };
+  readonly topThree: ReadonlyArray<TransitionPlayer>;
+}
+
+export interface TransitionNextGame {
+  readonly id: string;
+  readonly title: string;
+  readonly publisher?: string;
+  readonly emoji?: string;
+  readonly cover?: readonly [string, string];
+  readonly weight?: number;
+  readonly estimated: string;
+  readonly rules: ReadonlyArray<KBRule>;
+  readonly setup: ReadonlyArray<SetupChecklistItem>;
+}
+
+export interface GameTransitionDialogProps {
+  readonly open: boolean;
+  readonly lastGame: TransitionLastGame;
+  readonly nextGame: TransitionNextGame;
+  readonly rulesStatus?: KBRulesQuickGlanceStatus;
+  readonly submodal?: TransitionSubmodal;
+  readonly mobile?: boolean;
+  readonly nightCode?: string;
+  readonly onClose?: () => void;
+  readonly onPlayNext?: () => void;
+  readonly onOpenSubmodal?: (which: 'skip' | 'end') => void;
+  readonly onConfirmSubmodal?: () => void;
+  readonly onCancelSubmodal?: () => void;
+  readonly onRetryRules?: () => void;
+  readonly onProceedWithoutRules?: () => void;
+  readonly className?: string;
+}
+
+const DIALOG_TITLE_ID = 'game-transition-dialog-title';
+
+export function GameTransitionDialog({
+  open,
+  lastGame,
+  nextGame,
+  rulesStatus = 'ok',
+  submodal = null,
+  mobile = false,
+  nightCode,
+  onClose,
+  onPlayNext,
+  onOpenSubmodal,
+  onConfirmSubmodal,
+  onCancelSubmodal,
+  onRetryRules,
+  onProceedWithoutRules,
+  className,
+}: GameTransitionDialogProps): JSX.Element | null {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={DIALOG_TITLE_ID}
+      data-mobile={mobile ? 'true' : 'false'}
+      className={[
+        'relative flex flex-col overflow-hidden bg-card',
+        mobile
+          ? 'w-full h-full'
+          : 'w-[600px] h-[500px] max-h-full rounded-xl border border-border shadow-lg',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <DialogHeader mobile={mobile} nightCode={nightCode} onClose={onClose} />
+
+      <div
+        className={[
+          'flex-1 min-h-0 overflow-y-auto',
+          mobile ? 'flex flex-col' : 'grid grid-cols-2',
+        ].join(' ')}
+      >
+        <RecapPanel game={lastGame} mobile={mobile} />
+        <PreviewPanel
+          game={nextGame}
+          rulesStatus={rulesStatus}
+          mobile={mobile}
+          onRetryRules={onRetryRules}
+          onProceedWithoutRules={onProceedWithoutRules}
+        />
+      </div>
+
+      <DialogFooter
+        mobile={mobile}
+        onPlayNext={onPlayNext}
+        onSkipClick={onOpenSubmodal ? () => onOpenSubmodal('skip') : undefined}
+        onEndClick={onOpenSubmodal ? () => onOpenSubmodal('end') : undefined}
+      />
+
+      {submodal === 'skip' ? (
+        <ConfirmSubmodal
+          tone="warning"
+          icon="⏭"
+          title={`Saltare ${nextGame.title}?`}
+          body="Verrà rimosso dai planned games di questa serata. Resterà in libreria ma il diary non avrà entries per questa session."
+          primaryLabel="Salta e prossimo"
+          primaryIcon="⏭"
+          onConfirm={onConfirmSubmodal}
+          onCancel={onCancelSubmodal}
+        />
+      ) : null}
+      {submodal === 'end' ? (
+        <ConfirmSubmodal
+          tone="danger"
+          icon="🛑"
+          title="Terminare la serata qui?"
+          body="Andrai al Summary con i game registrati. Gli upcoming verranno archiviati come 'non giocati'. Il diary sarà finalizzato."
+          primaryLabel="Termina · vai a Summary"
+          primaryIcon="🛑"
+          onConfirm={onConfirmSubmodal}
+          onCancel={onCancelSubmodal}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface DialogHeaderProps {
+  readonly mobile: boolean;
+  readonly nightCode?: string;
+  readonly onClose?: () => void;
+}
+
+function DialogHeader({ mobile, nightCode, onClose }: DialogHeaderProps): JSX.Element {
+  return (
+    <div
+      className={[
+        'flex items-center gap-2.5 border-b border-border',
+        mobile ? 'px-4 py-3.5' : 'px-4 py-3.5',
+      ].join(' ')}
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-base"
+        style={{
+          background: 'linear-gradient(135deg, hsl(var(--c-event)), hsl(var(--c-session)))',
+          color: '#fff',
+        }}
+      >
+        ➡️
+      </div>
+      <div className="min-w-0 flex-1">
+        {nightCode ? (
+          <span className="block font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-entity-event">
+            Game transition · {nightCode}
+          </span>
+        ) : (
+          <span className="block font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-entity-event">
+            Game transition
+          </span>
+        )}
+        <h2
+          id={DIALOG_TITLE_ID}
+          className="m-0 font-display text-[14.5px] font-extrabold tracking-tight text-foreground"
+        >
+          Pronti per il prossimo gioco?
+        </h2>
+      </div>
+      {onClose ? (
+        <button
+          type="button"
+          aria-label="Chiudi"
+          onClick={onClose}
+          className="h-8 w-8 shrink-0 rounded-md border border-border bg-card text-base font-bold text-muted-foreground cursor-pointer"
+        >
+          ×
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+interface DialogFooterProps {
+  readonly mobile: boolean;
+  readonly onPlayNext?: () => void;
+  readonly onSkipClick?: () => void;
+  readonly onEndClick?: () => void;
+}
+
+function DialogFooter({
+  mobile,
+  onPlayNext,
+  onSkipClick,
+  onEndClick,
+}: DialogFooterProps): JSX.Element {
+  return (
+    <div
+      className={[
+        'flex shrink-0 items-center gap-2 border-t border-border bg-muted',
+        mobile ? 'flex-wrap px-4 py-3' : 'px-4 py-3',
+      ].join(' ')}
+    >
+      <button
+        type="button"
+        onClick={onSkipClick}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[hsl(var(--c-warning)/0.4)] bg-transparent px-3 py-2 font-display text-[12.5px] font-extrabold text-[hsl(var(--c-warning))] cursor-pointer"
+      >
+        <span aria-hidden="true">⏭</span>
+        Salta gioco
+      </button>
+      <button
+        type="button"
+        onClick={onEndClick}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[hsl(var(--c-danger)/0.4)] bg-transparent px-3 py-2 font-display text-[12.5px] font-extrabold text-[hsl(var(--c-danger))] cursor-pointer"
+      >
+        <span aria-hidden="true">🛑</span>
+        Termina serata qui
+      </button>
+      <div className="flex-1" />
+      <button
+        type="button"
+        onClick={onPlayNext}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 px-4 py-2.5 font-display text-[13.5px] font-extrabold cursor-pointer"
+        style={{
+          background: 'linear-gradient(135deg, hsl(var(--c-session)), hsl(var(--c-chat)))',
+          color: '#fff',
+          boxShadow: '0 6px 18px hsl(var(--c-session) / 0.4)',
+        }}
+      >
+        ▶ Avvia prossima session
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+  );
+}
+
+interface RecapPanelProps {
+  readonly game: TransitionLastGame;
+  readonly mobile: boolean;
+}
+
+function RecapPanel({ game, mobile }: RecapPanelProps): JSX.Element {
+  return (
+    <section
+      aria-label="Ultimo gioco"
+      className={[
+        'flex min-w-0 flex-col gap-3 bg-entity-event/[0.04]',
+        mobile ? 'border-b border-border' : 'border-r border-border',
+        mobile ? 'px-4 py-3.5' : 'px-4 py-4',
+      ].join(' ')}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="text-sm">
+          ⏪
+        </span>
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-event">
+          Ultimo gioco
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md text-[26px] shadow-sm"
+          style={
+            game.cover
+              ? { background: `linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})` }
+              : { background: 'var(--bg-muted)' }
+          }
+        >
+          {game.emoji ?? '🎲'}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-display text-base font-extrabold leading-tight text-foreground">
+            {game.title}
+          </div>
+          {(game.publisher ?? game.endedAt) ? (
+            <div className="mt-0.5 font-mono text-[10px] font-bold text-muted-foreground">
+              {game.publisher}
+              {game.publisher && game.endedAt ? ' · finito ' : ''}
+              {!game.publisher && game.endedAt ? 'finito ' : ''}
+              {game.endedAt}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Winner banner */}
+      <div className="flex items-center gap-2.5 rounded-md border border-entity-event/30 bg-entity-event/10 px-3 py-2.5 ring-[3px] ring-entity-event/[0.06]">
+        <span aria-hidden="true" className="text-[22px]">
+          🏆
+        </span>
+        <div className="min-w-0 flex-1">
+          <span className="block font-mono text-[9px] font-extrabold uppercase tracking-wider text-entity-event">
+            Winner · {game.duration}
+          </span>
+          <div className="mt-px font-display text-[14px] font-extrabold text-foreground">
+            {game.winner.name}{' '}
+            <span className="tabular-nums text-entity-event">{game.winner.score}pt</span>
+          </div>
+        </div>
+        <span
+          aria-label={`Winner avatar ${game.winner.initials}`}
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 font-display text-[11px] font-extrabold"
+          style={{
+            background: `hsl(${game.winner.color}, 60%, 55%)`,
+            color: '#fff',
+            borderColor: 'hsl(var(--c-event) / 0.4)' as string,
+          }}
+        >
+          {game.winner.initials}
+        </span>
+      </div>
+
+      {/* Top-3 score list */}
+      {game.topThree.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          <span className="font-mono text-[9.5px] font-extrabold uppercase tracking-wider text-muted-foreground">
+            Classifica · Top 3
+          </span>
+          <ul role="list" className="flex flex-col gap-1 m-0 p-0 list-none">
+            {game.topThree.slice(0, 3).map((player, i) => {
+              const isWinner = i === 0;
+              return (
+                <li
+                  key={player.id}
+                  data-rank={i + 1}
+                  className={[
+                    'flex items-center gap-2.5 rounded-sm px-2.5 py-1.5',
+                    isWinner
+                      ? 'border border-entity-event/30 bg-entity-event/[0.08]'
+                      : 'border border-border bg-card',
+                  ].join(' ')}
+                >
+                  <span
+                    aria-label={`Rank ${i + 1}`}
+                    className="inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full font-display text-[10px] font-extrabold"
+                    style={
+                      isWinner
+                        ? { background: 'hsl(var(--c-event))', color: '#fff' }
+                        : { background: 'var(--bg-muted)', color: 'var(--text-sec)' }
+                    }
+                  >
+                    {i + 1}
+                  </span>
+                  <span
+                    aria-label={`Player ${player.initials}`}
+                    className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full font-display text-[9px] font-extrabold"
+                    style={{
+                      background: `hsl(${player.color}, 60%, 55%)`,
+                      color: '#fff',
+                    }}
+                  >
+                    {player.initials}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-display text-xs font-extrabold text-foreground">
+                      {player.name}
+                    </div>
+                    {player.delta ? (
+                      <div className="truncate font-mono text-[9px] font-bold text-muted-foreground">
+                        {player.delta}
+                      </div>
+                    ) : null}
+                  </div>
+                  {player.score !== undefined ? (
+                    <span
+                      className={[
+                        'font-mono text-sm font-extrabold tabular-nums',
+                        isWinner ? 'text-entity-event' : 'text-foreground',
+                      ].join(' ')}
+                    >
+                      {player.score}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+interface PreviewPanelProps {
+  readonly game: TransitionNextGame;
+  readonly rulesStatus: KBRulesQuickGlanceStatus;
+  readonly mobile: boolean;
+  readonly onRetryRules?: () => void;
+  readonly onProceedWithoutRules?: () => void;
+}
+
+function PreviewPanel({
+  game,
+  rulesStatus,
+  mobile,
+  onRetryRules,
+  onProceedWithoutRules,
+}: PreviewPanelProps): JSX.Element {
+  return (
+    <section
+      aria-label="Prossimo gioco"
+      className={[
+        'flex flex-1 min-w-0 flex-col gap-3 bg-card',
+        mobile ? 'px-4 py-3.5' : 'px-4 py-4',
+      ].join(' ')}
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true" className="text-sm">
+          ⏩
+        </span>
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-session">
+          Prossimo gioco
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md text-[26px] shadow-sm"
+          style={
+            game.cover
+              ? { background: `linear-gradient(135deg, ${game.cover[0]}, ${game.cover[1]})` }
+              : { background: 'var(--bg-muted)' }
+          }
+        >
+          {game.emoji ?? '🎲'}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-display text-base font-extrabold leading-tight text-foreground">
+            {game.title}
+          </div>
+          {(game.publisher ?? game.weight !== undefined) ? (
+            <div className="mt-0.5 font-mono text-[10px] font-bold text-muted-foreground">
+              {game.publisher}
+              {game.publisher && game.weight !== undefined ? ' · ' : ''}
+              {game.weight !== undefined ? `weight ${game.weight.toFixed(2)}` : ''}
+            </div>
+          ) : null}
+        </div>
+        <span className="inline-flex shrink-0 items-center gap-1 rounded-pill border border-entity-session/30 bg-entity-session/15 px-2 py-0.5 font-mono text-[11px] font-extrabold tabular-nums text-entity-session">
+          <span aria-hidden="true">⏱</span>~{game.estimated}
+        </span>
+      </div>
+
+      <KBRulesQuickGlance
+        status={rulesStatus}
+        rules={game.rules}
+        onRetry={onRetryRules}
+        onProceed={onProceedWithoutRules}
+      />
+
+      <SetupChecklist items={game.setup} />
+    </section>
+  );
+}
+
+interface ConfirmSubmodalProps {
+  readonly tone: 'warning' | 'danger';
+  readonly icon: string;
+  readonly title: string;
+  readonly body: string;
+  readonly primaryLabel: string;
+  readonly primaryIcon: string;
+  readonly onConfirm?: () => void;
+  readonly onCancel?: () => void;
+}
+
+function ConfirmSubmodal({
+  tone,
+  icon,
+  title,
+  body,
+  primaryLabel,
+  primaryIcon,
+  onConfirm,
+  onCancel,
+}: ConfirmSubmodalProps): JSX.Element {
+  const toneClass =
+    tone === 'danger'
+      ? {
+          fg: 'hsl(var(--c-danger))',
+          bgIcon: 'hsl(var(--c-danger) / 0.12)',
+          border: 'hsl(var(--c-danger) / 0.32)',
+          shadow: '0 4px 14px hsl(var(--c-danger) / 0.35)',
+        }
+      : {
+          fg: 'hsl(var(--c-warning))',
+          bgIcon: 'hsl(var(--c-warning) / 0.12)',
+          border: 'hsl(var(--c-warning) / 0.32)',
+          shadow: '0 4px 14px hsl(var(--c-warning) / 0.35)',
+        };
+
+  return (
+    <div
+      className="absolute inset-0 z-[60] flex items-center justify-center p-4 backdrop-blur-md"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="transition-confirm-title"
+        className="flex w-full max-w-[380px] flex-col gap-3 rounded-xl bg-card shadow-lg p-4"
+        style={{ borderColor: toneClass.border, borderWidth: 1, borderStyle: 'solid' }}
+      >
+        <div
+          aria-hidden="true"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-[22px]"
+          style={{ background: toneClass.bgIcon, color: toneClass.fg }}
+        >
+          {icon}
+        </div>
+        <div>
+          <h3
+            id="transition-confirm-title"
+            className="m-0 font-display text-base font-extrabold tracking-tight text-foreground"
+          >
+            {title}
+          </h3>
+          <p className="mt-1.5 m-0 text-[12.5px] leading-relaxed text-muted-foreground">{body}</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex-[2] inline-flex items-center justify-center gap-1.5 rounded-md border-0 px-2.5 py-2.5 font-display text-[13px] font-extrabold cursor-pointer"
+            style={{ background: toneClass.fg, color: '#fff', boxShadow: toneClass.shadow }}
+          >
+            <span aria-hidden="true">{primaryIcon}</span>
+            {primaryLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-md border border-border-strong bg-transparent px-2.5 py-2.5 font-display text-[13px] font-bold text-muted-foreground cursor-pointer"
+          >
+            Annulla
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-nights/transition/index.ts
+++ b/apps/web/src/components/features/game-nights/transition/index.ts
@@ -1,0 +1,8 @@
+export { GameTransitionDialog } from '@/components/features/game-nights/transition/GameTransitionDialog';
+export type {
+  GameTransitionDialogProps,
+  TransitionLastGame,
+  TransitionNextGame,
+  TransitionPlayer,
+  TransitionSubmodal,
+} from '@/components/features/game-nights/transition/GameTransitionDialog';


### PR DESCRIPTION
## Summary — WIP draft

**PR 2/2** del cluster #1255 (sub-issue di #1026 Stage 3 de-versioning umbrella #1023). Implementa runtime screens per `/game-nights/[id]/{live,summary}` consumando i 6 primitives di PR #1258 (mergiata 2026-05-18) e i mockup K/L/M di PR #1250.

**Stato corrente**: 3 sub-component implementati. Root compositions (NightLiveHub, GameTransitionDialog, NightSummaryView) + routes + lib/routes.ts update + E2E smoke verranno aggiunti nei commit successivi su questo branch.

## Sub-component implementati (commit `a1d5d880b`)

| Component | Path | LOC | Test |
|---|---|---|---|
| `CrossGameDiaryTimeline` | `features/game-nights/live/` | 300 | 13 |
| `DiaryInlineWidget` | `features/game-nights/live/` | 140 | 16 ¹ |
| `PlannedGamesPane` (con `PlannedGameRow` inline) | `features/game-nights/live/` | 240 | 20 |
| **Totale** | | **680** | **49** |

¹ DiaryInlineWidget = screen #7 acceptance criterion dell'issue originale #487 (Diary inline widget compact 320×400 export riusabile).

## Pattern key

- **CrossGameDiaryTimeline**: timeline aggregata multi-session con cross-game divider auto-detect, sub-element `DiaryEventRow` inline (kind→entity color map: turn=session, score=player, custom=chat, end=event, system=toolkit), filter chips opzionali via `onFilterChange` (tablist), ARIA `role="log" aria-live="polite"` per live updates, avatar player con `aria-label="Player <initials>"`
- **DiaryInlineWidget**: wrapper compact che riusa CrossGameDiaryTimeline in mode `compact`, slice ultimi N eventi (default 7), header con count auto-derived sessions, Live pulsing badge opzionale, Annota CTA + "Apri timeline ↗" footer, varianti `embedded` (fixed size + shadow) vs default (fluid 100%)
- **PlannedGamesPane**: lista games con 3 status variant (`completed` toolkit-tinted opacity 0.80, `inprogress` session-tinted bg + pulsing dot ring, `upcoming` game orange + ⏳), border-left tone-aware, cover gradient, winner banner inline per completed, PlayOrder lock badge, empty state, compact mobile mode

## Acceptance criteria (cluster #1026)

- ✅ AC3.2 token-aware: tutti i componenti usano `bg-entity-*` utility o `var(--c-*)` arbitrary — zero hardcoded color (lint OK)
- ✅ AC3.4 coverage: 49 test su 680 LOC ≈ ottimo ratio, edge cases (empty arrays, missing props, unknown player ids), ARIA (`role="log"`, `tablist`, `aria-live`, `aria-label`, `aria-hidden` decorative)
- ⏳ AC3.1 visual diff: pending integration in root composition NightLiveHub + visual regression baseline
- ⏳ AC3.3 legacy elimination: pending route integration
- ⏳ AC3.5 lib/routes.ts: pending route addition

## TODO (next commits on this branch)

- [ ] NightLiveHub root composition (3-pane desktop / mobile tabs) integrando i 3 sub-component
- [ ] GameTransitionDialog (root composition L) + sub-elements
- [ ] NightSummaryView + PerGameRecapRow (root composition M)
- [ ] Route `/game-nights/[id]/live/page.tsx` + `/summary/page.tsx`
- [ ] `lib/routes.ts` update
- [ ] E2E smoke playwright

## Test plan

- [x] `pnpm vitest run src/components/features/game-nights/live` — 49/49 pass
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm eslint src/components/features/game-nights/live` — 0 errors 0 warnings
- [ ] E2E smoke su `/game-nights/[id]/live` (pending route)
- [ ] Visual regression conformity vs mockup K/L/M (pending root composition)

Refs #1255 (cluster), #1026 (Stage 3 tracking), #1023 (umbrella), #1250 (mockup K/L/M), #1258 (primitives PR 1/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)