### PR TITLE
feat(kb): #747 PR-A — paragraph_numbers schema + repo lookup for G4

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PhotoBatchPage.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PhotoBatchPage.cs
@@ -37,6 +37,14 @@ public sealed class PhotoBatchPage : Entity<Guid>
     /// <summary>Gets the raw text extracted from this page, if available.</summary>
     public string? ExtractedText { get; private set; }
 
+    /// <summary>
+    /// Gets the narrative paragraph numbers detected on this page.
+    /// Issue #747: enables paragraph-number lookup distinct from physical page index.
+    /// Empty array when the OCR pipeline hasn't extracted paragraph IDs yet — preserves
+    /// legacy upload behavior and makes the field non-breaking for existing rows.
+    /// </summary>
+    public int[] ParagraphNumbers { get; private set; } = [];
+
     /// <summary>Gets the UTC timestamp when this page was indexed.</summary>
     public DateTime IndexedAt { get; private set; }
 
@@ -46,6 +54,8 @@ public sealed class PhotoBatchPage : Entity<Guid>
 
     /// <summary>
     /// Creates a new <see cref="PhotoBatchPage"/> after OCR processing.
+    /// Issue #747: <paramref name="paragraphNumbers"/> is optional to preserve callers
+    /// that don't (yet) extract narrative paragraph IDs.
     /// </summary>
     public static PhotoBatchPage Create(
         Guid batchId,
@@ -55,7 +65,8 @@ public sealed class PhotoBatchPage : Entity<Guid>
         PageOrientation orientation,
         bool isBlank,
         string[] warnings,
-        string? extractedText)
+        string? extractedText,
+        int[]? paragraphNumbers = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(blobKey);
 
@@ -71,6 +82,7 @@ public sealed class PhotoBatchPage : Entity<Guid>
             IsBlank = isBlank,
             Warnings = warnings ?? [],
             ExtractedText = extractedText,
+            ParagraphNumbers = paragraphNumbers ?? [],
             IndexedAt = DateTime.UtcNow
         };
     }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPhotoBatchUploadRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPhotoBatchUploadRepository.cs
