### PR TITLE
release: #1357 R2 tagging-directive fix → main-staging (Phase 1 unblock)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,21 @@ tests/Api.Tests/          # Backend test suite
 | Snapshot drift | `make seed-index` (rigenera) or `make dev` (fallback) — [workflow](./docs/for-developers/workflows/snapshot-seed-workflow.md#compat-gate--exit-codes) |
 | Full ops reference | [docs/for-developers/operations/operations-manual.md](./docs/for-developers/operations/operations-manual.md) |
 
+## Known Flaky Tests
+
+Tests confirmed failing on `main-dev` baseline independently of any specific PR. Triage tracked in #1349.
+
+| Test | File | First observed | Reason | Action |
+|---|---|---|---|---|
+| `Should_Fail_When_GameId_Is_Empty` | `Api.Tests` | #1341 baseline | Pre-existing validator behavior mismatch | Document, do not block CI |
+| `Handle_EmptyGuid_ReturnsNull` | `Api.Tests` | #1341 baseline | Pre-existing | Document |
+| `Handle_WithSearchFilter_ReturnsMatchingGames` | `Api.Tests` | #1341 baseline | EF Core InMemory provider does not support `ILike` (Postgres-specific) | Integration test only — exclude from unit suite |
+| `*_S3Storage_*` (2 tests) | `Api.Tests` | #1341 baseline | Mock verification timing / strict mode mismatch | Document |
+
+**Policy**: PRs MUST NOT cause the unit-test fail count to grow above this baseline. The CI `Backend Fast` job is non-required while these are pending fixes; a future cleanup will either fix the root cause (e.g., switch ILike test to integration) or skip with `[Trait("Skip", "<issue#>")]`.
+
+When fixing one of these, remove the row from this table in the same PR.
+
 ## AI Assistant Rules
 
 ### 🔒 Active Freezes

--- a/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageServiceFactory.cs
@@ -65,12 +65,34 @@ internal static class BlobStorageServiceFactory
         var credentials = new BasicAWSCredentials(options.AccessKey, options.SecretKey);
         var s3Client = new AmazonS3Client(credentials, s3Config);
 
+        // Issue #1357: Cloudflare R2 rejects `x-amz-tagging-directive` with HTTP 501
+        // "not implemented". The AWS SDK adds this header to every CopyObject request
+        // by default (S3MetadataDirective.COPY), blocking the storage-layout-migration
+        // drainer (#1314) against R2 buckets. Stripping it on a BeforeRequestEvent hook
+        // is safe across providers: AWS S3 treats absent + present-with-default-COPY
+        // identically (source object tags are preserved either way), and R2/MinIO/B2
+        // simply stop returning 501.
+        s3Client.BeforeRequestEvent += StripUnsupportedR2Headers;
+
         logger.LogInformation(
             "Initialized S3 storage: endpoint={Endpoint}, bucket={Bucket}, region={Region}, encryption={Encryption}",
             options.Endpoint, options.BucketName, options.Region, options.EnableEncryption);
 
         var layoutOptions = serviceProvider.GetRequiredService<IOptions<StorageLayoutOptions>>();
         return new S3BlobStorageService(s3Client, options, layoutOptions, logger);
+    }
+
+    /// <summary>
+    /// Issue #1357: removes S3 extension headers that Cloudflare R2 does not implement.
+    /// Currently strips <c>x-amz-tagging-directive</c>; extend the allowlist when new
+    /// AWS-only extensions surface in drainer/copy paths.
+    /// </summary>
+    internal static void StripUnsupportedR2Headers(object? sender, RequestEventArgs e)
+    {
+        if (e is WebServiceRequestEventArgs args)
+        {
+            args.Headers.Remove("x-amz-tagging-directive");
+        }
     }
 
     private static IBlobStorageService CreateLocalStorageService(IServiceProvider serviceProvider, IConfiguration config)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/LaunchAdminPdfProcessingCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/LaunchAdminPdfProcessingCommandHandlerTests.cs
@@ -68,6 +68,7 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = pdfId,
+            SharedGameId = gameId,
             FileName = "rulebook.pdf",
             FilePath = "/uploads/rulebook.pdf",
             UploadedByUserId = UserId,
