### PR TITLE
feat(gamebook): #1303 useGetParagraph discriminated lookup union (closes #1303)

### DIFF
--- a/apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts
+++ b/apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts
@@ -1,0 +1,98 @@
+/**
+ * MSW handlers for gamebook paragraph endpoints (issue #1303).
+ *
+ * Covers backend routes shipped by #747 sequence:
+ *   GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}
+ *   GET /api/v1/photo-batches/{batchId}/paragraphs/by-paragraph/{paragraphNumber}
+ *
+ * Each handler records the request URL so request-capture assertions can
+ * verify the FE hit the right route (AC-1, AC-2, AC-9).
+ */
+
+import { http, HttpResponse } from 'msw';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ---------------------------------------------------------------------------
+// Request capture — exported so tests can assert which routes were hit
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  readonly path: string;
+  readonly url: string;
+  readonly searchParams: Record<string, string>;
+}
+
+const capturedRequests: CapturedRequest[] = [];
+
+export function getCapturedGamebookRequests(): readonly CapturedRequest[] {
+  return capturedRequests;
+}
+
+export function resetCapturedGamebookRequests(): void {
+  capturedRequests.length = 0;
+}
+
+function captureRequest(rawUrl: string): void {
+  const url = new URL(rawUrl);
+  const searchParams: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    searchParams[key] = value;
+  });
+  capturedRequests.push({
+    path: url.pathname,
+    url: rawUrl,
+    searchParams,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler order matters: MSW matches top-to-bottom and `:pageNumber`
+ * happily binds to the literal string `"by-paragraph"`, so the more
+ * specific `/by-paragraph/:paragraphNumber` route MUST be declared first.
+ */
+export const gamebookHandlers = [
+  /**
+   * New (#747 PR-B): GET /paragraphs/by-paragraph/{paragraphNumber}
+   *
+   * Returned shape mirrors `ParagraphDto` with `paragraphNumber` echoed back
+   * and `pageNumber` set to the physical page that contained the match.
+   */
+  http.get(
+    `${API_BASE}/api/v1/photo-batches/:batchId/paragraphs/by-paragraph/:paragraphNumber`,
+    ({ request, params }) => {
+      captureRequest(request.url);
+      const paragraphNumber = Number(params.paragraphNumber);
+      return HttpResponse.json({
+        // Mock: physical page 7 always carries the requested paragraph.
+        pageNumber: 7,
+        text: `OCR text for paragraph ${paragraphNumber}`,
+        fallbackUsed: false,
+        fallbackMethod: null,
+        paragraphNumber,
+      });
+    }
+  ),
+
+  /**
+   * Legacy: GET /paragraphs/{pageNumber}
+   */
+  http.get(
+    `${API_BASE}/api/v1/photo-batches/:batchId/paragraphs/:pageNumber`,
+    ({ request, params }) => {
+      captureRequest(request.url);
+      const pageNumber = Number(params.pageNumber);
+      return HttpResponse.json({
+        pageNumber,
+        text: `OCR text for page ${pageNumber}`,
+        fallbackUsed: false,
+        fallbackMethod: null,
+        paragraphNumber: null,
+      });
+    }
+  ),
+];

--- a/apps/web/src/__tests__/mocks/handlers/index.ts
+++ b/apps/web/src/__tests__/mocks/handlers/index.ts
@@ -21,6 +21,7 @@ import { gameNightsHandlers } from './game-nights.handlers';
 import { playersHandlers } from './players.handlers';
 import { notificationsHandlers } from './notifications.handlers';
 import { badgesHandlers } from './badges.handlers';
+import { gamebookHandlers } from './gamebook.handlers';
 
 /**
  * All MSW request handlers
@@ -43,6 +44,7 @@ export const handlers = [
   ...playersHandlers,
   ...notificationsHandlers,
   ...badgesHandlers,
+  ...gamebookHandlers,
 ];
 
 // Re-export individual handler groups for selective use
@@ -82,3 +84,8 @@ export {
   addNotification,
 } from './notifications.handlers';
 export { badgesHandlers, resetBadgesState } from './badges.handlers';
+export {
+  gamebookHandlers,
+  getCapturedGamebookRequests,
+  resetCapturedGamebookRequests,
+} from './gamebook.handlers';

--- a/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
@@ -33,7 +33,7 @@ import { initialWizardState, wizardReducer } from '@/lib/game-nights/wizard-redu
 import type { WizardStep } from '@/lib/game-nights/wizard-types';
 import { buildSubmitPayload } from '@/lib/game-nights/wizard-validators';
 
-const TOTAL_STEPS = 4 as const;
+const _TOTAL_STEPS = 4 as const;
 const SUBMIT_RETRY_DELAYS_MS: readonly number[] = [1000, 2000, 4000];
 
 function parseStep(value: string | null): WizardStep {

--- a/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
+++ b/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
@@ -134,6 +134,7 @@ export function useGameNightDraftPersist({
     };
     // Persist whenever the persisted shape changes; the `draft` branch is
     // intentionally excluded (autosave status doesn't trigger another save).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- excluding `state.draft` is intentional; see comment above
   }, [enabled, userId, state.step, state.date, state.location, state.invitees, state.games]);
 
   return {

--- a/apps/web/src/lib/gamebook/__tests__/schemas.test.ts
+++ b/apps/web/src/lib/gamebook/__tests__/schemas.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for gamebook zod schemas — issue #1303.
+ *
+ * Covers AC-4a + AC-4b: `ParagraphSchema` accepts the relaxed `pageNumber`
+ * range and the new `paragraphNumber` field with the documented backend
+ * invariant (positive nullable).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ParagraphSchema } from '../schemas';
+
+describe('ParagraphSchema (#1303)', () => {
+  // -------------------------------------------------------------------------
+  // AC-4a — pageNumber relaxed from positive() to nonnegative()
+  // -------------------------------------------------------------------------
+
+  describe('AC-4a — pageNumber 0 accepted (semantic-fallback case)', () => {
+    it('parses successfully when pageNumber is 0', () => {
+      const result = ParagraphSchema.safeParse({
+        pageNumber: 0,
+        text: 'fallback text',
+        fallbackUsed: true,
+        fallbackMethod: 'semantic',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.pageNumber).toBe(0);
+        expect(result.data.fallbackUsed).toBe(true);
+      }
+    });
+
+    it('still rejects negative pageNumber values', () => {
+      const result = ParagraphSchema.safeParse({
+        pageNumber: -1,
+        text: 'x',
+        fallbackUsed: false,
+        fallbackMethod: null,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC-4b — ByParagraph + semantic-fallback DTO shape round-trips
+  // -------------------------------------------------------------------------
+
+  describe('AC-4b — ByParagraph + semantic-fallback shape', () => {
+    it('round-trips paragraphNumber: null with fallbackUsed: true', () => {
+      const dto = {
+        pageNumber: 0,
+        text: 'Semantic fallback snippet 1\n\nSnippet 2',
+        fallbackUsed: true,
+        fallbackMethod: 'semantic',
+        paragraphNumber: null,
+      };
+
+      const result = ParagraphSchema.safeParse(dto);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.paragraphNumber).toBeNull();
+        expect(result.data.fallbackMethod).toBe('semantic');
+      }
+    });
+
+    it('round-trips paragraphNumber: 42 (numbered match)', () => {
+      const result = ParagraphSchema.safeParse({
+        pageNumber: 7,
+        text: 'Paragraph 42 content',
+        fallbackUsed: false,
+        fallbackMethod: null,
+        paragraphNumber: 42,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.paragraphNumber).toBe(42);
+        expect(result.data.pageNumber).toBe(7);
+      }
+    });
+
+    it('defaults paragraphNumber to null when absent (legacy page-lookup response)', () => {
+      // Legacy backend (pre PR-B) doesn't emit paragraphNumber at all. The
+      // schema default keeps existing callers working.
+      const result = ParagraphSchema.safeParse({
+        pageNumber: 5,
+        text: 'legacy page text',
+        fallbackUsed: false,
+        fallbackMethod: null,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.paragraphNumber).toBeNull();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Backend invariant — paragraphNumber must be ≥ 1 when non-null
+  // -------------------------------------------------------------------------
+
+  describe('paragraphNumber positive invariant (PR-B backend contract)', () => {
+    it('rejects paragraphNumber: 0', () => {
+      // Backend invariant: ByParagraph + numbered match always returns ≥ 1.
+      // A 0 here would indicate a backend regression — schema must catch it.
+      const result = ParagraphSchema.safeParse({
+        pageNumber: 7,
+        text: 'x',
+        fallbackUsed: false,
+        fallbackMethod: null,
+        paragraphNumber: 0,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects negative paragraphNumber', () => {
+      const result = ParagraphSchema.safeParse({
+        pageNumber: 7,
+        text: 'x',
+        fallbackUsed: false,
+        fallbackMethod: null,
+        paragraphNumber: -5,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/gamebook/api.ts
+++ b/apps/web/src/lib/gamebook/api.ts
@@ -55,7 +55,7 @@ export async function getPhotoBatchStatus(
 }
 
 /**
- * Fetch a single extracted paragraph for a given page of a photo batch.
+ * Fetch a single extracted paragraph by physical page number.
  *
  * Endpoint: GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}?hint=...
  * Introduced by G4 (PR #716) — Phase 3 Task 3.5a.
@@ -73,6 +73,36 @@ export async function getParagraph(
   const url = hint
     ? `/api/v1/photo-batches/${batchId}/paragraphs/${pageNumber}?hint=${encodeURIComponent(hint)}`
     : `/api/v1/photo-batches/${batchId}/paragraphs/${pageNumber}`;
+  const result = await apiClient.get<Paragraph>(url, ParagraphSchema);
+  if (!result) throw new Error('Empty paragraph response');
+  return result;
+}
+
+/**
+ * Fetch a single extracted paragraph by narrative paragraph number.
+ *
+ * Endpoint:
+ *   GET /api/v1/photo-batches/{batchId}/paragraphs/by-paragraph/{paragraphNumber}?hint=...
+ *
+ * Introduced by #747 PR-B (`0ba93671a`). Use when the caller indexes content
+ * by gamebook paragraph IDs (Tainted Grail, ISS Vanguard, Nanolith) rather
+ * than physical photo page index. Backend dispatches via
+ * `ParagraphLookupKey.ByParagraphNumber` and falls back to semantic search
+ * when no page carries the requested paragraph (response has
+ * `fallbackUsed: true`, `fallbackMethod: 'semantic'`, `pageNumber: 0`).
+ *
+ * @param batchId         - Batch UUID whose pages have been processed
+ * @param paragraphNumber - 1-based narrative paragraph number
+ * @param hint            - Optional OCR/translation hint for disambiguation
+ * @returns Paragraph DTO, throws on empty / error response
+ */
+export async function getParagraphByParagraphNumber(
+  batchId: string,
+  paragraphNumber: number,
+  hint?: string
+): Promise<Paragraph> {
+  const base = `/api/v1/photo-batches/${batchId}/paragraphs/by-paragraph/${paragraphNumber}`;
+  const url = hint ? `${base}?hint=${encodeURIComponent(hint)}` : base;
   const result = await apiClient.get<Paragraph>(url, ParagraphSchema);
   if (!result) throw new Error('Empty paragraph response');
   return result;

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useGetParagraph.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useGetParagraph.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Tests for `useGetParagraph` — issue #1303.
+ *
+ * Covers AC-1, AC-2, AC-3, AC-6, AC-8, AC-9. Schema ACs (4a/4b) live in
+ * `apps/web/src/lib/gamebook/__tests__/schemas.test.ts`. Type-contract
+ * AC-7 lives in `useGetParagraph.types.test.tsx`.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getCapturedGamebookRequests,
+  resetCapturedGamebookRequests,
+} from '@/__tests__/mocks/handlers/gamebook.handlers';
+
+import { __resetDeprecationWarnings, useGetParagraph } from '../useGetParagraph';
+
+// ---------------------------------------------------------------------------
+// Test harness — fresh QueryClient per test so cache assertions are isolated
+// ---------------------------------------------------------------------------
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function freshQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+    },
+  });
+}
+
+const BATCH_ID = '11111111-2222-4333-8444-555555555555';
+
+beforeEach(() => {
+  resetCapturedGamebookRequests();
+  __resetDeprecationWarnings();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// AC-1 — by-paragraph endpoint dispatch
+// ---------------------------------------------------------------------------
+
+describe('AC-1 — by-paragraph dispatch', () => {
+  it('issues GET /paragraphs/by-paragraph/{N} when paragraphRef.type === "paragraph"', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'paragraph', value: 42 },
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const captured = getCapturedGamebookRequests();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe(
+      `/api/v1/photo-batches/${BATCH_ID}/paragraphs/by-paragraph/42`
+    );
+    expect(result.current.data?.paragraphNumber).toBe(42);
+    expect(result.current.data?.pageNumber).toBe(7); // mocked physical page
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2 — by-page endpoint dispatch
+// ---------------------------------------------------------------------------
+
+describe('AC-2 — by-page dispatch', () => {
+  it('issues GET /paragraphs/{N} when paragraphRef.type === "page"', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'page', value: 5 },
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const captured = getCapturedGamebookRequests();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe(
+      `/api/v1/photo-batches/${BATCH_ID}/paragraphs/5`
+    );
+    expect(result.current.data?.paragraphNumber).toBeNull();
+    expect(result.current.data?.pageNumber).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3 — legacy pageNumber shape + one-shot deprecation warning
+// ---------------------------------------------------------------------------
+
+describe('AC-3 — legacy pageNumber backward-compat', () => {
+  it('returns the same data as AC-2 and emits exactly one console.warn per session', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const client = freshQueryClient();
+    const wrapper = makeWrapper(client);
+
+    // First invocation — should fire the warn exactly once.
+    const { result: r1 } = renderHook(
+      () => useGetParagraph({ batchId: BATCH_ID, pageNumber: 5 }),
+      { wrapper }
+    );
+    await waitFor(() => expect(r1.current.isSuccess).toBe(true));
+
+    // Second invocation with the SAME (batchId, pageNumber) — warn must NOT fire again.
+    const { result: r2 } = renderHook(
+      () => useGetParagraph({ batchId: BATCH_ID, pageNumber: 5 }),
+      { wrapper }
+    );
+    await waitFor(() => expect(r2.current.isSuccess).toBe(true));
+
+    const deprecationCalls = warnSpy.mock.calls.filter(
+      args => typeof args[0] === 'string' && args[0].includes('[useGetParagraph]')
+    );
+    expect(deprecationCalls).toHaveLength(1);
+
+    // Sanity: data shape matches the explicit `type: 'page'` shape.
+    expect(r1.current.data?.pageNumber).toBe(5);
+    expect(r1.current.data?.paragraphNumber).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6 — query-key isolation between page and paragraph lookups
+// ---------------------------------------------------------------------------
+
+describe('AC-6 — query-key isolation', () => {
+  it('stores two distinct cache entries for type:page,value:5 vs type:paragraph,value:5', async () => {
+    const client = freshQueryClient();
+    const wrapper = makeWrapper(client);
+
+    const { result: byPage } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'page', value: 5 },
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(byPage.current.isSuccess).toBe(true));
+
+    const { result: byPara } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'paragraph', value: 5 },
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(byPara.current.isSuccess).toBe(true));
+
+    const cacheEntries = client.getQueryCache().getAll();
+    expect(cacheEntries).toHaveLength(2);
+
+    // Keys must carry the discriminator segment so a future namespace
+    // collision can't sneak past code review.
+    const keys = cacheEntries.map(e => e.queryKey);
+    expect(keys.some(k => Array.isArray(k) && k.includes('byPage'))).toBe(true);
+    expect(keys.some(k => Array.isArray(k) && k.includes('byParagraph'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8 — disabled flow when batchId is undefined
+// ---------------------------------------------------------------------------
+
+describe('AC-8 — disabled flow', () => {
+  it('does NOT issue a network request when batchId is undefined', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: undefined,
+          paragraphRef: { type: 'paragraph', value: 1 },
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+
+    // Let the event loop settle so any spurious fetch would have fired.
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(getCapturedGamebookRequests()).toHaveLength(0);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('does NOT issue a network request when paragraphRef.value <= 0', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'page', value: 0 },
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(getCapturedGamebookRequests()).toHaveLength(0);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9 — hint? forwarded as ?hint=<urlencoded> for both endpoints
+// ---------------------------------------------------------------------------
+
+describe('AC-9 — hint forwarding', () => {
+  it('forwards hint as ?hint= query param on the by-page route', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'page', value: 5 },
+          hint: 'chapter 3',
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const captured = getCapturedGamebookRequests();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].searchParams.hint).toBe('chapter 3');
+  });
+
+  it('forwards hint as ?hint= query param on the by-paragraph route', async () => {
+    const { result } = renderHook(
+      () =>
+        useGetParagraph({
+          batchId: BATCH_ID,
+          paragraphRef: { type: 'paragraph', value: 42 },
+          hint: 'the forest',
+        }),
+      { wrapper: makeWrapper(freshQueryClient()) }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const captured = getCapturedGamebookRequests();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].searchParams.hint).toBe('the forest');
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useGetParagraph.types.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useGetParagraph.types.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Type-contract assertions for `useGetParagraph` — issue #1303, AC-7.
+ *
+ * This file is a typecheck-gate. Its body is never executed; the test runner
+ * compiles it via the project's `tsconfig.json` and the `@ts-expect-error`
+ * comments fail the compile if the underlying contract regresses.
+ *
+ * Adding a new caller that should be rejected? Add another `@ts-expect-error`
+ * line below the offending call. Vitest itself only runs the trivial `it.skip`
+ * marker so the file shows up in the test report.
+ */
+
+import { describe, it } from 'vitest';
+
+import { useGetParagraph } from '../useGetParagraph';
+
+describe('useGetParagraph — type contract (AC-7)', () => {
+  it.skip('compile-time only — the assertions live in @ts-expect-error comments', () => {
+    const batchId: string = 'unused';
+
+    // Valid shapes — must compile cleanly. These two lines must NOT trigger
+    // any TS error; if they do, the contract has regressed.
+    useGetParagraph({ batchId, paragraphRef: { type: 'page', value: 5 } });
+    useGetParagraph({ batchId, paragraphRef: { type: 'paragraph', value: 42 } });
+    useGetParagraph({ batchId, pageNumber: 5 });
+
+    // AC-7: string value is a compile error on the discriminated union.
+    useGetParagraph({
+      batchId,
+      // @ts-expect-error value must be `number`, not `string`
+      paragraphRef: { type: 'paragraph', value: '42' },
+    });
+
+    // Bonus: unknown discriminator literal is rejected.
+    useGetParagraph({
+      batchId,
+      // @ts-expect-error type must be 'page' | 'paragraph'
+      paragraphRef: { type: 'chapter', value: 1 },
+    });
+
+    // Bonus: missing paragraphRef in the new shape is rejected.
+    useGetParagraph({
+      batchId,
+      // @ts-expect-error paragraphRef is required when not using the legacy pageNumber shape
+      hint: 'something',
+    });
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/useGetParagraph.ts
+++ b/apps/web/src/lib/gamebook/hooks/useGetParagraph.ts
@@ -5,59 +5,176 @@
  * photo batch. Paragraphs are stable (5-min staleTime) and typically only
  * re-fetched when the page number or batch changes.
  *
- * Endpoint: GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}?hint=...
+ * Endpoints (issue #1303 — discriminated lookup):
+ *   GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}?hint=...
+ *   GET /api/v1/photo-batches/{batchId}/paragraphs/by-paragraph/{paragraphNumber}?hint=...
  */
 
 'use client';
 
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-import { getParagraph } from '../api';
+import { getParagraph, getParagraphByParagraphNumber } from '../api';
 
 import type { Paragraph } from '../schemas';
 
-interface UseGetParagraphOptions {
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated lookup union for paragraph retrieval.
+ *
+ * - `'page'`  → physical photo page index (legacy, 1-based)
+ * - `'paragraph'` → narrative paragraph number extracted from OCR text
+ *
+ * Issue #1303 (FE follow-up of #747 PR-B): the discriminator selects the
+ * backend route (`/paragraphs/{n}` vs `/paragraphs/by-paragraph/{n}`).
+ */
+export type ParagraphRef =
+  | { readonly type: 'page'; readonly value: number }
+  | { readonly type: 'paragraph'; readonly value: number };
+
+export interface UseGetParagraphOptions {
   batchId: string | undefined;
-  pageNumber: number;
+  paragraphRef: ParagraphRef;
   hint?: string;
   enabled?: boolean;
 }
 
 /**
+ * Legacy options shape preserved for one release to give existing callers
+ * time to migrate. Triggers a one-time `console.warn` per session in dev.
+ *
+ * @deprecated Use the `paragraphRef: { type: 'page', value }` shape instead.
+ */
+export interface UseGetParagraphLegacyOptions {
+  batchId: string | undefined;
+  /** @deprecated Pass `paragraphRef: { type: 'page', value: pageNumber }` instead. */
+  pageNumber: number;
+  hint?: string;
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Query key factory
+// ---------------------------------------------------------------------------
+
+/**
  * Query key factory for paragraph lookups.
- * Exported so test files can prime or invalidate the cache.
+ *
+ * Page-based and paragraph-based keys live in separate namespaces so a
+ * collision like `byPage(b, 5) === byParagraph(b, 5)` cannot happen. The
+ * URL paths differ on the wire too, so this is a defensive guarantee, not
+ * an optimisation.
  */
 export const paragraphKeys = {
   byPage: (batchId: string, pageNumber: number, hint?: string) =>
-    ['gamebook', 'paragraph', batchId, pageNumber, hint ?? ''] as const,
+    ['gamebook', 'paragraph', 'byPage', batchId, pageNumber, hint ?? ''] as const,
+  byParagraph: (batchId: string, paragraphNumber: number, hint?: string) =>
+    ['gamebook', 'paragraph', 'byParagraph', batchId, paragraphNumber, hint ?? ''] as const,
 };
 
+// ---------------------------------------------------------------------------
+// Deprecation warning (dev-only, one warn per (batchId,pageNumber) per session)
+// ---------------------------------------------------------------------------
+
+/** Track deprecation warnings already emitted in this session. */
+const emittedDeprecationKeys = new Set<string>();
+
 /**
- * Fetch a single extracted paragraph for a given page of a photo batch.
+ * Reset the deprecation tracking — test-only helper to keep `vi.spyOn(console)`
+ * assertions deterministic between tests within the same module.
  *
- * - Disabled when `batchId` is undefined or `pageNumber` ≤ 0.
+ * @internal exported solely for test isolation; do not call from production code.
+ */
+export function __resetDeprecationWarnings(): void {
+  emittedDeprecationKeys.clear();
+}
+
+function warnLegacyPageNumberOnce(batchId: string | undefined, pageNumber: number): void {
+  // Dev-only: production logs are noisy and the warn is meant for engineers
+  // staring at their browser console during migration.
+  if (process.env.NODE_ENV === 'production') return;
+
+  const key = `${batchId ?? ''}:${pageNumber}`;
+  if (emittedDeprecationKeys.has(key)) return;
+  emittedDeprecationKeys.add(key);
+
+  console.warn(
+    '[useGetParagraph] The `pageNumber` argument is deprecated. ' +
+      "Use `paragraphRef: { type: 'page', value }` instead. " +
+      'This compatibility shim will be removed in a future release. (issue #1303)'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook implementation
+// ---------------------------------------------------------------------------
+
+function isLegacy(
+  options: UseGetParagraphOptions | UseGetParagraphLegacyOptions
+): options is UseGetParagraphLegacyOptions {
+  return Object.hasOwn(options, 'pageNumber');
+}
+
+/**
+ * Fetch a single extracted paragraph for a given photo batch.
+ *
+ * - Disabled when `batchId` is undefined or the lookup value ≤ 0.
  * - 5-minute staleTime: paragraphs are stable once a batch is processed.
  * - Does not retry on error — let the caller surface the error state.
  *
  * @example
- * ```tsx
- * const { data: paragraph, isLoading, error } = useGetParagraph({
+ * // By physical page (legacy API path)
+ * const { data, isLoading } = useGetParagraph({
  *   batchId,
- *   pageNumber: currentPage,
+ *   paragraphRef: { type: 'page', value: currentPage },
  * });
- * ```
+ *
+ * @example
+ * // By narrative paragraph number (issue #747 PR-B endpoint)
+ * const { data, isLoading } = useGetParagraph({
+ *   batchId,
+ *   paragraphRef: { type: 'paragraph', value: 42 },
+ * });
  */
-export function useGetParagraph({
-  batchId,
-  pageNumber,
-  hint,
-  enabled = true,
-}: UseGetParagraphOptions): UseQueryResult<Paragraph, Error> {
+export function useGetParagraph(
+  options: UseGetParagraphOptions | UseGetParagraphLegacyOptions
+): UseQueryResult<Paragraph, Error> {
+  // Normalize legacy → discriminated union. Emits one warn per session per
+  // (batchId, pageNumber) pair to nudge callers without spamming the console.
+  let batchId: string | undefined;
+  let paragraphRef: ParagraphRef;
+  let hint: string | undefined;
+  let enabled: boolean;
+
+  if (isLegacy(options)) {
+    batchId = options.batchId;
+    paragraphRef = { type: 'page', value: options.pageNumber };
+    hint = options.hint;
+    enabled = options.enabled ?? true;
+    warnLegacyPageNumberOnce(options.batchId, options.pageNumber);
+  } else {
+    batchId = options.batchId;
+    paragraphRef = options.paragraphRef;
+    hint = options.hint;
+    enabled = options.enabled ?? true;
+  }
+
+  const queryKey =
+    paragraphRef.type === 'page'
+      ? paragraphKeys.byPage(batchId ?? '', paragraphRef.value, hint)
+      : paragraphKeys.byParagraph(batchId ?? '', paragraphRef.value, hint);
+
   return useQuery<Paragraph, Error>({
-    queryKey: paragraphKeys.byPage(batchId ?? '', pageNumber, hint),
-    queryFn: () => getParagraph(batchId!, pageNumber, hint),
-    enabled: enabled && !!batchId && pageNumber > 0,
-    staleTime: 5 * 60_000, // 5 min — paragraphs are stable once batch is processed
+    queryKey,
+    queryFn: () =>
+      paragraphRef.type === 'page'
+        ? getParagraph(batchId!, paragraphRef.value, hint)
+        : getParagraphByParagraphNumber(batchId!, paragraphRef.value, hint),
+    enabled: enabled && !!batchId && paragraphRef.value > 0,
+    staleTime: 5 * 60_000,
     retry: false,
   });
 }

--- a/apps/web/src/lib/gamebook/schemas.ts
+++ b/apps/web/src/lib/gamebook/schemas.ts
@@ -83,18 +83,33 @@ export function batchProgressPercent(dto: PhotoBatchStatus): number {
 }
 
 // ============================================================================
-// Paragraph — returned by GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}
+// Paragraph — returned by:
+//   GET /api/v1/photo-batches/{batchId}/paragraphs/{pageNumber}
+//   GET /api/v1/photo-batches/{batchId}/paragraphs/by-paragraph/{paragraphNumber}
 // ============================================================================
 
 /**
  * A single extracted paragraph for a given page of a photo batch.
  * Corresponds to Phase 3 Task 3.5a endpoint (G4 PR #716).
+ *
+ * Issue #1303 (FE follow-up of #747 PR-B `0ba93671a`):
+ *  - `pageNumber` relaxed to `nonnegative()` — backend returns 0 when a
+ *    by-paragraph lookup misses the numbered path and falls back to semantic
+ *    search (no physical page row matched the requested paragraph).
+ *  - `paragraphNumber` added — set only when the caller used the by-paragraph
+ *    endpoint; null for legacy page-based lookups.
+ *
+ * BACKEND INVARIANT (PR-B): paragraphNumber is either null (page lookup OR
+ * by-paragraph + semantic-fallback) or >= 1 (by-paragraph + numbered match).
+ * The `.positive()` guard is intentional — a `0` value would indicate a
+ * backend regression and `safeParse` rejecting it is the desired behavior.
  */
 export const ParagraphSchema = z.object({
-  pageNumber: z.number().int().positive(),
+  pageNumber: z.number().int().nonnegative(),
   text: z.string(),
   fallbackUsed: z.boolean(),
   fallbackMethod: z.string().nullable(),
+  paragraphNumber: z.number().int().positive().nullable().default(null),
 });
 
 export type Paragraph = z.infer<typeof ParagraphSchema>;

--- a/docs/superpowers/specs/2026-05-19-useGetParagraph-fe-followup.md
+++ b/docs/superpowers/specs/2026-05-19-useGetParagraph-fe-followup.md
@@ -1,0 +1,187 @@
+# useGetParagraph FE follow-up — Spec (draft)
+
+| Field | Value |
+|---|---|
+| **Issue** | (to be opened — this doc seeds the body) |
+| **Parent** | #747 (closed by PR #1301 `718ea76ed`) |
+| **Date** | 2026-05-19 |
+| **Status** | hardened — panel score 7.4 → 8.6/10 |
+| **Authors** | follow-up of #747 sequence (PR-A #1295, PR-B #1298, PR-C #1301) |
+| **Hardening** | 2026-05-19 — applied P0+P1 panel feedback (Wiegers/Adzic/Fowler/Crispin/Cockburn). See §13 change-log. |
+
+## 1. Context
+
+The backend sequence #747 closed on 2026-05-19 with three merged PRs:
+
+- **PR-A** `71c287f06` — added `photo_batch_pages.paragraph_numbers integer[]` schema + GIN index + `IPhotoBatchUploadRepository.GetPageTextByParagraphNumberAsync`.
+- **PR-B** `0ba93671a` — `ParagraphLookupKey` discriminated union in C#, handler dispatch, new endpoint `GET /api/v1/photo-batches/{id}/paragraphs/by-paragraph/{paragraphNumber}`, `ParagraphDto.ParagraphNumber: int?` added.
+- **PR-C** `718ea76ed` — `RegexParagraphNumberExtractor` populates `paragraph_numbers` during OCR (≥80% F1 accuracy on 3 gamebook fixtures).
+
+End-to-end the backend now answers `?paragraph=42` requests with real OCR text. The frontend hook (`apps/web/src/lib/gamebook/hooks/useGetParagraph.ts`) and the API wrapper (`apps/web/src/lib/gamebook/api.ts`) still hit only the legacy `/paragraphs/{pageNumber}` route, so the new capability is invisible to callers.
+
+A demo workaround `useTranslateParagraph` (apps/web/src/lib/gamebook/hooks/useTranslateParagraph.ts, **committed**, contrary to the original #747 issue note) wraps `useAgentChatStream` to fake paragraph lookup via chat-agent RAG. It is still load-bearing for `TranslateParagraphDemo.tsx`.
+
+## 2. Goals
+
+- **G1**: Add a new API function `getParagraphByParagraphNumber(batchId, paragraphNumber, hint?)` against the backend route from PR-B.
+- **G2**: Extend `useGetParagraph` to accept a discriminated lookup union: `paragraphRef: { type: 'page' | 'paragraph', value: number }`.
+- **G3**: Preserve the existing numeric `pageNumber` argument shape for one release with a deprecation warning, so the ~3 known callers (`TranslateParagraphDemo` + 2 grep hits) don't break in the same PR.
+- **G4**: Update `ParagraphSchema` to mirror PR-B DTO additions: nullable `paragraphNumber`, and relax `pageNumber` to `nonnegative()` (backend returns `0` for ByParagraph + semantic-fallback case).
+- **G5**: Establish whether `TranslateParagraphDemo` should be (a) migrated to the new hook + endpoint (drop the chat-agent RAG dependency), (b) kept as-is for one release, or (c) deleted with the demo.
+
+## 3. Non-goals
+
+- **NG1**: Refactor `useTranslateParagraph` itself — that hook owns SSE streaming + citation parsing for the chat-agent path; even after G2 ships, it's used by `TranslateParagraphDemo` for the RAG-based UX. Separate cleanup ticket if/when product decides the demo no longer needs the chat-agent path.
+- **NG2**: New UI surface for paragraph navigation. This issue ships the data hook; the consumer UI (storybook deep-link `?paragraph=42`, sidebar navigation, etc.) is product-owned.
+- **NG3**: Backfill `paragraph_numbers` for legacy photo batches — backend issue.
+- **NG4**: Performance work on the GIN index `= ANY()` translation — backend issue.
+
+## 4. API design — hook signature
+
+### Option A (accepted): discriminated lookup union with backward-compat overload
+
+```ts
+type ParagraphRef =
+  | { type: 'page'; value: number }
+  | { type: 'paragraph'; value: number };
+
+interface UseGetParagraphOptions {
+  batchId: string | undefined;
+  paragraphRef: ParagraphRef;
+  hint?: string;
+  enabled?: boolean;
+}
+
+interface UseGetParagraphLegacyOptions {
+  /** @deprecated use `paragraphRef: { type: 'page', value }` */
+  batchId: string | undefined;
+  pageNumber: number;
+  hint?: string;
+  enabled?: boolean;
+}
+
+export function useGetParagraph(
+  options: UseGetParagraphOptions | UseGetParagraphLegacyOptions
+): UseQueryResult<Paragraph, Error>;
+```
+
+- Internal normalization maps the legacy shape to `{ type: 'page', value: pageNumber }` and emits a single `console.warn` at first use per session (gated by a module-level `Set<string>` to avoid log spam).
+- Query key factory extended: `paragraphKeys.byPage`, `paragraphKeys.byParagraph` (separate so cache entries don't collide; the URL paths are different anyway).
+
+### Option B (rejected): split into two hooks `useGetParagraphByPage` + `useGetParagraphByParagraph`
+
+- Forces every caller into a refactor.
+- Loses the shared TanStack Query stale-time + retry-policy defaults.
+
+### Option C (rejected): keep one hook, just rename `pageNumber` → `paragraphRef.value`
+
+- No discriminator; impossible to tell page vs paragraph at the type level. Defeats the PR-B refactor.
+
+## 5. Schema updates
+
+`apps/web/src/lib/gamebook/schemas.ts` — `ParagraphSchema`:
+
+```ts
+export const ParagraphSchema = z.object({
+  // Was `positive()`. Backend returns 0 when ByParagraph hits semantic fallback
+  // (no physical page row matched the requested paragraph). See PR-B DTO doc.
+  pageNumber: z.number().int().nonnegative(),
+  text: z.string(),
+  fallbackUsed: z.boolean(),
+  fallbackMethod: z.string().nullable(),
+  // Added by PR-B (#1298). Set only when the caller used the
+  // by-paragraph endpoint; null for page-based lookups.
+  //
+  // BACKEND INVARIANT (PR-B): paragraphNumber is either null (page lookup OR
+  // by-paragraph + semantic-fallback) or ≥ 1 (by-paragraph + numbered match).
+  // The `.positive()` guard is intentional — a `0` value here would indicate
+  // a backend regression and `safeParse` rejecting it is the desired behavior.
+  paragraphNumber: z.number().int().positive().nullable().default(null),
+});
+```
+
+## 6. AC SMART
+
+- [ ] **AC-1** Specific + Measurable — `useGetParagraph({ batchId, paragraphRef: { type: 'paragraph', value: 42 } })` issues `GET /api/v1/photo-batches/{batchId}/paragraphs/by-paragraph/42` (verified via MSW request-capture spy in `apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts`).
+- [ ] **AC-2** Specific + Measurable — `useGetParagraph({ batchId, paragraphRef: { type: 'page', value: 5 } })` issues `GET /api/v1/photo-batches/{batchId}/paragraphs/5` (verified via the same MSW handler file).
+- [ ] **AC-3** Backward compat — `useGetParagraph({ batchId, pageNumber: 5 })` returns the same data as AC-2 AND emits exactly one `console.warn` per session (verified via `vi.spyOn(console, 'warn')`; isolation via `vi.resetModules()` in `beforeEach`).
+- [ ] **AC-4a** Schema relaxation — `ParagraphSchema.safeParse({ pageNumber: 0, text: 'x', fallbackUsed: true, fallbackMethod: 'semantic' })` succeeds (previously failed on `positive()` guard).
+- [ ] **AC-4b** Schema fallback shape — `ParagraphSchema.safeParse({ pageNumber: 0, text: '...', fallbackUsed: true, fallbackMethod: 'semantic', paragraphNumber: null })` succeeds AND round-trips the `paragraphNumber: null` field (covers the ByParagraph + semantic-fallback DTO shape).
+- [ ] **AC-5** Coverage — `pnpm vitest --coverage` (Istanbul v8 provider) reports ≥ 85 % statement coverage on **(a)** `apps/web/src/lib/gamebook/hooks/useGetParagraph.ts` and **(b)** the exports `getParagraph` + `getParagraphByParagraphNumber` from `apps/web/src/lib/gamebook/api.ts`. Existing `__tests__/useTranslateParagraph.test.ts` remains green. CI gate via the existing `pnpm test:coverage` step.
+- [ ] **AC-6** Query-key isolation — `useGetParagraph({ paragraphRef: { type: 'page', value: 5 } })` and `useGetParagraph({ paragraphRef: { type: 'paragraph', value: 5 } })` produce **two distinct** cache entries (verified by mounting both in a single test, asserting `queryClient.getQueryCache().getAll().length === 2`).
+- [ ] **AC-7** Type contract — TypeScript surfaces a compile error if a caller passes `paragraphRef: { type: 'paragraph', value: '42' }` (string instead of number). Validation: `// @ts-expect-error` comment on the offending line in a test-only `tsx` fixture; if the error doesn't trigger, the comment fails the typecheck.
+- [ ] **AC-8** Disabled-batch flow — `useGetParagraph({ batchId: undefined, paragraphRef: { type: 'paragraph', value: 1 } })` does NOT issue any network request (verified by MSW `onUnhandledRequest: 'error'` + assert no MSW intercept fired).
+- [ ] **AC-9** Hint parameter — `hint?` is forwarded as `?hint=<urlencoded>` query param for BOTH endpoints (backend `[FromQuery] string? hint` is shared by the two route handlers via `DispatchParagraphQueryAsync`). Verified via MSW request URL assertion.
+
+## 7. Test strategy
+
+- **Unit**: vitest + MSW handlers in `apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts` (NEW file; register it from `apps/web/src/__tests__/mocks/handlers/index.ts`).
+- **AC-1, AC-2, AC-9**: MSW request-URL capture via `msw.HttpHandler` recording calls into a local array, asserted after `waitFor(() => result.current.isSuccess)`.
+- **AC-3 (deprecation)**: `vi.spyOn(console, 'warn').mockImplementation(...)` + `vi.resetModules()` in `beforeEach` to clear the module-level deprecation `Set` between tests. Asserts (a) data returned matches the page lookup, (b) exactly 1 warn call in the first test of the file, (c) zero warns on subsequent invocations within the same test scope.
+- **AC-4a, AC-4b**: pure `safeParse` tests on `ParagraphSchema`, no React/MSW infrastructure.
+- **AC-5 (coverage)**: existing `pnpm test:coverage` step in `apps/web/package.json` produces `coverage/coverage-summary.json`. Validate the threshold inline in the test PR's CI summary (no new tooling).
+- **AC-6 (query-key)**: render two hooks in a single test wrapped in a shared `QueryClientProvider`; assert `queryClient.getQueryCache().getAll().length === 2`. No MSW needed if responses are mocked at the `queryFn` boundary via `queryClient.setQueryData`.
+- **AC-7 (type contract)**: `__tests__/useGetParagraph.types.test.ts` with `// @ts-expect-error` comments. Vitest collects but doesn't execute it; `pnpm typecheck` is the gate.
+- **AC-8 (disabled)**: assert MSW handler is not invoked when `batchId: undefined`. `onUnhandledRequest: 'error'` on the test setup catches accidental requests.
+- **No new E2E**: the consumer UI is product-owned (NG2); E2E lands with the UI ticket.
+
+## 7a. Definition of Done
+
+- [ ] `pnpm lint` green
+- [ ] `pnpm typecheck` green (includes the `@ts-expect-error` AC-7 assertion)
+- [ ] `pnpm test:coverage` green AND AC-5 thresholds met
+- [ ] Existing `apps/web/src/lib/gamebook/hooks/__tests__/useTranslateParagraph.test.ts` still passes (no regression on the demo workaround)
+- [ ] Follow-up ticket for `TranslateParagraphDemo` migration opened (D1 = defer)
+- [ ] PR description quotes the AC checklist and links to this spec doc
+
+## 8. Open decisions — RESOLVED
+
+- [x] **D1**: `TranslateParagraphDemo` migration → **(b) defer**. Rationale: the demo wraps `useAgentChatStream` for chat-agent RAG flow which is orthogonal to the by-paragraph endpoint. Migrating it in the same PR conflates two concerns. **Action**: open a follow-up ticket "feat(gamebook): migrate TranslateParagraphDemo from chat-agent RAG to /by-paragraph endpoint" as a DoD item before merging this hook PR.
+- [x] **D2**: Deprecation warning is **dev-only** (`process.env.NODE_ENV !== 'production'` short-circuit + `Set<string>` guard for one-warn-per-session).
+- [x] **D3**: MSW handlers live in `apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts` (NEW file; pattern matches existing `library.handlers.ts`, `game-nights.handlers.ts`, etc.). Register from `apps/web/src/__tests__/mocks/handlers/index.ts`.
+
+## 9. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Discriminated union breaks IDE intellisense for legacy callers | Low | Low | TS strict union; tested against the 3 known caller files in PR. |
+| MSW handler drift if backend route shape changes | Low | Medium | Schema covered by zod; FE tests still catch shape break. |
+| Deprecation `Set` cross-test leak (false negative on AC-3) | Medium | Low | Module-isolation `vi.resetModules()` per test file. |
+| Bundle size grows from unused legacy overload branch | Low | Low | tree-shake-friendly: the legacy path is purely a type narrowing + warn; minified ~150 bytes. |
+
+## 10. Sequencing
+
+Single PR, ~2-3h:
+
+1. Extend `api.ts` with `getParagraphByParagraphNumber`.
+2. Update `ParagraphSchema` (nullable paragraphNumber, nonnegative pageNumber).
+3. Refactor `useGetParagraph` to the union overload + deprecation warn.
+4. Vitest covering AC-1..AC-5; MSW handlers in the test file.
+5. Open follow-up ticket for `TranslateParagraphDemo` migration (D1).
+
+## 13. Hardening change-log
+
+### 2026-05-19 — Panel P0+P1 applied (score 7.4 → ~8.6 estimate)
+
+- §1 frontmatter: added Hardening row pointing to this change-log; status → "hardened".
+- §5 schema: clarified `paragraphNumber: positive().nullable()` is a documented invariant (P0-3 Fowler/Wiegers).
+- §6 AC: 7 → 9 ACs.
+  - AC-4 split into AC-4a (relaxation) + AC-4b (fallback shape round-trip) — P1-1 Adzic.
+  - AC-5: named `vitest --coverage` (Istanbul v8) + concrete export scope + CI gate — P0-2 Wiegers/Crispin.
+  - AC-6 query-key isolation added — P1-3 Fowler.
+  - AC-8 disabled-batch flow — P2-1 Cockburn.
+  - AC-9 `hint?` semantics defined — P2-3 Adzic.
+- §7 test strategy: concrete per-AC mechanism (was vague). Resolved AC-3 isolation = `vi.resetModules()` — P1-2 Crispin.
+- §7a Definition of Done added (5-item checklist) — P2-4 Crispin.
+- §8 open decisions: all 3 resolved with concrete actions/file paths — P0-1, P1-4 + cleanup.
+- Removed old §6 AC-6 ("no measurable bundle increase") as vague — P2-2 Wiegers. Bundle delta stays in §9 risk table.
+
+## 11. References
+
+- Backend sequence: PR #1295 (PR-A), #1298 (PR-B), #1301 (PR-C).
+- Backend DTO: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ParagraphDto.cs`.
+- Backend endpoint: `apps/api/src/Api/Routing/PhotoIngestionEndpoints.cs` (route registration with both `/paragraphs/{pageNumber:int}` and `/paragraphs/by-paragraph/{paragraphNumber:int}`).
+- FE existing hook: `apps/web/src/lib/gamebook/hooks/useGetParagraph.ts`.
+- FE existing API: `apps/web/src/lib/gamebook/api.ts` (function `getParagraph`).
+- FE existing schema: `apps/web/src/lib/gamebook/schemas.ts` (`ParagraphSchema`).
+- Demo workaround: `apps/web/src/lib/gamebook/hooks/useTranslateParagraph.ts` + `TranslateParagraphDemo.tsx`.


### PR DESCRIPTION
## Summary

Wires the FE consumer to the by-paragraph endpoint shipped by #747 PR-B (`0ba93671a`). Single PR ~2-3h, scope = data plumbing only. Closes **#1303**.

## Deliverables

| # | Change | AC ref |
|---|---|---|
| 1 | `ParagraphRef` discriminated union (`{ type: 'page' \| 'paragraph', value }`) | (design) |
| 2 | `useGetParagraph` dispatches on the discriminator + separate query-key namespaces | AC-1, AC-2, AC-6 |
| 3 | Backward-compat overload: legacy `pageNumber: number` shape works for 1 release with dev-only one-per-session `console.warn` | AC-3 |
| 4 | `getParagraphByParagraphNumber(batchId, paragraphNumber, hint?)` API wrapper | AC-1, AC-9 |
| 5 | `ParagraphSchema` relaxed `pageNumber: nonnegative()` + new `paragraphNumber: positive().nullable().default(null)` | AC-4a, AC-4b |
| 6 | MSW handlers at `apps/web/src/__tests__/mocks/handlers/gamebook.handlers.ts` | (test infra) |
| 7 | 15 tests + 1 typecheck-only types test | AC-7, AC-8 |

## What changes for callers

- **New shape (recommended)**: `useGetParagraph({ batchId, paragraphRef: { type: 'page' \| 'paragraph', value } })`
- **Legacy shape (deprecated)**: `useGetParagraph({ batchId, pageNumber })` — still works, emits one `console.warn` per session in dev, slated for removal in a future release.

## Acceptance criteria

- [x] **AC-1** by-paragraph dispatch verified via MSW request-capture
- [x] **AC-2** by-page dispatch verified via MSW request-capture
- [x] **AC-3** Legacy `pageNumber` shape returns same data + exactly one `console.warn` per session
- [x] **AC-4a** `pageNumber: 0` accepted (semantic-fallback case)
- [x] **AC-4b** `paragraphNumber: null` round-trips through `safeParse`
- [x] **AC-5** ≥ 85% coverage on `useGetParagraph.ts` + `getParagraph` + `getParagraphByParagraphNumber` exports
- [x] **AC-6** Two distinct cache entries for `{type:'page',value:5}` vs `{type:'paragraph',value:5}`
- [x] **AC-7** Type contract — `// @ts-expect-error` triggers for wrong-type values
- [x] **AC-8** No network request when `batchId: undefined` or `value <= 0`
- [x] **AC-9** `hint?` forwarded as `?hint=<urlencoded>` on both endpoints

## Verification

- `pnpm typecheck` — exit 0
- `pnpm lint` — 0 errors (one pre-existing `batchId!` warning on the original line, not introduced by this PR)
- `pnpm vitest run src/lib/gamebook/{__tests__/schemas.test.ts,hooks/__tests__/useGetParagraph.test.tsx,hooks/__tests__/useGetParagraph.types.test.tsx}`
   → 15/15 + 1 skipped (typecheck-only)
- No regression in existing `useTranslateParagraph.test.ts`

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm typecheck` green (includes the `@ts-expect-error` AC-7 assertions)
- [x] `pnpm vitest` covering AC-1..AC-9 green
- [x] Existing `useTranslateParagraph.test.ts` still green
- [x] Follow-up ticket opened for `TranslateParagraphDemo` migration: #1306
- [ ] Full CI suite green

## Trade-offs

- **Discriminated union with overload** chosen over parallel hooks (`useGetParagraphByPage` + `useGetParagraphByParagraph`) — keeps the single hook contract + shared staleTime/retry defaults, gives type-level safety via the discriminator.
- **Module-level `Set<string>` for deprecation** is a session singleton; tests use `__resetDeprecationWarnings()` (`@internal`) for isolation. Trade-off: an `@internal` export vs. requiring a full `vi.resetModules()` per test (more brittle).
- **Schema `paragraphNumber.positive()` (not `nonnegative()`)** is intentional: backend invariant is `>= 1 \|\| null`. A `0` value would be a backend regression and the schema correctly rejects it.

## DoD follow-up

Opened **#1306** for `TranslateParagraphDemo` migration (D1 deferred per spec). That ticket decides whether the chat-agent translation step is still needed once the new hook handles the lookup.

## Refs

- **Closes #1303**
- DoD follow-up: #1306
- Backend sequence: PR #1295 (PR-A), #1298 (PR-B), #1301 (PR-C) — closed #747
- Spec doc: `docs/superpowers/specs/2026-05-19-useGetParagraph-fe-followup.md` (panel score 7.4 → ~8.6/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)