### PR TITLE
fix(e2e): #1315 — wire NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED into webServer env (unblock v2-states bootstrap)

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -577,6 +577,21 @@ export default defineConfig({
                   // `next start` (inlined at build time — flag must be present when CI runs
                   // `pnpm build` ahead of `next start`).
                   NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED: 'true',
+                  // Issue #1315 — `next start` runtime evaluates `proxy.ts` middleware
+                  // each request. The middleware's `isAuthBypassAllowed` guard is
+                  // `NODE_ENV !== 'production' || isVisualTestBuild`. `next start` sets
+                  // NODE_ENV=production, so without this flag the bypass requires the
+                  // build-time `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED` to ALSO be set
+                  // at *runtime* on the spawned process (Next.js does NOT replay
+                  // `NEXT_PUBLIC_*` build-time vars onto the server-side process.env
+                  // for middleware/server components). The CI workflow already sets
+                  // this var for `pnpm build` so client bundles inline correctly; here
+                  // we mirror it onto the webServer process so the server-side proxy
+                  // sees the same signal. Without this, `(authenticated)` routes using
+                  // `page.context().route()` API mocks (no `?fixture=` hatch) redirect
+                  // to /login because `isSessionCookieValid` falls through to a backend
+                  // fetch that times out in CI.
+                  NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED: '1',
                 },
               },
               mockupServer,


### PR DESCRIPTION
## Summary

Closes #1315. Unblocks the `Visual Regression — Migrated Routes` workflow `v2-states` bootstrap step, which has been failing all 28 `(authenticated)`-route behavioral tests since PR #1171 (game-night-detail v2) merged on main-dev.

## Root cause

In CI, Playwright spawns `next start` for the prod build's webServer. `next start` runs with `NODE_ENV=production`, so [`proxy.ts:385`](https://github.com/meepleAi-app/meepleai-monorepo/blob/41bad41be/apps/web/src/proxy.ts#L385) evaluates:

```typescript
const isVisualTestBuild = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1';
const isAuthBypassAllowed = process.env.NODE_ENV !== 'production' || isVisualTestBuild;
```

to `false` unless `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED` is set on the **runtime** process. The CI workflow only sets that var for the `pnpm build` step (so client bundles inline `IS_VISUAL_TEST_BUILD=true`) — it does NOT re-set it on the `pnpm test:v2-states:update` step. The spawned `next start` process sees `process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === undefined`, the middleware bypass never engages, `isSessionCookieValid()` falls through to a backend fetch at port 8080 (unreachable in CI) → false → 307 redirect to /login.

## Why only some specs failed

Specs using the `?fixture=` URL hatch (e.g. `e2e/v2-states/game-night-create.spec.ts` from my W4) sidestep the middleware entirely because state is short-circuited pre-mount, so they accidentally worked even with the redirect. Specs using `page.context().route()` API mocks for the live render path (every game-night-detail AC-H1 scenario, every game-nights-index empty-state scenario, all the axe-core violation tests on those routes) redirect before any mock fires.

## Fix

Mirror the build-time flag onto the Playwright webServer's runtime env block in [`apps/web/playwright.config.ts`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/playwright.config.ts#L571-L580). The flag is now set both at **build time** (client bundle constant-fold via the workflow `Build Next.js (production)` step) AND at **runtime** (server-side middleware via this config).

No change required to `proxy.ts` itself — the existing guard logic is correct, it just wasn't being signaled at runtime.

## Side effects

Components that gate on `IS_VISUAL_TEST_BUILD` (`LibraryHubV2`, `AgentDetailViewV2`, `PlayerDetailView`, etc.) are **client-side constant-folded** — they already had `true` baked in by the CI build step's env. Server-side `IS_VISUAL_TEST_BUILD` evaluation (rare, usually just middleware/server actions) now agrees with client-side; any seam that bridges the two becomes consistent rather than divergent.

## Verification path

Local repro was impossible without restarting the user's already-running dev server. Verification will happen in CI via this PR's check run.

Post-merge: re-dispatch `Visual Regression — Migrated Routes` with `project_filter=v2-states` to (1) confirm the fix and (2) materialize the 10 PNG baselines for `v2-states/game-night-create.spec.ts` (the remaining SP7 #950 W4 follow-up, blocked on this fix landing).

## Test plan

- [ ] CI Dev Fast green
- [ ] Post-merge dispatch of `Visual Regression — Migrated Routes` mode=bootstrap project_filter=v2-states completes successfully
- [ ] All `e2e/v2-states/game-night-detail.spec.ts` AC-H1 scenarios pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)