### PR TITLE
fix(tests): clear 3 baseline flaky tests + remove stale S3 entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,21 +262,24 @@ tests/Api.Tests/          # Backend test suite
 ## Known Flaky Tests
 
 Tests confirmed failing on `main-dev` baseline independently of any specific PR.
-Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved).
+Triage history: #1349 (closed, Phase 2d carryover) → #1422 (2026-05-21, 12 SharedGameId/PDF cluster resolved) → 2026-05-22 (4 baseline failures cleared; S3Storage entry was stale).
+
+_Baseline currently empty._ Re-add a row here if a new pre-existing failure surfaces in `main-dev`.
 
 | Test | File | First observed | Reason | Action |
 |---|---|---|---|---|
-| `Should_Fail_When_GameId_Is_Empty` | `Api.Tests` | #1341 baseline | Pre-existing validator behavior mismatch | Document, do not block CI |
-| `Handle_EmptyGuid_ReturnsNull` | `Api.Tests` | #1341 baseline | Pre-existing | Document |
-| `Handle_WithSearchFilter_ReturnsMatchingGames` | `Api.Tests` | #1341 baseline | EF Core InMemory provider does not support `ILike` (Postgres-specific) | Integration test only — exclude from unit suite |
-| `*_S3Storage_*` (2 tests) | `Api.Tests` | #1341 baseline | Mock verification timing / strict mode mismatch | Document |
+| _(none)_ | | | | |
+
+**Resolved 2026-05-22**: 3 documented baseline failures fixed + 1 stale entry removed.
+- `Should_Fail_When_GameId_Is_Empty` — fixed by adding `Cascade(CascadeMode.Stop)` to `CreateRuleConflictFaqCommandValidator.RuleFor(x => x.GameId)` so the async `GameExists` check (which calls `GameRef.Shared(Guid.Empty)` → `ArgumentException`) is skipped when `NotEmpty()` already failed.
+- `Handle_EmptyGuid_ReturnsNull` (in `GetGameByIdQueryHandlerTests`) — fixed by short-circuiting the handler on `Guid.Empty` before constructing `GameRef.Shared(...)`; the test now also asserts the provider is never consulted. The 4 same-named tests in `DocumentProcessing` were never failing (they mock `repository.GetByIdAsync(Guid)` directly without going through `GameRef`).
+- `Handle_WithSearchFilter_ReturnsMatchingGames` — moved to `Integration/GameManagement/GetAllGamesQueryHandlerIntegrationTests.cs` (Testcontainers Postgres), where `EF.Functions.ILike` translates to SQL `ILIKE`. The Unit class retained the non-search scenarios.
+- `*_S3Storage_*` (2 tests) — entry was stale: all unit tests in `S3BlobStorageServiceTests` pass; the 11 skipped tests in `S3BlobStorageIntegrationTests` only require Docker.
 
 **Resolved in #1422 (2026-05-21)**: 12 undocumented SharedGameId/PDF cluster failures triaged and cleared.
 Root cause: regression from PR #1345/#1347 (Phase 2d delete `GameEntity` + drop `games` table, 2026-05-20). Test fixtures still relied on the dropped `pdf_documents.GameId` column → handlers filtering on `SharedGameId` returned 0 items. Resolution: **11 fixed** via fixture drift correction (add `SharedGameId` to `PdfDocumentEntity`/`TextChunkEntity` setups + `Publisher = "Kosmos"` on `DegradedAgentContext` full-metadata test) + **1 deleted** (`Handle_WithSharedGameId_ResolvesToActualGameId` — Post-Phase 2d the resolver step in `CreateChatThreadCommandHandler:46-54` is a degenerate identity lookup; cross-table resolution no longer exists).
 
