### PR TITLE
feat(gamebook): client-side EXIF GPS stripper (closes #834)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -169,6 +169,7 @@
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "pdfjs-dist": "5.7.284",
+    "piexifjs": "^1.0.6",
     "prismjs": "^1.30.0",
     "qrcode.react": "^4.2.0",
     "react": "19.2.6",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       pdfjs-dist:
         specifier: 5.7.284
         version: 5.7.284
+      piexifjs:
+        specifier: ^1.0.6
+        version: 1.0.6
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -7898,6 +7901,9 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  piexifjs@1.0.6:
+    resolution: {integrity: sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag==}
+
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
@@ -9168,8 +9174,8 @@ packages:
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
@@ -11901,7 +11907,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.61':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@pdf-viewer/react@1.19.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(pdfjs-dist@5.7.284)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -18090,6 +18096,8 @@ snapshots:
 
   pidtree@0.3.1: {}
 
+  piexifjs@1.0.6: {}
+
   pify@3.0.0: {}
 
   pkg-dir@4.2.0:
@@ -19605,7 +19613,7 @@ snapshots:
 
   third-party-web@0.27.0: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   timers-browserify@2.0.12:
     dependencies:

--- a/apps/web/src/lib/gamebook/clientExifStripper.test.ts
+++ b/apps/web/src/lib/gamebook/clientExifStripper.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for clientExifStripper (issue #834 — privacy AC-2..AC-7).
+ *
+ * Test fixtures are generated programmatically (no binary commits) by injecting
+ * GPS metadata into a minimal 1x1 JPEG seed via piexifjs. This keeps the test
+ * suite hermetic and avoids EXIF generator dependencies.
+ */
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error -- piexifjs ships JS only, no @types/piexifjs
+import piexif from 'piexifjs';
+
+import { stripExif, type StripResult } from './clientExifStripper';
+
+// ---------------------------------------------------------------------------
+// Fixture generators
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal 1x1 white-pixel JPEG (Baseline DCT, no EXIF).
+ * Captured from `ffmpeg -f lavfi -i color=white:1x1 -frames:v 1 -f mjpeg`
+ * and base64-encoded. Stable across environments.
+ */
+const MINIMAL_JPEG_NO_EXIF_BASE64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB' +
+  'AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEB' +
+  'AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIA' +
+  'AhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEB' +
+  'AAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AB//Z';
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToFile(bytes: Uint8Array, name: string, type: string): File {
+  return new File([bytes], name, { type, lastModified: 0 });
+}
+
+function makeJpegNoExif(name = 'plain.jpg'): File {
+  return bytesToFile(base64ToBytes(MINIMAL_JPEG_NO_EXIF_BASE64), name, 'image/jpeg');
+}
+
+/**
+ * Build a JPEG fixture with GPS coordinates + Orientation injected via piexifjs.
+ * GPS=(45.46, 9.19) ≈ Milan; Orientation=6 (90° CW, common iPhone landscape).
+ */
+function makeJpegWithGpsAndOrientation(name = 'with-gps.jpg'): File {
+  const baseDataUri = `data:image/jpeg;base64,${MINIMAL_JPEG_NO_EXIF_BASE64}`;
+  const gpsIfd: Record<number, unknown> = {
+    [piexif.GPSIFD.GPSLatitudeRef]: 'N',
+    [piexif.GPSIFD.GPSLatitude]: [
+      [45, 1],
+      [27, 1],
+      [3600, 100],
+    ],
+    [piexif.GPSIFD.GPSLongitudeRef]: 'E',
+    [piexif.GPSIFD.GPSLongitude]: [
+      [9, 1],
+      [11, 1],
+      [2400, 100],
+    ],
+  };
+  const zerothIfd: Record<number, unknown> = {
+    [piexif.ImageIFD.Orientation]: 6,
+    [piexif.ImageIFD.Make]: 'Apple',
+    [piexif.ImageIFD.Model]: 'iPhone 15 Pro',
+  };
+  const exifIfd: Record<number, unknown> = {
+    [piexif.ExifIFD.DateTimeOriginal]: '2026:05:18 14:30:00',
+  };
+
+  const exifObj = {
+    '0th': zerothIfd,
+    Exif: exifIfd,
+    GPS: gpsIfd,
+    Interop: {},
+    '1st': {},
+    thumbnail: null,
+  };
+
+  const exifBytes = piexif.dump(exifObj);
+  const newDataUri = piexif.insert(exifBytes, baseDataUri);
+  const newBase64 = newDataUri.split(',')[1];
+  return bytesToFile(base64ToBytes(newBase64), name, 'image/jpeg');
+}
+
+/**
+ * Corrupted JPEG: valid SOI marker (FFD8) but garbage afterward.
+ * piexifjs.load() throws "given data is not jpeg" on this.
+ */
+function makeCorruptedJpeg(name = 'corrupt.jpg'): File {
+  const bytes = new Uint8Array([0xff, 0xd8, 0x00, 0x00, 0x00, 0x00]);
+  return bytesToFile(bytes, name, 'image/jpeg');
+}
+
+// ---------------------------------------------------------------------------
+// Tests — AC-2..AC-7 from issue #834
+// ---------------------------------------------------------------------------
+
+describe('stripExif', () => {
+  describe('happy path — JPEG with GPS (AC-2, AC-3, AC-4)', () => {
+    it('returns kind=success with tagsRemoved > 0 when GPS present', async () => {
+      const input = makeJpegWithGpsAndOrientation('vacation.jpg');
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        // GPS lat/lon ref + lat + lon ref + lon + Make + Model + DateTimeOriginal = 7 tags
+        expect(result.tagsRemoved).toBeGreaterThanOrEqual(7);
+        expect(result.file.name).toBe('vacation.jpg');
+        expect(result.file.type).toBe('image/jpeg');
+      }
+    });
+
+    it('removes GPS tags from output (AC-2)', async () => {
+      const input = makeJpegWithGpsAndOrientation();
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') return;
+
+      const outputBytes = await result.file.arrayBuffer();
+      const outputBase64 = btoa(String.fromCharCode(...new Uint8Array(outputBytes)));
+      const outputDataUri = `data:image/jpeg;base64,${outputBase64}`;
+      const exif = piexif.load(outputDataUri);
+
+      expect(Object.keys(exif.GPS ?? {})).toHaveLength(0);
+    });
+
+    it('preserves Orientation tag for OCR rotation (AC-4)', async () => {
+      const input = makeJpegWithGpsAndOrientation();
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') return;
+
+      const outputBytes = await result.file.arrayBuffer();
+      const outputBase64 = btoa(String.fromCharCode(...new Uint8Array(outputBytes)));
+      const outputDataUri = `data:image/jpeg;base64,${outputBase64}`;
+      const exif = piexif.load(outputDataUri);
+
+      expect(exif['0th']?.[piexif.ImageIFD.Orientation]).toBe(6);
+    });
+
+    it('removes device fingerprint tags (Make, Model)', async () => {
+      const input = makeJpegWithGpsAndOrientation();
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') return;
+
+      const outputBytes = await result.file.arrayBuffer();
+      const outputBase64 = btoa(String.fromCharCode(...new Uint8Array(outputBytes)));
+      const outputDataUri = `data:image/jpeg;base64,${outputBase64}`;
+      const exif = piexif.load(outputDataUri);
+
+      expect(exif['0th']?.[piexif.ImageIFD.Make]).toBeUndefined();
+      expect(exif['0th']?.[piexif.ImageIFD.Model]).toBeUndefined();
+    });
+
+    it('removes DateTimeOriginal (timezone leak)', async () => {
+      const input = makeJpegWithGpsAndOrientation();
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') return;
+
+      const outputBytes = await result.file.arrayBuffer();
+      const outputBase64 = btoa(String.fromCharCode(...new Uint8Array(outputBytes)));
+      const outputDataUri = `data:image/jpeg;base64,${outputBase64}`;
+      const exif = piexif.load(outputDataUri);
+
+      expect(exif.Exif?.[piexif.ExifIFD.DateTimeOriginal]).toBeUndefined();
+    });
+  });
+
+  describe('fallback — image without EXIF (AC-5)', () => {
+    it('returns kind=fallback-no-exif for JPEG without EXIF block', async () => {
+      const input = makeJpegNoExif('plain.jpg');
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('fallback-no-exif');
+      if (result.kind === 'fallback-no-exif') {
+        expect(result.file).toBe(input);
+      }
+    });
+
+    it('returns kind=fallback-no-exif for PNG (out of scope, no re-encode)', async () => {
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const input = bytesToFile(pngBytes, 'screenshot.png', 'image/png');
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('fallback-no-exif');
+      if (result.kind === 'fallback-no-exif') {
+        expect(result.file).toBe(input);
+      }
+    });
+  });
+
+  describe('error-corrupted (AC-6)', () => {
+    it('returns kind=error-corrupted for malformed JPEG', async () => {
+      const input = makeCorruptedJpeg();
+      const result = await stripExif(input);
+
+      expect(result.kind).toBe('error-corrupted');
+      if (result.kind === 'error-corrupted') {
+        expect(result.reason).toBeTruthy();
+        expect(typeof result.reason).toBe('string');
+      }
+    });
+  });
+
+  describe('error-unsupported (AC-7)', () => {
+    it('returns kind=error-unsupported for HEIC mime type', async () => {
+      const bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+      const input = bytesToFile(bytes, 'live-photo.heic', 'image/heic');
+      const result = await stripExif(input);
+
+      expect(result).toEqual<StripResult>({
+        kind: 'error-unsupported',
+        format: 'heic',
+      });
+    });
+
+    it('returns kind=error-unsupported for HEIC extension without mime', async () => {
+      const bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+      const input = bytesToFile(bytes, 'live-photo.heic', '');
+      const result = await stripExif(input);
+
+      expect(result).toEqual<StripResult>({
+        kind: 'error-unsupported',
+        format: 'heic',
+      });
+    });
+
+    it('returns kind=error-unsupported for AVIF', async () => {
+      const bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18]);
+      const input = bytesToFile(bytes, 'photo.avif', 'image/avif');
+      const result = await stripExif(input);
+
+      expect(result).toEqual<StripResult>({
+        kind: 'error-unsupported',
+        format: 'avif',
+      });
+    });
+  });
+});

