### PR TITLE
feat(admin): shared-games categories CRUD dialogs — Phase 1 FE stub

### DIFF
--- a/apps/web/src/components/admin/shared-games/__tests__/categories-table.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/categories-table.test.tsx
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 const mockLoggerDebug = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/logger', () => ({
   logger: {
     debug: (...args: unknown[]) => mockLoggerDebug(...args),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     error: vi.fn(),
   },
   getLogger: () => ({
     debug: (...args: unknown[]) => mockLoggerDebug(...args),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     error: vi.fn(),
   }),
   resetLogger: vi.fn(),
@@ -36,7 +37,7 @@ describe('CategoriesTable', () => {
     expect(addButton).toBeInTheDocument();
   });
 
-  it('displays all 8 mock categories', () => {
+  it('displays all 8 initial categories', () => {
     render(<CategoriesTable />);
 
     expect(screen.getByText('Strategy')).toBeInTheDocument();
@@ -56,13 +57,95 @@ describe('CategoriesTable', () => {
     expect(screen.getByText('28 games')).toBeInTheDocument(); // Party
   });
 
-  it('handles Add Category button click', () => {
-    mockLoggerDebug.mockClear();
+  // Issue #1429 Phase 1: dialog wiring — Add / Edit / Delete flows.
+  // Tests cover the local-state mutations only; Phase 2 will swap the
+  // mutations for a TanStack mutation hook and the assertions for the
+  // happy-path will change to assert on the queryClient cache, not the DOM.
+
+  it('opens the Add Category dialog when the header button is clicked', () => {
     render(<CategoriesTable />);
 
-    const addButton = screen.getByRole('button', { name: /add category/i });
-    fireEvent.click(addButton);
+    fireEvent.click(screen.getByRole('button', { name: /add category/i }));
 
-    expect(mockLoggerDebug).toHaveBeenCalledWith('Add category');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /add category/i })).toBeInTheDocument();
+  });
+
+  it('appends a new row when the Add dialog is submitted', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add category/i }));
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.change(within(dialog).getByLabelText(/name/i), {
+      target: { value: 'Eurogame' },
+    });
+    fireEvent.change(within(dialog).getByLabelText(/emoji/i), {
+      target: { value: '🏰' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /add category/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByText('Eurogame')).toBeInTheDocument();
+  });
+
+  it('rejects an empty name on submit and keeps the dialog open', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add category/i }));
+    const dialog = screen.getByRole('dialog');
+
+    // No name typed — submit should surface validation and not close.
+    fireEvent.click(within(dialog).getByRole('button', { name: /add category/i }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(within(dialog).getByRole('alert')).toHaveTextContent(/name is required/i);
+  });
+
+  it('opens the Edit dialog seeded with the row values', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit strategy/i }));
+    const dialog = screen.getByRole('dialog');
+
+    expect(within(dialog).getByRole('heading', { name: /edit category/i })).toBeInTheDocument();
+    expect(within(dialog).getByLabelText(/name/i)).toHaveValue('Strategy');
+  });
+
+  it('updates a row when the Edit dialog is submitted', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit strategy/i }));
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.change(within(dialog).getByLabelText(/name/i), {
+      target: { value: 'Heavy Strategy' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByText('Heavy Strategy')).toBeInTheDocument();
+    expect(screen.queryByText('Strategy')).not.toBeInTheDocument();
+  });
+
+  it('opens the Delete confirmation with a warning when the category has games', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete strategy/i }));
+    const dialog = screen.getByRole('dialog');
+
+    expect(within(dialog).getByText(/strategy/i)).toBeInTheDocument();
+    expect(within(dialog).getByRole('alert')).toHaveTextContent(/42 games are currently tagged/i);
+  });
+
+  it('removes a row when the Delete is confirmed', () => {
+    render(<CategoriesTable />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete party/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Party')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/shared-games/categories-table.tsx
+++ b/apps/web/src/components/admin/shared-games/categories-table.tsx
@@ -1,12 +1,16 @@
 /* eslint-disable local/no-hardcoded-color-utility -- admin CRUD chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13c admin scope (--admin-* decision deferred to DS-15). */
 'use client';
 
+import { useState } from 'react';
+
 import { PlusIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/primitives/button';
 import { logger } from '@/lib/logger';
 
+import { CategoryFormDialog, type CategoryFormValue } from './category-form-dialog';
 import { CategoryRow } from './category-row';
+import { DeleteCategoryConfirm } from './delete-category-confirm';
 
 interface Category {
   id: string;
@@ -16,31 +20,74 @@ interface Category {
   color: string;
 }
 
-const MOCK_CATEGORIES: Category[] = [
+const INITIAL_CATEGORIES: Category[] = [
   { id: '1', name: 'Strategy', emoji: '♟️', gameCount: 42, color: '#3b82f6' },
   { id: '2', name: 'Party', emoji: '🎉', gameCount: 28, color: '#ec4899' },
   { id: '3', name: 'Cooperative', emoji: '🤝', gameCount: 19, color: '#10b981' },
   { id: '4', name: 'Deck Building', emoji: '🃏', gameCount: 15, color: '#8b5cf6' },
-  { id: '5', name: 'Family', emoji: '👨\u200d👩\u200d👧\u200d👦', gameCount: 34, color: '#f59e0b' },
+  { id: '5', name: 'Family', emoji: '👨‍👩‍👧‍👦', gameCount: 34, color: '#f59e0b' },
   { id: '6', name: 'Abstract', emoji: '🔷', gameCount: 12, color: '#06b6d4' },
   { id: '7', name: 'Thematic', emoji: '🗺️', gameCount: 23, color: '#ef4444' },
   { id: '8', name: 'Euro', emoji: '🏛️', gameCount: 31, color: '#6366f1' },
 ];
 
 export function CategoriesTable() {
+  // TODO(#1429 Phase 2): replace `INITIAL_CATEGORIES` + local state with a
+  // TanStack Query hook backed by `GET /api/v1/admin/categories` once the
+  // BE endpoints exist. The handlers below will swap to mutation hooks
+  // (`useMutation` with optimistic updates) rather than direct setState.
+  const [categories, setCategories] = useState<Category[]>(INITIAL_CATEGORIES);
+  const [editing, setEditing] = useState<Category | null>(null);
+  const [deleting, setDeleting] = useState<Category | null>(null);
+  const [adding, setAdding] = useState(false);
+
   const handleEdit = (id: string) => {
-    // TODO: Implement edit dialog
-    logger.debug(`Edit category: ${id}`);
+    const category = categories.find(c => c.id === id);
+    if (!category) {
+      logger.warn(`Edit requested for unknown category id=${id}`);
+      return;
+    }
+    setEditing(category);
   };
 
   const handleDelete = (id: string) => {
-    // TODO: Implement delete confirmation
-    logger.debug(`Delete category: ${id}`);
+    const category = categories.find(c => c.id === id);
+    if (!category) {
+      logger.warn(`Delete requested for unknown category id=${id}`);
+      return;
+    }
+    setDeleting(category);
   };
 
   const handleAddCategory = () => {
-    // TODO: Implement add category dialog
-    logger.debug('Add category');
+    setAdding(true);
+  };
+
+  const handleSaveAdd = (value: CategoryFormValue) => {
+    // Local-state mutation only (Phase 1). Phase 2 will swap this for a
+    // POST /api/v1/admin/categories mutation; the temporary id below is
+    // a client-side placeholder until the server assigns one.
+    const id = `local-${Date.now().toString(36)}`;
+    setCategories(prev => [...prev, { ...value, gameCount: 0, id }]);
+    setAdding(false);
+  };
+
+  const handleSaveEdit = (value: CategoryFormValue) => {
+    if (editing === null) {
+      return;
+    }
+    const targetId = editing.id;
+    setCategories(prev => prev.map(c => (c.id === targetId ? { ...c, ...value } : c)));
+    setEditing(null);
+  };
+
+  const handleConfirmDelete = () => {
+    if (deleting === null) {
+      return;
+    }
+    const targetId = deleting.id;
+    setCategories(prev => prev.filter(c => c.id !== targetId));
+    setDeleting(null);
   };
 
   return (
@@ -85,7 +132,7 @@ export function CategoriesTable() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200/50 dark:divide-zinc-700/50">
-              {MOCK_CATEGORIES.map(category => (
+              {categories.map(category => (
                 <CategoryRow
                   key={category.id}
                   name={category.name}
@@ -105,6 +152,25 @@ export function CategoriesTable() {
       <p className="text-xs text-muted-foreground dark:text-muted-foreground italic">
         Note: Drag-to-reorder functionality will be added in a future update
       </p>
+
+      <CategoryFormDialog open={adding} onClose={() => setAdding(false)} onSave={handleSaveAdd} />
+
+      <CategoryFormDialog
+        open={editing !== null}
+        initial={
+          editing ? { color: editing.color, emoji: editing.emoji, name: editing.name } : undefined
+        }
+        onClose={() => setEditing(null)}
+        onSave={handleSaveEdit}
+      />
+
+      <DeleteCategoryConfirm
+        open={deleting !== null}
+        categoryName={deleting?.name ?? ''}
+        gameCount={deleting?.gameCount ?? 0}
+        onClose={() => setDeleting(null)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/admin/shared-games/category-form-dialog.tsx
+++ b/apps/web/src/components/admin/shared-games/category-form-dialog.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin CRUD chrome: matches the existing categories-table palette (amber + zinc). DS-13c admin scope (--admin-* decision deferred to DS-15). */
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+
+export interface CategoryFormValue {
+  /** Hex color string, e.g. "#3b82f6". */
+  readonly color: string;
+  /** Single-character emoji (or short emoji sequence). */
+  readonly emoji: string;
+  /** Visible category name, 1..50 chars after trim. */
+  readonly name: string;
+}
+
+export interface CategoryFormDialogProps {
+  /** When true the dialog is open. Use a controlled-component pattern. */
+  readonly open: boolean;
+  /** Initial form values for edit mode; pass undefined for add mode. */
+  readonly initial?: CategoryFormValue;
+  /** Called when the user dismisses without submitting. */
+  readonly onClose: () => void;
+  /**
+   * Called with the validated values on submit. Issue #1429: persistence is
+   * the caller's responsibility — Phase 1 keeps a local MOCK_CATEGORIES list;
+   * Phase 2 will swap the caller in for a TanStack mutation.
+   */
+  readonly onSave: (value: CategoryFormValue) => void;
+}
+
+const DEFAULT_FORM: CategoryFormValue = {
+  color: '#3b82f6',
+  emoji: '🎲',
+  name: '',
+};
+
+/**
+ * Add / Edit category dialog (issue #1429, Phase 1 FE-only stub).
+ *
+ * Single component handles both add and edit by checking whether `initial`
+ * is provided. Validation is intentionally minimal (presence + length); the
+ * BE-side schema validation will land alongside Phase 2 once the
+ * `/api/v1/admin/categories` endpoints exist.
+ */
+export function CategoryFormDialog({ initial, onClose, onSave, open }: CategoryFormDialogProps) {
+  const isEdit = initial !== undefined;
+  const [form, setForm] = useState<CategoryFormValue>(initial ?? DEFAULT_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the form every time the dialog is reopened so a stale Edit value
+  // doesn't bleed into a subsequent Add (or vice versa).
+  useEffect(() => {
+    if (open) {
+      setForm(initial ?? DEFAULT_FORM);
+      setError(null);
+    }
+  }, [initial, open]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = form.name.trim();
+    if (trimmedName.length === 0) {
+      setError('Name is required.');
+      return;
+    }
+    if (trimmedName.length > 50) {
+      setError('Name must be 50 characters or fewer.');
+      return;
+    }
+    if (form.emoji.trim().length === 0) {
+      setError('Emoji is required.');
+      return;
+    }
+    if (!/^#[0-9a-fA-F]{6}$/.test(form.color)) {
+      setError('Color must be a 6-digit hex like #3b82f6.');
+      return;
+    }
+    onSave({ color: form.color, emoji: form.emoji.trim(), name: trimmedName });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{isEdit ? 'Edit category' : 'Add category'}</DialogTitle>
+            <DialogDescription>
+              {isEdit
+                ? 'Update the category metadata. Changes apply to all games tagged with this category.'
+                : 'Define a new category for shared-game tagging.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="category-name">Name</Label>
+              <Input
+                autoFocus
+                id="category-name"
+                maxLength={50}
+                onChange={event => setForm(prev => ({ ...prev, name: event.target.value }))}
+                placeholder="e.g. Strategy"
+                value={form.name}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="category-emoji">Emoji</Label>
+              <Input
+                id="category-emoji"
+                maxLength={4}
+                onChange={event => setForm(prev => ({ ...prev, emoji: event.target.value }))}
+                placeholder="e.g. 🎲"
+                value={form.emoji}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="category-color">Color (hex)</Label>
+              <div className="flex items-center gap-3">
+                <Input
+                  className="font-mono"
+                  id="category-color"
+                  maxLength={7}
+                  onChange={event => setForm(prev => ({ ...prev, color: event.target.value }))}
+                  placeholder="#3b82f6"
+                  value={form.color}
+                />
+                <div
+                  aria-hidden
+                  className="h-9 w-9 rounded-full border-2 border-border dark:border-zinc-600 shrink-0"
+                  style={{ backgroundColor: form.color }}
+                />
+              </div>
+            </div>
+
+            {error !== null && (
+              <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button onClick={onClose} type="button" variant="ghost">
+              Cancel
+            </Button>
+            <Button className="bg-amber-500 hover:bg-amber-600 text-white" type="submit">
+              {isEdit ? 'Save changes' : 'Add category'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/delete-category-confirm.tsx
+++ b/apps/web/src/components/admin/shared-games/delete-category-confirm.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin CRUD chrome: matches the existing categories-table palette (red + zinc). DS-13c admin scope (--admin-* decision deferred to DS-15). */
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export interface DeleteCategoryConfirmProps {
+  /** Category display name (shown in the warning message). */
+  readonly categoryName: string;
+  /** Games currently tagged with this category — drives the "warning" state. */
+  readonly gameCount: number;
+  /** When true the dialog is open. Controlled-component pattern. */
+  readonly open: boolean;
+  /** Dismiss without deleting. */
+  readonly onClose: () => void;
+  /** User confirmed deletion. Caller is responsible for the actual delete. */
+  readonly onConfirm: () => void;
+}
+
+/**
+ * Delete-category confirmation dialog (issue #1429, Phase 1 FE-only stub).
+ *
+ * Surfaces a warning when the category is currently tagging games so the
+ * operator can't accidentally remove a popular tag. Phase 2 will pair this
+ * with a BE-side cascading-delete rule (re-tag affected games to a fallback,
+ * or block the delete server-side until they're untagged).
+ */
+export function DeleteCategoryConfirm({
+  categoryName,
+  gameCount,
+  onClose,
+  onConfirm,
+  open,
+}: DeleteCategoryConfirmProps) {
+  const hasGames = gameCount > 0;
+  return (
+    <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete category</DialogTitle>
+          <DialogDescription>This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          <p className="text-sm text-foreground dark:text-zinc-100">
+            Are you sure you want to delete{' '}
+            <span className="font-semibold">&ldquo;{categoryName}&rdquo;</span>?
+          </p>
+
+          {hasGames && (
+            <p
+              className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300"
+              role="alert"
+            >
+              <strong>Warning:</strong> {gameCount} {gameCount === 1 ? 'game is' : 'games are'}{' '}
+              currently tagged with this category. They will lose this tag.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose} type="button" variant="ghost">
+            Cancel
+          </Button>
+          <Button
+            className="bg-red-600 hover:bg-red-700 text-white"
+            onClick={onConfirm}
+            type="button"
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Closes #1429

Adds Add / Edit / Delete dialogs for the admin Categories table, wired to local-state mutations so the operator can interact with the surface even before the BE endpoints exist. Surfaced via #564 Q2 TODO/FIXME triage (2026-05-22) — the original page shipped with \`MOCK_CATEGORIES\` hardcoded and three no-op handlers (\`logger.debug\` only).

Scope is intentionally **Phase 1 FE-only**. Phase 2 (tracked in #1429) will swap \`MOCK_CATEGORIES\` + local-state for a TanStack Query hook + \`useMutation\`, once \`GET/POST/PUT/DELETE /api/v1/admin/categories\` ships.

## New files

- \`category-form-dialog.tsx\` — Add/Edit dialog (single component, \`isEdit\` detected from \`initial\` prop). Form validates name (1..50 chars), emoji (presence), color (6-digit hex). Form resets on every open so an Add doesn't see a stale Edit value.
- \`delete-category-confirm.tsx\` — Confirmation dialog with a warning banner when the category has \`N > 0\` tagged games.

## Wiring (\`categories-table.tsx\`)

- \`MOCK_CATEGORIES\` const → \`INITIAL_CATEGORIES\` seed consumed by \`useState\`.
- \`handleEdit\` / \`handleDelete\` resolve the row by id and open the respective dialog (instead of \`logger.debug\`).
- \`handleAddCategory\` opens the Add dialog.
- Local-state mutations: Add appends with \`local-<ts>\` id placeholder; Edit immutably updates the matching id; Delete filters by id.
- Inline \`TODO(#1429 Phase 2)\` at the seed describing the swap target.

## Tests (\`categories-table.test.tsx\`)

Pre-existing 5 tests kept (header, button, 8 initial rows, game count). The "logger.debug Add category" assertion replaced — handler no longer invokes logger on the happy path. Added **6 dialog-flow tests** covering: Add opens, Add appends row, empty-name validation surfaces alert + keeps dialog open, Edit seeds form with row values, Edit updates row, Delete shows warning when \`gameCount > 0\`, Delete removes row on confirm.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm vitest run categories-table.test.tsx\` — **11/11 pass**
- [ ] CI Frontend Static green
- [ ] Manual smoke on \`/admin/(dashboard)\` categories surface (visual review of dialogs)

## What is intentionally NOT in this PR

- Drag-to-reorder (the existing italic note "Drag-to-reorder functionality will be added in a future update" stays).
- BE endpoints for \`/api/v1/admin/categories\` — Phase 2 (separate PR, gated on BE design discussion: admin permissions, soft-delete vs cascade, schema for \`shared_games_categories\` table).
- The duplicate \`CategoriesTable.tsx\` (PascalCase, issue #4862) is a *different* component using \`EntityTableView\` — left untouched, it serves a different read-only view of categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)