-**Policy**: PRs MUST NOT cause the unit-test fail count to grow above this baseline. The CI `Backend Fast` job is non-required while these are pending fixes; a future cleanup will either fix the root cause (e.g., switch ILike test to integration) or skip with `[Trait("Skip", "<issue#>")]`.
-
-When fixing one of these, remove the row from this table in the same PR.
+**Policy**: PRs MUST NOT cause the unit-test fail count to grow above this baseline (currently zero). Future regressions: either fix the root cause or skip with `[Trait("Skip", "<issue#>")]` and add a row here in the same PR.
 
 ## AI Assistant Rules
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameByIdQueryHandler.cs
@@ -25,6 +25,11 @@ internal class GetGameByIdQueryHandler : IQueryHandler<GetGameByIdQuery, GameDto
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        if (query.GameId == Guid.Empty)
+        {
+            return null;
+        }
+
         var coreData = await _gameCoreData
             .GetCoreDataAsync(GameRef.Shared(query.GameId), cancellationToken)
             .ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleConflictFAQs/CreateRuleConflictFaqCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/RuleConflictFAQs/CreateRuleConflictFaqCommandValidator.cs
@@ -18,6 +18,7 @@ internal sealed class CreateRuleConflictFaqCommandValidator : AbstractValidator<
         _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
 
         RuleFor(x => x.GameId)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("GameId is required")
             .MustAsync(GameExists)

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetAllGamesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetAllGamesQueryHandlerTests.cs
@@ -178,27 +178,9 @@ public class GetAllGamesQueryHandlerTests
         chess.BggId.Should().BeNull();
     }
 
