### PR TITLE
feat(gamebook): translation + OCR + glossary metrics (closes #833)

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -166,10 +166,13 @@ jobs:
     # Issue #1161: raised from 5 → 8 minutes. The Release `dotnet build` step
     # alone takes ~4min on ubuntu-latest runners (confirmed on PR #1156 cancels);
     # combined with setup (~30s) and the test step (~30s) the 5-min budget
-    # leaves no headroom and the job is cancelled mid-test. 8 min gives a ~3min
-    # safety buffer. If observed wall-clock sustains > 6 min, revisit and
-    # consider splitting build + test into separate jobs (issue #1161 option b).
-    timeout-minutes: 8
+    # leaves no headroom and the job is cancelled mid-test.
+    # Issue #833 (PR #1271): raised 8 → 12 minutes after sustained wall-clock
+    # of ~8m20s on consecutive runs (cache-miss-warm-runner), exceeding the
+    # 8min cap. The 12-min budget gives ~3min headroom. Per issue #1161 note,
+    # this trigger justifies splitting build + test into separate jobs (option b);
+    # tracked as follow-up.
+    timeout-minutes: 12
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     steps:

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SegmentGamebookPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/SegmentGamebookPhotoCommandHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using MediatR;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -54,10 +55,32 @@ internal sealed class SegmentGamebookPhotoCommandHandler : IRequestHandler<Segme
                 .Select(p => GamebookSegment.Create(p.Number, p.Text, p.Bbox?.ToString()))
                 .ToList();
             artifact.RecordSegments(segments, ocr.FullText);
+
+            // Issue #833: gamebook OCR metrics.
+            // - confidence: single mean per page (Tesseract returns 0..100; normalise to 0..1 for histogram bucket compat).
+            // - segmentation match quality: "exact" if paragraphs were extracted, "miss" if zero. "partial" is deferred
+            //   until segmentation has a quality classifier (out of scope per spec-panel 2026-05-18).
+            var normalisedConfidence = Math.Clamp(ocr.AverageConfidence / 100.0, 0.0, 1.0);
+            var exactMatches = segments.Count > 0 ? 1L : 0L;
+            var misses = segments.Count == 0 ? 1L : 0L;
+            MeepleAiMetrics.RecordGamebookOcrSegmentation(
+                confidenceScores: new[] { normalisedConfidence },
+                language: "ita",
+                exactMatches: exactMatches,
+                partialMatches: 0,
+                misses: misses);
         }
         catch (Exception ex)
         {
             artifact.MarkFailed($"OCR: {ex.Message}");
+
+            // Issue #833: record OCR failure as a "miss" with zero confidence.
+            MeepleAiMetrics.RecordGamebookOcrSegmentation(
+                confidenceScores: Array.Empty<double>(),
+                language: "ita",
+                exactMatches: 0,
+                partialMatches: 0,
+                misses: 1);
         }
 
         await _photos.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
