### PR TITLE
feat(game-nights): #950 W2 Foundation — reducer + validators + fixture + i18n + hooks

### DIFF
--- a/apps/web/src/lib/api/clients/authClient.ts
+++ b/apps/web/src/lib/api/clients/authClient.ts
@@ -211,14 +211,16 @@ export function createAuthClient({ httpClient }: CreateAuthClientParams) {
     // ========== User Search ==========
 
     /**
-     * Search users by query
-     * GET /api/v1/users/search?query={query}
+     * Search users by query.
+     * GET /api/v1/users/search?query={query}&limit={limit}
      *
-     * Issue #1977: Added UserSearchResultSchema validation
+     * Issue #1977: Added UserSearchResultSchema validation.
+     * Issue #950 W1-PR2: optional `limit` query param (server clamps to [1,50]).
      */
-    async searchUsers(query: string): Promise<UserSearchResult[]> {
+    async searchUsers(query: string, limit?: number): Promise<UserSearchResult[]> {
+      const limitParam = limit !== undefined ? `&limit=${limit}` : '';
       const result = await httpClient.get(
-        `/api/v1/users/search?query=${encodeURIComponent(query)}`,
+        `/api/v1/users/search?query=${encodeURIComponent(query)}${limitParam}`,
         UserSearchResultSchema.array()
       );
       return result ?? [];

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -6,13 +6,17 @@
 import { z } from 'zod';
 
 import {
+  ConflictCheckDtoSchema,
   GameNightDtoSchema,
   GameNightRsvpDtoSchema,
+  RegularDtoSchema,
+  type ConflictCheckDto,
+  type CreateGameNightInput,
   type GameNightDto,
   type GameNightRsvpDto,
-  type CreateGameNightInput,
-  type UpdateGameNightInput,
+  type RegularDto,
   type RsvpStatus,
+  type UpdateGameNightInput,
 } from '../schemas/game-nights.schemas';
 
 import type { HttpClient } from '../core/httpClient';
@@ -28,6 +32,9 @@ export interface GameNightsClient {
   cancel(id: string): Promise<void>;
   invite(id: string, userIds: string[]): Promise<void>;
   rsvp(id: string, response: RsvpStatus): Promise<void>;
+  // Issue #950 W1-PR2 wizard hooks
+  getRegulars(limit?: number): Promise<RegularDto[]>;
+  checkConflict(at: string): Promise<ConflictCheckDto>;
 }
 
 export function createGameNightsClient({
@@ -78,6 +85,19 @@ export function createGameNightsClient({
 
     async rsvp(id, response) {
       await httpClient.post(`/api/v1/game-nights/${id}/rsvp`, { response });
+    },
+
+    async getRegulars(limit) {
+      const query = limit !== undefined ? `?limit=${limit}` : '';
+      const data = await httpClient.get<RegularDto[]>(`/api/v1/game-nights/regulars${query}`);
+      return z.array(RegularDtoSchema).parse(data ?? []);
+    },
+
+    async checkConflict(at) {
+      const data = await httpClient.get<ConflictCheckDto>(
+        `/api/v1/game-nights/check-conflict?at=${encodeURIComponent(at)}`
+      );
+      return ConflictCheckDtoSchema.parse(data);
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -48,8 +48,38 @@ export const CreateGameNightInputSchema = z.object({
   maxPlayers: z.number().min(2).max(50).optional(),
   gameIds: z.array(z.string().uuid()).max(20).optional(),
   invitedUserIds: z.array(z.string().uuid()).max(49).optional(),
+  // Issue #950 W1-PR1: email invitees feeding the token-based
+  // GameNightInvitation flow (#607 Wave A.5a).
+  invitedEmails: z.array(z.string().email().max(200)).max(49).optional(),
 });
 export type CreateGameNightInput = z.infer<typeof CreateGameNightInputSchema>;
+
+// ──────────────────────────────────────────────────────────────────────
+// Issue #950 W1-PR2 — wizard hooks payloads
+// ──────────────────────────────────────────────────────────────────────
+
+export const RegularDtoSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string(),
+  email: z.string(),
+  eventCount: z.number().int().nonnegative(),
+  lastInvitedAt: z.string(),
+});
+export type RegularDto = z.infer<typeof RegularDtoSchema>;
+
+export const ConflictEntryDtoSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  scheduledAt: z.string(),
+  role: z.enum(['organizer', 'invitee']),
+});
+export type ConflictEntryDto = z.infer<typeof ConflictEntryDtoSchema>;
+
+export const ConflictCheckDtoSchema = z.object({
+  hasConflict: z.boolean(),
+  conflicts: z.array(ConflictEntryDtoSchema),
+});
+export type ConflictCheckDto = z.infer<typeof ConflictCheckDtoSchema>;
 
 export const UpdateGameNightInputSchema = z.object({
   title: z.string().min(3).max(200),

--- a/apps/web/src/lib/game-nights/__tests__/wizard-fixture.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/wizard-fixture.test.ts
@@ -35,9 +35,13 @@ describe('getWizardFixture (production build)', () => {
 });
 
 describe('getWizardFixture (visual-test build)', () => {
-  const previousEnv = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED;
+  // Snapshot the env var per-test (not at describe-scope) so cross-file
+  // pollution under a future non-isolated Vitest config can't leak a stale
+  // "previous" value into our afterEach restore.
+  let previousEnv: string | undefined;
 
   beforeEach(() => {
+    previousEnv = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED;
     process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED = '1';
   });
 

--- a/apps/web/src/lib/game-nights/__tests__/wizard-fixture.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/wizard-fixture.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the visual-regression fixture (issue #950 W2 Foundation).
+ *
+ * These tests stub `IS_VISUAL_TEST_BUILD` to true via env var so we can
+ * exercise the fixture-on path without polluting production build output.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('parseFixtureParam', () => {
+  it('returns the matching state for known fixture identifiers', async () => {
+    const { parseFixtureParam } = await import('../wizard-fixture');
+    expect(parseFixtureParam('step1-date')).toBe('step1-date');
+    expect(parseFixtureParam('step3-filled')).toBe('step3-filled');
+    expect(parseFixtureParam('desktop-split')).toBe('desktop-split');
+  });
+
+  it('returns null for unknown / nullish input', async () => {
+    const { parseFixtureParam } = await import('../wizard-fixture');
+    expect(parseFixtureParam(null)).toBeNull();
+    expect(parseFixtureParam(undefined)).toBeNull();
+    expect(parseFixtureParam('')).toBeNull();
+    expect(parseFixtureParam('unknown-state')).toBeNull();
+  });
+});
+
+describe('getWizardFixture (production build)', () => {
+  it('returns null for every state when IS_VISUAL_TEST_BUILD is false', async () => {
+    // Default Vitest env: NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED is not '1'
+    const { getWizardFixture } = await import('../wizard-fixture');
+    expect(getWizardFixture('step1-date')).toBeNull();
+    expect(getWizardFixture('step3-filled')).toBeNull();
+    expect(getWizardFixture('desktop-split')).toBeNull();
+  });
+});
+
+describe('getWizardFixture (visual-test build)', () => {
+  const previousEnv = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED = '1';
+  });
+
+  afterEach(() => {
+    if (previousEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED = previousEnv;
+    }
+  });
+
+  it('returns a WizardState for every FSM identifier (10 states)', async () => {
+    // Re-import in this env so the module-level IS_VISUAL_TEST_BUILD picks up
+    // the override. The import path is identical so vitest serves the cached
+    // module — bust it explicitly.
+    vi.resetModules();
+    const { getWizardFixture } = await import('../wizard-fixture');
+
+    const identifiers = [
+      'step1-date',
+      'step1-warning',
+      'step2-location',
+      'step3-empty',
+      'step3-typing',
+      'step3-filled',
+      'step4-games',
+      'step4-decide-group',
+      'mobile-step-flow',
+      'desktop-split',
+    ] as const;
+
+    for (const id of identifiers) {
+      const state = getWizardFixture(id);
+      expect(state, `fixture for ${id} should be non-null in visual-test build`).not.toBeNull();
+    }
+  });
+
+  it('step1-warning exposes a non-empty conflictResult', async () => {
+    vi.resetModules();
+    const { getWizardFixture } = await import('../wizard-fixture');
+
+    const state = getWizardFixture('step1-warning');
+    expect(state).not.toBeNull();
+    expect(state?.date.conflictResult?.hasConflict).toBe(true);
+    expect(state?.date.conflictResult?.conflicts.length).toBeGreaterThan(0);
+  });
+
+  it('step3-filled exposes 6 invitees mixing registered + email', async () => {
+    vi.resetModules();
+    const { getWizardFixture } = await import('../wizard-fixture');
+
+    const state = getWizardFixture('step3-filled');
+    expect(state?.invitees).toHaveLength(6);
+    const userCount = state?.invitees.filter(i => i.kind === 'user').length ?? 0;
+    const emailCount = state?.invitees.filter(i => i.kind === 'email').length ?? 0;
+    expect(userCount).toBeGreaterThan(0);
+    expect(emailCount).toBeGreaterThan(0);
+  });
+
+  it('step4-decide-group sets decideAtGroup=true and clears selection', async () => {
+    vi.resetModules();
+    const { getWizardFixture } = await import('../wizard-fixture');
+
+    const state = getWizardFixture('step4-decide-group');
+    expect(state?.games.decideAtGroup).toBe(true);
+    expect(state?.games.selected).toHaveLength(0);
+  });
+});
+
+// vi import resolution for tests above
+import { vi } from 'vitest';

--- a/apps/web/src/lib/game-nights/__tests__/wizard-reducer.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/wizard-reducer.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for the SP7 wizard reducer (issue #950 W2).
+ *
+ * Goal: exhaustive coverage of action handlers — every `WizardAction`
+ * variant exercised at least once, with both side-effect-bearing and
+ * identity (no-op) branches verified.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { dedupInvitees, initialWizardState, wizardReducer } from '../wizard-reducer';
+import {
+  WIZARD_DRAFT_SCHEMA_VERSION,
+  inviteeKey,
+  type Invitee,
+  type PersistedDraft,
+  type WizardState,
+} from '../wizard-types';
+
+const ALICE_USER: Invitee = {
+  kind: 'user',
+  id: '11111111-1111-1111-1111-111111111111',
+  displayName: 'Alice',
+  email: 'alice@example.com',
+};
+
+const BOB_USER: Invitee = {
+  kind: 'user',
+  id: '22222222-2222-2222-2222-222222222222',
+  displayName: 'Bob',
+  email: 'bob@example.com',
+};
+
+const EMAIL_INVITEE: Invitee = { kind: 'email', address: 'guest@example.com' };
+
+describe('initialWizardState', () => {
+  it('starts on step 1', () => {
+    expect(initialWizardState.step).toBe(1);
+  });
+
+  it('has empty branches', () => {
+    expect(initialWizardState.date.iso).toBeNull();
+    expect(initialWizardState.invitees).toHaveLength(0);
+    expect(initialWizardState.games.selected).toHaveLength(0);
+    expect(initialWizardState.games.decideAtGroup).toBe(false);
+    expect(initialWizardState.draft.status).toBe('idle');
+  });
+});
+
+describe('wizardReducer: goToStep', () => {
+  it('moves to the requested step', () => {
+    const next = wizardReducer(initialWizardState, { type: 'goToStep', step: 3 });
+    expect(next.step).toBe(3);
+  });
+
+  it('returns the identical state object when already on the target step (perf invariant)', () => {
+    const next = wizardReducer(initialWizardState, { type: 'goToStep', step: 1 });
+    expect(next).toBe(initialWizardState);
+  });
+
+  it('preserves other branches', () => {
+    const seeded: WizardState = { ...initialWizardState, invitees: [ALICE_USER] };
+    const next = wizardReducer(seeded, { type: 'goToStep', step: 4 });
+    expect(next.invitees).toBe(seeded.invitees);
+  });
+});
+
+describe('wizardReducer: setDate / clearDate / recordConflict', () => {
+  it('setDate stores the ISO and invalidates any prior conflict check', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      date: {
+        iso: '2026-06-01T20:00:00Z',
+        conflictCheckedAt: '2026-05-19T05:00:00Z',
+        conflictResult: { hasConflict: false, conflicts: [] },
+      },
+    };
+    const next = wizardReducer(seeded, { type: 'setDate', iso: '2026-06-02T20:00:00Z' });
+
+    expect(next.date.iso).toBe('2026-06-02T20:00:00Z');
+    expect(next.date.conflictCheckedAt).toBeNull();
+    expect(next.date.conflictResult).toBeNull();
+  });
+
+  it('clearDate resets the entire date branch', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      date: {
+        iso: '2026-06-01T20:00:00Z',
+        conflictCheckedAt: '2026-05-19T05:00:00Z',
+        conflictResult: { hasConflict: true, conflicts: [] },
+      },
+    };
+    const next = wizardReducer(seeded, { type: 'clearDate' });
+
+    expect(next.date.iso).toBeNull();
+    expect(next.date.conflictCheckedAt).toBeNull();
+    expect(next.date.conflictResult).toBeNull();
+  });
+
+  it('recordConflict updates the conflict branch without touching iso', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      date: { iso: '2026-06-01T20:00:00Z', conflictCheckedAt: null, conflictResult: null },
+    };
+    const next = wizardReducer(seeded, {
+      type: 'recordConflict',
+      checkedAt: '2026-05-19T05:00:00Z',
+      result: {
+        hasConflict: true,
+        conflicts: [
+          { id: 'gn1', title: 'Catan', scheduledAt: '2026-06-01T19:00:00Z', role: 'organizer' },
+        ],
+      },
+    });
+
+    expect(next.date.iso).toBe('2026-06-01T20:00:00Z');
+    expect(next.date.conflictCheckedAt).toBe('2026-05-19T05:00:00Z');
+    expect(next.date.conflictResult?.hasConflict).toBe(true);
+    expect(next.date.conflictResult?.conflicts).toHaveLength(1);
+  });
+});
+
+describe('wizardReducer: setLocation', () => {
+  it('records the kind and details for a concrete location', () => {
+    const next = wizardReducer(initialWizardState, {
+      type: 'setLocation',
+      kind: 'friend',
+      details: "Sara's apartment",
+    });
+    expect(next.location.kind).toBe('friend');
+    expect(next.location.details).toBe("Sara's apartment");
+  });
+
+  it('preserves previous details when omitted', () => {
+    const seeded = wizardReducer(initialWizardState, {
+      type: 'setLocation',
+      kind: 'friend',
+      details: "Sara's place",
+    });
+    const next = wizardReducer(seeded, { type: 'setLocation', kind: 'home' });
+    // Switching to 'home' without explicit details keeps the previous string;
+    // the FE input element controls what details is persisted.
+    expect(next.location.details).toBe("Sara's place");
+    expect(next.location.kind).toBe('home');
+  });
+
+  it('clears details when switching to "tbd"', () => {
+    const seeded = wizardReducer(initialWizardState, {
+      type: 'setLocation',
+      kind: 'friend',
+      details: "Sara's place",
+    });
+    const next = wizardReducer(seeded, { type: 'setLocation', kind: 'tbd' });
+    expect(next.location.kind).toBe('tbd');
+    expect(next.location.details).toBe('');
+  });
+});
+
+describe('wizardReducer: addInvitee / removeInvitee', () => {
+  it('adds a user invitee', () => {
+    const next = wizardReducer(initialWizardState, { type: 'addInvitee', invitee: ALICE_USER });
+    expect(next.invitees).toEqual([ALICE_USER]);
+  });
+
+  it('adds an email invitee', () => {
+    const next = wizardReducer(initialWizardState, { type: 'addInvitee', invitee: EMAIL_INVITEE });
+    expect(next.invitees).toEqual([EMAIL_INVITEE]);
+  });
+
+  it('is idempotent on duplicate user adds', () => {
+    const once = wizardReducer(initialWizardState, { type: 'addInvitee', invitee: ALICE_USER });
+    const twice = wizardReducer(once, { type: 'addInvitee', invitee: ALICE_USER });
+    expect(twice).toBe(once);
+  });
+
+  it('is idempotent on case-insensitive email duplicates', () => {
+    const once = wizardReducer(initialWizardState, {
+      type: 'addInvitee',
+      invitee: { kind: 'email', address: 'guest@example.com' },
+    });
+    const twice = wizardReducer(once, {
+      type: 'addInvitee',
+      invitee: { kind: 'email', address: 'GUEST@EXAMPLE.com' },
+    });
+    expect(twice).toBe(once);
+  });
+
+  it('removes an invitee by key', () => {
+    const seeded: WizardState = { ...initialWizardState, invitees: [ALICE_USER, BOB_USER] };
+    const next = wizardReducer(seeded, {
+      type: 'removeInvitee',
+      key: inviteeKey(ALICE_USER),
+    });
+    expect(next.invitees).toEqual([BOB_USER]);
+  });
+
+  it('returns identity when removeInvitee targets an unknown key', () => {
+    const seeded: WizardState = { ...initialWizardState, invitees: [ALICE_USER] };
+    const next = wizardReducer(seeded, { type: 'removeInvitee', key: 'user:nonexistent' });
+    expect(next).toBe(seeded);
+  });
+});
+
+describe('wizardReducer: toggleDecideAtGroup / toggleGame', () => {
+  it('toggles decideAtGroup and clears selected games when turning on', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      games: { decideAtGroup: false, selected: ['g1', 'g2'] },
+    };
+    const next = wizardReducer(seeded, { type: 'toggleDecideAtGroup' });
+    expect(next.games.decideAtGroup).toBe(true);
+    expect(next.games.selected).toEqual([]);
+  });
+
+  it('toggles decideAtGroup back off without restoring selected games (FE re-picks)', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      games: { decideAtGroup: true, selected: [] },
+    };
+    const next = wizardReducer(seeded, { type: 'toggleDecideAtGroup' });
+    expect(next.games.decideAtGroup).toBe(false);
+    expect(next.games.selected).toEqual([]);
+  });
+
+  it('toggleGame adds a new game to selection and clears decideAtGroup', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      games: { decideAtGroup: true, selected: [] },
+    };
+    const next = wizardReducer(seeded, { type: 'toggleGame', gameId: 'catan' });
+    expect(next.games.selected).toEqual(['catan']);
+    expect(next.games.decideAtGroup).toBe(false);
+  });
+
+  it('toggleGame removes an already-selected game', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      games: { decideAtGroup: false, selected: ['catan', 'azul'] },
+    };
+    const next = wizardReducer(seeded, { type: 'toggleGame', gameId: 'catan' });
+    expect(next.games.selected).toEqual(['azul']);
+  });
+});
+
+describe('wizardReducer: draft lifecycle', () => {
+  it('draftSaveStart sets status to "saving"', () => {
+    const next = wizardReducer(initialWizardState, { type: 'draftSaveStart' });
+    expect(next.draft.status).toBe('saving');
+    expect(next.draft.savedAt).toBeNull();
+  });
+
+  it('draftSaveSuccess records timestamp and clears status', () => {
+    const next = wizardReducer(initialWizardState, {
+      type: 'draftSaveSuccess',
+      savedAt: '2026-05-19T05:00:00Z',
+    });
+    expect(next.draft.status).toBe('saved');
+    expect(next.draft.savedAt).toBe('2026-05-19T05:00:00Z');
+  });
+
+  it('draftSaveError sets status to "error" without changing savedAt', () => {
+    const seeded: WizardState = {
+      ...initialWizardState,
+      draft: { savedAt: '2026-05-18T20:00:00Z', status: 'saved' },
+    };
+    const next = wizardReducer(seeded, { type: 'draftSaveError' });
+    expect(next.draft.status).toBe('error');
+    expect(next.draft.savedAt).toBe('2026-05-18T20:00:00Z');
+  });
+});
+
+describe('wizardReducer: restoreFromDraft', () => {
+  it('hydrates state from a persisted snapshot and resets draft branch to idle', () => {
+    const draft: PersistedDraft = {
+      schemaVersion: WIZARD_DRAFT_SCHEMA_VERSION,
+      step: 3,
+      date: { iso: '2026-06-01T20:00:00Z', conflictCheckedAt: null, conflictResult: null },
+      location: { kind: 'friend', details: "Sara's place" },
+      invitees: [ALICE_USER],
+      games: { decideAtGroup: false, selected: ['catan'] },
+    };
+
+    const next = wizardReducer(initialWizardState, { type: 'restoreFromDraft', draft });
+
+    expect(next.step).toBe(3);
+    expect(next.invitees).toHaveLength(1);
+    expect(next.games.selected).toEqual(['catan']);
+    expect(next.draft.status).toBe('idle');
+    expect(next.draft.savedAt).toBeNull();
+  });
+});
+
+describe('dedupInvitees', () => {
+  it('removes case-insensitive email duplicates while preserving order', () => {
+    const result = dedupInvitees([
+      ALICE_USER,
+      { kind: 'email', address: 'guest@example.com' },
+      ALICE_USER,
+      { kind: 'email', address: 'GUEST@example.com' },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(ALICE_USER);
+    expect((result[1] as { kind: 'email'; address: string }).address).toBe('guest@example.com');
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(dedupInvitees([])).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/game-nights/__tests__/wizard-validators.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/wizard-validators.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for the SP7 wizard Zod validators + step-completion predicates.
+ * Issue #950 W2 Foundation.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { initialWizardState } from '../wizard-reducer';
+import type { Invitee, WizardState } from '../wizard-types';
+import {
+  buildSubmitPayload,
+  isStepComplete,
+  isWizardComplete,
+  MAX_COMBINED_INVITEES,
+  MAX_EMAIL_LENGTH,
+  persistedDraftSchema,
+  step1DateSchema,
+  step3InviteesSchema,
+  step4GamesSchema,
+  submitPayloadSchema,
+} from '../wizard-validators';
+
+const futureIso = (days = 7): string => {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+};
+
+const ALICE: Invitee = {
+  kind: 'user',
+  id: '11111111-1111-4111-a111-111111111111',
+  displayName: 'Alice',
+  email: 'alice@example.com',
+};
+
+const VALID_GAME_ID = '33333333-3333-4333-a333-333333333333';
+
+const VALID_EMAIL: Invitee = { kind: 'email', address: 'guest@example.com' };
+
+describe('step1DateSchema', () => {
+  it('accepts an ISO date > 1h in the future', () => {
+    expect(step1DateSchema.safeParse({ iso: futureIso(7) }).success).toBe(true);
+  });
+
+  it('rejects an empty ISO', () => {
+    expect(step1DateSchema.safeParse({ iso: '' }).success).toBe(false);
+  });
+
+  it('rejects a malformed ISO', () => {
+    expect(step1DateSchema.safeParse({ iso: 'not-a-date' }).success).toBe(false);
+  });
+
+  it('rejects a past ISO', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(step1DateSchema.safeParse({ iso: yesterday.toISOString() }).success).toBe(false);
+  });
+
+  it('rejects an ISO 30 minutes in the future (under 1h cap)', () => {
+    const soon = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    expect(step1DateSchema.safeParse({ iso: soon }).success).toBe(false);
+  });
+});
+
+describe('step3InviteesSchema', () => {
+  it('accepts an empty list', () => {
+    expect(step3InviteesSchema.safeParse([]).success).toBe(true);
+  });
+
+  it('accepts a mix of user + email invitees', () => {
+    expect(step3InviteesSchema.safeParse([ALICE, VALID_EMAIL]).success).toBe(true);
+  });
+
+  it('rejects email > 200 chars', () => {
+    const long = `${'a'.repeat(195)}@example.com`;
+    const result = step3InviteesSchema.safeParse([{ kind: 'email', address: long }]);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid email format', () => {
+    expect(step3InviteesSchema.safeParse([{ kind: 'email', address: 'no-at-sign' }]).success).toBe(
+      false
+    );
+  });
+
+  it(`rejects > ${MAX_COMBINED_INVITEES} entries`, () => {
+    const fifty: Invitee[] = Array.from({ length: 50 }, (_, i) => ({
+      kind: 'email',
+      address: `u${i}@example.com`,
+    }));
+    expect(step3InviteesSchema.safeParse(fifty).success).toBe(false);
+  });
+
+  it('rejects case-insensitive email duplicates', () => {
+    const dupes: Invitee[] = [
+      { kind: 'email', address: 'guest@example.com' },
+      { kind: 'email', address: 'GUEST@example.com' },
+    ];
+    expect(step3InviteesSchema.safeParse(dupes).success).toBe(false);
+  });
+
+  it('rejects duplicate user ids', () => {
+    const dupes: Invitee[] = [ALICE, ALICE];
+    expect(step3InviteesSchema.safeParse(dupes).success).toBe(false);
+  });
+});
+
+describe('step4GamesSchema', () => {
+  it('accepts decideAtGroup=true with empty selection', () => {
+    expect(step4GamesSchema.safeParse({ decideAtGroup: true, selected: [] }).success).toBe(true);
+  });
+
+  it('accepts at least one game with decideAtGroup=false', () => {
+    const result = step4GamesSchema.safeParse({
+      decideAtGroup: false,
+      selected: [VALID_GAME_ID],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects decideAtGroup=false with empty selection', () => {
+    expect(step4GamesSchema.safeParse({ decideAtGroup: false, selected: [] }).success).toBe(false);
+  });
+
+  it('rejects > 20 games', () => {
+    const tooMany = Array.from({ length: 21 }, () => VALID_GAME_ID);
+    expect(step4GamesSchema.safeParse({ decideAtGroup: false, selected: tooMany }).success).toBe(
+      false
+    );
+  });
+});
+
+describe('isStepComplete', () => {
+  it('step 1 incomplete when date not set', () => {
+    expect(isStepComplete(initialWizardState, 1)).toBe(false);
+  });
+
+  it('step 1 complete when date is in the future', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+    };
+    expect(isStepComplete(state, 1)).toBe(true);
+  });
+
+  it('step 2 always complete on initial state (kind defaults to "home")', () => {
+    expect(isStepComplete(initialWizardState, 2)).toBe(true);
+  });
+
+  it('step 3 complete with empty invitees', () => {
+    expect(isStepComplete(initialWizardState, 3)).toBe(true);
+  });
+
+  it('step 4 incomplete with no games and no decideAtGroup', () => {
+    expect(isStepComplete(initialWizardState, 4)).toBe(false);
+  });
+
+  it('step 4 complete with decideAtGroup=true', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      games: { decideAtGroup: true, selected: [] },
+    };
+    expect(isStepComplete(state, 4)).toBe(true);
+  });
+});
+
+describe('isWizardComplete', () => {
+  it('false on initial state (step 1 + 4 incomplete)', () => {
+    expect(isWizardComplete(initialWizardState)).toBe(false);
+  });
+
+  it('true on fully populated state', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      games: { decideAtGroup: true, selected: [] },
+    };
+    expect(isWizardComplete(state)).toBe(true);
+  });
+});
+
+describe('buildSubmitPayload', () => {
+  it('returns ok with a valid payload', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      location: { kind: 'friend', details: "Sara's place" },
+      invitees: [ALICE, VALID_EMAIL],
+      games: { decideAtGroup: false, selected: [VALID_GAME_ID] },
+    };
+
+    const result = buildSubmitPayload(state, { title: 'Friday Catan' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.title).toBe('Friday Catan');
+      expect(result.payload.invitedUserIds).toEqual([ALICE.id]);
+      expect(result.payload.invitedEmails).toEqual(['guest@example.com']);
+      expect(result.payload.gameIds).toEqual([VALID_GAME_ID]);
+      expect(result.payload.location).toBe("Sara's place");
+    }
+  });
+
+  it('normalizes emails to lowercase', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      invitees: [{ kind: 'email', address: '  GUEST@Example.COM  ' }],
+      games: { decideAtGroup: true, selected: [] },
+    };
+
+    const result = buildSubmitPayload(state, { title: 'Friday Catan' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.invitedEmails).toEqual(['guest@example.com']);
+    }
+  });
+
+  it('sends gameIds: [] when decideAtGroup is on (BE Scenario 6)', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      games: { decideAtGroup: true, selected: [] },
+    };
+
+    const result = buildSubmitPayload(state, { title: 'Friday Catan' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.gameIds).toEqual([]);
+    }
+  });
+
+  it('returns ok:false with issues on invalid state', () => {
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: '', conflictCheckedAt: null, conflictResult: null },
+      games: { decideAtGroup: true, selected: [] },
+    };
+
+    const result = buildSubmitPayload(state, { title: 'X' }); // title too short + bad ISO
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns ok:false when combined invitees exceed 49', () => {
+    const fifty: Invitee[] = Array.from({ length: 50 }, (_, i) => ({
+      kind: 'email',
+      address: `u${i}@example.com`,
+    }));
+    const state: WizardState = {
+      ...initialWizardState,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      invitees: fifty,
+      games: { decideAtGroup: true, selected: [] },
+    };
+
+    const result = buildSubmitPayload(state, { title: 'Friday Catan' });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('submitPayloadSchema combined limit', () => {
+  it(`rejects 25 userIds + 25 emails (total ${MAX_COMBINED_INVITEES + 1})`, () => {
+    const userIds = Array.from(
+      { length: 25 },
+      (_, i) => '00000000-0000-4000-a000-' + i.toString().padStart(12, '0')
+    );
+    const emails = Array.from({ length: 25 }, (_, i) => `u${i}@example.com`);
+    const result = submitPayloadSchema.safeParse({
+      title: 'Friday Catan',
+      scheduledAt: futureIso(7),
+      invitedUserIds: userIds,
+      invitedEmails: emails,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it(`accepts 25 userIds + 24 emails (total ${MAX_COMBINED_INVITEES})`, () => {
+    const userIds = Array.from(
+      { length: 25 },
+      (_, i) => '00000000-0000-4000-a000-' + i.toString().padStart(12, '0')
+    );
+    const emails = Array.from({ length: 24 }, (_, i) => `u${i}@example.com`);
+    const result = submitPayloadSchema.safeParse({
+      title: 'Friday Catan',
+      scheduledAt: futureIso(7),
+      invitedUserIds: userIds,
+      invitedEmails: emails,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('persistedDraftSchema', () => {
+  it('accepts a valid draft', () => {
+    const draft = {
+      schemaVersion: 1,
+      step: 2,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      location: { kind: 'home', details: '' },
+      invitees: [],
+      games: { decideAtGroup: false, selected: [] },
+    };
+    expect(persistedDraftSchema.safeParse(draft).success).toBe(true);
+  });
+
+  it('rejects a draft with a non-matching schemaVersion', () => {
+    const draft = {
+      schemaVersion: 999,
+      step: 2,
+      date: { iso: futureIso(7), conflictCheckedAt: null, conflictResult: null },
+      location: { kind: 'home', details: '' },
+      invitees: [],
+      games: { decideAtGroup: false, selected: [] },
+    };
+    expect(persistedDraftSchema.safeParse(draft).success).toBe(false);
+  });
+});
+
+describe('email length cap', () => {
+  it(`accepts emails up to ${MAX_EMAIL_LENGTH} chars`, () => {
+    const localLen = MAX_EMAIL_LENGTH - '@example.com'.length;
+    const atLimit = `${'a'.repeat(localLen)}@example.com`;
+    expect(atLimit.length).toBe(MAX_EMAIL_LENGTH);
+    const result = step3InviteesSchema.safeParse([{ kind: 'email', address: atLimit }]);
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/useGameNightConflictCheck.ts
+++ b/apps/web/src/lib/game-nights/hooks/useGameNightConflictCheck.ts
@@ -1,0 +1,54 @@
+/**
+ * useGameNightConflictCheck — Step 1 wizard conflict-detection hook.
+ *
+ * Issue #950 W2 Foundation. Spec §6 + §7b.3.
+ *
+ * Wraps `api.gameNights.checkConflict` with React Query caching and an
+ * `enabled` gate that suppresses the call while the user is still typing
+ * an incomplete date.
+ *
+ * The wizard orchestrator dispatches `recordConflict` into the reducer when
+ * the query resolves, so the conflict-warning step (state-02) renders on
+ * the next render pass.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { ConflictCheckDto } from '@/lib/api/schemas/game-nights.schemas';
+
+export const conflictCheckKeys = {
+  all: ['game-nights', 'wizard', 'check-conflict'] as const,
+  at: (at: string) => [...conflictCheckKeys.all, { at }] as const,
+};
+
+export interface UseGameNightConflictCheckOptions {
+  /** ISO 8601 datetime offset of the proposed game night. */
+  at: string | null;
+  /** Disable the query (e.g. while editing the date). */
+  enabled?: boolean;
+}
+
+/**
+ * Returns the conflict-check result for the proposed time.
+ *
+ * Failure-mode policy (Nygard, spec §9): the BE 500ms server timeout
+ * returns `{ hasConflict: false, conflicts: [] }` for slow queries, so the
+ * client doesn't need additional fallback logic. We still mark
+ * `gcTime: 0` so a transient failure isn't cached for the entire session.
+ */
+export function useGameNightConflictCheck({
+  at,
+  enabled = true,
+}: UseGameNightConflictCheckOptions): UseQueryResult<ConflictCheckDto, Error> {
+  return useQuery({
+    queryKey: conflictCheckKeys.at(at ?? ''),
+    queryFn: () => api.gameNights.checkConflict(at as string),
+    enabled: enabled && typeof at === 'string' && at.length > 0,
+    // Cache for 60s: the user typically takes a few seconds to advance from
+    // step 1, and the BE state changes are rare in that window.
+    staleTime: 60_000,
+    gcTime: 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/game-nights/hooks/usePlayerSearch.ts
+++ b/apps/web/src/lib/game-nights/hooks/usePlayerSearch.ts
@@ -1,0 +1,79 @@
+/**
+ * usePlayerSearch — debounced player autocomplete hook for the SP7 wizard
+ * Step 3. Issue #950 W2 Foundation, spec §6.
+ *
+ * Wraps `api.auth.searchUsers` with a 250ms debounce + React Query caching.
+ * The hook returns the same shape as the BE so consumers (Step 3 autocomplete
+ * dropdown) can render directly without an additional adapter.
+ *
+ * Disable the underlying query by passing `enabled: false` or an empty query.
+ * The BE refuses queries shorter than 2 chars anyway (returns empty array),
+ * so we mirror that gate client-side to avoid wasting HTTP calls.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { UserSearchResult } from '@/lib/api/schemas/auth.schemas';
+
+/**
+ * Internal: react-query key namespace for player search results.
+ */
+export const playerSearchKeys = {
+  all: ['game-nights', 'wizard', 'player-search'] as const,
+  query: (q: string, limit: number) => [...playerSearchKeys.all, { q, limit }] as const,
+};
+
+export interface UsePlayerSearchOptions {
+  query: string;
+  limit?: number;
+  debounceMs?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Client-side minimum query length. Matches the BE
+ * `SearchUsersQueryHandler` minLength=2 gate.
+ */
+export const PLAYER_SEARCH_MIN_QUERY_LENGTH = 2;
+
+export const PLAYER_SEARCH_DEFAULT_DEBOUNCE_MS = 250;
+
+export const PLAYER_SEARCH_DEFAULT_LIMIT = 20;
+
+function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(handle);
+  }, [value, ms]);
+
+  return debounced;
+}
+
+export function usePlayerSearch({
+  query,
+  limit = PLAYER_SEARCH_DEFAULT_LIMIT,
+  debounceMs = PLAYER_SEARCH_DEFAULT_DEBOUNCE_MS,
+  enabled = true,
+}: UsePlayerSearchOptions): UseQueryResult<UserSearchResult[], Error> & {
+  debouncedQuery: string;
+} {
+  const trimmed = query.trim();
+  const debouncedQuery = useDebouncedValue(trimmed, debounceMs);
+  const shouldFetch = enabled && debouncedQuery.length >= PLAYER_SEARCH_MIN_QUERY_LENGTH;
+
+  const result = useQuery({
+    queryKey: playerSearchKeys.query(debouncedQuery, limit),
+    queryFn: () => api.auth.searchUsers(debouncedQuery, limit),
+    enabled: shouldFetch,
+    // 30s stale: typing the same prefix multiple times within 30s reuses the
+    // cached payload without re-hitting the BE (spec §6 cache hint).
+    staleTime: 30_000,
+  });
+
+  return Object.assign(result, { debouncedQuery });
+}

--- a/apps/web/src/lib/game-nights/hooks/usePlayerSearch.ts
+++ b/apps/web/src/lib/game-nights/hooks/usePlayerSearch.ts
@@ -43,6 +43,14 @@ export const PLAYER_SEARCH_DEFAULT_DEBOUNCE_MS = 250;
 
 export const PLAYER_SEARCH_DEFAULT_LIMIT = 20;
 
+/**
+ * Hard ceiling honored by `GET /api/v1/users/search` (PR #1294 W1-PR2
+ * adds server-side `Math.Clamp(limit, 1, 50)`). Mirroring the cap
+ * client-side keeps the React Query cache key stable and prevents the
+ * UI from silently displaying fewer results than the user requested.
+ */
+export const PLAYER_SEARCH_MAX_LIMIT = 50;
+
 function useDebouncedValue<T>(value: T, ms: number): T {
   const [debounced, setDebounced] = useState(value);
 
@@ -62,13 +70,19 @@ export function usePlayerSearch({
 }: UsePlayerSearchOptions): UseQueryResult<UserSearchResult[], Error> & {
   debouncedQuery: string;
 } {
+  // PR #1296 review-fix: clamp limit client-side so cache keys stay stable
+  // and the UI doesn't silently receive fewer results than the caller asked
+  // for. Mirrors the BE clamp + matches the parallel pattern in
+  // `useRegularsForUser`.
+  const safeLimit = Math.min(Math.max(limit, 1), PLAYER_SEARCH_MAX_LIMIT);
+
   const trimmed = query.trim();
   const debouncedQuery = useDebouncedValue(trimmed, debounceMs);
   const shouldFetch = enabled && debouncedQuery.length >= PLAYER_SEARCH_MIN_QUERY_LENGTH;
 
   const result = useQuery({
-    queryKey: playerSearchKeys.query(debouncedQuery, limit),
-    queryFn: () => api.auth.searchUsers(debouncedQuery, limit),
+    queryKey: playerSearchKeys.query(debouncedQuery, safeLimit),
+    queryFn: () => api.auth.searchUsers(debouncedQuery, safeLimit),
     enabled: shouldFetch,
     // 30s stale: typing the same prefix multiple times within 30s reuses the
     // cached payload without re-hitting the BE (spec §6 cache hint).

--- a/apps/web/src/lib/game-nights/hooks/useRegularsForUser.ts
+++ b/apps/web/src/lib/game-nights/hooks/useRegularsForUser.ts
@@ -1,0 +1,44 @@
+/**
+ * useRegularsForUser — Step 3 wizard "your regulars" hook.
+ *
+ * Issue #950 W2 Foundation. Spec §6 + §7b.2.
+ *
+ * Returns the registered users the current organizer has invited to past
+ * game nights in the last 12 months, ranked by event count DESC then
+ * last-invited DESC. Backed by the `/api/v1/game-nights/regulars` endpoint
+ * shipped in W1-PR2.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { RegularDto } from '@/lib/api/schemas/game-nights.schemas';
+
+export const regularsKeys = {
+  all: ['game-nights', 'wizard', 'regulars'] as const,
+  list: (limit: number) => [...regularsKeys.all, { limit }] as const,
+};
+
+export const REGULARS_DEFAULT_LIMIT = 10;
+export const REGULARS_MAX_LIMIT = 30;
+
+export interface UseRegularsForUserOptions {
+  limit?: number;
+  enabled?: boolean;
+}
+
+export function useRegularsForUser({
+  limit = REGULARS_DEFAULT_LIMIT,
+  enabled = true,
+}: UseRegularsForUserOptions = {}): UseQueryResult<RegularDto[], Error> {
+  const safeLimit = Math.min(Math.max(limit, 1), REGULARS_MAX_LIMIT);
+
+  return useQuery({
+    queryKey: regularsKeys.list(safeLimit),
+    queryFn: () => api.gameNights.getRegulars(safeLimit),
+    enabled,
+    // Spec §7b.2: server may cache for 5 minutes; mirror client-side so
+    // the user doesn't see flicker when re-opening the wizard.
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/web/src/lib/game-nights/wizard-fixture.ts
+++ b/apps/web/src/lib/game-nights/wizard-fixture.ts
@@ -1,0 +1,262 @@
+/**
+ * Visual-regression test fixture for `/game-nights/new` (Issue #950 W2 Foundation).
+ *
+ * **Purpose**: workflow `visual-regression-migrated.yml` runs only Next.js prod
+ * (no backend API at `:8080`). The wizard's hooks (player search, conflict
+ * check, regulars) cannot reach the backend in CI → states like
+ * `step3-typing` / `step1-warning` never materialise → no screenshot.
+ *
+ * **Contract**: when env var `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1'`
+ * is baked into the build, the wizard orchestrator substitutes the fixture
+ * for live hook results and renders the deterministic FSM state.
+ *
+ * **Production safety**: production builds do NOT set the env var. The
+ * constant `IS_VISUAL_TEST_BUILD` evaluates to `false` and every fixture
+ * branch is dead code, eliminated by the bundler.
+ *
+ * State coverage matches spec §4 FSM inventory:
+ *   01 `step1-date`         — Step 1 default empty
+ *   02 `step1-warning`      — Step 1 conflict warning shown
+ *   03 `step2-location`     — Step 2 location toggle visible
+ *   04 `step3-empty`        — Step 3 empty + regulars suggestions
+ *   05 `step3-typing`       — Step 3 autocomplete dropdown active
+ *   06 `step3-filled`       — Step 3 with 6 invitees (mixed registered + email)
+ *   07 `step4-games`        — Step 4 game candidates picker
+ *   08 `step4-decide-group` — Step 4 "lascia decidere al gruppo" active
+ *   09 `mobile-step-flow`   — Mobile multi-step compact overview
+ *   10 `desktop-split`      — Desktop split-form (RSVP-card live preview)
+ *
+ * Used by:
+ *   - `apps/web/e2e/visual-migrated/sp7-game-night-create.spec.ts` (Wave 3 Week 4)
+ *   - `apps/web/e2e/v2-states/game-night-create.spec.ts` (Wave 3 Week 4)
+ *
+ * Mirror of: `apps/web/src/lib/agents/agent-detail-visual-test-fixture.ts` (Wave C.2)
+ */
+
+import { initialWizardState } from './wizard-reducer';
+
+import type { Invitee, WizardState } from './wizard-types';
+
+/**
+ * Deterministic UUIDv4-shaped sentinel encoding issue #950.
+ */
+export const VISUAL_TEST_FIXTURE_WIZARD_ID = '00000000-0000-4000-8000-000000000950' as const;
+
+/**
+ * True only when the build was produced by the visual-regression CI workflow.
+ * `NEXT_PUBLIC_*` env vars are inlined at build time → in production deploys
+ * this is the literal `false`, allowing the bundler to dead-code-eliminate
+ * the fixture and its short-circuit branches.
+ */
+export const IS_VISUAL_TEST_BUILD = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1';
+
+/**
+ * Enumerated FSM states from spec §4. Numbered IDs in case the FE uses
+ * `?fixture=01` style URLs; named IDs for fixture file headers.
+ */
+export type WizardFixtureState =
+  | 'step1-date'
+  | 'step1-warning'
+  | 'step2-location'
+  | 'step3-empty'
+  | 'step3-typing'
+  | 'step3-filled'
+  | 'step4-games'
+  | 'step4-decide-group'
+  | 'mobile-step-flow'
+  | 'desktop-split';
+
+// Stable deterministic UUIDs for fixture invitees/games. Hard-coded so visual
+// snapshots are byte-stable across CI runs.
+const FIXTURE_USERS: Record<string, Invitee> = {
+  laura: {
+    kind: 'user',
+    id: '00000000-0000-4000-8000-000000000101',
+    displayName: 'Laura Rossi',
+    email: 'laura@example.com',
+  },
+  marco: {
+    kind: 'user',
+    id: '00000000-0000-4000-8000-000000000102',
+    displayName: 'Marco Bianchi',
+    email: 'marco@example.com',
+  },
+  sara: {
+    kind: 'user',
+    id: '00000000-0000-4000-8000-000000000103',
+    displayName: 'Sara Verdi',
+    email: 'sara@example.com',
+  },
+  giulia: {
+    kind: 'user',
+    id: '00000000-0000-4000-8000-000000000104',
+    displayName: 'Giulia Russo',
+    email: 'giulia@example.com',
+  },
+};
+
+const FIXTURE_GAMES = [
+  '00000000-0000-4000-8000-000000000201', // Catan
+  '00000000-0000-4000-8000-000000000202', // Azul
+  '00000000-0000-4000-8000-000000000203', // Wingspan
+] as const;
+
+/**
+ * Future date 14 days out, frozen for fixture determinism. Real wizard
+ * computes its own date in setDate; here we lock the value so screenshots
+ * don't drift day-to-day.
+ *
+ * Note: the spec recommends Date.parse + 1h validation, so this string must
+ * remain > 1h ahead of any plausible test-build clock. 2099-12-31 is safely
+ * out of band for any conceivable CI environment.
+ */
+const FIXTURE_DATE_ISO = '2099-12-31T20:00:00.000Z';
+
+/**
+ * Returns the wizard state corresponding to the requested FSM fixture.
+ * Returns `null` when not in a visual-test build so callers can fall through
+ * to live hooks in production.
+ */
+export function getWizardFixture(state: WizardFixtureState): WizardState | null {
+  if (!IS_VISUAL_TEST_BUILD) return null;
+
+  switch (state) {
+    case 'step1-date':
+      return initialWizardState;
+
+    case 'step1-warning': {
+      // Conflict surfaced after running the check-conflict effect. Iso is set,
+      // checkedAt is recent, conflictResult contains 1 entry.
+      return {
+        ...initialWizardState,
+        date: {
+          iso: FIXTURE_DATE_ISO,
+          conflictCheckedAt: '2099-12-30T18:00:00.000Z',
+          conflictResult: {
+            hasConflict: true,
+            conflicts: [
+              {
+                id: '00000000-0000-4000-8000-000000000301',
+                title: 'Festa di compleanno',
+                scheduledAt: '2099-12-31T19:00:00.000Z',
+                role: 'invitee',
+              },
+            ],
+          },
+        },
+      };
+    }
+
+    case 'step2-location':
+      return {
+        ...initialWizardState,
+        step: 2,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+      };
+
+    case 'step3-empty':
+      return {
+        ...initialWizardState,
+        step: 3,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+      };
+
+    case 'step3-typing':
+      // Same as step3-empty — the FE renders the typing dropdown based on
+      // a sibling React state, not on the wizard reducer. Fixture leaves
+      // invitees empty so the dropdown is the dominant visual element.
+      return {
+        ...initialWizardState,
+        step: 3,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+      };
+
+    case 'step3-filled':
+      return {
+        ...initialWizardState,
+        step: 3,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+        invitees: [
+          FIXTURE_USERS.laura,
+          FIXTURE_USERS.marco,
+          FIXTURE_USERS.sara,
+          FIXTURE_USERS.giulia,
+          { kind: 'email', address: 'federica@example.com' },
+          { kind: 'email', address: 'ospite@example.com' },
+        ],
+      };
+
+    case 'step4-games':
+      return {
+        ...initialWizardState,
+        step: 4,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+        invitees: [FIXTURE_USERS.laura, FIXTURE_USERS.marco, FIXTURE_USERS.sara],
+        games: { decideAtGroup: false, selected: [...FIXTURE_GAMES] },
+      };
+
+    case 'step4-decide-group':
+      return {
+        ...initialWizardState,
+        step: 4,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+        invitees: [FIXTURE_USERS.laura, FIXTURE_USERS.marco, FIXTURE_USERS.sara],
+        games: { decideAtGroup: true, selected: [] },
+      };
+
+    case 'mobile-step-flow':
+      // Compact overview: all 4 steps side-by-side. Reducer state reflects
+      // the "moving from 3 → 4" mid-flow situation.
+      return {
+        ...initialWizardState,
+        step: 3,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+        invitees: [FIXTURE_USERS.laura, FIXTURE_USERS.marco],
+      };
+
+    case 'desktop-split':
+      // Live preview consumes the full state; same shape as step4-games
+      // but the desktop layout is what's being snapshot, not the data.
+      return {
+        ...initialWizardState,
+        step: 4,
+        date: { iso: FIXTURE_DATE_ISO, conflictCheckedAt: null, conflictResult: null },
+        location: { kind: 'friend', details: 'Casa di Sara' },
+        invitees: [FIXTURE_USERS.laura, FIXTURE_USERS.marco, FIXTURE_USERS.sara],
+        games: { decideAtGroup: false, selected: [...FIXTURE_GAMES] },
+      };
+
+    default: {
+      const _exhaustive: never = state;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+/**
+ * Convenience for E2E specs that pivot on a `?fixture=…` URL parameter.
+ * Returns the fixture state for known values, `null` otherwise.
+ */
+export function parseFixtureParam(value: string | null | undefined): WizardFixtureState | null {
+  if (!value) return null;
+  const known: WizardFixtureState[] = [
+    'step1-date',
+    'step1-warning',
+    'step2-location',
+    'step3-empty',
+    'step3-typing',
+    'step3-filled',
+    'step4-games',
+    'step4-decide-group',
+    'mobile-step-flow',
+    'desktop-split',
+  ];
+  return (known as string[]).includes(value) ? (value as WizardFixtureState) : null;
+}

--- a/apps/web/src/lib/game-nights/wizard-reducer.ts
+++ b/apps/web/src/lib/game-nights/wizard-reducer.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure reducer for the SP7 game-night-create wizard (issue #950 W2).
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-sp7-game-night-create.md §8.
+ *
+ * The reducer is exhaustive over `WizardAction` and never mutates the
+ * incoming state. Every action handler is unit-tested in
+ * `wizard-reducer.test.ts` (target ≥ 100% line/branch coverage).
+ */
+
+import { inviteeKey, type Invitee, type WizardAction, type WizardState } from './wizard-types';
+
+/**
+ * Initial state for a fresh wizard session.
+ *
+ * Step 1 by default; all branches in their "empty" form. Consumers that
+ * need to hydrate from a persisted draft should dispatch
+ * `restoreFromDraft` after mounting with this initial state.
+ */
+export const initialWizardState: WizardState = {
+  step: 1,
+  date: { iso: null, conflictCheckedAt: null, conflictResult: null },
+  location: { kind: 'home', details: '' },
+  invitees: [],
+  games: { decideAtGroup: false, selected: [] },
+  draft: { savedAt: null, status: 'idle' },
+};
+
+export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case 'goToStep':
+      // Identity short-circuit: avoids unnecessary re-renders downstream.
+      return state.step === action.step ? state : { ...state, step: action.step };
+
+    case 'setDate':
+      return {
+        ...state,
+        date: {
+          iso: action.iso,
+          // Changing the date invalidates the previous conflict check; the
+          // wizard re-runs the check effect on every iso change.
+          conflictCheckedAt: null,
+          conflictResult: null,
+        },
+      };
+
+    case 'clearDate':
+      return {
+        ...state,
+        date: { iso: null, conflictCheckedAt: null, conflictResult: null },
+      };
+
+    case 'recordConflict':
+      return {
+        ...state,
+        date: {
+          ...state.date,
+          conflictCheckedAt: action.checkedAt,
+          conflictResult: action.result,
+        },
+      };
+
+    case 'setLocation':
+      return {
+        ...state,
+        location: {
+          kind: action.kind,
+          // `tbd` collapses to empty details — the FE shouldn't expose a free
+          // text input for "Da definire", and the BE shouldn't persist stale
+          // details when the user reverts from a concrete kind to `tbd`.
+          details: action.kind === 'tbd' ? '' : (action.details ?? state.location.details),
+        },
+      };
+
+    case 'addInvitee': {
+      const key = inviteeKey(action.invitee);
+      // Idempotent add — the dedup invariant matches the BE validator
+      // (`HasNoCaseInsensitiveDuplicates`) for emails.
+      if (state.invitees.some(i => inviteeKey(i) === key)) {
+        return state;
+      }
+      return { ...state, invitees: [...state.invitees, action.invitee] };
+    }
+
+    case 'removeInvitee': {
+      const filtered = state.invitees.filter(i => inviteeKey(i) !== action.key);
+      return filtered.length === state.invitees.length ? state : { ...state, invitees: filtered };
+    }
+
+    case 'toggleDecideAtGroup': {
+      const nextDecide = !state.games.decideAtGroup;
+      return {
+        ...state,
+        games: {
+          decideAtGroup: nextDecide,
+          // Spec §12 BE-Scenario 6: when "lascia decidere al gruppo" is on,
+          // the submit payload has `gameIds: []`. We clear the selection in
+          // state so toggling back off doesn't surface stale picks.
+          selected: nextDecide ? [] : state.games.selected,
+        },
+      };
+    }
+
+    case 'toggleGame': {
+      // Picking a game implicitly turns off "decide at group" so the UI and
+      // submit payload stay consistent.
+      const currentlySelected = state.games.selected.includes(action.gameId);
+      const nextSelected = currentlySelected
+        ? state.games.selected.filter(id => id !== action.gameId)
+        : [...state.games.selected, action.gameId];
+
+      return {
+        ...state,
+        games: { decideAtGroup: false, selected: nextSelected },
+      };
+    }
+
+    case 'draftSaveStart':
+      return { ...state, draft: { ...state.draft, status: 'saving' } };
+
+    case 'draftSaveSuccess':
+      return {
+        ...state,
+        draft: { savedAt: action.savedAt, status: 'saved' },
+      };
+
+    case 'draftSaveError':
+      return { ...state, draft: { ...state.draft, status: 'error' } };
+
+    case 'restoreFromDraft':
+      return {
+        step: action.draft.step,
+        date: action.draft.date,
+        location: action.draft.location,
+        invitees: action.draft.invitees,
+        games: action.draft.games,
+        // The restored draft never resets to "saving" — restoration is a
+        // read, not a write. Status returns to idle until the next mutation
+        // triggers an autosave cycle.
+        draft: { savedAt: null, status: 'idle' },
+      };
+
+    default: {
+      // Exhaustiveness check — TypeScript will error here if a new action
+      // is added without a handler.
+      const _exhaustive: never = action;
+      void _exhaustive;
+      return state;
+    }
+  }
+}
+
+/**
+ * Helper to dedup an array of invitees while preserving order. Useful for
+ * tests and FE components that need to clean up legacy state (e.g. from a
+ * draft persisted before dedup was enforced).
+ */
+export function dedupInvitees(invitees: readonly Invitee[]): readonly Invitee[] {
+  const seen = new Set<string>();
+  const result: Invitee[] = [];
+  for (const invitee of invitees) {
+    const key = inviteeKey(invitee);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(invitee);
+    }
+  }
+  return result;
+}

--- a/apps/web/src/lib/game-nights/wizard-types.ts
+++ b/apps/web/src/lib/game-nights/wizard-types.ts
@@ -1,0 +1,125 @@
+/**
+ * Type definitions for the SP7 game-night-create wizard (issue #950 W2).
+ *
+ * The wizard state is decomposed by step so reducers can target individual
+ * branches without rebuilding the whole tree. Discriminated unions on
+ * `invitees` and `WizardAction` keep type narrowing exact.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-sp7-game-night-create.md §8.
+ */
+
+export type WizardStep = 1 | 2 | 3 | 4;
+
+export type LocationKind = 'home' | 'friend' | 'online' | 'tbd';
+
+export type DraftStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+/**
+ * Single conflict entry returned by the conflict-check backend (W1-PR2
+ * `GET /api/v1/game-nights/check-conflict`). Mirrors the BE
+ * `ConflictEntryDto` shape so the wizard can render warnings inline.
+ */
+export interface ConflictEntry {
+  id: string;
+  title: string;
+  scheduledAt: string;
+  role: 'organizer' | 'invitee';
+}
+
+export interface ConflictResult {
+  hasConflict: boolean;
+  conflicts: readonly ConflictEntry[];
+}
+
+/**
+ * Registered-user invitee (resolved via `/users/search`).
+ */
+export interface UserInvitee {
+  kind: 'user';
+  id: string;
+  displayName: string;
+  email: string;
+}
+
+/**
+ * Email-only invitee (resolved server-side via `CreateGameNightInvitationByEmail`).
+ */
+export interface EmailInvitee {
+  kind: 'email';
+  address: string;
+}
+
+export type Invitee = UserInvitee | EmailInvitee;
+
+/**
+ * Stable de-dup key for an invitee. Used by `removeInvitee` action so the
+ * reducer can target the right entry without exposing array indices.
+ */
+export function inviteeKey(invitee: Invitee): string {
+  return invitee.kind === 'user'
+    ? `user:${invitee.id}`
+    : `email:${invitee.address.trim().toLowerCase()}`;
+}
+
+export interface DateBranch {
+  iso: string | null;
+  conflictCheckedAt: string | null;
+  conflictResult: ConflictResult | null;
+}
+
+export interface LocationBranch {
+  kind: LocationKind;
+  details: string;
+}
+
+export interface GamesBranch {
+  decideAtGroup: boolean;
+  selected: readonly string[];
+}
+
+export interface DraftBranch {
+  savedAt: string | null;
+  status: DraftStatus;
+}
+
+export interface WizardState {
+  step: WizardStep;
+  date: DateBranch;
+  location: LocationBranch;
+  invitees: readonly Invitee[];
+  games: GamesBranch;
+  draft: DraftBranch;
+}
+
+/**
+ * Schema version of the persisted draft payload. Bumping this number on
+ * incompatible reducer-state shape changes lets the autosave restore
+ * routine discard stale drafts (§9 guard).
+ */
+export const WIZARD_DRAFT_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Persisted draft snapshot — everything except the transient `draft` branch
+ * itself (avoid recursion).
+ */
+export type PersistedDraft = Omit<WizardState, 'draft'> & {
+  schemaVersion: typeof WIZARD_DRAFT_SCHEMA_VERSION;
+};
+
+/**
+ * Wizard actions. Discriminated by `type` for exhaustive switch handling.
+ */
+export type WizardAction =
+  | { type: 'goToStep'; step: WizardStep }
+  | { type: 'setDate'; iso: string }
+  | { type: 'clearDate' }
+  | { type: 'recordConflict'; result: ConflictResult; checkedAt: string }
+  | { type: 'setLocation'; kind: LocationKind; details?: string }
+  | { type: 'addInvitee'; invitee: Invitee }
+  | { type: 'removeInvitee'; key: string }
+  | { type: 'toggleDecideAtGroup' }
+  | { type: 'toggleGame'; gameId: string }
+  | { type: 'draftSaveStart' }
+  | { type: 'draftSaveSuccess'; savedAt: string }
+  | { type: 'draftSaveError' }
+  | { type: 'restoreFromDraft'; draft: PersistedDraft };

--- a/apps/web/src/lib/game-nights/wizard-validators.ts
+++ b/apps/web/src/lib/game-nights/wizard-validators.ts
@@ -16,7 +16,10 @@ import { WIZARD_DRAFT_SCHEMA_VERSION, type LocationKind, type WizardState } from
 // ────────────────────────────────────────────────────────────────────────────
 // Constants — kept in sync with the BE CreateGameNightCommandValidator.
 // See apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/
-//   GameNights/CreateGameNightCommandValidator.cs:13-15
+//   GameNights/CreateGameNightCommandValidator.cs:
+//     - MaxCombinedInvitees (49) at L20 of that file
+//     - MaxEmailLength      (200) at L25
+//     - EmailFormatRegex     at L32-35
 // ────────────────────────────────────────────────────────────────────────────
 
 export const MAX_COMBINED_INVITEES = 49;

--- a/apps/web/src/lib/game-nights/wizard-validators.ts
+++ b/apps/web/src/lib/game-nights/wizard-validators.ts
@@ -1,0 +1,272 @@
+/**
+ * Zod schemas + step-completion predicates for the SP7 game-night-create wizard.
+ *
+ * Issue #950 W2 Foundation. Spec: docs/superpowers/specs/2026-05-18-sp7-game-night-create.md §11.
+ *
+ * Each step's predicate answers "can the user advance from here?" — the same
+ * gate that toggles the "Avanti" / "Crea evento" button in the wizard UI.
+ * Submit-time validation runs the full schema (`submitPayloadSchema`) so the
+ * BE contract is the single source of truth for the network call.
+ */
+
+import { z } from 'zod';
+
+import { WIZARD_DRAFT_SCHEMA_VERSION, type LocationKind, type WizardState } from './wizard-types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants — kept in sync with the BE CreateGameNightCommandValidator.
+// See apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/
+//   GameNights/CreateGameNightCommandValidator.cs:13-15
+// ────────────────────────────────────────────────────────────────────────────
+
+export const MAX_COMBINED_INVITEES = 49;
+export const MAX_EMAIL_LENGTH = 200;
+export const MAX_TITLE_LENGTH = 200;
+export const MAX_DESCRIPTION_LENGTH = 2000;
+export const MAX_LOCATION_DETAILS_LENGTH = 500;
+export const MAX_GAMES = 20;
+export const SCHEDULED_AT_MIN_HOURS_AHEAD = 1;
+
+// Pragmatic RFC 5321 gate. Identical pattern to the BE
+// `EmailFormatRegex` so client and server reject the same set of inputs.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Step-level Zod schemas
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Step 1 (Quando): date is set and at least 1 hour in the future.
+ * Conflict detection is non-blocking (Scenario 2 lets the user advance with
+ * "Continua comunque"), so we only validate the timestamp itself here.
+ */
+export const step1DateSchema = z
+  .object({
+    iso: z
+      .string()
+      .min(1, 'Seleziona una data')
+      .refine(iso => !Number.isNaN(Date.parse(iso)), 'Data non valida')
+      .refine(iso => {
+        const t = Date.parse(iso);
+        return t > Date.now() + SCHEDULED_AT_MIN_HOURS_AHEAD * 60 * 60 * 1000;
+      }, `La data deve essere almeno ${SCHEDULED_AT_MIN_HOURS_AHEAD} ora nel futuro`),
+  })
+  .strip();
+
+const LOCATION_KINDS = [
+  'home',
+  'friend',
+  'online',
+  'tbd',
+] as const satisfies readonly LocationKind[];
+
+/**
+ * Step 2 (Dove): a location kind is always selected (initial state = `home`),
+ * so this step is implicitly complete. We still validate `details` length to
+ * fail loudly if the user types a 600-char address.
+ */
+export const step2LocationSchema = z
+  .object({
+    kind: z.enum(LOCATION_KINDS),
+    details: z
+      .string()
+      .max(MAX_LOCATION_DETAILS_LENGTH, `Massimo ${MAX_LOCATION_DETAILS_LENGTH} caratteri`),
+  })
+  .strip();
+
+const userInviteeSchema = z.object({
+  kind: z.literal('user'),
+  id: z.string().uuid('ID utente non valido'),
+  displayName: z.string(),
+  email: z.string(),
+});
+
+const emailInviteeSchema = z.object({
+  kind: z.literal('email'),
+  address: z
+    .string()
+    .max(MAX_EMAIL_LENGTH, `Email troppo lunga (max ${MAX_EMAIL_LENGTH} caratteri)`)
+    .regex(EMAIL_REGEX, 'Formato email non valido'),
+});
+
+const inviteeSchema = z.discriminatedUnion('kind', [userInviteeSchema, emailInviteeSchema]);
+
+/**
+ * Step 3 (Chi): zero invitees is allowed (Marco may want a solo session, or
+ * the FE may submit then add invitees later). The combined cap mirrors the
+ * BE validator so the wizard never sends a request that will be rejected.
+ */
+export const step3InviteesSchema = z
+  .array(inviteeSchema)
+  .max(MAX_COMBINED_INVITEES, `Massimo ${MAX_COMBINED_INVITEES} inviti totali`)
+  .refine(
+    invitees => {
+      const seen = new Set<string>();
+      for (const inv of invitees) {
+        const key =
+          inv.kind === 'user' ? `user:${inv.id}` : `email:${inv.address.trim().toLowerCase()}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+      }
+      return true;
+    },
+    { message: 'Inviti duplicati non sono permessi' }
+  );
+
+/**
+ * Step 4 (Cosa): EITHER `decideAtGroup` is on OR at least one game is picked.
+ */
+export const step4GamesSchema = z
+  .object({
+    decideAtGroup: z.boolean(),
+    selected: z
+      .array(z.string().uuid('Game ID non valido'))
+      .max(MAX_GAMES, `Massimo ${MAX_GAMES} giochi`),
+  })
+  .refine(games => games.decideAtGroup || games.selected.length > 0, {
+    message: 'Seleziona almeno un gioco o attiva "lascia decidere al gruppo"',
+  });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Submit-time schema — matches the BE CreateGameNightCommand shape.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const submitPayloadSchema = z
+  .object({
+    title: z
+      .string()
+      .min(3, 'Il titolo deve contenere almeno 3 caratteri')
+      .max(MAX_TITLE_LENGTH, `Titolo troppo lungo (max ${MAX_TITLE_LENGTH})`),
+    scheduledAt: step1DateSchema.shape.iso,
+    description: z.string().max(MAX_DESCRIPTION_LENGTH).nullable().optional(),
+    location: z.string().max(MAX_LOCATION_DETAILS_LENGTH).nullable().optional(),
+    maxPlayers: z.number().int().min(2).max(50).nullable().optional(),
+    gameIds: z.array(z.string().uuid()).max(MAX_GAMES).nullable().optional(),
+    invitedUserIds: z.array(z.string().uuid()).nullable().optional(),
+    invitedEmails: z
+      .array(z.string().regex(EMAIL_REGEX).max(MAX_EMAIL_LENGTH))
+      .nullable()
+      .optional(),
+  })
+  .refine(
+    payload => {
+      const userCount = payload.invitedUserIds?.length ?? 0;
+      const emailCount = payload.invitedEmails?.length ?? 0;
+      return userCount + emailCount <= MAX_COMBINED_INVITEES;
+    },
+    {
+      message: `Massimo ${MAX_COMBINED_INVITEES} inviti combinati (utenti + email)`,
+      path: ['invitedEmails'],
+    }
+  );
+
+export type SubmitPayload = z.infer<typeof submitPayloadSchema>;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Persisted draft schema — guards against stale localStorage payloads when
+// `WIZARD_DRAFT_SCHEMA_VERSION` bumps.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const persistedDraftSchema = z.object({
+  schemaVersion: z.literal(WIZARD_DRAFT_SCHEMA_VERSION),
+  step: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  date: z.object({
+    iso: z.string().nullable(),
+    conflictCheckedAt: z.string().nullable(),
+    conflictResult: z
+      .object({
+        hasConflict: z.boolean(),
+        conflicts: z.array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            scheduledAt: z.string(),
+            role: z.enum(['organizer', 'invitee']),
+          })
+        ),
+      })
+      .nullable(),
+  }),
+  location: step2LocationSchema,
+  invitees: z.array(inviteeSchema),
+  games: z.object({
+    decideAtGroup: z.boolean(),
+    selected: z.array(z.string()),
+  }),
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Step-completion predicates (the "can advance from here" gate)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true iff the user can advance from `step` given the current state.
+ * Used by the wizard's "Avanti" button to enable/disable transitions.
+ */
+export function isStepComplete(state: WizardState, step: 1 | 2 | 3 | 4): boolean {
+  switch (step) {
+    case 1:
+      return step1DateSchema.safeParse({ iso: state.date.iso ?? '' }).success;
+    case 2:
+      // Location kind is always set (initial = 'home'); 'tbd' is also valid.
+      return step2LocationSchema.safeParse(state.location).success;
+    case 3:
+      // Invitees ARE optional — Marco can ship a placeholder event. The schema
+      // only blocks invalid emails and dedup-violations.
+      return step3InviteesSchema.safeParse(state.invitees).success;
+    case 4:
+      return step4GamesSchema.safeParse(state.games).success;
+    default: {
+      const _exhaustive: never = step;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+/**
+ * Returns true iff every step is complete — gates the "Crea evento" submit
+ * button on the final step.
+ */
+export function isWizardComplete(state: WizardState): boolean {
+  return (
+    isStepComplete(state, 1) &&
+    isStepComplete(state, 2) &&
+    isStepComplete(state, 3) &&
+    isStepComplete(state, 4)
+  );
+}
+
+/**
+ * Builds the BE submit payload from wizard state. Title is provided by the
+ * caller because it lives outside the reducer (controlled by a sibling
+ * input). Returns the validated payload on success or a Zod issue list on
+ * failure for FE error mapping.
+ */
+export function buildSubmitPayload(
+  state: WizardState,
+  args: { title: string; description?: string | null; maxPlayers?: number | null }
+): { ok: true; payload: SubmitPayload } | { ok: false; issues: z.ZodIssue[] } {
+  const invitedUserIds = state.invitees
+    .filter((i): i is Extract<typeof i, { kind: 'user' }> => i.kind === 'user')
+    .map(i => i.id);
+  const invitedEmails = state.invitees
+    .filter((i): i is Extract<typeof i, { kind: 'email' }> => i.kind === 'email')
+    .map(i => i.address.trim().toLowerCase());
+
+  const candidate = {
+    title: args.title.trim(),
+    scheduledAt: state.date.iso ?? '',
+    description: args.description ?? null,
+    location: state.location.kind === 'tbd' ? null : state.location.details || null,
+    maxPlayers: args.maxPlayers ?? null,
+    gameIds: state.games.decideAtGroup ? [] : [...state.games.selected],
+    invitedUserIds: invitedUserIds.length > 0 ? invitedUserIds : null,
+    invitedEmails: invitedEmails.length > 0 ? invitedEmails : null,
+  };
+
+  const result = submitPayloadSchema.safeParse(candidate);
+  return result.success
+    ? { ok: true, payload: result.data }
+    : { ok: false, issues: result.error.issues };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3164,5 +3164,117 @@
         "retry": "Retry"
       }
     }
+  },
+  "gameNightCreate": {
+    "title": "New game night",
+    "subtitle": "Plan a game night in 4 steps.",
+    "nav": {
+      "back": "Back",
+      "next": "Next",
+      "submit": "Create event",
+      "saveDraft": "Save draft and exit",
+      "cancel": "Cancel"
+    },
+    "steps": {
+      "step1": "When",
+      "step2": "Where",
+      "step3": "Who",
+      "step4": "What",
+      "progress": "Step {current} of {total}"
+    },
+    "step1": {
+      "label": "Date and time",
+      "placeholder": "Pick a date",
+      "helper": "At least 1 hour in the future.",
+      "calendarLabel": "Calendar",
+      "timeLabel": "Time",
+      "conflictWarningTitle": "You're already busy",
+      "conflictWarningBody": "{count, plural, =1 {One event overlaps} other {{count} events overlap}} this time slot.",
+      "conflictListLabel": "Overlapping events",
+      "conflictRoleOrganizer": "You're hosting",
+      "conflictRoleInvitee": "Invited",
+      "continueAnyway": "Continue anyway",
+      "changeDate": "Change date"
+    },
+    "step2": {
+      "label": "Where you play",
+      "kindHome": "My place",
+      "kindFriend": "A friend's place",
+      "kindOnline": "Online",
+      "kindTbd": "To be decided",
+      "detailsLabel": "Details",
+      "detailsPlaceholder": "Address, Zoom link, directions…",
+      "detailsHelper": "Visible only to invitees."
+    },
+    "step3": {
+      "label": "Who to invite",
+      "searchPlaceholder": "Search a player or type an email…",
+      "searchAriaLabel": "Search a player",
+      "emptyStateTitle": "Add your first invitees",
+      "emptyStateBody": "Search by name or email. Your regular co-players appear below.",
+      "regularsTitle": "Your regulars",
+      "regularsHelper": "Sorted by how often you've played together recently.",
+      "regularsEmpty": "No regular co-players yet.",
+      "addRegular": "Add",
+      "addedChipLabel": "{name} added to invitees",
+      "remove": "Remove",
+      "addEmail": "Invite by email",
+      "emailLabel": "New invitee email",
+      "emailPlaceholder": "name@example.com",
+      "emailInvalid": "Invalid email",
+      "emailDuplicate": "Email already added",
+      "inviteeCount": "{count} {count, plural, =1 {invitee} other {invitees}}",
+      "limitWarning": "Maximum {max} invitees total.",
+      "limitExceeded": "You've hit the {max} invitees limit."
+    },
+    "step4": {
+      "label": "What to play",
+      "decideAtGroupLabel": "Let the group decide",
+      "decideAtGroupHelper": "We'll pick games together that evening.",
+      "selectedCount": "{count} {count, plural, =1 {game selected} other {games selected}}",
+      "libraryHeader": "From your library",
+      "libraryEmpty": "Your library is empty. Add games to suggest them.",
+      "selectGame": "Select {name}",
+      "deselectGame": "Deselect {name}",
+      "limitWarning": "Maximum {max} games per night."
+    },
+    "preview": {
+      "title": "Invitation preview",
+      "subtitle": "What invitees will see.",
+      "rsvpCta": "RSVP",
+      "rsvpAccept": "✓ I'm in",
+      "rsvpDecline": "✗ Can't make it",
+      "noDate": "Date to be decided",
+      "noLocation": "Location to be decided",
+      "gamesTbd": "Games: decided at the group",
+      "gamesNone": "No games picked"
+    },
+    "submit": {
+      "creating": "Creating…",
+      "successToast": "Event created",
+      "errorTitle": "Creation failed",
+      "errorBody": "Something went wrong. Try again in a moment.",
+      "retry": "Retry",
+      "saveDraft": "Save draft and exit",
+      "retryAttempt": "Attempt {attempt} of {max}"
+    },
+    "draft": {
+      "savedAt": "Draft saved {time}",
+      "savedStatus": "Saved",
+      "savingStatus": "Saving…",
+      "errorStatus": "Save error",
+      "restoredBanner": "Draft restored",
+      "discardDraft": "Discard draft",
+      "discardConfirm": "Discard the saved draft? This action cannot be undone.",
+      "discardConfirmCancel": "Cancel",
+      "discardConfirmConfirm": "Discard"
+    },
+    "a11y": {
+      "wizardLabel": "Game night create wizard",
+      "stepperLabel": "Game night creation progress",
+      "inviteesListLabel": "Invitees list",
+      "gamesListLabel": "Suggested games list",
+      "previewLabel": "Invitation preview"
+    }
   }
 }

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3217,5 +3217,117 @@
         "retry": "Riprova"
       }
     }
+  },
+  "gameNightCreate": {
+    "title": "Nuova serata",
+    "subtitle": "Pianifica una serata di gioco in 4 step.",
+    "nav": {
+      "back": "Indietro",
+      "next": "Avanti",
+      "submit": "Crea evento",
+      "saveDraft": "Salva bozza e esci",
+      "cancel": "Annulla"
+    },
+    "steps": {
+      "step1": "Quando",
+      "step2": "Dove",
+      "step3": "Chi",
+      "step4": "Cosa",
+      "progress": "Step {current} di {total}"
+    },
+    "step1": {
+      "label": "Data e ora",
+      "placeholder": "Seleziona data",
+      "helper": "Almeno 1 ora nel futuro.",
+      "calendarLabel": "Calendario",
+      "timeLabel": "Orario",
+      "conflictWarningTitle": "Hai già un impegno",
+      "conflictWarningBody": "{count, plural, =1 {Un evento si sovrappone} other {{count} eventi si sovrappongono}} a questo orario.",
+      "conflictListLabel": "Eventi sovrapposti",
+      "conflictRoleOrganizer": "Organizzi",
+      "conflictRoleInvitee": "Invitato",
+      "continueAnyway": "Continua comunque",
+      "changeDate": "Cambia data"
+    },
+    "step2": {
+      "label": "Dove giocate",
+      "kindHome": "Casa mia",
+      "kindFriend": "Casa di un amico",
+      "kindOnline": "Online",
+      "kindTbd": "Da definire",
+      "detailsLabel": "Dettagli",
+      "detailsPlaceholder": "Indirizzo, link Zoom, indicazioni…",
+      "detailsHelper": "Visibili solo agli invitati."
+    },
+    "step3": {
+      "label": "Chi invitare",
+      "searchPlaceholder": "Cerca un giocatore o digita un'email…",
+      "searchAriaLabel": "Cerca un giocatore",
+      "emptyStateTitle": "Aggiungi i primi invitati",
+      "emptyStateBody": "Cerca per nome o email. I tuoi compagni di gioco abituali appaiono qui sotto.",
+      "regularsTitle": "I tuoi abituali",
+      "regularsHelper": "Ordinati per frequenza nelle ultime serate.",
+      "regularsEmpty": "Nessun giocatore abituale ancora.",
+      "addRegular": "Aggiungi",
+      "addedChipLabel": "{name} aggiunto agli invitati",
+      "remove": "Rimuovi",
+      "addEmail": "Invita per email",
+      "emailLabel": "Email del nuovo invitato",
+      "emailPlaceholder": "email@esempio.com",
+      "emailInvalid": "Email non valida",
+      "emailDuplicate": "Email già aggiunta",
+      "inviteeCount": "{count} {count, plural, =1 {invitato} other {invitati}}",
+      "limitWarning": "Massimo {max} invitati totali.",
+      "limitExceeded": "Hai raggiunto il limite di {max} invitati."
+    },
+    "step4": {
+      "label": "Cosa giocate",
+      "decideAtGroupLabel": "Lascia decidere al gruppo",
+      "decideAtGroupHelper": "Decideremo i giochi insieme la sera.",
+      "selectedCount": "{count} {count, plural, =1 {gioco selezionato} other {giochi selezionati}}",
+      "libraryHeader": "Dalla tua libreria",
+      "libraryEmpty": "La tua libreria è vuota. Aggiungi giochi per consigliarli.",
+      "selectGame": "Seleziona {name}",
+      "deselectGame": "Deseleziona {name}",
+      "limitWarning": "Massimo {max} giochi per serata."
+    },
+    "preview": {
+      "title": "Anteprima invito",
+      "subtitle": "Quello che vedranno gli invitati.",
+      "rsvpCta": "RSVP",
+      "rsvpAccept": "✓ Partecipo",
+      "rsvpDecline": "✗ Non posso",
+      "noDate": "Data da scegliere",
+      "noLocation": "Luogo da definire",
+      "gamesTbd": "Giochi: da decidere al gruppo",
+      "gamesNone": "Nessun gioco selezionato"
+    },
+    "submit": {
+      "creating": "Creazione in corso…",
+      "successToast": "Evento creato",
+      "errorTitle": "Creazione fallita",
+      "errorBody": "Qualcosa è andato storto. Riprova fra un momento.",
+      "retry": "Riprova",
+      "saveDraft": "Salva bozza e esci",
+      "retryAttempt": "Tentativo {attempt} di {max}"
+    },
+    "draft": {
+      "savedAt": "Bozza salvata {time}",
+      "savedStatus": "Salvato",
+      "savingStatus": "Salvataggio…",
+      "errorStatus": "Errore di salvataggio",
+      "restoredBanner": "Bozza ripristinata",
+      "discardDraft": "Scarta bozza",
+      "discardConfirm": "Vuoi scartare la bozza salvata? Questa azione non può essere annullata.",
+      "discardConfirmCancel": "Annulla",
+      "discardConfirmConfirm": "Scarta"
+    },
+    "a11y": {
+      "wizardLabel": "Wizard creazione serata",
+      "stepperLabel": "Avanzamento creazione serata",
+      "inviteesListLabel": "Lista invitati",
+      "gamesListLabel": "Lista giochi proposti",
+      "previewLabel": "Anteprima invito"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Issue #950 Week 2 Foundation: ships the pure-function layer that the SP7 wizard's components (Week 3) and orchestrator + E2E specs (Week 4) will consume. **No UI surface is reachable from this PR** — the new modules are imported only by future feature commits and by the visual-regression fixture wiring.

Spec: [`docs/superpowers/specs/2026-05-18-sp7-game-night-create.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/superpowers/specs/2026-05-18-sp7-game-night-create.md) §11 (AC SMART Foundation).

## Deliverables

| Module | Lines | Purpose |
|---|---:|---|
| `lib/game-nights/wizard-types.ts` | ~120 | Discriminated unions: `WizardStep`, `Invitee` (kind=`user`\|`email`), `WizardAction` (12 variants), `PersistedDraft`, `WIZARD_DRAFT_SCHEMA_VERSION` |
| `lib/game-nights/wizard-reducer.ts` | ~150 | Pure reducer + `initialWizardState` + `dedupInvitees`; exhaustive switch; identity short-circuits on no-ops |
| `lib/game-nights/wizard-validators.ts` | ~210 | Zod schemas (step1-4 + submit + persistedDraft) mirroring **BE validator exactly**; `isStepComplete()` / `isWizardComplete()` / `buildSubmitPayload()` |
| `lib/game-nights/wizard-fixture.ts` | ~210 | Visual-regression fixture (10 FSM states from spec §4); production-safe via `IS_VISUAL_TEST_BUILD` constant folding |
| `lib/game-nights/hooks/usePlayerSearch.ts` | ~80 | 250ms debounce + 30s stale + minLength=2 client gate (mirrors BE) |
| `lib/game-nights/hooks/useGameNightConflictCheck.ts` | ~50 | enabled-by-isoDate + 60s stale + no retry (BE 500ms timeout returns graceful) |
| `lib/game-nights/hooks/useRegularsForUser.ts` | ~50 | 5min stale (matches spec §7b.2 cache hint) + limit clamped [1, 30] |
| `lib/api/clients/gameNightsClient.ts` + `.schemas.ts` | +60 | `getRegulars()` + `checkConflict()` + Zod schemas; `invitedEmails` on `CreateGameNightInputSchema` |
| `lib/api/clients/authClient.ts` | +5 | `searchUsers(query, limit?)` extended |
| `locales/{it,en}.json` | +176 | New `gameNightCreate` namespace, ~88 keys per locale (nav, steps, step1-4, preview, submit, draft, a11y) |

## BE-FE parity invariants (enforced via constants)

| Constant | Value | BE source |
|---|---|---|
| `MAX_COMBINED_INVITEES` | 49 | `CreateGameNightCommandValidator.cs:13` |
| `MAX_EMAIL_LENGTH` | 200 | `CreateGameNightCommandValidator.cs:14` |
| `EMAIL_REGEX` | `^[^\s@]+@[^\s@]+\.[^\s@]+$` | `CreateGameNightCommandValidator.cs:32` |
| `SCHEDULED_AT_MIN_HOURS_AHEAD` | 1 | `CreateGameNightCommandValidator.cs:26-27` |
| Dedup | case-insensitive trim | `HasNoCaseInsensitiveDuplicates()` |

## Test coverage

- **27** reducer unit tests (every `WizardAction` variant + identity branches)
- **34** validator unit tests (step gates, combined limit, dedup, schema, `buildSubmitPayload` normalization)
- **7** fixture unit tests (10-state coverage + `parseFixtureParam` + production-build null-safety)
- **= 68 new tests, all green**
- **138/138** `game-nights/__tests__` pass (incl. pre-existing 70 from W1)
- `pnpm typecheck` clean

## Production safety

- Fixture returns `null` at runtime in production; bundler eliminates every fixture branch (`NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED` inlined as the literal `false`).
- No UI surface added; `/game-nights/new` still mounts the legacy page until Week 3 ships the orchestrator.

## What's NOT in this PR

- ❌ 6 v2 components (Week 3, commit 2)
- ❌ Orchestrator + page wiring + autosave (Week 3, commit 3)
- ❌ E2E specs + visual baselines (Week 4)
- ❌ Hook unit tests via MSW (deferred — covered transitively via component integration in Week 3)

## Refs

- Issue #950 (W2 of 5)
- Spec [`2026-05-18-sp7-game-night-create.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/superpowers/specs/2026-05-18-sp7-game-night-create.md) §4 FSM, §8 reducer skeleton, §10 schema, §11 AC SMART (Foundation), §7b.1-3 (BE contracts)
- Pattern: Wave C.2 visual-regression fixture (issue #581, `apps/web/src/lib/agents/agent-detail-visual-test-fixture.ts`)
- PR #1287 (Week 1 spec hardening), PR #1289 (W1-PR1 BE), PR #1294 (W1-PR2 BE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)