### PR TITLE
feat(storage): #1314 PR 2 — layout migration with Outbox-backed 5-phase rollout

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IStorageOperationOutboxService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IStorageOperationOutboxService.cs
@@ -1,0 +1,34 @@
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Caller-facing surface to enqueue a single blob storage move (legacy → new
+/// layout) onto the outbox. Issue #1314 PR 2.
+///
+/// Rows are durably persisted (UNIQUE index on <c>LegacyKey</c> dedupes
+/// re-runs of the migration script) and drained out-of-band by
+/// <c>StorageOperationOutboxBackgroundService</c>, which performs the actual
+/// <c>aws s3 mv legacy → new</c> with retry + exponential backoff.
+/// </summary>
+public interface IStorageOperationOutboxService
+{
+    /// <summary>
+    /// Enqueue a single storage move. Returns true if a new row was inserted,
+    /// false if a row with the same legacy key already exists (idempotent).
+    /// </summary>
+    /// <param name="migrationId">Correlation id for the migration batch this row belongs to.</param>
+    /// <param name="legacyKey">Source S3 key under <c>pdf_uploads/...</c>.</param>
+    /// <param name="category">Blob category — drives the target prefix via <c>ToS3Folder()</c>.</param>
+    /// <param name="resourceKey">Resource id under which both legacy and new keys live.</param>
+    /// <param name="scheduledAt">Earliest time the drainer should attempt the move (UTC). Defaults to now.</param>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>True if a new row was inserted; false if a duplicate legacy key was detected.</returns>
+    Task<bool> EnqueueAsync(
+        Guid migrationId,
+        string legacyKey,
+        BlobCategory category,
+        string resourceKey,
+        DateTime? scheduledAt = null,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Entities/StorageOperationOutboxEntity.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Entities/StorageOperationOutboxEntity.cs
@@ -1,0 +1,84 @@
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Entities;
+
+/// <summary>
+/// Persistence model for the storage-operation outbox (issue #1314 PR 2).
+///
+/// Each row represents a pending or completed move of a single S3 / local blob
+/// from the legacy layout (<c>pdf_uploads/{resourceKey}/{fileId}_{filename}</c>)
+/// to the new categorized layout (<c>{category.ToS3Folder()}/{resourceKey}/{fileId}_{filename}</c>).
+///
+/// The outbox decouples DB commit from the side effect (aws s3 mv): a row is
+/// inserted atomically with whatever DB transaction owns the source object,
+/// and a background drainer (<c>StorageOperationOutboxBackgroundService</c>)
+/// executes the actual S3 move with retry + exponential backoff.
+///
+/// Mirrored from <c>EmailOutboxEntity</c> (UserNotifications BC), same state
+/// machine: <c>Pending → Sent | FailedPermanent</c>.
+/// </summary>
+public class StorageOperationOutboxEntity
+{
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Correlation id for the migration batch this row belongs to (UUID).
+    /// Set once per migration run; used in structured logs + metrics for
+    /// per-run progress dashboards.
+    /// </summary>
+    public Guid MigrationId { get; init; }
+
+    /// <summary>
+    /// Source S3 key under the legacy layout
+    /// (e.g. <c>pdf_uploads/{gameId}/{fileId}_{filename}</c>).
+    /// </summary>
+    public string LegacyKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Target S3 key under the new categorized layout
+    /// (e.g. <c>pdfs/{resourceKey}/{fileId}_{filename}</c>).
+    /// </summary>
+    public string NewKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Blob category of the source object. Drives the target prefix via
+    /// <c>BlobCategoryExtensions.ToS3Folder()</c>. Stored as string for
+    /// schema-evolution friendliness (adding a new <see cref="BlobCategory"/>
+    /// value does not require a DB migration).
+    /// </summary>
+    public string Category { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The resource key under which both legacy and new keys live
+    /// (the second path segment in either layout).
+    /// </summary>
+    public string ResourceKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Earliest time at which the drainer should attempt this move (UTC).
+    /// Bumped forward by exponential backoff on transient failures.
+    /// </summary>
+    public DateTime ScheduledAt { get; init; }
+
+    /// <summary>
+    /// Time at which the move completed successfully, or null if pending/failed.
+    /// </summary>
+    public DateTime? SentAt { get; set; }
+
+    /// <summary>
+    /// Number of move attempts so far (used by retry/backoff logic).
+    /// </summary>
+    public int AttemptCount { get; set; }
+
+    /// <summary>
+    /// Last error message captured during the move, or null on success.
+    /// </summary>
+    public string? LastError { get; set; }
+
+    public DateTime CreatedAt { get; init; }
+
+    /// <summary>
+    /// Lifecycle status. One of: Pending | Sent | FailedPermanent.
+    /// </summary>
+    public string Status { get; set; } = "Pending";
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/StorageOperationOutboxService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/StorageOperationOutboxService.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Entities;
+using Api.Infrastructure;
+using Api.Services.Pdf;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IStorageOperationOutboxService"/>.
+/// Inserts <see cref="StorageOperationOutboxEntity"/> rows; duplicate
+/// <c>LegacyKey</c> values are swallowed (UNIQUE constraint violation =
+/// no-op, the move is already enqueued / completed).
+/// </summary>
+internal sealed class StorageOperationOutboxService : IStorageOperationOutboxService
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<StorageOperationOutboxService> _logger;
+
+    public StorageOperationOutboxService(
+        MeepleAiDbContext db,
+        TimeProvider timeProvider,
+        ILogger<StorageOperationOutboxService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> EnqueueAsync(
+        Guid migrationId,
+        string legacyKey,
+        BlobCategory category,
+        string resourceKey,
+        DateTime? scheduledAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(legacyKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceKey);
+
+        // Derive the target NewKey by replacing the legacy prefix with the
+        // category prefix. The legacy key shape is `pdf_uploads/{resourceKey}/{fileId}_{filename}`;
+        // the new key shape is `{category.ToS3Folder()}/{resourceKey}/{fileId}_{filename}`.
+        var newKey = DeriveNewKey(legacyKey, category);
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var row = new StorageOperationOutboxEntity
+        {
+            Id = Guid.NewGuid(),
+            MigrationId = migrationId,
+            LegacyKey = legacyKey,
+            NewKey = newKey,
+            Category = category.ToString(),
+            ResourceKey = resourceKey,
+            ScheduledAt = scheduledAt ?? now,
+            CreatedAt = now,
+            Status = "Pending",
+        };
+
+        _db.StorageOperationOutbox.Add(row);
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateException ex)
+            when (IsUniqueViolation(ex))
+        {
+            // Idempotent path: another caller already enqueued this legacy key.
+            _db.Entry(row).State = EntityState.Detached;
+            _logger.LogDebug(
+                ex,
+                "Storage outbox: duplicate LegacyKey '{LegacyKey}' (migration {MigrationId}); treating as no-op",
+                legacyKey, migrationId);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Replaces the leading <c>pdf_uploads</c> segment with the categorized
+    /// folder. If the legacy key does not start with the expected prefix
+    /// (shouldn't happen post-PR 1) the original key is returned unchanged
+    /// — the drainer will fail the move on attempt and log the malformed key.
+    /// </summary>
+    private static string DeriveNewKey(string legacyKey, BlobCategory category)
+    {
+        const string LegacyPrefix = "pdf_uploads/";
+        if (!legacyKey.StartsWith(LegacyPrefix, StringComparison.Ordinal))
+        {
+            return legacyKey;
+        }
+        return string.Concat(category.ToS3Folder(), "/", legacyKey.AsSpan(LegacyPrefix.Length));
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        // Postgres unique-violation surfaces as SqlState 23505 inside the
+        // inner exception. We avoid taking a hard dependency on Npgsql here
+        // by sniffing the type name + message — good enough for an idempotent
+        // dedup path.
+        var inner = ex.InnerException;
+        if (inner is null)
+        {
+            return false;
+        }
+
+        var typeName = inner.GetType().FullName ?? string.Empty;
+        var message = inner.Message ?? string.Empty;
+        return typeName.Contains("PostgresException", StringComparison.OrdinalIgnoreCase)
+            && message.Contains("IX_storage_operation_outbox_legacy_key", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/StorageOperationOutboxService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/StorageOperationOutboxService.cs
@@ -95,19 +95,25 @@ internal sealed class StorageOperationOutboxService : IStorageOperationOutboxSer
 
     private static bool IsUniqueViolation(DbUpdateException ex)
     {
-        // Postgres unique-violation surfaces as SqlState 23505 inside the
-        // inner exception. We avoid taking a hard dependency on Npgsql here
-        // by sniffing the type name + message — good enough for an idempotent
-        // dedup path.
+        // Postgres unique-violation surfaces as SqlState 23505 (ISO/IEC 9075
+        // stable across Postgres versions). Read via reflection to avoid a
+        // hard compile-time Npgsql reference; the `SqlState` property name is
+        // a stable part of Npgsql's PostgresException contract and Npgsql is
+        // already a runtime dependency of the application.
+        //
+        // Why not message-sniff on the index name? The previous approach was
+        // fragile: it required the literal index name to appear verbatim in
+        // the exception message, which is not contractual. Future Postgres
+        // versions could format the message differently and break the dedup
+        // path silently.
         var inner = ex.InnerException;
         if (inner is null)
         {
             return false;
         }
 
-        var typeName = inner.GetType().FullName ?? string.Empty;
-        var message = inner.Message ?? string.Empty;
-        return typeName.Contains("PostgresException", StringComparison.OrdinalIgnoreCase)
-            && message.Contains("IX_storage_operation_outbox_legacy_key", StringComparison.OrdinalIgnoreCase);
+        var sqlStateProperty = inner.GetType().GetProperty("SqlState");
+        return sqlStateProperty?.GetValue(inner) is string sqlState
+            && string.Equals(sqlState, "23505", StringComparison.Ordinal);
     }
 }

--- a/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ApplicationServiceExtensions.cs
@@ -108,13 +108,27 @@ internal static class ApplicationServiceExtensions
         return services;
     }
 
-    internal static IServiceCollection AddPdfServices(this IServiceCollection services)
+    internal static IServiceCollection AddPdfServices(this IServiceCollection services, IConfiguration? configuration = null)
     {
         // PDF sub-services (SOLID refactoring - Phase 3)
         services.AddScoped<ITableDetectionService, TableDetectionService>();
         services.AddScoped<ITableCellParser, TableCellParser>();
         services.AddScoped<ITableStructureAnalyzer, TableStructureAnalyzer>();
         services.AddScoped<IPdfMetadataExtractor, PdfMetadataExtractor>();
+
+        // Issue #1314 PR 2: storage layout migration feature flags.
+        // Bound via Options pattern so background services + the blob factory
+        // share a single instance; default values match Phase 0 (deploy infra
+        // with no behavior change — Legacy write, Dual read, migration off).
+        if (configuration is not null)
+        {
+            services.Configure<StorageLayoutOptions>(configuration.GetSection(StorageLayoutOptions.SectionName));
+        }
+        else
+        {
+            services.Configure<StorageLayoutOptions>(_ => { });
+        }
+
         // Issue #2703: Factory pattern for storage provider selection (local or S3)
         services.AddScoped<IBlobStorageService>(sp => BlobStorageServiceFactory.Create(sp));
 

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -523,6 +523,14 @@ internal static class InfrastructureServiceExtensions
             BoundedContexts.UserNotifications.Infrastructure.Services.EmailOutboxService>();
         services.AddHostedService<Infrastructure.BackgroundServices.EmailOutboxBackgroundService>();
 
+        // Issue #1314 PR 2: storage-layout migration outbox + drainer. Same
+        // pattern as email outbox above (scoped service + hosted drainer).
+        // The drainer no-ops when StorageLayout:MigrationEnabled=false.
+        services.AddScoped<
+            BoundedContexts.DocumentProcessing.Application.Services.IStorageOperationOutboxService,
+            BoundedContexts.DocumentProcessing.Infrastructure.Services.StorageOperationOutboxService>();
+        services.AddHostedService<Infrastructure.BackgroundServices.StorageOperationOutboxBackgroundService>();
+
         // Issue #936: Infisical secrets management client (POC)
         services.AddHttpClient("Infisical", client =>
         {

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
@@ -1,0 +1,261 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Entities;
+using Api.Infrastructure;
+using Api.Observability;
+using Api.Services.Pdf;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Api.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Drains the <c>storage_operation_outbox</c> table (issue #1314 PR 2).
+/// Mirrors <c>EmailOutboxBackgroundService</c>: poll every 30s, batch 25,
+/// per-row try, exponential backoff [1m, 5m, 30m, 2h, 6h], MaxAttempts 5
+/// before transition to FailedPermanent.
+///
+/// For each Pending row the service:
+///   1. Verifies the legacy object still exists at <see cref="StorageOperationOutboxEntity.LegacyKey"/>.
+///   2. Issues an <c>aws s3 mv</c>-equivalent (CopyObjectAsync + DeleteObjectAsync)
+///      to move the object to <see cref="StorageOperationOutboxEntity.NewKey"/>.
+///   3. On success marks the row Sent + sets SentAt.
+///   4. On failure increments AttemptCount + reschedules.
+///
+/// Disabled by default (<see cref="StorageLayoutOptions.MigrationEnabled"/> = false)
+/// so the service can be deployed to all environments at Phase 0 without
+/// triggering moves. Operator flips the flag to start Phase 1.
+///
+/// Only runs against S3-compatible storage. For local-FS dev environments
+/// (<c>STORAGE_PROVIDER=local</c>) the service still polls but logs a single
+/// warning per tick and otherwise no-ops — local-layout migration is left as
+/// an explicit operator action (script in <c>scripts/migrate-storage-local.sh</c>,
+/// out of scope for PR 2).
+/// </summary>
+internal sealed class StorageOperationOutboxBackgroundService : BackgroundService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+    private const int BatchSize = 25;
+    private const int MaxAttempts = 5;
+
+    private static readonly TimeSpan[] BackoffSchedule =
+    [
+        TimeSpan.FromMinutes(1),
+        TimeSpan.FromMinutes(5),
+        TimeSpan.FromMinutes(30),
+        TimeSpan.FromHours(2),
+        TimeSpan.FromHours(6),
+    ];
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly StorageLayoutOptions _layoutOptions;
+    private readonly ILogger<StorageOperationOutboxBackgroundService> _logger;
+
+    public StorageOperationOutboxBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider,
+        IOptions<StorageLayoutOptions> layoutOptions,
+        ILogger<StorageOperationOutboxBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        ArgumentNullException.ThrowIfNull(layoutOptions);
+        _layoutOptions = layoutOptions.Value;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_layoutOptions.MigrationEnabled)
+        {
+            _logger.LogInformation(
+                "StorageOperationOutboxBackgroundService started but disabled (StorageLayout:MigrationEnabled=false). " +
+                "Service will not drain the outbox; flip the flag to enable Phase 1 migration.");
+            // Keep the service alive (BackgroundService contract) but skip the
+            // drain loop. Operator can restart the pod after flipping the flag.
+            await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken).ConfigureAwait(false);
+            return;
+        }
+
+        _logger.LogInformation(
+            "StorageOperationOutboxBackgroundService started. Poll interval: {Interval}s, batch size: {BatchSize}, max attempts: {MaxAttempts}",
+            PollInterval.TotalSeconds,
+            BatchSize,
+            MaxAttempts);
+
+        // Announce active layout version once per drainer lifecycle (PR 2 obs spec).
+        MeepleAiMetrics.StorageLayoutVersionAnnouncementsTotal.Add(
+            1,
+            new KeyValuePair<string, object?>("layout_version", _layoutOptions.LayoutVersionLabel));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DrainOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE BOUNDARY: transient errors in the drain loop
+            // must not crash the host. Next poll tick retries.
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Unhandled error during storage-outbox drain");
+            }
+#pragma warning restore CA1031
+
+            try
+            {
+                await Task.Delay(PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comments about per-row flush — false-positive on em-dashes.")]
+    private async Task DrainOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var blobStorage = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+
+        // Drainer only operates against S3 storage — local FS migration is an
+        // explicit operator action. The DI factory returns S3BlobStorageService
+        // when STORAGE_PROVIDER=s3 (see BlobStorageServiceFactory).
+        if (blobStorage is not S3BlobStorageService s3Storage)
+        {
+            _logger.LogDebug("Storage outbox drain skipped: blob storage is not S3-backed");
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var due = await dbContext.StorageOperationOutbox
+            .Where(e => e.Status == "Pending" && e.ScheduledAt <= now)
+            .OrderBy(e => e.ScheduledAt)
+            .Take(BatchSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (due.Count == 0)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Storage outbox: draining {Count} pending row(s)", due.Count);
+
+        foreach (var row in due)
+        {
+            await TryMoveAsync(row, dbContext, s3Storage, cancellationToken).ConfigureAwait(false);
+            // Flush per-row so a cancellation mid-batch does NOT lose mutations
+            // from rows already processed (Sent / AttemptCount++).
+            await dbContext.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [SuppressMessage("SonarAnalyzer.CSharp", "S125", Justification = "Explanatory comments — false-positive on em-dashes.")]
+    private async Task TryMoveAsync(
+        StorageOperationOutboxEntity row,
+        MeepleAiDbContext dbContext,
+        S3BlobStorageService s3Storage,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var s3Client = s3Storage.S3Client;
+            var bucket = s3Storage.Options.BucketName;
+
+            // Copy legacy → new. CopyObjectAsync is atomic on the S3 side; if
+            // it succeeds the new key is durable before we delete the legacy.
+            await s3Client.CopyObjectAsync(new CopyObjectRequest
+            {
+                SourceBucket = bucket,
+                SourceKey = row.LegacyKey,
+                DestinationBucket = bucket,
+                DestinationKey = row.NewKey,
+                ServerSideEncryptionMethod = s3Storage.Options.EnableEncryption
+                    ? ServerSideEncryptionMethod.AES256
+                    : ServerSideEncryptionMethod.None,
+            }, cancellationToken).ConfigureAwait(false);
+
+            // Delete legacy after successful copy. If this fails, the row stays
+            // Pending — next attempt will see the new key already in place
+            // (CopyObjectAsync is idempotent under identical source/dest) and
+            // re-issue the delete.
+            await s3Client.DeleteObjectAsync(new DeleteObjectRequest
+            {
+                BucketName = bucket,
+                Key = row.LegacyKey,
+            }, cancellationToken).ConfigureAwait(false);
+
+            row.Status = "Sent";
+            row.SentAt = _timeProvider.GetUtcNow().UtcDateTime;
+            row.LastError = null;
+            row.AttemptCount += 1;
+
+            stopwatch.Stop();
+            MeepleAiMetrics.StorageMigrationDurationMs.Record(
+                stopwatch.Elapsed.TotalMilliseconds,
+                new KeyValuePair<string, object?>("category", row.Category));
+            MeepleAiMetrics.StorageMigrationObjectsMigratedTotal.Add(
+                1,
+                new KeyValuePair<string, object?>("status", "success"),
+                new KeyValuePair<string, object?>("category", row.Category));
+
+            _logger.LogInformation(
+                "Storage outbox: moved {LegacyKey} → {NewKey} (migration {MigrationId})",
+                row.LegacyKey, row.NewKey, row.MigrationId);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            row.AttemptCount += 1;
+            row.LastError = TruncateError(ex.Message);
+
+            if (row.AttemptCount >= MaxAttempts)
+            {
+                row.Status = "FailedPermanent";
+                MeepleAiMetrics.StorageMigrationObjectsMigratedTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>("status", "failed_permanent"),
+                    new KeyValuePair<string, object?>("category", row.Category));
+                _logger.LogError(
+                    ex,
+                    "Storage outbox row {RowId} marked FailedPermanent after {Attempts} attempts. " +
+                    "LegacyKey: {LegacyKey}; migration {MigrationId}",
+                    row.Id, row.AttemptCount, row.LegacyKey, row.MigrationId);
+            }
+            else
+            {
+                MeepleAiMetrics.StorageMigrationObjectsMigratedTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>("status", "failed"),
+                    new KeyValuePair<string, object?>("category", row.Category));
+                var backoffIndex = Math.Min(row.AttemptCount - 1, BackoffSchedule.Length - 1);
+                var nextAttempt = _timeProvider.GetUtcNow().UtcDateTime + BackoffSchedule[backoffIndex];
+
+                // ScheduledAt is init-only on the entity — bump via the change
+                // tracker rather than mutating the property directly.
+                dbContext.Entry(row).Property(nameof(StorageOperationOutboxEntity.ScheduledAt)).CurrentValue = nextAttempt;
+
+                _logger.LogWarning(
+                    ex,
+                    "Storage outbox row {RowId} attempt {Attempt}/{Max} failed; rescheduled to {NextAttempt}",
+                    row.Id, row.AttemptCount, MaxAttempts, nextAttempt);
+            }
+        }
+#pragma warning restore CA1031
+    }
+
+    private static string TruncateError(string message)
+    {
+        const int MaxLen = 1990;
+        return message.Length <= MaxLen ? message : message[..MaxLen] + "...";
+    }
+}

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
@@ -171,28 +171,57 @@ internal sealed class StorageOperationOutboxBackgroundService : BackgroundServic
             var s3Client = s3Storage.S3Client;
             var bucket = s3Storage.Options.BucketName;
 
-            // Copy legacy → new. CopyObjectAsync is atomic on the S3 side; if
-            // it succeeds the new key is durable before we delete the legacy.
-            await s3Client.CopyObjectAsync(new CopyObjectRequest
+            // Resilience to mid-migration cleanup races (review finding #3):
+            // if NewKey already exists (CopyObject succeeded on a previous
+            // attempt + DeleteObject failed) AND LegacyKey is gone (external
+            // cleanup, e.g. the orphan-cleanup script from PR #1316), we
+            // would otherwise call CopyObjectAsync against a missing source
+            // and burn retries until FailedPermanent — even though the move
+            // is effectively complete. Pre-check both keys and short-circuit
+            // to the delete step (or skip the move entirely).
+            var newKeyExists = await KeyExistsAsync(s3Client, bucket, row.NewKey, cancellationToken).ConfigureAwait(false);
+            if (!newKeyExists)
             {
-                SourceBucket = bucket,
-                SourceKey = row.LegacyKey,
-                DestinationBucket = bucket,
-                DestinationKey = row.NewKey,
-                ServerSideEncryptionMethod = s3Storage.Options.EnableEncryption
-                    ? ServerSideEncryptionMethod.AES256
-                    : ServerSideEncryptionMethod.None,
-            }, cancellationToken).ConfigureAwait(false);
+                // Standard path: copy legacy → new. CopyObjectAsync is atomic
+                // on the S3 side; if it succeeds the new key is durable
+                // before we delete the legacy.
+                await s3Client.CopyObjectAsync(new CopyObjectRequest
+                {
+                    SourceBucket = bucket,
+                    SourceKey = row.LegacyKey,
+                    DestinationBucket = bucket,
+                    DestinationKey = row.NewKey,
+                    ServerSideEncryptionMethod = s3Storage.Options.EnableEncryption
+                        ? ServerSideEncryptionMethod.AES256
+                        : ServerSideEncryptionMethod.None,
+                }, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Storage outbox: NewKey {NewKey} already exists (prior attempt or external migration); skipping copy",
+                    row.NewKey);
+            }
 
-            // Delete legacy after successful copy. If this fails, the row stays
-            // Pending — next attempt will see the new key already in place
-            // (CopyObjectAsync is idempotent under identical source/dest) and
-            // re-issue the delete.
-            await s3Client.DeleteObjectAsync(new DeleteObjectRequest
+            // Delete legacy. If the key was already cleaned up externally we
+            // swallow the NoSuchKey error — the migration goal (object lives
+            // at NewKey, not at LegacyKey) is already satisfied.
+            try
             {
-                BucketName = bucket,
-                Key = row.LegacyKey,
-            }, cancellationToken).ConfigureAwait(false);
+                await s3Client.DeleteObjectAsync(new DeleteObjectRequest
+                {
+                    BucketName = bucket,
+                    Key = row.LegacyKey,
+                }, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AmazonS3Exception delEx)
+                when (delEx.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation(
+                    delEx,
+                    "Storage outbox: LegacyKey {LegacyKey} already deleted externally; treating as success",
+                    row.LegacyKey);
+            }
 
             row.Status = "Sent";
             row.SentAt = _timeProvider.GetUtcNow().UtcDateTime;
@@ -257,5 +286,26 @@ internal sealed class StorageOperationOutboxBackgroundService : BackgroundServic
     {
         const int MaxLen = 1990;
         return message.Length <= MaxLen ? message : message[..MaxLen] + "...";
+    }
+
+    /// <summary>
+    /// Lightweight existence probe via <c>ListObjectsV2</c> with prefix=key
+    /// and MaxKeys=1. Returns true if S3 contains an object at exactly the
+    /// supplied key. Used by the move pre-check (review finding #3) to avoid
+    /// burning retries on copy-against-missing-source races.
+    /// </summary>
+    private static async Task<bool> KeyExistsAsync(IAmazonS3 s3Client, string bucket, string key, CancellationToken ct)
+    {
+        var response = await s3Client.ListObjectsV2Async(new ListObjectsV2Request
+        {
+            BucketName = bucket,
+            Prefix = key,
+            MaxKeys = 1,
+        }, ct).ConfigureAwait(false);
+
+        // ListObjectsV2 prefix-match: confirm the returned object key matches
+        // exactly (Prefix is a "starts-with" filter, so e.g. requesting key
+        // "a/b" could match "a/b" AND "a/bc/d").
+        return response.S3Objects.Any(o => string.Equals(o.Key, key, StringComparison.Ordinal));
     }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/StorageOperationOutboxEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/StorageOperationOutboxEntityConfiguration.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.DocumentProcessing;
+
+/// <summary>
+/// EF Core configuration for <see cref="StorageOperationOutboxEntity"/>
+/// (issue #1314 PR 2). Maps to <c>storage_operation_outbox</c> table.
+/// Drainer query (<c>WHERE status='Pending' AND scheduled_at &lt;= now ORDER BY scheduled_at</c>)
+/// is served by the composite index on (Status, ScheduledAt) — mirrors the
+/// EmailOutbox processor index.
+/// </summary>
+internal class StorageOperationOutboxEntityConfiguration : IEntityTypeConfiguration<StorageOperationOutboxEntity>
+{
+    public void Configure(EntityTypeBuilder<StorageOperationOutboxEntity> builder)
+    {
+        builder.ToTable("storage_operation_outbox");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id).IsRequired();
+        builder.Property(e => e.MigrationId).IsRequired();
+        builder.Property(e => e.LegacyKey).IsRequired().HasMaxLength(512);
+        builder.Property(e => e.NewKey).IsRequired().HasMaxLength(512);
+        builder.Property(e => e.Category).IsRequired().HasMaxLength(64);
+        builder.Property(e => e.ResourceKey).IsRequired().HasMaxLength(128);
+        builder.Property(e => e.ScheduledAt).IsRequired();
+        builder.Property(e => e.SentAt);
+        builder.Property(e => e.AttemptCount).IsRequired().HasDefaultValue(0);
+        builder.Property(e => e.LastError).HasMaxLength(2000);
+        builder.Property(e => e.CreatedAt).IsRequired();
+        builder.Property(e => e.Status).IsRequired().HasMaxLength(32).HasDefaultValue("Pending");
+
+        // Drainer pickup pattern: WHERE status='Pending' AND scheduled_at <= now ORDER BY scheduled_at
+        builder.HasIndex(e => new { e.Status, e.ScheduledAt })
+            .HasDatabaseName("IX_storage_operation_outbox_status_scheduled_at");
+
+        // Correlation lookups: per-migration-run progress queries + dashboards.
+        builder.HasIndex(e => e.MigrationId)
+            .HasDatabaseName("IX_storage_operation_outbox_migration_id");
+
+        // Idempotency at the move level: re-running a migration script must not
+        // produce duplicate rows for the same legacy key. Caller of EnqueueAsync
+        // checks this unique constraint to skip already-enqueued moves.
+        builder.HasIndex(e => e.LegacyKey)
+            .HasDatabaseName("IX_storage_operation_outbox_legacy_key")
+            .IsUnique();
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -259,6 +259,10 @@ public class MeepleAiDbContext : DbContext
     public DbSet<BoundedContexts.UserNotifications.Infrastructure.Entities.EmailOutboxEntity> EmailOutbox
         => Set<BoundedContexts.UserNotifications.Infrastructure.Entities.EmailOutboxEntity>();
 
+    // Issue #1314 PR 2: outbox pattern for storage layout migration (legacy → categorized).
+    public DbSet<BoundedContexts.DocumentProcessing.Infrastructure.Entities.StorageOperationOutboxEntity> StorageOperationOutbox
+        => Set<BoundedContexts.DocumentProcessing.Infrastructure.Entities.StorageOperationOutboxEntity>();
+
     // Issue #52: Email template admin management
     public DbSet<Api.Infrastructure.Entities.UserNotifications.EmailTemplateEntity> EmailTemplates => Set<Api.Infrastructure.Entities.UserNotifications.EmailTemplateEntity>();
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260519163520_AddStorageOperationOutbox_Issue1314.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260519163520_AddStorageOperationOutbox_Issue1314.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519163520_AddStorageOperationOutbox_Issue1314")]
+    partial class AddStorageOperationOutbox_Issue1314
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -4516,56 +4519,6 @@ namespace Api.Infrastructure.Migrations
                         .HasDatabaseName("ix_step_log_entries_step_id");
 
                     b.ToTable("step_log_entries", (string)null);
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.DomainEventLog.DomainEventLogEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("AggregateId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("AggregateType")
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<Guid>("EventId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("EventType")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<DateTime>("LoggedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime>("OccurredAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("PayloadJson")
-                        .IsRequired()
-                        .HasColumnType("jsonb");
-
-                    b.Property<Guid?>("UserId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("EventId")
-                        .IsUnique()
-                        .HasDatabaseName("ux_domain_event_logs_eventid");
-
-                    b.HasIndex("LoggedAt")
-                        .HasDatabaseName("ix_domain_event_logs_loggedat");
-
-                    b.HasIndex("UserId", "LoggedAt")
-                        .IsDescending(false, true)
-                        .HasDatabaseName("ix_domain_event_logs_user_loggedat");
-
-                    b.ToTable("domain_event_logs", (string)null);
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.EmailVerificationEntity", b =>

--- a/apps/api/src/Api/Infrastructure/Migrations/20260519163520_AddStorageOperationOutbox_Issue1314.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260519163520_AddStorageOperationOutbox_Issue1314.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStorageOperationOutbox_Issue1314 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "storage_operation_outbox",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    MigrationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LegacyKey = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    NewKey = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Category = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ResourceKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ScheduledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    AttemptCount = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "Pending")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_storage_operation_outbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_storage_operation_outbox_legacy_key",
+                table: "storage_operation_outbox",
+                column: "LegacyKey",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_storage_operation_outbox_migration_id",
+                table: "storage_operation_outbox",
+                column: "MigrationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_storage_operation_outbox_status_scheduled_at",
+                table: "storage_operation_outbox",
+                columns: new[] { "Status", "ScheduledAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "storage_operation_outbox");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Storage.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Storage.cs
@@ -1,4 +1,7 @@
 // Issue #1314 PR 2: Storage layout migration observability metrics.
+using Api.Services.Pdf;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using System.Diagnostics.Metrics;
 
 namespace Api.Observability;
@@ -28,14 +31,65 @@ internal static partial class MeepleAiMetrics
         description: "Storage-layout migration per-object move duration in milliseconds");
 
     /// <summary>
-    /// Gauge-like UpDownCounter for the currently-active layout version.
-    /// Value 1 is incremented each time the drainer pod starts; the
-    /// <c>layout_version</c> tag carries the human-readable label
-    /// ("v1-gameId", "v1-gameId-migrating", "v2-categorized").
-    /// Useful for confirming a deployed env is actually on the expected mode.
+    /// Per-drainer-lifecycle counter that increments once at startup, tagged
+    /// with the active <c>layout_version</c> label. This is an EVENT counter
+    /// — useful for tracking when a pod restart switched layout versions —
+    /// NOT a current-state indicator. For current state, query the
+    /// <c>meepleai.storage.layout.version.current</c> ObservableGauge
+    /// registered via <see cref="RegisterStorageLayoutVersionGauge"/>.
     /// </summary>
     public static readonly Counter<long> StorageLayoutVersionAnnouncementsTotal = Meter.CreateCounter<long>(
         name: "meepleai.storage.layout.version.announcements.total",
         unit: "events",
         description: "Storage-layout version announcement events on drainer startup, tagged by layout_version");
+
+    private static IServiceProvider? _layoutVersionGaugeRoot;
+
+    /// <summary>
+    /// Wires the current-layout-version gauge to the application's DI root.
+    /// Must be called once at startup (after <c>BuildServiceProvider</c>) so
+    /// the gauge can resolve <see cref="StorageLayoutOptions"/> at scrape
+    /// time. Idempotent — subsequent calls are ignored.
+    /// </summary>
+    internal static void RegisterStorageLayoutVersionGauge(IServiceProvider serviceProvider)
+    {
+        if (_layoutVersionGaugeRoot is not null)
+        {
+            return;
+        }
+        _layoutVersionGaugeRoot = serviceProvider;
+
+        // ObservableGauge resolves StorageLayoutOptions at scrape time, so a
+        // pod that flips StorageLayout:WriteMode without restart (e.g. via
+        // IOptionsMonitor) would surface the change on the next Prometheus
+        // scrape. As of this writing the application reads options once at
+        // startup, so in practice the gauge value matches the announcement
+        // counter — but the gauge is the correct queryable surface for
+        // "what layout version is active right now in this pod".
+        Meter.CreateObservableGauge<int>(
+            name: "meepleai.storage.layout.version.current",
+            observeValue: () =>
+            {
+                using var scope = _layoutVersionGaugeRoot!.CreateScope();
+                var options = scope.ServiceProvider.GetRequiredService<IOptions<StorageLayoutOptions>>().Value;
+                return new Measurement<int>(
+                    LayoutVersionToInt(options.WriteMode),
+                    new KeyValuePair<string, object?>("layout_version", options.LayoutVersionLabel));
+            },
+            unit: "version",
+            description: "Currently-active storage layout version. 1=v1-gameId, 2=v1-gameId-migrating, 3=v2-categorized");
+    }
+
+    /// <summary>
+    /// Stable integer encoding of the layout version. Prometheus does not
+    /// support string-valued gauges, so we expose an int + carry the human
+    /// label as a tag.
+    /// </summary>
+    private static int LayoutVersionToInt(StorageWriteMode mode) => mode switch
+    {
+        StorageWriteMode.Legacy => 1,
+        StorageWriteMode.Dual => 2,
+        StorageWriteMode.New => 3,
+        _ => 0,
+    };
 }

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Storage.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Storage.cs
@@ -1,0 +1,41 @@
+// Issue #1314 PR 2: Storage layout migration observability metrics.
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>
+    /// Counter for storage-migration objects moved by the outbox drainer.
+    /// Tagged by <c>status</c> (success | failed | failed_permanent) and
+    /// <c>category</c> (Pdf | SessionPhoto | GameImage | VisionSnapshot |
+    /// GamebookPhoto | PhotoBatch). Used by the Phase 1 dashboard to track
+    /// migration progress and error rate.
+    /// </summary>
+    public static readonly Counter<long> StorageMigrationObjectsMigratedTotal = Meter.CreateCounter<long>(
+        name: "meepleai.storage.migration.objects_migrated.total",
+        unit: "objects",
+        description: "Total storage-layout migration object moves, tagged by status + category");
+
+    /// <summary>
+    /// Histogram for per-object move duration in milliseconds (CopyObjectAsync
+    /// + DeleteObjectAsync round-trip). Tagged by <c>category</c>. Drives the
+    /// Phase 1 SLO ("p99 &lt; 5s per object").
+    /// </summary>
+    public static readonly Histogram<double> StorageMigrationDurationMs = Meter.CreateHistogram<double>(
+        name: "meepleai.storage.migration.duration",
+        unit: "ms",
+        description: "Storage-layout migration per-object move duration in milliseconds");
+
+    /// <summary>
+    /// Gauge-like UpDownCounter for the currently-active layout version.
+    /// Value 1 is incremented each time the drainer pod starts; the
+    /// <c>layout_version</c> tag carries the human-readable label
+    /// ("v1-gameId", "v1-gameId-migrating", "v2-categorized").
+    /// Useful for confirming a deployed env is actually on the expected mode.
+    /// </summary>
+    public static readonly Counter<long> StorageLayoutVersionAnnouncementsTotal = Meter.CreateCounter<long>(
+        name: "meepleai.storage.layout.version.announcements.total",
+        unit: "events",
+        description: "Storage-layout version announcement events on drainer startup, tagged by layout_version");
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -505,6 +505,10 @@ if (builder.Environment.IsDevelopment())
 
 var app = builder.Build();
 
+// Issue #1314 PR 2: wire the current-layout-version ObservableGauge once
+// the DI root is built. Idempotent — safe across HotReload restarts.
+Api.Observability.MeepleAiMetrics.RegisterStorageLayoutVersionGauge(app.Services);
+
 #if DEBUG
 if (app.Environment.IsDevelopment())
 {

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -344,7 +344,7 @@ builder.Services.AddMediatR(cfg =>
 builder.Services.AddVectorSearchServices(builder.Configuration);
 builder.Services.AddDomainServices();
 builder.Services.AddAiServices();
-builder.Services.AddPdfServices();
+builder.Services.AddPdfServices(builder.Configuration);
 builder.Services.AddChatServices();
 builder.Services.AddAdminServices();
 builder.Services.AddBggServices();

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -1,5 +1,6 @@
 using Api.Helpers;
 using Api.Infrastructure.Security;
+using Microsoft.Extensions.Options;
 
 namespace Api.Services.Pdf;
 
@@ -10,12 +11,16 @@ namespace Api.Services.Pdf;
 internal class BlobStorageService : IBlobStorageService
 {
     private readonly string _storageBasePath;
+    private readonly StorageLayoutOptions _layoutOptions;
     private readonly ILogger<BlobStorageService> _logger;
 
     public BlobStorageService(
         IConfiguration config,
+        IOptions<StorageLayoutOptions> layoutOptions,
         ILogger<BlobStorageService> logger)
     {
+        ArgumentNullException.ThrowIfNull(layoutOptions);
+        _layoutOptions = layoutOptions.Value;
         _logger = logger;
         _storageBasePath = config["PDF_STORAGE_PATH"] ?? Path.Combine(Directory.GetCurrentDirectory(), "pdf_uploads");
 
@@ -27,18 +32,58 @@ internal class BlobStorageService : IBlobStorageService
         }
     }
 
+    /// <summary>
+    /// Resolves the on-disk subdirectory under which a blob lives, based on
+    /// <see cref="StorageLayoutOptions.WriteMode"/> (for writes) or each
+    /// <see cref="StorageReadMode"/> candidate (for reads).
+    /// Legacy layout uses <c>{_storageBasePath}/{resourceKey}/</c>; the new
+    /// categorized layout uses <c>{_storageBasePath}/{category.ToS3Folder()}/{resourceKey}/</c>.
+    /// </summary>
+    private string ResolveResourceDir(BlobCategory category, string resourceKey, bool forNewLayout)
+    {
+        if (forNewLayout)
+        {
+            var categoryFolder = category.ToS3Folder();
+            var categoryDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, categoryFolder);
+            return PathSecurity.ValidatePathIsInDirectory(categoryDir, resourceKey);
+        }
+
+        return PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+    }
+
+    private IEnumerable<string> EnumerateReadDirs(BlobCategory category, string resourceKey)
+    {
+        switch (_layoutOptions.ReadMode)
+        {
+            case StorageReadMode.New:
+                yield return ResolveResourceDir(category, resourceKey, forNewLayout: true);
+                break;
+            case StorageReadMode.Legacy:
+                yield return ResolveResourceDir(category, resourceKey, forNewLayout: false);
+                break;
+            case StorageReadMode.Dual:
+                yield return ResolveResourceDir(category, resourceKey, forNewLayout: true);
+                yield return ResolveResourceDir(category, resourceKey, forNewLayout: false);
+                break;
+            default:
+                yield return ResolveResourceDir(category, resourceKey, forNewLayout: false);
+                break;
+        }
+    }
+
     public async Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
-        // PR 1 behavior preservation: ignore `category`, render legacy single-folder layout
-        // under _storageBasePath/{resourceKey}/. PR 2 will branch on category behind feature flag.
-        _ = category;
         try
         {
             // SECURITY: Validate resourceKey to prevent path traversal
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
             var fileId = Guid.NewGuid().ToString("N");
-            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+            // PR 2: WriteMode.New routes to the categorized subdirectory; Legacy
+            // (and Dual which writes the legacy copy first) routes to the
+            // resourceKey-only subdirectory under _storageBasePath.
+            var forNewLayout = _layoutOptions.WriteMode == StorageWriteMode.New;
+            var resourceDir = ResolveResourceDir(category, resourceKey, forNewLayout);
             Directory.CreateDirectory(resourceDir);
 
             var sanitizedFileName = SanitizeFileName(fileName);
@@ -82,7 +127,6 @@ internal class BlobStorageService : IBlobStorageService
 
     public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
-        _ = category; // PR 1 behavior preservation
         FileStream? fileStream = null;
         try
         {
@@ -90,18 +134,27 @@ internal class BlobStorageService : IBlobStorageService
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
-            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
-
-            if (files.Length == 0)
+            // PR 2: layout-aware retrieval — probe each candidate directory in
+            // ReadMode order. First non-empty match wins.
+            foreach (var resourceDir in EnumerateReadDirs(category, resourceKey))
             {
-                _logger.LogWarning("File not found for {FileId} in {ResourceKey}", fileId, resourceKey);
-                return Task.FromResult<Stream?>(null);
+                if (!Directory.Exists(resourceDir))
+                {
+                    continue;
+                }
+
+                var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
+                if (files.Length == 0)
+                {
+                    continue;
+                }
+
+                fileStream = new FileStream(files[0], FileMode.Open, FileAccess.Read, FileShare.Read);
+                return Task.FromResult<Stream?>(fileStream);
             }
 
-            var filePath = files[0];
-            fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return Task.FromResult<Stream?>(fileStream);
+            _logger.LogWarning("File not found for {FileId} in {ResourceKey}", fileId, resourceKey);
+            return Task.FromResult<Stream?>(null);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
@@ -123,26 +176,34 @@ internal class BlobStorageService : IBlobStorageService
 
     public async Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
     {
-        _ = category; // PR 1 behavior preservation
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
-            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
+            // PR 2: layout-aware deletion — sweep every candidate directory in
+            // ReadMode order so a mid-migration delete cleans up both copies.
+            var deletedAny = false;
+            foreach (var resourceDir in EnumerateReadDirs(category, resourceKey))
+            {
+                if (!Directory.Exists(resourceDir))
+                {
+                    continue;
+                }
 
-            if (files.Length == 0)
+                foreach (var file in Directory.GetFiles(resourceDir, $"{fileId}_*"))
+                {
+                    File.Delete(file);
+                    _logger.LogInformation("Deleted file at {FilePath}", file);
+                    deletedAny = true;
+                }
+            }
+
+            if (!deletedAny)
             {
                 _logger.LogWarning("File not found for deletion: {FileId} in {ResourceKey}", fileId, resourceKey);
                 return false;
-            }
-
-            foreach (var file in files)
-            {
-                File.Delete(file);
-                _logger.LogInformation("Deleted file at {FilePath}", file);
             }
 
             return await Task.FromResult(true).ConfigureAwait(false);
@@ -173,32 +234,41 @@ internal class BlobStorageService : IBlobStorageService
 
     public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
     {
-        _ = category; // PR 1 behavior preservation
         // SECURITY: Validate resourceKey to prevent path traversal
         PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-        var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
+        // PR 2: GetStoragePath returns the path under the active WriteMode layout
+        // (the path callers would observe when storing a new blob).
+        var forNewLayout = _layoutOptions.WriteMode == StorageWriteMode.New;
+        var resourceDir = ResolveResourceDir(category, resourceKey, forNewLayout);
         var sanitizedFileName = SanitizeFileName(fileName);
         return Path.Combine(resourceDir, $"{fileId}_{sanitizedFileName}");
     }
 
     public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
     {
-        _ = category; // PR 1 behavior preservation
         try
         {
             // SECURITY: Validate parameters to prevent path traversal (SEC-738, CWE-22, CWE-73)
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            var resourceDir = PathSecurity.ValidatePathIsInDirectory(_storageBasePath, resourceKey);
-            if (!Directory.Exists(resourceDir))
+            // PR 2: layout-aware existence check — return true if ANY candidate
+            // directory contains a file matching the fileId prefix.
+            foreach (var resourceDir in EnumerateReadDirs(category, resourceKey))
             {
-                return Task.FromResult(false);
+                if (!Directory.Exists(resourceDir))
+                {
+                    continue;
+                }
+
+                if (Directory.GetFiles(resourceDir, $"{fileId}_*").Length > 0)
+                {
+                    return Task.FromResult(true);
+                }
             }
 
-            var files = Directory.GetFiles(resourceDir, $"{fileId}_*");
-            return Task.FromResult(files.Length > 0);
+            return Task.FromResult(false);
         }
         catch (ArgumentException)
         {

--- a/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
@@ -1,6 +1,7 @@
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
+using Microsoft.Extensions.Options;
 using System.Globalization;
 
 namespace Api.Services.Pdf;
@@ -68,12 +69,14 @@ internal static class BlobStorageServiceFactory
             "Initialized S3 storage: endpoint={Endpoint}, bucket={Bucket}, region={Region}, encryption={Encryption}",
             options.Endpoint, options.BucketName, options.Region, options.EnableEncryption);
 
-        return new S3BlobStorageService(s3Client, options, logger);
+        var layoutOptions = serviceProvider.GetRequiredService<IOptions<StorageLayoutOptions>>();
+        return new S3BlobStorageService(s3Client, options, layoutOptions, logger);
     }
 
     private static IBlobStorageService CreateLocalStorageService(IServiceProvider serviceProvider, IConfiguration config)
     {
         var logger = serviceProvider.GetRequiredService<ILogger<BlobStorageService>>();
-        return new BlobStorageService(config, logger);
+        var layoutOptions = serviceProvider.GetRequiredService<IOptions<StorageLayoutOptions>>();
+        return new BlobStorageService(config, layoutOptions, logger);
     }
 }

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -2,6 +2,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.Helpers;
 using Api.Infrastructure.Security;
+using Microsoft.Extensions.Options;
 
 namespace Api.Services.Pdf;
 
@@ -11,17 +12,28 @@ namespace Api.Services.Pdf;
 /// </summary>
 internal sealed class S3BlobStorageService : IBlobStorageService
 {
+    /// <summary>
+    /// Legacy S3 prefix used by PR 1 (pre-layout-migration). All read paths
+    /// fall back to this prefix when <see cref="StorageLayoutOptions.ReadMode"/>
+    /// is <see cref="StorageReadMode.Dual"/> or <see cref="StorageReadMode.Legacy"/>.
+    /// </summary>
+    internal const string LegacyPrefix = "pdf_uploads";
+
     private readonly IAmazonS3 _s3Client;
     private readonly S3StorageOptions _options;
+    private readonly StorageLayoutOptions _layoutOptions;
     private readonly ILogger<S3BlobStorageService> _logger;
 
     public S3BlobStorageService(
         IAmazonS3 s3Client,
         S3StorageOptions options,
+        IOptions<StorageLayoutOptions> layoutOptions,
         ILogger<S3BlobStorageService> logger)
     {
         _s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        ArgumentNullException.ThrowIfNull(layoutOptions);
+        _layoutOptions = layoutOptions.Value;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -97,26 +109,14 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
-            // PR 2 will switch to category.ToS3Folder() behind STORAGE_WRITE_MODE flag.
-            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
-
-            var listRequest = new ListObjectsV2Request
-            {
-                BucketName = _options.BucketName,
-                Prefix = prefix,
-                MaxKeys = 1
-            };
-
-            var listResponse = await _s3Client.ListObjectsV2Async(listRequest, ct).ConfigureAwait(false);
-
-            if (listResponse.S3Objects.Count == 0)
+            // PR 2: layout-aware key resolution via TryResolveKeyAsync. Honors
+            // StorageLayoutOptions.ReadMode (Legacy / New / Dual-with-fallback).
+            var s3Key = await TryResolveKeyAsync(fileId, category, resourceKey, ct).ConfigureAwait(false);
+            if (s3Key is null)
             {
                 _logger.LogWarning("File not found in S3 for {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return null;
             }
-
-            var s3Key = listResponse.S3Objects[0].Key;
 
             var getRequest = new GetObjectRequest
             {
@@ -158,36 +158,36 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            // Find the exact S3 key (since filename may vary)
-            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
-            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
-
-            var listRequest = new ListObjectsV2Request
+            // PR 2: delete the object under BOTH layouts when ReadMode is Dual,
+            // so a mid-migration delete cleans up both copies. List up to 10
+            // matching objects per layout to handle the edge case of a
+            // duplicate fileId (should not happen but defensive).
+            var matchedAny = false;
+            foreach (var prefix in EnumerateReadPrefixes(category, resourceKey, fileId))
             {
-                BucketName = _options.BucketName,
-                Prefix = prefix,
-                MaxKeys = 10 // Allow multiple files with same ID (edge case)
-            };
+                var listResponse = await _s3Client.ListObjectsV2Async(new ListObjectsV2Request
+                {
+                    BucketName = _options.BucketName,
+                    Prefix = prefix,
+                    MaxKeys = 10,
+                }, ct).ConfigureAwait(false);
 
-            var listResponse = await _s3Client.ListObjectsV2Async(listRequest, ct).ConfigureAwait(false);
+                foreach (var s3Object in listResponse.S3Objects)
+                {
+                    matchedAny = true;
+                    await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
+                    {
+                        BucketName = _options.BucketName,
+                        Key = s3Object.Key,
+                    }, ct).ConfigureAwait(false);
+                    _logger.LogInformation("Deleted file from S3: {Key}", s3Object.Key);
+                }
+            }
 
-            if (listResponse.S3Objects.Count == 0)
+            if (!matchedAny)
             {
                 _logger.LogWarning("File not found for deletion: {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return false;
-            }
-
-            // Delete all matching files
-            foreach (var s3Object in listResponse.S3Objects)
-            {
-                var deleteRequest = new DeleteObjectRequest
-                {
-                    BucketName = _options.BucketName,
-                    Key = s3Object.Key
-                };
-
-                await _s3Client.DeleteObjectAsync(deleteRequest, ct).ConfigureAwait(false);
-                _logger.LogInformation("Deleted file from S3: {Key}", s3Object.Key);
             }
 
             return true;
@@ -228,21 +228,10 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
-            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
-
-            var listRequest = new ListObjectsV2Request
-            {
-                BucketName = _options.BucketName,
-                Prefix = prefix,
-                MaxKeys = 1
-            };
-
-            // Proper async with cancellation support
-            var listResponse = await _s3Client.ListObjectsV2Async(listRequest, cancellationToken)
-                .ConfigureAwait(false);
-
-            return listResponse.S3Objects.Count > 0;
+            // PR 2: layout-aware existence check. Returns true if ANY prefix
+            // (new or legacy, per ReadMode) resolves to a stored object.
+            var resolved = await TryResolveKeyAsync(fileId, category, resourceKey, cancellationToken).ConfigureAwait(false);
+            return resolved is not null;
         }
         catch (ArgumentException)
         {
@@ -270,16 +259,95 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 
     /// <summary>
     /// Constructs the canonical S3 key for a blob.
-    /// PR 1 of issue #1314 preserves the legacy <c>pdf_uploads/</c> prefix regardless
-    /// of <paramref name="category"/> to keep S3 key output byte-identical pre/post
-    /// the signature refactor. PR 2 will wire <see cref="BlobCategoryExtensions.ToS3Folder"/>
-    /// here behind the <c>STORAGE_WRITE_MODE</c> feature flag.
+    /// PR 2 of issue #1314 honors <see cref="StorageLayoutOptions.WriteMode"/>:
+    /// in <see cref="StorageWriteMode.Legacy"/> the key is rendered under the
+    /// legacy <c>pdf_uploads/</c> prefix; in <see cref="StorageWriteMode.New"/>
+    /// (and <see cref="StorageWriteMode.Dual"/>, reserved for rollback) it is
+    /// rendered under the categorized prefix via
+    /// <see cref="BlobCategoryExtensions.ToS3Folder"/>.
     /// </summary>
-    private static string GetS3Key(string fileId, BlobCategory category, string resourceKey, string sanitizedFileName)
+    private string GetS3Key(string fileId, BlobCategory category, string resourceKey, string sanitizedFileName)
+        => GetS3KeyForLayout(fileId, category, resourceKey, sanitizedFileName, _layoutOptions.WriteMode);
+
+    private static string GetS3KeyForLayout(string fileId, BlobCategory category, string resourceKey, string sanitizedFileName, StorageWriteMode mode)
     {
-        // PR 1: behavior preservation — ignore `category`, render legacy prefix.
-        _ = category;
-        return $"pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}";
+        var prefix = mode switch
+        {
+            StorageWriteMode.Legacy => LegacyPrefix,
+            StorageWriteMode.Dual => LegacyPrefix, // Dual-write writes the legacy copy first; the new copy is enqueued via the outbox.
+            StorageWriteMode.New => category.ToS3Folder(),
+            _ => LegacyPrefix,
+        };
+        return $"{prefix}/{resourceKey}/{fileId}_{sanitizedFileName}";
+    }
+
+    /// <summary>
+    /// S3 prefix shape <c>{prefix}/{resourceKey}/{fileId}_</c> used by the
+    /// <c>ListObjectsV2</c> probes inside Retrieve / Delete / Exists / Presign.
+    /// Returns the layout dictated by <see cref="StorageLayoutOptions.ReadMode"/>:
+    /// <see cref="StorageReadMode.New"/> probes only the categorized prefix,
+    /// <see cref="StorageReadMode.Legacy"/> probes only the legacy prefix,
+    /// <see cref="StorageReadMode.Dual"/> probes the new prefix first and
+    /// falls back to the legacy prefix on miss.
+    /// </summary>
+    private async Task<string?> TryResolveKeyAsync(
+        string fileId,
+        BlobCategory category,
+        string resourceKey,
+        CancellationToken ct)
+    {
+        async Task<string?> ProbeAsync(string prefixKey)
+        {
+            var listResponse = await _s3Client
+                .ListObjectsV2Async(new ListObjectsV2Request
+                {
+                    BucketName = _options.BucketName,
+                    Prefix = prefixKey,
+                    MaxKeys = 1,
+                }, ct)
+                .ConfigureAwait(false);
+            return listResponse.S3Objects.Count > 0 ? listResponse.S3Objects[0].Key : null;
+        }
+
+        var newPrefix = $"{category.ToS3Folder()}/{resourceKey}/{fileId}_";
+        var legacyPrefix = $"{LegacyPrefix}/{resourceKey}/{fileId}_";
+
+        return _layoutOptions.ReadMode switch
+        {
+            StorageReadMode.New => await ProbeAsync(newPrefix).ConfigureAwait(false),
+            StorageReadMode.Legacy => await ProbeAsync(legacyPrefix).ConfigureAwait(false),
+            StorageReadMode.Dual => await ProbeAsync(newPrefix).ConfigureAwait(false)
+                                   ?? await ProbeAsync(legacyPrefix).ConfigureAwait(false),
+            _ => await ProbeAsync(legacyPrefix).ConfigureAwait(false),
+        };
+    }
+
+    /// <summary>
+    /// Enumerates the prefixes that <see cref="DeleteAsync"/> must scan based
+    /// on <see cref="StorageLayoutOptions.ReadMode"/>. In Dual mode both
+    /// layouts are deleted to ensure a complete cleanup mid-migration.
+    /// </summary>
+    private IEnumerable<string> EnumerateReadPrefixes(BlobCategory category, string resourceKey, string fileId)
+    {
+        var newPrefix = $"{category.ToS3Folder()}/{resourceKey}/{fileId}_";
+        var legacyPrefix = $"{LegacyPrefix}/{resourceKey}/{fileId}_";
+
+        switch (_layoutOptions.ReadMode)
+        {
+            case StorageReadMode.New:
+                yield return newPrefix;
+                break;
+            case StorageReadMode.Legacy:
+                yield return legacyPrefix;
+                break;
+            case StorageReadMode.Dual:
+                yield return newPrefix;
+                yield return legacyPrefix;
+                break;
+            default:
+                yield return legacyPrefix;
+                break;
+        }
     }
 
     /// <summary>
@@ -298,26 +366,15 @@ internal sealed class S3BlobStorageService : IBlobStorageService
             PathSecurity.ValidateIdentifier(fileId, nameof(fileId));
             PathSecurity.ValidateIdentifier(resourceKey, nameof(resourceKey));
 
-            // Find the exact S3 key
-            // PR 1 behavior preservation: prefix unchanged from legacy gameId-based layout.
-            var prefix = $"pdf_uploads/{resourceKey}/{fileId}_";
-
-            var listRequest = new ListObjectsV2Request
-            {
-                BucketName = _options.BucketName,
-                Prefix = prefix,
-                MaxKeys = 1
-            };
-
-            var listResponse = await _s3Client.ListObjectsV2Async(listRequest).ConfigureAwait(false);
-
-            if (listResponse.S3Objects.Count == 0)
+            // PR 2: layout-aware key resolution; presign whatever the active
+            // ReadMode finds (new-only / legacy-only / dual-with-fallback).
+            var s3Key = await TryResolveKeyAsync(fileId, category, resourceKey, CancellationToken.None).ConfigureAwait(false);
+            if (s3Key is null)
             {
                 _logger.LogWarning("Cannot generate pre-signed URL: file not found {FileId} in {Category}/{ResourceKey}", fileId, category, resourceKey);
                 return null;
             }
 
-            var s3Key = listResponse.S3Objects[0].Key;
             var expiry = expirySeconds ?? _options.PresignedUrlExpirySeconds;
 
             var request = new GetPreSignedUrlRequest

--- a/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
+++ b/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
@@ -1,0 +1,100 @@
+namespace Api.Services.Pdf;
+
+/// <summary>
+/// Feature flags driving the 5-phase storage layout migration (issue #1314 PR 2).
+///
+/// Default (safe): Legacy + Dual + false → identical behavior to PR 1
+/// (S3 keys under <c>pdf_uploads/{resourceKey}/...</c>, reads attempt both
+/// layouts to support graceful cutover). Phase progression is driven by
+/// flipping these flags in deployed configuration; no code change is
+/// required between phases.
+/// </summary>
+internal sealed class StorageLayoutOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json / env-var binding.
+    /// </summary>
+    public const string SectionName = "StorageLayout";
+
+    /// <summary>
+    /// Controls the S3 key prefix used by <c>StoreAsync</c> for new uploads.
+    /// </summary>
+    public StorageWriteMode WriteMode { get; init; } = StorageWriteMode.Legacy;
+
+    /// <summary>
+    /// Controls the S3 key prefix used by Retrieve/Delete/Exists/GetPresignedDownloadUrl
+    /// for existing objects. In <see cref="StorageReadMode.Dual"/> the implementation
+    /// tries the new layout first and falls back to the legacy layout on miss.
+    /// </summary>
+    public StorageReadMode ReadMode { get; init; } = StorageReadMode.Dual;
+
+    /// <summary>
+    /// Enables the <c>StorageOperationOutboxBackgroundService</c> drainer.
+    /// When false, the background service is registered but exits the loop
+    /// after one tick — useful in dev / test environments and during
+    /// Phase 0 (deploy infra without triggering the migration).
+    /// </summary>
+    public bool MigrationEnabled { get; init; }
+
+    /// <summary>
+    /// Layout-version label exposed via Prometheus gauge <c>storage_layout_version</c>
+    /// and the <c>S3StorageHealthCheck</c> output. Derived from <see cref="WriteMode"/>.
+    /// </summary>
+    public string LayoutVersionLabel => WriteMode switch
+    {
+        StorageWriteMode.Legacy => "v1-gameId",
+        StorageWriteMode.Dual => "v1-gameId-migrating",
+        StorageWriteMode.New => "v2-categorized",
+        _ => "unknown",
+    };
+}
+
+/// <summary>
+/// Controls the S3 prefix for new uploads.
+/// </summary>
+internal enum StorageWriteMode
+{
+    /// <summary>
+    /// New uploads land at <c>pdf_uploads/{resourceKey}/{fileId}_{filename}</c>
+    /// (pre-PR 2 behavior). Phase 0 + Phase 1 default.
+    /// </summary>
+    Legacy,
+
+    /// <summary>
+    /// New uploads land at BOTH legacy AND new layout (dual-write window).
+    /// Optional middle phase — currently UNUSED by PR 2 but reserved for
+    /// rollback safety if Phase 2 cutover needs to be aborted.
+    /// </summary>
+    Dual,
+
+    /// <summary>
+    /// New uploads land at <c>{category.ToS3Folder()}/{resourceKey}/{fileId}_{filename}</c>
+    /// (post-migration target). Phase 2 onwards.
+    /// </summary>
+    New,
+}
+
+/// <summary>
+/// Controls the S3 prefix used by reads (Retrieve / Delete / Exists / Presign).
+/// </summary>
+internal enum StorageReadMode
+{
+    /// <summary>
+    /// Reads only look in the legacy layout. Used in Phase 4 cleanup once
+    /// the legacy folder has been emptied.
+    /// </summary>
+    Legacy,
+
+    /// <summary>
+    /// Reads look in the new layout first, then fall back to the legacy
+    /// layout on miss. Phase 0 → Phase 3 default — supports outstanding
+    /// presigned URLs and any object not yet migrated.
+    /// </summary>
+    Dual,
+
+    /// <summary>
+    /// Reads only look in the new layout. Used in Phase 3 once the grace
+    /// window for outstanding presigned URLs has elapsed.
+    /// </summary>
+    New,
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
@@ -125,7 +125,11 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
             };
 
             var logger = new Mock<ILogger<S3BlobStorageService>>().Object;
-            _sut = new S3BlobStorageService(_s3Client, _options, logger);
+            _sut = new S3BlobStorageService(
+                _s3Client,
+                _options,
+                Microsoft.Extensions.Options.Options.Create(new StorageLayoutOptions()),
+                logger);
 
             // Quick smoke test to verify S3 connectivity
             using var probe = new MemoryStream("probe"u8.ToArray());

--- a/apps/api/tests/Api.Tests/Unit/Services/BlobStorageServiceLayoutTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/BlobStorageServiceLayoutTests.cs
@@ -1,0 +1,181 @@
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Api.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for the local-filesystem <see cref="BlobStorageService"/> under
+/// each <see cref="StorageLayoutOptions"/> mode (issue #1314 PR 2).
+///
+/// Verifies the behavior matrix:
+/// - WriteMode = Legacy → new uploads land at <c>{basePath}/{resourceKey}/{fileId}_{filename}</c>
+/// - WriteMode = New    → new uploads land at <c>{basePath}/{category.ToS3Folder()}/{resourceKey}/{fileId}_{filename}</c>
+/// - ReadMode  = Dual   → reads probe new layout first, fall back to legacy
+/// - ReadMode  = Legacy → reads only probe legacy layout
+/// - ReadMode  = New    → reads only probe new layout
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Issue", "1314")]
+public sealed class BlobStorageServiceLayoutTests : IDisposable
+{
+    private readonly string _basePath;
+
+    public BlobStorageServiceLayoutTests()
+    {
+        _basePath = Path.Combine(Path.GetTempPath(), $"meepleai-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_basePath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_basePath))
+        {
+            Directory.Delete(_basePath, recursive: true);
+        }
+    }
+
+    private BlobStorageService CreateSut(StorageLayoutOptions options)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["PDF_STORAGE_PATH"] = _basePath })
+            .Build();
+        var wrapped = Options.Create(options);
+        return new BlobStorageService(config, wrapped, NullLogger<BlobStorageService>.Instance);
+    }
+
+    [Fact]
+    public async Task StoreAsync_WriteModeLegacy_FilePath_UnderResourceKeyDirectly()
+    {
+        var sut = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy });
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        var result = await sut.StoreAsync(stream, "rule.pdf", BlobCategory.Pdf, "game-abc");
+
+        result.Success.Should().BeTrue();
+        result.FilePath.Should().StartWith(Path.Combine(_basePath, "game-abc") + Path.DirectorySeparatorChar);
+        result.FilePath.Should().NotContain(Path.Combine(_basePath, "pdfs"));
+    }
+
+    [Fact]
+    public async Task StoreAsync_WriteModeNew_FilePath_UnderCategorizedFolder()
+    {
+        var sut = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.New });
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        var result = await sut.StoreAsync(stream, "rule.pdf", BlobCategory.Pdf, "game-abc");
+
+        result.Success.Should().BeTrue();
+        result.FilePath.Should().StartWith(Path.Combine(_basePath, "pdfs", "game-abc") + Path.DirectorySeparatorChar);
+    }
+
+    [Fact]
+    public async Task RetrieveAsync_ReadModeDual_FindsLegacyWhenNewMissing()
+    {
+        // Arrange: write under Legacy, read under Dual → should fall back.
+        var writer = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy });
+        using (var stream = new MemoryStream(new byte[] { 4, 2 }))
+        {
+            await writer.StoreAsync(stream, "f.pdf", BlobCategory.Pdf, "g1");
+        }
+        var fileId = ExtractFileId(writer);
+
+        var reader = CreateSut(new StorageLayoutOptions
+        {
+            WriteMode = StorageWriteMode.Legacy,
+            ReadMode = StorageReadMode.Dual,
+        });
+
+        using var retrieved = await reader.RetrieveAsync(fileId, BlobCategory.Pdf, "g1");
+
+        retrieved.Should().NotBeNull("dual-mode read must fall back to the legacy layout when no new-layout object exists");
+    }
+
+    [Fact]
+    public async Task RetrieveAsync_ReadModeNew_DoesNotFindLegacy()
+    {
+        // Arrange: write under Legacy, but try to read under New-only → must miss.
+        var writer = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy });
+        using (var stream = new MemoryStream(new byte[] { 9 }))
+        {
+            await writer.StoreAsync(stream, "f.pdf", BlobCategory.Pdf, "g2");
+        }
+        var fileId = ExtractFileId(writer);
+
+        var reader = CreateSut(new StorageLayoutOptions
+        {
+            WriteMode = StorageWriteMode.New,
+            ReadMode = StorageReadMode.New,
+        });
+
+        using var retrieved = await reader.RetrieveAsync(fileId, BlobCategory.Pdf, "g2");
+
+        retrieved.Should().BeNull("New-only read mode must NOT fall back to the legacy layout");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReadModeDual_SweepsBothLayouts()
+    {
+        // Arrange: write the same fileId under BOTH layouts (manual setup).
+        var writerLegacy = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy });
+        using (var stream = new MemoryStream(new byte[] { 1 }))
+        {
+            await writerLegacy.StoreAsync(stream, "f.pdf", BlobCategory.Pdf, "g3");
+        }
+
+        var writerNew = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.New });
+        using (var stream = new MemoryStream(new byte[] { 2 }))
+        {
+            await writerNew.StoreAsync(stream, "f.pdf", BlobCategory.Pdf, "g3");
+        }
+
+        // Sanity: both directories exist.
+        Directory.Exists(Path.Combine(_basePath, "g3")).Should().BeTrue();
+        Directory.Exists(Path.Combine(_basePath, "pdfs", "g3")).Should().BeTrue();
+
+        var deleter = CreateSut(new StorageLayoutOptions
+        {
+            ReadMode = StorageReadMode.Dual,
+        });
+
+        var legacyFiles = Directory.GetFiles(Path.Combine(_basePath, "g3"), "*");
+        var legacyFileId = ExtractFileIdFromFileName(legacyFiles[0]);
+
+        // Delete via dual mode — sweeps BOTH layouts.
+        var deleted = await deleter.DeleteAsync(legacyFileId, BlobCategory.Pdf, "g3");
+
+        deleted.Should().BeTrue();
+        Directory.GetFiles(Path.Combine(_basePath, "g3"), $"{legacyFileId}_*")
+            .Should().BeEmpty("dual-mode delete must clean the legacy layout");
+    }
+
+    /// <summary>
+    /// Convenience: read back the most recently uploaded fileId from the
+    /// last write the supplied service performed. Brittle, but adequate for
+    /// the test scope (one file per resourceKey).
+    /// </summary>
+    private string ExtractFileId(BlobStorageService _)
+    {
+        // We don't expose fileId on the test surface; in the tests above, the
+        // call sequence guarantees exactly one file per resourceKey directory,
+        // so we infer it from disk.
+        foreach (var dir in Directory.EnumerateDirectories(_basePath, "*", SearchOption.AllDirectories))
+        {
+            foreach (var file in Directory.GetFiles(dir, "*_*"))
+            {
+                return ExtractFileIdFromFileName(file);
+            }
+        }
+        throw new InvalidOperationException("No fileId found on disk for fixture");
+    }
+
+    private static string ExtractFileIdFromFileName(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var idx = fileName.IndexOf('_', StringComparison.Ordinal);
+        return idx > 0 ? fileName[..idx] : fileName;
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Services/BlobStorageServiceLayoutTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/BlobStorageServiceLayoutTests.cs
@@ -73,6 +73,51 @@ public sealed class BlobStorageServiceLayoutTests : IDisposable
     }
 
     [Fact]
+    public async Task RetrieveAsync_ReadModeDual_PrefersNewLayoutWhenBothExist()
+    {
+        // Phase 2 ordering invariant: once the drainer has moved an object
+        // to the new prefix, subsequent reads MUST serve from the new copy,
+        // not from the legacy copy (which is about to be / has been deleted).
+        // Reverting the probe order in TryResolveKeyAsync / EnumerateReadDirs
+        // would silently break this invariant — this test guards against it.
+
+        var writerLegacy = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy });
+        var writerNew = CreateSut(new StorageLayoutOptions { WriteMode = StorageWriteMode.New });
+
+        // Plant distinct payloads under each layout so we can identify which
+        // copy was served. The fileId returned by the legacy upload is the
+        // one we'll query — the new-layout write uses a different fileId so
+        // we plant it manually under the same fileId to simulate a successful
+        // drainer move.
+        using (var stream = new MemoryStream(new byte[] { 0xAA }))
+        {
+            await writerLegacy.StoreAsync(stream, "f.pdf", BlobCategory.Pdf, "g-both");
+        }
+
+        var legacyDir = Path.Combine(_basePath, "g-both");
+        var legacyFiles = Directory.GetFiles(legacyDir, "*");
+        var fileId = ExtractFileIdFromFileName(legacyFiles[0]);
+
+        // Simulate the drainer's post-CopyObject state: same fileId exists
+        // under BOTH layouts. The new-layout copy has different bytes (0xBB).
+        var newDir = Path.Combine(_basePath, "pdfs", "g-both");
+        Directory.CreateDirectory(newDir);
+        await File.WriteAllBytesAsync(Path.Combine(newDir, $"{fileId}_f.pdf"), new byte[] { 0xBB });
+
+        var reader = CreateSut(new StorageLayoutOptions { ReadMode = StorageReadMode.Dual });
+
+        using var retrieved = await reader.RetrieveAsync(fileId, BlobCategory.Pdf, "g-both");
+
+        retrieved.Should().NotBeNull();
+        var buf = new byte[1];
+        var bytesRead = await retrieved!.ReadAsync(buf.AsMemory());
+        bytesRead.Should().Be(1);
+        buf[0].Should().Be(0xBB,
+            because: "Dual ReadMode MUST serve the NEW layout copy when both exist " +
+                     "— reverting this priority would break Phase 2 cutover correctness");
+    }
+
+    [Fact]
     public async Task RetrieveAsync_ReadModeDual_FindsLegacyWhenNewMissing()
     {
         // Arrange: write under Legacy, read under Dual → should fall back.

--- a/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
@@ -2,6 +2,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Api.Services.Pdf;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using System.Net;
 using Xunit;
@@ -34,7 +35,14 @@ public sealed class S3BlobStorageServiceTests : IDisposable
             ForcePathStyle = false
         };
 
-        _sut = new S3BlobStorageService(_mockS3Client.Object, _options, _mockLogger.Object);
+        // PR 2 introduces StorageLayoutOptions. Default is Legacy write + Dual
+        // read which matches pre-PR-2 behavior, so existing test assertions
+        // (legacy `pdf_uploads/...` prefix) still hold.
+        _sut = new S3BlobStorageService(
+            _mockS3Client.Object,
+            _options,
+            Options.Create(new StorageLayoutOptions()),
+            _mockLogger.Object);
     }
 
     public void Dispose()

--- a/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
@@ -1,0 +1,74 @@
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Api.Tests.Unit.Services;
+
+/// <summary>
+/// Tests for <see cref="StorageLayoutOptions"/> (issue #1314 PR 2).
+/// Verifies default values for Phase 0 deploy + configuration binding +
+/// <see cref="StorageLayoutOptions.LayoutVersionLabel"/> derivation.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Issue", "1314")]
+public sealed class StorageLayoutOptionsTests
+{
+    [Fact]
+    public void Defaults_AreSafeForPhase0Deploy()
+    {
+        // Phase 0 invariant: a fresh deploy must not trigger any migration
+        // behavior. Defaults are Legacy write + Dual read + migration off.
+        var options = new StorageLayoutOptions();
+
+        options.WriteMode.Should().Be(StorageWriteMode.Legacy);
+        options.ReadMode.Should().Be(StorageReadMode.Dual);
+        options.MigrationEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LayoutVersionLabel_DerivesFromWriteMode()
+    {
+        new StorageLayoutOptions { WriteMode = StorageWriteMode.Legacy }
+            .LayoutVersionLabel.Should().Be("v1-gameId");
+        new StorageLayoutOptions { WriteMode = StorageWriteMode.Dual }
+            .LayoutVersionLabel.Should().Be("v1-gameId-migrating");
+        new StorageLayoutOptions { WriteMode = StorageWriteMode.New }
+            .LayoutVersionLabel.Should().Be("v2-categorized");
+    }
+
+    [Theory]
+    [InlineData("Legacy", StorageWriteMode.Legacy)]
+    [InlineData("Dual", StorageWriteMode.Dual)]
+    [InlineData("New", StorageWriteMode.New)]
+    internal void ConfigBinding_WriteModeFromStringValue(string configValue, StorageWriteMode expected)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["StorageLayout:WriteMode"] = configValue,
+                ["StorageLayout:ReadMode"] = "Dual",
+                ["StorageLayout:MigrationEnabled"] = "false",
+            })
+            .Build();
+
+        var bound = config.GetSection(StorageLayoutOptions.SectionName).Get<StorageLayoutOptions>();
+        bound.Should().NotBeNull();
+        bound!.WriteMode.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ConfigBinding_MigrationEnabledTrue_WhenStringTrue()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["StorageLayout:MigrationEnabled"] = "true",
+            })
+            .Build();
+
+        var bound = config.GetSection(StorageLayoutOptions.SectionName).Get<StorageLayoutOptions>();
+        bound.Should().NotBeNull();
+        bound!.MigrationEnabled.Should().BeTrue();
+    }
+}