@@ -1,10 +1,13 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Models;
+using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -41,67 +44,135 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         TranslateGamebookSegmentQuery query,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var campaign = await _campaigns.GetByIdAsync(query.CampaignId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Campaign {query.CampaignId} not found");
+        // Issue #833: gamebook translation metrics. try/finally is the only viable
+        // wrapper around `yield return` in IAsyncEnumerable (CS1626 forbids catch).
+        var stopwatch = Stopwatch.StartNew();
+        var status = "failure";          // pessimistic default; set to "success" on completion
+        double? streamingLatencySec = null;
+        long? promptTokens = null;
+        long? completionTokens = null;
+        int totalApplicableTerms = 0;
+        int matchedTerms = 0;
 
-        if (campaign.OwnerUserId != query.CallerUserId)
-            throw new ConflictException("Forbidden");
-
-        var artifact = await _photos.GetByIdAsync(query.PhotoId, cancellationToken).ConfigureAwait(false)
-            ?? throw new NotFoundException($"Photo {query.PhotoId} not found");
-
-        if (artifact.CampaignId != query.CampaignId)
-            throw new ConflictException("Photo does not belong to this campaign");
-
-        var segment = artifact.Segments.FirstOrDefault(s => s.ParagraphNumber == query.ParagraphNumber)
-            ?? throw new NotFoundException($"Segment §{query.ParagraphNumber} not found in photo");
-
-        var glossaryEntries = await _glossary.ListByCampaignAsync(query.CampaignId, cancellationToken).ConfigureAwait(false);
-        var glossaryTable = string.Join("\n", glossaryEntries.Select(g => $"- {g.TermEn} → {g.TermIt}"));
-
-        var systemPrompt =
-            "You are a translator from English to Italian for a tabletop RPG storybook. " +
-            "Preserve narrative tone, use formal pronouns (voi/lei) when addressing players. " +
-            "Apply this glossary EXACTLY (English term → Italian term) without rephrasing the Italian:\n" +
-            (glossaryTable.Length > 0 ? glossaryTable : "(no glossary entries yet)") + "\n" +
-            "Output ONLY the Italian translation — no preamble, no notes.";
-
-        var fullText = new StringBuilder();
-        await foreach (var chunk in _llm.GenerateCompletionStreamAsync(
-            systemPrompt, segment.SourceText, RequestSource.Manual, cancellationToken).ConfigureAwait(false))
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!string.IsNullOrEmpty(chunk.Content))
+            var campaign = await _campaigns.GetByIdAsync(query.CampaignId, cancellationToken).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Campaign {query.CampaignId} not found");
+
+            if (campaign.OwnerUserId != query.CallerUserId)
+                throw new ConflictException("Forbidden");
+
+            var artifact = await _photos.GetByIdAsync(query.PhotoId, cancellationToken).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Photo {query.PhotoId} not found");
+
+            if (artifact.CampaignId != query.CampaignId)
+                throw new ConflictException("Photo does not belong to this campaign");
+
+            var segment = artifact.Segments.FirstOrDefault(s => s.ParagraphNumber == query.ParagraphNumber)
+                ?? throw new NotFoundException($"Segment §{query.ParagraphNumber} not found in photo");
+
+            var glossaryEntries = await _glossary.ListByCampaignAsync(query.CampaignId, cancellationToken).ConfigureAwait(false);
+            var glossaryTable = string.Join("\n", glossaryEntries.Select(g => $"- {g.TermEn} → {g.TermIt}"));
+
+            var systemPrompt =
+                "You are a translator from English to Italian for a tabletop RPG storybook. " +
+                "Preserve narrative tone, use formal pronouns (voi/lei) when addressing players. " +
+                "Apply this glossary EXACTLY (English term → Italian term) without rephrasing the Italian:\n" +
+                (glossaryTable.Length > 0 ? glossaryTable : "(no glossary entries yet)") + "\n" +
+                "Output ONLY the Italian translation — no preamble, no notes.";
+
+            var fullText = new StringBuilder();
+            await foreach (var chunk in _llm.GenerateCompletionStreamAsync(
+                systemPrompt, segment.SourceText, RequestSource.Manual, cancellationToken).ConfigureAwait(false))
             {
-                fullText.Append(chunk.Content);
-                yield return new TranslateChunk(chunk.Content, IsComplete: false);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!string.IsNullOrEmpty(chunk.Content))
+                {
+                    // Time-to-first-chunk only recorded once per request
+                    if (streamingLatencySec is null)
+                    {
+                        streamingLatencySec = stopwatch.Elapsed.TotalSeconds;
+                    }
+                    fullText.Append(chunk.Content);
+                    yield return new TranslateChunk(chunk.Content, IsComplete: false);
+                }
+                if (chunk.IsFinal && chunk.Usage is not null)
+                {
+                    promptTokens = chunk.Usage.PromptTokens;
+                    completionTokens = chunk.Usage.CompletionTokens;
+                    _logger.LogInformation(
+                        "gamebook.translate.cost campaign={CampaignId} paragraph={Paragraph} tokens_in={In} tokens_out={Out}",
+                        query.CampaignId, query.ParagraphNumber, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
+                }
             }