@@ -101,6 +102,7 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = pdfId,
+            SharedGameId = gameId,
             FileName = "rulebook.pdf",
             FilePath = "/uploads/rulebook.pdf",
             UploadedByUserId = UserId,
@@ -121,25 +123,26 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // SharedGameId resolution: wizard passes SharedGameId, handler resolves to Game.Id
+    // SharedGameId direct resolution (post-Phase2d #1345):
+    // games table is gone; command.GameId IS the SharedGame.Id used for both lookup and PDF FK.
     // ────────────────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Handle_WithSharedGameId_ResolvesToActualGameId()
     {
-        // Arrange
+        // Arrange: SharedGame exists; PDF references it via SharedGameId
         var sharedGameId = Guid.NewGuid();
-        var actualGameId = Guid.NewGuid();
         var pdfId = Guid.NewGuid();
 
-        // Game entity links SharedGameId → actual Game.Id
         _dbContext.SharedGames.Add(new SharedGameEntity
         {
-            Id = actualGameId,
-            Title = "Catan" });
+            Id = sharedGameId,
+            Title = "Catan"
+        });
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
-            Id = pdfId,   // PDF references actual Game.Id
+            Id = pdfId,
+            SharedGameId = sharedGameId,
             FileName = "catan.pdf",
             FilePath = "/uploads/catan.pdf",
             UploadedByUserId = UserId,
@@ -148,14 +151,13 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         await _dbContext.SaveChangesAsync();
         SetupDefaultPipelineMocks();
 
-        // Command uses SharedGameId (as the wizard does)
         var command = new LaunchAdminPdfProcessingCommand(
             GameId: sharedGameId, PdfDocumentId: pdfId, LaunchedByUserId: UserId);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert: handler resolved SharedGameId and found the PDF
+        // Assert: handler found SharedGame + PDF directly
         result.Status.Should().Be("processing");
         result.Priority.Should().Be("Admin");
 
@@ -253,6 +255,7 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = pdfId,
+            SharedGameId = gameId,
             FileName = "spirit-island.pdf",
             FilePath = "/uploads/spirit-island.pdf",
             UploadedByUserId = UserId
@@ -293,6 +296,7 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = pdfId,
+            SharedGameId = gameId,
             FileName = "everdell.pdf",
             FilePath = "/uploads/everdell.pdf",
             UploadedByUserId = UserId
