### PR TITLE
fix(e2e): #1315 follow-up — force locale=it-IT in v2-states Playwright projects

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -374,6 +374,14 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         baseURL: 'http://localhost:3000',
         viewport: { width: 1440, height: 900 },
+        // Issue #1315 follow-up — force `it` locale so text-based assertions
+        // (e.g. `getByRole('heading', { name: /serata non trovata/i })`) match
+        // the project's primary language. Without this, Playwright Chrome
+        // defaults to `en-US` and `IntlProvider`'s `getBrowserLocale()` resolves
+        // to `en`, producing English strings the specs don't match. The mockup
+        // baselines that conformity verifies are also IT, so locale parity
+        // across the v2-states test surface is the right default.
+        locale: 'it-IT',
       },
       expect: {
         toHaveScreenshot: {
@@ -391,6 +399,7 @@ export default defineConfig({
         ...devices['Pixel 5'],
         baseURL: 'http://localhost:3000',
         viewport: { width: 375, height: 812 },
+        locale: 'it-IT',
       },
       expect: {
         toHaveScreenshot: {


### PR DESCRIPTION
## Summary

Follow-up to PR #1319 (merged). PR #1319 fixed the proxy bypass server-side runtime, but the verify re-dispatch [run 26100232055] surfaced a second issue: text-based assertions (`getByRole('heading', { name: /serata non trovata/i })`) timing out because the rendered heading was **"Game night not found"** (EN), not "Serata non trovata" (IT).

The page snapshot in the error-context confirmed the correct error-shell structure renders; only the locale was wrong.

## Root cause

`IntlProvider.getBrowserLocale()` ([`src/components/providers/IntlProvider.tsx:42`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/src/components/providers/IntlProvider.tsx#L42)) inspects `window.navigator.language` and returns `'en'` when the browser locale is `en-*`. Playwright's `devices['Desktop Chrome']` / `devices['Pixel 5']` default to `en-US`, so the v2-states projects were silently running in English while the test assertions and existing mockup baselines were all IT.

## Fix

Explicitly set `locale: 'it-IT'` in both `v2-states-desktop` and `v2-states-mobile` `use` blocks. Matches `DEFAULT_LOCALE = LOCALES.IT` from `src/locales/index.ts` and the i18n strings the AC-H1 scenarios expect.

## Out of scope

`visual-migrated-*` projects also default to `en-US` browser locale, and PR #1317 just landed 26 baselines for `visual-migrated/sp7-game-night-create.spec.ts` generated under that EN render. Touching the locale there would require regenerating all of them. Tracking as separate concern; outside #1315 scope. The existing FAQ / shared-games / etc. baselines under `visual-migrated-*` are visual-only assertions and don't break with a locale mismatch.

## Verification path

Post-merge: re-dispatch `Visual Regression — Migrated Routes` with `project_filter=v2-states`. Expected outcomes:
- 5 AC-H1 scenarios on `game-night-detail.spec.ts` pass
- `game-nights-index.spec.ts` empty-state + axe-core a11y violations on game-night routes pass
- 10 new PNG baselines materialize under `v2-states/game-night-create.spec.ts-snapshots/`
- Closes #1315

## Test plan

- [ ] CI Dev Fast green
- [ ] Post-merge dispatch of `Visual Regression — Migrated Routes` mode=bootstrap project_filter=v2-states completes successfully
- [ ] AC-H1.d not-found assertion finds the IT "Serata non trovata" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)