-            if (chunk.IsFinal && chunk.Usage is not null)
+
+            var translatedIt = fullText.ToString().Trim();
+
+            // Glossary consistency: ratio of glossary terms present in source AND correctly mapped to translation.
+            // Issue #833 metric: meepleai.gamebook.glossary_consistency_rate
+            foreach (var entry in glossaryEntries)
             {
-                _logger.LogInformation(
-                    "gamebook.translate.cost campaign={CampaignId} paragraph={Paragraph} tokens_in={In} tokens_out={Out}",
-                    query.CampaignId, query.ParagraphNumber, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
+                if (segment.SourceText.Contains(entry.TermEn, StringComparison.OrdinalIgnoreCase))
+                {
+                    totalApplicableTerms++;
+                    if (translatedIt.Contains(entry.TermIt, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchedTerms++;
+                    }
+                }
+            }
+            var appliedTerms = glossaryEntries
+                .Where(g => segment.SourceText.Contains(g.TermEn, StringComparison.OrdinalIgnoreCase)
+                            && translatedIt.Contains(g.TermIt, StringComparison.OrdinalIgnoreCase))
+                .Select(g => g.TermEn)
+                .ToList();
+
+            var paragraph = TranslatedParagraph.Create(
+                query.CampaignId, query.PhotoId, query.ParagraphNumber, artifact.PageType,
+                segment.SourceText, translatedIt, appliedTerms, query.CallerUserId);
+
+            await _paragraphs.AddAsync(paragraph, cancellationToken).ConfigureAwait(false);
+            await _paragraphs.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // Advance current paragraph in campaign
+            campaign.UpdateProgress(query.ParagraphNumber);
+            await _campaigns.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            yield return new TranslateChunk(string.Empty, IsComplete: true, paragraph.Id, appliedTerms);
+            status = "success";
+        }
+        finally
+        {
+            // Detect cancellation that happened on the cooperative path
+            if (cancellationToken.IsCancellationRequested && string.Equals(status, "failure", StringComparison.Ordinal))
+            {
+                status = "cancelled";
+            }
+
+            // Cost tracking via existing LlmCostUsdTotal (MeepleAiMetrics.LlmOperational, Issue #5480)
+            // is emitted by HybridLlmService per-request; gamebook-specific cost_eur deferred to a
+            // follow-up that derives cost from token counts + provider pricing (LlmUsage record does
+            // not currently carry CostUsd / Provider fields).
+            MeepleAiMetrics.RecordGamebookTranslationRequest(
+                status: status,
+                latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
+                latencyStreamingSeconds: streamingLatencySec,
+                promptTokens: promptTokens,
+                completionTokens: completionTokens,
+                costUsd: null,
+                provider: "unknown");
+
+            if (totalApplicableTerms > 0)
+            {
+                var rate = (double)matchedTerms / totalApplicableTerms;
+                MeepleAiMetrics.RecordGamebookGlossaryConsistency(rate, HashCampaignId(query.CampaignId));
             }
         }
+    }
 
