### PR TITLE
fix(storage): #1357 strip x-amz-tagging-directive header (R2 compat)

### DIFF
--- a/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
@@ -65,12 +65,34 @@ internal static class BlobStorageServiceFactory
         var credentials = new BasicAWSCredentials(options.AccessKey, options.SecretKey);
         var s3Client = new AmazonS3Client(credentials, s3Config);
 
+        // Issue #1357: Cloudflare R2 rejects `x-amz-tagging-directive` with HTTP 501
+        // "not implemented". The AWS SDK adds this header to every CopyObject request
+        // by default (S3MetadataDirective.COPY), blocking the storage-layout-migration
+        // drainer (#1314) against R2 buckets. Stripping it on a BeforeRequestEvent hook
+        // is safe across providers: AWS S3 treats absent + present-with-default-COPY
+        // identically (source object tags are preserved either way), and R2/MinIO/B2
+        // simply stop returning 501.
+        s3Client.BeforeRequestEvent += StripUnsupportedR2Headers;
+
         logger.LogInformation(
             "Initialized S3 storage: endpoint={Endpoint}, bucket={Bucket}, region={Region}, encryption={Encryption}",
             options.Endpoint, options.BucketName, options.Region, options.EnableEncryption);
 
         var layoutOptions = serviceProvider.GetRequiredService<IOptions<StorageLayoutOptions>>();
         return new S3BlobStorageService(s3Client, options, layoutOptions, logger);
+    }
+
+    /// <summary>
+    /// Issue #1357: removes S3 extension headers that Cloudflare R2 does not implement.
+    /// Currently strips <c>x-amz-tagging-directive</c>; extend the allowlist when new
+    /// AWS-only extensions surface in drainer/copy paths.
+    /// </summary>
+    internal static void StripUnsupportedR2Headers(object? sender, RequestEventArgs e)
+    {
+        if (e is WebServiceRequestEventArgs args)
+        {
+            args.Headers.Remove("x-amz-tagging-directive");
+        }
     }
 
     private static IBlobStorageService CreateLocalStorageService(IServiceProvider serviceProvider, IConfiguration config)


### PR DESCRIPTION
## Summary

- Strip `x-amz-tagging-directive` header from outbound S3 requests via `BeforeRequestEvent` hook on `AmazonS3Client`. Cloudflare R2 returns HTTP 501 for this header (AWS S3 extension not implemented by R2).
- Single-line fix at the factory level → both `StorageOperationOutboxBackgroundService` (drainer) and `ReverseStorageMigrationCommandHandler` inherit it via DI.

## Context

- Issue: #1357 (P0 blocker for #1314 Phase 1 storage migration)
- Discovered during the staging Phase 1 rollout on 2026-05-20: enqueue 216 PDF objects → 0/216 Sent, all `WRN Storage outbox row ... attempt 1/5 failed` with the R2 501.
- Drainer disabled on staging post-fix discovery: `StorageLayout__MigrationEnabled=false` in `infra/secrets/storage.secret` (manually flipped). Pending rows are idempotent — re-enabling the flag after this PR ships will retry from `AttemptCount` and complete the move.

## Why this is safe

- AWS S3 treats absent + present-with-default-COPY identically: when `TaggingDirective` is COPY, source object tags are preserved. The same outcome happens when the header is absent. R2/MinIO/B2 just stop returning 501.
- Single-handler attached at client construction; nothing else mutates request headers, so the hook runs deterministically.
- No new dependencies, no public API surface change.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [ ] Re-deploy to staging, flip `StorageLayout__MigrationEnabled=true`, observe drainer process pending rows from migration `2f50ce96-ac0c-4b0b-be22-4afa172085ca` (216 currently Pending).
- [ ] Verify `pdf_uploads/` objects move to the new categorized layout and Sent = 216, Pending = 0, FailedPermanent = 0.

## Follow-ups (out of scope here)

- Add MinIO integration test that asserts CopyObject works without the tagging header (catches future SDK regressions). Tracked separately.
- Audit other AWS-only extension headers that may surface in `PutObject` / `GetObject` paths against R2.

## Refs

- #1314 — Refactor IBlobStorageService PDF storage layout (closed 2026-05-19)
- #1333 — Phase 1 storage migration trigger (closed 2026-05-20)
- #1357 — bug(storage): Phase 1 drainer fails against R2 — `x-amz-tagging-directive` header rejected
- PR #1327 — Storage layout migration with Outbox-backed 5-phase rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
