### PR TITLE
feat(gamebook): resume-state desktop responsive variants (closes #954)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/EmptyFirstTime.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/EmptyFirstTime.tsx
@@ -24,7 +24,7 @@ export function EmptyFirstTime({
     <section
       data-testid="gamebook-resume-empty-first-time"
       data-state="state-01-first-time"
-      className="flex flex-col gap-5 px-4 py-6 max-w-screen-sm mx-auto"
+      className="flex flex-col gap-5 px-4 py-6 max-w-screen-sm lg:max-w-2xl mx-auto"
     >
       <div
         aria-hidden

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/MultiCampaignList.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/MultiCampaignList.tsx
@@ -72,7 +72,7 @@ export function MultiCampaignList({
     <section
       data-testid="gamebook-resume-multi-list"
       data-state="state-03-multi-campaign"
-      className="max-w-screen-sm mx-auto px-4 py-6 space-y-4"
+      className="mx-auto px-4 py-6 space-y-4 max-w-screen-sm lg:max-w-6xl"
     >
       <header>
         <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -86,7 +86,9 @@ export function MultiCampaignList({
         </p>
       </header>
 
-      <ul className="flex flex-col gap-3">
+      {/* Desktop: 2-col grid (mockup state-03-desktop-grid).
+          Mobile: stack vertical (default). */}
+      <ul className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4">
         {campaigns.map((campaign, idx) => {
           const accent = idx === 0 ? 'var(--c-game)' : 'var(--c-agent)';
           const days = daysSince(campaign.lastReadAt);

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/ResumeHero.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/ResumeHero.tsx
@@ -33,46 +33,75 @@ export function ResumeHero({ campaign, gameId, onCreateNew }: ResumeHeroProps): 
     <section
       data-testid="gamebook-resume-hero"
       data-state="state-02-single-resume"
-      className="max-w-screen-sm mx-auto px-4 py-6"
+      className="mx-auto px-4 py-6 max-w-screen-sm lg:max-w-6xl lg:grid lg:grid-cols-[380px_minmax(0,1fr)] lg:gap-8"
     >
-      <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Bentornato
-      </p>
-      <article className="overflow-hidden rounded-2xl border border-[var(--c-game)]/30 bg-background shadow-sm">
-        <div className="h-1 bg-[var(--c-game)]" aria-hidden />
-        <div className="px-5 py-5 space-y-4">
-          <header>
-            <h2 className="text-xl font-bold leading-tight">{campaign.title}</h2>
-            <p className="mt-1 text-xs text-muted-foreground">Ultima sessione {lastLabel}</p>
-          </header>
-
-          <div className="flex items-baseline gap-3">
-            <span className="text-4xl font-extrabold tabular-nums text-[var(--c-game)]">
-              §{campaign.currentParagraph}
-            </span>
-            <span className="text-xs text-muted-foreground">ultimo paragrafo letto</span>
-          </div>
-
-          <div className="flex flex-col gap-2">
+      {/* Sidebar — visible only on desktop (lg+).
+          Mockup state-02-desktop-split-view: 380px lista campagne / single-entry preview. */}
+      <aside
+        data-testid="gamebook-resume-hero-sidebar"
+        className="hidden lg:block"
+        aria-label="Elenco campagne"
+      >
+        <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Le tue campagne
+        </p>
+        <ul className="space-y-2">
+          <li>
             <Link
               href={`/library/${gameId}/play/${campaign.id}`}
-              data-testid="gamebook-resume-hero-cta"
-              className="inline-flex items-center justify-center rounded-md bg-[var(--c-game)] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:opacity-95"
+              className="block rounded-lg border border-[var(--c-game)]/40 bg-[var(--c-game)]/5 px-4 py-3 text-sm font-medium text-[var(--c-game)] hover:bg-[var(--c-game)]/10"
+              aria-current="page"
             >
-              Riprendi → §{next}
+              <span className="block truncate font-semibold">{campaign.title}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                §{campaign.currentParagraph} · {lastLabel}
+              </span>
             </Link>
-            {onCreateNew && (
-              <button
-                type="button"
-                onClick={onCreateNew}
-                className="rounded-md border border-border bg-background px-5 py-2.5 text-sm font-semibold text-foreground hover:bg-muted"
+          </li>
+        </ul>
+      </aside>
+
+      {/* Main pane — single-resume hero card. Sole content on mobile, right pane on desktop. */}
+      <div data-testid="gamebook-resume-hero-main">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground lg:hidden">
+          Bentornato
+        </p>
+        <article className="overflow-hidden rounded-2xl border border-[var(--c-game)]/30 bg-background shadow-sm">
+          <div className="h-1 bg-[var(--c-game)]" aria-hidden />
+          <div className="px-5 py-5 space-y-4 lg:px-8 lg:py-7">
+            <header>
+              <h2 className="text-xl font-bold leading-tight lg:text-2xl">{campaign.title}</h2>
+              <p className="mt-1 text-xs text-muted-foreground">Ultima sessione {lastLabel}</p>
+            </header>
+
+            <div className="flex items-baseline gap-3">
+              <span className="text-4xl font-extrabold tabular-nums text-[var(--c-game)] lg:text-5xl">
+                §{campaign.currentParagraph}
+              </span>
+              <span className="text-xs text-muted-foreground">ultimo paragrafo letto</span>
+            </div>
+
+            <div className="flex flex-col gap-2 lg:flex-row lg:gap-3">
+              <Link
+                href={`/library/${gameId}/play/${campaign.id}`}
+                data-testid="gamebook-resume-hero-cta"
+                className="inline-flex items-center justify-center rounded-md bg-[var(--c-game)] px-5 py-3 text-sm font-semibold text-white shadow-sm hover:opacity-95"
               >
-                + Nuova campagna
-              </button>
-            )}
+                Riprendi → §{next}
+              </Link>
+              {onCreateNew && (
+                <button
+                  type="button"
+                  onClick={onCreateNew}
+                  className="rounded-md border border-border bg-background px-5 py-2.5 text-sm font-semibold text-foreground hover:bg-muted"
+                >
+                  + Nuova campagna
+                </button>
+              )}
+            </div>
           </div>
-        </div>
-      </article>
+        </article>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/StaleWarningCard.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/StaleWarningCard.tsx
@@ -40,7 +40,7 @@ export function StaleWarningCard({
     <section
       data-testid="gamebook-resume-stale-warning"
       data-state="state-04-stale-warning"
-      className="max-w-screen-sm mx-auto px-4 py-6"
+      className="max-w-screen-sm lg:max-w-2xl mx-auto px-4 py-6"
     >
       <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Bentornato

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/__tests__/GamebookResumeShell.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/_components/__tests__/GamebookResumeShell.test.tsx
@@ -121,4 +121,42 @@ describe('GamebookResumeShell — dispatch logic (mockup G 4 stati)', () => {
 
     expect(screen.getByTestId('gamebook-resume-shell-error')).toBeInTheDocument();
   });
+
+  // Issue #954 — desktop responsive variants (mockup state-02-desktop-split-view + state-03-desktop-grid).
+  it('renders ResumeHero with desktop split-view sidebar wrapper at lg+', () => {
+    vi.mocked(hookModule.useUserCampaigns).mockReturnValue({
+      data: [buildCampaign()],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    wrap(<GamebookResumeShell gameId="g1" />);
+
+    const hero = screen.getByTestId('gamebook-resume-hero');
+    // Split-view container uses lg:grid + lg:grid-cols-[380px_minmax(0,1fr)]
+    expect(hero.className).toMatch(/lg:grid/);
+    expect(hero.className).toMatch(/lg:grid-cols-\[380px_minmax\(0,1fr\)\]/);
+    // Sidebar wrapper (hidden on mobile, visible on lg+)
+    const sidebar = screen.getByTestId('gamebook-resume-hero-sidebar');
+    expect(sidebar.className).toMatch(/hidden/);
+    expect(sidebar.className).toMatch(/lg:block/);
+    // Main pane remains rendered
+    expect(screen.getByTestId('gamebook-resume-hero-main')).toBeInTheDocument();
+  });
+
+  it('renders MultiCampaignList with lg:grid-cols-2 grid at lg+', () => {
+    vi.mocked(hookModule.useUserCampaigns).mockReturnValue({
+      data: [buildCampaign({ id: 'c1', title: 'A' }), buildCampaign({ id: 'c2', title: 'B' })],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    wrap(<GamebookResumeShell gameId="g1" />);
+
+    const list = screen.getByTestId('gamebook-resume-multi-list');
+    // The container itself is the section; the inner <ul> carries the responsive grid.
+    const ul = list.querySelector('ul');
+    expect(ul).not.toBeNull();
+    expect(ul!.className).toMatch(/lg:grid-cols-2/);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the two desktop responsive variants of mockup G that remained outstanding after the 2026-05-08 mobile-first PR shipping #835. Issue body was reformulated 2026-05-19 (spec-panel score 5.0 → 7.9) when an audit revealed that 85% of the original DoD was already in production.

CSS-only delta on 4 components + 2 new responsive assertion tests.

| Component | Mobile (unchanged) | Desktop (lg+) |
|-----------|--------------------|-----|
| `ResumeHero` | hero card stack | `lg:grid-cols-[380px_minmax(0,1fr)]` split-view + sidebar preview |
| `MultiCampaignList` | `grid-cols-1` vertical stack | `lg:grid-cols-2` 2-col grid, container `lg:max-w-6xl` |
| `EmptyFirstTime` | `max-w-screen-sm` | `lg:max-w-2xl` |
| `StaleWarningCard` | `max-w-screen-sm` | `lg:max-w-2xl` |

## Test plan

- [x] `pnpm vitest run` on `GamebookResumeShell.test.tsx` → 8/8 (6 existing + 2 new)
- [x] `pnpm typecheck` clean
- [x] Pre-commit + pre-push hooks pass
- [ ] CI Frontend Tests
- [ ] CI Frontend Static (lint + typecheck)
- [ ] CodeQL JS

## DoD vs #954 (reformulated body)

| AC | Status |
|----|--------|
| AC-1 ResumeHero split-view at lg+ | ✅ |
| AC-2 MultiCampaignList 2-col grid at lg+ | ✅ |
| AC-3 Empty + Stale max-w expansion | ✅ |
| AC-4 Unit tests | ✅ 2 new responsive assertions |
| AC-5 Visual baselines | ⏸️ deferred (CI auto-bootstrap on next mockup conformity run; not required to land CSS) |
| AC-6 Location convention superseded note | ✅ documented in commit |
| AC-7 Bundle delta ≤ +5 KB | ✅ CSS-only |

## Out of scope (per reformulated body)

- Tablet variant 768–1023px — falls back to mobile, acceptable
- Inline rename modal hover affordances — separate enhancement
- Real-time campaigns sync (WebSocket) — TTL refresh sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)