@@ -348,6 +352,7 @@ public sealed class LaunchAdminPdfProcessingCommandHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = pdfId,
+            SharedGameId = gameId,
             FileName = "arkham.pdf",
             FilePath = "/uploads/arkham.pdf",
             UploadedByUserId = UserId

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlerEnrichmentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlerEnrichmentTests.cs
@@ -68,6 +68,7 @@ public sealed class QueueStreamEventHandlerEnrichmentTests : IDisposable
         _db.SharedGameDocuments.Add(new SharedGameDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             PdfDocumentId = pdfDocId,
             DocumentType = 0,
             CreatedAt = DateTime.UtcNow,
@@ -200,6 +201,7 @@ public sealed class QueueStreamEventHandlerEnrichmentTests : IDisposable
         _db.SharedGameDocuments.Add(new SharedGameDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             PdfDocumentId = pdfDocId,
             DocumentType = 0,
             CreatedAt = DateTime.UtcNow,

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
@@ -666,20 +666,19 @@ public class IndexPdfCommandHandlerTests
     [Fact]
     [Trait("Category", TestCategories.Unit)]
     [Trait("BoundedContext", "DocumentProcessing")]
-    public async Task Handle_SharedGamePdf_ResolvesGameIdFromGamesTable()
+    public async Task Handle_SharedGamePdf_PropagatesSharedGameIdToChunks()
     {
-        // Arrange — SharedGame PDF has null PrivateGameId, only SharedGameId set.
-        // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — see PdfGameIdResolver.
-        // We seed a matching SharedGameEntity so the resolver can map SharedGameId → games.Id.
+        // Arrange — SharedGame PDF has SharedGameId set (PrivateGameId null).
+        // Post-Phase2d (#1345): text_chunks.GameId IS shared_games.id directly
+        // (legacy games table removed; PdfGameIdResolver returns SharedGameId).
         using var context = CreateFreshDbContext();
         var (chunkingServiceMock, embeddingServiceMock, loggerMock, indexingSettingsMock) = CreateMocks();
 
         var sharedGameId = Guid.NewGuid();
-        var gamesId = Guid.NewGuid();
         await context.SharedGames.AddAsync(new SharedGameEntity
         {
-            Id = gamesId,
-            Title = "Shared Game Mirror",
+            Id = sharedGameId,
+            Title = "Test SharedGame",
             CreatedAt = DateTime.UtcNow
         });
 
@@ -688,6 +687,7 @@ public class IndexPdfCommandHandlerTests
         {
             Id = pdfId,
             PrivateGameId = null,
+            SharedGameId = sharedGameId,
             FileName = "shared-game-rules.pdf",
             FilePath = "/uploads/shared-game-rules.pdf",
             FileSizeBytes = 2048,
@@ -726,7 +726,7 @@ public class IndexPdfCommandHandlerTests
         // Assert — indexing succeeds
         result.Success.Should().BeTrue();
 
-        // Assert — text chunks have SharedGameId propagated AND GameId resolved to games.Id
+        // Assert — text chunks have SharedGameId propagated AND GameId == SharedGameId (post-Phase2d)
         var savedChunks = await context.TextChunks
             .Where(tc => tc.PdfDocumentId == pdfId)
             .ToListAsync();
@@ -735,7 +735,7 @@ public class IndexPdfCommandHandlerTests
         savedChunks.Should().AllSatisfy(chunk =>
         {
             chunk.SharedGameId.Should().Be(sharedGameId, "SharedGameId must propagate from PDF to text chunks");
-            chunk.GameId.Should().Be(gamesId, "GameId must resolve to games.Id via SharedGameId (FK to games, not shared_games)");
+            chunk.GameId.Should().Be(sharedGameId, "post-Phase2d: text_chunks.GameId IS shared_games.id (no more legacy games table)");
         });
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfGameIdResolverTests.cs
@@ -14,8 +14,10 @@ namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
 
 /// <summary>
 /// Unit tests for <see cref="PdfGameIdResolver"/>.
-/// Verifies FK-correct resolution of <c>text_chunks.GameId</c> from a <see cref="PdfDocumentEntity"/>:
-/// private path returns PrivateGameId; shared path looks up <c>games.Id</c> via SharedGameId.
+/// Verifies resolution of <c>text_chunks.GameId</c> from a <see cref="PdfDocumentEntity"/>:
+/// private path returns PrivateGameId; shared path returns SharedGameId directly.
+/// Post-Phase2d (#1345): legacy <c>games</c> table is gone; no lookup needed — resolver
+/// returns the PDF's SharedGameId/PrivateGameId directly.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "DocumentProcessing")]
@@ -72,42 +74,16 @@ public class PdfGameIdResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_SharedGameWithoutMatchingGamesRow_ReturnsNull()
+    public async Task ResolveAsync_SharedGameIdSet_ReturnsSharedGameId()
     {
-        using var db = CreateDbContext();
-        var sharedGameId = Guid.Parse("22222222-2222-2222-2222-222222222222");
-        var pdf = new PdfDocumentEntity
-        {
-            Id = Guid.NewGuid(),
-            FileName = "x.pdf",
-            FilePath = "/tmp/x.pdf",
-            UploadedByUserId = Guid.NewGuid(),
-            ProcessingState = "Ready"
-        };
-
-        var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task ResolveAsync_SharedGameWithMatchingGamesRow_ReturnsGamesId()
-    {
+        // Post-Phase2d (#1345): resolver returns SharedGameId directly, no DB lookup.
         using var db = CreateDbContext();
         var sharedGameId = Guid.Parse("33333333-3333-3333-3333-333333333333");
-        var gamesId = Guid.Parse("44444444-4444-4444-4444-444444444444");
-
-        db.SharedGames.Add(new SharedGameEntity
-        {
-            Id = gamesId,
-            Title = "Test",
-            CreatedAt = DateTime.UtcNow
-        });
-        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "x.pdf",
             FilePath = "/tmp/x.pdf",
             UploadedByUserId = Guid.NewGuid(),
@@ -116,7 +92,7 @@ public class PdfGameIdResolverTests
 
         var result = await PdfGameIdResolver.ResolveAsync(db, pdf, TestContext.Current.CancellationToken);
 
-        result.Should().Be(gamesId);
+        result.Should().Be(sharedGameId);
     }
 
     [Fact]
@@ -125,20 +101,12 @@ public class PdfGameIdResolverTests
         using var db = CreateDbContext();
         var privateGameId = Guid.Parse("55555555-5555-5555-5555-555555555555");
         var sharedGameId = Guid.Parse("66666666-6666-6666-6666-666666666666");
-        var gamesId = Guid.Parse("77777777-7777-7777-7777-777777777777");
-
-        db.SharedGames.Add(new SharedGameEntity
-        {
-            Id = gamesId,
-            Title = "Should not be returned",
-            CreatedAt = DateTime.UtcNow
-        });
-        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
             PrivateGameId = privateGameId,
+            SharedGameId = sharedGameId,
             FileName = "x.pdf",
             FilePath = "/tmp/x.pdf",
             UploadedByUserId = Guid.NewGuid(),

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
@@ -105,6 +105,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests : IDisposable
             FileName = "rulebook.pdf",
             FilePath = "/uploads/rulebook.pdf",
             UploadedByUserId = UserId,
+            SharedGameId = GameId,
             ProcessingPriority = "Admin",
         });
         await _dbContext.SaveChangesAsync();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagAccessServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagAccessServiceTests.cs
@@ -62,6 +62,7 @@ public class RagAccessServiceTests
         {
             Id = Guid.NewGuid(),
             UserId = UserId,
+            SharedGameId = GameId,
             OwnershipDeclaredAt = DateTime.UtcNow
         });
         await db.SaveChangesAsync();
@@ -84,6 +85,7 @@ public class RagAccessServiceTests
         {
             Id = Guid.NewGuid(),
             UserId = UserId,
+            SharedGameId = GameId,
             OwnershipDeclaredAt = null
         });
         await db.SaveChangesAsync();
@@ -112,12 +114,14 @@ public class RagAccessServiceTests
             new VectorDocumentEntity
             {
                 Id = completedDocId,
+                SharedGameId = GameId,
                 PdfDocumentId = Guid.NewGuid(),
                 IndexingStatus = "completed"
             },
             new VectorDocumentEntity
             {
                 Id = pendingDocId,
+                SharedGameId = GameId,
                 PdfDocumentId = Guid.NewGuid(),
                 IndexingStatus = "pending"
             });

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/CitationValidationServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/CitationValidationServiceTests.cs
@@ -43,7 +43,9 @@ public class CitationValidationServiceTests
     }
 
     /// <summary>
