### PR TITLE
chore(infra): cleanup stale GameEntity references in comments (refs #1320)

### DIFF
--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
@@ -56,7 +56,7 @@ internal class GameToolkitEntityConfiguration : IEntityTypeConfiguration<GameToo
         // Concurrency token
         builder.Property(e => e.RowVersion).IsRowVersion();
 
-        // FK to GameEntity (SharedGame) — optional
+        // FK to SharedGameEntity — optional
         builder.HasOne(e => e.Game)
             .WithMany()
             .HasForeignKey(e => e.GameId)

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -33,7 +33,7 @@ internal static class PdfSeeder
     /// </summary>
     /// <param name="db">Database context.</param>
     /// <param name="manifest">The loaded seed manifest (used to resolve game-PDF mappings).</param>
-    /// <param name="gameMap">Dictionary mapping BggId to GameEntity.Id, produced by GameSeeder.</param>
+    /// <param name="gameMap">Dictionary mapping BggId to SharedGame.Id, produced by GameSeeder (post-Phase2d: legacy GameEntity bridge removed).</param>
     /// <param name="systemUserId">System/admin user ID used for the UploadedByUserId FK.</param>
     /// <param name="primaryBlob">Primary blob storage service (destination for PDFs).</param>
     /// <param name="seedBlob">Seed blob reader (source bucket for seed PDFs).</param>
@@ -101,22 +101,23 @@ internal static class PdfSeeder
 
             try
             {
-                // Resolve GameEntity.Id from the gameMap built by GameSeeder
+                // Resolve SharedGame.Id from the gameMap built by GameSeeder (post-Phase2d: GameEntity bridge removed).
                 if (!gameMap.TryGetValue(entry.BggId!.Value, out var gameId))
                 {
                     logger.LogWarning(
-                        "PdfSeeder: no GameEntity found for BggId={BggId} ('{Title}'). Skipping blob PDF.",
+                        "PdfSeeder: no SharedGame found for BggId={BggId} ('{Title}'). Skipping blob PDF.",
                         entry.BggId, entry.Title);
                     skipped++;
                     continue;
                 }
 
-                // Resolve the SharedGameId (community-catalog id). PdfDocumentEntity now stores SharedGameId directly
-                // after the 2026-04-19 migration, so this is the key field for both idempotency and persistence.
+                // Validate the SharedGameId exists (identity-mapped lookup post-Phase2d).
+                // PdfDocumentEntity now stores SharedGameId directly after the 2026-04-19 migration,
+                // so this is the key field for both idempotency and persistence.
                 if (!gameIdToSharedId.TryGetValue(gameId, out var sharedGameId))
                 {
                     logger.LogWarning(
-                        "PdfSeeder: no SharedGameId linked to GameEntity {GameId} ('{Title}'). Skipping blob PDF.",
+                        "PdfSeeder: SharedGameId {GameId} ('{Title}') not found in catalog. Skipping blob PDF.",
                         gameId, entry.Title);
                     skipped++;
                     continue;


### PR DESCRIPTION
## Summary

Follow-up to PR #1347 (Phase 2d) — applies the 3 cosmetic nits raised by the independent code reviewer.

## Changes

- \`PdfSeeder.cs:36\` — XML doc updated to reference \`SharedGame.Id\`
- \`PdfSeeder.cs:104-123\` — Inline comments + LogWarning messages: "GameEntity" → "SharedGame" / "SharedGameId"
- \`GameToolkitEntityConfiguration.cs:59\` — \`// FK to GameEntity (SharedGame)\` → \`// FK to SharedGameEntity\`

## What this does NOT do

- No behavioral changes
- No schema changes
- No new tests needed (comments and log strings only)

## Verification

Build clean: 0 errors, 0 warnings.

Refs: #1320
Predecessor: PR #1347 (already merged)