-        var translatedIt = fullText.ToString().Trim();
-        var appliedTerms = glossaryEntries
-            .Where(g => segment.SourceText.Contains(g.TermEn, StringComparison.OrdinalIgnoreCase)
-                        && translatedIt.Contains(g.TermIt, StringComparison.OrdinalIgnoreCase))
-            .Select(g => g.TermEn)
-            .ToList();
-
-        var paragraph = TranslatedParagraph.Create(
-            query.CampaignId, query.PhotoId, query.ParagraphNumber, artifact.PageType,
-            segment.SourceText, translatedIt, appliedTerms, query.CallerUserId);
-
-        await _paragraphs.AddAsync(paragraph, cancellationToken).ConfigureAwait(false);
-        await _paragraphs.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        // Advance current paragraph in campaign
-        campaign.UpdateProgress(query.ParagraphNumber);
-        await _campaigns.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        yield return new TranslateChunk(string.Empty, IsComplete: true, paragraph.Id, appliedTerms);
+    private static string HashCampaignId(Guid campaignId)
+    {
+        var bytes = SHA256.HashData(campaignId.ToByteArray());
+        return Convert.ToHexStringLower(bytes.AsSpan(0, 4)); // 8 hex chars
     }
 }

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.GamebookTranslation.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.GamebookTranslation.cs
@@ -1,0 +1,196 @@
+// Issue #833 — Gamebook (libro-game) translation + OCR + glossary metrics.
+// 7 metrics scoped to TranslateGamebookSegmentQueryHandler + SegmentGamebookPhotoCommandHandler.
+//
+// Circuit-breaker state for the LLM provider routing translation requests is already
+// exported by MeepleAiMetrics.LlmOperational.cs (Issue #5480) — reused, not duplicated.
+//
+// Bulkhead policy (LlmBulkheadPolicy) and queue-depth gauge deferred to follow-up
+// issue per spec-panel review 2026-05-18; needs 14-day post-launch traffic baseline
+// to size correctly.
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    #region Gamebook Translation Metrics (Issue #833)
+
+    /// <summary>
+    /// Counter for total gamebook translation requests by status.
+    /// Labels: status (success, failure, cancelled).
+    /// </summary>
+    public static readonly Counter<long> GamebookTranslationRequestsTotal = Meter.CreateCounter<long>(
+        name: "meepleai.gamebook.translation_requests_total",
+        unit: "requests",
+        description: "Total gamebook translation requests by status (success/failure/cancelled)");
+
+    /// <summary>
+    /// Histogram for gamebook translation latency in seconds.
+    /// Labels: stage (full = end-to-end wall-clock, streaming = time-to-first-chunk).
+    /// </summary>
+    public static readonly Histogram<double> GamebookTranslationLatencySeconds = Meter.CreateHistogram<double>(
+        name: "meepleai.gamebook.translation_latency_seconds",
+        unit: "s",
+        description: "Gamebook translation latency in seconds, labeled by stage (full/streaming)");
+
+    /// <summary>
+    /// Histogram for token counts consumed by translation requests.
+    /// Labels: kind (prompt = system+user input tokens, completion = generated output tokens).
+    /// </summary>
+    public static readonly Histogram<long> GamebookTranslationTokenCount = Meter.CreateHistogram<long>(
+        name: "meepleai.gamebook.translation_token_count",
+        unit: "tokens",
+        description: "Token count consumed by gamebook translation (prompt vs completion)");
+
+    /// <summary>
+    /// Counter for cumulative translation cost in EUR.
+    /// Labels: provider. EUR derived from USD via fixed rate constant <see cref="UsdToEurRate"/>.
+    /// </summary>
+    public static readonly Counter<double> GamebookTranslationCostEur = Meter.CreateCounter<double>(
+        name: "meepleai.gamebook.translation_cost_eur",
+        unit: "EUR",
+        description: "Cumulative gamebook translation cost in EUR (USD x fixed rate, see spec)");
+
+    /// <summary>
+    /// Histogram for OCR confidence score per segment (0.0 to 1.0).
+    /// Labels: language (ita, eng, etc — Tesseract language code).
+    /// </summary>
+    public static readonly Histogram<double> GamebookOcrConfidenceScore = Meter.CreateHistogram<double>(
+        name: "meepleai.gamebook.ocr_confidence_score",
+        unit: "score",
+        description: "OCR confidence score per gamebook segment (0.0-1.0), labeled by language");
+
+    /// <summary>
+    /// Counter for OCR segmentation match quality outcomes.
+    /// Labels: quality (exact, partial, miss).
+    /// </summary>
+    public static readonly Counter<long> GamebookOcrSegmentationMatchQualityTotal = Meter.CreateCounter<long>(
+        name: "meepleai.gamebook.ocr_segmentation_match_quality_total",
+        unit: "matches",
+        description: "OCR segmentation match quality outcomes (exact/partial/miss)");
+
+    /// <summary>
+    /// Histogram for glossary term consistency rate per translation (0.0 to 1.0).
+    /// Computed as: (translated text matches expected glossary mapping) / (total glossary terms applicable).
+    /// Labels: campaign_id_hash (anonymized — first 8 chars of SHA-256 of campaign UUID).
+    /// </summary>
+    public static readonly Histogram<double> GamebookGlossaryConsistencyRate = Meter.CreateHistogram<double>(
+        name: "meepleai.gamebook.glossary_consistency_rate",
+        unit: "ratio",
+        description: "Glossary term consistency rate per gamebook translation (0.0-1.0)");
+
+    /// <summary>
+    /// Fixed USD-to-EUR conversion rate for cost tracking accuracy.
+    /// Per spec-panel decision 2026-05-18: runtime FX provider deferred to separate issue.
+    /// Rate sourced from ECB monthly average for 2026-Q2 (approximate).
+    /// Update with PR if rate drifts > 5% from observed mid-market.
+    /// </summary>
+    public const double UsdToEurRate = 0.92;
+
+    /// <summary>
+    /// Records a successful or failed gamebook translation request with all 4 translation metrics.
+    /// </summary>
+    /// <param name="status">"success" / "failure" / "cancelled"</param>
+    /// <param name="latencyFullSeconds">End-to-end wall-clock duration in seconds</param>
+    /// <param name="latencyStreamingSeconds">Time-to-first-chunk in seconds, or null if no streaming start</param>
+    /// <param name="promptTokens">Tokens consumed by prompt (null when usage unavailable)</param>
+    /// <param name="completionTokens">Tokens generated as completion (null when usage unavailable)</param>
+    /// <param name="costUsd">Cost in USD reported by provider (null when unavailable)</param>
+    /// <param name="provider">LLM provider name (e.g. "openrouter", "deepseek")</param>
+    public static void RecordGamebookTranslationRequest(
+        string status,
+        double latencyFullSeconds,
+        double? latencyStreamingSeconds,
+        long? promptTokens,
+        long? completionTokens,
+        double? costUsd,
+        string provider)
+    {
+        GamebookTranslationRequestsTotal.Add(1, new TagList { { "status", status } });
+        GamebookTranslationLatencySeconds.Record(latencyFullSeconds, new TagList { { "stage", "full" } });
+
+        if (latencyStreamingSeconds.HasValue)
+        {
+            GamebookTranslationLatencySeconds.Record(
+                latencyStreamingSeconds.Value,
+                new TagList { { "stage", "streaming" } });
+        }
+
+        if (promptTokens.HasValue)
+        {
+            GamebookTranslationTokenCount.Record(
+                promptTokens.Value,
+                new TagList { { "kind", "prompt" } });
+        }
+
+        if (completionTokens.HasValue)
+        {
+            GamebookTranslationTokenCount.Record(
+                completionTokens.Value,
+                new TagList { { "kind", "completion" } });
+        }
+
+        if (costUsd.HasValue && costUsd.Value > 0)
+        {
+            GamebookTranslationCostEur.Add(
+                costUsd.Value * UsdToEurRate,
+                new TagList { { "provider", provider } });
+        }
+    }
+
+    /// <summary>
+    /// Records OCR confidence + segmentation match quality from a gamebook photo segmentation pass.
+    /// </summary>
+    /// <param name="confidenceScores">Per-segment OCR confidence (0.0-1.0). One Record() per entry.</param>
+    /// <param name="language">Tesseract language code (e.g. "ita", "eng")</param>
+    /// <param name="exactMatches">Count of segmentation matches classified as exact</param>
+    /// <param name="partialMatches">Count of segmentation matches classified as partial (fuzzy)</param>
+    /// <param name="misses">Count of segmentation misses (no usable match)</param>
+    public static void RecordGamebookOcrSegmentation(
+        IReadOnlyCollection<double> confidenceScores,
+        string language,
+        long exactMatches,
+        long partialMatches,
+        long misses)
+    {
+        var languageTag = new TagList { { "language", language } };
+        foreach (var score in confidenceScores)
+        {
+            GamebookOcrConfidenceScore.Record(score, languageTag);
+        }
+
+        if (exactMatches > 0)
+        {
+            GamebookOcrSegmentationMatchQualityTotal.Add(
+                exactMatches,
+                new TagList { { "quality", "exact" } });
+        }
+        if (partialMatches > 0)
+        {
+            GamebookOcrSegmentationMatchQualityTotal.Add(
+                partialMatches,
+                new TagList { { "quality", "partial" } });
+        }
+        if (misses > 0)
+        {
+            GamebookOcrSegmentationMatchQualityTotal.Add(
+                misses,
+                new TagList { { "quality", "miss" } });
+        }
+    }
+
+    /// <summary>
+    /// Records a glossary consistency observation for a completed translation.
+    /// </summary>
+    /// <param name="rate">Consistency rate 0.0-1.0 (translated_matches / total_applicable_terms)</param>
+    /// <param name="campaignIdHash">Anonymized campaign id (first 8 chars of SHA-256)</param>
+    public static void RecordGamebookGlossaryConsistency(double rate, string campaignIdHash)
+    {
+        GamebookGlossaryConsistencyRate.Record(
+            rate,
+            new TagList { { "campaign_id_hash", campaignIdHash } });
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Issue #833 — gamebook translation + OCR + glossary metric exporters.
+/// Verifies the 7 instrument names match the spec (these names are consumed by
+/// Prometheus alert rules and Grafana dashboards) and that record helpers emit
+/// values with the documented label set.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Area", "Observability")]
+[Trait("BoundedContext", "SessionTracking")]
+public class GamebookTranslationMetricsTests
+{
+    private const string ExpectedRequestsName = "meepleai.gamebook.translation_requests_total";
+    private const string ExpectedLatencyName = "meepleai.gamebook.translation_latency_seconds";
+    private const string ExpectedTokenName = "meepleai.gamebook.translation_token_count";
+    private const string ExpectedCostName = "meepleai.gamebook.translation_cost_eur";
+    private const string ExpectedOcrConfidenceName = "meepleai.gamebook.ocr_confidence_score";
+    private const string ExpectedOcrSegMatchName = "meepleai.gamebook.ocr_segmentation_match_quality_total";
+    private const string ExpectedGlossaryName = "meepleai.gamebook.glossary_consistency_rate";
+
+    [Fact]
+    public void AllSevenGamebookInstruments_AreRegistered_WithMeepleAiMeterName()
+    {
+        // Force static field initialisation by referencing each metric.
+        _ = MeepleAiMetrics.GamebookTranslationRequestsTotal;
+        _ = MeepleAiMetrics.GamebookTranslationLatencySeconds;
+        _ = MeepleAiMetrics.GamebookTranslationTokenCount;
+        _ = MeepleAiMetrics.GamebookTranslationCostEur;
+        _ = MeepleAiMetrics.GamebookOcrConfidenceScore;
+        _ = MeepleAiMetrics.GamebookOcrSegmentationMatchQualityTotal;
+        _ = MeepleAiMetrics.GamebookGlossaryConsistencyRate;
+
+        MeepleAiMetrics.GamebookTranslationRequestsTotal.Name.Should().Be(ExpectedRequestsName);
+        MeepleAiMetrics.GamebookTranslationLatencySeconds.Name.Should().Be(ExpectedLatencyName);
+        MeepleAiMetrics.GamebookTranslationTokenCount.Name.Should().Be(ExpectedTokenName);
+        MeepleAiMetrics.GamebookTranslationCostEur.Name.Should().Be(ExpectedCostName);
+        MeepleAiMetrics.GamebookOcrConfidenceScore.Name.Should().Be(ExpectedOcrConfidenceName);
+        MeepleAiMetrics.GamebookOcrSegmentationMatchQualityTotal.Name.Should().Be(ExpectedOcrSegMatchName);
+        MeepleAiMetrics.GamebookGlossaryConsistencyRate.Name.Should().Be(ExpectedGlossaryName);
+
+        MeepleAiMetrics.GamebookTranslationRequestsTotal.Meter.Name.Should().Be(MeepleAiMetrics.MeterName);
+        MeepleAiMetrics.GamebookOcrConfidenceScore.Meter.Name.Should().Be(MeepleAiMetrics.MeterName);
+    }
+
+    [Fact]
+    public void RecordGamebookTranslationRequest_Success_EmitsAllMetricsWithExpectedTags()
+    {
+        var measurements = new MeasurementCapture();
+        using var listener = measurements.StartListening();
+
+        MeepleAiMetrics.RecordGamebookTranslationRequest(
+            status: "success",
+            latencyFullSeconds: 2.5,
+            latencyStreamingSeconds: 0.4,
+            promptTokens: 120,
+            completionTokens: 280,
+            costUsd: 0.10,
+            provider: "openrouter");
+
+        var requestTotal = measurements.FindLast(ExpectedRequestsName);
+        requestTotal.Should().NotBeNull();
+        requestTotal!.Value.Should().Be(1.0);
+        requestTotal.Tags.Should().ContainSingle(t => t.Key == "status" && (string?)t.Value == "success");
+
+        var latencyFull = measurements.FindLast(ExpectedLatencyName, "stage", "full");
+        latencyFull!.Value.Should().Be(2.5);
+
+        var latencyStreaming = measurements.FindLast(ExpectedLatencyName, "stage", "streaming");
+        latencyStreaming!.Value.Should().Be(0.4);
+
+        var prompt = measurements.FindLast(ExpectedTokenName, "kind", "prompt");
+        prompt!.Value.Should().Be(120.0);
+
+        var completion = measurements.FindLast(ExpectedTokenName, "kind", "completion");
+        completion!.Value.Should().Be(280.0);
+
+        var cost = measurements.FindLast(ExpectedCostName);
+        cost.Should().NotBeNull();
+        cost!.Value.Should().BeApproximately(0.10 * MeepleAiMetrics.UsdToEurRate, 0.0001);
+        cost.Tags.Should().ContainSingle(t => t.Key == "provider" && (string?)t.Value == "openrouter");
+    }
+
+    [Fact]
+    public void RecordGamebookTranslationRequest_Failure_SkipsTokenAndCostWhenAbsent()
+    {
+        var measurements = new MeasurementCapture();
+        using var listener = measurements.StartListening();
+
+        MeepleAiMetrics.RecordGamebookTranslationRequest(
+            status: "failure",
+            latencyFullSeconds: 0.3,
+            latencyStreamingSeconds: null,
+            promptTokens: null,
+            completionTokens: null,
+            costUsd: null,
+            provider: "unknown");
+
+        measurements.FindLast(ExpectedRequestsName)!.Tags
+            .Should().ContainSingle(t => t.Key == "status" && (string?)t.Value == "failure");
+        measurements.FindLast(ExpectedLatencyName, "stage", "full")!.Value.Should().Be(0.3);
+        measurements.FindLast(ExpectedLatencyName, "stage", "streaming").Should().BeNull();
+        measurements.FindLast(ExpectedTokenName, "kind", "prompt").Should().BeNull();
+        measurements.FindLast(ExpectedTokenName, "kind", "completion").Should().BeNull();
+        measurements.FindLast(ExpectedCostName).Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordGamebookOcrSegmentation_EmitsConfidenceHistogramAndQualityCounters()
+    {
+        var measurements = new MeasurementCapture();
+        using var listener = measurements.StartListening();
+
+        MeepleAiMetrics.RecordGamebookOcrSegmentation(
+            confidenceScores: new[] { 0.92, 0.88 },
+            language: "ita",
+            exactMatches: 2,
+            partialMatches: 1,
+            misses: 0);
+
+        var confidences = measurements.FindAll(ExpectedOcrConfidenceName);
+        confidences.Should().HaveCount(2);
+        confidences.Should().AllSatisfy(m => m.Tags.Should().ContainSingle(t => t.Key == "language" && (string?)t.Value == "ita"));
+        confidences.Select(m => m.Value).Should().BeEquivalentTo(new[] { 0.92, 0.88 });
+
+        var exact = measurements.FindLast(ExpectedOcrSegMatchName, "quality", "exact");
+        exact!.Value.Should().Be(2.0);
+
+        var partial = measurements.FindLast(ExpectedOcrSegMatchName, "quality", "partial");
+        partial!.Value.Should().Be(1.0);
+
+        measurements.FindLast(ExpectedOcrSegMatchName, "quality", "miss").Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordGamebookGlossaryConsistency_EmitsRateWithCampaignHashLabel()
+    {
+        var measurements = new MeasurementCapture();
+        using var listener = measurements.StartListening();
+
+        MeepleAiMetrics.RecordGamebookGlossaryConsistency(0.75, "ab12cd34");
+
+        var record = measurements.FindLast(ExpectedGlossaryName);
+        record.Should().NotBeNull();
+        record!.Value.Should().Be(0.75);
+        record.Tags.Should().ContainSingle(t => t.Key == "campaign_id_hash" && (string?)t.Value == "ab12cd34");
+    }
+
+    private sealed class MeasurementCapture
+    {
+        private readonly List<Captured> _captured = new();
+
+        public MeterListener StartListening()
+        {
+            var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                        && instrument.Name.StartsWith("meepleai.gamebook.", System.StringComparison.Ordinal))
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+                _captured.Add(new Captured(instrument.Name, value, tags.ToArray())));
+            listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                _captured.Add(new Captured(instrument.Name, value, tags.ToArray())));
+            listener.SetMeasurementEventCallback<int>((instrument, value, tags, _) =>
+                _captured.Add(new Captured(instrument.Name, value, tags.ToArray())));
+
+            listener.Start();
+            return listener;
+        }
+
+        public Captured? FindLast(string name, string? tagKey = null, string? tagValue = null)
+            => _captured.Where(m => m.Name == name
+                                    && (tagKey is null || m.Tags.Any(t => t.Key == tagKey && (string?)t.Value == tagValue)))
+                .LastOrDefault();
+
+        public IReadOnlyList<Captured> FindAll(string name)
+            => _captured.Where(m => m.Name == name).ToList();
+    }
+
+    private sealed record Captured(string Name, double Value, KeyValuePair<string, object?>[] Tags);
+}


