### PR TITLE
Wave 4: gamebook-multi-config E2E flag split + Wave 3 review recovery (#1390)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
@@ -610,7 +611,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                     language: item.lang,
                     sourceChunkId: tc?.Id,
                     isTranslation: item.isTranslation,
-                    roleTags: (int)(tc?.RoleTags ?? Api.BoundedContexts.GameManagement.Domain.ValueObjects.GameBookRole.None));
+                    roleTags: (int)(tc?.RoleTags ?? GameBookRole.None));
             }).ToList();
 
             await _vectorStore.IndexBatchAsync(embeddingEntities, cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/KnowledgeBaseIngestService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/KnowledgeBaseIngestService.cs
@@ -57,6 +57,9 @@ internal sealed class KnowledgeBaseIngestService(
         }
 
         // Map ACL DTOs → internal Embedding domain entities.
+        // Issue #1391: photo-batch chunks have no parent TextChunk row → RoleTags
+        // defaults to 0 (no role-match boost in semantic-mode search). When/if photo
+        // ingestion adopts role classification, propagate the classifier output here.
         var embeddings = requests
             .Select(r => new Embedding(
                 id: Guid.NewGuid(),

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/PgVectorEmbeddingEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/PgVectorEmbeddingEntity.cs
@@ -65,9 +65,13 @@ public class PgVectorEmbeddingEntity
     /// <summary>
     /// Issue #1391: denormalized copy of <c>text_chunks.role_tags</c> so semantic-mode
     /// pgvector queries can apply the role-match boost without joining the parent table.
-    /// Sync invariant: must equal <c>text_chunks.role_tags</c> for the row identified by
-    /// <see cref="SourceChunkId"/>. Maintained by the ingestion pipeline and by the
-    /// AddRoleTagsToPgVectorEmbeddings migration backfill.
+    /// Sync invariant: SHOULD equal <c>text_chunks.role_tags</c> for the row identified by
+    /// <see cref="SourceChunkId"/>. Maintained at write time by the ingestion pipeline and
+    /// once globally by the AddRoleTagsToPgVectorEmbeddings migration backfill. There is
+    /// no DB-level constraint nor event handler that propagates re-classifications, so
+    /// late calls to <c>TextChunk.AssignRoleTags</c> after pgvector ingestion will leave
+    /// this column stale until the next re-embed (VectorReembeddingService) runs. Tracked
+    /// for a future <c>TextChunkRoleReclassifiedDomainEvent</c> follow-up.
     /// </summary>
     [Required]
     [Column("role_tags")]

--- a/apps/api/src/Api/Infrastructure/Migrations/20260521104532_AddRoleTagsToPgVectorEmbeddings.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260521104532_AddRoleTagsToPgVectorEmbeddings.cs
@@ -38,6 +38,10 @@ namespace Api.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            // WARNING: dropping the column destroys the denormalized role_tags values.
+            // Re-running Up() restores them by re-backfilling from text_chunks
+            // (the source of truth on which the sync invariant is anchored), but any
+            // ingestion that ran while Up was reverted will have written zeroes.
             migrationBuilder.Sql("""
                 ALTER TABLE IF EXISTS pgvector_embeddings
                 DROP COLUMN IF EXISTS role_tags;

--- a/apps/api/src/Api/Infrastructure/Seeders/GameBookSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/GameBookSeeder.cs
@@ -194,6 +194,10 @@ internal class GameBookSeeder
         }
 
         // 2. Idempotency guard — skip if Nanolith GameBooks already exist.
+        // SeedNanolithAsync uses a single SaveChangesAsync (atomic insert of 4 books),
+        // so a count >0 means a full prior seed (no partial-state edge case to recover).
+        // If SeedNanolithAsync is ever refactored to per-book saves, change this guard
+        // to `existing.Count == 4` and re-seed missing entries instead of full-skipping.
         var existing = await _repo
             .ListByGameRefAsync(GameRef.Shared(nanolith.Id), ownerUserId: null, cancellationToken)
             .ConfigureAwait(false);
@@ -225,7 +229,13 @@ internal class GameBookSeeder
 
         if (pressStart is null || rules is null)
         {
-            _logger.LogInformation(
+            // Warning level: this is an "AC-scoped seed prerequisite missing" signal
+            // (Nanolith is in catalog but its PDFs were not uploaded by PdfSeeder).
+            // Easy to miss in non-dev logs at Information level, so escalate.
+            // FileName substring match (`press`, `start`, `rule`) is brittle to renames —
+            // future PDF named `start-here-guide.pdf` would steal a slot. Tracked for a
+            // manifest-driven lookup follow-up.
+            _logger.LogWarning(
                 "[GameBookSeeder] Nanolith PDFs not ready (pressStart={HasPressStart}, rules={HasRules}) — skipping; re-run after PDF ingestion completes.",
                 pressStart is not null, rules is not null);
             return;

--- a/apps/web/e2e/gamebook-multi-config.spec.ts
+++ b/apps/web/e2e/gamebook-multi-config.spec.ts
@@ -16,23 +16,24 @@ import { test, expect } from '@playwright/test';
  *
  *   pnpm test:e2e --grep "@gamebook-multi-config"
  *
- * Most tests are gated behind `test.skip()` until the seed is wired into
- * `CatalogSeedLayer` (deferred in F1+F2+F3 — see GameBookSeeder.cs class
- * doc). Once the orchestrator pass-through is added, flip the
- * `requiresSeededData` flag to `false`.
+ * Issue #1390: flag split now matches actual seed coverage —
+ *   - `requiresNanolithSeed` is `false` because PR #1389 wired Nanolith into
+ *     CatalogSeedLayer via GameBookSeeder.SeedNanolithIfReadyAsync.
+ *   - `requiresExpandedSeed` is still `true` because Fighting Fantasy +
+ *     Maracaibo + 7th Continent are NOT in the catalog manifest and their
+ *     GameBookSeeder paths are not yet invoked by the orchestrator (deferred
+ *     follow-up — manifest entries needed before flipping).
  *
  * Spec: docs/for-developers/specs/2026-05-19-gamebook-multi-book-generalization-design.md
  * Plan: docs/superpowers/plans/2026-05-19-gamebook-multi-book-generalization.md §F4
  */
 
-const requiresSeededData = true; // flip when seed orchestrator wiring lands
+const requiresNanolithSeed = false; // PR #1389 wired SeedNanolithIfReadyAsync into CatalogSeedLayer
+const requiresExpandedSeed = true; // flip when Maracaibo + FF + 7th Continent land in manifest
 
 test.describe('Gamebook multi-config @gamebook-multi-config', () => {
   test('BookPicker visible only when N>1 narrative books (Nanolith)', async ({ page }) => {
-    test.skip(
-      requiresSeededData,
-      'requires seeded Nanolith with 4 GameBooks (Phase F orchestrator wiring deferred)'
-    );
+    test.skip(requiresNanolithSeed, 'requires seeded Nanolith with 4 GameBooks');
 
     await page.goto('/library/games/nanolith/play');
     await page.getByTestId('photo-translate-cta').click();
@@ -45,7 +46,7 @@ test.describe('Gamebook multi-config @gamebook-multi-config', () => {
 
   test('BookPicker hidden when 1 narrative book (Maracaibo)', async ({ page }) => {
     test.skip(
-      requiresSeededData,
+      requiresExpandedSeed,
       'requires seeded Maracaibo with 2 GameBooks (rulebook+story); orchestrator wiring deferred'
     );
 
@@ -59,7 +60,7 @@ test.describe('Gamebook multi-config @gamebook-multi-config', () => {
     page,
   }) => {
     test.skip(
-      requiresSeededData,
+      requiresExpandedSeed,
       'requires seeded Fighting Fantasy + manifest entry (FF not yet in catalog manifests)'
     );
 
@@ -85,7 +86,7 @@ test.describe('Gamebook multi-config @gamebook-multi-config', () => {
     page,
   }) => {
     test.skip(
-      requiresSeededData,
+      requiresExpandedSeed,
       'requires seeded Maracaibo + role-aware query routing (D7 wiring)'
     );
 
@@ -105,7 +106,7 @@ test.describe('Gamebook multi-config @gamebook-multi-config', () => {
 
   test('Case C: 7th Continent — companion disabled when no GameBook (FM-19)', async ({ page }) => {
     test.skip(
-      requiresSeededData,
+      requiresExpandedSeed,
       'requires seeded 7th Continent SharedGame WITHOUT a GameBook (manifest only, no GameBookSeeder call)'
     );
 


### PR DESCRIPTION
## Summary

Ultima wave del gamebook follow-up bundle (PR #1362). Due commit:

### #1390 — E2E `requiresSeededData` flag flip

PR #1389 (Wave 3) ha wirato `GameBookSeeder.SeedNanolithIfReadyAsync` in `CatalogSeedLayer`, quindi il test E2E "BookPicker visible quando N>1 narrative books (Nanolith)" può ora girare contro un seed pipeline fresh.

Split del flag per matchare l'effettiva seed coverage:

- `requiresNanolithSeed = false` → Nanolith test enabled
- `requiresExpandedSeed = true` → FF + Maracaibo + 7th Continent ancora skip (NON in catalog manifest, `SeedNanolithIfReadyAsync` copre solo Nanolith — i seeder paths SeedFightingFantasyAsync/SeedMaracaiboAsync esistono ma non sono invocati dall'orchestrator finché i manifest entries mancano)

### Wave 3 review fix recovery

Il commit `8afaffed4` (review fixes Wave 3 PR #1409) non è stato incluso nel merge per race condition: push background ancora in corso quando ho fatto `gh pr merge --squash`. Re-applicato qui:

- I-1 (conf 85): comment KnowledgeBaseIngestService.cs:60 (photo-batch path → RoleTags=0 intentional)
- I-2 (conf 75): PgVectorEmbeddingEntity sync-invariant docstring softened + TODO follow-up
- m-1 (conf 80): AddRoleTagsToPgVectorEmbeddings Down() warning sul destroy data
- m-2 (conf 78) + m-3 (conf 72): GameBookSeeder filename-substring brittleness + log level Information → Warning
- m-4 (conf 70): idempotency assumption + refactor guidance
- m-5 (conf 70): GameBookRole using hoist in PdfProcessingPipelineService

Documentation/comment + log-level + using-hoist only. Zero behavioral change. Build OK.

## Test plan

- [x] Build BE OK (recovered Wave 3 code-comment changes — no behavioral diff)
- [x] FE typecheck OK (E2E spec is type-checked at build time)
- [ ] CI verde
- [ ] Code review sub-agent
- [ ] E2E Nanolith run against staging (gated by `@gamebook-multi-config` tag, not part of CI smoke; manual smoke recommended via `pnpm test:e2e --grep "@gamebook-multi-config"` after merge)

## Issue chiuse

Closes #1390

## Note per il reviewer

- Wave 4 è scoped piccola intenzionalmente: solo flag flip + recovery doc-only.
- I 3 follow-up issue da Wave 2 (#1404 ConflictException→ForbiddenException, #1405 remove GameId legacy alias, #1406 gameRefKind range future-proof) restano open.
- Recovery rationale: i fix originali Wave 3 erano documentation-only e già reviewed/approved; non sono blocker da rifare review intera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)