### PR TITLE
fix(test): #1315 follow-up — diary mock returns raw array, not envelope

### DIFF
--- a/apps/web/e2e/v2-states/game-night-detail.spec.ts
+++ b/apps/web/e2e/v2-states/game-night-detail.spec.ts
@@ -150,6 +150,12 @@ async function mockGameNightApis(page: Page, options: MockOptions): Promise<void
     }
     await route.continue();
   });
+  // Issue #1315 — diary endpoint returns a raw `DiaryEntryDto[]`, not a
+  // paginated envelope. The previous `{ items: [] }` shape was returned as-is
+  // by `getGameNightDiary` (no zod validation on the result), so the
+  // `[...entries]` spread in `GameNightDiaryPanel:36` threw `TypeError: entries
+  // is not iterable` and surfaced via the Next.js `error.tsx` boundary as
+  // "Errore serate di gioco" instead of the hero render.
   await page
     .context()
     .route(new RegExp(`/api/v1/game-nights/${EVENT_ID}/diary(\\?.*)?$`), async (route: Route) => {
@@ -157,7 +163,7 @@ async function mockGameNightApis(page: Page, options: MockOptions): Promise<void
         return route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ items: [] }),
+          body: JSON.stringify([]),
         });
       }
       await route.continue();


### PR DESCRIPTION
## Summary

Fourth and (hopefully final) fix in the #1315 chain. After PRs #1319 (proxy bypass), #1321 (locale=it), #1325 (UUID fixture), verify round [run 26112298093] reduced failures from 26 → 18. AC-H1.c (cancelled) now passes; AC-H1.a, b, e still fail at \`expect(actionBar).toBeVisible()\`.

The error-context page snapshot revealed the page is no longer the not-found shell — it's the **Next.js error.tsx boundary** ("Errore serate di gioco"). A React exception is escaping the render.

## Root cause

\`mockGameNightApis\` stubs \`/api/v1/game-nights/{id}/diary\` with \`body: { items: [] }\` — a paginated-envelope shape. The diary endpoint contract is a raw \`DiaryEntryDto[]\`. The client \`getGameNightDiary()\` does NOT zod-validate the response, it just \`return response ?? []\`. So \`entries\` ends up as \`{ items: [] }\` (object), and [\`GameNightDiaryPanel.tsx:36\`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/web/src/components/game-night/GameNightDiaryPanel.tsx#L36)'s \`[...entries].sort(...)\` throws \`TypeError: entries is not iterable\`. The exception propagates to the route segment error boundary.

## Fix

Mock body \`JSON.stringify([])\` instead of \`{ items: [] }\` — matches the actual endpoint contract.

## Why this only affects 3 of 5 AC-H1 scenarios

- AC-H1.a/b/e (Published events) → render GameNightDetailView's full flow → mounts GameNightDiaryPanel → throws → error boundary ❌
- AC-H1.c (Cancelled) → renders only Hero + CancelledBanner, no diary panel → passes ✅
- AC-H1.d (Not-found) → renders not-found shell early, no diary panel → passes ✅

## Verification

Post-merge: re-dispatch \`Visual Regression — Migrated Routes\` with \`project_filter=v2-states\`. Expected all 5 AC-H1 + a11y violation checks pass + 10 PNG baselines materialize.