-    [Fact]
-    public async Task Handle_WithSearchFilter_ReturnsMatchingGames()
-    {
-        // Arrange
-        await using var context = CreateContext();
-        context.SharedGames.AddRange(
-            MakeSharedGame("Catan"),
-            MakeSharedGame("Pandemic"),
-            MakeSharedGame("Carcassonne"));
-        await context.SaveChangesAsync();
-
-        var handler = CreateHandler(context);
-        // Note: ILike is PostgreSQL-specific; InMemory provider uses Contains fallback via EF
-        var query = new GetAllGamesQuery(Search: "Catan");
-
-        // Act
-        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
-
-        // Assert — InMemory does a case-sensitive Contains; PostgreSQL uses ILike
-        result.Games.Should().Contain(g => g.Title == "Catan");
-    }
+    // NOTE: Handle_WithSearchFilter_ReturnsMatchingGames lives in
+    // Api.Tests.Integration.GameManagement.GetAllGamesQueryHandlerIntegrationTests
+    // because EF.Functions.ILike is PostgreSQL-specific and InMemory cannot translate it.
 
     [Fact]
     public async Task Handle_PaginationReturnsCorrectPage()

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameByIdQueryHandlerTests.cs
@@ -144,20 +144,18 @@ public class GetGameByIdQueryHandlerTests
     [Fact]
     public async Task Handle_EmptyGuid_ReturnsNull()
     {
-        // Arrange
-        var gameId = Guid.Empty;
-
-        _gameCoreDataMock
-            .Setup(r => r.GetCoreDataAsync(GameRef.Shared(gameId), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((GameCoreData?)null);
-
-        var query = new GetGameByIdQuery(gameId);
+        // Arrange — Guid.Empty is rejected by the handler short-circuit (GameRef.Shared(Guid.Empty)
+        // would throw ArgumentException), so the provider is never consulted.
+        var query = new GetGameByIdQuery(Guid.Empty);
 
         // Act
         var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeNull();
+        _gameCoreDataMock.Verify(
+            r => r.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GetAllGamesQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GetAllGamesQueryHandlerIntegrationTests.cs
@@ -1,0 +1,86 @@
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for <see cref="GetAllGamesQueryHandler"/> that exercise the
+/// PostgreSQL-specific <c>EF.Functions.ILike</c> case-insensitive search.
+///
+/// Lives here (not next to the Unit class) because EF InMemory provider does not
+/// translate <c>ILike</c>, so the search-filter scenario cannot run against InMemory.
+/// All other handler behaviors remain covered by the Unit test class.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Collection("Integration-GroupC")]
+public class GetAllGamesQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext? _dbContext;
+    private string? _connectionString;
+    private readonly string _databaseName = $"test_getallgames_ilike_{Guid.NewGuid():N}";
+
+    public GetAllGamesQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(_connectionString);
+        _dbContext = await Api.Tests.Infrastructure.TestHelpers.CreateDbContextAndMigrateAsync(_connectionString);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact]
+    public async Task Handle_WithSearchFilter_ReturnsMatchingGames()
+    {
+        // Arrange
+        _dbContext!.SharedGames.AddRange(
+            MakeSharedGame("Catan"),
+            MakeSharedGame("Pandemic"),
+            MakeSharedGame("Carcassonne"));
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var handler = new GetAllGamesQueryHandler(_dbContext);
+        var query = new GetAllGamesQuery(Search: "Catan");
+
+        // Act — Postgres provider translates EF.Functions.ILike to SQL ILIKE.
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Games.Should().Contain(g => g.Title == "Catan");
+        result.Games.Should().HaveCount(1);
+    }
+
+    private static SharedGameEntity MakeSharedGame(string title) => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = title,
+        YearPublished = 2020,
+        MinPlayers = 2,
+        MaxPlayers = 4,
+        PlayingTimeMinutes = 60,
+        MinAge = 10,
+        ImageUrl = string.Empty,
+        ThumbnailUrl = string.Empty,
+        Description = string.Empty,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow
+    };
+}


### PR DESCRIPTION
## Summary

Clears all 3 remaining documented flaky tests in `CLAUDE.md` "Known Flaky Tests" baseline and removes 1 stale entry. **Backend Fast baseline now has zero documented failures.**

| Test | Root cause | Fix |
|---|---|---|
| `Should_Fail_When_GameId_Is_Empty` | FluentValidation default `CascadeMode.Continue` ran the `MustAsync(GameExists)` rule even after `NotEmpty()` failed; `GameExists` calls `GameRef.Shared(Guid.Empty)` which throws `ArgumentException`. | Add `Cascade(CascadeMode.Stop)` to `RuleFor(x => x.GameId)` in `CreateRuleConflictFaqCommandValidator`. |
| `Handle_EmptyGuid_ReturnsNull` (in `GetGameByIdQueryHandlerTests`) | Moq setup expression evaluated `GameRef.Shared(Guid.Empty)` at Arrange time → throws. | Add `Guid.Empty` short-circuit to `GetGameByIdQueryHandler.Handle`. Test now asserts provider is never consulted in that path. |
| `Handle_WithSearchFilter_ReturnsMatchingGames` | `EF.Functions.ILike` is Postgres-specific; InMemory provider cannot translate it. | Moved to `Integration/GameManagement/GetAllGamesQueryHandlerIntegrationTests.cs` using `SharedTestcontainersFixture`. |
| `*_S3Storage_*` (2 tests) — entry was **stale** | All 15 unit tests in `S3BlobStorageServiceTests` already pass. The 11 skipped tests in the integration class only require Docker (not flaky). | Remove entry from CLAUDE.md. |

The 4 same-named `Handle_EmptyGuid_ReturnsNull` occurrences in `DocumentProcessing` were never failing — they mock `repository.GetByIdAsync(Guid)` directly without going through `GameRef`.

## Verified locally

- `CreateRuleConflictFaqCommandValidatorTests`: **19/19 pass**
- `GetGameByIdQueryHandlerTests`: **7/7 pass**
- `GetAllGamesQueryHandlerTests` + `GetAllGamesQueryHandlerIntegrationTests`: **7/7 pass** (incl. integration test against Testcontainers Postgres, ~7s)

## Discovery — unrelated, surfaced by pre-push hook

The pre-push hook caught a separate **pre-existing build failure** on `main-dev`:

```
Error: STEP_2_AUDIT_ROWS must have 17 entries (one per spec §3.1 call-site), got 16
  at apps/web/src/app/(public)/dev/meeple-card/page.tsx
```

Root cause: PR #1423 (`feat(dashboard,v2): Fase 1 orphan removal`) removed 1 component but did not update `step-2-audit-fixtures.ts` to match the page-level assertion. Pushed with `--no-verify` (user-authorized) since this PR does not touch `apps/web/` at all — needs a separate fix on the `meeple-card` dev showcase.

## Test plan

- [x] Backend unit + integration suite scoped to touched files passes locally
- [ ] CI `Backend Fast` green
- [ ] Spot-check the integration test runs against the shared Postgres testcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)