### PR TITLE
Wave 1: gamebook bundle bugfix (#1393 + #1394 + #1395)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierService.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Services;
@@ -141,8 +140,11 @@ internal class RoleClassifierService : IRoleClassifierService
         """;
 
     // D3: LLM fallback for ambiguous chunks (no heading match).
-    // System prompt instructs JSON array-of-arrays output; on parse failure
-    // we degrade gracefully to RulesReference per chunk (safe default for manuals).
+    // System prompt instructs JSON array-of-arrays output; we delegate to
+    // ILlmService.GenerateJsonAsync which tolerates prose preamble and markdown
+    // code fences (issue #1395). On unrecoverable parse failures the underlying
+    // service returns null and we degrade gracefully to RulesReference per chunk
+    // (safe default for manuals).
     private async Task<IReadOnlyList<GameBookRole>> ClassifyViaLlmAsync(
         IReadOnlyList<ChunkInput> chunks,
         CancellationToken cancellationToken)
@@ -156,22 +158,21 @@ internal class RoleClassifierService : IRoleClassifierService
 
         try
         {
-            var response = await _llmService.GenerateCompletionAsync(
+            var parsed = await _llmService.GenerateJsonAsync<string[][]>(
                 LlmSystemPrompt,
                 userPrompt,
                 RequestSource.RagClassification,
                 cancellationToken).ConfigureAwait(false);
 
-            if (!response.Success || string.IsNullOrWhiteSpace(response.Response))
+            if (parsed is null || parsed.Length == 0)
             {
                 _logger.LogWarning(
-                    "Role classifier LLM fallback returned no usable content (success={Success}); defaulting {Count} chunks to RulesReference",
-                    response.Success,
+                    "Role classifier LLM fallback returned no usable JSON; defaulting {Count} chunks to RulesReference",
                     chunks.Count);
                 return DefaultAll(chunks.Count);
             }
 
-            return ParseLlmResponse(response.Response, chunks.Count);
+            return MapParsedToRoles(parsed, chunks.Count);
         }
         catch (OperationCanceledException)
         {
@@ -203,33 +204,25 @@ internal class RoleClassifierService : IRoleClassifierService
         return sb.ToString();
     }
 
-    private static IReadOnlyList<GameBookRole> ParseLlmResponse(string content, int expectedCount)
+    private static IReadOnlyList<GameBookRole> MapParsedToRoles(string[][] parsed, int expectedCount)
     {
-        try
+        var result = new GameBookRole[expectedCount];
+        for (var i = 0; i < expectedCount; i++)
         {
-            var parsed = JsonSerializer.Deserialize<string[][]>(content) ?? Array.Empty<string[]>();
-            var result = new GameBookRole[expectedCount];
-            for (var i = 0; i < expectedCount; i++)
+            if (i >= parsed.Length || parsed[i] is null)
             {
-                if (i >= parsed.Length)
-                {
-                    result[i] = GameBookRole.RulesReference;
-                    continue;
-                }
-
-                var roles = GameBookRole.None;
-                foreach (var label in parsed[i])
-                {
-                    roles |= ParseLabel(label);
-                }
-                result[i] = roles == GameBookRole.None ? GameBookRole.RulesReference : roles;
+                result[i] = GameBookRole.RulesReference;
+                continue;
             }
-            return result;
+
+            var roles = GameBookRole.None;
+            foreach (var label in parsed[i])
+            {
+                roles |= ParseLabel(label);
+            }
+            result[i] = roles == GameBookRole.None ? GameBookRole.RulesReference : roles;
         }
-        catch (Exception ex) when (ex is JsonException or ArgumentException)
-        {
-            return DefaultAll(expectedCount);
-        }
+        return result;
     }
 
     private static GameBookRole ParseLabel(string label) => label?.ToLowerInvariant() switch

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandler.cs
@@ -15,11 +15,16 @@ namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 public class DeleteGamebookCampaignHandler : IRequestHandler<DeleteGamebookCampaignCommand>
 {
     private readonly IGamebookCampaignSessionRepository _repo;
+    private readonly ISessionBookProgressRepository _progress;
     private readonly IMediator _mediator;
 
-    public DeleteGamebookCampaignHandler(IGamebookCampaignSessionRepository repo, IMediator mediator)
+    public DeleteGamebookCampaignHandler(
+        IGamebookCampaignSessionRepository repo,
+        ISessionBookProgressRepository progress,
+        IMediator mediator)
     {
         _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        _progress = progress ?? throw new ArgumentNullException(nameof(progress));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
@@ -30,6 +35,12 @@ public class DeleteGamebookCampaignHandler : IRequestHandler<DeleteGamebookCampa
 
         if (session.OwnerUserId != cmd.CallerUserId)
             throw new ConflictException("Only owner can delete campaign");
+
+        // Issue #1394: SessionBookProgress rows have no FK cascade to the campaign,
+        // so we must explicitly purge orphans before the unit-of-work flush. The
+        // shared DbContext means SaveChangesAsync persists both the soft-delete
+        // and the orphan removal atomically.
+        await _progress.DeleteByCampaignAsync(session.Id, cancellationToken).ConfigureAwait(false);
 
         session.SoftDelete(cmd.CallerUserId);
         await _repo.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionBookProgressRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionBookProgressRepository.cs
@@ -23,4 +23,14 @@ public interface ISessionBookProgressRepository
 
     Task AddAsync(SessionBookProgress progress, CancellationToken cancellationToken);
     Task UpdateAsync(SessionBookProgress progress, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Issue #1394: stages a delete for every <see cref="SessionBookProgress"/> row tied to the
+    /// given campaign session, eliminating orphans left behind by campaign soft-delete (the
+    /// table has no FK cascade — app-layer integrity, parity with sibling SessionTracking
+    /// entities). The actual flush happens via the campaign repo's <c>SaveChangesAsync</c>
+    /// (unit-of-work pattern), so callers must invoke it AFTER staging the delete to keep
+    /// soft-delete + orphan removal atomic.
+    /// </summary>
+    Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken);
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionBookProgressRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionBookProgressRepository.cs
@@ -43,4 +43,14 @@ internal class SessionBookProgressRepository : ISessionBookProgressRepository
         _db.SessionBookProgresses.Update(progress);
         return Task.CompletedTask;
     }
+
+    public async Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+    {
+        var rows = await _db.SessionBookProgresses
+            .Where(p => p.CampaignSessionId == campaignSessionId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (rows.Count == 0) return;
+        _db.SessionBookProgresses.RemoveRange(rows);
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260520163017_RemoveGamebookProgressVO.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260520163017_RemoveGamebookProgressVO.cs
@@ -25,7 +25,9 @@ namespace Api.Infrastructure.Migrations
                 table: "gamebook_campaign_sessions",
                 type: "jsonb",
                 nullable: false,
-                defaultValue: "");
+                // Issue #1393: '' is not valid jsonb syntax — PostgreSQL rejects it with
+                // "invalid input syntax for type json". '{}' is the canonical empty-object literal.
+                defaultValue: "{}");
         }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierServiceTests.cs
@@ -58,13 +58,15 @@ public class RoleClassifierServiceTests
     [Fact]
     public async Task ClassifyAsync_AmbiguousChunk_FallsBackToLlm()
     {
+        // Issue #1395: service must use GenerateJsonAsync (which strips prose/markdown preamble)
+        // instead of raw GenerateCompletionAsync + manual JsonSerializer.Deserialize.
         _llmServiceMock
-            .Setup(x => x.GenerateCompletionAsync(
+            .Setup(x => x.GenerateJsonAsync<string[][]>(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 RequestSource.RagClassification,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(LlmCompletionResult.CreateSuccess("[[\"tutorial\",\"setup\"]]"));
+            .ReturnsAsync(new[] { new[] { "tutorial", "setup" } });
 
         var classifier = CreateSut();
         var chunk = new ChunkInput("Random Notes", "To start the game, ...");
@@ -75,11 +77,103 @@ public class RoleClassifierServiceTests
         result[0].HasFlag(GameBookRole.Tutorial).Should().BeTrue();
         result[0].HasFlag(GameBookRole.Setup).Should().BeTrue();
         _llmServiceMock.Verify(
-            x => x.GenerateCompletionAsync(
+            x => x.GenerateJsonAsync<string[][]>(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 RequestSource.RagClassification,
                 It.IsAny<CancellationToken>()),
             Times.Once);
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<RequestSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_AmbiguousChunk_LlmReturnsNull_DefaultsToRulesReference()
+    {
+        // Issue #1395: GenerateJsonAsync returns null on unrecoverable parse failures (e.g. truncated/garbage LLM output).
+        // Safe default for manuals: RulesReference.
+        _llmServiceMock
+            .Setup(x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string[][]?)null);
+
+        var classifier = CreateSut();
+        var chunk = new ChunkInput("Random Notes", "Body text here");
+
+        var result = await classifier.ClassifyAsync(new[] { chunk }, TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be(GameBookRole.RulesReference);
+        _llmServiceMock.Verify(
+            x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_AmbiguousChunk_LlmThrows_DefaultsToRulesReference()
+    {
+        // Issue #1395: ingestion must never fail because of LLM exceptions.
+        // Catch + log + degrade to safe default (RulesReference).
+        _llmServiceMock
+            .Setup(x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("LLM provider unreachable"));
+
+        var classifier = CreateSut();
+        var chunk = new ChunkInput("Random Notes", "Body text here");
+
+        var result = await classifier.ClassifyAsync(new[] { chunk }, TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be(GameBookRole.RulesReference);
+        _llmServiceMock.Verify(
+            x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_AmbiguousChunk_LlmReturnsFewerArrays_PadsRemainingWithRulesReference()
+    {
+        // Issue #1395: parity with legacy ParseLlmResponse fallback path —
+        // if LLM returns fewer chunk classifications than requested, missing entries default to RulesReference.
+        _llmServiceMock
+            .Setup(x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new[] { "narrative" } });
+
+        var classifier = CreateSut();
+        var chunks = new[]
+        {
+            new ChunkInput("Random Note 1", "First chunk body"),
+            new ChunkInput("Random Note 2", "Second chunk body"),
+        };
+
+        var result = await classifier.ClassifyAsync(chunks, TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(2);
+        result[0].Should().Be(GameBookRole.Narrative);
+        result[1].Should().Be(GameBookRole.RulesReference);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGamebookCampaignHandlerTests.cs
@@ -14,19 +14,29 @@ namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
 [Trait("BoundedContext", "SessionTracking")]
 public sealed class DeleteGamebookCampaignHandlerTests
 {
+    private sealed class CallCounter
+    {
+        private int _value;
+        public int Next() => System.Threading.Interlocked.Increment(ref _value);
+    }
+
     private sealed class FakeRepo : IGamebookCampaignSessionRepository
     {
+        private readonly CallCounter _counter;
         public List<GamebookCampaignSession> Store { get; } = new();
+        public int SaveCallOrder { get; private set; }
+
+        public FakeRepo(CallCounter counter) => _counter = counter;
 
         public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
             => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
 
-        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid ownerUserId, Guid? gameId, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
 
-        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default)
+        public Task AddAsync(GamebookCampaignSession session, CancellationToken ct = default)
         {
-            Store.Add(s);
+            Store.Add(session);
             return Task.CompletedTask;
         }
 
@@ -35,25 +45,61 @@ public sealed class DeleteGamebookCampaignHandlerTests
         public Task SaveChangesAsync(CancellationToken ct = default)
         {
             SaveCalls++;
+            SaveCallOrder = _counter.Next();
             return Task.CompletedTask;
         }
     }
 
-    private static (FakeRepo repo, DeleteGamebookCampaignHandler handler, GamebookCampaignSession session) BuildSut()
+    private sealed class FakeProgressRepo : ISessionBookProgressRepository
     {
-        var repo = new FakeRepo();
+        private readonly CallCounter _counter;
+        public Guid? DeletedCampaignId { get; private set; }
+        public int DeleteCallOrder { get; private set; }
+        public int DeleteCalls { get; private set; }
+
+        public FakeProgressRepo(CallCounter counter) => _counter = counter;
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken ct)
+        {
+            DeletedCampaignId = campaignSessionId;
+            DeleteCalls++;
+            DeleteCallOrder = _counter.Next();
+            return Task.CompletedTask;
+        }
+
+        public Task<SessionBookProgress?> GetByCampaignAndBookAsync(Guid campaignSessionId, Guid gameBookId, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<SessionBookProgress>> ListByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<SessionBookProgress?> GetMostRecentByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task AddAsync(SessionBookProgress progress, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task UpdateAsync(SessionBookProgress progress, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+
+    private static (FakeRepo repo, FakeProgressRepo progress, DeleteGamebookCampaignHandler handler, GamebookCampaignSession session) BuildSut()
+    {
+        var counter = new CallCounter();
+        var repo = new FakeRepo(counter);
+        var progress = new FakeProgressRepo(counter);
         var mediator = new Mock<IMediator>();
-        var handler = new DeleteGamebookCampaignHandler(repo, mediator.Object);
+        var handler = new DeleteGamebookCampaignHandler(repo, progress, mediator.Object);
         var userId = Guid.NewGuid();
         var session = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), userId, "Doomed Campaign");
         repo.Store.Add(session);
-        return (repo, handler, session);
+        return (repo, progress, handler, session);
     }
 
     [Fact]
     public async Task Handle_SoftDeletes_AndSaves()
     {
-        var (repo, handler, session) = BuildSut();
+        var (repo, _, handler, session) = BuildSut();
         var cmd = new DeleteGamebookCampaignCommand(session.Id, session.OwnerUserId);
 
         await handler.Handle(cmd, CancellationToken.None);
@@ -66,7 +112,7 @@ public sealed class DeleteGamebookCampaignHandlerTests
     [Fact]
     public async Task Handle_WhenSessionMissing_ThrowsNotFoundException()
     {
-        var (_, handler, _) = BuildSut();
+        var (_, _, handler, _) = BuildSut();
         var cmd = new DeleteGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid());
 
         var act = async () => await handler.Handle(cmd, CancellationToken.None);
@@ -77,7 +123,7 @@ public sealed class DeleteGamebookCampaignHandlerTests
     [Fact]
     public async Task Handle_WhenCallerIsNotOwner_ThrowsConflictException()
     {
-        var (_, handler, session) = BuildSut();
+        var (_, _, handler, session) = BuildSut();
         var differentUser = Guid.NewGuid();
         var cmd = new DeleteGamebookCampaignCommand(session.Id, differentUser);
 
@@ -85,5 +131,50 @@ public sealed class DeleteGamebookCampaignHandlerTests
 
         await act.Should().ThrowAsync<ConflictException>();
         session.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_DeletesSessionBookProgressOrphans_BeforeSaving()
+    {
+        // Issue #1394: SessionBookProgress rows have no FK cascade — handler must
+        // explicitly purge them via _progress.DeleteByCampaignAsync BEFORE the shared
+        // SaveChangesAsync flush so the delete + soft-delete persist atomically.
+        var (repo, progress, handler, session) = BuildSut();
+        var cmd = new DeleteGamebookCampaignCommand(session.Id, session.OwnerUserId);
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        progress.DeleteCalls.Should().Be(1);
+        progress.DeletedCampaignId.Should().Be(session.Id);
+        progress.DeleteCallOrder.Should().BeLessThan(repo.SaveCallOrder,
+            "DeleteByCampaignAsync must stage the delete before SaveChangesAsync flushes the unit of work");
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionMissing_DoesNotTouchProgressOrphans()
+    {
+        // Defensive: when campaign lookup fails we must short-circuit before touching
+        // the progress table to avoid orphaning rows that belong to a foreign user.
+        var (_, progress, handler, _) = BuildSut();
+        var cmd = new DeleteGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        progress.DeleteCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_DoesNotTouchProgressOrphans()
+    {
+        // Defensive: ownership check must run before any destructive action.
+        var (_, progress, handler, session) = BuildSut();
+        var differentUser = Guid.NewGuid();
+        var cmd = new DeleteGamebookCampaignCommand(session.Id, differentUser);
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+
+        progress.DeleteCalls.Should().Be(0);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpdateGamebookProgressHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpdateGamebookProgressHandlerTests.cs
@@ -65,6 +65,12 @@ public sealed class UpdateGamebookProgressHandlerTests
             // In-memory entity is mutated in place by UpdateLocation; no-op for the fake.
             return Task.CompletedTask;
         }
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+        {
+            Store.RemoveAll(p => p.CampaignSessionId == campaignSessionId);
+            return Task.CompletedTask;
+        }
     }
 
     private static (FakeCampaignRepo campaigns, FakeProgressRepo progress, UpdateGamebookProgressHandler handler, GamebookCampaignSession session) BuildSut()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
@@ -46,6 +46,12 @@ public sealed class GetGamebookCampaignHandlerTests
 
         public Task AddAsync(SessionBookProgress progress, CancellationToken cancellationToken) { Store.Add(progress); return Task.CompletedTask; }
         public Task UpdateAsync(SessionBookProgress progress, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+        {
+            Store.RemoveAll(p => p.CampaignSessionId == campaignSessionId);
+            return Task.CompletedTask;
+        }
     }
 
     private static (FakeCampaignRepo campaigns, FakeProgressRepo progress, GetGamebookCampaignHandler handler) BuildSut()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandlerTests.cs
@@ -52,6 +52,12 @@ public sealed class ListMyGamebookCampaignsHandlerTests
 
         public Task AddAsync(SessionBookProgress progress, CancellationToken cancellationToken) { Store.Add(progress); return Task.CompletedTask; }
         public Task UpdateAsync(SessionBookProgress progress, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+        {
+            Store.RemoveAll(p => p.CampaignSessionId == campaignSessionId);
+            return Task.CompletedTask;
+        }
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -85,6 +85,12 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         }
 
         public Task UpdateAsync(SessionBookProgress progress, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken cancellationToken)
+        {
+            Store.RemoveAll(p => p.CampaignSessionId == campaignSessionId);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeGlossaryRepo : IGamebookGlossaryRepository


### PR DESCRIPTION
## Summary

Bundled fix per tre regressioni follow-up della PR #1362 (gamebook multi-book generalization). Tre commit separati per chiarezza di review:

- **fix(rag) #1395**: `RoleClassifierService.ClassifyViaLlmAsync` migra da `GenerateCompletionAsync` + `JsonSerializer.Deserialize<string[][]>` raw a `ILlmService.GenerateJsonAsync<string[][]>()`, che pulisce prose preamble e markdown fence prima del parsing. Senza il fix una risposta LLM tipo `"Sure! Here is the classification:\n[[\"tutorial\"]]"` lanciava `JsonException`, il catch silenziava il fault e ogni ingestion batch finiva taggato `RulesReference`.
- **fix(gamebook) #1394**: `DeleteGamebookCampaignHandler` ora chiama `ISessionBookProgressRepository.DeleteByCampaignAsync` prima di `session.SoftDelete + SaveChangesAsync`, eliminando orphan rows che PR #1362 lasciava in `session_book_progresses` (la tabella non ha FK cascade). Nuovo metodo aggiunto all'interface + impl `ToListAsync + RemoveRange` per restare atomico con il flush della session.
- **fix(migration) #1393**: `RemoveGamebookProgressVO.Down()` ora usa `defaultValue: \"{}\"` invece di `\"\"` (PostgreSQL rifiuta string vuota come jsonb con `invalid input syntax for type json`). Verificato via `dotnet ef migrations script`.

## Test plan

- [x] `dotnet test --filter \"FullyQualifiedName~RoleClassifierServiceTests\"` → 7/7 PASS (3 esistenti + 4 nuovi: passthrough JSON, null fallback, exception fallback, partial-arrays padding)
- [x] `dotnet test --filter \"FullyQualifiedName~DeleteGamebookCampaignHandlerTests\"` → 6/6 PASS (3 esistenti + 3 nuovi: handler ordering via CallCounter, defensive non-touch on NotFound, defensive non-touch on Conflict)
- [x] `dotnet test --filter \"FullyQualifiedName~SessionTracking\"` → tutti i Fake repos sibling aggiornati con stub del nuovo metodo, compilation OK
- [x] `dotnet ef migrations script RemoveGamebookProgressVO AddSessionBookProgress` → emette `DEFAULT '{}'` corretto
- [x] Full Unit suite: 17488/17527 PASS (baseline 15 fail pre-esistenti — 0 nuove regressioni introdotte da questa PR)
- [ ] CI green
- [ ] Code review sub-agent

## Issue chiuse

Closes #1393
Closes #1394
Closes #1395

## Note per il reviewer

- I 3 commit sono separati per facilitare bisect; squash on merge li accorperà.
- 4 sibling FakeProgressRepo nei test esistenti hanno ricevuto lo stub `DeleteByCampaignAsync` come RemoveAll (Get/List/Translate/UpdateProgress handler tests) — necessario per compilation, semantica preservata.
- Il refactor #1395 elimina anche il `using System.Text.Json` non più necessario, e rinomina `ParseLlmResponse` → `MapParsedToRoles` (signature cambiata da `string` content a `string[][]` parsed, niente più try/catch JSON interno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)