### PR TITLE
fix(api): Administration role authorization → ForbiddenException (403)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommandHandler.cs
@@ -64,7 +64,7 @@ internal sealed class ImpersonateUserCommandHandler
         };
         if (adminLevel < 3)
         {
-            throw new ConflictException("Only admins or SuperAdmins can impersonate users");
+            throw new ForbiddenException("Only admins or SuperAdmins can impersonate users");
         }
 
         // Verify target user exists

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Operations/RestartServiceCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Operations/RestartServiceCommandHandler.cs
@@ -63,7 +63,7 @@ internal sealed class RestartServiceCommandHandler
             _logger.LogWarning(
                 "⚠️ SECURITY: Non-SuperAdmin {UserId} attempted to restart service",
                 command.AdminUserId);
-            throw new ConflictException("Only SuperAdmin can restart services");
+            throw new ForbiddenException("Only SuperAdmin can restart services");
         }
 
         // Create audit log

--- a/apps/api/src/Api/Routing/AdminOperationsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminOperationsEndpoints.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Administration.Application.Commands;
 using Api.BoundedContexts.Administration.Application.Commands.Operations;
+using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Administration.Application.Queries.Operations;
 using Api.Extensions;
 using Api.Infrastructure.Authorization;
@@ -104,6 +105,10 @@ internal static class AdminOperationsEndpoints
             ConfirmationLevel.Level2,
             "Restart API Service",
             "This will restart the API service. All active sessions will be terminated. Estimated downtime: 30-60 seconds."))
+        .Produces<RestartServiceResponseDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
         .WithSummary("Restart API service")
         .WithDescription("Triggers graceful shutdown; orchestrator handles restart. SuperAdmin only, Level 2 confirmation required.");
 
@@ -131,6 +136,11 @@ internal static class AdminOperationsEndpoints
             ConfirmationLevel.Level2,
             "Impersonate User",
             "You will gain full access to this user's account. All actions will be audited."))
+        .Produces<ImpersonateUserResponseDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
         .WithSummary("Impersonate user")
         .WithDescription("Creates session as target user for debugging. SuperAdmin only, Level 2 confirmation required.");
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonateUserCommandHandlerTests.cs
@@ -100,6 +100,31 @@ public class ImpersonateUserCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_CallerIsNotAdmin_ThrowsForbiddenException()
+    {
+        // Issue #1416: role-based authorization failures must map to HTTP 403,
+        // not 409. The handler's adminLevel < 3 guard rejects non-admin callers
+        // before any target-side checks.
+        var callerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var regularUser = CreateTestUser(callerId, "user@test.com", "user");
+
+        _mockUserRepository
+            .Setup(r => r.GetByIdAsync(callerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(regularUser);
+
+        var command = new ImpersonateUserCommand(targetId, callerId, "Trying to impersonate without admin role");
+
+        // Act
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ForbiddenException>()
+            .WithMessage("*Only admins or SuperAdmins can impersonate users*");
+    }
+
+    [Fact]
     public async Task Handle_TargetIsAdmin_ThrowsForbiddenException()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/Unit/Administration/Operations/RestartServiceCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Administration/Operations/RestartServiceCommandHandlerTests.cs
@@ -84,9 +84,11 @@ public sealed class RestartServiceCommandHandlerTests
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("BoundedContext", "Administration")]
-    public async Task Handle_NonSuperAdmin_ThrowsConflictException()
+    public async Task Handle_NonSuperAdmin_ThrowsForbiddenException()
     {
-        // Arrange
+        // Issue #1416: role-based authorization failures must map to HTTP 403,
+        // not 409, so external clients can distinguish authorization failures
+        // from real conflicts.
         var adminId = Guid.NewGuid();
         var command = new RestartServiceCommand("API", adminId);
 
@@ -98,7 +100,7 @@ public sealed class RestartServiceCommandHandlerTests
 
         // Act & Assert
         var act = () => _handler.Handle(command, CancellationToken.None);
-        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ForbiddenException>()).Which;
 
         exception.Message.Should().Be("Only SuperAdmin can restart services");
 


### PR DESCRIPTION
Closes #1416

Follow-up to #1404 / PR #1412 — same `ConflictException`-for-authorization anti-pattern existed in the Administration BC.

## Summary

Two Administration handlers threw `ConflictException` (HTTP 409) on role-based authorization failure. Same wire-level semantic mismatch as #1404: clients couldn't distinguish a true conflict from an authorization denial.

The fix also resolves an intra-file inconsistency in `ImpersonateUserCommandHandler`: same handler used `ConflictException` at line 67 for the caller-role guard and `ForbiddenException` at line 92 for the target-role guard — both are role checks, both should be 403.

## Handlers migrated (2)

- `ImpersonateUserCommandHandler.cs:67` — caller-side guard: `adminLevel < 3` (non-admin trying to impersonate). Now `ForbiddenException`. Message preserved verbatim: `"Only admins or SuperAdmins can impersonate users"`.
- `Operations/RestartServiceCommandHandler.cs:66` — SuperAdmin-only operation. Now `ForbiddenException`. Message preserved verbatim: `"Only SuperAdmin can restart services"`.

## Tests

- `RestartServiceCommandHandlerTests`: rename `Handle_NonSuperAdmin_ThrowsConflictException` → `…ThrowsForbiddenException`, swap assertion type, preserve message-string assertion.
- `ImpersonateUserCommandHandlerTests`: added missing `Handle_CallerIsNotAdmin_ThrowsForbiddenException` test — there was no prior unit coverage for the `adminLevel<3` guard at handler:67.

## OpenAPI updates (`AdminOperationsEndpoints.cs`)

Both endpoints previously declared NO `.Produces()` statuses. Added complete failure surface:

- `POST /admin/operations/restart-service`: `.Produces<RestartServiceResponseDto>(200)`, `.Produces(401/403/404)`.
- `POST /admin/operations/impersonate`: `.Produces<ImpersonateUserResponseDto>(200)`, `.Produces(401/403/404/409)`. The `409` is retained for the `"Cannot impersonate suspended user"` guard at handler:81 (user-state conflict, not authorization — intentionally unchanged).

The sibling impersonate endpoints in `AdminUserActivityEndpoints.cs:213` and `AdminUserActivityDetailEndpoints.cs:152` already declare `.Produces(403)` — no changes needed there.

## Untouched (semantically correct as 409)

- `ImpersonateUserCommandHandler.cs:81` — `"Cannot impersonate suspended user '{id}'"` is a user-state conflict, not authorization.
- `Infrastructure/RestartInfraServiceCommandHandlerTests` cooldown 409 — different handler (`RestartInfraServiceCommand`), state conflict.

## Test plan

- [x] `dotnet build apps/api/src/Api/Api.csproj` — clean (0 warn / 0 err)
- [x] `dotnet test --filter "FullyQualifiedName~ImpersonateUserCommandHandlerTests|FullyQualifiedName~RestartServiceCommandHandlerTests"` — 11/11 pass
- [ ] CI Backend Fast green (note: pre-existing baseline drift on main-dev applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)