### PR TITLE
chore(storage): #1314 Phase 4 — flip defaults Legacy/Dual → New/New

### DIFF
--- a/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
+++ b/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
@@ -3,11 +3,16 @@ namespace Api.Services.Pdf;
 /// <summary>
 /// Feature flags driving the 5-phase storage layout migration (issue #1314 PR 2).
 ///
-/// Default (safe): Legacy + Dual + false → identical behavior to PR 1
-/// (S3 keys under <c>pdf_uploads/{resourceKey}/...</c>, reads attempt both
-/// layouts to support graceful cutover). Phase progression is driven by
-/// flipping these flags in deployed configuration; no code change is
-/// required between phases.
+/// Phase 4 cleanup (2026-05-21): defaults flipped from Legacy/Dual → New/New
+/// after the staging migration completed end-to-end (216 PDFs moved,
+/// pdf_uploads/ empty, Paladins upload validated landing in pdfs/).
+/// The staging overlay flags in <c>infra/secrets/storage.secret</c> are now
+/// redundant but kept until the follow-up cleanup PR removes the
+/// branching code altogether.
+///
+/// Pre-Phase-4 default (safe): Legacy + Dual + false → identical behavior to
+/// PR 1 (S3 keys under <c>pdf_uploads/{resourceKey}/...</c>, reads attempt
+/// both layouts to support graceful cutover).
 /// </summary>
 internal sealed class StorageLayoutOptions
 {
@@ -19,20 +24,21 @@ internal sealed class StorageLayoutOptions
     /// <summary>
     /// Controls the S3 key prefix used by <c>StoreAsync</c> for new uploads.
     /// </summary>
-    public StorageWriteMode WriteMode { get; init; } = StorageWriteMode.Legacy;
+    public StorageWriteMode WriteMode { get; init; } = StorageWriteMode.New;
 
     /// <summary>
     /// Controls the S3 key prefix used by Retrieve/Delete/Exists/GetPresignedDownloadUrl
     /// for existing objects. In <see cref="StorageReadMode.Dual"/> the implementation
     /// tries the new layout first and falls back to the legacy layout on miss.
     /// </summary>
-    public StorageReadMode ReadMode { get; init; } = StorageReadMode.Dual;
+    public StorageReadMode ReadMode { get; init; } = StorageReadMode.New;
 
     /// <summary>
     /// Enables the <c>StorageOperationOutboxBackgroundService</c> drainer.
     /// When false, the background service is registered but exits the loop
-    /// after one tick — useful in dev / test environments and during
-    /// Phase 0 (deploy infra without triggering the migration).
+    /// after one tick — useful in dev / test environments. The outbox table
+    /// + drainer infrastructure are kept for future blob-layout migrations
+    /// (SessionPhoto, GameImage, etc.).
     /// </summary>
     public bool MigrationEnabled { get; init; }
 

--- a/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
@@ -15,14 +15,16 @@ namespace Api.Tests.Unit.Services;
 public sealed class StorageLayoutOptionsTests
 {
     [Fact]
-    public void Defaults_AreSafeForPhase0Deploy()
+    public void Defaults_MatchPhase4SteadyState()
     {
-        // Phase 0 invariant: a fresh deploy must not trigger any migration
-        // behavior. Defaults are Legacy write + Dual read + migration off.
+        // Phase 4 cleanup (2026-05-21): after the staging migration completed
+        // end-to-end, defaults flipped from Legacy/Dual to New/New. A fresh
+        // deploy now starts at the steady-state new-categorized layout; the
+        // migration drainer remains opt-in.
         var options = new StorageLayoutOptions();
 
-        options.WriteMode.Should().Be(StorageWriteMode.Legacy);
-        options.ReadMode.Should().Be(StorageReadMode.Dual);
+        options.WriteMode.Should().Be(StorageWriteMode.New);
+        options.ReadMode.Should().Be(StorageReadMode.New);
         options.MigrationEnabled.Should().BeFalse();
     }
 

--- a/scripts/phase1-resume-after-deploy.sh
+++ b/scripts/phase1-resume-after-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Post-deploy Phase 1 resume — run after deploy-staging.yml completes for the
+# fix #1357 tracking commit. Flips MigrationEnabled=true, force-recreates the
+# API container with the new image, and monitors drain progress for the
+# 216-row migration `2f50ce96-ac0c-4b0b-be22-4afa172085ca`.
+
+set -euo pipefail
+
+MIGRATION_ID="2f50ce96-ac0c-4b0b-be22-4afa172085ca"
+API_TAG="${API_TAG:?usage: API_TAG=ghcr.io/.../api:staging-20260520-XXXXX $0}"
+WEB_TAG="${WEB_TAG:-ghcr.io/meepleai-app/meepleai-monorepo/web:staging-20260520-890abe3}"
+
+echo "=== Step 1: flip flag to true ==="
+ssh meepleai-staging "sudo sed -i 's/^StorageLayout__MigrationEnabled=false/StorageLayout__MigrationEnabled=true/' /opt/meepleai/repo/infra/secrets/storage.secret && echo OK flipped"
+
+echo ""
+echo "=== Step 2: force-recreate API ==="
+ssh meepleai-staging "docker stop meepleai-api && docker rm meepleai-api && cd /opt/meepleai/repo/infra && \
+  API_IMAGE='${API_TAG}' WEB_IMAGE='${WEB_TAG}' \
+  docker compose -f docker-compose.yml -f compose.staging.yml --profile ai-essential --profile monitoring-essential up -d --no-deps api 2>&1 | tail -5"
+
+echo ""
+echo "=== Step 3: wait API healthy + verify flag ==="
+ssh meepleai-staging "until docker exec meepleai-api curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/v1/health 2>/dev/null | grep -q 200; do sleep 2; done; echo API healthy; docker exec meepleai-api printenv | grep StorageLayout; docker logs meepleai-api --since=20s 2>&1 | grep StorageOperationOutbox | head -3"
+
+echo ""
+echo "=== Step 4: monitor drain ${MIGRATION_ID} ==="
+for i in $(seq 1 40); do
+  STATE=$(ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -t -A -F'|' -c \"SELECT \\\"Status\\\", COUNT(*) FROM storage_operation_outbox WHERE \\\"MigrationId\\\" = '${MIGRATION_ID}' GROUP BY \\\"Status\\\" ORDER BY 1;\"" 2>&1 | tr -d '\r' | paste -sd, -)
+  echo "--- Cycle $i ($(date -u +%H:%M:%S)Z) --- $STATE"
+  PENDING=$(echo "$STATE" | grep -oE 'Pending\|[0-9]+' | grep -oE '[0-9]+' | head -1)
+  if [ -z "$PENDING" ] || [ "$PENDING" = "0" ]; then
+    echo ""
+    echo "🎯 Pending = 0 → migration complete"
+    break
+  fi
+  if [ $i -lt 40 ]; then
+    sleep 30
+  fi
+done
+
+echo ""
+echo "=== Final state ==="
+ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c \"SELECT \\\"Status\\\", COUNT(*) FROM storage_operation_outbox WHERE \\\"MigrationId\\\" = '${MIGRATION_ID}' GROUP BY \\\"Status\\\";\""
+
+echo ""
+echo "=== Audit pdf_uploads/ (should be 0 if all moved) ==="
+ssh meepleai-staging 'docker exec meepleai-api bash -c "
+NEW_MIGRATION_ID=\$(cat /proc/sys/kernel/random/uuid)
+curl -sS -o /tmp/login_body.json -w \"login=%{http_code}\\n\" -X POST http://localhost:8080/api/v1/auth/login -c /tmp/cj.txt -H Content-Type:application/json -d \"{\\\"email\\\":\\\"badsworm@gmail.com\\\",\\\"password\\\":\\\"Meeple1280!!\\\"}\"
+curl -sS -X POST http://localhost:8080/api/v1/admin/storage/migration/enqueue -b /tmp/cj.txt -H Content-Type:application/json -d \"{\\\"migrationId\\\":\\\"\$NEW_MIGRATION_ID\\\",\\\"legacyPrefix\\\":\\\"pdf_uploads/\\\",\\\"category\\\":\\\"Pdf\\\",\\\"dryRun\\\":true}\"
+rm -f /tmp/cj.txt /tmp/login_body.json
+"'


### PR DESCRIPTION
## Summary

Phase 4 cleanup minimal: flip the in-code defaults of `StorageLayoutOptions` from `Legacy/Dual` to `New/New` after the staging migration ran end-to-end on 2026-05-20 → 2026-05-21.

This **does not** remove the branching code (Legacy / Dual paths, `LegacyPrefix` constant, ReadMode switch in `TryResolveKeyAsync`) — that's a 17-file refactor tracked in a follow-up. The outbox + drainer infrastructure stay in place to support future blob-layout migrations (SessionPhoto, GameImage, etc.).

## Staging migration timeline (post-#1357)

| Phase | UTC | Outcome |
|---|---|---|
| 1 | 2026-05-21 01:15 | 216 PDFs migrated `pdf_uploads/* → pdfs/*`. Sent=216, Pending=0, FailedPermanent=0. |
| 2 | 2026-05-21 05:12 | `WriteMode=New` flipped. Validated by Paladins wizard upload landing at `pdfs/wizard-temp/d078b7bea7f94c42b4b5c9875fd4a5da_paladins.pdf`. |
| 3 | 2026-05-21 05:38 | `ReadMode=New` flipped. Metric `meepleai_storage_layout_version_current_version{layout_version="v2-categorized"} 3` reports the active layout. Zero NotFound errors in storage layer post-flip. |
| 4 (this PR) | now | Defaults flipped in code. After this deploys, the staging overlay flags in `infra/secrets/storage.secret` are redundant. |

Step 4.1 (move `pdf_uploads/` → `_trash/`) is a no-op because the legacy prefix is already empty (verified via dry-run audit 2026-05-21).

## Changes

- `apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs`: `WriteMode = New`, `ReadMode = New` (was `Legacy`, `Dual`).
- `apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs`: rename `Defaults_AreSafeForPhase0Deploy` → `Defaults_MatchPhase4SteadyState` and update assertions to match.
- `scripts/phase1-resume-after-deploy.sh`: helper script used during the 2026-05-20 rollout (kept for audit / re-runnability).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet test --filter "FullyQualifiedName~StorageLayoutOptionsTests|FullyQualifiedName~S3BlobStorageServiceTests|FullyQualifiedName~BlobStorageServiceLayoutTests"` → 27/27 passing.
- [ ] Post-deploy: verify `Initialized S3 storage` log still healthy + metric gauge still reports `layout_version=3`.

## Follow-ups (tracked separately, NOT in this PR)

- Remove `LegacyPrefix` constant + Legacy / Dual code paths in `S3BlobStorageService` and `BlobStorageService` (17-file refactor).
- Drop the now-redundant overlay flags from `infra/secrets/storage.secret` on staging via SSH (`sed -i '/StorageLayout__\(WriteMode\|ReadMode\|MigrationEnabled\)/d'` + force-recreate).
- Backfill: update `pdf_documents.FilePath` DB rows from `pdf_uploads/...` to `pdfs/...` for cosmetic consistency. Read layer recomputes the S3 key from `BlobCategory + resourceKey + fileId`, so this is purely a metadata-cleanup pass.

## Refs

- #1314 — Refactor IBlobStorageService PDF storage layout (closed 2026-05-19)
- #1357 — bug(storage): Phase 1 drainer fails against R2 (closed 2026-05-21)
- Runbook: `docs/for-developers/operations/2026-05-19-storage-layout-migration-runbook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
