### PR TITLE
Wave 2: gamebook GameRef DTO + progress endpoint (#1392 + #1388)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IGameBookRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IGameBookRepository.cs
@@ -10,4 +10,11 @@ public interface IGameBookRepository
     Task<GameBook?> FindCommunityByKbSourceAsync(Guid pdfDocId, CancellationToken ct);
     Task AddAsync(GameBook book, CancellationToken ct);
     Task UpdateAsync(GameBook book, CancellationToken ct);
+
+    /// <summary>
+    /// Issue #1388: batch lookup avoiding N+1 when callers need to resolve book
+    /// display names for a known set of ids (e.g. campaign progress endpoint).
+    /// Returns books in arbitrary order; callers must build a lookup dictionary.
+    /// </summary>
+    Task<IReadOnlyList<GameBook>> ListByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Repositories/GameBookRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Repositories/GameBookRepository.cs
@@ -58,4 +58,17 @@ internal class GameBookRepository : IGameBookRepository
         _db.GameBooks.Update(book);
         return Task.CompletedTask;
     }
+
+    public async Task<IReadOnlyList<GameBook>> ListByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        // Materialize once to keep the IN-clause stable and avoid double enumeration.
+        var idList = ids as IList<Guid> ?? ids.ToList();
+        if (idList.Count == 0) return Array.Empty<GameBook>();
+
+        return await _db.GameBooks
+            .Where(b => idList.Contains(b.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
@@ -59,9 +59,19 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
         }
 
         return new GamebookCampaignDto(
-            s.Id, s.GameRef.Id, s.OwnerUserId, s.Title,
-            currentParagraph, history, lastReadAt,
-            s.CreatedAt, s.UpdatedAt);
+            s.Id,
+            // Issue #1392: legacy GameId alias kept for backward compat; always
+            // equal to GameRefId until the FE migrates off it.
+            s.GameRef.Id,
+            s.GameRef.Id,
+            (int)s.GameRef.Kind,
+            s.OwnerUserId,
+            s.Title,
+            currentParagraph,
+            history,
+            lastReadAt,
+            s.CreatedAt,
+            s.UpdatedAt);
     }
 
     private static int ParseParagraph(string location)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
@@ -1,8 +1,18 @@
 namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
 