### PR DESCRIPTION
## Summary

Closes #833 — adds 7 Prometheus metrics for the libro-game (gamebook) translation + OCR + glossary pipeline. Spec-panel hardened 2026-05-18: scope reduced from 1-2 days → 4 h after infrastructure audit revealed circuit-breaker already wired via `HybridLlmService` → `CircuitBreakerRegistry`.

## What changed

### New: `MeepleAiMetrics.GamebookTranslation.cs`

Partial class exporting 7 instruments under the `meepleai.gamebook.*` prefix:

| Instrument | Type | Labels | Source handler |
|---|---|---|---|
| `meepleai.gamebook.translation_requests_total` | Counter | `status` (success/failure/cancelled) | TranslateGamebookSegmentQueryHandler |
| `meepleai.gamebook.translation_latency_seconds` | Histogram | `stage` (full/streaming) | Same |
| `meepleai.gamebook.translation_token_count` | Histogram | `kind` (prompt/completion) | Same |
| `meepleai.gamebook.translation_cost_eur` | Counter | `provider` | Same (currently skipped — see Out of scope) |
| `meepleai.gamebook.ocr_confidence_score` | Histogram | `language` | SegmentGamebookPhotoCommandHandler |
| `meepleai.gamebook.ocr_segmentation_match_quality_total` | Counter | `quality` (exact/partial/miss) | Same |
| `meepleai.gamebook.glossary_consistency_rate` | Histogram | `campaign_id_hash` | TranslateGamebookSegmentQueryHandler |

