### PR TITLE
fix(tests): #1422 clear 12 SharedGameId/PDF baseline failures (Phase 2d carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,8 @@ tests/Api.Tests/          # Backend test suite
 
 ## Known Flaky Tests
 
-Tests confirmed failing on `main-dev` baseline independently of any specific PR. Triage tracked in #1349.
+Tests confirmed failing on `main-dev` baseline independently of any specific PR.
+Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved).
 
 | Test | File | First observed | Reason | Action |
 |---|---|---|---|---|
@@ -269,6 +270,9 @@ Tests confirmed failing on `main-dev` baseline independently of any specific PR.
 | `Handle_EmptyGuid_ReturnsNull` | `Api.Tests` | #1341 baseline | Pre-existing | Document |
 | `Handle_WithSearchFilter_ReturnsMatchingGames` | `Api.Tests` | #1341 baseline | EF Core InMemory provider does not support `ILike` (Postgres-specific) | Integration test only — exclude from unit suite |
 | `*_S3Storage_*` (2 tests) | `Api.Tests` | #1341 baseline | Mock verification timing / strict mode mismatch | Document |
+
+**Resolved in #1422 (2026-05-21)**: 12 undocumented SharedGameId/PDF cluster failures triaged and cleared.
+Root cause: regression from PR #1345/#1347 (Phase 2d delete `GameEntity` + drop `games` table, 2026-05-20). Test fixtures still relied on the dropped `pdf_documents.GameId` column → handlers filtering on `SharedGameId` returned 0 items. Resolution: **11 fixed** via fixture drift correction (add `SharedGameId` to `PdfDocumentEntity`/`TextChunkEntity` setups + `Publisher = "Kosmos"` on `DegradedAgentContext` full-metadata test) + **1 deleted** (`Handle_WithSharedGameId_ResolvesToActualGameId` — Post-Phase 2d the resolver step in `CreateChatThreadCommandHandler:46-54` is a degenerate identity lookup; cross-table resolution no longer exists).
 
 **Policy**: PRs MUST NOT cause the unit-test fail count to grow above this baseline. The CI `Backend Fast` job is non-required while these are pending fixes; a future cleanup will either fix the root cause (e.g., switch ILike test to integration) or skip with `[Trait("Skip", "<issue#>")]`.
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandlerTests.cs
@@ -49,6 +49,7 @@ public class GetAllPdfsQueryHandlerTests
         ctx.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "test.pdf",
             FilePath = "/tmp/test.pdf",
             UploadedByUserId = Guid.NewGuid(),
@@ -138,6 +139,7 @@ public class GetAllPdfsQueryHandlerTests
         ctx.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameA,
             FileName = "a.pdf",
             FilePath = "/tmp/a.pdf",
             UploadedByUserId = Guid.NewGuid(),
