### PR TITLE
feat(kb): per-tier LLM model override on RAG query (closes #562)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandler.cs
@@ -7,11 +7,13 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence.Mappers;
+using Api.Configuration;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Translation;
 using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Options;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 
@@ -49,6 +51,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
     private readonly IHouseRuleMatcher _houseRuleMatcher;
     private readonly IPricingEngine _pricingEngine;
     private readonly IGenericTranslationService _genericTranslationService;
+    private readonly IOptionsMonitor<LlmQueryComplexityRoutingOptions> _routingOptions;
     private readonly ILogger<AskQuestionQueryHandler> _logger;
 
     public AskQuestionQueryHandler(
@@ -68,6 +71,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         IHouseRuleMatcher houseRuleMatcher,
         IPricingEngine pricingEngine,
         IGenericTranslationService genericTranslationService,
+        IOptionsMonitor<LlmQueryComplexityRoutingOptions> routingOptions,
         ILogger<AskQuestionQueryHandler> logger)
     {
         _searchQueryHandler = searchQueryHandler ?? throw new ArgumentNullException(nameof(searchQueryHandler));
@@ -86,6 +90,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _houseRuleMatcher = houseRuleMatcher ?? throw new ArgumentNullException(nameof(houseRuleMatcher));
         _pricingEngine = pricingEngine ?? throw new ArgumentNullException(nameof(pricingEngine));
         _genericTranslationService = genericTranslationService ?? throw new ArgumentNullException(nameof(genericTranslationService));
+        _routingOptions = routingOptions ?? throw new ArgumentNullException(nameof(routingOptions));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -102,10 +107,18 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogDebug(
             "[AskQuestionHandler] QueryComplexityAnalyzer: Question={Question}, RoutingTier={RoutingTier}",
             query.Question, queryRoutingTier);
-#pragma warning disable S1135, MA0026 // Deferred: requires ILlmService per-call model-override support (not yet available)
-        // TODO: Pass queryRoutingTier to ILlmService for model selection when per-call model-override support is available.
-        // Currently the tier is captured in RagQueryMetrics.Strategy for observability only.
-#pragma warning restore S1135, MA0026
+
+        // Issue #562: tier → model override resolved from `LlmRouting:QueryComplexityModels`.
+        // When the per-tier value is empty/null the handler keeps using the default model
+        // selected by ILlmService (backward-compatible no-op). Otherwise the routing
+        // dispatches through ILlmService.GenerateCompletionWithModelAsync (Issue #4332).
+        var modelOverride = _routingOptions.CurrentValue.ResolveOverride(queryRoutingTier);
+        if (modelOverride is not null)
+        {
+            _logger.LogDebug(
+                "[AskQuestionHandler] Per-tier model override active: Tier={Tier}, Model={Model}",
+                queryRoutingTier, modelOverride);
+        }
 
         // RAG access enforcement
         if (query.UserId.HasValue)
@@ -303,7 +316,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         _logger.LogDebug("[AskQuestionHandler] Step 4: Generating LLM answer...");
         var sw4 = System.Diagnostics.Stopwatch.StartNew();
         var (llmResponse, llmResult) = await GenerateLlmAnswerAndRecordMetricsAsync(
-            systemPrompt, userPrompt, cancellationToken).ConfigureAwait(false);
+            systemPrompt, userPrompt, modelOverride, cancellationToken).ConfigureAwait(false);
         sw4.Stop();
         _logger.LogInformation("[AskQuestionHandler] Step 4 DONE: LLM generation completed in {ElapsedMs}ms - Response: {ResponseLength} chars",
             sw4.ElapsedMilliseconds, llmResponse?.Length ?? 0);
@@ -468,13 +481,25 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
     private async Task<(string llmResponse, LlmCompletionResult llmResult)> GenerateLlmAnswerAndRecordMetricsAsync(
         string systemPrompt,
         string userPrompt,
+        string? modelOverride,
         CancellationToken cancellationToken)
     {
-        var llmResult = await _llmService.GenerateCompletionAsync(
-            systemPrompt,
-            userPrompt,
-            RequestSource.RagPipeline,
-            cancellationToken).ConfigureAwait(false);
+        // Issue #562: when modelOverride is provided (from LlmRouting:QueryComplexityModels),
+        // dispatch through GenerateCompletionWithModelAsync (Issue #4332). Otherwise
+        // fall back to the default model selection on ILlmService.
+        var llmResult = modelOverride is not null
+            ? await _llmService.GenerateCompletionWithModelAsync(
+                modelOverride,
+                systemPrompt,
+                userPrompt,
+                RequestSource.RagPipeline,
+                maxTokens: null,
+                cancellationToken).ConfigureAwait(false)
+            : await _llmService.GenerateCompletionAsync(
+                systemPrompt,
+                userPrompt,
+                RequestSource.RagPipeline,
+                cancellationToken).ConfigureAwait(false);
 
         var llmResponse = llmResult.Response;
 

--- a/apps/api/src/Api/Configuration/LlmQueryComplexityRoutingOptions.cs
+++ b/apps/api/src/Api/Configuration/LlmQueryComplexityRoutingOptions.cs
@@ -1,0 +1,68 @@
+namespace Api.Configuration;
+
+/// <summary>
+/// Issue #562 — per-call LLM model override based on
+/// <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier"/>.
+///
+/// Bound to <c>LlmRouting:QueryComplexityModels</c> in appsettings.json.
+///
+/// Semantics:
+/// <list type="bullet">
+///   <item>Each tier (<c>Low</c>/<c>Medium</c>/<c>High</c>) maps to an OPTIONAL model
+///         identifier (provider-prefixed, e.g. <c>"openai/gpt-4o-mini"</c>).</item>
+///   <item>When a tier's override is <c>null</c> or empty, the handler keeps using the
+///         default model selected by the underlying <see cref="Api.Services.ILlmService"/>
+///         (backward-compatible no-op).</item>
+///   <item>When set, the handler dispatches through
+///         <see cref="Api.Services.ILlmService.GenerateCompletionWithModelAsync"/>
+///         using the configured override.</item>
+/// </list>
+///
+/// Rationale: orthogonal to <see cref="Api.BoundedContexts.SystemConfiguration.Application.Services.ILlmTierRoutingService"/>
+/// (Issue #2596) — that one routes by USER tier (Anonymous/User/Editor/Admin/Premium),
+/// this one routes by QUERY complexity (Low/Medium/High). Both can coexist:
+/// query-complexity override wins per-call when configured, user-tier remains the
+/// fallback selection.
+/// </summary>
+internal sealed class LlmQueryComplexityRoutingOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json (relative to LlmRouting).
+    /// </summary>
+    public const string SectionName = "LlmRouting:QueryComplexityModels";
+
+    /// <summary>
+    /// Model override for <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.Low"/>
+    /// queries (short, factual lookups). Empty/null → default model.
+    /// </summary>
+    public string? Low { get; set; }
+
+    /// <summary>
+    /// Model override for <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.Medium"/>
+    /// queries. Empty/null → default model.
+    /// </summary>
+    public string? Medium { get; set; }
+
+    /// <summary>
+    /// Model override for <see cref="Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.High"/>
+    /// queries (complex analysis, comparisons). Empty/null → default model.
+    /// </summary>
+    public string? High { get; set; }
+
+    /// <summary>
+    /// Resolves the override for a given tier. Returns <c>null</c> when the entry is
+    /// missing or empty so the handler can dispatch to the default
+    /// <see cref="Api.Services.ILlmService.GenerateCompletionAsync"/> path.
+    /// </summary>
+    public string? ResolveOverride(Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier tier)
+    {
+        var raw = tier switch
+        {
+            Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.Low => Low,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.Medium => Medium,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.QueryRoutingTier.High => High,
+            _ => null,
+        };
+        return string.IsNullOrWhiteSpace(raw) ? null : raw;
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -263,6 +263,8 @@ builder.Services.Configure<RateLimitConfiguration>(builder.Configuration.GetSect
 builder.Services.Configure<FollowUpQuestionsConfiguration>(builder.Configuration.GetSection("FollowUpQuestions")); // CHAT-02
 builder.Services.Configure<RagPromptsConfiguration>(builder.Configuration.GetSection("RagPrompts")); // AI-07.1: RAG prompt templates
 builder.Services.Configure<HybridCacheConfiguration>(builder.Configuration.GetSection("HybridCache")); // PERF-05: HybridCache configuration
+builder.Services.Configure<LlmQueryComplexityRoutingOptions>(
+    builder.Configuration.GetSection(LlmQueryComplexityRoutingOptions.SectionName)); // Issue #562: per-call model override by query complexity tier
 builder.Services.Configure<HybridSearchConfiguration>(builder.Configuration.GetSection("HybridSearch")); // AI-14: Hybrid search configuration
 builder.Services.Configure<WeeklyEvaluationConfiguration>(builder.Configuration.GetSection("QualityEvaluation")); // BGAI-042: Weekly evaluation configuration
 builder.Services.Configure<BggImportQueueConfiguration>(builder.Configuration.GetSection("BggImportQueue")); // ISSUE-3541: BGG import queue configuration

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -292,7 +292,13 @@
     "EditorOpenRouterPercent": 80,
     "AdminModel": "meta-llama/llama-3.3-70b-instruct",
     "AdminOpenRouterPercent": 100,
-    "PremiumModel": "meta-llama/llama-3.3-70b-instruct"
+    "PremiumModel": "meta-llama/llama-3.3-70b-instruct",
+    "QueryComplexityModels": {
+      "_Comment": "Issue #562: per-call LLM model override by QueryRoutingTier (orthogonal to user-tier above). Empty/null = use default model. Provider-prefixed format (e.g. 'openai/gpt-4o-mini').",
+      "Low": "",
+      "Medium": "",
+      "High": ""
+    }
   },
   "AIAgents": {
     "DefaultTimeoutSeconds": 30

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -210,6 +210,9 @@ public class AskQuestionQueryHandlerSecurityTests
                 DurationMs = 250
             });
 
+        var routingOptionsMonitor = new Mock<Microsoft.Extensions.Options.IOptionsMonitor<Api.Configuration.LlmQueryComplexityRoutingOptions>>();
+        routingOptionsMonitor.Setup(m => m.CurrentValue).Returns(new Api.Configuration.LlmQueryComplexityRoutingOptions());
+
         _handler = new AskQuestionQueryHandler(
             _searchHandler,
             _mockQualityService.Object,
@@ -227,6 +230,7 @@ public class AskQuestionQueryHandlerSecurityTests
             CreatePermissiveHouseRuleMatcherMock(),
             CreatePermissivePricingEngineMock(),
             CreateNoOpTranslationServiceMock(),
+            routingOptionsMonitor.Object,
             _mockLogger.Object);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -436,7 +436,8 @@ public class AskQuestionQueryHandlerPhase2Tests
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
 
-    private AskQuestionQueryHandler BuildHandler() =>
+    private AskQuestionQueryHandler BuildHandler(
+        Api.Configuration.LlmQueryComplexityRoutingOptions? routingOverrides = null) =>
         new(
             _searchHandler,
             _mockQualityService.Object,
@@ -454,7 +455,16 @@ public class AskQuestionQueryHandlerPhase2Tests
             _mockHouseRuleMatcher.Object,
             _mockPricingEngine.Object,
             _mockTranslationService.Object,
+            BuildRoutingMonitor(routingOverrides ?? new Api.Configuration.LlmQueryComplexityRoutingOptions()),
             _mockLogger.Object);
+
+    private static Microsoft.Extensions.Options.IOptionsMonitor<Api.Configuration.LlmQueryComplexityRoutingOptions> BuildRoutingMonitor(
+        Api.Configuration.LlmQueryComplexityRoutingOptions value)
+    {
+        var monitor = new Mock<Microsoft.Extensions.Options.IOptionsMonitor<Api.Configuration.LlmQueryComplexityRoutingOptions>>();
+        monitor.Setup(m => m.CurrentValue).Returns(value);
+        return monitor.Object;
+    }
 
     private void SetupDefaultMocks(Guid gameId)
     {
@@ -592,5 +602,125 @@ public class AskQuestionQueryHandlerPhase2Tests
         mock.Setup(s => s.CanAccessRagAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         return mock.Object;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #562 — per-tier LLM model dispatch tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WithLowTierOverride_DispatchesGenerateCompletionWithModelAsync()
+    {
+        // Arrange — short factual query → Low tier (per QueryComplexityAnalyzer).
+        // Config sets explicit override for Low.
+        var gameId = Guid.NewGuid();
+        SetupDefaultMocksWithSearchResults(gameId, "answer");
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        _mockLlmService
+            .Setup(s => s.GenerateCompletionWithModelAsync(
+                "openai/gpt-4o-mini",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<RequestSource>(),
+                It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(
+                response: "answer",
+                usage: new LlmUsage(10, 10, 20),
+                cost: new LlmCost
+                {
+                    InputCost = 0.001m,
+                    OutputCost = 0.002m,
+                    ModelId = "openai/gpt-4o-mini",
+                    Provider = "openai"
+                }));
+
+        // "Quanti giocatori?" matches LowComplexityPrefix "quanti" → Low tier.
+        var query = new AskQuestionQuery(GameId: gameId, Question: "Quanti giocatori sono?");
+
+        var handler = BuildHandler(new Api.Configuration.LlmQueryComplexityRoutingOptions
+        {
+            Low = "openai/gpt-4o-mini"
+        });
+
+        // Act
+        await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert — override dispatched, default path NOT called.
+        _mockLlmService.Verify(s => s.GenerateCompletionWithModelAsync(
+            "openai/gpt-4o-mini",
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<RequestSource>(),
+            It.IsAny<int?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockLlmService.Verify(s => s.GenerateCompletionAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<RequestSource>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoTierOverride_FallsBackToDefaultGenerateCompletionAsync()
+    {
+        // Arrange — empty routing config → handler uses default GenerateCompletionAsync path.
+        var gameId = Guid.NewGuid();
+        SetupDefaultMocksWithSearchResults(gameId, "answer");
+
+        _mockPricingEngine
+            .Setup(p => p.ConsumeQuotaAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _mockHouseRuleMatcher
+            .Setup(m => m.FindMatchingHouseRuleAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var query = new AskQuestionQuery(GameId: gameId, Question: "Quanti giocatori sono?");
+        var handler = BuildHandler(); // default empty options
+
+        // Act
+        await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert — fall back to default path, NO override dispatch.
+        _mockLlmService.Verify(s => s.GenerateCompletionAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<RequestSource>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockLlmService.Verify(s => s.GenerateCompletionWithModelAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<RequestSource>(),
+            It.IsAny<int?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void LlmQueryComplexityRoutingOptions_ResolveOverride_ReturnsNullForEmptyOrWhitespace()
+    {
+        // Contract: empty/whitespace tier overrides resolve to null so the handler
+        // dispatches to GenerateCompletionAsync (backward-compatible no-op).
+        var opts = new Api.Configuration.LlmQueryComplexityRoutingOptions
+        {
+            Low = "",
+            Medium = "   ",
+            High = "openai/gpt-4o"
+        };
+
+        opts.ResolveOverride(QueryRoutingTier.Low).Should().BeNull();
+        opts.ResolveOverride(QueryRoutingTier.Medium).Should().BeNull();
+        opts.ResolveOverride(QueryRoutingTier.High).Should().Be("openai/gpt-4o");
     }
 }


### PR DESCRIPTION
## Summary

Resolves the deferred TODO at `AskQuestionQueryHandler.cs:96` (`#pragma S1135, MA0026`) by wiring `QueryComplexityAnalyzer` output to a config-driven model override using `ILlmService.GenerateCompletionWithModelAsync` (Issue #4332 infrastructure).

## Architecture

| Component | Purpose |
|-----------|---------|
| `LlmQueryComplexityRoutingOptions` | Typed binding for `LlmRouting:QueryComplexityModels` (Low/Medium/High → optional model id) |
| `ResolveOverride(QueryRoutingTier)` | Returns `null` for empty/whitespace (backward-compatible no-op), else the configured model id |
| `AskQuestionQueryHandler` | Injects `IOptionsMonitor<LlmQueryComplexityRoutingOptions>` (runtime reload). Dispatches `WithModelAsync` only when override is non-null |

## Orthogonality

This is **orthogonal** to `ILlmTierRoutingService` (#2596) — that routes by USER tier (Anonymous/User/Editor/Admin/Premium), this routes by QUERY complexity (Low/Medium/High). Both can coexist; per-call query override wins when configured, user-tier remains the fallback.

## DoD vs #562

- [x] Spec the routing matrix → `LlmRouting:QueryComplexityModels` in appsettings.json
- [x] Extend `ILlmService` interface → already done in #4332 (`GenerateCompletionWithModelAsync`)
- [x] Update at least one provider implementation → existing OpenRouter/Ollama path via WithModel
- [x] Wire `queryRoutingTier` through in `AskQuestionQueryHandler`
- [x] Remove the `#pragma warning` and TODO
- [x] Tests cover all tiers → 3 new tests (Low override / no-override fallback / contract empty-whitespace)

## Test plan

- [x] `dotnet build MeepleAI.Api.sln`: 0 errors
- [x] 10/10 unit tests verdi (7 existing + 3 new)
- [x] `AskQuestionQueryHandlerSecurityTests` updated with `IOptionsMonitor` ctor param
- [ ] CI Backend Fast (unit)
- [ ] CI Frontend Static / Tests / CodeQL

## Out of scope

- Hard-failure fallback policy (if override model unavailable) — for MVP we rely on `GenerateCompletionWithModelAsync` existing error surface
- Routing matrix validation at startup (alert on unknown model id) — separate enhancement if drift becomes observable

🤖 Generated with [Claude Code](https://claude.com/claude-code)