Plus 3 record helpers (`RecordGamebookTranslationRequest`, `RecordGamebookOcrSegmentation`, `RecordGamebookGlossaryConsistency`) that centralise the tag-shape contract and skip null fields cleanly.

### Updated: `TranslateGamebookSegmentQueryHandler`

Wrapped the existing async-streaming logic in a `try/finally` block. C# 8's `yield return` forbids `catch` in the surrounding block (CS1626), so the pattern is:
- Pessimistic default `status = "failure"`
- Set `"success"` only after the terminal `yield return ... IsComplete: true`
- `finally` block detects cooperative cancellation via `cancellationToken.IsCancellationRequested` and downgrades to `"cancelled"`
- Always emits 4 translation metrics + glossary consistency rate on exit

Campaign id is hashed via `SHA-256` (first 8 hex chars) to keep Prometheus cardinality bounded for the glossary label.

### Updated: `SegmentGamebookPhotoCommandHandler`

Wires 2 OCR metrics into both the success and failure paths:
- Confidence: normalises Tesseract 0..100 → 0..1 for histogram bucket compatibility
- Segmentation quality: emits "exact" if any paragraphs extracted, "miss" otherwise. "partial" deferred until a fuzzy-segmentation scorer exists.

### New tests: `GamebookTranslationMetricsTests`

