### PR TITLE
fix(ci): #1315 — upload bootstrap baselines even on partial test failure

### DIFF
--- a/.github/workflows/visual-regression-migrated.yml
+++ b/.github/workflows/visual-regression-migrated.yml
@@ -136,8 +136,14 @@ jobs:
         env:
           CI: true
 
+      # Issue #1315 — `always()` so the artifact uploads even when SOME tests
+      # in the bootstrap step fail. Bootstrapping is independent per spec file:
+      # one flaky spec shouldn't strand the baselines of the 30 other specs
+      # that completed successfully. The downstream review still sees only the
+      # PNGs that were actually generated; failing specs leave no snapshot.
       - name: Upload visual-migrated bootstrapped baselines
         if: |
+          always() &&
           github.event_name == 'workflow_dispatch' && inputs.mode == 'bootstrap' &&
           (inputs.project_filter == 'both' || inputs.project_filter == 'visual-migrated')
         uses: actions/upload-artifact@v7
@@ -149,6 +155,7 @@ jobs:
 
       - name: Upload v2-states bootstrapped baselines
         if: |
+          always() &&
           github.event_name == 'workflow_dispatch' && inputs.mode == 'bootstrap' &&
           (inputs.project_filter == 'both' || inputs.project_filter == 'v2-states')
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Fifth and final PR in the #1315 chain. After 4 fixes (PR #1319 proxy bypass, #1321 locale-it, #1325 UUID fixture, #1328 diary mock) reduced failures **28 → 26 → 18 → 6**, the latest verify run [26116265697](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26116265697) successfully generated **36 PNG baselines** for `v2-states/game-night-create.spec.ts` AND **304/310 specs passed**. The 6 residual failures are an unrelated 5th bug in `game-nights-index.spec.ts:filtered-empty @ mobile` (mock returns 500 → renders error state instead of empty).

**But**: the upload artifact step skipped because of those 6 unrelated failures, so the 36 baselines were lost. GitHub Actions defaults `if:` to implicit `success()`; any upstream failure causes the step to skip.

## Fix

Add `always()` to the `if:` blocks of both `Upload visual-migrated bootstrapped baselines` and `Upload v2-states bootstrapped baselines` steps. Bootstrapping is per-spec independent — one flaky spec shouldn't strand the baselines of the 30 other specs that completed.

The conditional gating (`workflow_dispatch` + `mode` + `project_filter`) is preserved; only the implicit success() gate is removed.

## Verification

Post-merge: re-dispatch `Visual Regression — Migrated Routes` with `project_filter=v2-states`. Expected:
- Same ~6 game-nights-index failures (tracked separately — out of #1315 scope)
- Upload step now fires regardless → artifact `v2-states-baselines-NNN` materializes with the 36 PNG
- Manual commit + PR of the 10 game-night-create PNGs → closes the SP7 #950 W4 follow-up

## Test plan

- [ ] CI Dev Fast green
- [ ] Post-merge dispatch produces a `v2-states-baselines-NNN` artifact even with the 6 residual game-nights-index failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)