@@ -28,6 +28,23 @@ internal interface IPhotoBatchUploadRepository : IRepository<PhotoBatchUpload, G
     Task<string?> GetPageTextAsync(Guid uploadId, int pageNumber, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns the extracted text of the first page in a batch whose
+    /// <c>paragraph_numbers</c> array contains <paramref name="paragraphNumber"/>,
+    /// or <c>null</c> when no page matches.
+    /// Issue #747: paragraph-number lookup distinct from physical page index.
+    /// </summary>
+    /// <remarks>
+    /// Several physical pages can carry the same narrative paragraph number when the
+    /// pipeline cannot disambiguate; the first page (ordered by <c>page_number</c>) is
+    /// returned to keep behavior deterministic. Callers needing every match should issue
+    /// a dedicated query.
+    /// </remarks>
+    Task<string?> GetPageTextByParagraphNumberAsync(
+        Guid uploadId,
+        int paragraphNumber,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Returns <c>true</c> when the batch exists AND belongs to the specified user.
     /// Used for ownership-based authorization before fetching page text.
     /// Libro Game AI Assistant MVP Phase 3 — G4: GetParagraphQuery.

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PhotoBatchUploadRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PhotoBatchUploadRepository.cs
@@ -100,6 +100,25 @@ internal sealed class PhotoBatchUploadRepository : RepositoryBase, IPhotoBatchUp
     }
 
     /// <inheritdoc/>
+    public async Task<string?> GetPageTextByParagraphNumberAsync(
+        Guid uploadId,
+        int paragraphNumber,
+        CancellationToken ct = default)
+    {
+        // Npgsql translates Array.Contains to PostgreSQL `paragraphNumber = ANY(paragraph_numbers)`,
+        // which uses the GIN index defined in PhotoBatchPageEntityConfiguration when the array
+        // operator is `@>` and falls back to a seq-scan otherwise. EF Core's `Contains` keeps the
+        // query LINQ-translatable across providers (in-memory test uses the same predicate).
+        return await DbContext.PhotoBatchPages
+            .AsNoTracking()
+            .Where(p => p.PhotoBatchUploadId == uploadId && p.ParagraphNumbers.Contains(paragraphNumber))
+            .OrderBy(p => p.PageNumber)
+            .Select(p => p.ExtractedText)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> BelongsToUserAsync(Guid uploadId, Guid userId, CancellationToken ct = default)
     {
         return await DbContext.PhotoBatchUploads

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PhotoBatchUploadEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PhotoBatchUploadEntityConfiguration.cs
@@ -182,6 +182,14 @@ internal sealed class PhotoBatchPageEntityConfiguration
             .HasColumnType("text")
             .IsRequired(false);
 
+        // Issue #747: narrative paragraph numbers stored as PostgreSQL native integer array.
+        // Default '{}' on the migration keeps backfill non-breaking for existing rows.
+        builder.Property(p => p.ParagraphNumbers)
+            .HasColumnName("paragraph_numbers")
+            .HasColumnType("integer[]")
+            .HasDefaultValueSql("'{}'::integer[]")
+            .IsRequired();
+
         builder.Property(p => p.IndexedAt)
             .HasColumnName("indexed_at")
             .IsRequired();
@@ -193,5 +201,12 @@ internal sealed class PhotoBatchPageEntityConfiguration
         builder.HasIndex(p => new { p.PhotoBatchUploadId, p.PageNumber })
             .IsUnique()
             .HasDatabaseName("uq_photo_batch_pages_batch_page");
+
+        // Issue #747: GIN index on paragraph_numbers supports `@> ARRAY[N]` containment
+        // queries used by GetByParagraphNumberAsync. Postgres-only; gracefully ignored
+        // by other providers via EF Core's HasMethod.
+        builder.HasIndex(p => p.ParagraphNumbers)
+            .HasDatabaseName("ix_photo_batch_pages_paragraph_numbers_gin")
+            .HasMethod("gin");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747")]
+    partial class AddParagraphNumbersToPhotoBatchPages_Issue747
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddParagraphNumbersToPhotoBatchPages_Issue747 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int[]>(
+                name: "paragraph_numbers",
+                table: "photo_batch_pages",
+                type: "integer[]",
+                nullable: false,
+                defaultValueSql: "'{}'::integer[]");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_photo_batch_pages_paragraph_numbers_gin",
+                table: "photo_batch_pages",
+                column: "paragraph_numbers")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_photo_batch_pages_paragraph_numbers_gin",
+                table: "photo_batch_pages");
+
+            migrationBuilder.DropColumn(
+                name: "paragraph_numbers",
+                table: "photo_batch_pages");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PhotoBatchUploadRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PhotoBatchUploadRepositoryIntegrationTests.cs
@@ -1,0 +1,192 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+
+/// <summary>
+/// Integration tests for <see cref="PhotoBatchUploadRepository"/> against a real PostgreSQL
+/// database via Testcontainers. Validates the new <c>GetPageTextByParagraphNumberAsync</c>
+/// query path introduced by issue #747 — paragraph-number lookup distinct from physical
+/// page index.
+/// </summary>
+/// <remarks>
+/// Postgres-backed because the lookup relies on the native <c>integer[]</c> column type and
+/// the <c>paragraph_numbers @> ARRAY[N]</c> / <c>= ANY(paragraph_numbers)</c> translation —
+/// neither is faithfully reproducible by EF Core InMemory, which silently returns the wrong
+/// result for array containment checks.
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PhotoBatchUploadRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private PhotoBatchUploadRepository _repository = null!;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private Guid _userId;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public PhotoBatchUploadRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_photobatch_repo_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Token);
+
+        _userId = Guid.NewGuid();
+
+        var mockCollector = new Mock<IDomainEventCollector>();
+        mockCollector
+            .Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+
+        _repository = new PhotoBatchUploadRepository(_dbContext, mockCollector.Object);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetPageTextByParagraphNumberAsync — issue #747 PR-A
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_MatchingPage_ReturnsExtractedText()
+    {
+        // Arrange — single batch with one page tagged with paragraph 42.
+        var batchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 3, Text: "Il pedone si sposta di una casella.", ParagraphNumbers: new[] { 42 }));
+
+        // Act
+        var text = await _repository.GetPageTextByParagraphNumberAsync(batchId, 42, Token);
+
+        // Assert
+        text.Should().Be("Il pedone si sposta di una casella.");
+    }
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_NoMatch_ReturnsNull()
+    {
+        // Arrange — page exists but carries different paragraph numbers.
+        var batchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 1, Text: "Pagina 1", ParagraphNumbers: new[] { 10, 11 }));
+
+        // Act
+        var text = await _repository.GetPageTextByParagraphNumberAsync(batchId, 42, Token);
+
+        // Assert
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_DifferentBatch_ReturnsNull()
+    {
+        // Arrange — paragraph 42 lives in OTHER_BATCH, not in the queried batch.
+        await SeedBatchWithPagesAsync(
+            (PageNumber: 1, Text: "Wrong batch text", ParagraphNumbers: new[] { 42 }));
+
+        var queriedBatchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 1, Text: "Queried batch text", ParagraphNumbers: new[] { 7 }));
+
+        // Act
+        var text = await _repository.GetPageTextByParagraphNumberAsync(queriedBatchId, 42, Token);
+
+        // Assert — repository must filter by PhotoBatchUploadId.
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_MultiplePagesWithSameParagraph_ReturnsFirstByPageNumber()
+    {
+        // Arrange — paragraph 7 appears on physical pages 5 AND 2; expect page 2's text.
+        // Insertion order intentionally reversed to prove the ORDER BY is applied at query
+        // time, not at insertion time.
+        var batchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 5, Text: "Pagina 5 contiene paragrafo 7 (duplicato)", ParagraphNumbers: new[] { 7 }),
+            (PageNumber: 2, Text: "Pagina 2 con paragrafo 7", ParagraphNumbers: new[] { 7 }));
+
+        // Act
+        var text = await _repository.GetPageTextByParagraphNumberAsync(batchId, 7, Token);
+
+        // Assert
+        text.Should().Be("Pagina 2 con paragrafo 7");
+    }
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_EmptyParagraphsArray_ReturnsNull()
+    {
+        // Arrange — legacy upload without paragraph extraction. paragraph_numbers = '{}'.
+        var batchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 1, Text: "Legacy page (no paragraphs)", ParagraphNumbers: Array.Empty<int>()));
+
+        // Act
+        var text = await _repository.GetPageTextByParagraphNumberAsync(batchId, 42, Token);
+
+        // Assert
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPageTextByParagraphNumber_PageWithMultipleParagraphs_MatchesAnyOfThem()
+    {
+        // Arrange — one page carries paragraphs 10, 11, 12 (spread covers 3 paragraphs).
+        var batchId = await SeedBatchWithPagesAsync(
+            (PageNumber: 4, Text: "Spread con paragrafi 10-12", ParagraphNumbers: new[] { 10, 11, 12 }));
+
+        // Act + Assert — every paragraph number in the array must return the page text.
+        (await _repository.GetPageTextByParagraphNumberAsync(batchId, 10, Token)).Should().Be("Spread con paragrafi 10-12");
+        (await _repository.GetPageTextByParagraphNumberAsync(batchId, 11, Token)).Should().Be("Spread con paragrafi 10-12");
+        (await _repository.GetPageTextByParagraphNumberAsync(batchId, 12, Token)).Should().Be("Spread con paragrafi 10-12");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private async Task<Guid> SeedBatchWithPagesAsync(
+        params (int PageNumber, string Text, int[] ParagraphNumbers)[] pages)
+    {
+        var batch = PhotoBatchUpload.Create(_userId, Guid.NewGuid(), "it", pages.Length);
+        _dbContext.PhotoBatchUploads.Add(batch);
+
+        foreach (var (pageNumber, text, paragraphNumbers) in pages)
+        {
+            var page = PhotoBatchPage.Create(
+                batchId: batch.Id,
+                pageNumber: pageNumber,
+                blobKey: $"blob://test/{batch.Id}/page-{pageNumber}",
+                confidence: 0.95,
+                orientation: PageOrientation.Portrait,
+                isBlank: false,
+                warnings: Array.Empty<string>(),
+                extractedText: text,
+                paragraphNumbers: paragraphNumbers);
+            _dbContext.PhotoBatchPages.Add(page);
+        }
+
+        await _dbContext.SaveChangesAsync(Token);
+        _dbContext.ChangeTracker.Clear();
+        return batch.Id;
+    }
+}


