### PR TITLE
feat(game-nights): #950 W3-PR2 — orchestrator + autosave + URL sync

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
@@ -1,0 +1,337 @@
+/**
+ * NewGameNightContent — client-side orchestrator for `/game-nights/new`.
+ *
+ * Issue #950 W3 Commit 3. Spec §11 AC-O.1 through AC-O.5:
+ *   - O.1: GameNightCreateWizard composed with all 6 v2 components
+ *   - O.2: page.tsx swaps the legacy form for this wizard
+ *   - O.3: URL `?step=N` sync (URL → reducer on mount; reducer → URL on goToStep)
+ *   - O.4: Autosave hook + restore + clear-on-success
+ *   - O.5: useCreateGameNight mutation with retry [1s, 2s, 4s]
+ */
+
+'use client';
+
+import { useEffect, useMemo, useReducer, useRef, useState, type ReactElement } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import {
+  GameNightCreateWizard,
+  type GameNightCreateWizardLabels,
+  type GameCandidateOption,
+} from '@/components/features/game-night-create';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
+import { useCreateGameNight } from '@/hooks/queries/useGameNights';
+import { useLibrary } from '@/hooks/queries/useLibrary';
+import { useToast } from '@/hooks/useToast';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useGameNightConflictCheck } from '@/lib/game-nights/hooks/useGameNightConflictCheck';
+import { useGameNightDraftPersist } from '@/lib/game-nights/hooks/useGameNightDraftPersist';
+import { usePlayerSearch } from '@/lib/game-nights/hooks/usePlayerSearch';
+import { useRegularsForUser } from '@/lib/game-nights/hooks/useRegularsForUser';
+import { initialWizardState, wizardReducer } from '@/lib/game-nights/wizard-reducer';
+import type { WizardStep } from '@/lib/game-nights/wizard-types';
+import { buildSubmitPayload } from '@/lib/game-nights/wizard-validators';
+
+const TOTAL_STEPS = 4 as const;
+const SUBMIT_RETRY_DELAYS_MS: readonly number[] = [1000, 2000, 4000];
+
+function parseStep(value: string | null): WizardStep {
+  const n = value ? Number.parseInt(value, 10) : NaN;
+  return n === 1 || n === 2 || n === 3 || n === 4 ? n : 1;
+}
+
+/**
+ * Build the deeply-nested labels object the wizard expects from the flat
+ * i18n catalog. Pure derivation; useMemo'd to avoid re-render churn.
+ */
+function buildWizardLabels(
+  t: (key: string, values?: Record<string, unknown>) => string
+): GameNightCreateWizardLabels {
+  return {
+    title: t('gameNightCreate.title'),
+    subtitle: t('gameNightCreate.subtitle'),
+    nav: {
+      back: t('gameNightCreate.nav.back'),
+      next: t('gameNightCreate.nav.next'),
+      submit: t('gameNightCreate.nav.submit'),
+      cancel: t('gameNightCreate.nav.cancel'),
+    },
+    steps: {
+      step1: t('gameNightCreate.steps.step1'),
+      step2: t('gameNightCreate.steps.step2'),
+      step3: t('gameNightCreate.steps.step3'),
+      step4: t('gameNightCreate.steps.step4'),
+      progress: (current, total) => t('gameNightCreate.steps.progress', { current, total }),
+    },
+    a11y: {
+      wizardLabel: t('gameNightCreate.a11y.wizardLabel'),
+      stepperLabel: t('gameNightCreate.a11y.stepperLabel'),
+    },
+    step1: {
+      label: t('gameNightCreate.step1.label'),
+      helper: t('gameNightCreate.step1.helper'),
+      conflictWarningTitle: t('gameNightCreate.step1.conflictWarningTitle'),
+      conflictWarningBody: count => t('gameNightCreate.step1.conflictWarningBody', { count }),
+      conflictRoleOrganizer: t('gameNightCreate.step1.conflictRoleOrganizer'),
+      conflictRoleInvitee: t('gameNightCreate.step1.conflictRoleInvitee'),
+      continueAnyway: t('gameNightCreate.step1.continueAnyway'),
+      checking: t('gameNightCreate.step1.continueAnyway'),
+    },
+    step2: {
+      label: t('gameNightCreate.step2.label'),
+      kindHome: t('gameNightCreate.step2.kindHome'),
+      kindFriend: t('gameNightCreate.step2.kindFriend'),
+      kindOnline: t('gameNightCreate.step2.kindOnline'),
+      kindTbd: t('gameNightCreate.step2.kindTbd'),
+      detailsLabel: t('gameNightCreate.step2.detailsLabel'),
+      detailsPlaceholder: t('gameNightCreate.step2.detailsPlaceholder'),
+      detailsHelper: t('gameNightCreate.step2.detailsHelper'),
+    },
+    step3: {
+      label: t('gameNightCreate.step3.label'),
+      searchPlaceholder: t('gameNightCreate.step3.searchPlaceholder'),
+      searchAriaLabel: t('gameNightCreate.step3.searchAriaLabel'),
+      regularsTitle: t('gameNightCreate.step3.regularsTitle'),
+      regularsHelper: t('gameNightCreate.step3.regularsHelper'),
+      regularsEmpty: t('gameNightCreate.step3.regularsEmpty'),
+      addRegular: t('gameNightCreate.step3.addRegular'),
+      remove: t('gameNightCreate.step3.remove'),
+      addEmail: t('gameNightCreate.step3.addEmail'),
+      emailInvalid: t('gameNightCreate.step3.emailInvalid'),
+      emailDuplicate: t('gameNightCreate.step3.emailDuplicate'),
+      inviteeCount: count => t('gameNightCreate.step3.inviteeCount', { count }),
+      limitWarning: max => t('gameNightCreate.step3.limitWarning', { max }),
+      searching: t('gameNightCreate.step3.searching'),
+    },
+    step4: {
+      label: t('gameNightCreate.step4.label'),
+      decideAtGroupLabel: t('gameNightCreate.step4.decideAtGroupLabel'),
+      decideAtGroupHelper: t('gameNightCreate.step4.decideAtGroupHelper'),
+      selectedCount: count => t('gameNightCreate.step4.selectedCount', { count }),
+      libraryHeader: t('gameNightCreate.step4.libraryHeader'),
+      libraryEmpty: t('gameNightCreate.step4.libraryEmpty'),
+      selectGame: name => t('gameNightCreate.step4.selectGame', { name }),
+      deselectGame: name => t('gameNightCreate.step4.deselectGame', { name }),
+    },
+    preview: {
+      title: t('gameNightCreate.preview.title'),
+      subtitle: t('gameNightCreate.preview.subtitle'),
+      rsvpAccept: t('gameNightCreate.preview.rsvpAccept'),
+      rsvpDecline: t('gameNightCreate.preview.rsvpDecline'),
+      noDate: t('gameNightCreate.preview.noDate'),
+      noLocation: t('gameNightCreate.preview.noLocation'),
+      gamesTbd: t('gameNightCreate.preview.gamesTbd'),
+      gamesNone: t('gameNightCreate.preview.gamesNone'),
+      sectionWhen: t('gameNightCreate.preview.sectionWhen'),
+      sectionWhere: t('gameNightCreate.preview.sectionWhere'),
+      sectionWhat: t('gameNightCreate.preview.sectionWhat'),
+      sectionWho: t('gameNightCreate.preview.sectionWho'),
+      kindHome: t('gameNightCreate.preview.kindHome'),
+      kindFriend: t('gameNightCreate.preview.kindFriend'),
+      kindOnline: t('gameNightCreate.preview.kindOnline'),
+    },
+  };
+}
+
+export function NewGameNightContent(): ReactElement {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { t } = useTranslation();
+  const { toast } = useToast();
+
+  const currentUserQuery = useCurrentUser();
+  const userId = currentUserQuery.data?.id ?? null;
+  const organizerName = currentUserQuery.data?.displayName ?? currentUserQuery.data?.email ?? '';
+
+  // URL → initial step. The wizard reducer source-of-truths the rest;
+  // we only sync `?step=` (data is kept in reducer, not URL — spec §8).
+  const initialStep = parseStep(searchParams.get('step'));
+  const [state, dispatch] = useReducer(wizardReducer, {
+    ...initialWizardState,
+    step: initialStep,
+  });
+
+  const [title, setTitle] = useState('');
+  const [playerSearchQuery, setPlayerSearchQuery] = useState('');
+
+  // ─── Autosave: load draft on mount, persist on changes, clear on success
+  const draftPersist = useGameNightDraftPersist({ userId, state });
+  const draftRestoredRef = useRef(false);
+  useEffect(() => {
+    if (draftRestoredRef.current) return;
+    if (draftPersist.initialDraft != null) {
+      dispatch({ type: 'restoreFromDraft', draft: draftPersist.initialDraft });
+    }
+    draftRestoredRef.current = true;
+  }, [draftPersist.initialDraft]);
+
+  // ─── URL `?step=` sync (reducer → URL)
+  useEffect(() => {
+    const current = searchParams.get('step');
+    const next = String(state.step);
+    if (current === next) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('step', next);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [state.step, router, searchParams]);
+
+  // ─── Step 3 hooks
+  const playerSearch = usePlayerSearch({ query: playerSearchQuery });
+  const regularsQuery = useRegularsForUser({ enabled: state.step === 3 });
+
+  // ─── Step 1 conflict check effect — dispatch when result lands
+  const conflictCheck = useGameNightConflictCheck({
+    at: state.date.iso,
+    enabled: state.date.iso != null,
+  });
+  const lastDispatchedIsoRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!conflictCheck.data) return;
+    if (state.date.iso == null) return;
+    if (lastDispatchedIsoRef.current === state.date.iso) return;
+    dispatch({
+      type: 'recordConflict',
+      result: conflictCheck.data,
+      checkedAt: new Date().toISOString(),
+    });
+    lastDispatchedIsoRef.current = state.date.iso;
+  }, [conflictCheck.data, state.date.iso]);
+
+  // ─── Step 4 library
+  const libraryQuery = useLibrary({ pageSize: 50 }, state.step === 4);
+  const libraryGames = useMemo<readonly GameCandidateOption[]>(() => {
+    const items = libraryQuery.data?.items ?? [];
+    return items.map(entry => ({
+      id: entry.gameId,
+      title: entry.gameTitle,
+      imageUrl: entry.gameImageUrl,
+      minPlayers: entry.minPlayers ?? null,
+      maxPlayers: entry.maxPlayers ?? null,
+      playingTimeMinutes: entry.playingTimeMinutes ?? null,
+    }));
+  }, [libraryQuery.data]);
+
+  // ─── Submit with retry [1s, 2s, 4s]
+  const createMutation = useCreateGameNight();
+  const [isSubmittingWithRetry, setIsSubmittingWithRetry] = useState(false);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (isSubmittingWithRetry) return;
+    const payloadResult = buildSubmitPayload(state, { title });
+    if (!payloadResult.ok) {
+      toast({
+        title: t('gameNightCreate.submit.errorTitle'),
+        description: t('gameNightCreate.submit.errorBody'),
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    // The buildSubmitPayload contract returns `null` for optional fields the
+    // user didn't fill; the legacy `CreateGameNightInput` shape on the
+    // mutation hook uses `undefined` for the same gate. Strip nulls so the
+    // type check passes without widening the shared schema (a wider change
+    // would touch unrelated callers).
+    const p = payloadResult.payload;
+    const mutationInput = {
+      title: p.title,
+      scheduledAt: p.scheduledAt,
+      ...(p.description != null ? { description: p.description } : {}),
+      ...(p.location != null ? { location: p.location } : {}),
+      ...(p.maxPlayers != null ? { maxPlayers: p.maxPlayers } : {}),
+      ...(p.gameIds != null ? { gameIds: p.gameIds } : {}),
+      ...(p.invitedUserIds != null ? { invitedUserIds: p.invitedUserIds } : {}),
+      ...(p.invitedEmails != null ? { invitedEmails: p.invitedEmails } : {}),
+    };
+
+    setIsSubmittingWithRetry(true);
+    const delays = [0, ...SUBMIT_RETRY_DELAYS_MS]; // first try has no pre-wait
+    let id: string | null = null;
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt < delays.length; attempt++) {
+      if (delays[attempt] > 0) {
+        await new Promise<void>(r => setTimeout(r, delays[attempt]));
+      }
+      try {
+        id = await createMutation.mutateAsync(mutationInput);
+        break;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+
+    setIsSubmittingWithRetry(false);
+
+    if (id) {
+      toast({
+        title: t('gameNightCreate.submit.successToast'),
+      });
+      draftPersist.clear();
+      router.push(`/game-nights/${id}`);
+      return;
+    }
+
+    toast({
+      title: t('gameNightCreate.submit.errorTitle'),
+      description: t('gameNightCreate.submit.errorBody'),
+      variant: 'destructive',
+    });
+    // lastError surfaces via toast; the wizard stays mounted with the
+    // user's data intact so they can retry or save the draft and exit.
+    void lastError;
+  };
+
+  const labels = useMemo(() => buildWizardLabels(t), [t]);
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="mb-4">
+        <label htmlFor="game-night-title" className="text-sm font-medium text-foreground">
+          {t('gameNightsIndex.header.ctaNew')}
+        </label>
+        <input
+          id="game-night-title"
+          type="text"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder={t('gameNightCreate.title')}
+          maxLength={200}
+          className="mt-1 w-full rounded-md border border-border bg-card px-3 py-2 text-foreground"
+          data-slot="game-night-create-title-input"
+        />
+      </div>
+
+      <GameNightCreateWizard
+        state={state}
+        dispatch={dispatch}
+        title={title}
+        organizerName={organizerName}
+        labels={labels}
+        playerSearchQuery={playerSearchQuery}
+        onPlayerSearchQueryChange={setPlayerSearchQuery}
+        playerSearchResults={playerSearch.data ?? []}
+        isSearchingPlayers={playerSearch.isFetching}
+        regulars={regularsQuery.data ?? []}
+        libraryGames={libraryGames}
+        onSubmit={() => {
+          void handleSubmit();
+        }}
+        isSubmitting={isSubmittingWithRetry || createMutation.isPending}
+        isCheckingConflict={conflictCheck.isFetching}
+      />
+
+      {draftPersist.isPending && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="mt-4 text-xs text-muted-foreground"
+          data-slot="game-night-create-draft-status"
+        >
+          {t('gameNightCreate.draft.savingStatus')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
@@ -76,7 +76,9 @@ function buildWizardLabels(
       conflictRoleOrganizer: t('gameNightCreate.step1.conflictRoleOrganizer'),
       conflictRoleInvitee: t('gameNightCreate.step1.conflictRoleInvitee'),
       continueAnyway: t('gameNightCreate.step1.continueAnyway'),
-      checking: t('gameNightCreate.step1.continueAnyway'),
+      // PR #1302 review fix: was reusing `continueAnyway` due to a
+      // copy-paste — now wired to the dedicated `checking` key.
+      checking: t('gameNightCreate.step1.checking'),
     },
     step2: {
       label: t('gameNightCreate.step2.label'),
@@ -216,6 +218,18 @@ export function NewGameNightContent(): ReactElement {
   const createMutation = useCreateGameNight();
   const [isSubmittingWithRetry, setIsSubmittingWithRetry] = useState(false);
 
+  // PR #1302 review fix: unmount guard for the multi-second retry loop.
+  // Without this, a user navigating away mid-retry would still trigger
+  // setIsSubmittingWithRetry(false) on the unmounted tree (React warning)
+  // and the late `router.push` would fire on a route the user already left.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const handleSubmit = async (): Promise<void> => {
     if (isSubmittingWithRetry) return;
     const payloadResult = buildSubmitPayload(state, { title });
@@ -251,9 +265,11 @@ export function NewGameNightContent(): ReactElement {
     let lastError: unknown = null;
 
     for (let attempt = 0; attempt < delays.length; attempt++) {
+      if (!isMountedRef.current) return;
       if (delays[attempt] > 0) {
         await new Promise<void>(r => setTimeout(r, delays[attempt]));
       }
+      if (!isMountedRef.current) return;
       try {
         id = await createMutation.mutateAsync(mutationInput);
         break;
@@ -262,6 +278,7 @@ export function NewGameNightContent(): ReactElement {
       }
     }
 
+    if (!isMountedRef.current) return;
     setIsSubmittingWithRetry(false);
 
     if (id) {
@@ -278,9 +295,12 @@ export function NewGameNightContent(): ReactElement {
       description: t('gameNightCreate.submit.errorBody'),
       variant: 'destructive',
     });
-    // lastError surfaces via toast; the wizard stays mounted with the
-    // user's data intact so they can retry or save the draft and exit.
-    void lastError;
+    // PR #1302 review fix: log retry exhaustion to console so SRE has a
+    // breadcrumb when investigating client-side submit failures. The toast
+    // is the user-facing surface.
+    if (lastError) {
+      console.error('[gamenight.create] retry exhausted', lastError);
+    }
   };
 
   const labels = useMemo(() => buildWizardLabels(t), [t]);

--- a/apps/web/src/app/(authenticated)/game-nights/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/page.tsx
@@ -1,42 +1,25 @@
 /**
- * Create Game Night Page
- * Issue #33 — P3 Game Night Frontend
+ * /game-nights/new — wizard route entry point.
+ *
+ * Issue #950 W3 Commit 3: swapped from the legacy single-form
+ * GameNightForm to the 4-step wizard orchestrator.
+ *
+ * Spec: docs/superpowers/specs/2026-05-18-sp7-game-night-create.md §11
+ * (AC-O.1, AC-O.2).
  */
 
-'use client';
+import { Suspense, type ReactElement } from 'react';
 
-import { useRouter } from 'next/navigation';
+import { NewGameNightContent } from './_content';
 
-import { useCreateGameNight } from '@/hooks/queries/useGameNights';
-import { useToast } from '@/hooks/useToast';
-import type { CreateGameNightInput } from '@/lib/api/schemas/game-nights.schemas';
-
-import { GameNightForm } from '../_components/GameNightForm';
-
-export default function NewGameNightPage() {
-  const router = useRouter();
-  const { toast } = useToast();
-  const createMutation = useCreateGameNight();
-
-  function handleSubmit(data: CreateGameNightInput) {
-    createMutation.mutate(data, {
-      onSuccess: id => {
-        toast({ title: 'Serata creata', description: 'La serata è stata creata come bozza.' });
-        router.push(`/game-nights/${id}`);
-      },
-      onError: () => {
-        toast({
-          title: 'Errore',
-          description: 'Impossibile creare la serata.',
-          variant: 'destructive',
-        });
-      },
-    });
-  }
-
+export default function NewGameNightPage(): ReactElement {
+  // The wizard reads `?step=` via useSearchParams; Next.js requires the
+  // calling client tree to be wrapped in Suspense for the static prerender
+  // bailout. The fallback is intentionally minimal — the wizard mounts
+  // within a few hundred ms once the route shell is hydrated.
   return (
-    <div className="p-4">
-      <GameNightForm onSubmit={handleSubmit} isSubmitting={createMutation.isPending} />
-    </div>
+    <Suspense fallback={null}>
+      <NewGameNightContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
+++ b/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
@@ -1,0 +1,148 @@
+/**
+ * useGameNightDraftPersist — autosave + restore for the SP7 wizard.
+ *
+ * Issue #950 W3 Commit 3. Spec §9 (draft autosave policy):
+ *   - Debounce 800ms after any reducer action that mutates form state.
+ *   - localStorage keyed `meepleai:gamenight-create-draft:<userId>`
+ *     (avoid cross-user leak).
+ *   - Schema version guard via `WIZARD_DRAFT_SCHEMA_VERSION` (drop on bump).
+ *   - 7-day TTL — drafts older than 7 days are discarded on read.
+ *   - Submit-success clears the draft via the returned `clear()` callback.
+ */
+
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  WIZARD_DRAFT_SCHEMA_VERSION,
+  type PersistedDraft,
+  type WizardState,
+} from '@/lib/game-nights/wizard-types';
+import { persistedDraftSchema } from '@/lib/game-nights/wizard-validators';
+
+const STORAGE_PREFIX = 'meepleai:gamenight-create-draft:';
+const DEBOUNCE_MS = 800;
+const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface StoredEnvelope {
+  readonly savedAt: number;
+  readonly draft: PersistedDraft;
+}
+
+function storageKey(userId: string): string {
+  return `${STORAGE_PREFIX}${userId}`;
+}
+
+function readDraft(userId: string): PersistedDraft | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId));
+    if (raw == null) return null;
+    const parsed = JSON.parse(raw) as StoredEnvelope;
+    if (Date.now() - parsed.savedAt > TTL_MS) {
+      window.localStorage.removeItem(storageKey(userId));
+      return null;
+    }
+    const validated = persistedDraftSchema.safeParse(parsed.draft);
+    if (!validated.success) {
+      // Schema version mismatch or corrupted payload — discard.
+      window.localStorage.removeItem(storageKey(userId));
+      return null;
+    }
+    return validated.data as PersistedDraft;
+  } catch {
+    return null;
+  }
+}
+
+function writeDraft(userId: string, state: WizardState): void {
+  if (typeof window === 'undefined') return;
+  // PersistedDraft is the WizardState minus the `draft` branch + schemaVersion.
+  const draft: PersistedDraft = {
+    schemaVersion: WIZARD_DRAFT_SCHEMA_VERSION,
+    step: state.step,
+    date: state.date,
+    location: state.location,
+    invitees: state.invitees,
+    games: state.games,
+  };
+  const envelope: StoredEnvelope = { savedAt: Date.now(), draft };
+  try {
+    window.localStorage.setItem(storageKey(userId), JSON.stringify(envelope));
+  } catch {
+    // localStorage full or denied — swallow; the spec accepts best-effort
+    // persistence (Nygard §9 risks).
+  }
+}
+
+function deleteDraft(userId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(storageKey(userId));
+  } catch {
+    // Ignore.
+  }
+}
+
+export interface UseGameNightDraftPersistOptions {
+  readonly userId: string | null;
+  readonly state: WizardState;
+  /**
+   * Skip autosave entirely (e.g. when the visual-test fixture short-circuits
+   * the orchestrator to a deterministic state).
+   */
+  readonly enabled?: boolean;
+}
+
+export interface UseGameNightDraftPersistResult {
+  /** The draft loaded from storage on mount, or null if none / stale. */
+  readonly initialDraft: PersistedDraft | null;
+  /** Imperative clear (call after successful submit / explicit discard). */
+  readonly clear: () => void;
+  /** Whether a save is currently scheduled (debounced). */
+  readonly isPending: boolean;
+}
+
+export function useGameNightDraftPersist({
+  userId,
+  state,
+  enabled = true,
+}: UseGameNightDraftPersistOptions): UseGameNightDraftPersistResult {
+  // Snapshot the initial draft on the FIRST render so consumers can dispatch
+  // `restoreFromDraft` exactly once. Subsequent state writes don't re-load
+  // (the user's edits would otherwise be overwritten on re-render).
+  const [initialDraft] = useState<PersistedDraft | null>(() =>
+    userId && enabled ? readDraft(userId) : null
+  );
+
+  const [isPending, setIsPending] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !userId) return undefined;
+
+    setIsPending(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      writeDraft(userId, state);
+      setIsPending(false);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // Persist whenever the persisted shape changes; the `draft` branch is
+    // intentionally excluded (autosave status doesn't trigger another save).
+  }, [enabled, userId, state.step, state.date, state.location, state.invitees, state.games]);
+
+  return {
+    initialDraft,
+    clear: () => {
+      if (timer.current) clearTimeout(timer.current);
+      setIsPending(false);
+      if (userId) deleteDraft(userId);
+    },
+    isPending,
+  };
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3194,7 +3194,8 @@
       "conflictRoleOrganizer": "You're hosting",
       "conflictRoleInvitee": "Invited",
       "continueAnyway": "Continue anyway",
-      "changeDate": "Change date"
+      "changeDate": "Change date",
+      "checking": "Checking for conflicts…"
     },
     "step2": {
       "label": "Where you play",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3247,7 +3247,8 @@
       "conflictRoleOrganizer": "Organizzi",
       "conflictRoleInvitee": "Invitato",
       "continueAnyway": "Continua comunque",
-      "changeDate": "Cambia data"
+      "changeDate": "Cambia data",
+      "checking": "Verifica conflitti in corso…"
     },
     "step2": {
       "label": "Dove giocate",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -610,7 +610,7 @@ instead.
 | `/sessions/[id]/{play,notes,players,scoreboard,join}` | `sp4-session-live.html` [partial] | Sub-views |
 | `/sessions/live/[id]` (+ `/agent`, `/photos`, `/players`, `/scores`) | `sp4-session-live.html` + `nanolith-runthrough-session-end.html` | — |
 | `/game-nights` | `sp4-game-nights-index.html` | Tier L pending |
-| `/game-nights/new` | `sp7-game-night-create.html` | — |
+| `/game-nights/new` | `sp7-game-night-create.html` | Tier L+ W3 done (PR #1297 components, PR #1302 orchestrator); W4 E2E + baselines pending |
 | `/game-nights/[id]` · `/[id]/edit` | `sp7-game-night-detail-rsvp.html` + `nanolith-game-night-storyboard.html` | Tier M done (PR #1171, RSVP cluster); tabbed/host surfaces pending |
 
 ### Authenticated — Play Records, Toolkit, Gamebook, Agents, KB


### PR DESCRIPTION
## Summary

Issue #950 Week 3 Commit 3: wires the SP7 wizard at `/game-nights/new`, swapping the legacy `GameNightForm` for the W3-PR1 wizard scaffold. **Spec §11 AC-O.1 through AC-O.5 satisfied.**

## Deliverables

| File | Purpose |
|---|---|
| `app/(authenticated)/game-nights/new/page.tsx` | Thin Suspense wrapper around the client content |
| `app/(authenticated)/game-nights/new/_content.tsx` | Client orchestrator (~290 LOC): `useReducer` + URL `?step=` sync + 5 hook integrations + submit retry + autosave wiring |
| `lib/game-nights/hooks/useGameNightDraftPersist.ts` | localStorage autosave (800ms debounce, 7-day TTL, per-user key, schema-version guard) |

## Spec parity

- **AC-O.1** ✅ `GameNightCreateWizard` composed with all 6 W3-PR1 components
- **AC-O.2** ✅ `page.tsx` swap from legacy `GameNightForm`
- **AC-O.3** ✅ URL `?step=N` sync (URL → reducer init on mount; reducer → URL on `goToStep` via `router.replace(?step=N, { scroll: false })`)
- **AC-O.4** ✅ Autosave on mount + 800ms debounce on every persisted-shape change + `clear()` on submit success
- **AC-O.5** ✅ `useCreateGameNight` mutation chained with retry delays `[0, 1s, 2s, 4s]` per spec §9; success → clear draft + `router.push(/game-nights/{id})`; failure → destructive toast

## Hook integrations

- `useGameNightConflictCheck(state.date.iso)` — dispatches `recordConflict` exactly once per ISO (guarded by `lastDispatchedIsoRef`)
- `usePlayerSearch` (debounced 250ms via Foundation hook) for Step 3
- `useRegularsForUser` — lazy `enabled: state.step === 3`
- `useLibrary({ pageSize: 50 }, state.step === 4)` — Step 4 game candidates
- `useCurrentUser` → organizer name + autosave userId key
- `useTranslation` (`t('gameNightCreate.*')`) → flat-to-nested `labels` derivation

## Build fix

Pre-push hook initially failed because `useSearchParams` requires a Suspense boundary during the static prerender bailout. Wrapped `<NewGameNightContent />` in `<Suspense fallback={null}>` in the server-component `page.tsx`. Verified locally with `pnpm build`.

## Test verification

- **151/151** game-nights tests pass (138 Foundation + 13 Components, no new orchestrator unit tests — Week 4 E2E specs exercise this exact route)
- `pnpm typecheck` clean
- `pnpm build` clean (after Suspense fix)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] 151/151 game-nights unit tests pass
- [ ] CI green
- [ ] Code review
- [ ] Manual smoke: `/game-nights/new` mounts wizard, step navigation works, draft restore on refresh

## What's NOT in this PR (deferred to Week 4)

- ❌ E2E happy path + 6 Gherkin scenarios (spec §12)
- ❌ Visual baselines for 10 FSM states (spec §4 + §13)
- ❌ A11y axe-core scans @ 375/768/1280
- ❌ Hook unit tests via MSW (Playwright E2E will cover the orchestrator)
- ❌ Visual-test `?fixture=...` hatch wiring (planned for Week 4 alongside the baselines)
- ❌ `v2-migration-matrix.md` row + conformity baseline (W4 §5)

## Refs

- Issue #950 (W3 Commit 3 of 3)
- Spec [`2026-05-18-sp7-game-night-create.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/superpowers/specs/2026-05-18-sp7-game-night-create.md) §11 AC-O, §9 (autosave/retry)
- W3-PR1 components: PR #1297
- W2 Foundation: PR #1296
- W1 backend: PR #1294 + #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)