--- a/apps/web/src/lib/gamebook/clientExifStripper.ts
+++ b/apps/web/src/lib/gamebook/clientExifStripper.ts
@@ -1,0 +1,230 @@
+/**
+ * Gamebook — Client-side EXIF GPS stripper (privacy)
+ *
+ * Strips EXIF metadata from JPEG photos before upload so user home location
+ * (GPS coordinates) is not leaked to server-side storage, AI vision pipelines,
+ * or admin incident-triage logs. Spec §6 privacy requirement; tracked by #834.
+ *
+ * Strategy: WHITELIST > BLACKLIST (default-secure).
+ * Strip ALL EXIF tags except an explicit allow-list of OCR/rendering-critical
+ * tags. Any new EXIF tag introduced by a future spec is stripped by default,
+ * so we never accidentally leak data via tags we did not know about.
+ *
+ * @see https://github.com/hMatoba/piexifjs
+ */
+// @ts-expect-error -- piexifjs ships JS only, no @types/piexifjs
+import piexif from 'piexifjs';
+
+// ---------------------------------------------------------------------------
+// Whitelist — tags preserved on strip
+// ---------------------------------------------------------------------------
+
+/**
+ * EXIF tags preserved on strip. Everything else (including GPS, timestamps,
+ * device fingerprint, OEM custom data) is removed.
+ *
+ * Numeric tag IDs per EXIF 2.32 spec (matches piexifjs constants):
+ * - 0x0112 Orientation       (OCR needs rotation hint, values 1..8)
+ * - 0xA002 PixelXDimension   (image width)
+ * - 0xA003 PixelYDimension   (image height)
+ * - 0xA001 ColorSpace        (sRGB / Adobe RGB)
+ */
+const PRESERVED_IFD0_TAG_IDS = new Set<number>([0x0112]);
+const PRESERVED_EXIF_TAG_IDS = new Set<number>([0xa002, 0xa003, 0xa001]);
+
+// ---------------------------------------------------------------------------
+// Result discriminated union
+// ---------------------------------------------------------------------------
+
+export type StripResult =
+  | { kind: 'success'; file: File; tagsRemoved: number }
+  | { kind: 'fallback-no-exif'; file: File }
+  | { kind: 'error-corrupted'; reason: string }
+  | { kind: 'error-unsupported'; format: string };
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+const UNSUPPORTED_EXTENSIONS = new Set(['heic', 'heif', 'avif']);
+
+function detectUnsupportedFormat(file: File): string | null {
+  const mime = file.type.toLowerCase();
+  if (mime === 'image/heic' || mime === 'image/heif') return 'heic';
+  if (mime === 'image/avif') return 'avif';
+
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (UNSUPPORTED_EXTENSIONS.has(ext)) return ext;
+
+  return null;
+}
+
+function isJpeg(file: File): boolean {
+  const mime = file.type.toLowerCase();
+  if (mime === 'image/jpeg' || mime === 'image/jpg') return true;
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  return ext === 'jpg' || ext === 'jpeg';
+}
+
+// ---------------------------------------------------------------------------
+// FileReader → data URI helper
+// ---------------------------------------------------------------------------
+
+function fileToDataUri(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('FileReader returned non-string result'));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => reject(new Error(`FileReader error: ${file.name}`));
+    reader.readAsDataURL(file);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip EXIF privacy-sensitive tags from an image File.
+ *
+ * @param file - Input File (typically from <input type="file"> or drop event)
+ * @returns StripResult — caller must inspect `.kind` to decide upload behaviour
+ *
+ * @example
+ *   const result = await stripExif(file);
+ *   switch (result.kind) {
+ *     case 'success':
+ *     case 'fallback-no-exif':
+ *       await uploadPhoto(result.file);
+ *       break;
+ *     case 'error-corrupted':
+ *       toast({ title: 'Image format not supported', description: result.reason });
+ *       break;
+ *     case 'error-unsupported':
+ *       toast({ title: 'Please convert to JPEG', description: `Format: ${result.format}` });
+ *       break;
+ *   }
+ */
+export async function stripExif(file: File): Promise<StripResult> {
+  const unsupported = detectUnsupportedFormat(file);
+  if (unsupported) {
+    return { kind: 'error-unsupported', format: unsupported };
+  }
+
+  // Non-JPEG files (typically PNG): no EXIF to strip via piexifjs.
+  // PNG can carry GPS in tEXt/iTXt textual chunks but stripping that is out
+  // of scope for this PR (see issue #834 "Out of scope").
+  if (!isJpeg(file)) {
+    return { kind: 'fallback-no-exif', file };
+  }
+
+  let dataUri: string;
+  try {
+    dataUri = await fileToDataUri(file);
+  } catch (err) {
+    return {
+      kind: 'error-corrupted',
+      reason: err instanceof Error ? err.message : 'Failed to read file',
+    };
+  }
+
+  let exifObj: Record<string, Record<number, unknown>>;
+  try {
+    exifObj = piexif.load(dataUri);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (/given data is not jpeg/i.test(reason)) {
+      return { kind: 'error-corrupted', reason: 'Not a valid JPEG file' };
+    }
+    return { kind: 'error-corrupted', reason };
+  }
+
+  // Count tags before strip (excluding thumbnail metadata buckets we ignore)
+  const originalCount =
+    Object.keys(exifObj['0th'] ?? {}).length +
+    Object.keys(exifObj.Exif ?? {}).length +
+    Object.keys(exifObj.GPS ?? {}).length +
+    Object.keys(exifObj.Interop ?? {}).length +
+    Object.keys(exifObj['1st'] ?? {}).length;
+
+  if (originalCount === 0) {
+    // JPEG without EXIF block (rare but valid) — no-op pass-through
+    return { kind: 'fallback-no-exif', file };
+  }
+
+  // Whitelist filter
+  const filteredIfd0: Record<number, unknown> = {};
+  for (const [tag, value] of Object.entries(exifObj['0th'] ?? {})) {
+    const tagId = Number(tag);
+    if (PRESERVED_IFD0_TAG_IDS.has(tagId)) {
+      filteredIfd0[tagId] = value;
+    }
+  }
+
+  const filteredExif: Record<number, unknown> = {};
+  for (const [tag, value] of Object.entries(exifObj.Exif ?? {})) {
+    const tagId = Number(tag);
+    if (PRESERVED_EXIF_TAG_IDS.has(tagId)) {
+      filteredExif[tagId] = value;
+    }
+  }
+
+  const stripped = {
+    '0th': filteredIfd0,
+    Exif: filteredExif,
+    GPS: {},
+    Interop: {},
+    '1st': {},
+    thumbnail: null,
+  };
+
+  const newCount = Object.keys(filteredIfd0).length + Object.keys(filteredExif).length;
+
+  let newDataUri: string;
+  try {
+    const exifBytes = piexif.dump(stripped);
+    newDataUri = piexif.insert(exifBytes, dataUri);
+  } catch (err) {
+    return {
+      kind: 'error-corrupted',
+      reason: err instanceof Error ? err.message : 'EXIF rewrite failed',
+    };
+  }
+
+  const newFile = dataUriToFile(newDataUri, file);
+  return {
+    kind: 'success',
+    file: newFile,
+    tagsRemoved: originalCount - newCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// data URI → File (internal helper)
+// ---------------------------------------------------------------------------
+
+function dataUriToFile(dataUri: string, original: File): File {
+  const [header, base64] = dataUri.split(',');
+  if (!header || !base64) {
+    throw new Error('Invalid data URI structure');
+  }
+  const mimeMatch = header.match(/:([^;]+);/);
+  const mime = mimeMatch?.[1] ?? original.type ?? 'image/jpeg';
+
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return new File([bytes], original.name, {
+    type: mime,
+    lastModified: original.lastModified,
+  });
+}

--- a/apps/web/src/lib/gamebook/hooks/__tests__/usePhotoUpload.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/usePhotoUpload.test.tsx
@@ -4,10 +4,12 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
 
 import * as photosApi from '@/lib/api/gamebook-photos';
+import * as stripperApi from '@/lib/gamebook/clientExifStripper';
 
-import { usePhotoUpload } from '../usePhotoUpload';
+import { usePhotoUpload, PhotoUploadStripError } from '../usePhotoUpload';
 
 vi.mock('@/lib/api/gamebook-photos');
+vi.mock('@/lib/gamebook/clientExifStripper');
 
 const CAMPAIGN_ID = '11111111-1111-4111-a111-111111111111';
 const PHOTO_ID = '22222222-2222-4222-a222-222222222222';
@@ -35,23 +37,56 @@ describe('usePhotoUpload', () => {
     vi.clearAllMocks();
   });
 
-  it('calls uploadPhoto and resolves artifact', async () => {
+  it('strips EXIF then uploads the stripped file (happy path)', async () => {
+    const original = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' });
+    const stripped = new File(['stripped'], 'photo.jpg', { type: 'image/jpeg' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'success',
+      file: stripped,
+      tagsRemoved: 5,
+    });
     vi.mocked(photosApi.uploadPhoto).mockResolvedValueOnce(fakeArtifact);
+
     const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const { result } = renderHook(() => usePhotoUpload(CAMPAIGN_ID), {
       wrapper: makeWrapper(qc),
     });
 
-    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' });
+    result.current.mutate({ file: original, pageType: 'Storybook' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(stripperApi.stripExif).toHaveBeenCalledWith(original);
+    expect(photosApi.uploadPhoto).toHaveBeenCalledWith(CAMPAIGN_ID, stripped, 'Storybook');
+    expect(result.current.data?.id).toBe(PHOTO_ID);
+  });
+
+  it('uploads original file on fallback-no-exif (no re-encode cost)', async () => {
+    const file = new File(['bytes'], 'screenshot.png', { type: 'image/png' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'fallback-no-exif',
+      file,
+    });
+    vi.mocked(photosApi.uploadPhoto).mockResolvedValueOnce(fakeArtifact);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => usePhotoUpload(CAMPAIGN_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
     result.current.mutate({ file, pageType: 'Storybook' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(photosApi.uploadPhoto).toHaveBeenCalledWith(CAMPAIGN_ID, file, 'Storybook');
-    expect(result.current.data?.id).toBe(PHOTO_ID);
   });
 
   it('invalidates gamebook photos query on success', async () => {
+    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'fallback-no-exif',
+      file,
+    });
     vi.mocked(photosApi.uploadPhoto).mockResolvedValueOnce(fakeArtifact);
+
     const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
 
@@ -59,7 +94,6 @@ describe('usePhotoUpload', () => {
       wrapper: makeWrapper(qc),
     });
 
-    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' });
     result.current.mutate({ file, pageType: 'Encounter' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -68,14 +102,65 @@ describe('usePhotoUpload', () => {
     );
   });
 
-  it('surfaces error on failure', async () => {
-    vi.mocked(photosApi.uploadPhoto).mockRejectedValueOnce(new Error('upload failed 413'));
+  it('aborts upload with PhotoUploadStripError on error-unsupported (HEIC)', async () => {
+    const file = new File(['bytes'], 'live-photo.heic', { type: 'image/heic' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'error-unsupported',
+      format: 'heic',
+    });
+
     const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     const { result } = renderHook(() => usePhotoUpload(CAMPAIGN_ID), {
       wrapper: makeWrapper(qc),
     });
 
-    result.current.mutate({ file: new File([], 'x.jpg'), pageType: 'Storybook' });
+    result.current.mutate({ file, pageType: 'Storybook' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(photosApi.uploadPhoto).not.toHaveBeenCalled();
+    expect(result.current.error).toBeInstanceOf(PhotoUploadStripError);
+    const err = result.current.error as PhotoUploadStripError;
+    expect(err.kind).toBe('error-unsupported');
+    expect(err.detail).toBe('heic');
+    expect(err.message).toMatch(/convert to JPEG/);
+  });
+
+  it('aborts upload with PhotoUploadStripError on error-corrupted', async () => {
+    const file = new File(['garbage'], 'broken.jpg', { type: 'image/jpeg' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'error-corrupted',
+      reason: 'Not a valid JPEG file',
+    });
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => usePhotoUpload(CAMPAIGN_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    result.current.mutate({ file, pageType: 'Storybook' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(photosApi.uploadPhoto).not.toHaveBeenCalled();
+    expect(result.current.error).toBeInstanceOf(PhotoUploadStripError);
+    const err = result.current.error as PhotoUploadStripError;
+    expect(err.kind).toBe('error-corrupted');
+    expect(err.detail).toBe('Not a valid JPEG file');
+  });
+
+  it('surfaces upload-failure error after stripper succeeds', async () => {
+    const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' });
+    vi.mocked(stripperApi.stripExif).mockResolvedValueOnce({
+      kind: 'fallback-no-exif',
+      file,
+    });
+    vi.mocked(photosApi.uploadPhoto).mockRejectedValueOnce(new Error('upload failed 413'));
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => usePhotoUpload(CAMPAIGN_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    result.current.mutate({ file, pageType: 'Storybook' });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error?.message).toMatch(/upload failed/);

--- a/apps/web/src/lib/gamebook/hooks/usePhotoUpload.ts
+++ b/apps/web/src/lib/gamebook/hooks/usePhotoUpload.ts
@@ -3,16 +3,48 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { uploadPhoto, type GamebookPhotoArtifact } from '@/lib/api/gamebook-photos';
+import { stripExif } from '@/lib/gamebook/clientExifStripper';
 
 export interface UploadPhotoArgs {
   file: File;
   pageType: 'Storybook' | 'Encounter';
 }
 
+/**
+ * Privacy-safe error class — thrown by usePhotoUpload mutationFn when the
+ * client-side EXIF stripper rejects the file (HEIC/HEIF/AVIF unsupported,
+ * or malformed EXIF). React Query routes this to `onError`, where the UI
+ * surfaces the appropriate toast. Issue #834.
+ */
+export class PhotoUploadStripError extends Error {
+  constructor(
+    public readonly kind: 'error-corrupted' | 'error-unsupported',
+    public readonly detail: string
+  ) {
+    super(
+      kind === 'error-unsupported'
+        ? `Unsupported format: ${detail}. Please convert to JPEG.`
+        : `Image format not supported: ${detail}`
+    );
+    this.name = 'PhotoUploadStripError';
+  }
+}
+
 export function usePhotoUpload(campaignId: string) {
   const qc = useQueryClient();
   return useMutation<GamebookPhotoArtifact, Error, UploadPhotoArgs>({
-    mutationFn: ({ file, pageType }) => uploadPhoto(campaignId, file, pageType),
+    mutationFn: async ({ file, pageType }) => {
+      const stripped = await stripExif(file);
+      switch (stripped.kind) {
+        case 'success':
+        case 'fallback-no-exif':
+          return uploadPhoto(campaignId, stripped.file, pageType);
+        case 'error-unsupported':
+          throw new PhotoUploadStripError('error-unsupported', stripped.format);
+        case 'error-corrupted':
+          throw new PhotoUploadStripError('error-corrupted', stripped.reason);
+      }
+    },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['gamebook', 'photos', campaignId] });
     },


### PR DESCRIPTION
## Summary

Closes #834 — implements client-side EXIF GPS stripping for gamebook photo uploads to prevent home-location leak via metadata. Spec §6 privacy requirement; audit gap R4 from cross-branch audit PR #831.

## What changed

### New: `apps/web/src/lib/gamebook/clientExifStripper.ts`

`stripExif(file: File): Promise<StripResult>` utility with **whitelist > blacklist** privacy strategy:

```typescript
const PRESERVED_IFD0_TAG_IDS = new Set([0x0112]);                  // Orientation
const PRESERVED_EXIF_TAG_IDS = new Set([0xa002, 0xa003, 0xa001]);  // dimensions + ColorSpace
// All other EXIF tags stripped (GPS, DateTime, Make, Model, SerialNumber, Software, MakerNote, ...)
```

Discriminated union result:
```typescript
type StripResult =
  | { kind: 'success'; file: File; tagsRemoved: number }
  | { kind: 'fallback-no-exif'; file: File }
  | { kind: 'error-corrupted'; reason: string }
  | { kind: 'error-unsupported'; format: string };
```

### Updated: `apps/web/src/lib/gamebook/hooks/usePhotoUpload.ts`

Wraps `uploadPhoto` API call. Stripper runs first; `error-*` results throw `PhotoUploadStripError` which React Query routes to `onError` for UI toast handling. `uploadPhoto` is never invoked when stripper rejects.

### Tests

- **`clientExifStripper.test.ts`** — 11 unit scenarios covering AC-2..AC-7 (GPS strip, Orientation preserved, device fingerprint removed, timezone removed, PNG/no-EXIF fallback, corrupted EXIF, HEIC/AVIF reject). Fixtures generated programmatically from a 1×1 JPEG seed (no binary commits, hermetic).
- **`usePhotoUpload.test.tsx`** — 6 integration scenarios (strip+upload happy path, fallback, HEIC abort, corrupted abort, upload-after-strip failure).

**Total: 17/17 pass locally (3.92s).**

### Library: `piexifjs@1.0.6`

- 5KB minified (within +10KB bundle budget)
- MIT license, 0 transitive deps
- Last update 2019-11-07 — accepted trade-off because EXIF format is static and scope is limited to *strip* (lower attack surface than *parse*)
- `pnpm audit` clean for piexifjs (1 pre-existing postcss vuln unrelated)

## AC checklist

- [x] **AC-1** — `piexifjs` added to `apps/web/package.json`, audit clean
- [x] **AC-2** — GPS tags absent from output (verified via round-trip `piexif.load()`)
- [x] **AC-3** — Image pixel data preserved (piexifjs inserts new EXIF block in-place, doesn't re-encode pixels)
- [x] **AC-4** — `Orientation` tag preserved when present in input
- [x] **AC-5** — JPEG-without-EXIF + PNG → `fallback-no-exif`, referential equality (no re-encode cost)
- [x] **AC-6** — Malformed EXIF → `error-corrupted`, reason populated
- [x] **AC-7** — `.heic` / `.avif` → `error-unsupported`, format key set
- [x] **AC-8** — `usePhotoUpload` integration: strips before POST, aborts with `PhotoUploadStripError` on stripper errors
- [ ] **AC-9** — Bundle size delta ≤ +10 KB — verified during pre-push hook frontend build (passed). CI to confirm in `Bundle Size` workflow.

## Out of scope (per issue body)

- **HEIC support** — explicit reject with `error-unsupported` toast. Re-evaluate if iOS user feedback signals demand.
- **PNG textual GPS chunks** (tEXt/iTXt) — defer until observed.
- **Server-side fallback for legacy browsers** without FileReader/Canvas — minimal modern-browser audience for v1 beta.
- **OEM custom EXIF tags** — `MakerNote` is in the strip set by default (whitelist approach catches all OEM variants).

## Test plan

- [x] `pnpm vitest run src/lib/gamebook/clientExifStripper.test.ts src/lib/gamebook/hooks/__tests__/usePhotoUpload.test.tsx` → 17/17 pass
- [x] `pnpm typecheck` → clean
- [x] `pnpm lint` → 0 errors (39 pre-existing warnings unrelated)
- [x] Pre-push hook frontend build → success (Next.js 16.2.6, 14.2s compile, all 158 static pages generated)
- [ ] CI: visual regression, A11y E2E, conformity gates pass
- [ ] Manual smoke (post-merge, on staging): upload iPhone photo with GPS via gamebook flow, verify uploaded file lacks GPS via server-side EXIF inspection

## Refs

- Closes #834
- Audit: PR #831 gap R4
- Spec design §6: `docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md`
- Original plan: Task 1.A.6.3 of `2026-05-07-libro-game-nanolith-iter1-plan.md`
- Pattern model: `apps/web/src/lib/gamebook/file-to-base64.ts` (sibling utility)
- Spec-panel review (2026-05-18): see issue #834 comment thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
