### PR TITLE
docs(infra): branch hygiene safeguards (closes #806)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -81,6 +81,7 @@ Frontend: cd apps/web && pnpm test:coverage
 ## Checklist
 
 - [ ] Code follows project style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards))
+- [ ] **Confirmed this PR's commit list is scoped to its title** (no absorbed/unrelated commits from a sibling branch — see [Branch Hygiene](../CONTRIBUTING.md#-branch-hygiene--before-creating-a-feature-branch) #806)
 - [ ] Self-review of code completed
 - [ ] Comments added for complex logic
 - [ ] Documentation updated (if applicable)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ git checkout -b feature/issue-{n}-{desc}
 
 If `git branch --show-current` prints `feature/...`, STOP. Run `git checkout main-dev && git pull` first.
 
+See also: [CONTRIBUTING.md § Branch Hygiene](./CONTRIBUTING.md#-branch-hygiene--before-creating-a-feature-branch) for the human-facing version (includes opening-PR checklist + recovery via `git rebase --onto`).
+
 **Commits**: `feat|fix|docs|refactor|test|chore(scope): description`
 
 ### Feature Development Flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,54 @@ git branch -D feature/issue-123-foo
 git remote prune origin
 ```
 
+### 🔴 Branch Hygiene — Before Creating a Feature Branch
+
+> **Root cause of issue #806** (PR #797 absorbed 17 unrelated commits from issue #730 because the new branch was created from an in-progress branch tip instead of `main-dev`). Multi-terminal AI agentic sessions are particularly prone to this when juggling concurrent branches.
+
+**ALWAYS run this pre-creation safety check before `git checkout -b feature/...`:**
+
+```bash
+# 1. Verify HEAD is on the intended parent (main-dev / main / main-staging),
+#    NOT on another in-progress feature/* branch
+git branch --show-current   # MUST print main-dev (or your intended parent)
+
+# 2. Working tree must be clean (no in-flight changes from another branch)
+git status                  # MUST show "nothing to commit, working tree clean"
+
+# 3. Parent branch must be up-to-date with origin (no divergence)
+git pull --ff-only          # MUST succeed without conflict
+
+# 4. NOW create the feature branch
+git checkout -b feature/issue-<n>-<desc>
+
+# 5. Optionally track parent for explicit lineage on later PRs
+git config branch.feature/issue-<n>-<desc>.parent main-dev
+```
+
+If `git branch --show-current` prints `feature/...`, **STOP**. Switch back first:
+```bash
+git checkout main-dev && git pull
+```
+
+#### ❌ What NOT to do
+
+```bash
+# DON'T: create new branch while still on another feature branch
+git checkout -b feature/issue-200-new   # while HEAD is on feature/issue-100-old
+# → All in-progress commits from #100 get absorbed into #200's ancestry
+# → PR #200 will show #100's commits under #200's title (issue #806)
+```
+
+#### PR opening checklist
+
+When opening a PR, verify:
+
+- [ ] **PR title scope matches commit list** — `feat(scope)` should not include commits from unrelated `feat(other-scope)` work
+- [ ] **PR file count + LOC are proportional** to the title (e.g., `feat(infra)` should not have 30+ files unless explicit doc reorg)
+- [ ] **Commit subjects reference the same issue number** as the branch name (heuristic: `feat(*): #<branch-issue> ...` for each commit, not `feat(*): #<other-issue> ...`)
+
+If any of these red-flag, the branch was likely created on top of an in-progress sibling — fix via `git rebase --onto main-dev <wrong-base> HEAD` before opening the PR.
+
 ---
 
 ## References


### PR DESCRIPTION
## Summary

Adds Tier 1 documentation safeguards from #806 to prevent recurrence of PR #797 contamination (17 unrelated commits absorbed when a feature branch was created on top of an in-progress sibling).

**3 files** · **+51 LOC** · docs-only · no build/test impact.

## Changes

- **CONTRIBUTING.md** — new `🔴 Branch Hygiene — Before Creating a Feature Branch` section under Branching Strategy. Includes:
  - 4-step pre-creation safety check with rationale per command
  - Explicit "what NOT to do" example reproducing the #797 mistake
  - PR-opening checklist (title scope · file count · commit-issue cross-check)
  - Recovery hint via `git rebase --onto main-dev <wrong-base> HEAD`
- **CLAUDE.md** — cross-link to the new CONTRIBUTING section so the AI-agent rule and human rule stay in sync. The existing `🔴 Branch Hygiene Rule (#806)` block remains the load-bearing doc for agents.
- **.github/pull_request_template.md** — new top-level checklist item: "Confirmed this PR's commit list is scoped to its title (no absorbed/unrelated commits from a sibling branch — see Branch Hygiene #806)".

## DoD vs #806

| AC | Status |
|----|--------|
| CONTRIBUTING.md updated with branch hygiene section | ✅ |
| CLAUDE.md updated with AI-agentic-session guidance | ✅ pre-existing + cross-link added |
| Decision recorded on Tier 2 hook + Action | 🗒️ See issue comment (recommend defer 6 months) |
| No main-dev history rewrite | ✅ N/A (doc-only) |

## Tier 2 deferral rationale (full details in issue comment)

Tier 2 (pre-push hook + GitHub Action PR scope check) deferred 6 months. The new PR-opening checklist + file-count-vs-title heuristic gives reviewers the signal to catch contamination at PR review time. Tier 2 automation risks false-positives (e.g., legitimate doc-reorg PRs with 30+ files); will re-evaluate 2026-11-19 if Tier 1 fails to catch a recurrence.

## Test plan

- [x] CONTRIBUTING.md renders correctly (markdown lint clean — no headings broken)
- [x] CLAUDE.md cross-link target resolves
- [x] PR template renders in this PR's own preview (this PR uses the updated template)
- [ ] CI: doc-only path, no build/test workflows expected to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)