### PR DESCRIPTION
## Summary

Phase A of #747 (`[G4 enhancement] paragraph-number lookup`). Adds the enabling primitive — schema column, GIN index, entity property, and repository seam — so the discriminated-union query refactor (PR-B) and OCR extraction pipeline (PR-C) can land on a stable foundation.

## Why decompose

Spec estimate is **3–5 days backend**. PR-A keeps the surface ≤ 200 lines of production code so the repo seam can be reviewed and merged independently from:
- **PR-B** (query refactor + handler dispatch on `ParagraphLookupKey`)
- **PR-C** (OCR regex extraction + ≥ 80% accuracy AC on 3 gamebook test set)

## Deliverables

| # | Change | Spec ref |
|---|---|---|
| 1 | Migration `20260519054522_AddParagraphNumbersToPhotoBatchPages_Issue747` — additive `integer[]` column + GIN index | Scope §1 |
| 2 | `PhotoBatchPage.ParagraphNumbers` property + optional `paragraphNumbers` parameter on `Create(...)` factory | Scope §3 |
| 3 | `IPhotoBatchUploadRepository.GetPageTextByParagraphNumberAsync(uploadId, paragraphNumber, ct)` returning `string?` | Scope §4 |
| 4 | 6 Testcontainers integration tests covering match / no-match / cross-batch / multi-page tie-break / empty-array / multi-paragraph page | (test strategy) |

