### PR TITLE
docs(claude): document known flaky tests baseline (refs #1349)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,21 @@ tests/Api.Tests/          # Backend test suite
 | Snapshot drift | `make seed-index` (rigenera) or `make dev` (fallback) — [workflow](./docs/for-developers/workflows/snapshot-seed-workflow.md#compat-gate--exit-codes) |
 | Full ops reference | [docs/for-developers/operations/operations-manual.md](./docs/for-developers/operations/operations-manual.md) |
 
+## Known Flaky Tests
+
+Tests confirmed failing on `main-dev` baseline independently of any specific PR. Triage tracked in #1349.
+
+| Test | File | First observed | Reason | Action |
+|---|---|---|---|---|
+| `Should_Fail_When_GameId_Is_Empty` | `Api.Tests` | #1341 baseline | Pre-existing validator behavior mismatch | Document, do not block CI |
+| `Handle_EmptyGuid_ReturnsNull` | `Api.Tests` | #1341 baseline | Pre-existing | Document |
+| `Handle_WithSearchFilter_ReturnsMatchingGames` | `Api.Tests` | #1341 baseline | EF Core InMemory provider does not support `ILike` (Postgres-specific) | Integration test only — exclude from unit suite |
+| `*_S3Storage_*` (2 tests) | `Api.Tests` | #1341 baseline | Mock verification timing / strict mode mismatch | Document |
+
+**Policy**: PRs MUST NOT cause the unit-test fail count to grow above this baseline. The CI `Backend Fast` job is non-required while these are pending fixes; a future cleanup will either fix the root cause (e.g., switch ILike test to integration) or skip with `[Trait("Skip", "<issue#>")]`.
+
+When fixing one of these, remove the row from this table in the same PR.
+
 ## AI Assistant Rules
 
 ### 🔒 Active Freezes


### PR DESCRIPTION
## Summary

Documents the 5 pre-existing flaky tests confirmed on \`main-dev\` baseline. These are NOT regressions from Phase 2d (#1320/#1347) — they were noted in PR #1341 closing review.

## Why CLAUDE.md

PRs touching test code can stumble on these failures and waste time chasing root causes that are already triaged. Surface the baseline so future contributors:
1. Know not to attempt fixing as part of unrelated work
2. Have a clear remediation path for each (root cause + action)
3. Can update the table when actually fixing one

## Policy

\`Backend Fast\` CI job is non-required while these are pending. PRs must NOT grow the unit-test fail count above this baseline.

When fixing one of these tests, remove the row from the table in the same PR.

## Predecessor / Refs

- Phase 2d PR: #1347
- Phase 2d cleanup: #1351
- Cluster A + D fixes: #1352
- Cluster B + E + G fixes: #1354
- Triage tracking: #1349 (closing this completes the triage)
- Master tracking: #1320