-    /// Seeds test data into the given context and returns the IDs
+    /// Seeds test data into the given context and returns the IDs.
+    /// Post-Phase2d (#1345): PDFs must have SharedGameId set so
+    /// CitationValidationService can find them via SharedGameId filter.
     /// </summary>
     private static async Task<(Guid gameId, Guid pdf1Id, Guid pdf2Id)> SeedTestDataAsync(
         MeepleAiDbContext context)
@@ -56,6 +58,7 @@ public class CitationValidationServiceTests
             new PdfDocumentEntity
             {
                 Id = pdf1Id,
+                SharedGameId = gameId,
                 FileName = "test-rules.pdf",
                 FilePath = "/test/rules.pdf",
                 FileSizeBytes = 1000,
@@ -66,6 +69,7 @@ public class CitationValidationServiceTests
             new PdfDocumentEntity
             {
                 Id = pdf2Id,
+                SharedGameId = gameId,
                 FileName = "test-expansion.pdf",
                 FilePath = "/test/expansion.pdf",
                 FileSizeBytes = 2000,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/Projections/CopyrightDataProjectionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/Projections/CopyrightDataProjectionTests.cs
@@ -135,6 +135,7 @@ public class CopyrightDataProjectionTests
         {
             Id = docId,
             UploadedByUserId = uploaderId,
+            SharedGameId = gameId,
             FileName = "rules.pdf",
             FilePath = "/uploads/rules.pdf",
             LicenseType = (int)LicenseType.CreativeCommons,
@@ -310,6 +311,7 @@ public class CopyrightDataProjectionTests
         {
             Id = Guid.NewGuid(),
             UserId = userId,
+            SharedGameId = gameId,
             OwnershipDeclaredAt = DateTime.UtcNow
         });
         await db.SaveChangesAsync();
@@ -398,6 +400,7 @@ public class CopyrightDataProjectionTests
         {
             Id = Guid.NewGuid(),
             UserId = userId,
+            SharedGameId = ownedGameId,
             OwnershipDeclaredAt = DateTime.UtcNow
         });
         await db.SaveChangesAsync();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/ToolkitChangedForCatalogAggregatesHandlerTests.cs
@@ -148,10 +148,11 @@ public sealed class ToolkitChangedForCatalogAggregatesHandlerTests
     [Fact]
     public async Task Handle_ToolkitWithSharedGameLinkage_InvalidatesPerGameTag()
     {
-        // Wave A.4 — verify that when a Toolkit is linked through Game.SharedGameId
+        // Wave A.4 — verify that when a Toolkit is linked to a SharedGame
         // the per-game detail cache (`shared-game:{id}`) is also evicted.
+        // Post-Phase2d (#1345): toolkit.GameId IS shared_games.id directly
+        // (no more legacy Game.SharedGameId bridge).
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
-        var sharedGameId = Guid.NewGuid();
         var gameId = Guid.NewGuid();
 
         db.SharedGames.Add(new SharedGameEntity
@@ -165,7 +166,7 @@ public sealed class ToolkitChangedForCatalogAggregatesHandlerTests
         await db.SaveChangesAsync();
 
         var cache = CreateHybridCache();
-        var perGameTag = $"shared-game:{sharedGameId}";
+        var perGameTag = $"shared-game:{gameId}";
 
         await cache.GetOrCreateAsync<string>(
             key: "detail-cache-key",

--- a/apps/api/tests/Api.Tests/Unit/UserLibrary/GetUserLibraryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/UserLibrary/GetUserLibraryQueryHandlerTests.cs
@@ -79,6 +79,7 @@ public sealed class GetUserLibraryQueryHandlerTests : IDisposable
         _dbContext.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = gameId,
             FileName = "rules.pdf",
             FilePath = "/pdfs/rules.pdf",
             FileSizeBytes = 1024,


### PR DESCRIPTION
## Summary

Deploy Issue #1357 fix (R2 `x-amz-tagging-directive` header strip) to staging so Phase 1 storage migration can resume from the 216 Pending rows enqueued during the 2026-05-20 rollout attempt.

## Changes since the last main-staging merge (PR #1353 / `a6073eeaf3`)

| Commit | Title | Note |
|---|---|---|
| `06d91fc1c` | fix(storage): #1357 strip x-amz-tagging-directive header (R2 compat) | The critical fix |
| `00c528223` | docs(claude): document known flaky tests baseline (refs #1349) | Docs only |
| ... | (other recent main-dev commits) | Bundled because we ship main-dev → main-staging as a single deploy |

## Post-merge plan

1. `deploy-staging.yml` auto-triggers on merge → ~3h end-to-end (Build Images 58m dominant).
2. After deploy success: SSH staging, flip `StorageLayout__MigrationEnabled` back to `true` in `infra/secrets/storage.secret`, force-recreate the `meepleai-api` container.
3. Drainer (now with the R2 fix) processes the 216 Pending rows of migration `2f50ce96-ac0c-4b0b-be22-4afa172085ca` from the previous rollout — idempotent retry from `AttemptCount`.
4. Verify Sent=216, Pending=0, FailedPermanent=0.

## Risks

- Same destructive bundle context as PR #1353 (drop games table is already applied). Net delta is the R2 fix + small docs/test churn.
- The 216 Pending rows have `AttemptCount=1-2` from the 2026-05-20 attempts; max attempts is 5. After fix lands they should succeed on next attempt.

## Refs

- #1357 — bug(storage): Phase 1 drainer fails against R2
- #1314 — Refactor IBlobStorageService PDF storage layout
- PR #1358 — fix(storage): strip x-amz-tagging-directive header

🤖 Generated with [Claude Code](https://claude.com/claude-code)
