### PR TITLE
fix(test): #1315 follow-up 2/2 — synthesize valid UUIDs in buildRsvpDto

### DIFF
--- a/apps/web/e2e/v2-states/game-night-detail.spec.ts
+++ b/apps/web/e2e/v2-states/game-night-detail.spec.ts
@@ -71,9 +71,16 @@ function buildEventDto(overrides: EventFixture): unknown {
   };
 }
 
+// Issue #1315 — `GameNightRsvpDtoSchema` validates `id` as `z.string().uuid()`.
+// The previous synthesis `${rsvp.userId.slice(0, 8)}-rsvp` produced strings like
+// "00000000-rsvp" which fail UUID validation and silently reject the entire
+// `getRsvps()` response, propagating to `useGameNightDetail.isError=true` and
+// rendering the not-found shell. Synthesize a deterministic v4 UUID per user
+// instead — substitute the trailing 12 chars (the node identifier) with
+// "f1f1f1f1f1f1" so callers can distinguish rsvp IDs from user IDs at a glance.
 function buildRsvpDto(rsvp: RsvpFixture): unknown {
   return {
-    id: `${rsvp.userId.slice(0, 8)}-rsvp`,
+    id: `${rsvp.userId.slice(0, 24)}f1f1f1f1f1f1`,
     userId: rsvp.userId,
     userName: rsvp.userName,
     status: rsvp.status,


### PR DESCRIPTION
## Summary

Third (and hopefully last) fix in the #1315 chain. PRs #1319 (proxy bypass at runtime) and #1321 (force `locale: it-IT` in v2-states projects) unmasked this latent bug: even with the bypass engaged and Italian rendering, 26 of 30 v2-states/game-night-detail.spec.ts test runs still failed at `waitForSelector('[data-testid="game-night-detail-hero"]')` (timeout 30s).

The verify re-dispatch ([run 26106593942](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26106593942)) downloaded artifact confirmed:
- All 3 mocked API calls fired and returned 200 with valid bodies
- The page rendered the **error shell** ("Serata non trovata") instead of the hero

## Root cause

[`buildRsvpDto`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/e2e/v2-states/game-night-detail.spec.ts#L74-L82) synthesized:

```ts
id: `${rsvp.userId.slice(0, 8)}-rsvp`
```

For `userId = '00000000-0000-4000-8000-000000000fff'`, this produces `"00000000-rsvp"` — **not a valid UUID**.

The client-side [`api.gameNights.getRsvps(id)`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/src/lib/api/clients/gameNightsClient.ts#L62) validates the response with `z.array(GameNightRsvpDtoSchema).parse(data ?? [])`, where [`GameNightRsvpDtoSchema.id`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/src/lib/api/schemas/game-nights.schemas.ts#L9) is `z.string().uuid()`.

→ Zod parse throws → `rsvpsQuery.isError = true` → `useGameNightDetail.isError = (eventQuery.isError || rsvpsQuery.isError) = true` → `GameNightDetailView` short-circuits to the not-found shell.

Even though the event query returned 200 with a valid event DTO (`status: 'Published'`), the rsvps query's silent zod throw collapsed the entire page into the error branch.

## Why this didn't surface earlier

This was a long-standing latent bug since PR #1171 — the test only surfaces under the exact prod-build + proxy-bypass + it-IT-locale combination that the bootstrap workflow exercises. Earlier dispatches redirected to /login before any zod-validated query fired. The test was almost certainly never run end-to-end in CI before the recent dispatches.

## Fix

Synthesize a deterministic valid v4 UUID per RSVP by replacing the node identifier (last 12 chars) with `"f1f1f1f1f1f1"`. This preserves:
- v4 marker at position 14 (`4`)
- variant marker at position 19 (`8`/`9`/`a`/`b`)

…inherited from the original userId, so the result is always a valid v4 UUID. Per-user determinism is preserved — `userId 00000000-0000-4000-8000-000000000fff` → rsvp id `00000000-0000-4000-8000-f1f1f1f1f1f1`.

## Verification path

Post-merge: re-dispatch `Visual Regression — Migrated Routes` with `project_filter=v2-states`. Expected:
- All 5 AC-H1 scenarios pass (including the 4 still failing — a/b/c/e — plus d which already passed)
- 10 PNG baselines for `v2-states/game-night-create.spec.ts` materialize
- Closes #1315

## Test plan

- [ ] CI Dev Fast green
- [ ] Post-merge dispatch of `Visual Regression — Migrated Routes` mode=bootstrap project_filter=v2-states completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)