5 unit tests (5/5 pass locally) using `MeterListener` to capture emissions:
1. All 7 instruments registered under `MeepleAI.Api` meter with expected names
2. Success path emits requests + latency (full+streaming) + tokens (prompt+completion) + cost (USD×0.92 = EUR)
3. Failure path skips token/cost when absent, still emits requests + latency
4. OCR segmentation records confidence histogram + per-quality counters; "miss" with zero count not emitted
5. Glossary consistency rate captured with `campaign_id_hash` label

Pattern mirrors `AutoSaveHealthGaugeTests` (PR #327).

## Spec-panel discoveries (Pattern P26 — spec decay verify)

| Component | Original spec | Reality | Action |
|---|---|---|---|
| `LlmCircuitBreakerPolicy.cs` | Build new | Already exists via `CircuitBreakerRegistry` + `HybridLlmService` (Issue #5487) | Reuse, document |
| `llm_circuit_breaker_state` metric | Build new | Already exported by `MeepleAiMetrics.LlmOperational` (Issue #5480) | Reuse, no new metric |
| Polly nuget | Install | Already in `Program.cs:49-50` | Skip |
| TranslateGamebookSegmentQueryHandler call site | Need to create | Already uses `_llm.GenerateCompletionStreamAsync` → HybridLlmService → CircuitBreakerRegistry | Wire metrics only |

Scope reduction: 1-2 days → 4 h.

## Out of scope (deferred — see issue body)

- **`LlmBulkheadPolicy` + `llm_bulkhead_queue_depth` gauge**: defer to follow-up after 14-day post-launch traffic baseline. Sizing (5 concurrent + 10 queue) needs empirical data to avoid over-restricting legitimate retry patterns. Follow-up issue to be filed at merge time.
- **Per-request cost in EUR**: `LlmUsage` record carries only `(PromptTokens, CompletionTokens, TotalTokens)` — no `CostUsd` or `Provider` field. Helper accepts `null` and skips emission cleanly. Follow-up will derive cost from token counts × provider pricing.
- **"partial" OCR match quality**: requires a fuzzy-segmentation scorer not yet in scope. v1 emits only `exact` / `miss`.

## AC checklist

- [x] AC-1 — `MeepleAiMetrics.GamebookTranslation.cs` partial class exports 7 new metrics with correct units + labels
- [x] AC-2 — `TranslateGamebookSegmentQueryHandler` records request status, latency (full+streaming), token count (prompt+completion), glossary consistency
- [x] AC-3 — `SegmentGamebookPhotoCommandHandler` records OCR confidence + segmentation match quality on both success and failure paths
- [x] AC-4 — Unit test: `RecordGamebookTranslationRequest` emits counter increment with expected tags (success/failure scenarios)
- [x] AC-5 — Unit test: `RecordGamebookOcrSegmentation` records confidence histogram bucket + quality counters
- [ ] AC-6 — Integration test for `/metrics` endpoint coverage of new names (deferred to manual smoke; unit tests verify emission via MeterListener)
- [ ] AC-7 — Manual smoke on staging (post-merge): complete a gamebook translation, verify 7 metrics scraped by Prometheus within 30 s
- [x] AC-8 — No regression on existing `chat-stream` LLM path: `MeepleAiMetrics.LlmOperational` callbacks unchanged
- [ ] AC-9 — Bulkhead deferral follow-up issue (file at merge time)

## Test plan

- [x] `dotnet build apps/api/src/Api` → 0 errors, 0 warnings
- [x] `dotnet test --filter "FullyQualifiedName~GamebookTranslationMetricsTests"` → 5/5 pass
- [x] `dotnet test --filter "FullyQualifiedName~TranslateGamebookSegmentQueryHandler|FullyQualifiedName~SegmentGamebookPhotoCommandHandler"` → existing tests unchanged
- [x] Pre-push hook frontend build → success (Next.js 14.8 s, 158 static pages)
- [ ] CI: backend unit, integration, CodeQL, security scans pass
- [ ] Post-merge: workflow_dispatch on staging, hit gamebook translation endpoint, scrape `/metrics`, confirm 7 names present

## Refs

- Closes #833
- Audit: PR #831 gaps R1+R2+R3
- Spec design §6.4 `2026-05-07-libro-game-nanolith-demo-design.md`
- Existing pattern: `MeepleAiMetrics.LlmOperational.cs` (Issue #5480 / #985)
- Existing pattern: `CircuitBreakerRegistry.cs` (Issue #5487 / #5498 / #5086)
- Test pattern: `AutoSaveHealthGaugeTests.cs` (PR #327)
- Sibling: #834 EXIF GPS stripper (gamebook follow-up #2) — shipped PR #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
