### PR TITLE
refactor(gamebook): remove deprecated GameId alias from GamebookCampaignDto

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
@@ -60,9 +60,6 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
 
         return new GamebookCampaignDto(
             s.Id,
-            // Issue #1392: legacy GameId alias kept for backward compat; always
-            // equal to GameRefId until the FE migrates off it.
-            s.GameRef.Id,
             s.GameRef.Id,
             (int)s.GameRef.Kind,
             s.OwnerUserId,

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
@@ -1,16 +1,14 @@
 namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
 
 /// <summary>
-/// Wire shape returned by GamebookCampaignEndpoints. Issue #1392 added
+/// Wire shape returned by GamebookCampaignEndpoints. Issue #1392 introduced
 /// <see cref="GameRefId"/> + <see cref="GameRefKind"/> so the FE can distinguish
-/// shared vs private campaigns without hardcoding <c>kind: Shared</c>. The legacy
-/// <see cref="GameId"/> field is retained as an alias for backward compatibility
-/// (always equal to <see cref="GameRefId"/>) and will be removed once all FE callers
-/// have migrated.
+/// shared vs private campaigns without hardcoding <c>kind: Shared</c>. Issue #1405
+/// removed the legacy <c>GameId</c> alias after all FE consumers migrated to
+/// <see cref="GameRefId"/>.
 /// </summary>
 public sealed record GamebookCampaignDto(
     Guid Id,
-    Guid GameId,
     Guid GameRefId,
     int GameRefKind,
     Guid OwnerUserId,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
@@ -48,12 +48,13 @@ public sealed class CreateGamebookCampaignHandlerTests
 
         // Assert
         dto.Title.Should().Be("My Campaign");
-        dto.GameId.Should().Be(gameId);
         dto.OwnerUserId.Should().Be(userId);
         dto.CurrentParagraph.Should().Be(0);
         dto.Id.Should().NotBeEmpty();
         // Issue #1392: DTO must expose GameRef discriminator so FE can
         // distinguish shared vs private campaigns without hardcoding Shared.
+        // Issue #1405: legacy GameId alias removed; gameRefId is the canonical
+        // ref identifier.
         dto.GameRefId.Should().Be(gameId);
         dto.GameRefKind.Should().Be((int)GameRefKind.Shared);
         repo.Store.Should().HaveCount(1);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookCampaignHandlerTests.cs
@@ -78,8 +78,6 @@ public sealed class GetGamebookCampaignHandlerTests
 
         dto.GameRefId.Should().Be(sharedGameId);
         dto.GameRefKind.Should().Be((int)GameRefKind.Shared);
-        // Legacy alias preserved.
-        dto.GameId.Should().Be(sharedGameId);
     }
 
     [Fact]
@@ -98,7 +96,6 @@ public sealed class GetGamebookCampaignHandlerTests
 
         dto.GameRefId.Should().Be(privateGameId);
         dto.GameRefKind.Should().Be((int)GameRefKind.Private);
-        dto.GameId.Should().Be(privateGameId);
     }
 
     [Fact]

