### PR TITLE
fix(deploy): default API_IMAGE/WEB_IMAGE to staging-latest in deploy step

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -639,6 +639,18 @@ jobs:
             for f in secrets/*.secret; do source "$f" 2>/dev/null; done
             set +a
 
+            # Issue #1399-C: compose.staging.yml uses ${API_IMAGE:?...} and
+            # ${WEB_IMAGE:?...} guards on both services. When only ONE service
+            # is rebuilt this run, the other env var would be unset and the
+            # whole `docker compose up` aborts (even though we pass --no-deps
+            # and only target the changed service). Default both vars to the
+            # staging-latest tag the build job always promotes (lines ~346,
+            # ~356) so the unchanged service keeps pointing at its previous
+            # deploy. The rebuilt service then overrides its var below with
+            # the freshly-pushed digest.
+            export API_IMAGE="${{ env.API_IMAGE }}:staging-latest"
+            export WEB_IMAGE="${{ env.WEB_IMAGE }}:staging-latest"
+
             SERVICES=""
 
             # Pull and tag only changed images


### PR DESCRIPTION
Refs #1399 (sub-task **C** only — Storage Phase 4 cleanup A+B will land in a separate PR).

## Problem

\`deploy-staging.yml\`'s deploy step exports either \`API_IMAGE\` or \`WEB_IMAGE\` (or both) **only when** the corresponding service was rebuilt this run. \`compose.staging.yml\` uses \`\${API_IMAGE:?...}\` and \`\${WEB_IMAGE:?...}\` guards on both services, so \`docker compose up -d --no-deps <only-changed>\` still fails at parse time because the unset var triggers the \`?\`-guard. The whole deploy aborts AFTER the container has been removed for \`--force-recreate\`, leaving the unchanged service down — manual recovery via inline env vars was the workaround during the 2026-05-20/21 rollout (per issue #1399 part C).

## Fix

Default both \`API_IMAGE\` and \`WEB_IMAGE\` to \`<repo>:staging-latest\` before the conditional override. The build job promotes the \`staging-latest\` tag for any rebuilt service (\`deploy-staging.yml:346\` for API, \`:356\` for Web), so the unchanged service stays on its previous deploy's image. The rebuilt service then overwrites its var with the freshly-pushed digest as before.

## Why staging-latest (not a digest pin)

- \`staging-latest\` is always present on GHCR once the first staging deploy ran — no boot-strap risk.
- For build-once-promote, the unchanged service's correct image **is** whatever \`staging-latest\` currently points at — it was already running in production. Pinning a digest from \`docker inspect\` on the server would work too, but it requires an extra SSH round-trip and the tag is sufficient.
- This trades a tiny amount of immutability (the tag is mutable) for operational simplicity. The \`?\`-guards on the compose file remain in place to fail loudly if **both** vars are unset (e.g. first-ever deploy).

## Test plan

- [x] YAML structure unchanged (positional)
- [ ] CI green
- [ ] Next mixed-deploy (only api OR only web rebuilt) on staging completes without manual recovery — observation gate, not blocking this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)