### PR TITLE
Audit fix: route /sessions/[id] (closes #1371)

### DIFF
--- a/apps/web/src/components/features/session-summary/PhotosGallery.tsx
+++ b/apps/web/src/components/features/session-summary/PhotosGallery.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
 /**
  * PhotosGallery — Wave D.3 v2 component (Issue #756).
  *
@@ -135,6 +134,7 @@ export function PhotosGallery({
                 <span
                   className={clsx(
                     'absolute bottom-1.5 left-1.5 max-w-[calc(100%-1rem)] truncate rounded-full px-2 py-0.5',
+                    // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on bg-foreground/45 overlay; bg is in separate clsx arg so rule can't detect the colored context
                     'font-mono text-[9px] font-extrabold text-white',
                     'bg-foreground/45'
                   )}

--- a/apps/web/src/components/features/session-summary/PlayAgainCta.tsx
+++ b/apps/web/src/components/features/session-summary/PlayAgainCta.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
 /**
  * PlayAgainCta — Wave D.3 v2 component (Issue #756).
  *
@@ -89,6 +88,7 @@ export function PlayAgainCta({
         data-slot="play-again-cta-button"
         data-disabled={disabled || undefined}
         className={clsx(
+          // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on bg-entity-session CTA button; entity bg is in a separate clsx string
           'inline-flex h-10 shrink-0 items-center justify-center gap-1.5 rounded-lg px-5 text-sm font-semibold text-white shadow-sm transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           disabled

--- a/apps/web/src/components/features/session-summary/SessionShareCard.tsx
+++ b/apps/web/src/components/features/session-summary/SessionShareCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
 /**
  * SessionShareCard — Wave D.3 v2 component (Issue #756).
  *
@@ -99,6 +98,7 @@ function PreviewPodiumCell({ participant, place, theme }: PreviewPodiumCellProps
         </span>
       )}
       <div
+        // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on style-prop gradient bg (.e-bg pattern); bg is in style prop, not className
         className="flex items-center justify-center rounded-full font-extrabold text-white"
         style={{
           width: size,

--- a/apps/web/src/components/features/session-summary/SessionSummaryHero.tsx
+++ b/apps/web/src/components/features/session-summary/SessionSummaryHero.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
 /**
  * SessionSummaryHero — Wave D.3 v2 component (Issue #756).
  *
@@ -187,6 +186,7 @@ function PodiumPlace({ entry, tied, podiumPlaceAriaLabel }: PodiumPlaceProps): R
         </span>
       )}
       <div
+        // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on style-prop gradient bg (.e-bg pattern); bg is in style prop, not className
         className="relative flex items-center justify-center rounded-full font-extrabold text-white"
         style={{
           width: AVATAR_SIZE_PX[place],
@@ -211,6 +211,7 @@ function PodiumPlace({ entry, tied, podiumPlaceAriaLabel }: PodiumPlaceProps): R
         {tied && isWinner && (
           <span
             data-slot="podium-tied-badge"
+            // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on entity-toolkit bg (style prop); .e-bg pattern
             className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full text-[9px] font-extrabold text-white"
             style={{
               background: 'var(--color-entity-toolkit)',

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -263,17 +263,17 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-session-summary-parts.jsx` | `SessionSummaryHero` | `apps/web/src/components/features/session-summary/SessionSummaryHero.tsx` | `/sessions/[id]` | done | #762 | T A M V | #PR |
-| `sp4-session-summary-parts.jsx` | `SessionKpiGrid` | `apps/web/src/components/features/session-summary/SessionKpiGrid.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary-parts.jsx` | `ScoringBreakdownTable` | `apps/web/src/components/features/session-summary/ScoringBreakdownTable.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary-parts.jsx` | `ConnectionBar` | `apps/web/src/components/features/session-summary/ConnectionBar.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary-parts.jsx` | `AchievementsCarousel` | `apps/web/src/components/features/session-summary/AchievementsCarousel.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `SessionDiaryTimeline` | `apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `PhotosGallery` | `apps/web/src/components/features/session-summary/PhotosGallery.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `ChatHighlights` | `apps/web/src/components/features/session-summary/ChatHighlights.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `SessionShareCard` | `apps/web/src/components/features/session-summary/SessionShareCard.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `PlayAgainCta` | `apps/web/src/components/features/session-summary/PlayAgainCta.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
-| `sp4-session-summary.jsx` | `Confetti` | `apps/web/src/components/features/session-summary/Confetti.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary-parts.jsx` | `SessionSummaryHero` | `apps/web/src/components/features/session-summary/SessionSummaryHero.tsx` | `/sessions/[id]` | done | #762 | T A M V | #1384 |
+| `sp4-session-summary-parts.jsx` | `SessionKpiGrid` | `apps/web/src/components/features/session-summary/SessionKpiGrid.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary-parts.jsx` | `ScoringBreakdownTable` | `apps/web/src/components/features/session-summary/ScoringBreakdownTable.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary-parts.jsx` | `ConnectionBar` | `apps/web/src/components/features/session-summary/ConnectionBar.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary-parts.jsx` | `AchievementsCarousel` | `apps/web/src/components/features/session-summary/AchievementsCarousel.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `SessionDiaryTimeline` | `apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `PhotosGallery` | `apps/web/src/components/features/session-summary/PhotosGallery.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `ChatHighlights` | `apps/web/src/components/features/session-summary/ChatHighlights.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `SessionShareCard` | `apps/web/src/components/features/session-summary/SessionShareCard.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `PlayAgainCta` | `apps/web/src/components/features/session-summary/PlayAgainCta.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
+| `sp4-session-summary.jsx` | `Confetti` | `apps/web/src/components/features/session-summary/Confetti.tsx` | `/sessions/[id]` | done | #762 | T A V | #1384 |
 
 ## Wave 3 — 31 components
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -263,17 +263,17 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-session-summary-parts.jsx` | `SessionSummaryHero` | `apps/web/src/components/features/session-summary/SessionSummaryHero.tsx` | `/sessions/[id]` | done | #762 | T A M V | — |
-| `sp4-session-summary-parts.jsx` | `SessionKpiGrid` | `apps/web/src/components/features/session-summary/SessionKpiGrid.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary-parts.jsx` | `ScoringBreakdownTable` | `apps/web/src/components/features/session-summary/ScoringBreakdownTable.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary-parts.jsx` | `ConnectionBar` | `apps/web/src/components/features/session-summary/ConnectionBar.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary-parts.jsx` | `AchievementsCarousel` | `apps/web/src/components/features/session-summary/AchievementsCarousel.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `SessionDiaryTimeline` | `apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `PhotosGallery` | `apps/web/src/components/features/session-summary/PhotosGallery.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `ChatHighlights` | `apps/web/src/components/features/session-summary/ChatHighlights.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `SessionShareCard` | `apps/web/src/components/features/session-summary/SessionShareCard.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `PlayAgainCta` | `apps/web/src/components/features/session-summary/PlayAgainCta.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
-| `sp4-session-summary.jsx` | `Confetti` | `apps/web/src/components/features/session-summary/Confetti.tsx` | `/sessions/[id]` | done | #762 | T A V | — |
+| `sp4-session-summary-parts.jsx` | `SessionSummaryHero` | `apps/web/src/components/features/session-summary/SessionSummaryHero.tsx` | `/sessions/[id]` | done | #762 | T A M V | #PR |
+| `sp4-session-summary-parts.jsx` | `SessionKpiGrid` | `apps/web/src/components/features/session-summary/SessionKpiGrid.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary-parts.jsx` | `ScoringBreakdownTable` | `apps/web/src/components/features/session-summary/ScoringBreakdownTable.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary-parts.jsx` | `ConnectionBar` | `apps/web/src/components/features/session-summary/ConnectionBar.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary-parts.jsx` | `AchievementsCarousel` | `apps/web/src/components/features/session-summary/AchievementsCarousel.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `SessionDiaryTimeline` | `apps/web/src/components/features/session-summary/SessionDiaryTimeline.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `PhotosGallery` | `apps/web/src/components/features/session-summary/PhotosGallery.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `ChatHighlights` | `apps/web/src/components/features/session-summary/ChatHighlights.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `SessionShareCard` | `apps/web/src/components/features/session-summary/SessionShareCard.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `PlayAgainCta` | `apps/web/src/components/features/session-summary/PlayAgainCta.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
+| `sp4-session-summary.jsx` | `Confetti` | `apps/web/src/components/features/session-summary/Confetti.tsx` | `/sessions/[id]` | done | #762 | T A V | #PR |
 
 ## Wave 3 — 31 components
 


### PR DESCRIPTION
## Summary

Closes #1371 for route /sessions/[id] (19 findings).

## Decisions

| Finding | Decision | Rationale |
|---|---|---|
| `SessionSummaryHero.tsx` (tokens): file-level eslint-disable | FIX | Removed file-level disable; replaced with 2 targeted `eslint-disable-next-line` on `text-white` usages where bg is in style prop (not className), so the rule's colored-bg exemption cannot auto-detect the context |
| `PhotosGallery.tsx` (tokens): file-level eslint-disable | FIX | Removed file-level disable; replaced with 1 targeted `eslint-disable-next-line` on `text-white` in a separate clsx string from `bg-foreground/45` |
| `SessionShareCard.tsx` (tokens): file-level eslint-disable | FIX | Removed file-level disable; replaced with 1 targeted `eslint-disable-next-line` on `text-white` where bg is in style prop. Line 258 (`bg-gradient-to-br … text-white`) is already exempt by the rule's colored-bg detection. |
| `PlayAgainCta.tsx` (tokens): file-level eslint-disable | FIX | Removed file-level disable; replaced with 1 targeted `eslint-disable-next-line` on `text-white` where `bg-entity-session` is in a separate clsx string |
| Nav: Missing Link to `/sessions` (11 components) | SKIP_FP | `layout.tsx` already has `parentHref="/sessions"` / `parentLabel="Sessioni"` in `PageHeader`. The back-link is present at the layout level. Audit doesn't scan `layout.tsx` since it targets feature components directly. |
| `SessionKpiGrid.tsx` (structural): Missing h1 | SKIP_FP | Component is a section within `/sessions/[id]` page. `SessionSummaryHero.tsx` owns `<h1>` (line 312). Adding h1 to a sub-section would create duplicate h1 — accessibility anti-pattern. |
| `ScoringBreakdownTable.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component; h1 owned by SessionSummaryHero in parent page |
| `ConnectionBar.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `AchievementsCarousel.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `SessionDiaryTimeline.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `SessionDiaryTimeline.tsx` (structural): Missing h2 | SKIP_FP | Mockup h2 belongs to a different section in the full page layout, not to this isolated component |
| `PhotosGallery.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `PhotosGallery.tsx` (structural): Missing h2 | SKIP_FP | Same rationale — mockup h2 at page level |
| `ChatHighlights.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `ChatHighlights.tsx` (structural): Missing h2 | SKIP_FP | Same rationale |
| `SessionShareCard.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `SessionShareCard.tsx` (structural): Missing h2 | SKIP_FP | Same rationale |
| `PlayAgainCta.tsx` (structural): Missing h1 | SKIP_FP | Same rationale — sub-component |
| `PlayAgainCta.tsx` (structural): Missing h2 | SKIP_FP | Same rationale |

**Totals:** 4 FIX / 15 SKIP_FP / 0 DEFER

### Key rationale for SKIP_FP decisions

**Nav (1 finding, 11 components):** `layout.tsx` at `/sessions/[id]/layout.tsx` uses `PageHeader` with `parentHref="/sessions"` and `parentLabel="Sessioni"`. The back-link is present at the layout level, invisible to the audit which scans feature components individually.

**Structural (14 findings):** `SessionSummaryHero` already contains `<h1 id={headlineId}>` (line 312 in the file). All other session-summary components are sections rendered under that h1. Adding h1/h2 to sub-sections would violate WCAG 1.3.1 (multiple h1 on one page is an anti-pattern). The audit tool cannot trace the parent→child relationship from feature component files to page.tsx.

## Test plan

- [x] `pnpm eslint` passes for all 4 modified files (0 errors)
- [x] `pnpm typecheck` passes (0 errors)
- [x] File-level `eslint-disable` removed from 4 files; replaced with targeted line-level disables
- [x] Matrix `audit_pr` column updated for all 11 session-summary components

Closes #1371

🤖 Generated by audit fix-wave plan (2026-05-21-fix-waves)