### PR TITLE
chore(ci): #850 PR2 — cache key fingerprints + vars.CACHE_VERSION knob

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -60,12 +60,16 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Cache NuGet packages
+        # Issue #850 AC-3: tight key fingerprint includes Directory.Packages.props
+        # and global.json so SDK/centralized-package changes also invalidate.
+        # AC-7: `vars.CACHE_VERSION` is the global emergency-invalidation knob:
+        # `gh variable set CACHE_VERSION --body v2` flushes all caches at once.
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: nuget-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-nuget-
+            nuget-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Restore Dependencies
         working-directory: apps/api

--- a/.github/workflows/e2e-library-to-game.yml
+++ b/.github/workflows/e2e-library-to-game.yml
@@ -55,12 +55,16 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm store
+        # Issue #850 AC-3: include `.npmrc` in hash so registry/config changes
+        # also invalidate. AC-7: `vars.CACHE_VERSION` is the global
+        # emergency-invalidation knob: `gh variable set CACHE_VERSION --body v2`
+        # flushes all caches at once.
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: pnpm-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '.npmrc') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            pnpm-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-
 
       - name: Install dependencies
         working-directory: apps/web

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -178,12 +178,16 @@ jobs:
           working-directory: apps/web
 
       - name: Cache Playwright Browsers
+        # Issue #850 AC-3: hash `apps/web/package.json` (NOT lock-file) so
+        # Playwright version bumps invalidate cache even before lock regen.
+        # AC-7: `vars.CACHE_VERSION` is the global emergency-invalidation knob:
+        # `gh variable set CACHE_VERSION --body v2` flushes all caches at once.
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('apps/web/pnpm-lock.yaml') }}
+          key: playwright-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/web/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-playwright-
+            playwright-${{ vars.CACHE_VERSION || 'v1' }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install Playwright Browsers
         working-directory: apps/web


### PR DESCRIPTION
## Summary

PR 2 of 3 for issue #850 (DevOps CI cost optimization, parent epic #842 P1).

Scope: AC-3 (tight cache key fingerprints) + AC-7 (`vars.CACHE_VERSION` emergency-invalidation knob).

## Cache key formula

Updates the 3 existing `actions/cache@` usages to match the AC-3 spec formula:

| Cache | Workflow | New key |
|-------|----------|---------|
| **NuGet** | `backend-e2e-tests.yml:63` | `nuget-${{ vars.CACHE_VERSION \|\| 'v1' }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', 'global.json') }}` |
| **pnpm**  | `e2e-library-to-game.yml:58` | `pnpm-${{ vars.CACHE_VERSION \|\| 'v1' }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '.npmrc') }}` |
| **Playwright** | `test-e2e.yml:181` | `playwright-${{ vars.CACHE_VERSION \|\| 'v1' }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('apps/web/package.json') }}` |

## Why each hash widened

- **NuGet**: added `Directory.Packages.props` (central package management) + `global.json` (SDK version) so backend tooling/SDK changes invalidate cache
- **pnpm**: added `.npmrc` so registry/auth config changes invalidate cache
- **Playwright**: switched from `pnpm-lock.yaml` to `apps/web/package.json` so Playwright version bumps invalidate BEFORE lock-file regen (catches pre-resolution edits)

## Emergency invalidation (AC-7)

Operator can flush **all** caches with a single command:

\`\`\`bash
gh variable set CACHE_VERSION --body v2
\`\`\`

The `\${{ vars.CACHE_VERSION || 'v1' }}` fallback means: without the repo variable set, all keys use `'v1'` (no behavior change at merge). Setting it to any other value rotates the cache namespace globally — flushing NuGet + pnpm + Playwright simultaneously.

## Restore-keys also rotated

Each cache's `restore-keys:` line was updated coherently with the same prefix + CACHE_VERSION fragment. Without this, restore-keys would fall back to stale entries from the old key namespace (the very issue AC-7 wants to avoid).

## Out of scope (deferred)

| Change | Reason |
|--------|--------|
| Add NuGet cache to `dev-fast.yml` / `dev-async.yml` | Scope creep (no cache today, separate enhancement) |
| Migrate `setup-node@v6 cache: pnpm` built-ins to `actions/cache@` | Built-in cache doesn't support CACHE_VERSION custom keys; would require larger refactor |
| `test-performance.yml` Next.js cache | Not in AC-3 target list |
| `docs-linkcheck.yml` lychee cache | Not in AC-3 target list |

## Spec-panel checks

| Expert | Concern | Resolution |
|--------|---------|------------|
| **Hightower** | Single-knob ops | ✅ `vars.CACHE_VERSION` global override |
| **Nygard** | One-time cache-MISS at merge | ✅ `restore-keys:` provides degraded fallback; documented |
| **Wiegers** | Playwright key choice | ✅ `package.json` over lock for pre-resolution sensitivity |
| **Crispin** | AC-7 testability | ✅ First post-merge run will MISS, second HIT — observable in `ci-minutes-digest` |
| **Fowler** | Restore-keys coherence | ✅ Rotated together with primary key |

## Test plan

- [x] YAML syntax valid (`python yaml.safe_load` on 3 files)
- [x] Pinning policy unchanged (no new third-party action `uses:`)
- [x] Restore-keys patterns match new primary keys
- [ ] CI green on this PR (lint/typecheck/unit — fast path)
- [ ] Manual smoke (post-merge): first run cache-MISS on new key (one-time penalty), second run cache-HIT (validates AC-7 mechanism)
- [ ] AC-3 validation: `ci-minutes-digest` Day-7 will show cache hit rate ≥70%

## Stacking

- **PR1** ([#1285](https://github.com/meepleAi-app/meepleai-monorepo/pull/1285)): concurrency + paths-ignore (AC-1, AC-2). Zero file overlap with this PR — both can merge independently in any order.
- **PR2** (this PR): cache keys + CACHE_VERSION (AC-3, AC-7)
- **PR3** (next): per-job `paths-filter` skip (AC-4)

## Refs

- Parent issue: #850 (stays OPEN until Day-14 digest comparison)
- Parent epic: #842 (last sub-issue open)
- ADR-054 (Multi-Branch Strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)