+/// <summary>
+/// Wire shape returned by GamebookCampaignEndpoints. Issue #1392 added
+/// <see cref="GameRefId"/> + <see cref="GameRefKind"/> so the FE can distinguish
+/// shared vs private campaigns without hardcoding <c>kind: Shared</c>. The legacy
+/// <see cref="GameId"/> field is retained as an alias for backward compatibility
+/// (always equal to <see cref="GameRefId"/>) and will be removed once all FE callers
+/// have migrated.
+/// </summary>
 public sealed record GamebookCampaignDto(
     Guid Id,
     Guid GameId,
+    Guid GameRefId,
+    int GameRefKind,
     Guid OwnerUserId,
     string Title,
     int CurrentParagraph,

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionBookProgressDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionBookProgressDto.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
+
+/// <summary>
+/// Per-book progress row returned by GET /api/v1/gamebook/campaigns/{id}/progress
+/// (issue #1388). One entry per <c>SessionBookProgress</c> row tied to the campaign;
+/// the FE renders them in a "Resume Books" list so users can pick up any book they
+/// have engaged with.
+/// </summary>
+/// <param name="BookId">The <c>GameBook.Id</c> the progress row tracks.</param>
+/// <param name="BookName">The <c>GameBook.DisplayName</c> resolved server-side; the FE renders this as-is (no client-side join).</param>
+/// <param name="LastLocation">Last visited paragraph / section label, formatted as stored (e.g. "§289"). The FE does not interpret <c>ParagraphScheme</c>.</param>
+/// <param name="LastVisitedAt">UTC ISO-8601 timestamp of the most recent visit to this book within the campaign.</param>
+public sealed record SessionBookProgressDto(
+    Guid BookId,
+    string BookName,
+    string LastLocation,
+    DateTimeOffset LastVisitedAt);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressHandler.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #1388: returns one <see cref="SessionBookProgressDto"/> per book the user
+/// has engaged with inside the campaign, sorted by most-recent visit first so the
+/// FE "Resume Books" list highlights the latest read. Joins <c>SessionBookProgress</c>
+/// rows with <c>GameBook</c> entries server-side via a single batch lookup
+/// (<see cref="IGameBookRepository.ListByIdsAsync"/>) to avoid N+1. Orphan progress
+/// rows (book deleted under the campaign) are filtered out instead of failing the
+/// request — a defensive choice to keep the play surface coherent.
+/// </summary>
+public class GetCampaignProgressHandler : IRequestHandler<GetCampaignProgressQuery, IReadOnlyList<SessionBookProgressDto>>
+{
+    private readonly IGamebookCampaignSessionRepository _campaigns;
+    private readonly ISessionBookProgressRepository _progress;
+    private readonly IGameBookRepository _books;
+
+    public GetCampaignProgressHandler(
+        IGamebookCampaignSessionRepository campaigns,
+        ISessionBookProgressRepository progress,
+        IGameBookRepository books)
+    {
+        ArgumentNullException.ThrowIfNull(campaigns);
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(books);
+        _campaigns = campaigns;
+        _progress = progress;
+        _books = books;
+    }
+
+    public async Task<IReadOnlyList<SessionBookProgressDto>> Handle(GetCampaignProgressQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _campaigns.GetByIdAsync(request.CampaignId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Campaign {request.CampaignId} not found");
+
+        if (session.OwnerUserId != request.CallerUserId)
+            throw new ConflictException("Forbidden");
+
+        var progressRows = await _progress.ListByCampaignAsync(session.Id, cancellationToken).ConfigureAwait(false);
+        if (progressRows.Count == 0)
+        {
+            return Array.Empty<SessionBookProgressDto>();
+        }
+
+        var bookIds = progressRows.Select(p => p.GameBookId).Distinct().ToList();
+        var books = await _books.ListByIdsAsync(bookIds, cancellationToken).ConfigureAwait(false);
+        var booksById = books.ToDictionary(b => b.Id);
+
+        return progressRows
+            .Where(p => booksById.ContainsKey(p.GameBookId))
+            .OrderByDescending(p => p.LastVisitedAt)
+            .Select(p => new SessionBookProgressDto(
+                p.GameBookId,
+                booksById[p.GameBookId].DisplayName,
+                p.LastLocation,
+                p.LastVisitedAt))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressQuery.cs
@@ -1,0 +1,12 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #1388: returns the per-book progress rows for a campaign so the FE can
+/// populate the "Resume Books" list on the play page. Ownership is enforced in
+/// the handler — non-owners receive <see cref="Api.Middleware.Exceptions.ConflictException"/>.
+/// </summary>
+public sealed record GetCampaignProgressQuery(Guid CampaignId, Guid CallerUserId)
+    : IRequest<IReadOnlyList<SessionBookProgressDto>>;

--- a/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
@@ -20,6 +20,7 @@ internal static class GamebookCampaignEndpoints
         MapCreateCampaignEndpoint(group);
         MapListCampaignsEndpoint(group);
         MapGetCampaignEndpoint(group);
+        MapGetCampaignProgressEndpoint(group);
         MapUpdateProgressEndpoint(group);
         MapRenameCampaignEndpoint(group);
         MapDeleteCampaignEndpoint(group);
@@ -119,6 +120,40 @@ internal static class GamebookCampaignEndpoints
         .WithTags("Gamebook")
         .WithSummary("Get a gamebook campaign by ID")
         .WithDescription("Returns the gamebook campaign with the specified ID, if it belongs to the authenticated user.")
+        .WithOpenApi();
+    }
+
+    private static void MapGetCampaignProgressEndpoint(RouteGroupBuilder group)
+    {
+        // Issue #1388: per-book progress for the ResumeBooksList on the FE play page.
+        group.MapGet("/gamebook/campaigns/{id:guid}/progress", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var rows = await mediator.Send(
+                new GetCampaignProgressQuery(id, userId), ct
+            ).ConfigureAwait(false);
+
+            return Results.Ok(rows);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<IReadOnlyList<SessionBookProgressDto>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
+        .WithTags("Gamebook")
+        .WithSummary("Get per-book progress rows for a gamebook campaign")
+        .WithDescription("Returns one entry per book the authenticated owner has engaged with, sorted by most recent visit first. Orphan progress rows (book deleted) are filtered out.")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.SharedKernel.Domain.ValueObjects;
 using FluentAssertions;
 using MediatR;
 using Moq;
@@ -51,6 +52,10 @@ public sealed class CreateGamebookCampaignHandlerTests
         dto.OwnerUserId.Should().Be(userId);
         dto.CurrentParagraph.Should().Be(0);
         dto.Id.Should().NotBeEmpty();
+        // Issue #1392: DTO must expose GameRef discriminator so FE can
+        // distinguish shared vs private campaigns without hardcoding Shared.
+        dto.GameRefId.Should().Be(gameId);
+        dto.GameRefKind.Should().Be((int)GameRefKind.Shared);
         repo.Store.Should().HaveCount(1);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetCampaignProgressHandlerTests.cs
@@ -1,0 +1,193 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class GetCampaignProgressHandlerTests
+{
+    private sealed class FakeCampaignRepo : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid ownerUserId, Guid? gameId, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default) { Store.Add(s); return Task.CompletedTask; }
+        public Task SaveChangesAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeProgressRepo : ISessionBookProgressRepository
+    {
+        public List<SessionBookProgress> Store { get; } = new();
+
+        public Task<SessionBookProgress?> GetByCampaignAndBookAsync(Guid campaignSessionId, Guid gameBookId, CancellationToken ct)
+            => Task.FromResult(Store.FirstOrDefault(p => p.CampaignSessionId == campaignSessionId && p.GameBookId == gameBookId));
+
+        public Task<IReadOnlyList<SessionBookProgress>> ListByCampaignAsync(Guid campaignSessionId, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<SessionBookProgress>>(
+                Store.Where(p => p.CampaignSessionId == campaignSessionId).ToList());
+
+        public Task<SessionBookProgress?> GetMostRecentByCampaignAsync(Guid campaignSessionId, CancellationToken ct)
+            => Task.FromResult(Store
+                .Where(p => p.CampaignSessionId == campaignSessionId)
+                .OrderByDescending(p => p.LastVisitedAt)
+                .FirstOrDefault());
+
+        public Task AddAsync(SessionBookProgress p, CancellationToken ct) { Store.Add(p); return Task.CompletedTask; }
+        public Task UpdateAsync(SessionBookProgress p, CancellationToken ct) => Task.CompletedTask;
+
+        public Task DeleteByCampaignAsync(Guid campaignSessionId, CancellationToken ct)
+        {
+            Store.RemoveAll(p => p.CampaignSessionId == campaignSessionId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeGameBookRepo : IGameBookRepository
+    {
+        public List<GameBook> Store { get; } = new();
+
+        public Task<GameBook?> GetByIdAsync(Guid id, CancellationToken ct)
+            => Task.FromResult(Store.FirstOrDefault(b => b.Id == id));
+
+        public Task<IReadOnlyList<GameBook>> ListByGameRefAsync(GameRef gameRef, Guid? ownerUserId, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<GameBook>>(Store);
+
+        public Task<GameBook?> FindCommunityByKbSourceAsync(Guid pdfDocId, CancellationToken ct)
+            => Task.FromResult<GameBook?>(null);
+
+        public Task AddAsync(GameBook book, CancellationToken ct) { Store.Add(book); return Task.CompletedTask; }
+        public Task UpdateAsync(GameBook book, CancellationToken ct) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<GameBook>> ListByIdsAsync(IEnumerable<Guid> ids, CancellationToken ct)
+        {
+            var set = new HashSet<Guid>(ids);
+            return Task.FromResult<IReadOnlyList<GameBook>>(
+                Store.Where(b => set.Contains(b.Id)).ToList());
+        }
+    }
+
+    private static (FakeCampaignRepo c, FakeProgressRepo p, FakeGameBookRepo b, GetCampaignProgressHandler h, GamebookCampaignSession session) BuildSut()
+    {
+        var c = new FakeCampaignRepo();
+        var p = new FakeProgressRepo();
+        var b = new FakeGameBookRepo();
+        var h = new GetCampaignProgressHandler(c, p, b);
+        var userId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Shared(sharedGameId), userId, "Test Campaign");
+        c.Store.Add(session);
+        return (c, p, b, h, session);
+    }
+
+    private static GameBook BuildBook(Guid? id, string displayName, GameRef gameRef)
+    {
+        var book = GameBook.CreateCommunity(
+            gameRef,
+            displayName,
+            GameBookRole.Narrative,
+            ParagraphScheme.ParagraphNumber,
+            "en",
+            sequentialRead: false,
+            kbSourceDocId: null,
+            physicalOnly: false,
+            createdBy: Guid.NewGuid());
+        if (id is not null)
+        {
+            // Test seam: align book.Id with the SessionBookProgress.GameBookId pointer.
+            typeof(GameBook)
+                .GetProperty(nameof(GameBook.Id))!
+                .SetValue(book, id.Value);
+        }
+        return book;
+    }
+
+    [Fact]
+    public async Task Handle_CampaignMissing_ThrowsNotFoundException()
+    {
+        var (_, _, _, h, _) = BuildSut();
+        var query = new GetCampaignProgressQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        var act = async () => await h.Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_CallerIsNotOwner_ThrowsConflictException()
+    {
+        var (_, _, _, h, session) = BuildSut();
+        var differentUser = Guid.NewGuid();
+        var query = new GetCampaignProgressQuery(session.Id, differentUser);
+
+        var act = async () => await h.Handle(query, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_NoProgressRows_ReturnsEmptyList()
+    {
+        var (_, _, _, h, session) = BuildSut();
+        var query = new GetCampaignProgressQuery(session.Id, session.OwnerUserId);
+
+        var result = await h.Handle(query, CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithProgressRows_ReturnsDtoSortedByLastVisitedDesc()
+    {
+        // Acceptance criteria #1388: DTO has BookId, BookName, LastLocation, LastVisitedAt.
+        // Most recently visited book appears first so the FE "Resume" list highlights it.
+        var (_, progress, books, h, session) = BuildSut();
+        var bookA = BuildBook(Guid.NewGuid(), "Press Start", session.GameRef);
+        var bookB = BuildBook(Guid.NewGuid(), "Rules Reference", session.GameRef);
+        books.Store.Add(bookA);
+        books.Store.Add(bookB);
+
+        var older = SessionBookProgress.Create(session.Id, bookA.Id, "§120");
+        await Task.Delay(15, TestContext.Current.CancellationToken);
+        var newer = SessionBookProgress.Create(session.Id, bookB.Id, "§250");
+        progress.Store.Add(older);
+        progress.Store.Add(newer);
+
+        var result = await h.Handle(new GetCampaignProgressQuery(session.Id, session.OwnerUserId), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].BookId.Should().Be(bookB.Id);
+        result[0].BookName.Should().Be("Rules Reference");
+        result[0].LastLocation.Should().Be("§250");
+        result[0].LastVisitedAt.Should().Be(newer.LastVisitedAt);
+        result[1].BookId.Should().Be(bookA.Id);
+        result[1].BookName.Should().Be("Press Start");
+    }
+
+    [Fact]
+    public async Task Handle_ProgressRowWithoutMatchingBook_IsFilteredOut()
+    {
+        // Defensive: book deletions may leave dangling progress rows. The endpoint
+        // skips them rather than 500ing (so the FE always renders a coherent list).
+        var (_, progress, books, h, session) = BuildSut();
+        var bookA = BuildBook(Guid.NewGuid(), "Press Start", session.GameRef);
+        books.Store.Add(bookA);
+        progress.Store.Add(SessionBookProgress.Create(session.Id, bookA.Id, "§50"));
+        progress.Store.Add(SessionBookProgress.Create(session.Id, Guid.NewGuid(), "§99")); // orphan
+
+        var result = await h.Handle(new GetCampaignProgressQuery(session.Id, session.OwnerUserId), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].BookId.Should().Be(bookA.Id);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
@@ -63,6 +63,45 @@ public sealed class GetGamebookCampaignHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SharedCampaign_DtoExposesSharedDiscriminator()
+    {
+        // Issue #1392: GamebookCampaignDto must surface GameRef discriminator so
+        // FE callers can stop hardcoding GameRefKind.Shared in client routing.
+        var (campaigns, _, handler) = BuildSut();
+        var userId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Shared(sharedGameId), userId, "Shared");
+        campaigns.Store.Add(session);
+        var query = new GetGamebookCampaignQuery(session.Id, userId);
+
+        var dto = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        dto.GameRefId.Should().Be(sharedGameId);
+        dto.GameRefKind.Should().Be((int)GameRefKind.Shared);
+        // Legacy alias preserved.
+        dto.GameId.Should().Be(sharedGameId);
+    }
+
+    [Fact]
+    public async Task Handle_PrivateCampaign_DtoExposesPrivateDiscriminator()
+    {
+        // Issue #1392: GameRefKind=1 propagates so FE can request the right
+        // book picker variant for private-library campaigns.
+        var (campaigns, _, handler) = BuildSut();
+        var userId = Guid.NewGuid();
+        var privateGameId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Private(privateGameId), userId, "Private");
+        campaigns.Store.Add(session);
+        var query = new GetGamebookCampaignQuery(session.Id, userId);
+
+        var dto = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        dto.GameRefId.Should().Be(privateGameId);
+        dto.GameRefKind.Should().Be((int)GameRefKind.Private);
+        dto.GameId.Should().Be(privateGameId);
+    }
+
+    [Fact]
     public async Task Handle_NoProgressRows_ReturnsZeroParagraphAndEmptyHistory()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/GetCampaignProgressEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/GetCampaignProgressEndpointTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Infrastructure;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// Issue #1388: integration test for GET /api/v1/gamebook/campaigns/{id}/progress.
+/// Exercises the auth pipeline + MediatR DI registration + route param binding +
+/// EF-side join (ListByIdsAsync) end-to-end against a real Postgres testcontainer.
+/// Follows the conservative auth pattern used by sibling endpoint tests: accepts
+/// either OK (middleware honors the seeded session cookie) or Unauthorized.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class GetCampaignProgressEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public GetCampaignProgressEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"campaign_progress_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetCampaignProgress_WithoutAuth_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync($"/api/v1/gamebook/campaigns/{Guid.NewGuid()}/progress");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetCampaignProgress_WithSeededCampaignAndProgress_ReturnsOkOrUnauthorized()
+    {
+        // Arrange: seed a campaign + 2 GameBooks + 2 SessionBookProgress rows.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var sharedGameId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Shared(sharedGameId), userId, "End-to-end Test");
+        var bookA = GameBook.CreateCommunity(
+            GameRef.Shared(sharedGameId),
+            "Press Start",
+            GameBookRole.Tutorial,
+            ParagraphScheme.ParagraphNumber,
+            "en",
+            sequentialRead: false,
+            kbSourceDocId: null,
+            physicalOnly: false,
+            createdBy: userId);
+        var bookB = GameBook.CreateCommunity(
+            GameRef.Shared(sharedGameId),
+            "Rules Reference",
+            GameBookRole.RulesReference,
+            ParagraphScheme.ParagraphNumber,
+            "en",
+            sequentialRead: false,
+            kbSourceDocId: null,
+            physicalOnly: false,
+            createdBy: userId);
+
+        await dbContext.GamebookCampaignSessions.AddAsync(session);
+        await dbContext.GameBooks.AddAsync(bookA);
+        await dbContext.GameBooks.AddAsync(bookB);
+        await dbContext.SaveChangesAsync();
+
+        var olderProgress = SessionBookProgress.Create(session.Id, bookA.Id, "§42");
+        await Task.Delay(15);
+        var newerProgress = SessionBookProgress.Create(session.Id, bookB.Id, "§99");
+        await dbContext.SessionBookProgresses.AddAsync(olderProgress);
+        await dbContext.SessionBookProgresses.AddAsync(newerProgress);
+        await dbContext.SaveChangesAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/gamebook/campaigns/{session.Id}/progress",
+            sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert — sibling integration tests use this conservative pattern because
+        // the test middleware may or may not honor the seeded session cookie.
+        (response.StatusCode == HttpStatusCode.OK ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"Expected OK or Unauthorized, got {response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task GetCampaignProgress_NonExistentCampaign_ReturnsNotFoundOrUnauthorized()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/gamebook/campaigns/{Guid.NewGuid()}/progress",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        (response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.Unauthorized).Should().BeTrue(
+            $"Expected NotFound or Unauthorized, got {response.StatusCode}");
+    }
+}

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
@@ -20,9 +20,14 @@ export function Content({
   const router = useRouter();
   // Issue #1392: derive the GameRef discriminator from the campaign DTO so
   // private-game campaigns route correctly (the BE now emits gameRefKind).
-  // Fallback to Shared + route gameId while the campaign is still loading —
-  // BookPicker gracefully renders an empty list for unknown gameIds.
-  const { data: campaign } = useGamebookCampaign(campaignId);
+  // Fallback to Shared + route gameId while the campaign is still loading.
+  // On fetch errors (e.g. deleted campaign) we log + still render the shell
+  // with the route-gameId fallback to avoid a hard crash — the picker copy
+  // surfaces the empty state to the user.
+  const { data: campaign, isError, error } = useGamebookCampaign(campaignId);
+  if (isError && process.env.NODE_ENV !== 'production') {
+    console.warn('[gamebook] campaign fetch failed, using route-gameId fallback', error);
+  }
   const gameRef: GameRef = useMemo(() => {
     if (campaign) {
       return {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useCallback, type ReactElement } from 'react';
+import { useCallback, useMemo, type ReactElement } from 'react';
 
 import { useRouter } from 'next/navigation';
 
 import { GamebookPlayShell } from '@/components/features/gamebook';
 import { ResumeBooksList } from '@/components/features/gamebook/ResumeBooksList';
 import { GameRefKind, type GameRef } from '@/lib/api/gamebook';
+import { useCampaignProgress } from '@/lib/gamebook/hooks/useCampaignProgress';
+import { useGamebookCampaign } from '@/lib/gamebook/hooks/useGamebookCampaign';
 
 export function Content({
   campaignId,
@@ -16,22 +18,24 @@ export function Content({
   gameId: string;
 }): ReactElement {
   const router = useRouter();
-  // E3 (multi-book): default discriminator to Shared until the campaign DTO
-  // exposes `GameRef` natively (see _content.tsx in /translate for the same
-  // rationale). Empty-book responses are handled by the picker.
-  const gameRef: GameRef = { id: gameId, kind: GameRefKind.Shared };
+  // Issue #1392: derive the GameRef discriminator from the campaign DTO so
+  // private-game campaigns route correctly (the BE now emits gameRefKind).
+  // Fallback to Shared + route gameId while the campaign is still loading —
+  // BookPicker gracefully renders an empty list for unknown gameIds.
+  const { data: campaign } = useGamebookCampaign(campaignId);
+  const gameRef: GameRef = useMemo(() => {
+    if (campaign) {
+      return {
+        id: campaign.gameRefId,
+        kind: campaign.gameRefKind === 1 ? GameRefKind.Private : GameRefKind.Shared,
+      };
+    }
+    return { id: gameId, kind: GameRefKind.Shared };
+  }, [campaign, gameId]);
 
-  // E2 wiring placeholder: a GET endpoint for per-book `SessionBookProgress`
-  // does not yet exist (deferred Phase F follow-up — query handler + endpoint
-  // pair). Until then we pass an empty progress list so the component renders
-  // its empty-state copy. When the endpoint lands, swap to:
-  //   const { data: progress } = useSessionBookProgress(campaignId);
-  const bookProgress: Array<{
-    bookId: string;
-    bookName: string;
-    lastLocation: string;
-    lastVisitedAt: string;
-  }> = [];
+  // Issue #1388: GET /campaigns/{id}/progress returns one row per book the user
+  // has engaged with, server-side sorted by most-recent visit first.
+  const { data: bookProgress = [] } = useCampaignProgress(campaignId);
 
   const handleResume = useCallback(
     (bookId: string) => {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import type { ReactElement } from 'react';
+import { useMemo, type ReactElement } from 'react';
 
 import { TranslateViewer } from '@/components/features/gamebook';
 import { GameRefKind, type GameRef } from '@/lib/api/gamebook';
+import { useGamebookCampaign } from '@/lib/gamebook/hooks/useGamebookCampaign';
 
 /**
  * Routes under `/library/[gameId]/...` (PR #1037 IA consolidation) accept any
- * SharedGame id. Until the campaign DTO exposes the `GameRef` discriminator
- * (deferred follow-up), we default `kind` to `Shared` here — the BookPicker
- * endpoint will gracefully return an empty list for private-game gameIds,
- * surfacing the "no narrative books" copy.
+ * SharedGame id. Issue #1392: derive the GameRef discriminator from the
+ * campaign DTO so private-game campaigns route correctly. Fallback to Shared +
+ * route gameId while the campaign is still loading — the BookPicker endpoint
+ * gracefully returns an empty list for unknown gameIds.
  */
 export function Content({
   gameId,
@@ -19,7 +20,16 @@ export function Content({
   gameId: string;
   campaignId: string;
 }): ReactElement {
-  const gameRef: GameRef = { id: gameId, kind: GameRefKind.Shared };
+  const { data: campaign } = useGamebookCampaign(campaignId);
+  const gameRef: GameRef = useMemo(() => {
+    if (campaign) {
+      return {
+        id: campaign.gameRefId,
+        kind: campaign.gameRefKind === 1 ? GameRefKind.Private : GameRefKind.Shared,
+      };
+    }
+    return { id: gameId, kind: GameRefKind.Shared };
+  }, [campaign, gameId]);
   return (
     <main className="min-h-[calc(100vh-var(--app-topbar-height,64px))]">
       <TranslateViewer campaignId={campaignId} gameRef={gameRef} />

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
@@ -20,7 +20,10 @@ export function Content({
   gameId: string;
   campaignId: string;
 }): ReactElement {
-  const { data: campaign } = useGamebookCampaign(campaignId);
+  const { data: campaign, isError, error } = useGamebookCampaign(campaignId);
+  if (isError && process.env.NODE_ENV !== 'production') {
+    console.warn('[gamebook] campaign fetch failed, using route-gameId fallback', error);
+  }
   const gameRef: GameRef = useMemo(() => {
     if (campaign) {
       return {

--- a/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   GamebookCampaignSchema,
+  SessionBookProgressSchema,
   createCampaign,
   getCampaign,
+  getCampaignProgress,
   listMyCampaigns,
   updateProgress,
 } from '../gamebook-campaigns';
@@ -12,6 +14,9 @@ import {
 const validRow = {
   id: '11111111-1111-4111-a111-111111111111',
   gameId: '22222222-2222-4222-a222-222222222222',
+  // Issue #1392: gameRefId/gameRefKind mirror the new BE discriminator fields.
+  gameRefId: '22222222-2222-4222-a222-222222222222',
+  gameRefKind: 0, // Shared
   ownerUserId: '33333333-3333-4333-a333-333333333333',
   title: 'Campagna #1',
   currentParagraph: 47,
@@ -33,6 +38,21 @@ describe('GamebookCampaignSchema', () => {
   it('handles null history → empty array', () => {
     const parsed = GamebookCampaignSchema.parse({ ...validRow, history: null });
     expect(parsed.history).toEqual([]);
+  });
+
+  it('parses GameRef discriminator (issue #1392)', () => {
+    const parsed = GamebookCampaignSchema.parse(validRow);
+    expect(parsed.gameRefId).toBe(validRow.gameRefId);
+    expect(parsed.gameRefKind).toBe(0);
+  });
+
+  it('rejects gameRefKind out of range', () => {
+    expect(() => GamebookCampaignSchema.parse({ ...validRow, gameRefKind: 2 })).toThrow();
+  });
+
+  it('parses Private discriminator', () => {
+    const parsed = GamebookCampaignSchema.parse({ ...validRow, gameRefKind: 1 });
+    expect(parsed.gameRefKind).toBe(1);
   });
 });
 
@@ -96,5 +116,52 @@ describe('gamebook-campaigns client', () => {
   it('throws helpful error on non-2xx', async () => {
     fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403 }));
     await expect(getCampaign(validRow.id)).rejects.toThrow(/403/);
+  });
+
+  it('getCampaignProgress GETs /progress and parses array (issue #1388)', async () => {
+    const row = {
+      bookId: '55555555-5555-4555-a555-555555555555',
+      bookName: 'Press Start',
+      lastLocation: '§250',
+      lastVisitedAt: '2026-05-21T10:00:00Z',
+    };
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify([row]), { status: 200 }));
+
+    const result = await getCampaignProgress(validRow.id);
+
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/api/v1/gamebook/campaigns/${validRow.id}/progress`
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(row);
+  });
+
+  it('getCampaignProgress returns empty array when BE has no progress rows', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('[]', { status: 200 }));
+    const result = await getCampaignProgress(validRow.id);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('SessionBookProgressSchema', () => {
+  const validRow = {
+    bookId: '55555555-5555-4555-a555-555555555555',
+    bookName: 'Rules Reference',
+    lastLocation: '§120',
+    lastVisitedAt: '2026-05-21T10:00:00Z',
+  };
+
+  it('parses valid row', () => {
+    expect(() => SessionBookProgressSchema.parse(validRow)).not.toThrow();
+  });
+
+  it('rejects non-UUID bookId', () => {
+    expect(() => SessionBookProgressSchema.parse({ ...validRow, bookId: 'not-a-uuid' })).toThrow();
+  });
+
+  it('rejects non-ISO lastVisitedAt', () => {
+    expect(() =>
+      SessionBookProgressSchema.parse({ ...validRow, lastVisitedAt: 'yesterday' })
+    ).toThrow();
   });
 });

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -18,7 +18,15 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 export const GamebookCampaignSchema = z.object({
   id: z.string().uuid(),
+  /**
+   * Legacy alias for `gameRefId`, kept for backward compatibility with callers
+   * that haven't migrated to the discriminator (#1392). Always equal to `gameRefId`.
+   */
   gameId: z.string().uuid(),
+  /** Issue #1392: discriminator-aware ref id (SharedGame or PrivateGame, see `gameRefKind`). */
+  gameRefId: z.string().uuid(),
+  /** Issue #1392: discriminator, 0 = Shared, 1 = Private. Mirrors backend `GameRefKind`. */
+  gameRefKind: z.number().int().min(0).max(1),
   ownerUserId: z.string().uuid(),
   title: z.string().min(1).max(200),
   currentParagraph: z.number().int().min(0),
@@ -103,6 +111,28 @@ export async function updateProgress(
     }
   );
   return parseJson(res, GamebookCampaignSchema);
+}
+
+/**
+ * Issue #1388: per-book progress rows for the ResumeBooksList on the play page.
+ * Sorted server-side by most recent visit first. Orphan rows (book deleted)
+ * are filtered out by the BE handler.
+ */
+export const SessionBookProgressSchema = z.object({
+  bookId: z.string().uuid(),
+  bookName: z.string(),
+  lastLocation: z.string(),
+  lastVisitedAt: z.string().datetime({ offset: true }),
+});
+
+export type SessionBookProgressRow = z.infer<typeof SessionBookProgressSchema>;
+
+export async function getCampaignProgress(id: string): Promise<SessionBookProgressRow[]> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(id)}/progress`,
+    { credentials: 'include' }
+  );
+  return parseJson(res, z.array(SessionBookProgressSchema));
 }
 
 export async function renameCampaign(id: string, title: string): Promise<GamebookCampaign> {

--- a/apps/web/src/lib/gamebook/hooks/useCampaignProgress.ts
+++ b/apps/web/src/lib/gamebook/hooks/useCampaignProgress.ts
@@ -1,0 +1,26 @@
+/**
+ * Issue #1388: TanStack Query hook for per-book progress on a gamebook campaign.
+ *
+ * Returns `SessionBookProgressRow[]` (already sorted server-side by most recent
+ * visit) so the FE `ResumeBooksList` can render rows without further sorting.
+ * Disabled while `campaignId` is undefined (avoids a noisy request during the
+ * initial route hydration).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getCampaignProgress, type SessionBookProgressRow } from '@/lib/api/gamebook-campaigns';
+
+export const campaignProgressKeys = {
+  byCampaign: (campaignId: string) => ['gamebook', 'campaigns', campaignId, 'progress'] as const,
+};
+
+export function useCampaignProgress(campaignId: string | undefined) {
+  return useQuery<SessionBookProgressRow[]>({
+    queryKey: campaignId
+      ? campaignProgressKeys.byCampaign(campaignId)
+      : ['gamebook', 'campaigns', 'noop', 'progress'],
+    queryFn: () => getCampaignProgress(campaignId!),
+    enabled: !!campaignId,
+  });
+}


### PR DESCRIPTION
## Summary

Wave 2 bundle, follow-up della PR #1362 (gamebook multi-book generalization). Issue indipendenti a livello backend, fortemente correlate FE-side: entrambe servono `_content.tsx` della play page.

### #1392 — GameRef discriminator → GamebookCampaignDto

- `GamebookCampaignDto` espone ora `GameRefId: Guid` + `GameRefKind: int` (0 = Shared, 1 = Private) accanto al legacy `GameId` (kept come alias backward-compat).
- `CreateGamebookCampaignHandler.MapToDto` popola entrambi da `session.GameRef`.
- FE Zod schema parses i nuovi field con range validation `gameRefKind ∈ {0, 1}`. Sia `play/_content.tsx` sia `play/translate/_content.tsx` smettono di hardcoded `kind: Shared` e derivano il discriminator da `useGamebookCampaign(campaignId)` (fallback Shared durante loading frame, BookPicker tollera unknown).

### #1388 — GET /api/v1/gamebook/campaigns/{id}/progress

- Nuovo `SessionBookProgressDto(bookId, bookName, lastLocation, lastVisitedAt)`.
- `GetCampaignProgressQuery` + `Handler` (auth check, batch resolve display name via nuovo `IGameBookRepository.ListByIdsAsync` per evitare N+1, filter orphan rows, sort by `lastVisitedAt` DESC).
- `MapGetCampaignProgressEndpoint` (MediatR + auth + 401/404/409).
- FE `getCampaignProgress(id)` client + `useCampaignProgress(campaignId)` hook (TanStack Query).
- `play/_content.tsx` consuma il hook, popola `ResumeBooksList` con dati reali (placeholder array vuoto rimosso).

## Test plan

- [x] BE unit (handler suites): 24/24 Wave 2 handlers PASS + 5/5 nuovi `GetCampaignProgressHandlerTests`
- [x] FE unit: 16/16 in `gamebook-campaigns.test.ts` (3 schema #1392 + 3 client/schema #1388)
- [x] Full BE unit suite: 17495/17534 PASS, 15 fail (baseline pre-esistenti pre-Wave 1, zero nuove regressioni)
- [ ] CI verde
- [ ] Code review sub-agent

## Issue chiuse

Closes #1392
Closes #1388

## Note per il reviewer

- DTO additivo per #1392: `GameId` legacy field kept (identico a `GameRefId`) per ridurre il blast radius FE. Da rimuovere in follow-up dopo full migration FE callers.
- `ListByIdsAsync` aggiunge un metodo public a `IGameBookRepository` (no fake implementor esistenti grep-confermato); impl usa `Where(b => idList.Contains(b.Id))` con early-return su empty input.
- Orphan progress rows (book deleted under campaign) sono filtrati lato handler, non 500. Defensive scelta per garantire UI coerente.
- I 2 `_content.tsx` usano `useMemo` per il `gameRef` derivation per evitare re-render thrashing del shell child component durante refetch del campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)