@@ -146,6 +148,7 @@ public class GetAllPdfsQueryHandlerTests
         ctx.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameB,
             FileName = "b.pdf",
             FilePath = "/tmp/b.pdf",
             UploadedByUserId = Guid.NewGuid(),

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatThreadCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatThreadCommandHandlerTests.cs
@@ -117,30 +117,14 @@ public sealed class CreateChatThreadCommandHandlerTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact]
-    public async Task Handle_WithSharedGameId_ResolvesToActualGameId()
-    {
-        // Arrange: game exists with a SharedGameId link
-        var actualGameId = Guid.NewGuid();
-        var sharedGameId = Guid.NewGuid();
-        var userId = Guid.NewGuid();
-
-        _db.SharedGames.Add(new SharedGameEntity { Id = actualGameId, Title = "Puerto Rico" });
-        await _db.SaveChangesAsync();
-
-        // Frontend passes sharedGameId (from user_library_entries.shared_game_id)
-        var command = new CreateChatThreadCommand(UserId: userId, GameId: sharedGameId, Title: "Chat about Puerto Rico");
-
-        // Act
-        var result = await _handler.Handle(command, CancellationToken.None);
-
-        // Assert: the thread should use the actual games.Id, not the sharedGameId
-        result.Should().NotBeNull();
-        result.GameId.Should().Be(actualGameId);
-        _mockRepo.Verify(r => r.AddAsync(
-            It.Is<ChatThread>(t => t.GameId == actualGameId),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
+    // Test 'Handle_WithSharedGameId_ResolvesToActualGameId' removed in #1422:
+    // Post-Phase 2d (PR #1345/#1347, 2026-05-20), GameEntity is dropped and
+    // SharedGameEntity.Id is authoritative. The handler's resolver step
+    // (CreateChatThreadCommandHandler.cs:46-54) is now a degenerate identity
+    // lookup against shared_games — no cross-table resolution exists anymore,
+    // so this test verified a behavior that is structurally impossible.
+    // 'Handle_WithDirectGameId_DoesNotResolve' below covers the surviving
+    // contract (the Id is passed through when it matches a SharedGame row).
 
     [Fact]
     public async Task Handle_WithDirectGameId_DoesNotResolve()

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/DegradedAgentServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/DegradedAgentServiceTests.cs
@@ -35,6 +35,7 @@ public class DegradedAgentServiceTests
             PlayTimeMinutes = 90,
             ComplexityWeight = 2.3m,
             YearPublished = "1995",
+            Publisher = "Kosmos",
             Categories = new List<string> { "Strategy", "Economic" },
             Mechanics = new List<string> { "Dice Rolling", "Trading" },
             Designer = "Klaus Teuber"

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/GraphRagExtractionTests.cs
@@ -299,6 +299,7 @@ public sealed class GraphRagExtractionTests : IDisposable
         var pdfDoc = new PdfDocumentEntity
         {
             Id = _pdfDocumentId,
+            SharedGameId = _gameId,
             FileName = "Catan Rules.pdf",
             FilePath = "/fake/path/test.pdf",
             ContentType = "application/pdf",

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/GetGamePdfsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/GetGamePdfsQueryHandlerTests.cs
@@ -65,6 +65,7 @@ public class GetGamePdfsQueryHandlerTests
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = gameId,
             FileName = "TestRules.pdf",
             FilePath = "/test/path.pdf",
             FileSizeBytes = 1_000_000,
@@ -99,6 +100,7 @@ public class GetGamePdfsQueryHandlerTests
         var pdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "SharedRules.pdf",
             FilePath = "/test/shared.pdf",
             FileSizeBytes = 500_000,
@@ -166,6 +168,7 @@ public class GetGamePdfsQueryHandlerTests
         _db.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "ItExpansionRules.pdf",
             FilePath = "/tmp/it.pdf",
             FileSizeBytes = 200,
@@ -197,6 +200,7 @@ public class GetGamePdfsQueryHandlerTests
         var olderPdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "OlderRules.pdf",
             FilePath = "/test/older.pdf",
             FileSizeBytes = 100_000,
@@ -207,6 +211,7 @@ public class GetGamePdfsQueryHandlerTests
         var newerPdf = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
             FileName = "NewerRules.pdf",
             FilePath = "/test/newer.pdf",
             FileSizeBytes = 200_000,

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -249,6 +249,7 @@ public sealed class PdfSeederBlobTests
         db.PdfDocuments.Add(new PdfDocumentEntity
         {
             Id = oldDocId,
+            SharedGameId = gameId,
             FileName = "gloomhaven.pdf",
             FilePath = "/old/path",
             FileSizeBytes = 100,

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SharedGameRagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SharedGameRagIntegrationTests.cs
@@ -53,6 +53,7 @@ public sealed class SharedGameRagIntegrationTests
         {
             Id = Guid.NewGuid(),
             GameId = gameId,
+            SharedGameId = sharedGameId,
             PdfDocumentId = pdfDocId,
             Content = "Roll two dice and move your piece.",
             ChunkIndex = 0,


### PR DESCRIPTION
## Summary

Resolves the 12 undocumented unit-test failures tracked in #1422. Root cause is a single regression from **PR #1345/#1347 — Phase 2d delete `GameEntity` + drop `games` table** (commit `b396a94b8`, 2026-05-20): the legacy `pdf_documents.GameId` column was dropped, but several test fixtures still relied on it. Post-migration handlers filter on `SharedGameId`, so setups without it returned 0 items.

**Resolution**: **11 fixed** via fixture drift correction + **1 deleted** as obsolete. Zero `[Trait(\"Skip\", \"#1422\")]` markers needed.

## Cluster breakdown

### Cluster 1 — PDF query handlers (6 tests fixed)

| Test | Fix |
|------|-----|
| `Handle_WhenPdfExistsForGame_ReturnsPdf` | Add `SharedGameId = gameId` |
| `Handle_WhenPdfExistsForSharedGame_ReturnsPdf` | Add `SharedGameId = sharedGameId` |
| `Handle_WhenPdfLinkedViaGamesSharedGameId_ReturnsPdf` | Add `SharedGameId = sharedGameId` on second PDF |
| `Handle_ReturnsPdfsOrderedByUploadDateDescending` | Add `SharedGameId = sharedGameId` on both PDFs |
| `Handle_WhenPdfIsReady_MapsStatusToCompleted_AndFiltersBySharedGameId` | Add `SharedGameId = sharedGameId` |
| `Handle_WhenGameIdFilter_OnlyReturnsPdfsForThatSharedGame` | Add `SharedGameId = sharedGameA/B` |

### Cluster 2 — KnowledgeBase / GraphRag (4 tests resolved)

| Test | Fix |
|------|-----|
| `ProcessAsync_WithEntityExtractor_CallsExtractAndSavesRelations` | Add `SharedGameId = _gameId` to `SeedPdfDocument` helper |
| `ProcessAsync_TruncatesTextTo8000Chars` | (same helper) |
| `SharedGameId_ShouldBePersisted_WhenSetOnTextChunkEntity` | Add `SharedGameId = sharedGameId` on `TextChunkEntity` |
| `BuildDegradedSystemPrompt_WithFullMetadata_ShouldIncludeAllFields` | Add `Publisher = \"Kosmos\"` to `DegradedAgentContext` |
| `Handle_WithSharedGameId_ResolvesToActualGameId` | **DELETED** — feature obsolete post-Phase 2d. The resolver step in `CreateChatThreadCommandHandler:46-54` is now a degenerate identity lookup; cross-table resolution no longer exists. Replaced with an inline comment explaining the deletion. |

### Cluster 3 — PdfSeeder hash drift (1 test fixed)

| Test | Fix |
|------|-----|
| `SeedAsync_HashDrift_DeletesOldCascadeAndReinserts` | Add `SharedGameId = gameId` on pre-seeded `PdfDocumentEntity`. `PdfSeeder:87` filters existing PDFs by `SharedGameId.HasValue` — without it the old doc was never picked up for cascade delete (table ended with 2 rows instead of 1). |

## Bisection report (AC6)

`git log` over the affected handler + test files isolates the regression commit:

```
b396a94b8  refactor(infra): Phase 2d — delete GameEntity + drop games table (#1345) (#1347)
```

This commit's message itself acknowledges the carryover: *\"Migration Safety Gate green. Runtime test failures tracked in #1349.\"* (#1349 was the predecessor triage, closed; #1422 is the consolidated follow-up.) The Phase 2d diff already touched these same test files with `-7 / -20 +13` line removals, leaving the surviving setups inconsistent — half of the test methods now set `SharedGameId` explicitly, the other half do not.

## Verification

```
dotnet test --filter \"FullyQualifiedName~<each-of-the-11-test-names>\"
# Superato! Non superati: 0. Superati: 11. Ignorati: 0. Totale: 11. Durata: 3 s
```

All 11 originally-failing tests pass locally. The 12th test was deleted, so it cannot fail.

## CLAUDE.md update

The `Known Flaky Tests` section in `CLAUDE.md` is updated with:
- History pointer `#1349 (closed) → #1422 (this PR)`
- Cleanup note documenting the 11 fixes + 1 deletion + the underlying root cause

Baseline returns to the 3 originally-documented named tests + the 2 `*_S3Storage_*` generic entries (5 total documented failures).

## Acceptance criteria (from #1422)

- [x] **AC1** — Triage cluster 1 (PDF query handlers): root cause + bisection identified (`b396a94b8`)
- [x] **AC2** — Triage cluster 2 (KnowledgeBase/GraphRag): same root cause confirmed
- [x] **AC3** — Triage cluster 3 (PdfSeeder hash-drift): same root cause confirmed
- [x] **AC4** — Decision per test: 11 fix + 1 delete, zero skip-by-trait
- [x] **AC5** — `CLAUDE.md` Known Flaky Tests table updated
- [x] **AC6** — Bisection report (commit SHA `b396a94b8` + PR #1345/#1347 reference) included above

## Test plan

- [x] Local: 11/11 tests pass (`dotnet test --filter`)
- [x] Pre-push: backend build verified (1m25s, 0 errors, 115 warnings unchanged)
- [ ] CI: Backend Fast on this PR — fail count should drop from 15 → 4 (3 named tests + 1 generic `*_S3Storage_*` entry covering 2 tests)
- [ ] Post-merge: verify Backend Fast on next main-dev PR remains stable

## Refs

- Closes #1422
- Root cause: PR #1345/#1347 (commit `b396a94b8`, 2026-05-20)
- Predecessor triage: #1349 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)