### PR TITLE
fix(storage): #1357 follow-up — opt into AsTracking for outbox drain/reverse

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ReverseStorageMigrationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ReverseStorageMigrationCommandHandler.cs
@@ -91,7 +91,13 @@ internal sealed class ReverseStorageMigrationCommandHandler
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // PERF-06: DbContext defaults to NoTracking globally.
+            // ReverseSentRowAsync + the Pending branch mutate `row.Status`
+            // and `row.LastError` directly; without AsTracking those changes
+            // never reach the DB through SaveChanges. Mirror fix in
+            // StorageOperationOutboxBackgroundService.DrainOnceAsync.
             var rows = await _db.StorageOperationOutbox
+                .AsTracking()
                 .Where(r => r.MigrationId == request.MigrationId)
                 .OrderBy(r => r.CreatedAt)
                 .Skip(offset)

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StorageOperationOutboxBackgroundService.cs
@@ -135,7 +135,16 @@ internal sealed class StorageOperationOutboxBackgroundService : BackgroundServic
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
 
+        // PERF-06: DbContext defaults to NoTracking globally. Drainer must
+        // opt into tracking so the success-path mutations on `row.Status`,
+        // `row.SentAt`, `row.AttemptCount`, `row.LastError` reach the DB
+        // through SaveChanges. Without this, SaveChanges silently no-ops
+        // (catch-path still works because it touches `dbContext.Entry(row)`,
+        // which forces the entity into the change tracker as Modified).
+        // Discovered during the Phase 1 rollout on 2026-05-20: drainer kept
+        // moving objects on S3 but the outbox rows stayed Pending forever.
         var due = await dbContext.StorageOperationOutbox
+            .AsTracking()
             .Where(e => e.Status == "Pending" && e.ScheduledAt <= now)
             .OrderBy(e => e.ScheduledAt)
             .Take(BatchSize)


### PR DESCRIPTION
## Summary

Follow-up to PR #1358 (R2 `x-amz-tagging-directive` fix). Opt into `AsTracking()` on the two `StorageOperationOutbox` queries — the drainer in `StorageOperationOutboxBackgroundService.DrainOnceAsync` and the reverse-migration command in `ReverseStorageMigrationCommandHandler`.

## Root cause

The DbContext defaults to `QueryTrackingBehavior.NoTracking` globally (PERF-06, see `InfrastructureServiceExtensions.cs:151`). When the drainer's success path mutates `row.Status = "Sent"` / `row.SentAt` / `row.AttemptCount += 1` / `row.LastError = null` directly on a NoTracking entity, `SaveChangesAsync` silently no-ops. The catch path was incidentally safe because it touches `dbContext.Entry(row).Property(...).CurrentValue = ...`, which force-promotes the entity into the tracker as Modified.

## Discovered during

Staging Phase 1 retry on 2026-05-20 after PR #1358 deployed:

- 216 rows enqueued (migration `2f50ce96-ac0c-4b0b-be22-4afa172085ca`).
- Drainer logged `Storage outbox: moved pdf_uploads/... → pdfs/...` for 25 of them (S3 CopyObject + DeleteObject completed).
- All 216 rows stayed `Status=Pending`, `AttemptCount=0`. Dry-run audit confirmed `pdf_uploads/` shrank from 216 → 191 objects on S3.
- Without `AsTracking`, drainer kept re-fetching the same 216 rows on every 30s poll, re-doing work on the 25 already-moved rows (idempotent thanks to `KeyExistsAsync` guard) but the DB never reflected progress.

## Why this is safe to apply mid-rollout

The drainer's `KeyExistsAsync(row.NewKey)` guard + `404-tolerant DeleteObject` make the move idempotent. After this PR deploys, re-enabling the drainer flag will:

1. Pull the 191 still-Pending rows (legacy key still on S3) and complete them normally.
2. For the 25 already-moved rows: NewKey exists → skip CopyObject, DeleteObject returns 404 → catch handler treats as success → `Status=Sent` → SaveChanges now persists (with AsTracking).

## Test plan

- [x] `dotnet build` clean.
- [ ] Deploy to staging.
- [ ] `StorageLayout__MigrationEnabled=true` + recreate API.
- [ ] Verify drainer drives `storage_operation_outbox WHERE MigrationId = '2f50ce96-...'` to Sent=216 / Pending=0 / FailedPermanent=0 within 15 min.
- [ ] Dry-run audit returns `totalObjects=0` for `pdf_uploads/`.

## Refs

- #1357 — bug(storage): Phase 1 drainer fails against R2 (this PR closes the second cause)
- PR #1358 — fix(storage): strip x-amz-tagging-directive header (deployed 2026-05-20)
- #1314 — Refactor IBlobStorageService PDF storage layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
