### PR TITLE
feat(infra): #520 R2 orphan PDF cleanup script + runbook (Opt. C)

### DIFF
--- a/docs/for-developers/operations/2026-05-19-r2-orphan-cleanup-runbook.md
+++ b/docs/for-developers/operations/2026-05-19-r2-orphan-cleanup-runbook.md
@@ -1,0 +1,152 @@
+# R2 Orphan PDF Cleanup Runbook
+
+**Date**: 2026-05-19 · **Issue**: [#520](https://github.com/meepleAi-app/meepleai-monorepo/issues/520) · **Scope**: Opt. C cleanup-only
+
+## Context
+
+Post-merge audit (PR #517, 2026-04-22) revealed ~82 orphan top-level prefixes under
+`pdf_uploads/` on `meepleai-uploads` (R2 staging) with no matching row in
+`pdf_documents.Id`, `PrivateGameId`, or `SharedGameId`. These are leftovers from
+games removed from the catalog without storage cleanup.
+
+The original issue body also proposed a `{gameId}` → `{pdfId}` layout migration,
+but `S3BlobStorageService.cs:271` (codice live) still keys objects as
+`pdf_uploads/{gameId}/{fileId}_{filename}`. That refactor is a separate epic
+(tracked in the spawned follow-up issue) and is **out of scope** for this runbook.
+
+This runbook removes the orphans via a reversible `_trash/` move (NOT a hard
+delete) with a 7-day grace window before permanent purge.
+
+## Pre-requisites
+
+- Access to staging server (SSH key `~/.ssh/meepleai-staging`).
+- R2 credentials present in `infra/secrets/storage.secret` (`S3_ENDPOINT`,
+  `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET_NAME`).
+- Postgres readonly DSN to staging (`PG_DSN`).
+- `aws` CLI v2 + `psql` available locally OR run from staging.
+- 30-min maintenance window — uploads during cleanup are race-safe (script
+  operates on classified orphans only, which by definition have no live row;
+  in-flight uploads cannot target an orphan prefix), but lower-traffic windows
+  reduce overall blast radius.
+
+## Step 1 — Pre-flight audit (snapshot)
+
+```bash
+export BUCKET=meepleai-uploads
+export S3_ENDPOINT="<r2-endpoint-from-storage.secret>"
+export AWS_ACCESS_KEY_ID="<from-storage.secret>"
+export AWS_SECRET_ACCESS_KEY="<from-storage.secret>"
+export PG_DSN="<staging-readonly-dsn>"
+
+./scripts/audit-pdf-storage.sh > docs/for-developers/operations/2026-05-19-r2-orphan-audit-pre.txt
+echo "exit=$?"
+```
+
+Expected:
+- Exit code `2` (orphans found) OR `0` (already clean).
+- Summary line `unknown: N` is the orphan count to cleanup.
+- Cross-check against issue #520 body baseline (`unknown: 82` at 2026-04-22).
+  Drift >5% is OK but flag it in the PR description for traceability.
+
+## Step 2 — Dry-run
+
+```bash
+./scripts/cleanup-orphan-pdfs.sh \
+    --manifest docs/for-developers/operations/2026-05-19-r2-orphan-manifest-dryrun.tsv
+```
+
+Expected:
+- Exit code `2` (orphans listed, no S3 writes).
+- Manifest TSV lists each orphan prefix with `object_count`, `total_size_bytes`,
+  status `dry-run`.
+- Each `[DRY] mv …` line targets `_trash/2026-05-19/pdf_uploads/<prefix>/`.
+
+Review the manifest. If any prefix looks load-bearing (e.g. matches a recent
+upload that the audit missed because of replication lag), abort and
+re-investigate.
+
+## Step 3 — Apply
+
+```bash
+./scripts/cleanup-orphan-pdfs.sh --apply \
+    --manifest docs/for-developers/operations/2026-05-19-r2-orphan-manifest-apply.tsv
+```
+
+Expected:
+- Exit code `0`.
+- Each line in manifest now has status `moved`.
+- `aws s3 ls s3://meepleai-uploads/_trash/2026-05-19/pdf_uploads/` shows the
+  rescued orphans.
+
+If any prefix fails (status `ERROR`):
+- Re-run the same command; `aws s3 mv` is idempotent — already-moved prefixes
+  return cleanly because the source is now empty.
+- Inspect logs for the failing prefix (likely transient R2 throttle or
+  permission issue).
+
+## Step 4 — Post-cleanup verification
+
+```bash
+./scripts/audit-pdf-storage.sh > docs/for-developers/operations/2026-05-19-r2-orphan-audit-post.txt
+echo "exit=$?"
+```
+
+Expected:
+- Exit code `0` (`unknown: 0`).
+- `matched_pdf` and `matched_game` totals match the pre-audit snapshot exactly
+  (no live data should have moved).
+
+Smoke test (optional but recommended): retrieve a random PDF via the staging
+API and verify download works.
+
+```bash
+curl -sSf -H "Cookie: <admin-session>" \
+    "https://staging.meepleai.example.com/api/v1/pdfs/<some-fileId>/download" \
+    -o /tmp/smoke.pdf
+```
+
+## Step 5 — Restore (only if needed)
+
+If a prefix turns out to be live (e.g. user reports a missing PDF):
+
+```bash
+PREFIX_TO_RESTORE="<orphan-prefix>"
+aws --endpoint-url "$S3_ENDPOINT" s3 mv \
+    "s3://$BUCKET/_trash/2026-05-19/pdf_uploads/$PREFIX_TO_RESTORE/" \
+    "s3://$BUCKET/pdf_uploads/$PREFIX_TO_RESTORE/" \
+    --recursive
+```
+
+Document the restore in the PR / incident report.
+
+## Step 6 — Permanent purge (after grace window)
+
+After 7 days (default; adjust per the change board if needed) AND only after
+confirmation from the operations channel that no restore requests came in:
+
+```bash
+PURGE_DATE="2026-05-19"
+aws --endpoint-url "$S3_ENDPOINT" s3 rm \
+    "s3://$BUCKET/_trash/$PURGE_DATE/" \
+    --recursive
+```
+
+Re-run the audit one last time to confirm storage clean state, then archive the
+manifest files alongside this runbook for traceability.
+
+## Observability / artifacts
+
+| File | Purpose |
+|---|---|
+| `2026-05-19-r2-orphan-audit-pre.txt` | Audit snapshot BEFORE cleanup |
+| `2026-05-19-r2-orphan-manifest-dryrun.tsv` | Planned moves (review gate) |
+| `2026-05-19-r2-orphan-manifest-apply.tsv` | Executed moves (per-prefix status) |
+| `2026-05-19-r2-orphan-audit-post.txt` | Audit AFTER cleanup (`unknown: 0`) |
+
+## Related
+
+- Issue #520 (this runbook) — Opt. C orphan cleanup.
+- Spawned follow-up: refactor `IBlobStorageService` layout `{gameId}` → `{pdfId}`
+  (deferred epic — see the linked issue in the PR closing #520).
+- `scripts/audit-pdf-storage.sh` — read-only classification.
+- `scripts/cleanup-orphan-pdfs.sh` — this runbook's executor.

--- a/scripts/audit-pdf-storage.sh
+++ b/scripts/audit-pdf-storage.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# Audit R2/S3 PDF storage layout to determine whether rebucket-pdfs-s3.sh is required.
+# Audit R2/S3 PDF storage layout. Classifies top-level prefixes under
+# pdf_uploads/ as pdfId-matched, gameId-matched, or unknown (orphan).
 #
 # Layouts:
-#   Legacy (pre 2026-04-19):  pdfs/{gameId}/{pdfId}.pdf
-#   Current (post-migration): pdfs/{pdfId}/{pdfId}.pdf      (uniform — gameId == pdfId)
+#   Current (S3BlobStorageService.cs:271 post-PR #517):
+#     pdf_uploads/{gameId}/{fileId}_{filename}
+#     where gameId == PrivateGameId OR SharedGameId, fileId == pdf_documents.Id
 #
-# Decision:
-#   - If every top-level prefix under pdfs/ is a pdfId present in pdf_documents.Id
-#     → layout is current → rebucket N/A
-#   - If any top-level prefix matches a gameId (PrivateGameId/SharedGameId) but not
-#     a pdfId → legacy entries exist → rebucket required
+# Decision matrix:
+#   - matched_pdf  = top-level prefix found in pdf_documents.Id        → ignore
+#   - matched_game = top-level prefix found in {PrivateGameId,SharedGameId} → live
+#   - unknown      = neither                                           → orphan (cleanup candidate)
 #
 # Usage:
 #   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
@@ -18,14 +19,14 @@
 #   [PG_DSN='postgres://user:pass@host:5432/meepleai_staging'] \
 #   ./scripts/audit-pdf-storage.sh
 #
-# If PG_DSN is omitted the script lists R2 prefixes and lets the operator
-# cross-reference manually.
+# Override PREFIX (default pdf_uploads/) if storage layout changes in future
+# (see issue #520 deferred refactor for {gameId} → {pdfId} epic).
 
 set -euo pipefail
 
 BUCKET="${BUCKET:?BUCKET env var required}"
 ENDPOINT="${S3_ENDPOINT:-}"
-PREFIX="${PREFIX:-pdfs/}"
+PREFIX="${PREFIX:-pdf_uploads/}"
 
 AWS_ARGS=()
 [[ -n "$ENDPOINT" ]] && AWS_ARGS+=(--endpoint-url "$ENDPOINT")
@@ -104,14 +105,15 @@ echo "  legacy-layout (gameId):  $matched_game"
 echo "  unknown:                 $unknown"
 echo
 
-if [[ $matched_game -eq 0 && $unknown -eq 0 ]]; then
-    echo "DECISION: rebucket N/A — all R2 prefixes match current pdfId layout."
+if [[ $unknown -eq 0 ]]; then
+    echo "DECISION: storage clean — zero orphan prefixes under $PREFIX."
     exit 0
-elif [[ $matched_game -gt 0 ]]; then
-    echo "DECISION: rebucket REQUIRED — $matched_game legacy gameId prefixes found."
-    echo "         Run: BUCKET=$BUCKET ./scripts/rebucket-pdfs-s3.sh --dry-run"
+elif [[ $unknown -gt 0 ]]; then
+    echo "DECISION: orphan cleanup AVAILABLE — $unknown prefixes have no matching pdf_documents row."
+    echo "         Dry-run: BUCKET=$BUCKET PG_DSN=... ./scripts/cleanup-orphan-pdfs.sh"
+    echo "         Apply:   BUCKET=$BUCKET PG_DSN=... ./scripts/cleanup-orphan-pdfs.sh --apply"
     exit 2
 else
-    echo "DECISION: INVESTIGATE — $unknown prefixes match neither pdfId nor gameId."
+    echo "DECISION: INVESTIGATE — unexpected classification state."
     exit 3
 fi

--- a/scripts/cleanup-orphan-pdfs.sh
+++ b/scripts/cleanup-orphan-pdfs.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Cleanup orphan PDF prefixes on S3/R2 (issue #520 Opt. C).
+#
+# Moves top-level prefixes under pdf_uploads/ that do NOT match any
+# pdf_documents.Id, PrivateGameId, or SharedGameId in the DB to a dated
+# _trash/ prefix (reversible move, NOT hard delete). Wait the grace period
+# documented in the runbook before permanent purge.
+#
+# Layout (matches S3BlobStorageService.cs:271 post-PR #517):
+#   pdf_uploads/{gameId}/{fileId}_{filename}
+#     gameId can be PrivateGameId OR SharedGameId
+#
+# Trash output:
+#   _trash/YYYY-MM-DD/pdf_uploads/{orphanPrefix}/
+#   Restore: aws s3 mv s3://<bucket>/_trash/<date>/pdf_uploads/<prefix>/ \
+#                       s3://<bucket>/pdf_uploads/<prefix>/ --recursive
+#   Purge after grace period (default 7 days; see runbook).
+#
+# Default mode is dry-run (no S3 writes). Use --apply to execute.
+#
+# Usage:
+#   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+#   S3_ENDPOINT=https://<acct>.r2.cloudflarestorage.com \
+#   BUCKET=meepleai-uploads \
+#   PG_DSN='postgres://user:pass@host:5432/meepleai_staging' \
+#   ./scripts/cleanup-orphan-pdfs.sh [--apply] [--manifest PATH] \
+#                                    [--prefix pdf_uploads/] [--trash-root _trash/]
+#
+# Exit codes:
+#   0 → no orphans found OR apply succeeded (full)
+#   1 → missing env / config error
+#   2 → orphans listed in dry-run (no S3 writes performed)
+#   3 → AWS or DB error during execution
+
+set -euo pipefail
+
+APPLY=0
+PREFIX="${PREFIX:-pdf_uploads/}"
+TRASH_ROOT="${TRASH_ROOT:-_trash/}"
+MANIFEST_PATH=""
+DATE_TAG="$(date -u +%Y-%m-%d)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) APPLY=1; shift ;;
+        --manifest)
+            [[ $# -lt 2 ]] && { echo "--manifest needs a path" >&2; exit 1; }
+            MANIFEST_PATH="$2"; shift 2 ;;
+        --prefix)
+            [[ $# -lt 2 ]] && { echo "--prefix needs a value" >&2; exit 1; }
+            PREFIX="$2"; shift 2 ;;
+        --trash-root)
+            [[ $# -lt 2 ]] && { echo "--trash-root needs a value" >&2; exit 1; }
+            TRASH_ROOT="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '1,40p' "$0"; exit 0 ;;
+        *)
+            echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Normalize trailing slashes
+PREFIX="${PREFIX%/}/"
+TRASH_ROOT="${TRASH_ROOT%/}/"
+
+# Required env
+BUCKET="${BUCKET:?BUCKET env var required}"
+PG_DSN="${PG_DSN:?PG_DSN env var required}"
+ENDPOINT="${S3_ENDPOINT:-}"
+
+AWS_ARGS=()
+[[ -n "$ENDPOINT" ]] && AWS_ARGS+=(--endpoint-url "$ENDPOINT")
+
+MODE_LABEL="DRY-RUN"
+[[ $APPLY -eq 1 ]] && MODE_LABEL="APPLY"
+
+echo "=== cleanup-orphan-pdfs ($MODE_LABEL) ==="
+echo "  bucket=$BUCKET prefix=$PREFIX trash=$TRASH_ROOT$DATE_TAG/"
+echo
+
+# 1. Fetch DB sets (pdfIds + gameIds)
+echo "[1/4] Querying DB for pdf_documents…"
+DB_DUMP=$(
+    psql "$PG_DSN" -t -A -F '|' <<'SQL'
+SELECT
+    REPLACE("Id"::text, '-', ''),
+    REPLACE(COALESCE("PrivateGameId"::text, "SharedGameId"::text, ''), '-', '')
+FROM pdf_documents
+WHERE "FilePath" IS NOT NULL;
+SQL
+) || { echo "psql query failed" >&2; exit 3; }
+
+declare -A PDF_IDS GAME_IDS
+while IFS='|' read -r pid gid; do
+    [[ -z "$pid" ]] && continue
+    PDF_IDS["$pid"]=1
+    [[ -n "$gid" ]] && GAME_IDS["$gid"]=1
+done <<< "$DB_DUMP"
+
+echo "  pdf_documents rows: ${#PDF_IDS[@]}"
+echo "  distinct game ids:  ${#GAME_IDS[@]}"
+echo
+
+# 2. List S3 top-level prefixes
+echo "[2/4] Listing S3 top-level prefixes under $PREFIX…"
+mapfile -t R2_IDS < <(
+    aws "${AWS_ARGS[@]}" s3 ls "s3://${BUCKET}/${PREFIX}" \
+        | awk '/^[[:space:]]+PRE /{print $2}' \
+        | sed 's|/$||'
+) || { echo "aws s3 ls failed" >&2; exit 3; }
+
+echo "  Found ${#R2_IDS[@]} top-level prefixes"
+echo
+
+# 3. Classify
+echo "[3/4] Classifying…"
+ORPHANS=()
+for id in "${R2_IDS[@]}"; do
+    idN="${id//-/}"
+    if [[ -n "${PDF_IDS[$idN]:-}" ]]; then
+        :
+    elif [[ -n "${GAME_IDS[$idN]:-}" ]]; then
+        :
+    else
+        ORPHANS+=("$id")
+    fi
+done
+
+orphan_count="${#ORPHANS[@]}"
+echo "  Orphan prefixes: $orphan_count"
+echo
+
+if [[ $orphan_count -eq 0 ]]; then
+    echo "Nothing to do — storage is clean."
+    exit 0
+fi
+
+# 4. Move (or dry-run)
+echo "[4/4] $MODE_LABEL — processing $orphan_count orphan prefix(es)…"
+
+# Manifest header
+MANIFEST_LINES=()
+MANIFEST_LINES+=("# cleanup-orphan-pdfs manifest")
+MANIFEST_LINES+=("# bucket=$BUCKET prefix=$PREFIX trash=$TRASH_ROOT$DATE_TAG/")
+MANIFEST_LINES+=("# mode=$MODE_LABEL utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+MANIFEST_LINES+=("prefix	object_count	total_size_bytes	status")
+
+total_objects=0
+total_size=0
+failures=0
+
+for prefix in "${ORPHANS[@]}"; do
+    src="s3://${BUCKET}/${PREFIX}${prefix}/"
+    dst="s3://${BUCKET}/${TRASH_ROOT}${DATE_TAG}/${PREFIX}${prefix}/"
+
+    # Discover size + object count for the prefix
+    summary=$(aws "${AWS_ARGS[@]}" s3 ls "$src" --recursive --summarize 2>/dev/null \
+        | tail -n 2 || echo "")
+    obj_count=$(echo "$summary" | awk '/Total Objects:/{print $3}')
+    obj_count="${obj_count:-0}"
+    size_bytes=$(echo "$summary" | awk '/Total Size:/{print $3}')
+    size_bytes="${size_bytes:-0}"
+
+    total_objects=$((total_objects + obj_count))
+    total_size=$((total_size + size_bytes))
+
+    if [[ $APPLY -eq 1 ]]; then
+        if aws "${AWS_ARGS[@]}" s3 mv "$src" "$dst" --recursive --only-show-errors; then
+            status="moved"
+        else
+            status="ERROR"
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  [DRY] mv $src -> $dst  ($obj_count objects, $size_bytes bytes)"
+        status="dry-run"
+    fi
+
+    MANIFEST_LINES+=("$prefix	$obj_count	$size_bytes	$status")
+done
+
+echo
+echo "=== Summary ==="
+echo "  orphan prefixes: $orphan_count"
+echo "  total objects:   $total_objects"
+echo "  total size:      $total_size bytes"
+[[ $failures -gt 0 ]] && echo "  failures:        $failures"
+echo
+
+# Write manifest
+if [[ -n "$MANIFEST_PATH" ]]; then
+    printf '%s\n' "${MANIFEST_LINES[@]}" > "$MANIFEST_PATH"
+    echo "Manifest written: $MANIFEST_PATH"
+fi
+
+if [[ $APPLY -eq 0 ]]; then
+    echo
+    echo "DRY-RUN complete. Re-run with --apply to move orphans to $TRASH_ROOT$DATE_TAG/."
+    exit 2
+fi
+
+if [[ $failures -gt 0 ]]; then
+    echo "APPLY completed with $failures failure(s); inspect logs." >&2
+    exit 3
+fi
+
+echo "APPLY OK — $orphan_count prefix(es) moved to $TRASH_ROOT$DATE_TAG/."
+echo "Restore: aws s3 mv s3://$BUCKET/$TRASH_ROOT$DATE_TAG/$PREFIX<prefix>/ \\"
+echo "             s3://$BUCKET/$PREFIX<prefix>/ --recursive"
+echo "Purge after grace window — see docs/for-developers/operations/2026-05-19-r2-orphan-cleanup-runbook.md"
+exit 0


### PR DESCRIPTION
## Summary

Closes #520 via **Opt. C** (orphan cleanup only) per the hardening review on the issue ([comment](https://github.com/meepleAi-app/meepleai-monorepo/issues/520#issuecomment-4487001830)). The layout refactor proposed in the original body (`{gameId}` → `{pdfId}`) is **out of scope** here; it was spawned as **#1314** because it requires a multi-day backend refactor of `IBlobStorageService` + every call site, which is not a quick-win.

This PR is **scripts + runbook only** — no runtime code changes, no DB migration, no live S3 writes. Execution against staging is a follow-up ops task gated by the new runbook.

- `scripts/audit-pdf-storage.sh` — default `PREFIX` `pdfs/` → `pdf_uploads/` (matches `S3BlobStorageService.cs:271`); decision matrix now points at the new cleanup script. Marked +x.
- `scripts/cleanup-orphan-pdfs.sh` — NEW (+x). Dry-run by default; `--apply` runs `aws s3 mv` to `_trash/YYYY-MM-DD/pdf_uploads/<prefix>/` (reversible). Manifest TSV with object counts + sizes per prefix. Exit codes `0`/`1`/`2`/`3` for clean / config-error / dry-run-with-orphans / aws-or-db-error.
- `docs/for-developers/operations/2026-05-19-r2-orphan-cleanup-runbook.md` — NEW 6-step runbook (pre-flight audit → dry-run → apply → verify → restore if needed → permanent purge after 7-day grace).

## Why we narrowed scope

The audit numbers in #520's body (`186/113/104/82` from 2026-04-22) are 27 days old and the "target `pdfId` layout" claim was **never implemented in the codice live**. Specifically:

| Source | Layout |
|---|---|
| `S3BlobStorageService.GetS3Key` (line 271) | `pdf_uploads/{gameId}/{fileId}_{sanitizedFileName}` |
| `MigrateStorageCommandHandler.cs:116` | `pdf_uploads/{gameId}/{fileNameWithId}` |
| Issue #520 body claim | `pdf_uploads/{pdfId}/...` ❌ aspirational, not implemented |

The pre-existing `rebucket-pdfs-s3.sh` is *also* obsolete (it hard-codes `pdfs/{gameId}/{pdfId}.pdf`, not the live `pdf_uploads/` layout). Kept around as reference material for #1314; not invoked by anything in this PR.

## Closes / Refs

- Closes #520
- Refs #1314 (Opt. A backend refactor, deferred epic)

## AC checklist (from hardening comment)

- [x] Decision A/B/C made → **C**
- [x] Audit script aligned with codice live (`pdf_uploads/` default)
- [x] `cleanup-orphan-pdfs.sh` with `--dry-run` default + `_trash/` safety net
- [x] Runbook with pre-flight audit + dry-run + apply + post-audit + restore + permanent purge
- [x] Opt. A epic spawned (#1314)
- [ ] Audit-pre + manifest-dryrun + audit-post artifacts committed → **deferred to the ops execution PR** (this PR ships the tooling; running it against staging needs SSH + R2 creds and produces real environment data)

## Test plan

- [x] `bash -n scripts/cleanup-orphan-pdfs.sh` — syntax OK
- [x] `bash -n scripts/audit-pdf-storage.sh` — syntax OK
- [x] `bash scripts/cleanup-orphan-pdfs.sh --help` — prints header
- [x] `bash scripts/cleanup-orphan-pdfs.sh --bogus` → exit 1
- [x] `bash scripts/cleanup-orphan-pdfs.sh` (no `BUCKET` env) → exit 1 with clear error
- [ ] Staging dry-run smoke (separate ops execution; runbook step 2) — produces `2026-05-19-r2-orphan-manifest-dryrun.tsv` for review

## Out of scope (Opt. A scope, tracked in #1314)

- Refactor `IBlobStorageService` API to drop `gameId` arg
- DB migration of `pdf_documents.FilePath` to the new shape
- Touching live PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
