### PR TITLE
refactor(storage): #1314 add BlobCategory enum + resourceKey signature (PR 1/2)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/MigrateStorageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/MigrateStorageCommandHandler.cs
@@ -90,7 +90,7 @@ internal sealed class MigrateStorageCommandHandler : IRequestHandler<MigrateStor
                 var fileId = fileNameWithId[..underscoreIndex];
 
                 // Check if file already exists on S3
-                var exists = await _storageService.ExistsAsync(fileId, gameId, cancellationToken)
+                var exists = await _storageService.ExistsAsync(fileId, BlobCategory.Pdf, gameId, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (exists)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/AddRulebookCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/AddRulebookCommandHandler.cs
@@ -208,7 +208,7 @@ internal sealed class AddRulebookCommandHandler : ICommandHandler<AddRulebookCom
         using (var stream = file.OpenReadStream())
         {
             storageResult = await _blobStorageService
-                .StoreAsync(stream, fileName, gameId.ToString(), cancellationToken)
+                .StoreAsync(stream, fileName, BlobCategory.Pdf, gameId.ToString(), cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -264,7 +264,7 @@ internal sealed class AddRulebookCommandHandler : ICommandHandler<AddRulebookCom
             // Clean up on quota failure
             try
             {
-                await _blobStorageService.DeleteAsync(storageResult.FileId!, gameId.ToString(), cancellationToken).ConfigureAwait(false);
+                await _blobStorageService.DeleteAsync(storageResult.FileId!, BlobCategory.Pdf, gameId.ToString(), cancellationToken).ConfigureAwait(false);
                 _db.PdfDocuments.Remove(pdfDoc);
                 await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -122,6 +122,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                         {
                             await _blobStorageService.DeleteAsync(
                                 storageResult.FileId,
+                                BlobCategory.Pdf,
                                 (session.PrivateGameId ?? session.GameId)?.ToString() ?? string.Empty,
                                 cancellationToken).ConfigureAwait(false);
                         }
@@ -274,6 +275,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
             storageResult = await _blobStorageService.StoreAsync(
                 assembledStream,
                 sanitizedFileName,
+                BlobCategory.Pdf,
                 (session.PrivateGameId ?? session.GameId)?.ToString() ?? "wizard-temp",
                 cancellationToken).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeletePdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeletePdfCommandHandler.cs
@@ -115,7 +115,7 @@ internal class DeletePdfCommandHandler : ICommandHandler<DeletePdfCommand, PdfDe
     {
         try
         {
-            await _blobStorageService.DeleteAsync(pdfId, gameId, cancellationToken).ConfigureAwait(false);
+            await _blobStorageService.DeleteAsync(pdfId, BlobCategory.Pdf, gameId, cancellationToken).ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
 #pragma warning disable S125 // Sections of code should not be commented out

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
@@ -59,6 +59,7 @@ internal class ExtractPdfTextCommandHandler : ICommandHandler<ExtractPdfTextComm
         var bucketKey = PdfStorageKey.ForPdf(pdf.Id);
         var fileStream = await _blobStorage.RetrieveAsync(
             bucketKey,
+            BlobCategory.Pdf,
             bucketKey,
             cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -193,7 +193,7 @@ internal partial class UploadPdfCommandHandler
         // E2E fix: Use blob storage service instead of direct filesystem access (supports S3/R2)
         // Task 4: bucket key decoupled from gameId — uses pdf.Id (see PdfStorageKey + rebucket scripts)
         var bucketKey = PdfStorageKey.ForPdf(pdfDoc.Id);
-        var fileStream = await _blobStorageService.RetrieveAsync(pdfId, bucketKey, cancellationToken).ConfigureAwait(false);
+        var fileStream = await _blobStorageService.RetrieveAsync(pdfId, BlobCategory.Pdf, bucketKey, cancellationToken).ConfigureAwait(false);
         if (fileStream == null)
         {
             // Fallback to local filesystem for backward compatibility

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -604,7 +604,7 @@ internal partial class UploadPdfCommandHandler : ICommandHandler<UploadPdfComman
             BlobStorageResult storageResult;
             using (var stream = file.OpenReadStream())
             {
-                storageResult = await _blobStorageService.StoreAsync(stream, fileName, gameId ?? privateGameId?.ToString() ?? string.Empty, cancellationToken).ConfigureAwait(false);
+                storageResult = await _blobStorageService.StoreAsync(stream, fileName, BlobCategory.Pdf, gameId ?? privateGameId?.ToString() ?? string.Empty, cancellationToken).ConfigureAwait(false);
             }
 
             if (!storageResult.Success || string.IsNullOrWhiteSpace(storageResult.FileId))
@@ -781,7 +781,7 @@ internal partial class UploadPdfCommandHandler : ICommandHandler<UploadPdfComman
     {
         try
         {
-            await _blobStorageService.DeleteAsync(fileId, gameId, cancellationToken).ConfigureAwait(false);
+            await _blobStorageService.DeleteAsync(fileId, BlobCategory.Pdf, gameId, cancellationToken).ConfigureAwait(false);
             _db.PdfDocuments.Remove(pdfDoc);
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -600,11 +600,23 @@ internal partial class UploadPdfCommandHandler : ICommandHandler<UploadPdfComman
     {
         try
         {
+            // Resolve resourceKey early to surface validation errors with a clear message
+            // instead of letting an empty string propagate to PathSecurity.ValidateIdentifier
+            // and produce a misleading "Unexpected error storing file" log (review finding #1).
+            var resourceKey = gameId ?? privateGameId?.ToString();
+            if (string.IsNullOrWhiteSpace(resourceKey))
+            {
+                _logger.LogError(
+                    "Cannot upload PDF '{FileName}': neither gameId nor privateGameId provided",
+                    fileName);
+                return (false, new BlobStorageResult(false, null, null, 0, "PDF upload requires gameId or privateGameId"), null);
+            }
+
             // Store file in blob storage
             BlobStorageResult storageResult;
             using (var stream = file.OpenReadStream())
             {
-                storageResult = await _blobStorageService.StoreAsync(stream, fileName, BlobCategory.Pdf, gameId ?? privateGameId?.ToString() ?? string.Empty, cancellationToken).ConfigureAwait(false);
+                storageResult = await _blobStorageService.StoreAsync(stream, fileName, BlobCategory.Pdf, resourceKey, cancellationToken).ConfigureAwait(false);
             }
 
             if (!storageResult.Success || string.IsNullOrWhiteSpace(storageResult.FileId))

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPhotoBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPhotoBatchCommandHandler.cs
@@ -58,7 +58,7 @@ internal sealed class UploadPhotoBatchCommandHandler
             var fileName = $"photo-batch-{batch.Id}-page-{i:D3}.jpg";
 
             using var stream = new MemoryStream(photoBytes);
-            await _blob.StoreAsync(stream, fileName, BlobCategory.Pdf, cmd.GameId.ToString(), cancellationToken).ConfigureAwait(false);
+            await _blob.StoreAsync(stream, fileName, BlobCategory.PhotoBatch, cmd.GameId.ToString(), cancellationToken).ConfigureAwait(false);
         }
 
         // 3. Enqueue background processing (fire-and-forget via IBackgroundTaskService)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPhotoBatchCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPhotoBatchCommandHandler.cs
@@ -58,7 +58,7 @@ internal sealed class UploadPhotoBatchCommandHandler
             var fileName = $"photo-batch-{batch.Id}-page-{i:D3}.jpg";
 
             using var stream = new MemoryStream(photoBytes);
-            await _blob.StoreAsync(stream, fileName, cmd.GameId.ToString(), cancellationToken).ConfigureAwait(false);
+            await _blob.StoreAsync(stream, fileName, BlobCategory.Pdf, cmd.GameId.ToString(), cancellationToken).ConfigureAwait(false);
         }
 
         // 3. Enqueue background processing (fire-and-forget via IBackgroundTaskService)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPrivatePdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPrivatePdfCommandHandler.cs
@@ -143,7 +143,7 @@ internal sealed class UploadPrivatePdfCommandHandler : ICommandHandler<UploadPri
         using (var stream = command.PdfFile.OpenReadStream())
         {
             storageResult = await _blobStorageService.StoreAsync(
-                stream, sanitizedFileName, gameIdString, cancellationToken).ConfigureAwait(false);
+                stream, sanitizedFileName, BlobCategory.Pdf, gameIdString, cancellationToken).ConfigureAwait(false);
         }
 
         if (!storageResult.Success || string.IsNullOrWhiteSpace(storageResult.FileId))

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/DownloadPdfQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/DownloadPdfQueryHandler.cs
@@ -79,7 +79,7 @@ internal class DownloadPdfQueryHandler : IQueryHandler<DownloadPdfQuery, PdfDown
         // Task 4: bucket key decoupled from gameId — uses pdf.Id (see PdfStorageKey + rebucket scripts)
         var bucketKey = PdfStorageKey.ForPdf(pdf.Id);
         var fileStream = await _blobStorageService
-            .RetrieveAsync(bucketKey, bucketKey, cancellationToken)
+            .RetrieveAsync(bucketKey, BlobCategory.Pdf, bucketKey, cancellationToken)
             .ConfigureAwait(false);
 
         if (fileStream == null)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfPageImageQueryHandler.cs
@@ -51,7 +51,7 @@ internal sealed class GetPdfPageImageQueryHandler : IQueryHandler<GetPdfPageImag
             throw new InvalidOperationException($"Cannot extract fileId from path: {pdfDoc.FilePath}");
 
         // Retrieve PDF bytes from blob storage
-        var pdfStream = await _blobStorageService.RetrieveAsync(fileId, bucket, cancellationToken).ConfigureAwait(false);
+        var pdfStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, bucket, cancellationToken).ConfigureAwait(false);
         if (pdfStream == null)
             throw new NotFoundException($"PDF file not found in storage: {fileId}/{bucket}");
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPhotoBatchStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPhotoBatchStatusQueryHandler.cs
@@ -46,7 +46,7 @@ internal sealed class GetPhotoBatchStatusQueryHandler
 
         // Parallel signed URLs — no CancellationToken on GetPresignedDownloadUrlAsync (interface contract)
         var thumbnailUrlTasks = pageEntries
-            .Select(p => _blob.GetPresignedDownloadUrlAsync(p.BlobKey, BlobCategory.Pdf, gameIdString, expirySeconds: 900));
+            .Select(p => _blob.GetPresignedDownloadUrlAsync(p.BlobKey, BlobCategory.PhotoBatch, gameIdString, expirySeconds: 900));
         var thumbnailUrls = await Task.WhenAll(thumbnailUrlTasks).ConfigureAwait(false);
 
         var pageDtos = pageEntries

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPhotoBatchStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPhotoBatchStatusQueryHandler.cs
@@ -46,7 +46,7 @@ internal sealed class GetPhotoBatchStatusQueryHandler
 
         // Parallel signed URLs — no CancellationToken on GetPresignedDownloadUrlAsync (interface contract)
         var thumbnailUrlTasks = pageEntries
-            .Select(p => _blob.GetPresignedDownloadUrlAsync(p.BlobKey, gameIdString, expirySeconds: 900));
+            .Select(p => _blob.GetPresignedDownloadUrlAsync(p.BlobKey, BlobCategory.Pdf, gameIdString, expirySeconds: 900));
         var thumbnailUrls = await Task.WhenAll(thumbnailUrlTasks).ConfigureAwait(false);
 
         var pageDtos = pageEntries

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -353,7 +353,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         // Issue #501: Use blob storage with correct GUID format (no hyphens) to match StoreAsync key format
         // Task 4: bucket key decoupled from gameId — uses pdf.Id (see PdfStorageKey + rebucket scripts)
         var fileId = PdfStorageKey.ForPdf(pdfDoc.Id);
-        var fileStream = await _blobStorageService.RetrieveAsync(fileId, fileId, cancellationToken).ConfigureAwait(false);
+        var fileStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, fileId, cancellationToken).ConfigureAwait(false);
 
         if (fileStream == null)
         {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
@@ -133,7 +133,7 @@ internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
         CancellationToken ct)
     {
         // 1. Retrieve blob from storage.
-        var stream = await _blob.RetrieveAsync(descriptor.BlobKey, BlobCategory.Pdf, gameIdString, ct).ConfigureAwait(false);
+        var stream = await _blob.RetrieveAsync(descriptor.BlobKey, BlobCategory.PhotoBatch, gameIdString, ct).ConfigureAwait(false);
         if (stream is null)
         {
             _logger.LogWarning(

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessor.cs
@@ -133,7 +133,7 @@ internal sealed class PhotoBatchProcessor : IPhotoBatchProcessor, IDisposable
         CancellationToken ct)
     {
         // 1. Retrieve blob from storage.
-        var stream = await _blob.RetrieveAsync(descriptor.BlobKey, gameIdString, ct).ConfigureAwait(false);
+        var stream = await _blob.RetrieveAsync(descriptor.BlobKey, BlobCategory.Pdf, gameIdString, ct).ConfigureAwait(false);
         if (stream is null)
         {
             _logger.LogWarning(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/UploadGameImageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/UploadGameImageCommandHandler.cs
@@ -125,7 +125,8 @@ internal class UploadGameImageCommandHandler : ICommandHandler<UploadGameImageCo
             var storageResult = await _storageService.StoreAsync(
                 stream: command.FileStream,
                 fileName: command.FileName,
-                gameId: command.GameId,
+                category: BlobCategory.GameImage,
+                resourceKey: command.GameId,
                 ct: cancellationToken
             ).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentService.cs
@@ -66,7 +66,7 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
 
         // Upload original
         var originalResult = await _blobStorage.StoreAsync(
-            fileStream, photoFileName, storageFolder, ct).ConfigureAwait(false);
+            fileStream, photoFileName, BlobCategory.SessionPhoto, storageFolder, ct).ConfigureAwait(false);
 
         if (!originalResult.Success)
         {
@@ -90,7 +90,7 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
             {
                 var thumbFileName = $"{playerId:N}_{Guid.NewGuid():N}_thumb.jpg";
                 var thumbResult = await _blobStorage.StoreAsync(
-                    thumbnailStream, thumbFileName, storageFolder, ct).ConfigureAwait(false);
+                    thumbnailStream, thumbFileName, BlobCategory.SessionPhoto, storageFolder, ct).ConfigureAwait(false);
 
                 if (thumbResult.Success)
                 {
@@ -134,7 +134,7 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
         if (fileId != null && folder != null)
         {
             var presignedUrl = await _blobStorage.GetPresignedDownloadUrlAsync(
-                fileId, folder, DownloadUrlExpirySeconds).ConfigureAwait(false);
+                fileId, BlobCategory.SessionPhoto, folder, DownloadUrlExpirySeconds).ConfigureAwait(false);
             if (presignedUrl != null)
             {
                 return presignedUrl;
@@ -162,7 +162,7 @@ internal sealed class SessionAttachmentService : ISessionAttachmentService
         var (fileId, folder) = ParseBlobPath(blobPath);
         if (fileId != null && folder != null)
         {
-            var deleted = await _blobStorage.DeleteAsync(fileId, folder).ConfigureAwait(false);
+            var deleted = await _blobStorage.DeleteAsync(fileId, BlobCategory.SessionPhoto, folder).ConfigureAwait(false);
             if (!deleted)
             {
                 _logger.LogWarning("Failed to delete blob at path: {Path}", blobPath);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/VisionSnapshotCommandHandler.cs
@@ -93,7 +93,7 @@ internal sealed class CreateVisionSnapshotCommandHandler
                 var fileName = imageUpload.FileName ?? $"snapshot_{snapshot.Id:N}_{snapshot.Images.Count}.jpg";
 
                 var storageResult = await _blobStorageService
-                    .StoreAsync(stream, fileName, gameIdForStorage, cancellationToken)
+                    .StoreAsync(stream, fileName, BlobCategory.VisionSnapshot, gameIdForStorage, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (!storageResult.Success || storageResult.FileId is null)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/VisionSnapshotQueryHandlers.cs
@@ -40,7 +40,7 @@ internal sealed class GetVisionSnapshotsQueryHandler
             foreach (var image in snapshot.Images)
             {
                 var downloadUrl = await _blobStorageService
-                    .GetPresignedDownloadUrlAsync(image.StorageKey, gameIdForStorage)
+                    .GetPresignedDownloadUrlAsync(image.StorageKey, BlobCategory.VisionSnapshot, gameIdForStorage)
                     .ConfigureAwait(false);
 
                 imageDtos.Add(new VisionSnapshotImageDto(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GameStateExtractor.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GameStateExtractor.cs
@@ -97,7 +97,7 @@ internal sealed class GameStateExtractor : IGameStateExtractor
             foreach (var image in snapshot.Images)
             {
                 using var stream = await _blobStorageService
-                    .RetrieveAsync(image.StorageKey, gameIdForStorage, ct)
+                    .RetrieveAsync(image.StorageKey, BlobCategory.VisionSnapshot, gameIdForStorage, ct)
                     .ConfigureAwait(false);
 
                 if (stream is null)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageService.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageService.cs
@@ -25,7 +25,7 @@ internal sealed class GamebookPhotoStorageService : IGamebookPhotoStorage
         {
             var fileName = $"{photoId:N}.jpg";
             var gameId = $"{GameIdPrefix}/{campaignId:N}";
-            var result = await _blob.StoreAsync(stripped, fileName, gameId, cancellationToken).ConfigureAwait(false);
+            var result = await _blob.StoreAsync(stripped, fileName, BlobCategory.GamebookPhoto, gameId, cancellationToken).ConfigureAwait(false);
             if (!result.Success || result.FileId is null)
                 throw new InvalidOperationException($"Photo upload failed: {result.ErrorMessage}");
 
@@ -37,14 +37,14 @@ internal sealed class GamebookPhotoStorageService : IGamebookPhotoStorage
     public async Task<Stream> RetrieveAsync(string storageKey, CancellationToken cancellationToken)
     {
         var (gameId, fileId) = SplitKey(storageKey);
-        var stream = await _blob.RetrieveAsync(fileId, gameId, cancellationToken).ConfigureAwait(false);
+        var stream = await _blob.RetrieveAsync(fileId, BlobCategory.GamebookPhoto, gameId, cancellationToken).ConfigureAwait(false);
         return stream ?? throw new InvalidOperationException($"Photo not found at key '{storageKey}'");
     }
 
     public async Task DeleteAsync(string storageKey, CancellationToken cancellationToken)
     {
         var (gameId, fileId) = SplitKey(storageKey);
-        _ = await _blob.DeleteAsync(fileId, gameId, cancellationToken).ConfigureAwait(false);
+        _ = await _blob.DeleteAsync(fileId, BlobCategory.GamebookPhoto, gameId, cancellationToken).ConfigureAwait(false);
     }
 
     private static (string GameId, string FileId) SplitKey(string storageKey)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadPdfForGameExtractionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadPdfForGameExtractionCommandHandler.cs
@@ -66,7 +66,8 @@ internal sealed class UploadPdfForGameExtractionCommandHandler
             var storageResult = await _blobStorageService.StoreAsync(
                 fileStream,
                 sanitizedFileName,
-                gameId: "wizard-temp",
+                category: BlobCategory.Pdf,
+                resourceKey: "wizard-temp",
                 ct: cancellationToken).ConfigureAwait(false);
 
             if (!storageResult.Success)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadSharedGamePdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadSharedGamePdfCommandHandler.cs
@@ -83,7 +83,8 @@ internal sealed class UploadSharedGamePdfCommandHandler
         var storageResult = await _blobStorageService.StoreAsync(
             fileStream,
             fileName,
-            gameId: $"shared-game-{command.SharedGameId}",
+            category: BlobCategory.Pdf,
+            resourceKey: $"shared-game-{command.SharedGameId}",
             ct: cancellationToken).ConfigureAwait(false);
 
         if (!storageResult.Success)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ExtractGameMetadataFromPdfByPdfIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ExtractGameMetadataFromPdfByPdfIdQueryHandler.cs
@@ -150,7 +150,7 @@ internal sealed class ExtractGameMetadataFromPdfByPdfIdQueryHandler
     {
         try
         {
-            var stream = await _blobStorageService.RetrieveAsync(fileId, bucket, ct).ConfigureAwait(false);
+            var stream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, bucket, ct).ConfigureAwait(false);
             if (stream == null)
                 _logger.LogWarning("[{RequestId}] PDF not found: fileId={FileId}, bucket={Bucket}", requestId, fileId, bucket);
             return stream;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ExtractGameMetadataFromPdfQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/ExtractGameMetadataFromPdfQueryHandler.cs
@@ -168,7 +168,7 @@ internal sealed class ExtractGameMetadataFromPdfQueryHandler : IQueryHandler<Ext
         {
             _logger.LogDebug("[{RequestId}] Retrieving PDF from storage: {FileId}", requestId, fileId);
 
-            var stream = await _blobStorageService.RetrieveAsync(fileId, "wizard-temp", cancellationToken)
+            var stream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, "wizard-temp", cancellationToken)
                 .ConfigureAwait(false);
 
             if (stream == null)

--- a/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
@@ -10,7 +10,7 @@ namespace Api.DevTools.MockImpls;
 
 /// <summary>
 /// In-memory mock of IBlobStorageService. Stores blobs in a ConcurrentDictionary
-/// keyed by "gameId/fileId". For unknown keys (e.g. stale Quartz jobs persisted
+/// keyed by "resourceKey/fileId". For unknown keys (e.g. stale Quartz jobs persisted
 /// in Postgres that reference blobs uploaded in a previous dev session) returns
 /// a minimal valid PDF placeholder instead of null — this prevents the PDF
 /// processing pipeline from crashing on orphaned jobs and is consistent with
@@ -18,37 +18,44 @@ namespace Api.DevTools.MockImpls;
 /// Pre-signed URLs return a synthetic localhost URL.
 /// No external S3/filesystem calls are made.
 /// </summary>
+/// <remarks>
+/// Issue #1314 PR 1: signature refactor — <c>gameId</c> replaced by
+/// <see cref="BlobCategory"/> + <c>resourceKey</c>. Internal key remains
+/// <c>{resourceKey}/{fileId}</c> to preserve behavior (PR 1 is behavior-preserving).
+/// </remarks>
 internal sealed class MockBlobStorageService : IBlobStorageService
 {
     // Minimal valid PDF header — enough to pass file type sniffing and stream reads.
     // The real PDF content does not matter because the PDF extractors are also mocked
     // and ignore the stream bytes entirely.
     private static readonly byte[] PlaceholderPdfBytes =
-        Encoding.ASCII.GetBytes("%PDF-1.4\n%\u00e2\u00e3\u00cf\u00d3\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n");
+        Encoding.ASCII.GetBytes("%PDF-1.4\n%âãÏÓ\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n");
 
     private readonly ConcurrentDictionary<string, byte[]> _store = new(StringComparer.Ordinal);
 
-    private static string KeyOf(string gameId, string fileId) => $"{gameId}/{fileId}";
+    private static string KeyOf(string resourceKey, string fileId) => $"{resourceKey}/{fileId}";
 
     /// <inheritdoc />
-    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, string gameId, CancellationToken ct = default)
+    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
+        _ = category; // PR 1 behavior preservation
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
         var bytes = ms.ToArray();
         var fileId = $"MOCK-{Guid.NewGuid():N}";
-        _store[KeyOf(gameId, fileId)] = bytes;
+        _store[KeyOf(resourceKey, fileId)] = bytes;
         return new BlobStorageResult(
             Success: true,
             FileId: fileId,
-            FilePath: $"mock://{gameId}/{fileId}/{fileName}",
+            FilePath: $"mock://{resourceKey}/{fileId}/{fileName}",
             FileSizeBytes: bytes.LongLength);
     }
 
     /// <inheritdoc />
-    public Task<Stream?> RetrieveAsync(string fileId, string gameId, CancellationToken ct = default)
+    public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
-        if (_store.TryGetValue(KeyOf(gameId, fileId), out var bytes))
+        _ = category; // PR 1 behavior preservation
+        if (_store.TryGetValue(KeyOf(resourceKey, fileId), out var bytes))
         {
             Stream s = new MemoryStream(bytes, writable: false);
             return Task.FromResult<Stream?>(s);
@@ -61,30 +68,36 @@ internal sealed class MockBlobStorageService : IBlobStorageService
     }
 
     /// <inheritdoc />
-    public Task<bool> DeleteAsync(string fileId, string gameId, CancellationToken ct = default)
+    public Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
+        _ = category; // PR 1 behavior preservation
         // Return true even for unknown keys — the mock semantics are "everything
         // is present", so "delete unknown" is a no-op success.
-        _store.TryRemove(KeyOf(gameId, fileId), out _);
+        _store.TryRemove(KeyOf(resourceKey, fileId), out _);
         return Task.FromResult(true);
     }
 
     /// <inheritdoc />
-    public string GetStoragePath(string fileId, string gameId, string fileName)
-        => $"mock://{gameId}/{fileId}/{fileName}";
+    public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
+    {
+        _ = category; // PR 1 behavior preservation
+        return $"mock://{resourceKey}/{fileId}/{fileName}";
+    }
 
     /// <inheritdoc />
-    public Task<bool> ExistsAsync(string fileId, string gameId, CancellationToken cancellationToken = default)
+    public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
     {
+        _ = (fileId, category, resourceKey, cancellationToken);
         // Everything "exists" in mock mode.
         return Task.FromResult(true);
     }
 
     /// <inheritdoc />
-    public Task<string?> GetPresignedDownloadUrlAsync(string fileId, string gameId, int? expirySeconds = null)
+    public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
     {
+        _ = category; // PR 1 behavior preservation
         // Always return a synthetic URL — the mock assumes every blob exists.
         return Task.FromResult<string?>(
-            $"http://localhost/mock-s3/{gameId}/{fileId}?expiry={expirySeconds ?? 3600}");
+            $"http://localhost/mock-s3/{resourceKey}/{fileId}?expiry={expirySeconds ?? 3600}");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -315,9 +315,17 @@ internal static class PdfSeeder
     /// Extracts the bare fileId from a storage path of shape
     /// <c>pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}</c>.
     /// Returns null if the path does not match the expected layout.
+    /// Exposed as <c>internal</c> for unit testing the null-return branches
+    /// (no path separator, trailing slash, no underscore in segment, leading
+    /// underscore in segment).
     /// </summary>
-    private static string? ExtractFileIdFromPath(string filePath)
+    internal static string? ExtractFileIdFromPath(string filePath)
     {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return null;
+        }
+
         // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
         var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
         if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
@@ -327,6 +335,7 @@ internal static class PdfSeeder
 
         var fileName = filePath[(lastSeparator + 1)..];
         var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        // <= 0 covers: not found (-1) AND leading underscore (= 0 ⇒ empty fileId).
         if (underscoreIndex <= 0)
         {
             return null;

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -168,7 +168,7 @@ internal static class PdfSeeder
                 // Stream from seed bucket → store into primary blob
                 var stream = await seedBlob.OpenReadAsync(blobKey, ct).ConfigureAwait(false);
                 await using var _ = stream.ConfigureAwait(false);
-                var result = await primaryBlob.StoreAsync(stream, fileName, PdfStorageKey.ForPdf(pdfId), ct).ConfigureAwait(false);
+                var result = await primaryBlob.StoreAsync(stream, fileName, BlobCategory.Pdf, PdfStorageKey.ForPdf(pdfId), ct).ConfigureAwait(false);
 
                 if (!result.Success)
                 {
@@ -278,7 +278,7 @@ internal static class PdfSeeder
             try
             {
                 // Extract fileId from filePath — use the path segment as-is
-                await primaryBlob.DeleteAsync(filePath, gameIdStr, ct).ConfigureAwait(false);
+                await primaryBlob.DeleteAsync(filePath, BlobCategory.Pdf, gameIdStr, ct).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
@@ -272,13 +273,26 @@ internal static class PdfSeeder
         ILogger logger,
         CancellationToken ct)
     {
-        // Best-effort delete from primary blob
+        // Best-effort delete from primary blob.
+        //
+        // filePath shape (S3 + local): "pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}".
+        // DeleteAsync expects the bare fileId (without prefix/underscore/filename).
+        // Review finding #3: previously the full filePath was passed as fileId, which
+        // failed PathSecurity.ValidateIdentifier silently — fix below extracts just the
+        // fileId GUID-without-hyphens segment.
         if (!string.IsNullOrEmpty(filePath))
         {
             try
             {
-                // Extract fileId from filePath — use the path segment as-is
-                await primaryBlob.DeleteAsync(filePath, BlobCategory.Pdf, gameIdStr, ct).ConfigureAwait(false);
+                var fileId = ExtractFileIdFromPath(filePath);
+                if (!string.IsNullOrEmpty(fileId))
+                {
+                    await primaryBlob.DeleteAsync(fileId, BlobCategory.Pdf, gameIdStr, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    logger.LogWarning("PdfSeeder: cannot extract fileId from path '{FilePath}', skipping blob delete", filePath);
+                }
             }
             catch (Exception ex)
             {
@@ -293,5 +307,31 @@ internal static class PdfSeeder
             db.PdfDocuments.Remove(entity);
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
+    }
+
+    private static readonly SearchValues<char> PathSeparators = SearchValues.Create("/\\");
+
+    /// <summary>
+    /// Extracts the bare fileId from a storage path of shape
+    /// <c>pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}</c>.
+    /// Returns null if the path does not match the expected layout.
+    /// </summary>
+    private static string? ExtractFileIdFromPath(string filePath)
+    {
+        // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
+        var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
+        if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
+        {
+            return null;
+        }
+
+        var fileName = filePath[(lastSeparator + 1)..];
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        if (underscoreIndex <= 0)
+        {
+            return null;
+        }
+
+        return fileName[..underscoreIndex];
     }
 }

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -27,19 +27,22 @@ internal class BlobStorageService : IBlobStorageService
         }
     }
 
-    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, string gameId, CancellationToken ct = default)
+    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
+        // PR 1 behavior preservation: ignore `category`, render legacy single-folder layout
+        // under _storageBasePath/{resourceKey}/. PR 2 will branch on category behind feature flag.
+        _ = category;
         try
         {
-            // SECURITY: Validate gameId to prevent path traversal
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            // SECURITY: Validate resourceKey to prevent path traversal
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
             var fileId = Guid.NewGuid().ToString("N");
-            var gameDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, gameId);
-            Directory.CreateDirectory(gameDir);
+            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+            Directory.CreateDirectory(resourceDir);
 
             var sanitizedFileName = SanitizeFileName(fileName);
-            var filePath = Path.Combine(gameDir, $"{fileId}_{sanitizedFileName}");
+            var filePath = Path.Combine(resourceDir, $"{fileId}_{sanitizedFileName}");
 
             // Save file to disk
             using (var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None))
@@ -55,12 +58,12 @@ internal class BlobStorageService : IBlobStorageService
         }
         catch (IOException ex)
         {
-            _logger.LogError(ex, "I/O error storing file for game {GameId}", gameId);
+            _logger.LogError(ex, "I/O error storing file in {ResourceKey}", resourceKey);
             return new BlobStorageResult(false, null, null, 0, $"I/O error: {ex.Message}");
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogError(ex, "Access denied storing file for game {GameId}", gameId);
+            _logger.LogError(ex, "Access denied storing file in {ResourceKey}", resourceKey);
             return new BlobStorageResult(false, null, null, 0, "Access denied to storage location");
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -71,27 +74,28 @@ internal class BlobStorageService : IBlobStorageService
             // throw various runtime exceptions (disk full, permissions, antivirus locks, path too long). We must
             // catch all exceptions to return error results instead of crashing the service.
             // Context: File system operations can fail in unpredictable ways across different OS environments
-            _logger.LogError(ex, "Unexpected error storing file for game {GameId}", gameId);
+            _logger.LogError(ex, "Unexpected error storing file in {ResourceKey}", resourceKey);
             return new BlobStorageResult(false, null, null, 0, ex.Message);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public Task<Stream?> RetrieveAsync(string fileId, string gameId, CancellationToken ct = default)
+    public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
+        _ = category; // PR 1 behavior preservation
         FileStream? fileStream = null;
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var gameDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, gameId);
-            var files = Directory.GetFiles(gameDir, $"{fileId}_*");
+            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
 
             if (files.Length == 0)
             {
-                _logger.LogWarning("File not found for {FileId} in game {GameId}", fileId, gameId);
+                _logger.LogWarning("File not found for {FileId} in {ResourceKey}", fileId, resourceKey);
                 return Task.FromResult<Stream?>(null);
             }
 
@@ -111,26 +115,27 @@ internal class BlobStorageService : IBlobStorageService
             // RESOURCE LEAK FIX: Dispose FileStream if created but exception occurred before returning
             fileStream?.Dispose();
 
-            _logger.LogError(ex, "Error retrieving file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogError(ex, "Error retrieving file {FileId} for {ResourceKey}", fileId, resourceKey);
             return Task.FromResult<Stream?>(null);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public async Task<bool> DeleteAsync(string fileId, string gameId, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
+        _ = category; // PR 1 behavior preservation
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var gameDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, gameId);
-            var files = Directory.GetFiles(gameDir, $"{fileId}_*");
+            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
 
             if (files.Length == 0)
             {
-                _logger.LogWarning("File not found for deletion: {FileId} in game {GameId}", fileId, gameId);
+                _logger.LogWarning("File not found for deletion: {FileId} in {ResourceKey}", fileId, resourceKey);
                 return false;
             }
 
@@ -144,12 +149,12 @@ internal class BlobStorageService : IBlobStorageService
         }
         catch (IOException ex)
         {
-            _logger.LogWarning(ex, "I/O error deleting file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "I/O error deleting file {FileId} for {ResourceKey}", fileId, resourceKey);
             return false;
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogWarning(ex, "Access denied deleting file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "Access denied deleting file {FileId} for {ResourceKey}", fileId, resourceKey);
             return false;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -160,42 +165,44 @@ internal class BlobStorageService : IBlobStorageService
             // can throw various runtime exceptions (file locked, permissions, antivirus blocks, disk errors). We
             // must catch all exceptions to return false instead of crashing the service.
             // Context: File system operations can fail in unpredictable ways across different OS environments
-            _logger.LogWarning(ex, "Unexpected error deleting file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "Unexpected error deleting file {FileId} for {ResourceKey}", fileId, resourceKey);
             return false;
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public string GetStoragePath(string fileId, string gameId, string fileName)
+    public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
     {
-        // SECURITY: Validate gameId to prevent path traversal
-        PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+        _ = category; // PR 1 behavior preservation
+        // SECURITY: Validate resourceKey to prevent path traversal
+        PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-        var gameDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, gameId);
+        var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
         var sanitizedFileName = SanitizeFileName(fileName);
-        return Path.Combine(gameDir, $"{fileId}_{sanitizedFileName}");
+        return Path.Combine(resourceDir, $"{fileId}_{sanitizedFileName}");
     }
 
-    public Task<bool> ExistsAsync(string fileId, string gameId, CancellationToken cancellationToken = default)
+    public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
     {
+        _ = category; // PR 1 behavior preservation
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var gameDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, gameId);
-            if (!Directory.Exists(gameDir))
+            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+            if (!Directory.Exists(resourceDir))
             {
                 return Task.FromResult(false);
             }
 
-            var files = Directory.GetFiles(gameDir, $"{fileId}_*");
+            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
             return Task.FromResult(files.Length > 0);
         }
         catch (ArgumentException)
         {
-            // Invalid gameId - path traversal attempt
+            // Invalid resourceKey - path traversal attempt
             return Task.FromResult(false);
         }
         catch (System.Security.SecurityException)
@@ -209,8 +216,9 @@ internal class BlobStorageService : IBlobStorageService
     /// Local storage does not support pre-signed URLs.
     /// Consumers should fall back to the API download endpoint when this returns null.
     /// </summary>
-    public Task<string?> GetPresignedDownloadUrlAsync(string fileId, string gameId, int? expirySeconds = null)
+    public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
     {
+        _ = (fileId, category, resourceKey, expirySeconds); // Local storage: no presigned URL
         return Task.FromResult<string?>(null);
     }
 

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -31,6 +31,14 @@ public enum BlobCategory
 
     /// <summary>Gamebook scanned photos. Target prefix <c>gamebook-photos/{gamebookId}/</c>.</summary>
     GamebookPhoto,
+
+    /// <summary>
+    /// JPEG photo batches uploaded for OCR + text extraction (Libro Game AI Assistant camera pipeline).
+    /// Each batch is N per-page captures of a physical rulebook/gamebook. Distinct from
+    /// <see cref="GamebookPhoto"/> (which is per-photo session storage) and <see cref="Pdf"/>
+    /// (which is the binary PDF document itself). Target prefix <c>photo-batches/{gameId}/</c>.
+    /// </summary>
+    PhotoBatch,
 }
 
 internal static class BlobCategoryExtensions
@@ -48,6 +56,7 @@ internal static class BlobCategoryExtensions
         BlobCategory.GameImage => "game-images",
         BlobCategory.VisionSnapshot => "vision-snapshots",
         BlobCategory.GamebookPhoto => "gamebook-photos",
+        BlobCategory.PhotoBatch => "photo-batches",
         _ => throw new ArgumentOutOfRangeException(nameof(category), category, null),
     };
 }

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -4,70 +4,125 @@
 namespace Api.Services.Pdf;
 
 /// <summary>
+/// Logical category for blob storage objects. Each category maps to a distinct
+/// S3 prefix via <see cref="BlobCategoryExtensions.ToS3Folder"/> so PDF, session photos,
+/// game images, vision snapshots and gamebook photos no longer share the legacy
+/// PDF-specific prefix.
+/// </summary>
+/// <remarks>
+/// Issue #1314 PR 1: this enum is added to the public surface of IBlobStorageService
+/// but the S3 key layout is INTENTIONALLY unchanged in PR 1 (behavior-preserving
+/// refactor). PR 2 of issue #1314 wires <see cref="BlobCategoryExtensions.ToS3Folder"/>
+/// into <see cref="S3BlobStorageService"/> behind feature flag for the 5-phase rollout.
+/// </remarks>
+public enum BlobCategory
+{
+    /// <summary>PDF documents (rulebooks, manuals). Legacy prefix <c>pdf_uploads/</c>, target <c>pdfs/</c>.</summary>
+    Pdf,
+
+    /// <summary>Session photos uploaded during a game night. Legacy prefix <c>pdf_uploads/session-photos-{sessionId}/</c>, target <c>session-photos/{sessionId}/</c>.</summary>
+    SessionPhoto,
+
+    /// <summary>Game catalog images (cover, thumbnail, hero). Legacy prefix <c>pdf_uploads/{gameId}/</c>, target <c>game-images/{gameId}/</c>.</summary>
+    GameImage,
+
+    /// <summary>Vision snapshot captures (in-session board states). Target prefix <c>vision-snapshots/{snapshotId}/</c>.</summary>
+    VisionSnapshot,
+
+    /// <summary>Gamebook scanned photos. Target prefix <c>gamebook-photos/{gamebookId}/</c>.</summary>
+    GamebookPhoto,
+}
+
+internal static class BlobCategoryExtensions
+{
+    /// <summary>
+    /// Returns the canonical S3 folder prefix for the given category. Used by PR 2
+    /// of issue #1314 when feature flag <c>STORAGE_WRITE_MODE=new</c>. PR 1 does not
+    /// consume this value — keys are still rendered via the legacy <c>pdf_uploads/</c>
+    /// prefix to preserve behavior.
+    /// </summary>
+    public static string ToS3Folder(this BlobCategory category) => category switch
+    {
+        BlobCategory.Pdf => "pdfs",
+        BlobCategory.SessionPhoto => "session-photos",
+        BlobCategory.GameImage => "game-images",
+        BlobCategory.VisionSnapshot => "vision-snapshots",
+        BlobCategory.GamebookPhoto => "gamebook-photos",
+        _ => throw new ArgumentOutOfRangeException(nameof(category), category, null),
+    };
+}
+
+/// <summary>
 /// Generic file storage service for managing blob storage operations
 /// Reusable for any file type beyond PDFs
 /// </summary>
 internal interface IBlobStorageService
 {
     /// <summary>
-    /// Stores a file from a stream
+    /// Stores a file from a stream.
     /// </summary>
-    /// <param name="stream">File stream to store</param>
-    /// <param name="fileName">Original file name</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="ct">Cancellation token</param>
-    /// <returns>Storage result with file ID and path</returns>
-    Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, string gameId, CancellationToken ct = default);
+    /// <param name="stream">File stream to store.</param>
+    /// <param name="fileName">Original file name.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier (e.g. pdfId, sessionId, gameId) used as folder key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Storage result with file ID and path.</returns>
+    Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default);
 
     /// <summary>
-    /// Retrieves a file stream by file ID
+    /// Retrieves a file stream by file ID.
     /// </summary>
-    /// <param name="fileId">File ID to retrieve</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="ct">Cancellation token</param>
-    /// <returns>File stream or null if not found</returns>
+    /// <param name="fileId">File ID to retrieve.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>File stream or null if not found.</returns>
     /// <remarks>
     /// IMPORTANT: Caller MUST dispose the returned stream to prevent resource leaks.
     /// For S3 storage, this also disposes the underlying GetObjectResponse connection.
     /// </remarks>
-    Task<Stream?> RetrieveAsync(string fileId, string gameId, CancellationToken ct = default);
+    Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default);
 
     /// <summary>
-    /// Deletes a file by file ID
+    /// Deletes a file by file ID.
     /// </summary>
-    /// <param name="fileId">File ID to delete</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="ct">Cancellation token</param>
-    /// <returns>True if deleted successfully</returns>
-    Task<bool> DeleteAsync(string fileId, string gameId, CancellationToken ct = default);
+    /// <param name="fileId">File ID to delete.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if deleted successfully.</returns>
+    Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets the storage path for a file
+    /// Gets the storage path for a file.
     /// </summary>
-    /// <param name="fileId">File ID</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="fileName">Original file name</param>
-    /// <returns>Full storage path</returns>
-    string GetStoragePath(string fileId, string gameId, string fileName);
+    /// <param name="fileId">File ID.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="fileName">Original file name.</param>
+    /// <returns>Full storage path.</returns>
+    string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName);
 
     /// <summary>
-    /// Checks if a file exists asynchronously
+    /// Checks if a file exists asynchronously.
     /// </summary>
-    /// <param name="fileId">File ID to check</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>True if file exists</returns>
-    Task<bool> ExistsAsync(string fileId, string gameId, CancellationToken cancellationToken = default);
+    /// <param name="fileId">File ID to check.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if file exists.</returns>
+    Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Generates a pre-signed URL for secure, temporary file downloads.
     /// Returns null for local storage (use API download endpoint instead).
     /// </summary>
-    /// <param name="fileId">File ID to generate URL for</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value)</param>
-    /// <returns>Pre-signed download URL, or null if not supported or file not found</returns>
-    Task<string?> GetPresignedDownloadUrlAsync(string fileId, string gameId, int? expirySeconds = null);
+    /// <param name="fileId">File ID to generate URL for.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value).</param>
+    /// <returns>Pre-signed download URL, or null if not supported or file not found.</returns>
+    Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null);
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -35,16 +35,16 @@ internal sealed class S3BlobStorageService : IBlobStorageService
     /// </summary>
     internal S3StorageOptions Options => _options;
 
-    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, string gameId, CancellationToken ct = default)
+    public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
         try
         {
-            // SECURITY: Validate gameId to prevent path traversal
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            // SECURITY: Validate resourceKey to prevent path traversal
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
             var fileId = Guid.NewGuid().ToString("N");
             var sanitizedFileName = SanitizeFileName(fileName);
-            var s3Key = GetS3Key(fileId, gameId, sanitizedFileName);
+            var s3Key = GetS3Key(fileId, category, resourceKey, sanitizedFileName);
 
             var request = new PutObjectRequest
             {
@@ -72,7 +72,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (AmazonS3Exception ex)
         {
-            _logger.LogError(ex, "S3 error storing file for game {GameId}: {ErrorCode}", gameId, ex.ErrorCode);
+            _logger.LogError(ex, "S3 error storing file in {Category}/{ResourceKey}: {ErrorCode}", category, resourceKey, ex.ErrorCode);
             return new BlobStorageResult(false, null, null, 0, $"S3 error: {ex.Message}");
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -83,23 +83,23 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             // S3 operations can throw various runtime exceptions (timeouts, network errors, authentication failures).
             // We must catch all exceptions to return error results instead of crashing the service.
             // Context: S3 operations can fail in unpredictable ways across different network conditions
-            _logger.LogError(ex, "Unexpected error storing file for game {GameId}", gameId);
+            _logger.LogError(ex, "Unexpected error storing file in {Category}/{ResourceKey}", category, resourceKey);
             return new BlobStorageResult(false, null, null, 0, ex.Message);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public async Task<Stream?> RetrieveAsync(string fileId, string gameId, CancellationToken ct = default)
+    public async Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            // S3 key pattern: pdf_uploads/{gameId}/{fileId}_{filename}
-            // We need to list objects with prefix to find the exact key (since filename may vary)
-            var prefix = $"pdf_uploads/{gameId}/{fileId}_";
+            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
+            // PR 2 will switch to category.ToS3Folder() behind STORAGE_WRITE_MODE flag.
+            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
 
             var listRequest = new ListObjectsV2Request
             {
@@ -112,7 +112,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 
             if (listResponse.S3Objects.Count == 0)
             {
-                _logger.LogWarning("File not found in S3 for {FileId} in game {GameId}", fileId, gameId);
+                _logger.LogWarning("File not found in S3 for {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return null;
             }
 
@@ -133,7 +133,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            _logger.LogWarning(ex, "File not found in S3 for {FileId} in game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "File not found in S3 for {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
             return null;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -144,22 +144,23 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             // S3 operations can throw various runtime exceptions (timeouts, network errors, authentication failures).
             // We must catch all exceptions to return null instead of crashing the service.
             // Context: S3 operations can fail in unpredictable ways across different network conditions
-            _logger.LogError(ex, "Error retrieving file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogError(ex, "Error retrieving file {FileId} for {Category}/{ResourceKey}", fileId, category, resourceKey);
             return null;
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public async Task<bool> DeleteAsync(string fileId, string gameId, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
             // Find the exact S3 key (since filename may vary)
-            var prefix = $"pdf_uploads/{gameId}/{fileId}_";
+            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
+            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
 
             var listRequest = new ListObjectsV2Request
             {
@@ -172,7 +173,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 
             if (listResponse.S3Objects.Count == 0)
             {
-                _logger.LogWarning("File not found for deletion: {FileId} in game {GameId}", fileId, gameId);
+                _logger.LogWarning("File not found for deletion: {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return false;
             }
 
@@ -193,7 +194,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (AmazonS3Exception ex)
         {
-            _logger.LogWarning(ex, "S3 error deleting file {FileId} for game {GameId}: {ErrorCode}", fileId, gameId, ex.ErrorCode);
+            _logger.LogWarning(ex, "S3 error deleting file {FileId} for {Category}/{ResourceKey}: {ErrorCode}", fileId, category, resourceKey, ex.ErrorCode);
             return false;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -204,30 +205,31 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             // S3 operations can throw various runtime exceptions (timeouts, network errors, authentication failures).
             // We must catch all exceptions to return false instead of crashing the service.
             // Context: S3 operations can fail in unpredictable ways across different network conditions
-            _logger.LogWarning(ex, "Unexpected error deleting file {FileId} for game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "Unexpected error deleting file {FileId} for {Category}/{ResourceKey}", fileId, category, resourceKey);
             return false;
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    public string GetStoragePath(string fileId, string gameId, string fileName)
+    public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
     {
-        // SECURITY: Validate gameId to prevent path traversal
-        PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+        // SECURITY: Validate resourceKey to prevent path traversal
+        PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
         var sanitizedFileName = SanitizeFileName(fileName);
-        return GetS3Key(fileId, gameId, sanitizedFileName);
+        return GetS3Key(fileId, category, resourceKey, sanitizedFileName);
     }
 
-    public async Task<bool> ExistsAsync(string fileId, string gameId, CancellationToken cancellationToken = default)
+    public async Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
     {
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var prefix = $"pdf_uploads/{gameId}/{fileId}_";
+            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
+            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
 
             var listRequest = new ListObjectsV2Request
             {
@@ -244,7 +246,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (ArgumentException)
         {
-            // Invalid gameId - path traversal attempt
+            // Invalid resourceKey - path traversal attempt
             return false;
         }
         catch (System.Security.SecurityException)
@@ -254,40 +256,51 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (AmazonS3Exception ex)
         {
-            _logger.LogWarning(ex, "S3 error checking file existence {FileId} in game {GameId}: {ErrorCode}", fileId, gameId, ex.ErrorCode);
+            _logger.LogWarning(ex, "S3 error checking file existence {FileId} in {Category}/{ResourceKey}: {ErrorCode}", fileId, category, resourceKey, ex.ErrorCode);
             return false;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Unexpected error checking file existence {FileId} in game {GameId}", fileId, gameId);
+            _logger.LogWarning(ex, "Unexpected error checking file existence {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
             return false;
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
-    private static string GetS3Key(string fileId, string gameId, string sanitizedFileName)
+    /// <summary>
+    /// Constructs the canonical S3 key for a blob.
+    /// PR 1 of issue #1314 preserves the legacy <c>pdf_uploads/</c> prefix regardless
+    /// of <paramref name="category"/> to keep S3 key output byte-identical pre/post
+    /// the signature refactor. PR 2 will wire <see cref="BlobCategoryExtensions.ToS3Folder"/>
+    /// here behind the <c>STORAGE_WRITE_MODE</c> feature flag.
+    /// </summary>
+    private static string GetS3Key(string fileId, BlobCategory category, string resourceKey, string sanitizedFileName)
     {
-        return $"pdf_uploads/{gameId}/{fileId}_{sanitizedFileName}";
+        // PR 1: behavior preservation — ignore `category`, render legacy prefix.
+        _ = category;
+        return $"pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}";
     }
 
     /// <summary>
-    /// Generates a pre-signed URL for secure, temporary file downloads
+    /// Generates a pre-signed URL for secure, temporary file downloads.
     /// </summary>
-    /// <param name="fileId">File ID to generate URL for</param>
-    /// <param name="gameId">Game ID for organization</param>
-    /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value)</param>
-    /// <returns>Pre-signed download URL or null if file not found</returns>
-    public async Task<string?> GetPresignedDownloadUrlAsync(string fileId, string gameId, int? expirySeconds = null)
+    /// <param name="fileId">File ID to generate URL for.</param>
+    /// <param name="category">Blob category for folder organization (PR 2 wiring).</param>
+    /// <param name="resourceKey">Opaque resource identifier used as folder key.</param>
+    /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value).</param>
+    /// <returns>Pre-signed download URL or null if file not found.</returns>
+    public async Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
     {
         try
         {
             // SECURITY: Validate parameters to prevent path traversal
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
-            PathSecurity.ValidateIdentifier(gameId, nameof(gameId));
+            PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
             // Find the exact S3 key
-            var prefix = $"pdf_uploads/{gameId}/{fileId}_";
+            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
+            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
 
             var listRequest = new ListObjectsV2Request
             {
@@ -300,7 +313,7 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 
             if (listResponse.S3Objects.Count == 0)
             {
-                _logger.LogWarning("Cannot generate pre-signed URL: file not found {FileId} in game {GameId}", fileId, gameId);
+                _logger.LogWarning("Cannot generate pre-signed URL: file not found {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return null;
             }
 
@@ -325,13 +338,13 @@ internal sealed class S3BlobStorageService : IBlobStorageService
         }
         catch (AmazonS3Exception ex)
         {
-            _logger.LogError(ex, "S3 error generating pre-signed URL for {FileId} in game {GameId}: {ErrorCode}", fileId, gameId, ex.ErrorCode);
+            _logger.LogError(ex, "S3 error generating pre-signed URL for {FileId} in {Category}/{ResourceKey}: {ErrorCode}", fileId, category, resourceKey, ex.ErrorCode);
             return null;
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error generating pre-signed URL for {FileId} in game {GameId}", fileId, gameId);
+            _logger.LogError(ex, "Unexpected error generating pre-signed URL for {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
             return null;
         }
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetPhotoBatchStatusQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetPhotoBatchStatusQueryHandlerTests.cs
@@ -36,7 +36,7 @@ public class GetPhotoBatchStatusQueryHandlerTests
              .Returns(batch);
 
         // GetPresignedDownloadUrlAsync has no CancellationToken param per interface contract
-        _blob.GetPresignedDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>())
+        _blob.GetPresignedDownloadUrlAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<int?>())
              .Returns(Task.FromResult<string?>("https://blob/thumb.jpg"));
 
         var sut = CreateSut();
@@ -134,6 +134,6 @@ public class GetPhotoBatchStatusQueryHandlerTests
 
         // Assert — no blob calls when batch has no pages
         await _blob.DidNotReceive().GetPresignedDownloadUrlAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int?>());
+            Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<int?>());
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPhotoBatchCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPhotoBatchCommandHandlerTests.cs
@@ -73,7 +73,7 @@ public class UploadPhotoBatchCommandHandlerTests
         await _blob.Received(1).StoreAsync(
             Arg.Any<Stream>(),
             Arg.Any<string>(),
-            BlobCategory.Pdf,
+            BlobCategory.PhotoBatch,
             cmd.GameId.ToString(),
             Arg.Any<CancellationToken>());
         await _mediator.Received(1).Send(
@@ -106,7 +106,7 @@ public class UploadPhotoBatchCommandHandlerTests
         await _blob.Received(3).StoreAsync(
             Arg.Any<Stream>(),
             Arg.Any<string>(),
-            BlobCategory.Pdf,
+            BlobCategory.PhotoBatch,
             cmd.GameId.ToString(),
             Arg.Any<CancellationToken>());
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPhotoBatchCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPhotoBatchCommandHandlerTests.cs
@@ -30,7 +30,7 @@ public class UploadPhotoBatchCommandHandlerTests
     {
         // Stub StoreAsync to return a success result (signature: string gameId, not Guid)
         _blob
-            .StoreAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .StoreAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new BlobStorageResult(
                 Success: true,
                 FileId: Guid.NewGuid().ToString(),
@@ -73,6 +73,7 @@ public class UploadPhotoBatchCommandHandlerTests
         await _blob.Received(1).StoreAsync(
             Arg.Any<Stream>(),
             Arg.Any<string>(),
+            BlobCategory.Pdf,
             cmd.GameId.ToString(),
             Arg.Any<CancellationToken>());
         await _mediator.Received(1).Send(
@@ -105,6 +106,7 @@ public class UploadPhotoBatchCommandHandlerTests
         await _blob.Received(3).StoreAsync(
             Arg.Any<Stream>(),
             Arg.Any<string>(),
+            BlobCategory.Pdf,
             cmd.GameId.ToString(),
             Arg.Any<CancellationToken>());
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPrivatePdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/UploadPrivatePdfCommandHandlerTests.cs
@@ -377,7 +377,7 @@ public class UploadPrivatePdfCommandHandlerTests
             .ReturnsAsync(libraryEntry);
 
         _mockBlobStorageService
-            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(false, null, null, 0, "Storage unavailable"));
 
         // Act
@@ -411,7 +411,7 @@ public class UploadPrivatePdfCommandHandlerTests
             .ReturnsAsync(libraryEntry);
 
         _mockBlobStorageService
-            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(true, pdfId.ToString(), $"/storage/{gameId}/{pdfId}/rulebook.pdf", 1024));
 
         // Act
@@ -462,7 +462,7 @@ public class UploadPrivatePdfCommandHandlerTests
             .ReturnsAsync(libraryEntry);
 
         _mockBlobStorageService
-            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(true, pdfId.ToString(), $"/storage/{gameId}/{pdfId}/passwd.pdf", 1024));
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/PhotoBatchProcessorTests.cs
@@ -81,7 +81,7 @@ public class PhotoBatchProcessorTests
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
 
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 10, 20, 30 }));
 
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
@@ -114,7 +114,7 @@ public class PhotoBatchProcessorTests
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
 
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3 }));
 
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
@@ -144,7 +144,7 @@ public class PhotoBatchProcessorTests
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
 
         // Sequential calls: first returns valid stream, second returns null
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(
                 _ => (Stream?)new MemoryStream(new byte[] { 1 }),
                 _ => (Stream?)null);
@@ -191,7 +191,7 @@ public class PhotoBatchProcessorTests
         var batchId = batch.Id;
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 99 }));
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult(confidence: 0.95));
@@ -218,7 +218,7 @@ public class PhotoBatchProcessorTests
         var batchId = batch.Id;
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 1 }));
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult());
@@ -251,7 +251,7 @@ public class PhotoBatchProcessorTests
         var batchId = batch.Id;
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3 }));
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult(text: "Move your piece forward three spaces.", confidence: 0.9, isBlank: false));
@@ -289,7 +289,7 @@ public class PhotoBatchProcessorTests
         var batchId = batch.Id;
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 1 }));
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult(text: "", confidence: 0.3, isBlank: true));
@@ -318,7 +318,7 @@ public class PhotoBatchProcessorTests
         var batchId = batch.Id;
 
         _repo.FindByIdWithPagesAsync(batchId, Arg.Any<CancellationToken>()).Returns(batch);
-        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _blob.RetrieveAsync(Arg.Any<string>(), Arg.Any<BlobCategory>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => (Stream)new MemoryStream(new byte[] { 1, 2, 3 }));
         _preprocessor.PreprocessAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
             .Returns(MakePreprocessResult(text: "Some board game text.", confidence: 0.85));

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/TestHelpers/PdfTestFixtureBuilder.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/TestHelpers/PdfTestFixtureBuilder.cs
@@ -208,13 +208,14 @@ internal class PdfTestFixtureBuilder
             .Setup(b => b.StoreAsync(
                 It.IsAny<Stream>(),
                 It.IsAny<string>(),
+                It.IsAny<BlobCategory>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Stream stream, string fileName, string gameId, CancellationToken ct) =>
+            .ReturnsAsync((Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
                 new BlobStorageResult(
                     Success: true,
                     FileId: fileId,
-                    FilePath: $"/uploads/{gameId}/{fileName}",
+                    FilePath: $"/uploads/{resourceKey}/{fileName}",
                     FileSizeBytes: stream.Length,
                     ErrorMessage: null));
 
@@ -233,6 +234,7 @@ internal class PdfTestFixtureBuilder
             .Setup(b => b.StoreAsync(
                 It.IsAny<Stream>(),
                 It.IsAny<string>(),
+                It.IsAny<BlobCategory>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/UploadGameImageCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/UploadGameImageCommandHandlerTests.cs
@@ -44,7 +44,7 @@ public class UploadGameImageCommandHandlerTests
             ImageType: ImageType.Image);
 
         _storageServiceMock
-            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), "test.png", gameId, It.IsAny<CancellationToken>()))
+            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), "test.png", BlobCategory.GameImage, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: fileId,
@@ -164,7 +164,7 @@ public class UploadGameImageCommandHandlerTests
             ImageType: ImageType.Image);
 
         _storageServiceMock
-            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), "test.png", gameId, It.IsAny<CancellationToken>()))
+            .Setup(s => s.StoreAsync(It.IsAny<Stream>(), "test.png", BlobCategory.GameImage, gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: false,
                 FileId: null,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/SessionAttachmentServiceTests.cs
@@ -65,7 +65,7 @@ public sealed class SessionAttachmentServiceTests
         using var stream = CreateMinimalJpegStream();
 
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(false, null, null, 0, "S3 error"));
 
         var result = await _sut.UploadAsync(
@@ -85,7 +85,7 @@ public sealed class SessionAttachmentServiceTests
         var storagePath = $"session-photos-abc/{fileId}_photo.jpg";
 
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(true, fileId, storagePath, 5000));
 
         var result = await _sut.UploadAsync(
@@ -106,8 +106,8 @@ public sealed class SessionAttachmentServiceTests
         string? capturedFolder = null;
 
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<Stream, string, string, CancellationToken>((_, _, folder, _) => capturedFolder = folder)
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((_, _, _, folder, _) => capturedFolder = folder)
             .ReturnsAsync(new BlobStorageResult(true, "fid", "path", 100));
 
         await _sut.UploadAsync(
@@ -126,8 +126,8 @@ public sealed class SessionAttachmentServiceTests
         string? capturedFileName = null;
 
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<Stream, string, string, CancellationToken>((_, fileName, _, _) => capturedFileName = fileName)
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((_, fileName, _, _, _) => capturedFileName = fileName)
             .ReturnsAsync(new BlobStorageResult(true, "fid", "path", 100));
 
         await _sut.UploadAsync(
@@ -148,9 +148,8 @@ public sealed class SessionAttachmentServiceTests
         var callCount = 0;
 
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<Stream, string, string, CancellationToken>((_, fileName, _, _) =>
-            {
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((_, fileName, _, _, _) => {
                 callCount++;
                 if (callCount == 1) capturedFileName = fileName; // Capture only the original upload
             })
@@ -172,7 +171,7 @@ public sealed class SessionAttachmentServiceTests
 
         var callCount = 0;
         _blobStorageMock
-            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
                 callCount++;
@@ -200,7 +199,7 @@ public sealed class SessionAttachmentServiceTests
     {
         var blobUrl = "folder/fileId_photo.jpg";
         _blobStorageMock
-            .Setup(x => x.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .Setup(x => x.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ReturnsAsync("https://s3.example.com/signed-url");
 
         var result = await _sut.GetDownloadUrlAsync(blobUrl);
@@ -213,7 +212,7 @@ public sealed class SessionAttachmentServiceTests
     {
         var blobUrl = "folder/fileId_photo.jpg";
         _blobStorageMock
-            .Setup(x => x.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .Setup(x => x.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ReturnsAsync((string?)null);
 
         var result = await _sut.GetDownloadUrlAsync(blobUrl);
@@ -238,8 +237,8 @@ public sealed class SessionAttachmentServiceTests
     {
         var deletedIds = new List<string>();
         _blobStorageMock
-            .Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<string, string, CancellationToken>((fileId, _, _) => deletedIds.Add(fileId))
+            .Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, BlobCategory, string, CancellationToken>((fileId, _, _, _) => deletedIds.Add(fileId))
             .ReturnsAsync(true);
 
         await _sut.DeleteBlobsAsync("folder/abc_photo.jpg", "folder/def_thumb.jpg");
@@ -254,8 +253,8 @@ public sealed class SessionAttachmentServiceTests
     {
         var deleteCount = 0;
         _blobStorageMock
-            .Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<string, string, CancellationToken>((_, _, _) => deleteCount++)
+            .Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, BlobCategory, string, CancellationToken>((_, _, _, _) => deleteCount++)
             .ReturnsAsync(true);
 
         await _sut.DeleteBlobsAsync("folder/abc_photo.jpg", null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
@@ -315,7 +315,7 @@ public sealed class GraphRagExtractionTests : IDisposable
     private void SetupBlobStorageToReturn()
     {
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // %PDF header
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs
@@ -325,7 +325,7 @@ public sealed class RaptorPipelineIntegrationTests : IDisposable
     private void SetupBlobStorageToReturn()
     {
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // %PDF header
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
@@ -25,36 +25,49 @@ public sealed class GamebookPhotoStorageServiceTests
         /// <summary>The last stream bytes passed to StoreAsync (for assertion).</summary>
         public byte[]? LastStoredBytes { get; private set; }
 
-        public Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, string gameId, CancellationToken ct = default)
+        public Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
         {
+            _ = category;
             var ms = new MemoryStream();
             stream.CopyTo(ms);
             LastStoredBytes = ms.ToArray();
             var fileId = Guid.NewGuid().ToString("N");
             _store[fileId] = LastStoredBytes;
-            return Task.FromResult(new BlobStorageResult(true, fileId, $"{gameId}/{fileName}", LastStoredBytes.Length));
+            return Task.FromResult(new BlobStorageResult(true, fileId, $"{resourceKey}/{fileName}", LastStoredBytes.Length));
         }
 
-        public Task<Stream?> RetrieveAsync(string fileId, string gameId, CancellationToken ct = default)
+        public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
         {
+            _ = (category, resourceKey);
             if (_store.TryGetValue(fileId, out var bytes))
                 return Task.FromResult<Stream?>(new MemoryStream(bytes));
             return Task.FromResult<Stream?>(null);
         }
 
-        public Task<bool> DeleteAsync(string fileId, string gameId, CancellationToken ct = default)
+        public Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
         {
+            _ = (category, resourceKey);
             _store.Remove(fileId);
             return Task.FromResult(true);
         }
 
-        public string GetStoragePath(string fileId, string gameId, string fileName) => $"{gameId}/{fileId}/{fileName}";
+        public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
+        {
+            _ = category;
+            return $"{resourceKey}/{fileId}/{fileName}";
+        }
 
-        public Task<bool> ExistsAsync(string fileId, string gameId, CancellationToken cancellationToken = default)
-            => Task.FromResult(_store.ContainsKey(fileId));
+        public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
+        {
+            _ = (category, resourceKey);
+            return Task.FromResult(_store.ContainsKey(fileId));
+        }
 
-        public Task<string?> GetPresignedDownloadUrlAsync(string fileId, string gameId, int? expirySeconds = null)
-            => Task.FromResult<string?>(null);
+        public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
+        {
+            _ = (fileId, category, resourceKey, expirySeconds);
+            return Task.FromResult<string?>(null);
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryHandlerTests.cs
@@ -207,7 +207,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
             UserId: Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync((Stream?)null);
 
         // Act
@@ -229,7 +229,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
             UserId: Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new IOException("S3 connection timeout"));
 
         // Act
@@ -581,7 +581,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
         var tokenPassed = false;
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .Callback<string, string, CancellationToken>((_, _, ct) =>
             {
                 tokenPassed = ct == cts.Token;
@@ -629,7 +629,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
             UserId: Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Simulated crash"));
 
         // Act
@@ -657,7 +657,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
     private void SetupPdfRetrieval()
     {
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
                 var pdfContent = "%PDF-1.4\ntest content\n%%EOF";

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryHandlerTests.cs
@@ -582,7 +582,7 @@ public class ExtractGameMetadataFromPdfQueryHandlerTests
 
         _blobStorageServiceMock
             .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
-            .Callback<string, string, CancellationToken>((_, _, ct) =>
+            .Callback<string, BlobCategory, string, CancellationToken>((_, _, _, ct) =>
             {
                 tokenPassed = ct == cts.Token;
             })

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryIntegrationTests.cs
@@ -70,7 +70,7 @@ public class ExtractGameMetadataFromPdfQueryIntegrationTests
         result.ConfidenceScore.Should().BeGreaterThanOrEqualTo(0.8);
 
         _blobStorageServiceMock.Verify(
-            b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()),
+            b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()),
             Times.Once);
         _pdfTextExtractorMock.Verify(
             p => p.ExtractTextAsync(It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()),
@@ -170,7 +170,7 @@ public class ExtractGameMetadataFromPdfQueryIntegrationTests
             UserId: Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("S3 service unavailable"));
 
         // Act
@@ -274,7 +274,7 @@ public class ExtractGameMetadataFromPdfQueryIntegrationTests
         var tokenReceived = false;
 
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .Callback<string, string, CancellationToken>((_, _, ct) =>
             {
                 tokenReceived = ct == cts.Token;
@@ -299,7 +299,7 @@ public class ExtractGameMetadataFromPdfQueryIntegrationTests
     private void SetupPdfRetrieval(Stream pdfStream)
     {
         _blobStorageServiceMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => pdfStream);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ExtractGameMetadataFromPdfQueryIntegrationTests.cs
@@ -275,7 +275,7 @@ public class ExtractGameMetadataFromPdfQueryIntegrationTests
 
         _blobStorageServiceMock
             .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
-            .Callback<string, string, CancellationToken>((_, _, ct) =>
+            .Callback<string, BlobCategory, string, CancellationToken>((_, _, _, ct) =>
             {
                 tokenReceived = ct == cts.Token;
             })

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UploadPdfForGameExtractionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UploadPdfForGameExtractionCommandHandlerTests.cs
@@ -388,7 +388,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         string? capturedFilename = null;
         _blobStorageServiceMock
             .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
-            .Callback<Stream, string, string, CancellationToken>((stream, filename, gameId, ct) =>
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((stream, filename, category, resourceKey, ct) =>
             {
                 capturedFilename = filename;
             })
@@ -457,7 +457,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         string? capturedFilename = null;
         _blobStorageServiceMock
             .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
-            .Callback<Stream, string, string, CancellationToken>((stream, filename, gameId, ct) =>
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((stream, filename, category, resourceKey, ct) =>
             {
                 capturedFilename = filename;
             })

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UploadPdfForGameExtractionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/UploadPdfForGameExtractionCommandHandlerTests.cs
@@ -105,7 +105,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         var expectedFilePath = "wizard-temp/test-file-id/test-document.pdf";
 
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: expectedFileId,
@@ -124,7 +124,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().BeNull();
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), "test-document.pdf", "wizard-temp", It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), "test-document.pdf", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -137,7 +137,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         var command = new UploadPdfForGameExtractionCommand(mockPdfFile, userId);
 
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: "large-file-id",
@@ -172,7 +172,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Be("No file provided. Please select a PDF file to upload.");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -191,7 +191,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Be("No file provided. Please select a PDF file to upload.");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -213,7 +213,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Contain("Maximum size is 50MB");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -236,7 +236,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Contain(contentType);
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -257,7 +257,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Contain("Missing PDF header signature");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -282,7 +282,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Contain("Missing EOF marker");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -301,7 +301,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         result.ErrorMessage.Should().Contain("File is too small to be a valid PDF");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -317,7 +317,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         var command = new UploadPdfForGameExtractionCommand(mockPdfFile, Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: false,
                 FileId: null,
@@ -352,7 +352,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         var command = new UploadPdfForGameExtractionCommand(mockPdfFile, Guid.NewGuid());
 
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new IOException("Disk full"));
 
         // Act
@@ -387,7 +387,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
 
         string? capturedFilename = null;
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .Callback<Stream, string, string, CancellationToken>((stream, filename, gameId, ct) =>
             {
                 capturedFilename = filename;
@@ -419,7 +419,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         capturedFilename.Should().Contain("manual");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -456,7 +456,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
 
         string? capturedFilename = null;
         _blobStorageServiceMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .Callback<Stream, string, string, CancellationToken>((stream, filename, gameId, ct) =>
             {
                 capturedFilename = filename;
@@ -486,7 +486,7 @@ public class UploadPdfForGameExtractionCommandHandlerTests
         capturedFilename.Should().EndWith(".pdf");
 
         _blobStorageServiceMock.Verify(
-            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()),
+            b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/UploadPdfForGameExtractionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/UploadPdfForGameExtractionIntegrationTests.cs
@@ -112,10 +112,10 @@ public sealed class UploadPdfForGameExtractionIntegrationTests : IAsyncLifetime
         var filename = Path.GetFileName(result.FilePath!);
         var fileId = filename.Split('_')[0]; // Extract GUID part before underscore
 
-        (await _blobStorageService!.ExistsAsync(fileId, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
 
         // Verify file can be retrieved
-        using var retrievedStream = await _blobStorageService.RetrieveAsync(fileId, "wizard-temp");
+        using var retrievedStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, "wizard-temp");
         retrievedStream.Should().NotBeNull();
         retrievedStream!.Length.Should().BeGreaterThan(0);
     }
@@ -139,10 +139,10 @@ public sealed class UploadPdfForGameExtractionIntegrationTests : IAsyncLifetime
         var filename = Path.GetFileName(result.FilePath!);
         var fileId = filename.Split('_')[0];
 
-        (await _blobStorageService!.ExistsAsync(fileId, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
 
         // Cleanup
-        await _blobStorageService.DeleteAsync(fileId, "wizard-temp");
+        await _blobStorageService.DeleteAsync(fileId, BlobCategory.Pdf, "wizard-temp");
     }
 
     [Fact]
@@ -179,9 +179,9 @@ public sealed class UploadPdfForGameExtractionIntegrationTests : IAsyncLifetime
         var fileId3 = filename3.Split('_')[0];
 
         // Verify all files exist independently
-        (await _blobStorageService!.ExistsAsync(fileId1, "wizard-temp")).Should().BeTrue();
-        (await _blobStorageService.ExistsAsync(fileId2, "wizard-temp")).Should().BeTrue();
-        (await _blobStorageService.ExistsAsync(fileId3, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId1, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId2, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId3, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
 
         // Verify unique file IDs
         result1.FileId!.Value.Should().NotBe(result2.FileId!.Value);
@@ -189,9 +189,9 @@ public sealed class UploadPdfForGameExtractionIntegrationTests : IAsyncLifetime
         result1.FileId!.Value.Should().NotBe(result3.FileId!.Value);
 
         // Cleanup
-        await _blobStorageService.DeleteAsync(fileId1, "wizard-temp");
-        await _blobStorageService.DeleteAsync(fileId2, "wizard-temp");
-        await _blobStorageService.DeleteAsync(fileId3, "wizard-temp");
+        await _blobStorageService.DeleteAsync(fileId1, BlobCategory.Pdf, "wizard-temp");
+        await _blobStorageService.DeleteAsync(fileId2, BlobCategory.Pdf, "wizard-temp");
+        await _blobStorageService.DeleteAsync(fileId3, BlobCategory.Pdf, "wizard-temp");
     }
 
     [Fact]
@@ -224,10 +224,10 @@ public sealed class UploadPdfForGameExtractionIntegrationTests : IAsyncLifetime
         var filename = Path.GetFileName(result.FilePath!);
         var fileId = filename.Split('_')[0];
 
-        (await _blobStorageService!.ExistsAsync(fileId, "wizard-temp")).Should().BeTrue();
+        (await _blobStorageService!.ExistsAsync(fileId, BlobCategory.Pdf, "wizard-temp")).Should().BeTrue();
 
         // Cleanup
-        await _blobStorageService.DeleteAsync(fileId, "wizard-temp");
+        await _blobStorageService.DeleteAsync(fileId, BlobCategory.Pdf, "wizard-temp");
     }
 
     #region Helper Methods

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardConcurrencyAndPerformanceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardConcurrencyAndPerformanceTests.cs
@@ -57,7 +57,7 @@ public class WizardConcurrencyAndPerformanceTests
                 var fileId = $"file-{sessionIndex}";
 
                 blobMock
-                    .Setup(b => b.StoreAsync(It.IsAny<Stream>(), fileName, "wizard-temp", It.IsAny<CancellationToken>()))
+                    .Setup(b => b.StoreAsync(It.IsAny<Stream>(), fileName, BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new BlobStorageResult(
                         Success: true,
                         FileId: fileId,
@@ -111,7 +111,7 @@ public class WizardConcurrencyAndPerformanceTests
 
                 // fileId format: handler extracts fileId by splitting filename on '_'
                 blobMock
-                    .Setup(b => b.RetrieveAsync(fileId, "wizard-temp", It.IsAny<CancellationToken>()))
+                    .Setup(b => b.RetrieveAsync(fileId, BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new MemoryStream(new byte[100]));
 
                 pdfExtractorMock
@@ -188,7 +188,7 @@ public class WizardConcurrencyAndPerformanceTests
         const long fileSizeBytes = 40_000_000;
 
         blobMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: "file-large",
@@ -222,7 +222,7 @@ public class WizardConcurrencyAndPerformanceTests
 
         // fileId format: handler extracts fileId by splitting filename on '_'
         blobMock
-            .Setup(b => b.RetrieveAsync("file-perf", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync("file-perf", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[500]));
 
         pdfExtractorMock
@@ -306,7 +306,7 @@ public class WizardConcurrencyAndPerformanceTests
                     var fileName = $"upload-{index}.pdf";
 
                     blobMock
-                        .Setup(b => b.StoreAsync(It.IsAny<Stream>(), fileName, "wizard-temp", It.IsAny<CancellationToken>()))
+                        .Setup(b => b.StoreAsync(It.IsAny<Stream>(), fileName, BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(new BlobStorageResult(
                             Success: true, FileId: $"file-{index}",
                             FilePath: $"file-{index}_{index}.pdf",
@@ -335,7 +335,7 @@ public class WizardConcurrencyAndPerformanceTests
                     var llmServiceMock = new Mock<ILlmService>();
 
                     blobMock
-                        .Setup(b => b.RetrieveAsync($"file-{index}", "wizard-temp", It.IsAny<CancellationToken>()))
+                        .Setup(b => b.RetrieveAsync($"file-{index}", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(new MemoryStream(new byte[100]));
 
                     pdfExtractorMock
@@ -376,7 +376,7 @@ public class WizardConcurrencyAndPerformanceTests
         var blobMock = new Mock<IBlobStorageService>();
 
         blobMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .Returns<Stream, string, string, CancellationToken>(async (_, _, _, ct) =>
             {
                 await Task.Delay(5000, ct); // Simulate slow storage

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardE2EWorkflowTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardE2EWorkflowTests.cs
@@ -63,7 +63,7 @@ public class WizardE2EWorkflowTests
         var uploadedFilePath = "file-abc_20260216.pdf";
 
         _blobStorageMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "catan-rules.pdf", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "catan-rules.pdf", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: "file-abc",
@@ -85,7 +85,7 @@ public class WizardE2EWorkflowTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync("file-abc", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync("file-abc", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(System.Text.Encoding.UTF8.GetBytes("PDF content for Catan rules")));
 
         _pdfExtractorMock
@@ -178,7 +178,7 @@ public class WizardE2EWorkflowTests
         var mockPdfFile = CreateValidMockPdfFile("obscure-game.pdf", 1_048_576);
 
         _blobStorageMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "obscure-game.pdf", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "obscure-game.pdf", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true, FileId: "file-xyz",
                 FilePath: "file-xyz_20260216.pdf",
@@ -197,7 +197,7 @@ public class WizardE2EWorkflowTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync("file-xyz", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync("file-xyz", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock
@@ -258,7 +258,7 @@ public class WizardE2EWorkflowTests
         var mockPdfFile = CreateValidMockPdfFile("scanned-image.pdf", 5_000_000);
 
         _blobStorageMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "scanned-image.pdf", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), "scanned-image.pdf", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true, FileId: "file-img",
                 FilePath: "file-img_20260216.pdf",
@@ -277,7 +277,7 @@ public class WizardE2EWorkflowTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync("file-img", "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync("file-img", BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock
@@ -303,7 +303,7 @@ public class WizardE2EWorkflowTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardFailureScenarioTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/WizardFailureScenarioTests.cs
@@ -61,7 +61,7 @@ public class WizardFailureScenarioTests
         var mockFile = CreateValidMockPdfFile("game-rules.pdf", 1_000_000);
 
         _blobStorageMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: false,
                 FileId: null,
@@ -88,7 +88,7 @@ public class WizardFailureScenarioTests
         var mockFile = CreateValidMockPdfFile("game-rules.pdf", 1_000_000);
 
         _blobStorageMock
-            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new IOException("Network connection lost"));
 
         var result = await handler.Handle(
@@ -197,7 +197,7 @@ public class WizardFailureScenarioTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync((Stream?)null);
 
         var result = await handler.Handle(
@@ -217,7 +217,7 @@ public class WizardFailureScenarioTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock
@@ -241,7 +241,7 @@ public class WizardFailureScenarioTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock
@@ -275,7 +275,7 @@ public class WizardFailureScenarioTests
             NullLogger<ExtractGameMetadataFromPdfQueryHandler>.Instance);
 
         _blobStorageMock
-            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), "wizard-temp", It.IsAny<CancellationToken>()))
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, "wizard-temp", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(new byte[100]));
 
         _pdfExtractorMock

--- a/apps/api/tests/Api.Tests/DevTools/BlobCategorySignatureSmokeTest.cs
+++ b/apps/api/tests/Api.Tests/DevTools/BlobCategorySignatureSmokeTest.cs
@@ -5,7 +5,7 @@ using Api.Services.Pdf;
 using FluentAssertions;
 using Xunit;
 
-namespace Api.Tests.Unit.Services;
+namespace Api.Tests.DevTools;
 
 /// <summary>
 /// Smoke test for issue #1314 PR 1 (signature refactor).

--- a/apps/api/tests/Api.Tests/DevTools/MockBlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/DevTools/MockBlobStorageServiceTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Api.DevTools.MockImpls;
+using Api.Services.Pdf;
 using Xunit;
 
 namespace Api.Tests.DevTools;
@@ -14,13 +15,13 @@ public class MockBlobStorageServiceTests
         var svc = new MockBlobStorageService();
         var content = System.Text.Encoding.UTF8.GetBytes("hello");
         using var input = new MemoryStream(content);
-        var stored = await svc.StoreAsync(input, "test.txt", "game-1", CancellationToken.None);
+        var stored = await svc.StoreAsync(input, "test.txt", BlobCategory.Pdf, "game-1", CancellationToken.None);
 
         Assert.True(stored.Success);
         Assert.NotNull(stored.FileId);
         Assert.StartsWith("MOCK-", stored.FileId);
 
-        using var retrieved = await svc.RetrieveAsync(stored.FileId!, "game-1", CancellationToken.None);
+        using var retrieved = await svc.RetrieveAsync(stored.FileId!, BlobCategory.Pdf, "game-1", CancellationToken.None);
         Assert.NotNull(retrieved);
         using var ms = new MemoryStream();
         await retrieved!.CopyToAsync(ms, CancellationToken.None);
@@ -34,7 +35,7 @@ public class MockBlobStorageServiceTests
         // return a minimal PDF placeholder so stale Quartz jobs persisted in
         // Postgres from a previous dev session do not crash the pipeline.
         var svc = new MockBlobStorageService();
-        using var result = await svc.RetrieveAsync("MOCK-none", "game-1", CancellationToken.None);
+        using var result = await svc.RetrieveAsync("MOCK-none", BlobCategory.Pdf, "game-1", CancellationToken.None);
         Assert.NotNull(result);
         using var ms = new MemoryStream();
         await result!.CopyToAsync(ms, CancellationToken.None);
@@ -52,14 +53,14 @@ public class MockBlobStorageServiceTests
     {
         var svc = new MockBlobStorageService();
         using var input = new MemoryStream(new byte[] { 1, 2, 3 });
-        var stored = await svc.StoreAsync(input, "x.bin", "g", CancellationToken.None);
+        var stored = await svc.StoreAsync(input, "x.bin", BlobCategory.Pdf, "g", CancellationToken.None);
 
         // Delete succeeds for stored blobs
-        Assert.True(await svc.DeleteAsync(stored.FileId!, "g", CancellationToken.None));
+        Assert.True(await svc.DeleteAsync(stored.FileId!, BlobCategory.Pdf, "g", CancellationToken.None));
 
         // After delete, Retrieve returns placeholder (not the stored content) —
         // the underlying map no longer has the key, so the fallback kicks in.
-        using var retrieved = await svc.RetrieveAsync(stored.FileId!, "g", CancellationToken.None);
+        using var retrieved = await svc.RetrieveAsync(stored.FileId!, BlobCategory.Pdf, "g", CancellationToken.None);
         Assert.NotNull(retrieved);
         using var ms = new MemoryStream();
         await retrieved!.CopyToAsync(ms, CancellationToken.None);
@@ -72,7 +73,7 @@ public class MockBlobStorageServiceTests
     {
         // Mock semantics: "everything is present" so delete-unknown is a no-op success.
         var svc = new MockBlobStorageService();
-        var result = await svc.DeleteAsync("MOCK-nonexistent", "g", CancellationToken.None);
+        var result = await svc.DeleteAsync("MOCK-nonexistent", BlobCategory.Pdf, "g", CancellationToken.None);
         Assert.True(result);
     }
 
@@ -81,8 +82,8 @@ public class MockBlobStorageServiceTests
     {
         var svc = new MockBlobStorageService();
         using var input = new MemoryStream(new byte[] { 42 });
-        var stored = await svc.StoreAsync(input, "a.bin", "g", CancellationToken.None);
-        Assert.True(await svc.ExistsAsync(stored.FileId!, "g", CancellationToken.None));
+        var stored = await svc.StoreAsync(input, "a.bin", BlobCategory.Pdf, "g", CancellationToken.None);
+        Assert.True(await svc.ExistsAsync(stored.FileId!, BlobCategory.Pdf, "g", CancellationToken.None));
     }
 
     [Fact]
@@ -90,7 +91,7 @@ public class MockBlobStorageServiceTests
     {
         // Mock semantics: "everything exists" so stale jobs don't see missing blobs.
         var svc = new MockBlobStorageService();
-        Assert.True(await svc.ExistsAsync("MOCK-unknown", "g", CancellationToken.None));
+        Assert.True(await svc.ExistsAsync("MOCK-unknown", BlobCategory.Pdf, "g", CancellationToken.None));
     }
 
     [Fact]
@@ -98,8 +99,8 @@ public class MockBlobStorageServiceTests
     {
         var svc = new MockBlobStorageService();
         using var input = new MemoryStream(new byte[] { 1 });
-        var stored = await svc.StoreAsync(input, "x.bin", "g", CancellationToken.None);
-        var url = await svc.GetPresignedDownloadUrlAsync(stored.FileId!, "g", 7200);
+        var stored = await svc.StoreAsync(input, "x.bin", BlobCategory.Pdf, "g", CancellationToken.None);
+        var url = await svc.GetPresignedDownloadUrlAsync(stored.FileId!, BlobCategory.Pdf, "g", 7200);
         Assert.NotNull(url);
         Assert.Contains("mock-s3", url!);
         Assert.Contains("7200", url!);
@@ -110,7 +111,7 @@ public class MockBlobStorageServiceTests
     {
         // Mock semantics: "everything exists" — URL is synthetic regardless.
         var svc = new MockBlobStorageService();
-        var url = await svc.GetPresignedDownloadUrlAsync("MOCK-none", "g");
+        var url = await svc.GetPresignedDownloadUrlAsync("MOCK-none", BlobCategory.Pdf, "g");
         Assert.NotNull(url);
         Assert.Contains("mock-s3", url!);
     }
@@ -119,7 +120,7 @@ public class MockBlobStorageServiceTests
     public void GetStoragePath_ReturnsMockPath()
     {
         var svc = new MockBlobStorageService();
-        var path = svc.GetStoragePath("file-id", "game-1", "doc.pdf");
+        var path = svc.GetStoragePath("file-id", BlobCategory.Pdf, "game-1", "doc.pdf");
         Assert.StartsWith("mock://", path);
         Assert.Contains("game-1", path);
         Assert.Contains("file-id", path);
@@ -131,7 +132,7 @@ public class MockBlobStorageServiceTests
         var svc = new MockBlobStorageService();
         var content = new byte[256];
         using var input = new MemoryStream(content);
-        var stored = await svc.StoreAsync(input, "big.bin", "g", CancellationToken.None);
+        var stored = await svc.StoreAsync(input, "big.bin", BlobCategory.Pdf, "g", CancellationToken.None);
         Assert.Equal(256L, stored.FileSizeBytes);
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -297,4 +297,44 @@ public sealed class PdfSeederBlobTests
         _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.Should().BeEmpty();
     }
+
+    // ---------------------------------------------------------------
+    // ExtractFileIdFromPath edge cases (review finding #3 follow-up)
+    // ---------------------------------------------------------------
+
+    [Theory]
+    // Happy paths — S3 forward-slash + Windows backslash layouts
+    [InlineData("pdf_uploads/gameId/abc123_rulebook.pdf", "abc123")]
+    [InlineData("pdf_uploads\\gameId\\abc123_rulebook.pdf", "abc123")]
+    [InlineData("C:\\storage\\pdf_uploads\\gameId\\fedcba_doc.pdf", "fedcba")]
+    // GUID-N fileId (32 hex chars, no underscores, no hyphens) — production shape
+    [InlineData("pdf_uploads/game/abcdef01234567890123456789abcdef_file.pdf", "abcdef01234567890123456789abcdef")]
+    // Filename contains underscore — only FIRST underscore in last segment splits fileId/filename
+    [InlineData("pdf_uploads/gameId/abc123_my_file_v2.pdf", "abc123")]
+    public void ExtractFileIdFromPath_ValidPaths_ReturnsFileId(string filePath, string expectedFileId)
+    {
+        var result = PdfSeeder.ExtractFileIdFromPath(filePath);
+        result.Should().Be(expectedFileId);
+    }
+
+    [Theory]
+    // Null / empty
+    [InlineData(null)]
+    [InlineData("")]
+    // No path separator → can't isolate last segment
+    [InlineData("singleSegment_file.pdf")]
+    [InlineData("noSeparatorNorUnderscore")]
+    // Trailing slash → no filename after last separator
+    [InlineData("pdf_uploads/gameId/")]
+    [InlineData("pdf_uploads\\gameId\\")]
+    // Last segment has no underscore → can't isolate fileId from filename
+    [InlineData("pdf_uploads/gameId/justAFile.pdf")]
+    [InlineData("pdf_uploads/gameId/no-underscore-here")]
+    // Leading underscore in last segment → fileId would be empty
+    [InlineData("pdf_uploads/gameId/_leadingUnderscore.pdf")]
+    public void ExtractFileIdFromPath_InvalidPaths_ReturnsNull(string? filePath)
+    {
+        var result = PdfSeeder.ExtractFileIdFromPath(filePath!);
+        result.Should().BeNull();
+    }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -94,7 +94,7 @@ public sealed class PdfSeederBlobTests
 
         // Assert
         _seedBlob.Verify(x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.Should().BeEmpty();
     }
 
@@ -115,7 +115,7 @@ public sealed class PdfSeederBlobTests
 
         // Post-migration (2026-04-19): seeder stores under pdfs/{pdfId}/ bucket, not pdfs/{gameId}/.
         // pdfId is generated inside the seeder, so match any bucket key here.
-        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(true, "file123", "/blobs/file123", 4));
 
         var manifest = CreateManifest(CreateBlobEntry());
@@ -212,7 +212,7 @@ public sealed class PdfSeederBlobTests
             _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
 
         // Assert — no store call, still only 1 doc
-        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.ToList().Should().HaveCount(1);
     }
 
@@ -234,9 +234,9 @@ public sealed class PdfSeederBlobTests
 
         // Post-migration (2026-04-19): seeder stores under pdfs/{pdfId}/ bucket, not pdfs/{gameId}/.
         // pdfId is generated inside the seeder, so match any bucket key here.
-        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(true, "newfile", "/blobs/newfile", 4));
-        _primaryBlob.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _primaryBlob.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "newhash"));
@@ -294,7 +294,7 @@ public sealed class PdfSeederBlobTests
 
         // Assert
         _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.Should().BeEmpty();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeletePdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeletePdfIntegrationTests.cs
@@ -116,7 +116,7 @@ public sealed class DeletePdfIntegrationTests : IAsyncLifetime
     {
         // Mock BlobStorage service (default: success)
         var blobStorageMock = new Mock<IBlobStorageService>();
-        blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
 
@@ -430,7 +430,7 @@ public sealed class DeletePdfIntegrationTests : IAsyncLifetime
 
         // Create mock BlobStorage that fails
         var blobStorageMock = new Mock<IBlobStorageService>();
-        blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Blob storage unavailable"));
 
         var handler = new DeletePdfCommandHandler(

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
@@ -129,14 +129,14 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
 
             // Quick smoke test to verify S3 connectivity
             using var probe = new MemoryStream("probe"u8.ToArray());
-            var probeResult = await _sut.StoreAsync(probe, "probe.txt", "healthcheck");
+            var probeResult = await _sut.StoreAsync(probe, "probe.txt", BlobCategory.Pdf, "healthcheck");
             if (!probeResult.Success)
             {
                 Console.WriteLine($"S3 connectivity probe failed: {probeResult.ErrorMessage}. Tests will be skipped.");
                 _skipTests = true;
                 return;
             }
-            await _sut.DeleteAsync(probeResult.FileId!, "healthcheck");
+            await _sut.DeleteAsync(probeResult.FileId!, BlobCategory.Pdf, "healthcheck");
         }
         catch (Exception ex)
         {
@@ -167,7 +167,7 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var gameId = Guid.NewGuid().ToString("N");
 
         // Act
-        var result = await _sut.StoreAsync(stream, "test-document.pdf", gameId);
+        var result = await _sut.StoreAsync(stream, "test-document.pdf", BlobCategory.Pdf, gameId);
 
         // Assert
         result.Success.Should().BeTrue();
@@ -186,11 +186,11 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var content = "Exists check content"u8.ToArray();
         using var stream = new MemoryStream(content);
         var gameId = Guid.NewGuid().ToString("N");
-        var storeResult = await _sut.StoreAsync(stream, "exists-test.pdf", gameId);
+        var storeResult = await _sut.StoreAsync(stream, "exists-test.pdf", BlobCategory.Pdf, gameId);
         storeResult.Success.Should().BeTrue();
 
         // Act
-        var exists = await _sut.ExistsAsync(storeResult.FileId!, gameId);
+        var exists = await _sut.ExistsAsync(storeResult.FileId!, BlobCategory.Pdf, gameId);
 
         // Assert
         exists.Should().BeTrue();
@@ -205,11 +205,11 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var originalContent = "Retrieve test content - should match exactly"u8.ToArray();
         using var storeStream = new MemoryStream(originalContent);
         var gameId = Guid.NewGuid().ToString("N");
-        var storeResult = await _sut.StoreAsync(storeStream, "retrieve-test.pdf", gameId);
+        var storeResult = await _sut.StoreAsync(storeStream, "retrieve-test.pdf", BlobCategory.Pdf, gameId);
         storeResult.Success.Should().BeTrue();
 
         // Act
-        using var retrievedStream = await _sut.RetrieveAsync(storeResult.FileId!, gameId);
+        using var retrievedStream = await _sut.RetrieveAsync(storeResult.FileId!, BlobCategory.Pdf, gameId);
 
         // Assert
         retrievedStream.Should().NotBeNull();
@@ -228,11 +228,11 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var content = "Presigned URL test content"u8.ToArray();
         using var stream = new MemoryStream(content);
         var gameId = Guid.NewGuid().ToString("N");
-        var storeResult = await _sut.StoreAsync(stream, "presigned-test.pdf", gameId);
+        var storeResult = await _sut.StoreAsync(stream, "presigned-test.pdf", BlobCategory.Pdf, gameId);
         storeResult.Success.Should().BeTrue();
 
         // Act
-        var url = await _sut.GetPresignedDownloadUrlAsync(storeResult.FileId!, gameId, expirySeconds: 300);
+        var url = await _sut.GetPresignedDownloadUrlAsync(storeResult.FileId!, BlobCategory.Pdf, gameId, expirySeconds: 300);
 
         // Assert
         url.Should().NotBeNull();
@@ -257,16 +257,16 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var content = "Delete test content"u8.ToArray();
         using var stream = new MemoryStream(content);
         var gameId = Guid.NewGuid().ToString("N");
-        var storeResult = await _sut.StoreAsync(stream, "delete-test.pdf", gameId);
+        var storeResult = await _sut.StoreAsync(stream, "delete-test.pdf", BlobCategory.Pdf, gameId);
         storeResult.Success.Should().BeTrue();
-        (await _sut.ExistsAsync(storeResult.FileId!, gameId)).Should().BeTrue();
+        (await _sut.ExistsAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeTrue();
 
         // Act
-        var deleted = await _sut.DeleteAsync(storeResult.FileId!, gameId);
+        var deleted = await _sut.DeleteAsync(storeResult.FileId!, BlobCategory.Pdf, gameId);
 
         // Assert
         deleted.Should().BeTrue();
-        (await _sut.ExistsAsync(storeResult.FileId!, gameId)).Should().BeFalse();
+        (await _sut.ExistsAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeFalse();
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         SkipIfNotAvailable();
 
         // Act
-        var result = await _sut.ExistsAsync("file123", "../../../etc/passwd");
+        var result = await _sut.ExistsAsync("file123", BlobCategory.Pdf, "../../../etc/passwd");
 
         // Assert
         result.Should().BeFalse();
@@ -290,7 +290,7 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var gameId = Guid.NewGuid().ToString("N");
 
         // Act
-        var result = await _sut.RetrieveAsync("nonexistentfile", gameId);
+        var result = await _sut.RetrieveAsync("nonexistentfile", BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeNull();
@@ -305,7 +305,7 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var gameId = Guid.NewGuid().ToString("N");
 
         // Act
-        var result = await _sut.DeleteAsync("nonexistentfile", gameId);
+        var result = await _sut.DeleteAsync("nonexistentfile", BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeFalse();
@@ -320,7 +320,7 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         var gameId = Guid.NewGuid().ToString("N");
 
         // Act
-        var result = await _sut.GetPresignedDownloadUrlAsync("nonexistentfile", gameId);
+        var result = await _sut.GetPresignedDownloadUrlAsync("nonexistentfile", BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeNull();
@@ -364,28 +364,28 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
 
         // 1. Store
         using var storeStream = new MemoryStream(content);
-        var storeResult = await _sut.StoreAsync(storeStream, "lifecycle-test.pdf", gameId);
+        var storeResult = await _sut.StoreAsync(storeStream, "lifecycle-test.pdf", BlobCategory.Pdf, gameId);
         (storeResult.Success).Should().BeTrue("Store failed");
 
         // 2. Exists
-        (await _sut.ExistsAsync(storeResult.FileId!, gameId)).Should().BeTrue("Exists failed after Store");
+        (await _sut.ExistsAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeTrue("Exists failed after Store");
 
         // 3. Retrieve and verify content
-        using var retrieveStream = await _sut.RetrieveAsync(storeResult.FileId!, gameId);
+        using var retrieveStream = await _sut.RetrieveAsync(storeResult.FileId!, BlobCategory.Pdf, gameId);
         retrieveStream.Should().NotBeNull();
         using var ms = new MemoryStream();
         await retrieveStream.CopyToAsync(ms);
         ms.ToArray().Should().BeEquivalentTo(content);
 
         // 4. Presigned URL
-        var url = await _sut.GetPresignedDownloadUrlAsync(storeResult.FileId!, gameId);
+        var url = await _sut.GetPresignedDownloadUrlAsync(storeResult.FileId!, BlobCategory.Pdf, gameId);
         url.Should().NotBeNull();
 
         // 5. Delete
-        (await _sut.DeleteAsync(storeResult.FileId!, gameId)).Should().BeTrue("Delete failed");
+        (await _sut.DeleteAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeTrue("Delete failed");
 
         // 6. Verify deletion
-        (await _sut.ExistsAsync(storeResult.FileId!, gameId)).Should().BeFalse("File still exists after Delete");
-        (await _sut.RetrieveAsync(storeResult.FileId!, gameId)).Should().BeNull();
+        (await _sut.ExistsAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeFalse("File still exists after Delete");
+        (await _sut.RetrieveAsync(storeResult.FileId!, BlobCategory.Pdf, gameId)).Should().BeNull();
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
@@ -93,11 +93,7 @@ public sealed class SeedCatalogBlobIntegrationTests
 
         var pdfFileId = Guid.NewGuid();
         _primaryBlob
-            .Setup(x => x.StoreAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(
                 Success: true,
                 FileId: pdfFileId.ToString(),
@@ -190,9 +186,7 @@ public sealed class SeedCatalogBlobIntegrationTests
             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
 
         _primaryBlob
-            .Setup(x => x.StoreAsync(
-                It.IsAny<Stream>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new BlobStorageResult(
                 Success: true,
                 FileId: Guid.NewGuid().ToString(),
@@ -213,11 +207,7 @@ public sealed class SeedCatalogBlobIntegrationTests
         pdfs.Should().NotContain(p => p.FileName == "unknown_rulebook.pdf");
 
         // The missing gameMap entry did not cause any blob store call
-        _primaryBlob.Verify(x => x.StoreAsync(
-            It.IsAny<Stream>(),
-            "unknown_rulebook.pdf",
-            It.IsAny<string>(),
-            It.IsAny<CancellationToken>()),
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), "unknown_rulebook.pdf", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -271,9 +261,7 @@ public sealed class SeedCatalogBlobIntegrationTests
         _seedBlob.Setup(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
         _primaryBlob
-            .Setup(x => x.StoreAsync(
-                It.IsAny<Stream>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new BlobStorageResult(
                 Success: true,
                 FileId: Guid.NewGuid().ToString(),
@@ -300,9 +288,7 @@ public sealed class SeedCatalogBlobIntegrationTests
         secondRunCount.Should().Be(1, "re-seeding with unchanged hash must not create duplicates");
 
         // StoreAsync invoked exactly once — second call short-circuits on hash match
-        _primaryBlob.Verify(x => x.StoreAsync(
-            It.IsAny<Stream>(), It.IsAny<string>(),
-            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -196,7 +196,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
         if (!services.Any(s => s.ServiceType == typeof(IBlobStorageService)))
         {
             var blobStorageMock = new Mock<IBlobStorageService>();
-            blobStorageMock.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>()!, It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            blobStorageMock.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Stream stream, string fileName, string gameId, CancellationToken ct) =>
                 {
                     var filePath = Path.Combine(_testDataDirectory!, $"{gameId}_{fileName}");
@@ -204,7 +204,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
                     stream.CopyTo(fileStream);
                     return new BlobStorageResult(true, Guid.NewGuid().ToString(), filePath, stream.Length, null);
                 });
-            blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>()!, It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            blobStorageMock.Setup(b => b.DeleteAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
             services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
         }
@@ -758,7 +758,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
 
         // Mock blob storage that always fails
         var failingBlobStorage = new Mock<IBlobStorageService>();
-        failingBlobStorage.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        failingBlobStorage.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(false, null, null, 0, "Simulated storage failure"));
         services.AddSingleton<IBlobStorageService>(failingBlobStorage.Object);
 
@@ -1008,7 +1008,7 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
         var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
 
         var permissionDeniedStorage = new Mock<IBlobStorageService>();
-        permissionDeniedStorage.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        permissionDeniedStorage.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BlobStorageResult(false, null, null, 0, "Access denied: Insufficient permissions"));
         services.AddSingleton<IBlobStorageService>(permissionDeniedStorage.Object);
 

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfMidPhaseCancellationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfMidPhaseCancellationTests.cs
@@ -206,12 +206,12 @@ public sealed class UploadPdfMidPhaseCancellationTests : IAsyncLifetime
         if (!services.Any(s => s.ServiceType == typeof(IBlobStorageService)))
         {
             var blobStorageMock = new Mock<IBlobStorageService>();
-            blobStorageMock.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Stream stream, string fileName, string gameId, CancellationToken ct) =>
+            blobStorageMock.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
                 {
                     // Sanitize filename for filesystem safety (tests may use malicious filenames)
                     var safeFileName = string.Join("_", fileName.Split(Path.GetInvalidFileNameChars()));
-                    var filePath = Path.Combine(_testDataDirectory!, $"{gameId}_{safeFileName}");
+                    var filePath = Path.Combine(_testDataDirectory!, $"{resourceKey}_{safeFileName}");
                     using var fileStream = File.Create(filePath);
                     stream.CopyTo(fileStream);
                     return new BlobStorageResult(true, Guid.NewGuid().ToString(), filePath, stream.Length, null);
@@ -324,8 +324,8 @@ public sealed class UploadPdfMidPhaseCancellationTests : IAsyncLifetime
 
         // Mock blob storage that delays then throws
         var midWriteBlob = new Mock<IBlobStorageService>();
-        midWriteBlob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(async (Stream stream, string fileName, string gameId, CancellationToken ct) =>
+        midWriteBlob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async (Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
             {
                 await Task.Delay(TestConstants.Timing.LargeDelay, ct); // Will throw TaskCanceledException
                 return new BlobStorageResult(false, null, null, 0, "Never reached");

--- a/apps/api/tests/Api.Tests/Unit/Services/BlobCategorySignatureSmokeTest.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/BlobCategorySignatureSmokeTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Api.Tests.Unit.Services;
 
 /// <summary>
-/// Behavioral-invariant smoke test for issue #1314 PR 1 (signature refactor).
+/// Smoke test for issue #1314 PR 1 (signature refactor).
 ///
 /// PR 1 introduces <see cref="BlobCategory"/> + <c>resourceKey</c> into the
 /// <see cref="IBlobStorageService"/> contract while preserving the legacy
@@ -16,21 +16,26 @@ namespace Api.Tests.Unit.Services;
 /// (PR 2 will wire <see cref="BlobCategoryExtensions.ToS3Folder"/> into key
 /// construction behind the <c>STORAGE_WRITE_MODE</c> feature flag).
 ///
-/// This test enforces the behavior preservation guarantee: every public method
-/// that touches a storage path must produce byte-identical output between
-/// pre-refactor and post-refactor for the same logical input.
+/// What THIS test guards:
+/// - <see cref="BlobCategoryExtensions.ToS3Folder"/> canonical prefix mapping
+///   (the contract that PR 2's migration runbook + outbox layer will consume).
+///   Any rename of these strings before PR 2 ships breaks the migration plan.
+/// - <see cref="MockBlobStorageService"/> path format is category-agnostic
+///   in PR 1 — guards against an accidental category-dependent path mutation
+///   in the mock that would silently break test fixtures relying on path
+///   stability.
 ///
-/// Coverage:
-/// - S3 key layout regression (5 prefix-scan sites in <see cref="S3BlobStorageService"/>):
-///   we cannot exercise the real S3 client here without Testcontainers (covered
-///   in <c>S3BlobStorageIntegrationTests</c>), so we assert the
-///   <see cref="BlobCategoryExtensions.ToS3Folder"/> contract values which are
-///   the future layout PR 2 will introduce.
-/// - <see cref="MockBlobStorageService"/> storage path format: round-trip 10
-///   distinct uploads across all 5 <see cref="BlobCategory"/> values and assert
-///   the <see cref="BlobStorageResult.FilePath"/> retains
-///   <c>{resourceKey}/{fileId}</c> shape regardless of category (category is
-///   discarded in PR 1).
+/// What this test does NOT guard (covered elsewhere):
+/// - <see cref="S3BlobStorageService.GetS3Key"/> byte-identity of the actual
+///   S3 key produced pre/post PR 1 → covered by
+///   <c>S3BlobStorageIntegrationTests</c> + <c>S3BlobStorageServiceTests</c>
+///   (Testcontainers MinIO + mocked AmazonS3 client respectively). The
+///   private <c>GetS3Key</c> method is exercised end-to-end by those suites
+///   via Store/Retrieve/Delete round-trips; not reachable from a pure-unit
+///   smoke test without reflection.
+/// - <see cref="BlobStorageService"/> local filesystem path byte-identity →
+///   no dedicated unit suite today (gap acknowledged for PR 2 test matrix
+///   item "Integration steady-state").
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("Issue", "1314")]
@@ -42,6 +47,7 @@ public sealed class BlobCategorySignatureSmokeTest
     [InlineData(BlobCategory.GameImage, "game-images")]
     [InlineData(BlobCategory.VisionSnapshot, "vision-snapshots")]
     [InlineData(BlobCategory.GamebookPhoto, "gamebook-photos")]
+    [InlineData(BlobCategory.PhotoBatch, "photo-batches")]
     public void ToS3Folder_ReturnsCanonicalPrefix(BlobCategory category, string expectedPrefix)
     {
         // PR 2 contract guard: the canonical S3 folder mapping must remain stable
@@ -69,6 +75,7 @@ public sealed class BlobCategorySignatureSmokeTest
             BlobCategory.GameImage,
             BlobCategory.VisionSnapshot,
             BlobCategory.GamebookPhoto,
+            BlobCategory.PhotoBatch,
         };
 
         var paths = new System.Collections.Generic.List<(BlobCategory category, string filePath)>();
@@ -108,6 +115,7 @@ public sealed class BlobCategorySignatureSmokeTest
     [InlineData(BlobCategory.GameImage)]
     [InlineData(BlobCategory.VisionSnapshot)]
     [InlineData(BlobCategory.GamebookPhoto)]
+    [InlineData(BlobCategory.PhotoBatch)]
     public void MockBlobStorage_GetStoragePath_IsCategoryAgnostic_InPR1(BlobCategory category)
     {
         // Companion guard: GetStoragePath must also be category-agnostic in PR 1.

--- a/apps/api/tests/Api.Tests/Unit/Services/BlobCategorySignatureSmokeTest.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/BlobCategorySignatureSmokeTest.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using System.Threading.Tasks;
+using Api.DevTools.MockImpls;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Unit.Services;
+
+/// <summary>
+/// Behavioral-invariant smoke test for issue #1314 PR 1 (signature refactor).
+///
+/// PR 1 introduces <see cref="BlobCategory"/> + <c>resourceKey</c> into the
+/// <see cref="IBlobStorageService"/> contract while preserving the legacy
+/// <c>pdf_uploads/{resourceKey}/{fileId}_{filename}</c> S3 key layout
+/// (PR 2 will wire <see cref="BlobCategoryExtensions.ToS3Folder"/> into key
+/// construction behind the <c>STORAGE_WRITE_MODE</c> feature flag).
+///
+/// This test enforces the behavior preservation guarantee: every public method
+/// that touches a storage path must produce byte-identical output between
+/// pre-refactor and post-refactor for the same logical input.
+///
+/// Coverage:
+/// - S3 key layout regression (5 prefix-scan sites in <see cref="S3BlobStorageService"/>):
+///   we cannot exercise the real S3 client here without Testcontainers (covered
+///   in <c>S3BlobStorageIntegrationTests</c>), so we assert the
+///   <see cref="BlobCategoryExtensions.ToS3Folder"/> contract values which are
+///   the future layout PR 2 will introduce.
+/// - <see cref="MockBlobStorageService"/> storage path format: round-trip 10
+///   distinct uploads across all 5 <see cref="BlobCategory"/> values and assert
+///   the <see cref="BlobStorageResult.FilePath"/> retains
+///   <c>{resourceKey}/{fileId}</c> shape regardless of category (category is
+///   discarded in PR 1).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Issue", "1314")]
+public sealed class BlobCategorySignatureSmokeTest
+{
+    [Theory]
+    [InlineData(BlobCategory.Pdf, "pdfs")]
+    [InlineData(BlobCategory.SessionPhoto, "session-photos")]
+    [InlineData(BlobCategory.GameImage, "game-images")]
+    [InlineData(BlobCategory.VisionSnapshot, "vision-snapshots")]
+    [InlineData(BlobCategory.GamebookPhoto, "gamebook-photos")]
+    public void ToS3Folder_ReturnsCanonicalPrefix(BlobCategory category, string expectedPrefix)
+    {
+        // PR 2 contract guard: the canonical S3 folder mapping must remain stable
+        // because the migration runbook (#1314 PR 2 Phase 1-3) targets these exact
+        // string values when rebucket-ing legacy objects.
+        category.ToS3Folder().Should().Be(expectedPrefix);
+    }
+
+    [Fact]
+    public async Task MockBlobStorage_StoreAsync_PathShape_IsCategoryAgnostic_InPR1()
+    {
+        // PR 1 behavior invariant: MockBlobStorageService.StoreAsync must produce
+        // the same FilePath shape `mock://{resourceKey}/{fileId}/{fileName}`
+        // regardless of category — category is discarded in PR 1.
+        // This guards against an accidental category-dependent path mutation
+        // that would silently break tests relying on path stability.
+
+        var svc = new MockBlobStorageService();
+        var content = new byte[] { 0x42 };
+
+        var categories = new[]
+        {
+            BlobCategory.Pdf,
+            BlobCategory.SessionPhoto,
+            BlobCategory.GameImage,
+            BlobCategory.VisionSnapshot,
+            BlobCategory.GamebookPhoto,
+        };
+
+        var paths = new System.Collections.Generic.List<(BlobCategory category, string filePath)>();
+        foreach (var category in categories)
+        {
+            // Upload twice per category (10 total uploads = smoke set spec)
+            for (int i = 0; i < 2; i++)
+            {
+                using var ms = new MemoryStream(content);
+                var result = await svc.StoreAsync(
+                    ms,
+                    fileName: $"sample-{i}.bin",
+                    category: category,
+                    resourceKey: "fixedResourceKey",
+                    ct: default);
+
+                result.Success.Should().BeTrue();
+                result.FilePath.Should().NotBeNullOrEmpty();
+                paths.Add((category, result.FilePath!));
+            }
+        }
+
+        // Invariant: every FilePath must start with the same fixed prefix and
+        // share the same shape — the only varying segment is the random fileId.
+        foreach (var (category, filePath) in paths)
+        {
+            filePath.Should().StartWith(
+                "mock://fixedResourceKey/MOCK-",
+                because: $"category {category} should NOT leak into the path in PR 1 (behavior preservation)");
+            filePath.Should().EndWith(".bin");
+        }
+    }
+
+    [Theory]
+    [InlineData(BlobCategory.Pdf)]
+    [InlineData(BlobCategory.SessionPhoto)]
+    [InlineData(BlobCategory.GameImage)]
+    [InlineData(BlobCategory.VisionSnapshot)]
+    [InlineData(BlobCategory.GamebookPhoto)]
+    public void MockBlobStorage_GetStoragePath_IsCategoryAgnostic_InPR1(BlobCategory category)
+    {
+        // Companion guard: GetStoragePath must also be category-agnostic in PR 1.
+        var svc = new MockBlobStorageService();
+
+        var path = svc.GetStoragePath(
+            fileId: "stableFileId",
+            category: category,
+            resourceKey: "stableResourceKey",
+            fileName: "doc.pdf");
+
+        path.Should().Be("mock://stableResourceKey/stableFileId/doc.pdf",
+            because: "MockBlobStorageService discards category in PR 1 — path depends only on resourceKey + fileId + fileName");
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
@@ -63,7 +63,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(putResponse);
 
         // Act
-        var result = await _sut.StoreAsync(stream, fileName, gameId);
+        var result = await _sut.StoreAsync(stream, fileName, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Success.Should().BeTrue();
@@ -94,7 +94,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ThrowsAsync(new AmazonS3Exception("Access denied"));
 
         // Act
-        var result = await _sut.StoreAsync(stream, fileName, gameId);
+        var result = await _sut.StoreAsync(stream, fileName, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Success.Should().BeFalse();
@@ -135,7 +135,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(getResponse);
 
         // Act
-        var result = await _sut.RetrieveAsync(fileId, gameId);
+        var result = await _sut.RetrieveAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().NotBeNull();
@@ -168,7 +168,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(listResponse);
 
         // Act
-        var result = await _sut.RetrieveAsync(fileId, gameId);
+        var result = await _sut.RetrieveAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeNull();
@@ -201,7 +201,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ThrowsAsync(new AmazonS3Exception("Not found") { StatusCode = HttpStatusCode.NotFound });
 
         // Act
-        var result = await _sut.RetrieveAsync(fileId, gameId);
+        var result = await _sut.RetrieveAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeNull();
@@ -239,7 +239,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(deleteResponse);
 
         // Act
-        var result = await _sut.DeleteAsync(fileId, gameId);
+        var result = await _sut.DeleteAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeTrue();
@@ -270,7 +270,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(listResponse);
 
         // Act
-        var result = await _sut.DeleteAsync(fileId, gameId);
+        var result = await _sut.DeleteAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeFalse();
@@ -289,7 +289,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
         var fileName = "test.pdf";
 
         // Act
-        var result = _sut.GetStoragePath(fileId, gameId, fileName);
+        var result = _sut.GetStoragePath(fileId, BlobCategory.Pdf, gameId, fileName);
 
         // Assert
         result.Should().Be($"pdf_uploads/{gameId}/{fileId}_test.pdf");
@@ -305,7 +305,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
 
         // Act & Assert
         var act = () =>
-            _sut.GetStoragePath(fileId, invalidGameId, fileName);
+            _sut.GetStoragePath(fileId, BlobCategory.Pdf, invalidGameId, fileName);
         act.Should().Throw<ArgumentException>();
     }
 
@@ -331,7 +331,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(listResponse);
 
         // Act
-        var result = await _sut.ExistsAsync(fileId, gameId);
+        var result = await _sut.ExistsAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeTrue();
@@ -356,7 +356,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(listResponse);
 
         // Act
-        var result = await _sut.ExistsAsync(fileId, gameId);
+        var result = await _sut.ExistsAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeFalse();
@@ -370,7 +370,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
         var invalidGameId = "../../../etc/passwd";
 
         // Act
-        var result = await _sut.ExistsAsync(fileId, invalidGameId);
+        var result = await _sut.ExistsAsync(fileId, BlobCategory.Pdf, invalidGameId);
 
         // Assert
         result.Should().BeFalse();
@@ -403,7 +403,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(expectedUrl);
 
         // Act
-        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, gameId);
+        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().NotBeNull();
@@ -436,7 +436,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(listResponse);
 
         // Act
-        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, gameId);
+        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, BlobCategory.Pdf, gameId);
 
         // Assert
         result.Should().BeNull();
@@ -474,7 +474,7 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             .ReturnsAsync(expectedUrl);
 
         // Act
-        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, gameId, customExpiry);
+        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, BlobCategory.Pdf, gameId, customExpiry);
 
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
## Summary

PR 1 of 2 for issue #1314 — **behavior-preserving signature refactor** of `IBlobStorageService`.

Resolves design decision **D2** from the spec-panel deliberation: introduce `BlobCategory` enum + opaque `resourceKey` parameter to replace the misnamed `gameId` parameter that was being abused as a folder slug by non-PDF consumers (e.g. `SessionAttachmentService.cs:63` was passing `"session-photos-{sessionId:N}"`).

**PR 1 is behavior-preserving** — S3 keys output byte-identical pre/post this PR. The new `BlobCategory` is stored in the contract surface but discarded in PR 1 (`_ = category` discard in all 3 implementations). **PR 2 will wire `BlobCategory.ToS3Folder()` into the actual S3 key construction behind a `STORAGE_WRITE_MODE` feature flag** for the 5-phase rollout (zero downtime via Outbox-backed dual-write — D1 decision).

## Changes (55 files: 29 src + 26 tests)

### New surface
- `BlobCategory` enum (5 values: `Pdf`, `SessionPhoto`, `GameImage`, `VisionSnapshot`, `GamebookPhoto`)
- `BlobCategoryExtensions.ToS3Folder()` static helper (canonical PR 2 layout: `pdfs/`, `session-photos/`, `game-images/`, `vision-snapshots/`, `gamebook-photos/`)
- `IBlobStorageService` signature: 6 methods migrated from `(fileId, gameId, ...)` → `(fileId, BlobCategory category, string resourceKey, ...)`

### Implementations updated (S3 keys IDENTICAL pre/post)
- `S3BlobStorageService` (5 prefix scans + `GetS3Key`)
- `BlobStorageService` (local filesystem provider)
- `MockBlobStorageService` (DevTools dev mock)

### Call sites migrated (26 files, 5 BC + Infrastructure)
- **DocumentProcessing** (11): PDF upload/download/extract/delete + photo batch
- **SharedGameCatalog** (5): wizard extract metadata + shared-game PDF upload
- **SessionTracking** (4): vision snapshots + gamebook photos
- **GameManagement** (2): `BlobCategory.SessionPhoto` for `SessionAttachmentService`, `BlobCategory.GameImage` for `UploadGameImageCommandHandler`
- **Administration** (1): `MigrateStorageCommandHandler`
- **Infrastructure** (1): `PdfSeeder`

### Test files updated (22) + new smoke test
- 22 test files updated to new mock setup signature (Moq + NSubstitute Setup patterns)
- New `BlobCategorySignatureSmokeTest` (11 assertions): behavior-preservation guard + canonical prefix mapping contract for PR 2 migration runbook

## Test plan

- [x] `dotnet build apps/api/src/Api/Api.csproj` — passes 0 errors 0 warnings
- [x] `dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj` — passes 0 errors (74 pre-existing warnings)
- [x] `BlobCategorySignatureSmokeTest` — **11/11 passed** (54ms)
- [ ] Full backend test suite — running on CI
- [ ] Integration tests with Testcontainers MinIO (`S3BlobStorageIntegrationTests`) — running on CI

## Out of scope (PR 2)

- `StorageOperationOutboxBackgroundService` + EF migration (mirror `EmailOutboxBackgroundService` pattern)
- Feature flags `STORAGE_WRITE_MODE` + `STORAGE_READ_MODE` + `STORAGE_MIGRATION_ENABLED`
- 5-phase rollout (Phase 0 deploy → Phase 1 background migration → Phase 2 switch writes → Phase 3 deprecation legacy reads → Phase 4 cleanup)
- Test matrix 6 categories (Unit + Integration steady + Integration cutover-mid + Concurrency + Restore-from-trash + Migration-speed)
- Observability metrics (`storage_migration_objects_migrated_total`, `storage_migration_duration_seconds`, `storage_layout_version`)
- Runbook + backout drill

See full PR 2 plan in [#1314 issue body](https://github.com/meepleAi-app/meepleai-monorepo/issues/1314).

## References

- Closes: D2 design decision of #1314 (signature design)
- Tracking: #1314
- Spec-panel review: https://github.com/meepleAi-app/meepleai-monorepo/issues/1314#issuecomment-4488028073
- D1/D2/D3 deliberation: https://github.com/meepleAi-app/meepleai-monorepo/issues/1314#issuecomment-4488244050

🤖 Generated with [Claude Code](https://claude.com/claude-code)
