### PR TITLE
test(conformity): add player-detail RUNBOOKS entry (refs #1269)

### DIFF
--- a/apps/web/e2e/visual-conformity/conformity.spec.ts
+++ b/apps/web/e2e/visual-conformity/conformity.spec.ts
@@ -65,6 +65,16 @@ const RUNBOOKS: Record<string, RouteRunbook> = {
     search: '?state=default',
     readySelector: 'main',
   },
+  // Stage 3 cluster #1113 — `PlayerDetailView` short-circuits to the
+  // `Sara Rossi` fixture when `IS_VISUAL_TEST_BUILD` is enabled. No URL
+  // override needed; the hero + stats grid render synchronously from the
+  // fixture so we wait on both data-slots before screenshot (matches the
+  // pattern in `visual-migrated/sp4-player-detail.spec.ts`).
+  // Refs: #1269 (this fix), #683 (route migration), #1113 (cluster).
+  'player-detail': {
+    readySelector: '[data-slot="player-detail-view"]',
+    contentSelector: '[data-slot="player-detail-stats-grid"]',
+  },
 };
 
 async function waitForRouteReady(page: Page, runbook: RouteRunbook): Promise<void> {


### PR DESCRIPTION
## Summary

Adds the missing `RUNBOOKS` entry for the `player-detail` route in `apps/web/e2e/visual-conformity/conformity.spec.ts`. Without it, the conformity gate throws `No runbook for route id "player-detail"` and never performs the visual diff. With this entry the test runs and exercises the existing baseline at `apps/web/e2e/visual-conformity/__mockup__/player-detail.{desktop,mobile}.png`.

Fixes **1 of 4** routes currently flagged in conformity-debt `#1269`.

## What was missing

`apps/web/e2e/visual-conformity/mockup-ownership.bootstrap.json` already maps the `player-detail` route (`/players/{playerId}`, fixture `playerId=sara-rossi`) and the baselines were generated by `bootstrap-mockup-baselines.yml`, but `conformity.spec.ts` only had RUNBOOKS for `library` and `library-game-detail`. Any unmapped route id triggers a hard throw by design (`conformity.spec.ts:113-118`).

## Why no URL override needed

`PlayerDetailView` short-circuits to the **Sara Rossi fixture** when `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` is set at build time (the conformity workflow does this — `visual-regression-conformity.yml:94`). Same pattern as `apps/web/e2e/visual-migrated/sp4-player-detail.spec.ts`. Waiting on `[data-slot="player-detail-view"]` + `[data-slot="player-detail-stats-grid"]` is sufficient for a stable `fullPage` capture.

## Remaining work for #1269 (sub-issue to be filed)

3 of 4 routes still fail — these are out of scope for this minimal fix:

- **`game-nights-index`** — also missing from RUNBOOKS, but has no `IS_VISUAL_TEST_BUILD` fixture. Requires either Phase 3b API-mock support in the runbook interface (commented as TODO in `conformity.spec.ts:11-17`) or a new fixture for `/game-nights` (Wave 3 #1170).
- **`/library`** + **`/library/{gameId}`** — architectural mockup-vs-route mismatch: `sp4-library-desktop.html` is a multi-screen design catalog (~9669px desktop, includes mobile tour + 5 desktop states stacked). The live route renders a single screen (~1752px). Conformity diff is structurally impossible without restructuring either the mockup HTML or the baseline generation (e.g. `screenshotSelector` to crop). Needs design coordination.

## Test plan

- [ ] CI: `Visual Regression — Mockup Conformity` runs the player-detail assertion (no longer thrown by missing-runbook guard)
- [ ] If the live route already matches the canonical mockup baseline, the gate goes green for that one route. If a residual visual diff exists, it surfaces in the `conformity-diffs-*` artifact and tells us whether `player-detail` also has implementation drift (currently masked by the throw)
- [ ] `pnpm typecheck` ✅ already passed local pre-commit
- [ ] Other 3 routes: still in the conformity-debt waiver list of `#1269`. Will land separately

Refs: `#1269`, `#683`, `#1113`, `#1066` (parent umbrella)