--- a/apps/web/src/components/features/gamebook/__tests__/GamebookPlayShell.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GamebookPlayShell.test.tsx
@@ -37,7 +37,8 @@ vi.mock('@/lib/stores/chat-panel-store', () => ({
 
 const fakeCampaign = {
   id: 'c1',
-  gameId: 'g1',
+  gameRefId: 'g1',
+  gameRefKind: 0,
   ownerUserId: 'u1',
   title: 'Campagna #1',
   currentParagraph: 47,

--- a/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
@@ -13,8 +13,8 @@ import {
 // Valid v4 UUIDs: position 14 = [1-8], position 19 = [89ab]
 const validRow = {
   id: '11111111-1111-4111-a111-111111111111',
-  gameId: '22222222-2222-4222-a222-222222222222',
-  // Issue #1392: gameRefId/gameRefKind mirror the new BE discriminator fields.
+  // Issue #1392 / #1405: gameRefId/gameRefKind are the canonical BE discriminator
+  // fields. The legacy `gameId` alias was removed in #1405.
   gameRefId: '22222222-2222-4222-a222-222222222222',
   gameRefKind: 0, // Shared
   ownerUserId: '33333333-3333-4333-a333-333333333333',
@@ -99,7 +99,7 @@ describe('gamebook-campaigns client', () => {
       })
     );
 
-    const result = await createCampaign({ gameId: validRow.gameId, title: validRow.title });
+    const result = await createCampaign({ gameId: validRow.gameRefId, title: validRow.title });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
@@ -107,7 +107,7 @@ describe('gamebook-campaigns client', () => {
     expect(init.method).toBe('POST');
     expect(init.credentials).toBe('include');
     expect(JSON.parse(init.body as string)).toEqual({
-      gameId: validRow.gameId,
+      gameId: validRow.gameRefId,
       title: validRow.title,
     });
     expect(result.id).toBe(validRow.id);
@@ -122,8 +122,8 @@ describe('gamebook-campaigns client', () => {
 
   it('listMyCampaigns appends gameId query when provided', async () => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify([validRow]), { status: 200 }));
-    await listMyCampaigns(validRow.gameId);
-    expect(fetchMock.mock.calls[0][0]).toContain(`gameId=${validRow.gameId}`);
+    await listMyCampaigns(validRow.gameRefId);
+    expect(fetchMock.mock.calls[0][0]).toContain(`gameId=${validRow.gameRefId}`);
   });
 
   it('updateProgress PUTs new paragraph with gameBookId (C2 multi-book)', async () => {

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -18,11 +18,6 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 export const GamebookCampaignSchema = z.object({
   id: z.string().uuid(),
-  /**
-   * Legacy alias for `gameRefId`, kept for backward compatibility with callers
-   * that haven't migrated to the discriminator (#1392). Always equal to `gameRefId`.
-   */
-  gameId: z.string().uuid(),
   /** Issue #1392: discriminator-aware ref id (SharedGame or PrivateGame, see `gameRefKind`). */
   gameRefId: z.string().uuid(),
   /**

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useGamebookCampaign.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useGamebookCampaign.test.tsx
@@ -13,7 +13,8 @@ vi.mock('@/lib/api/gamebook-campaigns');
 // Using arbitrary strings is fine here since getCampaign is fully mocked.
 const fakeCampaign = {
   id: 'abc',
-  gameId: 'g',
+  gameRefId: 'g',
+  gameRefKind: 0,
   ownerUserId: 'o',
   title: 'C1',
   currentParagraph: 47,


### PR DESCRIPTION
Closes #1405

PR #1402 (Wave 2) added \`GameRefId\` + \`GameRefKind\` as the canonical discriminator on \`GamebookCampaignDto\` and kept the legacy \`GameId\` field as an alias (always equal to \`GameRefId\`) to avoid breaking non-updated FE consumers shipped in the same release. Audit on \`main-dev\` confirms **zero FE consumers** read \`campaign.gameId\` from the DTO response — the two active sites (\`play/[campaignId]/_content.tsx:34\`, \`translate/_content.tsx:30\`) already use \`campaign.gameRefId\`. Safe to remove the alias.

## What changed

**Backend** (3 files):
- \`GamebookCampaignDto.cs\`: dropped the \`Guid GameId\` record positional parameter; refreshed XML doc to reflect the #1405 removal.
- \`CreateGamebookCampaignHandler.MapToDto\`: dropped the duplicate \`s.GameRef.Id\` argument that fed the alias.
- Tests: removed three \`dto.GameId.Should().Be(...)\` assertions (one in \`CreateGamebookCampaignHandlerTests\`, two in \`GetGamebookCampaignHandlerTests\`).

**Frontend** (4 files):
- \`gamebook-campaigns.ts\`: dropped \`gameId: z.string().uuid()\` field + its JSDoc.
- \`gamebook-campaigns.test.ts\`: dropped \`gameId\` from \`validRow\` fixture; swapped all 4 \`validRow.gameId\` references to \`validRow.gameRefId\` (same UUID, sourced from canonical field).
- \`useGamebookCampaign.test.tsx\` + \`GamebookPlayShell.test.tsx\`: dropped \`gameId\` from in-memory \`fakeCampaign\` mocks; added missing \`gameRefId\`/\`gameRefKind\` so the mock matches the post-removal DTO shape.

## What is intentionally NOT changed

The \`gameId\` parameter is still a valid **input** to \`createCampaign({ gameId, title })\`, \`listMyCampaigns(gameId?)\`, and on \`?gameId=<guid>\` query strings — that's the BE's identifier for the game, not the DTO output field removed here. The four 'input' usages in \`gamebook-campaigns.test.ts\` keep the \`gameId\` *parameter name* but source the UUID from \`validRow.gameRefId\`.

## Test plan

- [x] \`dotnet build apps/api/src/Api/Api.csproj\` — clean (0 warn / 0 err)
- [x] \`dotnet test --filter "FullyQualifiedName~Gamebook"\` — 93/93 pass (1 intentional skip)
- [x] \`pnpm vitest run\` (3 affected files) — 25/25 pass
- [x] \`pnpm typecheck\` — clean
- [ ] CI Backend Fast green
- [ ] CI Frontend Tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)