### PR TITLE
release: #1314 Phase 4 default flip → main-staging

### DIFF
--- a/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
+++ b/apps/api/src/Api/Services/Pdf/StorageLayoutOptions.cs
@@ -3,11 +3,16 @@ namespace Api.Services.Pdf;
 /// <summary>
 /// Feature flags driving the 5-phase storage layout migration (issue #1314 PR 2).
 ///
-/// Default (safe): Legacy + Dual + false → identical behavior to PR 1
-/// (S3 keys under <c>pdf_uploads/{resourceKey}/...</c>, reads attempt both
-/// layouts to support graceful cutover). Phase progression is driven by
-/// flipping these flags in deployed configuration; no code change is
-/// required between phases.
+/// Phase 4 cleanup (2026-05-21): defaults flipped from Legacy/Dual → New/New
+/// after the staging migration completed end-to-end (216 PDFs moved,
+/// pdf_uploads/ empty, Paladins upload validated landing in pdfs/).
+/// The staging overlay flags in <c>infra/secrets/storage.secret</c> are now
+/// redundant but kept until the follow-up cleanup PR removes the
+/// branching code altogether.
+///
+/// Pre-Phase-4 default (safe): Legacy + Dual + false → identical behavior to
+/// PR 1 (S3 keys under <c>pdf_uploads/{resourceKey}/...</c>, reads attempt
+/// both layouts to support graceful cutover).
 /// </summary>
 internal sealed class StorageLayoutOptions
 {
@@ -19,20 +24,21 @@ internal sealed class StorageLayoutOptions
     /// <summary>
     /// Controls the S3 key prefix used by <c>StoreAsync</c> for new uploads.
     /// </summary>
-    public StorageWriteMode WriteMode { get; init; } = StorageWriteMode.Legacy;
+    public StorageWriteMode WriteMode { get; init; } = StorageWriteMode.New;
 
     /// <summary>
     /// Controls the S3 key prefix used by Retrieve/Delete/Exists/GetPresignedDownloadUrl
     /// for existing objects. In <see cref="StorageReadMode.Dual"/> the implementation
     /// tries the new layout first and falls back to the legacy layout on miss.
     /// </summary>
-    public StorageReadMode ReadMode { get; init; } = StorageReadMode.Dual;
+    public StorageReadMode ReadMode { get; init; } = StorageReadMode.New;
 
     /// <summary>
     /// Enables the <c>StorageOperationOutboxBackgroundService</c> drainer.
     /// When false, the background service is registered but exits the loop
-    /// after one tick — useful in dev / test environments and during
-    /// Phase 0 (deploy infra without triggering the migration).
+    /// after one tick — useful in dev / test environments. The outbox table
+    /// + drainer infrastructure are kept for future blob-layout migrations
+    /// (SessionPhoto, GameImage, etc.).
     /// </summary>
     public bool MigrationEnabled { get; init; }
 

--- a/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/StorageLayoutOptionsTests.cs
@@ -15,14 +15,16 @@ namespace Api.Tests.Unit.Services;
 public sealed class StorageLayoutOptionsTests
 {
     [Fact]
-    public void Defaults_AreSafeForPhase0Deploy()
+    public void Defaults_MatchPhase4SteadyState()
     {
-        // Phase 0 invariant: a fresh deploy must not trigger any migration
-        // behavior. Defaults are Legacy write + Dual read + migration off.
+        // Phase 4 cleanup (2026-05-21): after the staging migration completed
+        // end-to-end, defaults flipped from Legacy/Dual to New/New. A fresh
+        // deploy now starts at the steady-state new-categorized layout; the
+        // migration drainer remains opt-in.
         var options = new StorageLayoutOptions();
 
-        options.WriteMode.Should().Be(StorageWriteMode.Legacy);
-        options.ReadMode.Should().Be(StorageReadMode.Dual);
+        options.WriteMode.Should().Be(StorageWriteMode.New);
+        options.ReadMode.Should().Be(StorageReadMode.New);
         options.MigrationEnabled.Should().BeFalse();
     }
 

--- a/scripts/phase1-resume-after-deploy.sh
+++ b/scripts/phase1-resume-after-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Post-deploy Phase 1 resume — run after deploy-staging.yml completes for the
+# fix #1357 tracking commit. Flips MigrationEnabled=true, force-recreates the
+# API container with the new image, and monitors drain progress for the
+# 216-row migration `2f50ce96-ac0c-4b0b-be22-4afa172085ca`.
+
+set -euo pipefail
+
+MIGRATION_ID="2f50ce96-ac0c-4b0b-be22-4afa172085ca"
+API_TAG="${API_TAG:?usage: API_TAG=ghcr.io/.../api:staging-20260520-XXXXX $0}"
+WEB_TAG="${WEB_TAG:-ghcr.io/meepleai-app/meepleai-monorepo/web:staging-20260520-890abe3}"
+
+echo "=== Step 1: flip flag to true ==="
+ssh meepleai-staging "sudo sed -i 's/^StorageLayout__MigrationEnabled=false/StorageLayout__MigrationEnabled=true/' /opt/meepleai/repo/infra/secrets/storage.secret && echo OK flipped"
+
+echo ""
+echo "=== Step 2: force-recreate API ==="
+ssh meepleai-staging "docker stop meepleai-api && docker rm meepleai-api && cd /opt/meepleai/repo/infra && \
+  API_IMAGE='${API_TAG}' WEB_IMAGE='${WEB_TAG}' \
+  docker compose -f docker-compose.yml -f compose.staging.yml --profile ai-essential --profile monitoring-essential up -d --no-deps api 2>&1 | tail -5"
+
+echo ""
+echo "=== Step 3: wait API healthy + verify flag ==="
+ssh meepleai-staging "until docker exec meepleai-api curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/v1/health 2>/dev/null | grep -q 200; do sleep 2; done; echo API healthy; docker exec meepleai-api printenv | grep StorageLayout; docker logs meepleai-api --since=20s 2>&1 | grep StorageOperationOutbox | head -3"
+
+echo ""
+echo "=== Step 4: monitor drain ${MIGRATION_ID} ==="
+for i in $(seq 1 40); do
+  STATE=$(ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -t -A -F'|' -c \"SELECT \\\"Status\\\", COUNT(*) FROM storage_operation_outbox WHERE \\\"MigrationId\\\" = '${MIGRATION_ID}' GROUP BY \\\"Status\\\" ORDER BY 1;\"" 2>&1 | tr -d '\r' | paste -sd, -)
+  echo "--- Cycle $i ($(date -u +%H:%M:%S)Z) --- $STATE"
+  PENDING=$(echo "$STATE" | grep -oE 'Pending\|[0-9]+' | grep -oE '[0-9]+' | head -1)
+  if [ -z "$PENDING" ] || [ "$PENDING" = "0" ]; then
+    echo ""
+    echo "🎯 Pending = 0 → migration complete"
+    break
+  fi
+  if [ $i -lt 40 ]; then
+    sleep 30
+  fi
+done
+
+echo ""
+echo "=== Final state ==="
+ssh meepleai-staging "docker exec meepleai-postgres psql -U meepleai -d meepleai_staging -c \"SELECT \\\"Status\\\", COUNT(*) FROM storage_operation_outbox WHERE \\\"MigrationId\\\" = '${MIGRATION_ID}' GROUP BY \\\"Status\\\";\""
+
+echo ""
+echo "=== Audit pdf_uploads/ (should be 0 if all moved) ==="
+ssh meepleai-staging 'docker exec meepleai-api bash -c "
+NEW_MIGRATION_ID=\$(cat /proc/sys/kernel/random/uuid)
+curl -sS -o /tmp/login_body.json -w \"login=%{http_code}\\n\" -X POST http://localhost:8080/api/v1/auth/login -c /tmp/cj.txt -H Content-Type:application/json -d \"{\\\"email\\\":\\\"badsworm@gmail.com\\\",\\\"password\\\":\\\"Meeple1280!!\\\"}\"
+curl -sS -X POST http://localhost:8080/api/v1/admin/storage/migration/enqueue -b /tmp/cj.txt -H Content-Type:application/json -d \"{\\\"migrationId\\\":\\\"\$NEW_MIGRATION_ID\\\",\\\"legacyPrefix\\\":\\\"pdf_uploads/\\\",\\\"category\\\":\\\"Pdf\\\",\\\"dryRun\\\":true}\"
+rm -f /tmp/cj.txt /tmp/login_body.json
+"'


### PR DESCRIPTION
## Summary

Release PR Phase 4 default flip (#1374) + small main-dev delta from the last main-staging deploy (`482faa477`) to main-staging.

## Highlights

- **PR #1374** — flip `StorageLayoutOptions` defaults from `Legacy/Dual` to `New/New`. After this deploys, the overlay flags in `infra/secrets/storage.secret` become redundant; remove them via SSH + force-recreate API post-deploy.
- Other main-dev commits since the last release (PR #1361) — unchanged scope, normal cadence.

## Post-merge plan

1. `deploy-staging.yml` auto-triggers on merge.
2. Wait ~3h for deploy success.
3. SSH staging → remove the 3 `StorageLayout__*` overlay flags from `storage.secret` → force-recreate `meepleai-api`.
4. Verify metric `meepleai_storage_layout_version_current_version{layout_version="v2-categorized"} 3` still reports correctly (now driven by code defaults, not env overlay).

## Refs

- #1314 — Refactor IBlobStorageService PDF storage layout
- PR #1374 — Phase 4 defaults flip
- PR #1361 — last main-dev → main-staging release (tracking fix #1357)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