## What's NOT in this PR

- ❌ `GetParagraphQuery` discriminated union refactor → PR-B
- ❌ OCR extraction (regex / smoldocling) → PR-C
- ❌ Backfill job for existing rows → out of issue scope (legacy rows stay with empty array, semantic fallback covers them)
- ❌ Frontend `useGetParagraph` signature → separate issue per issue body

## Trade-offs

- **Determinism on duplicate paragraphs**: when more than one page carries the same paragraph number (OCR ambiguity), the repository returns the **lowest `page_number`** match — caller-facing test `MultiplePagesWithSameParagraph_ReturnsFirstByPageNumber` pins this. An aggregator method returning all matches is a follow-up if PR-B needs it.
- **EF Core InMemory deliberately excluded**: it silently returns the wrong result for `paragraph_numbers @> ARRAY[N]`. Postgres-backed integration tests are the only faithful surface.
- **Non-breaking factory**: `Create(...)` adds `paragraphNumbers` as an optional final parameter, so existing call sites (e.g. `PhotoBatchProcessor`) compile untouched and keep emitting empty arrays until PR-C lands.

## Test plan

- [x] `dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj` → 0 errors
- [ ] Migration UP applies cleanly on fresh Testcontainers Postgres (covered by `PhotoBatchUploadRepositoryIntegrationTests` setup)
- [ ] Migration DOWN drops index + column idempotently
- [ ] 6 integration tests green on CI
- [ ] CI full suite green (CodeQL, security scan, backend fast, backend async)

## Refs

- Issue #747 — parent
- G4 source: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetParagraphQuery.cs`
- Demo workaround it replaces: `apps/web/src/lib/gamebook/hooks/useTranslateParagraph.ts` (demo-only, not committed)
- Vision doc: `docs/superpowers/specs/2026-05-04-libro-game-assistant-vision.md` §6 MVP scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)