--- a/apps/api/tests/Api.Tests/Unit/Services/StorageOperationOutboxServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/StorageOperationOutboxServiceTests.cs
@@ -1,0 +1,96 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Services.Pdf;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="StorageOperationOutboxService"/> (issue #1314 PR 2).
+/// Verifies enqueue persistence, idempotency on duplicate LegacyKey, and the
+/// LegacyKey → NewKey derivation rule.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Issue", "1314")]
+public sealed class StorageOperationOutboxServiceTests
+{
+    [Fact]
+    public async Task EnqueueAsync_ValidInputs_PersistsRowWithDerivedNewKey()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new StorageOperationOutboxService(db, TimeProvider.System, NullLogger<StorageOperationOutboxService>.Instance);
+
+        var migrationId = Guid.NewGuid();
+        var inserted = await sut.EnqueueAsync(
+            migrationId,
+            legacyKey: "pdf_uploads/game-abc/file123_rulebook.pdf",
+            category: BlobCategory.Pdf,
+            resourceKey: "game-abc");
+
+        inserted.Should().BeTrue();
+
+        var row = await db.StorageOperationOutbox.SingleAsync();
+        row.MigrationId.Should().Be(migrationId);
+        row.LegacyKey.Should().Be("pdf_uploads/game-abc/file123_rulebook.pdf");
+        row.NewKey.Should().Be("pdfs/game-abc/file123_rulebook.pdf");
+        row.Category.Should().Be("Pdf");
+        row.ResourceKey.Should().Be("game-abc");
+        row.Status.Should().Be("Pending");
+        row.AttemptCount.Should().Be(0);
+        row.SentAt.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(BlobCategory.Pdf, "pdfs")]
+    [InlineData(BlobCategory.SessionPhoto, "session-photos")]
+    [InlineData(BlobCategory.GameImage, "game-images")]
+    [InlineData(BlobCategory.VisionSnapshot, "vision-snapshots")]
+    [InlineData(BlobCategory.GamebookPhoto, "gamebook-photos")]
+    [InlineData(BlobCategory.PhotoBatch, "photo-batches")]
+    public async Task EnqueueAsync_DerivesNewKey_FromCategoryPrefix(BlobCategory category, string expectedPrefix)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new StorageOperationOutboxService(db, TimeProvider.System, NullLogger<StorageOperationOutboxService>.Instance);
+
+        await sut.EnqueueAsync(
+            Guid.NewGuid(),
+            legacyKey: "pdf_uploads/res-1/abc_file.bin",
+            category: category,
+            resourceKey: "res-1");
+
+        var row = await db.StorageOperationOutbox.SingleAsync();
+        row.NewKey.Should().StartWith($"{expectedPrefix}/");
+        row.NewKey.Should().EndWith("/res-1/abc_file.bin");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task EnqueueAsync_InvalidLegacyKey_ThrowsArgumentException(string? legacyKey)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new StorageOperationOutboxService(db, TimeProvider.System, NullLogger<StorageOperationOutboxService>.Instance);
+
+        var act = async () => await sut.EnqueueAsync(Guid.NewGuid(), legacyKey!, BlobCategory.Pdf, "res-1");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task EnqueueAsync_InvalidResourceKey_ThrowsArgumentException(string? resourceKey)
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new StorageOperationOutboxService(db, TimeProvider.System, NullLogger<StorageOperationOutboxService>.Instance);
+
+        var act = async () => await sut.EnqueueAsync(Guid.NewGuid(), "pdf_uploads/x/y_z.pdf", BlobCategory.Pdf, resourceKey!);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/docs/for-developers/operations/2026-05-19-storage-layout-migration-runbook.md
+++ b/docs/for-developers/operations/2026-05-19-storage-layout-migration-runbook.md
@@ -1,0 +1,312 @@
+# Storage Layout Migration Runbook — Issue #1314 PR 2
+
+**Status**: Phase 0 ready (PR 2 deployed, flags default-safe). Phase 1+ to be triggered by operator.
+**Owner**: Backend dev + DevOps
+**Estimated downtime**: 0 (zero-downtime rollout)
+**Estimated duration**: ~30min staging / 2-4h prod (Phase 1)
+
+---
+
+## Context
+
+Issue #1314 migrates S3 blob storage from legacy single-folder layout
+`pdf_uploads/{resourceKey}/{fileId}_{filename}` to a categorized layout
+`{category}/{resourceKey}/{fileId}_{filename}` where `{category}` is one of:
+
+| Category | Folder |
+|----------|--------|
+| `Pdf` | `pdfs/` |
+| `SessionPhoto` | `session-photos/` |
+| `GameImage` | `game-images/` |
+| `VisionSnapshot` | `vision-snapshots/` |
+| `GamebookPhoto` | `gamebook-photos/` |
+| `PhotoBatch` | `photo-batches/` |
+
+The migration uses an **Outbox pattern** (mirror of `EmailOutboxBackgroundService`):
+each object move is enqueued as a row in `storage_operation_outbox`, and a
+background drainer (`StorageOperationOutboxBackgroundService`) executes the
+move with retry + exponential backoff `[1m, 5m, 30m, 2h, 6h]` × MaxAttempts 5.
+
+---
+
+## Phase 0 — Deploy infra (no behavior change)
+
+**Goal**: PR 2 merged + deployed. Flags default-safe. No user-visible change.
+
+**Configuration** (default values, no override needed):
+
+```yaml
+StorageLayout:
+  WriteMode: Legacy        # New uploads → pdf_uploads/...
+  ReadMode: Dual           # Reads probe new prefix first, fall back to legacy
+  MigrationEnabled: false  # Drainer service starts but no-ops
+```
+
+**Verification**:
+
+```bash
+# 1. Health endpoint reports legacy layout version
+curl https://staging.meepleai.app/health/storage | jq '.data.layout_version'
+# Expected: "v1-gameId"
+
+# 2. Drainer pod logs the disabled-mode startup message
+kubectl logs deploy/api-staging | grep "StorageOperationOutbox"
+# Expected: "started but disabled (StorageLayout:MigrationEnabled=false)"
+
+# 3. Outbox table empty
+psql -c "SELECT COUNT(*) FROM storage_operation_outbox;"
+# Expected: 0
+```
+
+**Rollback (Phase 0)**: revert PR 2. No data migration was started.
+
+---
+
+## Phase 1 — Background migration (drainer ON)
+
+**Goal**: existing objects under legacy layout are moved to categorized layout
+in the background. New uploads still land at legacy layout.
+
+**Pre-requisites**:
+- ⬜ R2 backup snapshot of current state (T-zero snapshot for rollback)
+- ⬜ Phase 0 verified for ≥ 24h (no anomalies)
+- ⬜ Migration script ready to enumerate existing objects + enqueue outbox rows
+
+### Step 1.1 — Pre-migration audit
+
+```bash
+# Count objects under legacy prefix
+aws s3 ls s3://${BUCKET}/pdf_uploads/ --recursive --summarize | tail -2
+# Expected: ~150 objects staging, more in prod
+
+# Save manifest for rollback safety
+aws s3 ls s3://${BUCKET}/pdf_uploads/ --recursive > /tmp/manifest-pre-${BUCKET}.tsv
+```
+
+### Step 1.2 — Enable drainer flag
+
+```bash
+kubectl set env deploy/api-staging STORAGE_MIGRATION_ENABLED=true
+kubectl rollout restart deploy/api-staging
+```
+
+Wait for pod ready:
+```bash
+kubectl rollout status deploy/api-staging --timeout=120s
+```
+
+### Step 1.3 — Enqueue migration rows
+
+Run the enumerator script (TODO: provide `scripts/enqueue-storage-migration.sh`
+that lists `pdf_uploads/*` and POSTs to an admin endpoint that calls
+`IStorageOperationOutboxService.EnqueueAsync` per row).
+
+```bash
+./scripts/enqueue-storage-migration.sh \
+  --bucket ${BUCKET} \
+  --migration-id $(uuidgen) \
+  --prefix pdf_uploads/
+# Output: "Enqueued N migration rows under migration <UUID>"
+```
+
+### Step 1.4 — Monitor progress
+
+```bash
+# Prometheus / Grafana — storage migration dashboard
+open https://grafana.staging.meepleai.app/d/storage-migration
+
+# Or via psql
+psql -c "SELECT status, COUNT(*) FROM storage_operation_outbox GROUP BY status;"
+# Expected progression: Pending decreasing, Sent increasing.
+```
+
+**SLO**: `pending_rows` reaches 0 within 30 min (staging) / 2-4h (prod).
+
+**Alert**: any FailedPermanent row → halt migration, investigate, do NOT
+proceed to Phase 2.
+
+### Step 1.5 — Verify all rows Sent
+
+```bash
+psql -c "
+  SELECT COUNT(*) FILTER (WHERE status = 'Sent')          AS sent,
+         COUNT(*) FILTER (WHERE status = 'Pending')       AS pending,
+         COUNT(*) FILTER (WHERE status = 'FailedPermanent') AS failed
+  FROM storage_operation_outbox
+  WHERE migration_id = '<UUID-from-1.3>';
+"
+# Expected: sent = N, pending = 0, failed = 0
+```
+
+**Rollback (Phase 1)**: set `STORAGE_MIGRATION_ENABLED=false`, restart pods.
+Already-moved objects exist under BOTH layouts (CopyObject is followed by
+DeleteObject, but if DeleteObject failed the legacy copy survives — the
+outbox row stays Pending). Restore from T-zero snapshot if needed.
+
+---
+
+## Phase 2 — Switch writes to new layout
+
+**Goal**: new uploads land at the new categorized layout. Reads still dual.
+
+**Pre-requisites**:
+- ✅ Phase 1 complete (all rows Sent, 0 Pending, 0 FailedPermanent)
+- ⬜ Visual verification in R2 console: new prefixes (`pdfs/`, `session-photos/`, etc.) populated, `pdf_uploads/` empty (or close to it)
+
+### Step 2.1 — Flip WriteMode
+
+```bash
+kubectl set env deploy/api-staging \
+  STORAGE_WRITE_MODE=New \
+  STORAGE_READ_MODE=Dual
+kubectl rollout restart deploy/api-staging
+```
+
+### Step 2.2 — Verification
+
+```bash
+# Health endpoint reports the new layout
+curl https://staging.meepleai.app/health/storage | jq '.data.layout_version'
+# Expected: "v2-categorized"
+
+# Upload a test PDF + verify landing prefix
+curl -X POST -F "file=@test.pdf" https://staging.meepleai.app/api/v1/pdfs/upload
+aws s3 ls s3://${BUCKET}/pdfs/ --recursive | grep test.pdf
+# Expected: object exists under pdfs/{resourceKey}/...
+
+# Negative check: no new objects under pdf_uploads/
+aws s3 ls s3://${BUCKET}/pdf_uploads/ --recursive | wc -l
+# Expected: stable or decreasing (NO new objects appearing)
+```
+
+**Rollback (Phase 2)**: set `STORAGE_WRITE_MODE=Legacy`, restart. Any
+objects written under new layout during Phase 2 remain reachable via
+ReadMode=Dual.
+
+---
+
+## Phase 3 — Deprecation legacy reads
+
+**Goal**: presigned URLs emitted pre-cutover have expired (TTL_max = 3600s
++ buffer = 1h). All reads now target new layout only.
+
+**Pre-requisites**:
+- ✅ Phase 2 complete + verified for ≥ 24h (grace window for presigned URLs)
+- ✅ All new uploads observed at new prefix
+
+### Step 3.1 — Flip ReadMode
+
+```bash
+kubectl set env deploy/api-staging STORAGE_READ_MODE=New
+kubectl rollout restart deploy/api-staging
+```
+
+### Step 3.2 — Monitor for legacy-read attempts
+
+```bash
+# Counter should stay at 0
+curl https://staging.meepleai.app/metrics | grep storage_legacy_reads_total
+# Expected: 0 or absent
+```
+
+**Rollback (Phase 3)**: set `STORAGE_READ_MODE=Dual`, restart. Re-enables
+legacy fallback immediately.
+
+---
+
+## Phase 4 — Cleanup
+
+**Goal**: legacy `pdf_uploads/` folder removed from S3, feature flags removed
+from codebase.
+
+**Pre-requisites**:
+- ✅ Phase 3 complete + monitored for ≥ 7 days (no legacy-read attempts)
+
+### Step 4.1 — Move legacy folder to `_trash/`
+
+```bash
+# Reuse the #520 cleanup script pattern — move under a dated _trash/ for
+# safety, NOT outright delete.
+DATE=$(date +%F)
+aws s3 mv s3://${BUCKET}/pdf_uploads/ \
+          s3://${BUCKET}/_trash/${DATE}/pdf_uploads/ --recursive
+```
+
+### Step 4.2 — Drop feature flags from codebase
+
+Follow-up PR removes `StorageLayoutOptions`, the WriteMode/ReadMode branching
+in `S3BlobStorageService`/`BlobStorageService`, and the
+`StorageOperationOutboxBackgroundService` (or keeps it for future migrations).
+
+### Step 4.3 — Drop `_trash/` after 7d retention
+
+```bash
+aws s3 rm s3://${BUCKET}/_trash/${DATE}/pdf_uploads/ --recursive
+```
+
+---
+
+## Backout — Full reverse-migration
+
+**When**: Phase 2 detected as broken AND Phase 1 already complete (new objects
+exist at categorized prefixes).
+
+### Step B.1 — Halt new uploads at new layout
+
+```bash
+kubectl set env deploy/api-staging STORAGE_WRITE_MODE=Legacy
+kubectl rollout restart deploy/api-staging
+```
+
+### Step B.2 — Reverse-move objects
+
+Run the inverse of Phase 1 (script TBD: `scripts/reverse-storage-migration.sh`):
+list each categorized prefix and `aws s3 mv` back to `pdf_uploads/`.
+
+### Step B.3 — Verify health endpoint
+
+```bash
+curl https://staging.meepleai.app/health/storage | jq '.data.layout_version'
+# Expected: "v1-gameId" (back to Phase 0 state)
+```
+
+---
+
+## Observability
+
+### Prometheus metrics (PR 2 adds these)
+
+| Metric | Type | Tags | Description |
+|--------|------|------|-------------|
+| `meepleai_storage_migration_objects_migrated_total` | Counter | `status`, `category` | Per-object move outcomes (success / failed / failed_permanent) |
+| `meepleai_storage_migration_duration` | Histogram | `category` | Per-object move duration (CopyObject + DeleteObject) |
+| `meepleai_storage_layout_version_announcements_total` | Counter | `layout_version` | Drainer startup announcements (1 per pod restart) |
+
+### Grafana dashboard
+
+To be added at `infra/grafana/dashboards/storage-migration.json`. Panels:
+1. Progress: `sum(rate(meepleai_storage_migration_objects_migrated_total{status="success"}[5m]))`
+2. Error rate: `sum(rate(meepleai_storage_migration_objects_migrated_total{status="failed"}[5m]))`
+3. P99 duration: `histogram_quantile(0.99, rate(meepleai_storage_migration_duration_bucket[5m]))`
+4. Layout version: `meepleai_storage_layout_version_announcements_total`
+
+### Structured logs
+
+All drainer log entries are tagged with `MigrationId` (UUID per Step 1.3 batch)
+and `LegacyKey`/`NewKey`. Query in Loki:
+
+```logql
+{app="api"} |= "Storage outbox" | json | migration_id="<UUID>"
+```
+
+---
+
+## References
+
+- Issue #1314 — Refactor IBlobStorageService PDF storage layout
+- Issue #520 — R2 orphan PDF cleanup (predecessor cleanup script pattern)
+- PR #1322 — PR 1 signature refactor (behavior-preserving)
+- This PR — PR 2 layout migration (this runbook)
+- `EmailOutboxBackgroundService` — outbox pattern template
+- `apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs` — feature flags
+- `apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs` — drainer


### PR DESCRIPTION
## Summary

PR 2 of 2 for issue #1314 — **storage layout migration with Outbox-backed 5-phase rollout** (D1 decision from spec-panel deliberation).

**Stacked on PR #1322** (PR 1 — signature refactor). Target this branch base = `feature/issue-1314-blob-category-signature`. Once PR 1 lands on `main-dev`, this PR's base will auto-update to `main-dev` and become directly mergeable.

**Phase 0 is safe to deploy immediately**: all feature flags default to legacy behavior. Phase 1+ requires operator action via the runbook below.

## What this PR implements

### Outbox infrastructure
Mirror of `EmailOutboxBackgroundService` pattern (UserNotifications BC, proven in prod via I5 auth fixes 2026-05-06):

- `StorageOperationOutboxEntity` + EntityConfiguration + EF migration `AddStorageOperationOutbox_Issue1314`
  - 3 indexes: pickup composite `(Status, ScheduledAt)`, migration correlation `MigrationId`, **unique `LegacyKey`** (idempotent enqueue)
  - State machine: `Pending → Sent | FailedPermanent` (same as EmailOutbox)
- `IStorageOperationOutboxService` + implementation
  - Idempotent `EnqueueAsync` (swallows Postgres unique-violation 23505)
  - Derives `LegacyKey → NewKey` by category-prefix substitution
- `StorageOperationOutboxBackgroundService` drainer
  - Polls 30s, batch 25, exponential backoff `[1m, 5m, 30m, 2h, 6h]`, MaxAttempts 5
  - Per-row flush (cancellation safety mid-batch)
  - Disabled by default — flag flip starts Phase 1

### Feature flags (`StorageLayoutOptions`)

```yaml
StorageLayout:
  WriteMode: Legacy        # Legacy (default) | Dual (reserved) | New
  ReadMode: Dual           # Legacy | Dual (default — new-first, legacy-fallback) | New
  MigrationEnabled: false  # false (default — drainer no-ops)
```

Derived `LayoutVersionLabel`: `v1-gameId` (Legacy) / `v1-gameId-migrating` (Dual) / `v2-categorized` (New) — exposed via Prometheus + health endpoint.

### Layout switching in implementations

| Service | Layout switch |
|---|---|
| `S3BlobStorageService.GetS3Key` | Honors `WriteMode` for new uploads |
| `S3BlobStorageService.TryResolveKeyAsync` | Honors `ReadMode` (Legacy/New/Dual-with-fallback) for Retrieve/Exists/Presign |
| `S3BlobStorageService.DeleteAsync` (`EnumerateReadPrefixes`) | Sweeps **both** layouts in Dual mode for clean delete |
| `BlobStorageService` (local FS) | Equivalent switching via `ResolveResourceDir` + `EnumerateReadDirs` |

### Observability (OpenTelemetry via `System.Diagnostics.Metrics`)

Added partial class `MeepleAiMetrics.Storage.cs`:
- `meepleai.storage.migration.objects_migrated.total` (Counter, tags: `status`, `category`)
- `meepleai.storage.migration.duration` (Histogram, tag: `category`)
- `meepleai.storage.layout.version.announcements.total` (Counter, tag: `layout_version`)

### Runbook

`docs/for-developers/operations/2026-05-19-storage-layout-migration-runbook.md` — step-by-step 5-phase rollout + backout procedure + Grafana dashboard spec + Loki structured-log query.

| Phase | Trigger | Risk |
|---|---|---|
| 0 — Deploy infra | This PR merge | None (flags default-safe) |
| 1 — Background migration | Flip `MigrationEnabled=true` + enqueue script | Low (drainer is resilient) |
| 2 — Switch writes | Flip `WriteMode=New` | Medium (new uploads land new prefix) |
| 3 — Deprecate legacy reads | Flip `ReadMode=New` after 1h grace | Low |
| 4 — Cleanup | Move `pdf_uploads/` to `_trash/{date}/`, 7d retention | None (reversible) |

## Test plan

- [x] `dotnet build apps/api/src/Api` — 0 errors 0 warnings
- [x] `dotnet build apps/api/tests/Api.Tests` — 0 errors (pre-existing warnings)
- [x] **24 PR 2 unit tests** passed (7s):
  - 5 `StorageLayoutOptionsTests` — defaults + binding + label derivation
  - 5 `BlobStorageServiceLayoutTests` — WriteMode/ReadMode matrix on local FS
  - 14 `StorageOperationOutboxServiceTests` — enqueue + NewKey derivation × 6 categories + invalid-input guards
- [ ] Full backend test suite — running on CI (no regressions expected; existing S3 tests use default `StorageLayoutOptions()` which preserves PR 1 legacy behavior)

## Out of scope (deferred follow-up)

- Enqueue script (`scripts/enqueue-storage-migration.sh`) — enumerates `pdf_uploads/*` and calls `IStorageOperationOutboxService.EnqueueAsync` per row. Will be authored at the start of Phase 1 (operator-driven).
- Reverse-migration script (`scripts/reverse-storage-migration.sh`) — Phase B backout.
- Grafana dashboard JSON commit (`infra/grafana/dashboards/storage-migration.json`) — placeholder in runbook.
- Local-FS migration tooling — out of scope per runbook note (`local` provider is dev-only).
- Test matrix categories 5+6 (restore-from-trash + migration-speed) — require staging fixtures, deferred to Phase 1 operator-driven validation.

## References

- Closes design decision D1 of #1314 (cutover model — Outbox-backed dual-write, zero downtime)
- Stacked on PR #1322 (PR 1 — signature refactor + `BlobCategory` enum)
- Tracking: #1314
- Spec-panel D1/D2/D3 deliberation: https://github.com/meepleAi-app/meepleai-monorepo/issues/1314#issuecomment-4488244050
- Predecessor pattern: `EmailOutboxBackgroundService` (UserNotifications BC, I5 auth fixes 2026-05-06)
- Predecessor cleanup script pattern: #520 (R2 orphan PDF cleanup runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
