### PR TITLE
fix(dev): #1434 align meeple-card audit guard to 16 entries

### DIFF
--- a/apps/web/src/app/(public)/dev/meeple-card/step-2-audit-fixtures.ts
+++ b/apps/web/src/app/(public)/dev/meeple-card/step-2-audit-fixtures.ts
@@ -97,9 +97,11 @@ export const STEP_2_AUDIT_ROWS: AuditRow[] = [
   },
 ];
 
-if (STEP_2_AUDIT_ROWS.length !== 17) {
-  // This is a guard — spec §3.1 says exactly 17 call-sites.
+if (STEP_2_AUDIT_ROWS.length !== 16) {
+  // Guard — spec §3.1 originally listed 17 call-sites. PR #1423
+  // ("feat(dashboard,v2): Fase 1 orphan removal") removed 1 orphan
+  // component, bringing the active fixture set to 16. See #1434.
   throw new Error(
-    `STEP_2_AUDIT_ROWS must have 17 entries (one per spec §3.1 call-site), got ${STEP_2_AUDIT_ROWS.length}`
+    `STEP_2_AUDIT_ROWS must have 16 entries (one per spec §3.1 call-site), got ${STEP_2_AUDIT_ROWS.length}`
   );
 }


### PR DESCRIPTION
## Summary

PR #1423 (`362683aa7`, *"feat(dashboard,v2): Fase 1 orphan removal"*) removed 1 orphan component from the spec §3.1 call-site set, leaving 16 active fixtures in `step-2-audit-fixtures.ts`. The runtime guard was still asserting `length === 17` — breaking `pnpm build` during prerender of `/dev/meeple-card` and blocking the pre-push hook on main-dev.

Option A from issue #1434: align the guard to 16 + cross-reference PR #1423 in the comment.

```diff
-if (STEP_2_AUDIT_ROWS.length !== 17) {
-  // This is a guard — spec §3.1 says exactly 17 call-sites.
+if (STEP_2_AUDIT_ROWS.length !== 16) {
+  // Guard — spec §3.1 originally listed 17 call-sites. PR #1423
+  // ("feat(dashboard,v2): Fase 1 orphan removal") removed 1 orphan
+  // component, bringing the active fixture set to 16. See #1434.
   throw new Error(
-    `STEP_2_AUDIT_ROWS must have 17 entries (one per spec §3.1 call-site), got ${STEP_2_AUDIT_ROWS.length}`
+    `STEP_2_AUDIT_ROWS must have 16 entries (one per spec §3.1 call-site), got ${STEP_2_AUDIT_ROWS.length}`
   );
 }
```

## Verification

- `pnpm build` exits 0; full route prerender completes (verified locally).
- Pre-push hook on this branch passes end-to-end (frontend lint+typecheck+build + backend build).

## Closes

- #1434

## Test plan

- [x] Local `pnpm build` passes
- [ ] CI `Frontend Fast` green
- [ ] Pre-push hook works on a clean checkout of main-dev post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)