### PR TITLE
fix(game-nights): #950 fast-follow — clear post-merge ESLint errors

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/_content.tsx
@@ -38,7 +38,6 @@ import { initialWizardState, wizardReducer } from '@/lib/game-nights/wizard-redu
 import type { WizardStep } from '@/lib/game-nights/wizard-types';
 import { buildSubmitPayload } from '@/lib/game-nights/wizard-validators';
 
-const TOTAL_STEPS = 4 as const;
 const SUBMIT_RETRY_DELAYS_MS: readonly number[] = [1000, 2000, 4000];
 
 function parseStep(value: string | null): WizardStep {

--- a/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
+++ b/apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts
@@ -119,22 +119,29 @@ export function useGameNightDraftPersist({
   const [isPending, setIsPending] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Capture the latest `state` in a ref so the effect's deps array can list
+  // only the persisted slices (and skip `state.draft`, which is autosave
+  // status — including it would trigger an infinite re-save loop). The
+  // effect reads through the ref, so react-hooks/exhaustive-deps stays happy.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const { step, date, location, invitees, games } = state;
+
   useEffect(() => {
     if (!enabled || !userId) return undefined;
 
     setIsPending(true);
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => {
-      writeDraft(userId, state);
+      writeDraft(userId, stateRef.current);
       setIsPending(false);
     }, DEBOUNCE_MS);
 
     return () => {
       if (timer.current) clearTimeout(timer.current);
     };
-    // Persist whenever the persisted shape changes; the `draft` branch is
-    // intentionally excluded (autosave status doesn't trigger another save).
-  }, [enabled, userId, state.step, state.date, state.location, state.invitees, state.games]);
+  }, [enabled, userId, step, date, location, invitees, games]);
 
   return {
     initialDraft,


### PR DESCRIPTION
## Summary

Two `react-hooks/exhaustive-deps` + `no-unused-vars` ESLint errors surfaced on `main-dev` Dev Fast right after PR #1305 squash-merged. `Frontend Static (lint + typecheck)` is build-blocking, so this is a fast-follow to clear the gate before the next PR can land.

## Errors fixed

1. **`apps/web/src/lib/game-nights/hooks/useGameNightDraftPersist.ts:137`** — `useEffect`'s deps array listed `state.step / .date / .location / .invitees / .games` directly (intentional: excludes `state.draft` which is autosave status; including it loops). Fix: destructure persisted slices into named locals + capture `state` via `stateRef.current` inside the debounced setTimeout. Semantic preserved (skip draft), linter happy.
2. **`apps/web/src/app/(authenticated)/game-nights/new/_content.tsx:41`** — unused `const TOTAL_STEPS = 4`. The constant lives in `GameNightCreateWizard.tsx` where it's actually consumed; the orchestrator's copy was vestigial. Removed.

## Verification

- \`pnpm lint\` → **0 errors** (42 pre-existing warnings unchanged)
- \`pnpm typecheck\` → clean

## Test plan

- [x] Local lint + typecheck clean
- [ ] CI Dev Fast green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)