### PR TITLE
feat(game-nights): #950 W3 Components — 6 v2 wizard components + smoke tests

### DIFF
--- a/apps/web/src/components/features/game-night-create/GameCandidatesPicker.tsx
+++ b/apps/web/src/components/features/game-night-create/GameCandidatesPicker.tsx
@@ -1,0 +1,136 @@
+/**
+ * GameCandidatesPicker — Step 4 ("Cosa") component.
+ * Issue #950 W3 Components. Spec §5 (C5) + §12 Scenario 6 (decide-at-group).
+ *
+ * Pure component: receives the library game list and emits selection intent.
+ */
+
+'use client';
+
+import { useId, type ReactElement } from 'react';
+
+export interface GameCandidatesPickerLabels {
+  readonly label: string;
+  readonly decideAtGroupLabel: string;
+  readonly decideAtGroupHelper: string;
+  readonly selectedCount: (count: number) => string;
+  readonly libraryHeader: string;
+  readonly libraryEmpty: string;
+  readonly selectGame: (name: string) => string;
+  readonly deselectGame: (name: string) => string;
+}
+
+export interface GameCandidateOption {
+  readonly id: string;
+  readonly title: string;
+  readonly imageUrl?: string | null;
+  readonly minPlayers?: number | null;
+  readonly maxPlayers?: number | null;
+  readonly playingTimeMinutes?: number | null;
+}
+
+export interface GameCandidatesPickerProps {
+  readonly games: readonly GameCandidateOption[];
+  readonly selected: readonly string[];
+  readonly decideAtGroup: boolean;
+  readonly onToggleGame: (gameId: string) => void;
+  readonly onToggleDecideAtGroup: () => void;
+  readonly labels: GameCandidatesPickerLabels;
+}
+
+export function GameCandidatesPicker({
+  games,
+  selected,
+  decideAtGroup,
+  onToggleGame,
+  onToggleDecideAtGroup,
+  labels,
+}: GameCandidatesPickerProps): ReactElement {
+  const toggleId = useId();
+  const selectedSet = new Set(selected);
+
+  return (
+    <section
+      data-slot="game-night-create-step4"
+      aria-labelledby={`${toggleId}-label`}
+      className="flex flex-col gap-4"
+    >
+      <p id={`${toggleId}-label`} className="text-sm font-medium text-foreground">
+        {labels.label}
+      </p>
+
+      <label
+        htmlFor={toggleId}
+        className="flex items-start gap-3 rounded-md border border-border bg-card p-3"
+        data-slot="game-night-create-step4-decide-toggle"
+      >
+        <input
+          id={toggleId}
+          type="checkbox"
+          checked={decideAtGroup}
+          onChange={onToggleDecideAtGroup}
+          className="mt-1"
+        />
+        <span className="flex flex-col">
+          <span className="text-sm font-medium text-foreground">{labels.decideAtGroupLabel}</span>
+          <span className="text-xs text-muted-foreground">{labels.decideAtGroupHelper}</span>
+        </span>
+      </label>
+
+      <div
+        data-slot="game-night-create-step4-library"
+        aria-hidden={decideAtGroup}
+        className={decideAtGroup ? 'opacity-50 pointer-events-none' : ''}
+      >
+        <p className="text-sm font-medium text-foreground">{labels.libraryHeader}</p>
+        <p className="text-xs text-muted-foreground">{labels.selectedCount(selected.length)}</p>
+
+        {games.length === 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">{labels.libraryEmpty}</p>
+        ) : (
+          <ul
+            role="list"
+            className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3"
+            data-slot="game-night-create-step4-grid"
+          >
+            {games.map(game => {
+              const isSelected = selectedSet.has(game.id);
+              const ariaLabel = isSelected
+                ? labels.deselectGame(game.title)
+                : labels.selectGame(game.title);
+              return (
+                <li key={game.id}>
+                  <button
+                    type="button"
+                    onClick={() => onToggleGame(game.id)}
+                    aria-pressed={isSelected}
+                    aria-label={ariaLabel}
+                    data-slot={`game-night-create-step4-game-${game.id}`}
+                    className={
+                      isSelected
+                        ? 'flex w-full flex-col gap-2 rounded-md border border-primary bg-primary/10 p-3 text-left'
+                        : 'flex w-full flex-col gap-2 rounded-md border border-border bg-card p-3 text-left hover:border-primary'
+                    }
+                  >
+                    <span className="text-sm font-medium text-foreground">{game.title}</span>
+                    {(game.minPlayers || game.playingTimeMinutes) && (
+                      <span className="text-xs text-muted-foreground">
+                        {game.minPlayers && game.maxPlayers
+                          ? `${game.minPlayers}–${game.maxPlayers} 👤`
+                          : null}
+                        {game.minPlayers && game.maxPlayers && game.playingTimeMinutes
+                          ? ' · '
+                          : null}
+                        {game.playingTimeMinutes ? `${game.playingTimeMinutes}'` : null}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/GameNightCreateWizard.tsx
+++ b/apps/web/src/components/features/game-night-create/GameNightCreateWizard.tsx
@@ -1,0 +1,267 @@
+/**
+ * GameNightCreateWizard — orchestrator skeleton for the SP7 wizard.
+ * Issue #950 W3 Components (Commit 2). Spec §5 (C1) + §11 AC-O.1.
+ *
+ * This skeleton mounts the correct step component based on `state.step` and
+ * renders a step indicator + nav buttons. The full page wiring (URL
+ * `?step=` sync, autosave hook, mutation orchestration, retry policy) is
+ * Commit 3 (Week 3 PR-2). This commit ships the visual scaffold so Week 4
+ * E2E specs can target stable selectors.
+ */
+
+'use client';
+
+import { useMemo, type Dispatch, type ReactElement } from 'react';
+
+import type { UserSearchResult } from '@/lib/api/schemas/auth.schemas';
+import type { RegularDto } from '@/lib/api/schemas/game-nights.schemas';
+import type { WizardAction, WizardState, WizardStep } from '@/lib/game-nights/wizard-types';
+import { isStepComplete } from '@/lib/game-nights/wizard-validators';
+
+import {
+  GameCandidatesPicker,
+  type GameCandidatesPickerLabels,
+  type GameCandidateOption,
+} from './GameCandidatesPicker';
+import {
+  GameNightDateTimePicker,
+  type GameNightDateTimePickerLabels,
+} from './GameNightDateTimePicker';
+import {
+  GameNightLocationToggle,
+  type GameNightLocationToggleLabels,
+} from './GameNightLocationToggle';
+import {
+  PlayerInviteAutocomplete,
+  type PlayerInviteAutocompleteLabels,
+} from './PlayerInviteAutocomplete';
+import { RSVPCardLivePreview, type RSVPCardLivePreviewLabels } from './RSVPCardLivePreview';
+
+export interface GameNightCreateWizardLabels {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly nav: {
+    readonly back: string;
+    readonly next: string;
+    readonly submit: string;
+    readonly cancel: string;
+  };
+  readonly steps: {
+    readonly step1: string;
+    readonly step2: string;
+    readonly step3: string;
+    readonly step4: string;
+    readonly progress: (current: number, total: number) => string;
+  };
+  readonly a11y: {
+    readonly wizardLabel: string;
+    readonly stepperLabel: string;
+  };
+  readonly step1: GameNightDateTimePickerLabels;
+  readonly step2: GameNightLocationToggleLabels;
+  readonly step3: PlayerInviteAutocompleteLabels;
+  readonly step4: GameCandidatesPickerLabels;
+  readonly preview: RSVPCardLivePreviewLabels;
+}
+
+export interface GameNightCreateWizardProps {
+  readonly state: WizardState;
+  readonly dispatch: Dispatch<WizardAction>;
+  readonly title: string;
+  readonly organizerName: string;
+  readonly labels: GameNightCreateWizardLabels;
+
+  // Step 3 data (orchestrator passes resolved react-query results)
+  readonly playerSearchQuery: string;
+  readonly onPlayerSearchQueryChange: (q: string) => void;
+  readonly playerSearchResults: readonly UserSearchResult[];
+  readonly isSearchingPlayers?: boolean;
+  readonly regulars: readonly RegularDto[];
+
+  // Step 4 data
+  readonly libraryGames: readonly GameCandidateOption[];
+
+  // Submit flow
+  readonly onSubmit: () => void;
+  readonly isSubmitting?: boolean;
+
+  // Step 1 conflict surface
+  readonly isCheckingConflict?: boolean;
+}
+
+const TOTAL_STEPS = 4 as const;
+
+export function GameNightCreateWizard({
+  state,
+  dispatch,
+  title,
+  organizerName,
+  labels,
+  playerSearchQuery,
+  onPlayerSearchQueryChange,
+  playerSearchResults,
+  isSearchingPlayers = false,
+  regulars,
+  libraryGames,
+  onSubmit,
+  isSubmitting = false,
+  isCheckingConflict = false,
+}: GameNightCreateWizardProps): ReactElement {
+  const stepLabels = useMemo(
+    () => [labels.steps.step1, labels.steps.step2, labels.steps.step3, labels.steps.step4],
+    [labels.steps]
+  );
+
+  const canAdvance = isStepComplete(state, state.step);
+  const isFinalStep = state.step === TOTAL_STEPS;
+
+  const goPrev = (): void => {
+    if (state.step > 1) {
+      dispatch({ type: 'goToStep', step: (state.step - 1) as WizardStep });
+    }
+  };
+
+  const goNext = (): void => {
+    if (isFinalStep) {
+      onSubmit();
+      return;
+    }
+    dispatch({ type: 'goToStep', step: (state.step + 1) as WizardStep });
+  };
+
+  return (
+    <div
+      data-slot="game-night-create-wizard"
+      aria-label={labels.a11y.wizardLabel}
+      className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_1fr]"
+    >
+      <div className="flex flex-col gap-6">
+        <header className="flex flex-col gap-1">
+          <h1 className="text-xl font-semibold text-foreground">{labels.title}</h1>
+          <p className="text-sm text-muted-foreground">{labels.subtitle}</p>
+        </header>
+
+        <nav
+          aria-label={labels.a11y.stepperLabel}
+          className="flex items-center gap-2"
+          data-slot="game-night-create-stepper"
+        >
+          {stepLabels.map((label, idx) => {
+            const step = (idx + 1) as WizardStep;
+            const isCurrent = step === state.step;
+            const isComplete = step < state.step;
+            return (
+              <button
+                key={label}
+                type="button"
+                onClick={() => dispatch({ type: 'goToStep', step })}
+                aria-current={isCurrent ? 'step' : undefined}
+                data-slot={`game-night-create-stepper-step${step}`}
+                className={
+                  isCurrent
+                    ? 'rounded-full border border-primary bg-primary/10 px-3 py-1 text-xs font-medium text-foreground'
+                    : isComplete
+                      ? 'rounded-full border border-primary px-3 py-1 text-xs text-primary'
+                      : 'rounded-full border border-border px-3 py-1 text-xs text-muted-foreground'
+                }
+              >
+                {step}. {label}
+              </button>
+            );
+          })}
+        </nav>
+
+        <p className="text-xs text-muted-foreground">
+          {labels.steps.progress(state.step, TOTAL_STEPS)}
+        </p>
+
+        <div data-slot={`game-night-create-step-${state.step}-container`}>
+          {state.step === 1 && (
+            <GameNightDateTimePicker
+              iso={state.date.iso}
+              onSetDate={iso => dispatch({ type: 'setDate', iso })}
+              conflictResult={state.date.conflictResult}
+              isCheckingConflict={isCheckingConflict}
+              onContinueAnyway={() =>
+                dispatch({
+                  type: 'recordConflict',
+                  // Mark as checked but blank so the warning surface
+                  // dismisses; the date itself stays put.
+                  checkedAt: new Date().toISOString(),
+                  result: { hasConflict: false, conflicts: [] },
+                })
+              }
+              labels={labels.step1}
+            />
+          )}
+
+          {state.step === 2 && (
+            <GameNightLocationToggle
+              kind={state.location.kind}
+              details={state.location.details}
+              onSetLocation={(kind, details) => dispatch({ type: 'setLocation', kind, details })}
+              labels={labels.step2}
+            />
+          )}
+
+          {state.step === 3 && (
+            <PlayerInviteAutocomplete
+              invitees={state.invitees}
+              searchResults={playerSearchResults}
+              regulars={regulars}
+              query={playerSearchQuery}
+              onQueryChange={onPlayerSearchQueryChange}
+              onAddInvitee={invitee => dispatch({ type: 'addInvitee', invitee })}
+              onRemoveInvitee={key => dispatch({ type: 'removeInvitee', key })}
+              isSearching={isSearchingPlayers}
+              labels={labels.step3}
+            />
+          )}
+
+          {state.step === 4 && (
+            <GameCandidatesPicker
+              games={libraryGames}
+              selected={state.games.selected}
+              decideAtGroup={state.games.decideAtGroup}
+              onToggleGame={gameId => dispatch({ type: 'toggleGame', gameId })}
+              onToggleDecideAtGroup={() => dispatch({ type: 'toggleDecideAtGroup' })}
+              labels={labels.step4}
+            />
+          )}
+        </div>
+
+        <footer
+          className="flex items-center justify-between border-t border-border pt-4"
+          data-slot="game-night-create-nav"
+        >
+          <button
+            type="button"
+            onClick={goPrev}
+            disabled={state.step === 1}
+            className="rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+            data-slot="game-night-create-nav-back"
+          >
+            {labels.nav.back}
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={!canAdvance || isSubmitting}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            data-slot="game-night-create-nav-next"
+          >
+            {isFinalStep ? labels.nav.submit : labels.nav.next}
+          </button>
+        </footer>
+      </div>
+
+      <RSVPCardLivePreview
+        state={state}
+        title={title}
+        organizerName={organizerName}
+        games={libraryGames}
+        labels={labels.preview}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/GameNightDateTimePicker.tsx
+++ b/apps/web/src/components/features/game-night-create/GameNightDateTimePicker.tsx
@@ -1,0 +1,139 @@
+/**
+ * GameNightDateTimePicker — Step 1 ("Quando") component.
+ * Issue #950 W3 Components. Spec §5 (C2) + §12 Scenario 2 (conflict warning).
+ *
+ * Pure component: receives current ISO + conflict-check result + labels from
+ * the orchestrator and emits intent via `onSetDate` / `onContinueAnyway`.
+ */
+
+'use client';
+
+import { useId, type ReactElement } from 'react';
+
+import type { ConflictResult } from '@/lib/game-nights/wizard-types';
+
+export interface GameNightDateTimePickerLabels {
+  readonly label: string;
+  readonly helper: string;
+  readonly conflictWarningTitle: string;
+  /** Receives `{ count }` placeholder; the orchestrator formats it. */
+  readonly conflictWarningBody: (count: number) => string;
+  readonly conflictRoleOrganizer: string;
+  readonly conflictRoleInvitee: string;
+  readonly continueAnyway: string;
+  readonly checking: string;
+}
+
+export interface GameNightDateTimePickerProps {
+  /** Current ISO datetime (or null if unset). */
+  readonly iso: string | null;
+  readonly onSetDate: (iso: string) => void;
+  /** Conflict check result; null while no check has run yet. */
+  readonly conflictResult: ConflictResult | null;
+  readonly isCheckingConflict?: boolean;
+  /** Whether the user has explicitly overridden the conflict warning. */
+  readonly overrideAccepted?: boolean;
+  readonly onContinueAnyway?: () => void;
+  readonly labels: GameNightDateTimePickerLabels;
+}
+
+/**
+ * Converts an ISO string to the `YYYY-MM-DDTHH:MM` format expected by
+ * `<input type="datetime-local">`. Returns `''` for null/invalid input.
+ */
+function isoToInputValue(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function GameNightDateTimePicker({
+  iso,
+  onSetDate,
+  conflictResult,
+  isCheckingConflict = false,
+  overrideAccepted = false,
+  onContinueAnyway,
+  labels,
+}: GameNightDateTimePickerProps): ReactElement {
+  const inputId = useId();
+  const value = isoToInputValue(iso);
+  const showWarning = !overrideAccepted && conflictResult?.hasConflict === true;
+
+  return (
+    <section
+      data-slot="game-night-create-step1"
+      aria-labelledby={`${inputId}-label`}
+      className="flex flex-col gap-4"
+    >
+      <label
+        id={`${inputId}-label`}
+        htmlFor={inputId}
+        className="text-sm font-medium text-foreground"
+      >
+        {labels.label}
+      </label>
+      <input
+        id={inputId}
+        type="datetime-local"
+        value={value}
+        onChange={e => {
+          const next = e.target.value;
+          if (!next) return;
+          // Convert local datetime-local back to ISO; the reducer stores the
+          // canonical UTC form so conflict checks dedupe deterministically.
+          onSetDate(new Date(next).toISOString());
+        }}
+        className="rounded-md border border-border bg-card px-3 py-2 text-foreground"
+      />
+      <p className="text-xs text-muted-foreground">{labels.helper}</p>
+
+      {isCheckingConflict && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-xs text-muted-foreground"
+          data-slot="game-night-create-step1-checking"
+        >
+          {labels.checking}
+        </p>
+      )}
+
+      {showWarning && conflictResult && (
+        <div
+          role="alert"
+          data-slot="game-night-create-step1-conflict"
+          className="rounded-md border border-warning bg-warning/10 p-3 text-sm"
+        >
+          <p className="font-medium text-foreground">{labels.conflictWarningTitle}</p>
+          <p className="mt-1 text-muted-foreground">
+            {labels.conflictWarningBody(conflictResult.conflicts.length)}
+          </p>
+          <ul className="mt-2 flex flex-col gap-1">
+            {conflictResult.conflicts.map(c => (
+              <li key={c.id} className="text-xs text-foreground">
+                <span className="font-medium">{c.title}</span>
+                <span className="ml-2 text-muted-foreground">
+                  {c.role === 'organizer'
+                    ? labels.conflictRoleOrganizer
+                    : labels.conflictRoleInvitee}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {onContinueAnyway && (
+            <button
+              type="button"
+              onClick={onContinueAnyway}
+              className="mt-3 text-xs font-medium text-primary underline"
+            >
+              {labels.continueAnyway}
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/GameNightLocationToggle.tsx
+++ b/apps/web/src/components/features/game-night-create/GameNightLocationToggle.tsx
@@ -1,0 +1,119 @@
+/**
+ * GameNightLocationToggle — Step 2 ("Dove") component.
+ * Issue #950 W3 Components. Spec §5 (C3).
+ *
+ * 4-option segmented control + details textarea (hidden when kind=tbd).
+ * Pure component: orchestrator owns state, this only emits intent.
+ */
+
+'use client';
+
+import { useId, type ReactElement } from 'react';
+
+import type { LocationKind } from '@/lib/game-nights/wizard-types';
+
+export interface GameNightLocationToggleLabels {
+  readonly label: string;
+  readonly kindHome: string;
+  readonly kindFriend: string;
+  readonly kindOnline: string;
+  readonly kindTbd: string;
+  readonly detailsLabel: string;
+  readonly detailsPlaceholder: string;
+  readonly detailsHelper: string;
+}
+
+export interface GameNightLocationToggleProps {
+  readonly kind: LocationKind;
+  readonly details: string;
+  readonly onSetLocation: (kind: LocationKind, details: string) => void;
+  readonly labels: GameNightLocationToggleLabels;
+  /** Maximum allowed characters for details (mirror BE = 500). */
+  readonly maxDetailsLength?: number;
+}
+
+const OPTIONS: readonly LocationKind[] = ['home', 'friend', 'online', 'tbd'];
+
+function kindLabel(kind: LocationKind, labels: GameNightLocationToggleLabels): string {
+  switch (kind) {
+    case 'home':
+      return labels.kindHome;
+    case 'friend':
+      return labels.kindFriend;
+    case 'online':
+      return labels.kindOnline;
+    case 'tbd':
+      return labels.kindTbd;
+  }
+}
+
+export function GameNightLocationToggle({
+  kind,
+  details,
+  onSetLocation,
+  labels,
+  maxDetailsLength = 500,
+}: GameNightLocationToggleProps): ReactElement {
+  const groupId = useId();
+  const detailsId = useId();
+  const showDetails = kind !== 'tbd';
+
+  return (
+    <section
+      data-slot="game-night-create-step2"
+      aria-labelledby={`${groupId}-label`}
+      className="flex flex-col gap-4"
+    >
+      <p id={`${groupId}-label`} className="text-sm font-medium text-foreground">
+        {labels.label}
+      </p>
+
+      <div
+        role="radiogroup"
+        aria-labelledby={`${groupId}-label`}
+        className="flex flex-wrap gap-2"
+        data-slot="game-night-create-step2-kinds"
+      >
+        {OPTIONS.map(option => {
+          const selected = option === kind;
+          return (
+            <button
+              key={option}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onSetLocation(option, option === 'tbd' ? '' : details)}
+              data-slot={`game-night-create-step2-kind-${option}`}
+              className={
+                selected
+                  ? 'rounded-md border border-primary bg-primary/10 px-3 py-2 text-sm font-medium text-foreground'
+                  : 'rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground hover:text-foreground'
+              }
+            >
+              {kindLabel(option, labels)}
+            </button>
+          );
+        })}
+      </div>
+
+      {showDetails && (
+        <div className="flex flex-col gap-2">
+          <label htmlFor={detailsId} className="text-sm font-medium text-foreground">
+            {labels.detailsLabel}
+          </label>
+          <textarea
+            id={detailsId}
+            value={details}
+            onChange={e => onSetLocation(kind, e.target.value.slice(0, maxDetailsLength))}
+            maxLength={maxDetailsLength}
+            placeholder={labels.detailsPlaceholder}
+            rows={3}
+            className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground"
+            data-slot="game-night-create-step2-details"
+          />
+          <p className="text-xs text-muted-foreground">{labels.detailsHelper}</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/PlayerInviteAutocomplete.tsx
+++ b/apps/web/src/components/features/game-night-create/PlayerInviteAutocomplete.tsx
@@ -29,6 +29,12 @@ export interface PlayerInviteAutocompleteLabels {
   readonly emailDuplicate: string;
   readonly inviteeCount: (count: number) => string;
   readonly limitWarning: (max: number) => string;
+  /**
+   * Visible status text rendered while the player-search query is in flight.
+   * PR #1297 review fix: previously the loading region reused
+   * `searchAriaLabel`, which is an input *label*, not a status announcement.
+   */
+  readonly searching: string;
 }
 
 export interface PlayerInviteAutocompleteProps {
@@ -92,11 +98,17 @@ export function PlayerInviteAutocomplete({
       email: user.email,
     };
     if (existingKeys.has(inviteeKey(invitee))) return;
+    // PR #1297 review fix: clear stale `emailError` when the user picks a
+    // search result. Programmatic `onQueryChange('')` doesn't trigger the
+    // DOM input's `onChange`, so the error wouldn't reset otherwise.
+    setEmailError(null);
     onAddInvitee(invitee);
     onQueryChange('');
   };
 
   const handleAddRegular = (regular: RegularDto): void => {
+    // `handleAddUser` already clears the email error + query, so no
+    // additional bookkeeping needed here.
     handleAddUser({
       id: regular.id,
       displayName: regular.displayName,
@@ -152,8 +164,13 @@ export function PlayerInviteAutocomplete({
       </div>
 
       {searchResults.length > 0 && (
+        // PR #1297 review fix: dropped `role="listbox"` + `role="option"` +
+        // `aria-selected={false}`. A proper listbox would need
+        // `aria-activedescendant` + arrow-key navigation wired through the
+        // input; we ship the simpler native-button list here and revisit
+        // with a real combobox pattern when keyboard nav is wired in
+        // W3-PR2. Native <button> children are still fully keyboard-accessible.
         <ul
-          role="listbox"
           aria-label={labels.searchAriaLabel}
           className="flex flex-col gap-1 rounded-md border border-border bg-card"
           data-slot="game-night-create-step3-results"
@@ -168,7 +185,7 @@ export function PlayerInviteAutocomplete({
               })
             );
             return (
-              <li key={result.id} role="option" aria-selected={false}>
+              <li key={result.id}>
                 <button
                   type="button"
                   onClick={() => handleAddUser(result)}
@@ -185,8 +202,10 @@ export function PlayerInviteAutocomplete({
       )}
 
       {isSearching && (
+        // PR #1297 review fix: announce a dedicated "searching" message,
+        // not the input's aria-label.
         <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
-          {labels.searchAriaLabel}
+          {labels.searching}
         </p>
       )}
 

--- a/apps/web/src/components/features/game-night-create/PlayerInviteAutocomplete.tsx
+++ b/apps/web/src/components/features/game-night-create/PlayerInviteAutocomplete.tsx
@@ -1,0 +1,265 @@
+/**
+ * PlayerInviteAutocomplete — Step 3 ("Chi") component.
+ * Issue #950 W3 Components. Spec §5 (C4) + §12 Scenario 3 (mixed invitees).
+ *
+ * Pure component: orchestrator owns wizard state + react-query hooks and
+ * passes resolved data (searchResults, regulars) as props.
+ */
+
+'use client';
+
+import { useId, useState, type ReactElement } from 'react';
+
+import type { UserSearchResult } from '@/lib/api/schemas/auth.schemas';
+import type { RegularDto } from '@/lib/api/schemas/game-nights.schemas';
+import type { Invitee, UserInvitee } from '@/lib/game-nights/wizard-types';
+import { inviteeKey } from '@/lib/game-nights/wizard-types';
+
+export interface PlayerInviteAutocompleteLabels {
+  readonly label: string;
+  readonly searchPlaceholder: string;
+  readonly searchAriaLabel: string;
+  readonly regularsTitle: string;
+  readonly regularsHelper: string;
+  readonly regularsEmpty: string;
+  readonly addRegular: string;
+  readonly remove: string;
+  readonly addEmail: string;
+  readonly emailInvalid: string;
+  readonly emailDuplicate: string;
+  readonly inviteeCount: (count: number) => string;
+  readonly limitWarning: (max: number) => string;
+}
+
+export interface PlayerInviteAutocompleteProps {
+  readonly invitees: readonly Invitee[];
+  readonly searchResults: readonly UserSearchResult[];
+  readonly regulars: readonly RegularDto[];
+  readonly query: string;
+  readonly onQueryChange: (q: string) => void;
+  readonly onAddInvitee: (invitee: Invitee) => void;
+  readonly onRemoveInvitee: (key: string) => void;
+  readonly isSearching?: boolean;
+  readonly maxCombinedInvitees?: number;
+  readonly labels: PlayerInviteAutocompleteLabels;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value.trim());
+}
+
+export function PlayerInviteAutocomplete({
+  invitees,
+  searchResults,
+  regulars,
+  query,
+  onQueryChange,
+  onAddInvitee,
+  onRemoveInvitee,
+  isSearching = false,
+  maxCombinedInvitees = 49,
+  labels,
+}: PlayerInviteAutocompleteProps): ReactElement {
+  const inputId = useId();
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const atLimit = invitees.length >= maxCombinedInvitees;
+  const queryLooksLikeEmail = isEmail(query);
+  const existingKeys = new Set(invitees.map(inviteeKey));
+
+  const handleAddEmail = (): void => {
+    const trimmed = query.trim().toLowerCase();
+    if (!isEmail(trimmed)) {
+      setEmailError(labels.emailInvalid);
+      return;
+    }
+    if (existingKeys.has(inviteeKey({ kind: 'email', address: trimmed }))) {
+      setEmailError(labels.emailDuplicate);
+      return;
+    }
+    setEmailError(null);
+    onAddInvitee({ kind: 'email', address: trimmed });
+    onQueryChange('');
+  };
+
+  const handleAddUser = (user: UserSearchResult): void => {
+    const invitee: UserInvitee = {
+      kind: 'user',
+      id: user.id,
+      displayName: user.displayName,
+      email: user.email,
+    };
+    if (existingKeys.has(inviteeKey(invitee))) return;
+    onAddInvitee(invitee);
+    onQueryChange('');
+  };
+
+  const handleAddRegular = (regular: RegularDto): void => {
+    handleAddUser({
+      id: regular.id,
+      displayName: regular.displayName,
+      email: regular.email,
+    });
+  };
+
+  return (
+    <section
+      data-slot="game-night-create-step3"
+      aria-labelledby={`${inputId}-label`}
+      className="flex flex-col gap-4"
+    >
+      <label
+        id={`${inputId}-label`}
+        htmlFor={inputId}
+        className="text-sm font-medium text-foreground"
+      >
+        {labels.label}
+      </label>
+
+      <div className="flex flex-col gap-2">
+        <input
+          id={inputId}
+          type="search"
+          value={query}
+          onChange={e => {
+            setEmailError(null);
+            onQueryChange(e.target.value);
+          }}
+          placeholder={labels.searchPlaceholder}
+          aria-label={labels.searchAriaLabel}
+          disabled={atLimit}
+          className="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground"
+          data-slot="game-night-create-step3-search"
+        />
+        {queryLooksLikeEmail && (
+          <button
+            type="button"
+            onClick={handleAddEmail}
+            disabled={atLimit}
+            className="self-start text-xs font-medium text-primary underline"
+            data-slot="game-night-create-step3-add-email"
+          >
+            {labels.addEmail}
+          </button>
+        )}
+        {emailError && (
+          <p role="alert" className="text-xs text-destructive">
+            {emailError}
+          </p>
+        )}
+      </div>
+
+      {searchResults.length > 0 && (
+        <ul
+          role="listbox"
+          aria-label={labels.searchAriaLabel}
+          className="flex flex-col gap-1 rounded-md border border-border bg-card"
+          data-slot="game-night-create-step3-results"
+        >
+          {searchResults.map(result => {
+            const alreadyAdded = existingKeys.has(
+              inviteeKey({
+                kind: 'user',
+                id: result.id,
+                displayName: result.displayName,
+                email: result.email,
+              })
+            );
+            return (
+              <li key={result.id} role="option" aria-selected={false}>
+                <button
+                  type="button"
+                  onClick={() => handleAddUser(result)}
+                  disabled={alreadyAdded || atLimit}
+                  className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                >
+                  <span>{result.displayName}</span>
+                  <span className="text-xs text-muted-foreground">{result.email}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {isSearching && (
+        <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
+          {labels.searchAriaLabel}
+        </p>
+      )}
+
+      {!query && (
+        <div data-slot="game-night-create-step3-regulars">
+          <p className="text-sm font-medium text-foreground">{labels.regularsTitle}</p>
+          <p className="text-xs text-muted-foreground">{labels.regularsHelper}</p>
+          {regulars.length === 0 ? (
+            <p className="mt-2 text-xs text-muted-foreground">{labels.regularsEmpty}</p>
+          ) : (
+            <ul className="mt-2 flex flex-col gap-1">
+              {regulars.map(regular => {
+                const alreadyAdded = existingKeys.has(
+                  inviteeKey({
+                    kind: 'user',
+                    id: regular.id,
+                    displayName: regular.displayName,
+                    email: regular.email,
+                  })
+                );
+                return (
+                  <li key={regular.id} className="flex items-center justify-between">
+                    <span className="text-sm text-foreground">{regular.displayName}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleAddRegular(regular)}
+                      disabled={alreadyAdded || atLimit}
+                      className="text-xs font-medium text-primary underline disabled:opacity-50"
+                    >
+                      {labels.addRegular}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <div data-slot="game-night-create-step3-invitees">
+        <p className="text-sm font-medium text-foreground">
+          {labels.inviteeCount(invitees.length)}
+        </p>
+        {invitees.length > 0 && (
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {invitees.map(invitee => {
+              const key = inviteeKey(invitee);
+              const display = invitee.kind === 'user' ? invitee.displayName : invitee.address;
+              return (
+                <li
+                  key={key}
+                  className="flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1 text-xs"
+                >
+                  <span className="text-foreground">{display}</span>
+                  <button
+                    type="button"
+                    onClick={() => onRemoveInvitee(key)}
+                    aria-label={`${labels.remove} ${display}`}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    ×
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {atLimit && (
+          <p role="alert" className="mt-2 text-xs text-warning">
+            {labels.limitWarning(maxCombinedInvitees)}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/RSVPCardLivePreview.tsx
+++ b/apps/web/src/components/features/game-night-create/RSVPCardLivePreview.tsx
@@ -21,6 +21,16 @@ export interface RSVPCardLivePreviewLabels {
   readonly noLocation: string;
   readonly gamesTbd: string;
   readonly gamesNone: string;
+  // PR #1297 review fix: section headers + location-fallback strings
+  // must flow through the labels contract so non-IT locales don't leak
+  // Italian into the preview card.
+  readonly sectionWhen: string;
+  readonly sectionWhere: string;
+  readonly sectionWhat: string;
+  readonly sectionWho: string;
+  readonly kindHome: string;
+  readonly kindFriend: string;
+  readonly kindOnline: string;
 }
 
 export interface RSVPCardLivePreviewProps {
@@ -38,13 +48,16 @@ function locationLine(
 ): string {
   if (kind === 'tbd') return labels.noLocation;
   if (details.trim().length > 0) return details;
+  // PR #1297 review fix: each kind routes through labels (was hardcoded IT;
+  // the `home` branch also produced the literal string "Casa di home" due to
+  // an incorrect concat from an unfinished placeholder).
   switch (kind) {
     case 'home':
-      return 'Casa di ' + (kind as string);
+      return labels.kindHome;
     case 'friend':
-      return 'Casa di un amico';
+      return labels.kindFriend;
     case 'online':
-      return 'Online';
+      return labels.kindOnline;
   }
 }
 
@@ -99,21 +112,21 @@ export function RSVPCardLivePreview({
 
       <dl className="flex flex-col gap-2 text-sm">
         <div>
-          <dt className="text-xs uppercase text-muted-foreground">Quando</dt>
+          <dt className="text-xs uppercase text-muted-foreground">{labels.sectionWhen}</dt>
           <dd className="text-foreground">{formatDate(state.date.iso, labels.noDate)}</dd>
         </div>
         <div>
-          <dt className="text-xs uppercase text-muted-foreground">Dove</dt>
+          <dt className="text-xs uppercase text-muted-foreground">{labels.sectionWhere}</dt>
           <dd className="text-foreground">
             {locationLine(state.location.kind, state.location.details, labels)}
           </dd>
         </div>
         <div>
-          <dt className="text-xs uppercase text-muted-foreground">Cosa</dt>
+          <dt className="text-xs uppercase text-muted-foreground">{labels.sectionWhat}</dt>
           <dd className="text-foreground">{gamesLine(state, games, labels)}</dd>
         </div>
         <div>
-          <dt className="text-xs uppercase text-muted-foreground">Chi</dt>
+          <dt className="text-xs uppercase text-muted-foreground">{labels.sectionWho}</dt>
           <dd className="text-foreground">
             {state.invitees.length === 0
               ? '—'

--- a/apps/web/src/components/features/game-night-create/RSVPCardLivePreview.tsx
+++ b/apps/web/src/components/features/game-night-create/RSVPCardLivePreview.tsx
@@ -1,0 +1,143 @@
+/**
+ * RSVPCardLivePreview — desktop split-form live preview.
+ * Issue #950 W3 Components. Spec §5 (C6).
+ *
+ * Renders the invitation card as the recipient will see it; subscribes to
+ * the full WizardState so any change is reflected immediately.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import type { LocationKind, WizardState } from '@/lib/game-nights/wizard-types';
+
+export interface RSVPCardLivePreviewLabels {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly rsvpAccept: string;
+  readonly rsvpDecline: string;
+  readonly noDate: string;
+  readonly noLocation: string;
+  readonly gamesTbd: string;
+  readonly gamesNone: string;
+}
+
+export interface RSVPCardLivePreviewProps {
+  readonly state: WizardState;
+  readonly title: string;
+  readonly organizerName: string;
+  readonly games?: readonly { id: string; title: string }[];
+  readonly labels: RSVPCardLivePreviewLabels;
+}
+
+function locationLine(
+  kind: LocationKind,
+  details: string,
+  labels: RSVPCardLivePreviewLabels
+): string {
+  if (kind === 'tbd') return labels.noLocation;
+  if (details.trim().length > 0) return details;
+  switch (kind) {
+    case 'home':
+      return 'Casa di ' + (kind as string);
+    case 'friend':
+      return 'Casa di un amico';
+    case 'online':
+      return 'Online';
+  }
+}
+
+function gamesLine(
+  state: WizardState,
+  games: readonly { id: string; title: string }[],
+  labels: RSVPCardLivePreviewLabels
+): string {
+  if (state.games.decideAtGroup) return labels.gamesTbd;
+  if (state.games.selected.length === 0) return labels.gamesNone;
+  const titles = state.games.selected
+    .map(id => games.find(g => g.id === id)?.title ?? id)
+    .join(' · ');
+  return titles;
+}
+
+function formatDate(iso: string | null, fallback: string): string {
+  if (!iso) return fallback;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return fallback;
+  return d.toLocaleString(undefined, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function RSVPCardLivePreview({
+  state,
+  title,
+  organizerName,
+  games = [],
+  labels,
+}: RSVPCardLivePreviewProps): ReactElement {
+  return (
+    <aside
+      data-slot="game-night-create-preview"
+      aria-label={labels.title}
+      className="flex flex-col gap-4 rounded-lg border border-border bg-card p-4"
+    >
+      <header>
+        <p className="text-xs uppercase tracking-wider text-muted-foreground">{labels.title}</p>
+        <p className="text-xs text-muted-foreground">{labels.subtitle}</p>
+      </header>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-base font-semibold text-foreground">{title || '—'}</p>
+        <p className="text-xs text-muted-foreground">{organizerName}</p>
+      </div>
+
+      <dl className="flex flex-col gap-2 text-sm">
+        <div>
+          <dt className="text-xs uppercase text-muted-foreground">Quando</dt>
+          <dd className="text-foreground">{formatDate(state.date.iso, labels.noDate)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-muted-foreground">Dove</dt>
+          <dd className="text-foreground">
+            {locationLine(state.location.kind, state.location.details, labels)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-muted-foreground">Cosa</dt>
+          <dd className="text-foreground">{gamesLine(state, games, labels)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase text-muted-foreground">Chi</dt>
+          <dd className="text-foreground">
+            {state.invitees.length === 0
+              ? '—'
+              : state.invitees.map(i => (i.kind === 'user' ? i.displayName : i.address)).join(', ')}
+          </dd>
+        </div>
+      </dl>
+
+      <footer className="flex gap-2 pt-2">
+        <button
+          type="button"
+          disabled
+          className="flex-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground opacity-60"
+        >
+          {labels.rsvpAccept}
+        </button>
+        <button
+          type="button"
+          disabled
+          className="flex-1 rounded-md border border-border px-3 py-2 text-sm text-muted-foreground opacity-60"
+        >
+          {labels.rsvpDecline}
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/web/src/components/features/game-night-create/__tests__/components.test.tsx
+++ b/apps/web/src/components/features/game-night-create/__tests__/components.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * Smoke tests for the SP7 game-night-create components.
+ * Issue #950 W3 (Commit 2).
+ *
+ * Each component is exercised via a small render + a critical interaction
+ * (button click / select option / typing) to lock the prop contract. Full
+ * ≥85% coverage is deferred to W3-PR2 (orchestrator wiring) where the
+ * components are exercised in their realistic compositions.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  GameCandidatesPicker,
+  GameNightDateTimePicker,
+  GameNightLocationToggle,
+  PlayerInviteAutocomplete,
+  RSVPCardLivePreview,
+} from '../index';
+import { initialWizardState } from '@/lib/game-nights/wizard-reducer';
+
+const dateLabels = {
+  label: 'Quando',
+  helper: 'Almeno 1 ora nel futuro',
+  conflictWarningTitle: 'Hai già un impegno',
+  conflictWarningBody: (n: number) => `${n} eventi`,
+  conflictRoleOrganizer: 'Organizzi',
+  conflictRoleInvitee: 'Invitato',
+  continueAnyway: 'Continua comunque',
+  checking: 'Verifica…',
+};
+
+const locationLabels = {
+  label: 'Dove',
+  kindHome: 'Casa',
+  kindFriend: 'Casa di un amico',
+  kindOnline: 'Online',
+  kindTbd: 'Da definire',
+  detailsLabel: 'Dettagli',
+  detailsPlaceholder: 'Indirizzo',
+  detailsHelper: 'Visibili solo agli invitati',
+};
+
+const playerLabels = {
+  label: 'Chi',
+  searchPlaceholder: 'Cerca…',
+  searchAriaLabel: 'Cerca giocatori',
+  regularsTitle: 'Abituali',
+  regularsHelper: 'Per frequenza',
+  regularsEmpty: 'Nessuno',
+  addRegular: 'Aggiungi',
+  remove: 'Rimuovi',
+  addEmail: 'Invita per email',
+  emailInvalid: 'Email non valida',
+  emailDuplicate: 'Email già aggiunta',
+  inviteeCount: (n: number) => `${n} invitati`,
+  limitWarning: (max: number) => `Max ${max} invitati`,
+};
+
+const gameLabels = {
+  label: 'Cosa',
+  decideAtGroupLabel: 'Decide il gruppo',
+  decideAtGroupHelper: 'Decideremo insieme',
+  selectedCount: (n: number) => `${n} giochi`,
+  libraryHeader: 'La tua libreria',
+  libraryEmpty: 'Vuota',
+  selectGame: (name: string) => `Seleziona ${name}`,
+  deselectGame: (name: string) => `Deseleziona ${name}`,
+};
+
+const previewLabels = {
+  title: 'Anteprima',
+  subtitle: 'Cosa vedono gli invitati',
+  rsvpAccept: 'Partecipo',
+  rsvpDecline: 'Non posso',
+  noDate: 'Data da scegliere',
+  noLocation: 'Luogo da definire',
+  gamesTbd: 'Giochi: al gruppo',
+  gamesNone: 'Nessun gioco',
+};
+
+describe('GameNightDateTimePicker', () => {
+  it('renders the helper text', () => {
+    render(
+      <GameNightDateTimePicker
+        iso={null}
+        onSetDate={vi.fn()}
+        conflictResult={null}
+        labels={dateLabels}
+      />
+    );
+    expect(screen.getByText(dateLabels.helper)).toBeInTheDocument();
+  });
+
+  it('surfaces a conflict warning when conflictResult.hasConflict is true', () => {
+    render(
+      <GameNightDateTimePicker
+        iso="2099-12-31T20:00:00Z"
+        onSetDate={vi.fn()}
+        conflictResult={{
+          hasConflict: true,
+          conflicts: [
+            {
+              id: '00000000-0000-4000-8000-000000000301',
+              title: 'Catan',
+              scheduledAt: '2099-12-31T19:00:00Z',
+              role: 'organizer',
+            },
+          ],
+        }}
+        onContinueAnyway={vi.fn()}
+        labels={dateLabels}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(dateLabels.conflictWarningTitle);
+    expect(screen.getByRole('button', { name: dateLabels.continueAnyway })).toBeInTheDocument();
+  });
+
+  it('fires onContinueAnyway when override button is clicked', async () => {
+    const user = userEvent.setup();
+    const onContinueAnyway = vi.fn();
+    render(
+      <GameNightDateTimePicker
+        iso="2099-12-31T20:00:00Z"
+        onSetDate={vi.fn()}
+        conflictResult={{
+          hasConflict: true,
+          conflicts: [
+            {
+              id: '00000000-0000-4000-8000-000000000301',
+              title: 'Catan',
+              scheduledAt: '2099-12-31T19:00:00Z',
+              role: 'invitee',
+            },
+          ],
+        }}
+        onContinueAnyway={onContinueAnyway}
+        labels={dateLabels}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: dateLabels.continueAnyway }));
+    expect(onContinueAnyway).toHaveBeenCalledOnce();
+  });
+});
+
+describe('GameNightLocationToggle', () => {
+  it('renders 4 radio options', () => {
+    render(
+      <GameNightLocationToggle
+        kind="home"
+        details=""
+        onSetLocation={vi.fn()}
+        labels={locationLabels}
+      />
+    );
+    expect(screen.getAllByRole('radio')).toHaveLength(4);
+  });
+
+  it('selecting "tbd" hides the details textarea', () => {
+    const onSetLocation = vi.fn();
+    render(
+      <GameNightLocationToggle
+        kind="tbd"
+        details=""
+        onSetLocation={onSetLocation}
+        labels={locationLabels}
+      />
+    );
+    expect(screen.queryByLabelText(locationLabels.detailsLabel)).not.toBeInTheDocument();
+  });
+
+  it('emits onSetLocation with new kind when option clicked', async () => {
+    const user = userEvent.setup();
+    const onSetLocation = vi.fn();
+    render(
+      <GameNightLocationToggle
+        kind="home"
+        details=""
+        onSetLocation={onSetLocation}
+        labels={locationLabels}
+      />
+    );
+    await user.click(screen.getByRole('radio', { name: locationLabels.kindOnline }));
+    expect(onSetLocation).toHaveBeenCalledWith('online', '');
+  });
+});
+
+describe('PlayerInviteAutocomplete', () => {
+  it('renders the regulars list when query is empty', () => {
+    render(
+      <PlayerInviteAutocomplete
+        invitees={[]}
+        searchResults={[]}
+        regulars={[
+          {
+            id: '00000000-0000-4000-8000-000000000101',
+            displayName: 'Laura',
+            email: 'laura@example.com',
+            eventCount: 3,
+            lastInvitedAt: '2025-01-01T00:00:00Z',
+          },
+        ]}
+        query=""
+        onQueryChange={vi.fn()}
+        onAddInvitee={vi.fn()}
+        onRemoveInvitee={vi.fn()}
+        labels={playerLabels}
+      />
+    );
+    expect(screen.getByText('Laura')).toBeInTheDocument();
+  });
+
+  it('emits onAddInvitee when adding a regular', async () => {
+    const user = userEvent.setup();
+    const onAddInvitee = vi.fn();
+    render(
+      <PlayerInviteAutocomplete
+        invitees={[]}
+        searchResults={[]}
+        regulars={[
+          {
+            id: '00000000-0000-4000-8000-000000000101',
+            displayName: 'Laura',
+            email: 'laura@example.com',
+            eventCount: 3,
+            lastInvitedAt: '2025-01-01T00:00:00Z',
+          },
+        ]}
+        query=""
+        onQueryChange={vi.fn()}
+        onAddInvitee={onAddInvitee}
+        onRemoveInvitee={vi.fn()}
+        labels={playerLabels}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: playerLabels.addRegular }));
+    expect(onAddInvitee).toHaveBeenCalledWith({
+      kind: 'user',
+      id: '00000000-0000-4000-8000-000000000101',
+      displayName: 'Laura',
+      email: 'laura@example.com',
+    });
+  });
+
+  it('shows email-add button only when query looks like an email', () => {
+    render(
+      <PlayerInviteAutocomplete
+        invitees={[]}
+        searchResults={[]}
+        regulars={[]}
+        query="guest@example.com"
+        onQueryChange={vi.fn()}
+        onAddInvitee={vi.fn()}
+        onRemoveInvitee={vi.fn()}
+        labels={playerLabels}
+      />
+    );
+    expect(screen.getByRole('button', { name: playerLabels.addEmail })).toBeInTheDocument();
+  });
+});
+
+describe('GameCandidatesPicker', () => {
+  it('toggling decideAtGroup emits the action', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <GameCandidatesPicker
+        games={[]}
+        selected={[]}
+        decideAtGroup={false}
+        onToggleGame={vi.fn()}
+        onToggleDecideAtGroup={onToggle}
+        labels={gameLabels}
+      />
+    );
+    // The checkbox sits inside a <label> wrapping both its primary text and
+    // a helper line — accessible name is the concatenation. Use the
+    // single-checkbox role lookup instead of a brittle name match.
+    await user.click(screen.getByRole('checkbox'));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('emits onToggleGame when a card is clicked', async () => {
+    const user = userEvent.setup();
+    const onToggleGame = vi.fn();
+    render(
+      <GameCandidatesPicker
+        games={[{ id: '00000000-0000-4000-8000-000000000201', title: 'Catan' }]}
+        selected={[]}
+        decideAtGroup={false}
+        onToggleGame={onToggleGame}
+        onToggleDecideAtGroup={vi.fn()}
+        labels={gameLabels}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: gameLabels.selectGame('Catan') }));
+    expect(onToggleGame).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000201');
+  });
+});
+
+describe('RSVPCardLivePreview', () => {
+  it('renders the title fallback when title is empty', () => {
+    render(
+      <RSVPCardLivePreview
+        state={initialWizardState}
+        title=""
+        organizerName="Marco"
+        labels={previewLabels}
+      />
+    );
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText(previewLabels.noDate)).toBeInTheDocument();
+  });
+
+  it('renders games TBD label when decideAtGroup is true', () => {
+    render(
+      <RSVPCardLivePreview
+        state={{
+          ...initialWizardState,
+          games: { decideAtGroup: true, selected: [] },
+        }}
+        title="Friday Catan"
+        organizerName="Marco"
+        labels={previewLabels}
+      />
+    );
+    expect(screen.getByText(previewLabels.gamesTbd)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/game-night-create/__tests__/components.test.tsx
+++ b/apps/web/src/components/features/game-night-create/__tests__/components.test.tsx
@@ -57,6 +57,7 @@ const playerLabels = {
   emailDuplicate: 'Email già aggiunta',
   inviteeCount: (n: number) => `${n} invitati`,
   limitWarning: (max: number) => `Max ${max} invitati`,
+  searching: 'Ricerca…',
 };
 
 const gameLabels = {
@@ -79,6 +80,13 @@ const previewLabels = {
   noLocation: 'Luogo da definire',
   gamesTbd: 'Giochi: al gruppo',
   gamesNone: 'Nessun gioco',
+  sectionWhen: 'Quando',
+  sectionWhere: 'Dove',
+  sectionWhat: 'Cosa',
+  sectionWho: 'Chi',
+  kindHome: 'Casa mia',
+  kindFriend: 'Casa di un amico',
+  kindOnline: 'Online',
 };
 
 describe('GameNightDateTimePicker', () => {

--- a/apps/web/src/components/features/game-night-create/index.ts
+++ b/apps/web/src/components/features/game-night-create/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #950 W3 Components — public surface of the game-night-create feature.
+ *
+ * Components ship as pure functions with explicit label props; the orchestrator
+ * (Week 3 Commit 3) is responsible for injecting i18n strings + state.
+ */
+
+export { GameNightCreateWizard } from './GameNightCreateWizard';
+export type {
+  GameNightCreateWizardLabels,
+  GameNightCreateWizardProps,
+} from './GameNightCreateWizard';
+
+export { GameNightDateTimePicker } from './GameNightDateTimePicker';
+export type {
+  GameNightDateTimePickerLabels,
+  GameNightDateTimePickerProps,
+} from './GameNightDateTimePicker';
+
+export { GameNightLocationToggle } from './GameNightLocationToggle';
+export type {
+  GameNightLocationToggleLabels,
+  GameNightLocationToggleProps,
+} from './GameNightLocationToggle';
+
+export { PlayerInviteAutocomplete } from './PlayerInviteAutocomplete';
+export type {
+  PlayerInviteAutocompleteLabels,
+  PlayerInviteAutocompleteProps,
+} from './PlayerInviteAutocomplete';
+
+export { GameCandidatesPicker } from './GameCandidatesPicker';
+export type {
+  GameCandidateOption,
+  GameCandidatesPickerLabels,
+  GameCandidatesPickerProps,
+} from './GameCandidatesPicker';
+
+export { RSVPCardLivePreview } from './RSVPCardLivePreview';
+export type { RSVPCardLivePreviewLabels, RSVPCardLivePreviewProps } from './RSVPCardLivePreview';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3225,7 +3225,8 @@
       "emailDuplicate": "Email already added",
       "inviteeCount": "{count} {count, plural, =1 {invitee} other {invitees}}",
       "limitWarning": "Maximum {max} invitees total.",
-      "limitExceeded": "You've hit the {max} invitees limit."
+      "limitExceeded": "You've hit the {max} invitees limit.",
+      "searching": "Searching…"
     },
     "step4": {
       "label": "What to play",
@@ -3247,7 +3248,14 @@
       "noDate": "Date to be decided",
       "noLocation": "Location to be decided",
       "gamesTbd": "Games: decided at the group",
-      "gamesNone": "No games picked"
+      "gamesNone": "No games picked",
+      "sectionWhen": "When",
+      "sectionWhere": "Where",
+      "sectionWhat": "What",
+      "sectionWho": "Who",
+      "kindHome": "My place",
+      "kindFriend": "A friend's place",
+      "kindOnline": "Online"
     },
     "submit": {
       "creating": "Creating…",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3278,7 +3278,8 @@
       "emailDuplicate": "Email già aggiunta",
       "inviteeCount": "{count} {count, plural, =1 {invitato} other {invitati}}",
       "limitWarning": "Massimo {max} invitati totali.",
-      "limitExceeded": "Hai raggiunto il limite di {max} invitati."
+      "limitExceeded": "Hai raggiunto il limite di {max} invitati.",
+      "searching": "Ricerca in corso…"
     },
     "step4": {
       "label": "Cosa giocate",
@@ -3300,7 +3301,14 @@
       "noDate": "Data da scegliere",
       "noLocation": "Luogo da definire",
       "gamesTbd": "Giochi: da decidere al gruppo",
-      "gamesNone": "Nessun gioco selezionato"
+      "gamesNone": "Nessun gioco selezionato",
+      "sectionWhen": "Quando",
+      "sectionWhere": "Dove",
+      "sectionWhat": "Cosa",
+      "sectionWho": "Chi",
+      "kindHome": "Casa mia",
+      "kindFriend": "Casa di un amico",
+      "kindOnline": "Online"
     },
     "submit": {
       "creating": "Creazione in corso…",


### PR DESCRIPTION
## Summary

Issue #950 Week 3 Commit 2: ships the 6 v2 wizard components in `apps/web/src/components/features/game-night-create/`. **No route swap yet** — page wiring + URL `?step=` sync + autosave land in W3-PR2.

Spec [`2026-05-18-sp7-game-night-create.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/superpowers/specs/2026-05-18-sp7-game-night-create.md) §5 (C1-C6).

## Components

| # | File | Purpose |
|---|---|---|
| C1 | `GameNightCreateWizard.tsx` | Orchestrator skeleton: stepper + step routing + nav buttons + RSVP preview |
| C2 | `GameNightDateTimePicker.tsx` | Step 1 datetime-local input + conflict warning surface (Scenario 2) |
| C3 | `GameNightLocationToggle.tsx` | Step 2 4-option radio group + details textarea (hidden for tbd) |
| C4 | `PlayerInviteAutocomplete.tsx` | Step 3 search + regulars + email-add + chip list |
| C5 | `GameCandidatesPicker.tsx` | Step 4 library grid + decide-at-group toggle (Scenario 6) |
| C6 | `RSVPCardLivePreview.tsx` | Desktop split: invitation card live preview |

## Design principles

- **Pure components**: all i18n via `labels` prop; orchestrator owns state + react-query results
- **Semantic tokens only**: `bg-card`, `text-foreground`, `border-border`, `text-muted-foreground` — no hardcoded colors (CLAUDE.md DS-15)
- **A11y**: `role="radiogroup"`/`radio` (Step 2), `role="listbox"`/`option` (Step 3 search), `aria-pressed` (Step 4 cards), `role="alert"` (conflict warning + email errors)
- **`data-slot` attributes**: stable Week 4 E2E selectors (`game-night-create-wizard`, `game-night-create-stepper-step{1-4}`, `game-night-create-step{1-4}-container`, `game-night-create-step4-game-{id}`, `game-night-create-nav-{back,next}`, `game-night-create-preview`)
- **Discriminated unions exhausted**: `LocationKind`, `Invitee` (user|email) handled with explicit switches

## Test coverage

**13 smoke tests** covering critical interactions:
- DateTimePicker: helper render, conflict warning, continueAnyway callback
- LocationToggle: 4 radio options, tbd hides details, kind-click emit
- PlayerInviteAutocomplete: regulars list, regular-add emit, email-add gating
- GameCandidatesPicker: decideAtGroup toggle, game-card click
- RSVPCardLivePreview: empty-state fallback, decideAtGroup label

**NOT** full ≥85% per-component coverage (spec §11 AC-C.2 target). Deferred to W3-PR2 — orchestrator wiring tests will exercise every branch through realistic compositions with mocked hooks.

## Test plan

- [x] `pnpm typecheck` clean
- [x] 13 smoke tests pass
- [ ] CI green
- [ ] Code review

## What's NOT in this PR (deferred to W3-PR2)

- ❌ `page.tsx` swap from legacy to `GameNightCreateWizard`
- ❌ URL `?step=N` sync + `?fixture=...` visual-test hatch
- ❌ Autosave hook (`useGameNightDraftPersist`)
- ❌ Submit retry [1s, 2s, 4s] policy
- ❌ Hook integration tests via MSW
- ❌ E2E specs + visual baselines (Week 4)

## Refs

- Issue #950 (W3 Commit 2 of 3)
- Spec §5 (C1-C6), §11 AC-C (Components), §12 Scenario 2/3/6, §13 (test strategy)
- W2 Foundation: PR #1296 (reducer + validators + hooks consumed by these components)
- W1 backend: PR #1289 + #1294 (endpoints consumed via hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)