### PR TITLE
chore(ci): #850 PR1 — concurrency on notify-slack + paths-ignore on security-pentest

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -85,6 +85,16 @@ permissions:
   actions: read
   contents: read
 
+# Issue #850 AC-1: explicit concurrency block for AC compliance.
+# This is a reusable workflow (`workflow_call:`) — `github.run_id` keeps each
+# caller invocation in its own group so simultaneous notifications from
+# different parent workflows do NOT serialize. `cancel-in-progress: false`
+# is mandatory: cancelling a Slack notification mid-flight would lose
+# observability signal (failed deploy alert dropped, etc.).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   send:
     name: Send Slack Notification

--- a/.github/workflows/security-pentest.yml
+++ b/.github/workflows/security-pentest.yml
@@ -8,6 +8,16 @@ on:
     # See companion change in api-smoke.yml + #979 release-PR triage.
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
+    # Issue #850 AC-2: pentest hits real API endpoints — docs-only PRs cannot
+    # change pentest signal. Skip to save ~10-15 min per docs PR to main.
+    # Weekly cron still covers all changes regardless of trigger filter.
+    # Not in main-dev branch protection required-checks (verified 2026-05-18).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   workflow_dispatch:
   # Run weekly on Sundays at 3 AM UTC
   schedule:


### PR DESCRIPTION
## Summary

PR 1 of 3 for issue #850 (DevOps CI cost optimization, parent epic #842 P1).

Scope: AC-1 (concurrency) + AC-2 (paths-ignore) — minimal residual gap-closure.

## Repository audit 2026-05-18 vs spec snapshot 2026-05-13

| Metric | 2026-05-13 (spec) | 2026-05-18 (today) | Delta |
|--------|------:|------:|:-----:|
| Total workflow files | 44 | 53 | +9 |
| With `concurrency:` | 27 (61%) | **52 (98%)** | +25 ✅ |
| Missing `concurrency:` | 17 | **1** | −16 ✅ |
| With `paths-ignore:` | 0 | **4** | +4 ✅ |
| With `paths:` whitelist (equivalent) | n/a | 20+ | — |

Most of AC-1/AC-2 landed via interim PRs since the spec snapshot. This PR closes the residual gap:

## Changes

### 1. `notify-slack.yml` — concurrency added (AC-1)

This is a **reusable workflow** (`workflow_call:`). Naive `group: ${{ github.workflow }}-${{ github.ref }}` would serialize notifications from multiple parent workflows on the same branch — undesired (alerts get queued). Using `github.run_id` keeps each invocation isolated.

\`\`\`yaml
concurrency:
  group: \${{ github.workflow }}-\${{ github.run_id }}
  cancel-in-progress: false
\`\`\`

`cancel-in-progress: false` is **mandatory**: cancelling a Slack notification mid-flight would drop observability signal (e.g., failed-deploy alert silently lost).

### 2. `security-pentest.yml` — paths-ignore added (AC-2)

Pentest hits real API endpoints. Docs-only PRs cannot change pentest signal, so skipping saves ~10–15 min per docs-only prod-promotion PR. Weekly cron unaffected (still covers everything).

\`\`\`yaml
paths-ignore:
  - '**.md'
  - 'docs/**'
  - 'LICENSE'
  - '.gitignore'
  - '.editorconfig'
\`\`\`

**Branch protection check** (`gh api repos/.../branches/main/protection`): `security-pentest` is NOT in required-checks list. Safe to apply paths-ignore. Verified for `main`, `main-staging`, `main-dev`.

## Branch-aware cancel-in-progress audit

Per spec policy: `cancel-in-progress: true` is NOT safe on deploys/rollbacks/release/migrate-db.

| Workflow | cancel-in-progress | Type | Safe? |
|----------|:------------------:|------|:-----:|
| `deploy-staging.yml` | false | deploy | ✅ |
| `rollback.yml` | false | rollback | ✅ |
| `dev-auto-revert.yml` | false | auto-revert | ✅ |
| `prod.yml` | true | **PR gate** (not deploy) | ✅ |
| `staging.yml` | true | **PR gate** (not deploy) | ✅ |
| `notify-slack.yml` (this PR) | false | observability | ✅ |

`prod.yml` and `staging.yml` have `cancel-in-progress: true` but they are gate workflows (PR validation), not deployment workflows — the actual deploy lives in `deploy-staging.yml`. So the flag is safe.

## Out of scope (next PRs)

- **PR 2** — Cache key tightening + `vars.CACHE_VERSION` override knob (AC-3, AC-7)
- **PR 3** — Per-job `dorny/paths-filter` skip (AC-4)
- AC-5 (≥30% reduction) requires 14-day post-merge digest comparison (acknowledged in #850).

## Test plan

- [x] YAML syntax valid: `python -c "import yaml; yaml.safe_load(open(f, encoding='utf-8'))"` ✅
- [x] No unpinned third-party actions introduced (validate-workflows.yml passes)
- [x] Branch protection required-checks verified for all 3 protected branches
- [x] No deploy workflow modified
- [ ] CI green on this PR (lint/typecheck/unit — fast path, expected <3 min)
- [ ] Manual smoke: trigger a docs-only PR to main and verify `Security Penetration Tests` skipped

## Refs

- Closes part of #850 (issue stays OPEN until PR2/PR3 + Day-14 digest validation)
- Parent epic: #842 (DevOps Multi-Branch Strategy — last sub-issue open)
- ADR-054 (Multi-Branch Strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)