### PR TITLE
feat(admin): wire models-table to live /admin/ai-models (#1442 Phase 1a)

### DIFF
--- a/apps/web/src/components/admin/agents/__tests__/models-table.test.tsx
+++ b/apps/web/src/components/admin/agents/__tests__/models-table.test.tsx
@@ -1,64 +1,183 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AdminAiModelsApiError, type AiModelDto } from '@/lib/api/admin-ai-models';
+
+const seedModels: AiModelDto[] = [
+  {
+    id: 'mdl-gpt4',
+    modelId: 'gpt-4-turbo',
+    displayName: 'GPT-4 Turbo',
+    provider: 'OpenAI',
+    priority: 1,
+    isActive: true,
+    isPrimary: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    settings: {
+      maxTokens: 4096,
+      temperature: 0.7,
+      pricing: {
+        inputPricePerMillion: 10, // $10/M = $0.0100/k
+        outputPricePerMillion: 30,
+        currency: 'USD',
+      },
+    },
+    usage: {
+      totalRequests: 8420,
+      totalInputTokens: 1_000_000,
+      totalOutputTokens: 500_000,
+      totalTokensUsed: 1_500_000,
+      totalCostUsd: 25.5,
+      lastUsedAt: '2026-05-22T10:00:00Z',
+    },
+  },
+  {
+    id: 'mdl-gemini',
+    modelId: 'gemini-pro',
+    displayName: 'Gemini Pro',
+    provider: 'Google',
+    priority: 4,
+    isActive: false,
+    isPrimary: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    settings: {
+      maxTokens: 4096,
+      temperature: 0.7,
+      pricing: { inputPricePerMillion: 0.25, outputPricePerMillion: 0.5, currency: 'USD' },
+    },
+    usage: {
+      totalRequests: 420,
+      totalInputTokens: 50_000,
+      totalOutputTokens: 25_000,
+      totalTokensUsed: 75_000,
+      totalCostUsd: 0.03,
+      lastUsedAt: null,
+    },
+  },
+];
+
+const mocks = vi.hoisted(() => ({
+  queryState: {
+    data: undefined as AiModelDto[] | undefined,
+    isLoading: false,
+    isError: false,
+    error: null as unknown,
+  },
+  toggleState: {
+    isError: false,
+    isPending: false,
+    error: null as unknown,
+  },
+  toggleMutateAsync: vi.fn<(id: string) => Promise<AiModelDto>>(),
+}));
+
+vi.mock('@/hooks/queries/useAdminAiModels', () => ({
+  useAdminAiModels: () => ({
+    data: mocks.queryState.data,
+    isLoading: mocks.queryState.isLoading,
+    isError: mocks.queryState.isError,
+    error: mocks.queryState.error,
+  }),
+  useToggleAdminAiModel: () => ({
+    mutateAsync: mocks.toggleMutateAsync,
+    isError: mocks.toggleState.isError,
+    isPending: mocks.toggleState.isPending,
+    error: mocks.toggleState.error,
+  }),
+}));
 
 import { ModelsTable } from '../models-table';
 
-describe('ModelsTable', () => {
-  it('renders models table with headers', () => {
-    render(<ModelsTable />);
+beforeEach(() => {
+  mocks.queryState.data = seedModels;
+  mocks.queryState.isLoading = false;
+  mocks.queryState.isError = false;
+  mocks.queryState.error = null;
+  mocks.toggleState.isError = false;
+  mocks.toggleState.isPending = false;
+  mocks.toggleState.error = null;
+  mocks.toggleMutateAsync.mockReset();
+  mocks.toggleMutateAsync.mockResolvedValue(seedModels[0]);
+});
 
+describe('ModelsTable (#1442 Phase 1a — live API)', () => {
+  it('renders headers + section title', () => {
+    render(<ModelsTable />);
     expect(screen.getByText('AI Models')).toBeInTheDocument();
     expect(screen.getByText('Provider')).toBeInTheDocument();
     expect(screen.getByText('Model')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Cost/1k')).toBeInTheDocument();
+    expect(screen.getByText('Latency')).toBeInTheDocument();
+    expect(screen.getByText('Usage')).toBeInTheDocument();
   });
 
-  it('displays all mock models', () => {
+  it('renders rows from the server-mapped DTO', () => {
     render(<ModelsTable />);
-
     expect(screen.getByText('GPT-4 Turbo')).toBeInTheDocument();
-    expect(screen.getByText('Claude 3.5 Sonnet')).toBeInTheDocument();
-    expect(screen.getByText('GPT-3.5 Turbo')).toBeInTheDocument();
     expect(screen.getByText('Gemini Pro')).toBeInTheDocument();
-    expect(screen.getByText('Claude 3 Haiku')).toBeInTheDocument();
+    expect(screen.getByText('OpenAI')).toBeInTheDocument();
+    expect(screen.getByText('Google')).toBeInTheDocument();
   });
 
-  it('toggles model enabled state', () => {
+  it('displays cost derived from `inputPricePerMillion / 1000`', () => {
+    const { container } = render(<ModelsTable />);
+    // GPT-4 Turbo: 10 / 1000 = $0.0100 per 1k
+    expect(container.textContent).toContain('$0.0100');
+  });
+
+  it('renders avgLatency placeholder "—" because BE does not track it', () => {
     render(<ModelsTable />);
-
-    // Find Gemini Pro toggle (initially disabled)
-    const geminiRow = screen.getByText('Gemini Pro').closest('tr')!;
-    const toggle = geminiRow.querySelector('button')!;
-
-    // Should have gray background (disabled)
-    expect(toggle).toHaveClass('bg-muted'); // post DS-15 semantic token
-
-    // Click to enable
-    fireEvent.click(toggle);
-
-    // Should now have green background (enabled)
-    expect(toggle).toHaveClass('bg-green-500');
-
-    // Click again to disable
-    fireEvent.click(toggle);
-    expect(toggle).toHaveClass('bg-muted'); // post DS-15 semantic token
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 
-  it('shows cost and latency metrics', () => {
+  it('displays usage counts from UsageStats.TotalRequests', () => {
     const { container } = render(<ModelsTable />);
-
-    // Check for monetary values
-    expect(container.textContent).toContain('$0.0100'); // GPT-4 Turbo cost
-
-    // Check for latency values
-    expect(container.textContent).toContain('1.2s');
-  });
-
-  it('displays usage counts', () => {
-    const { container } = render(<ModelsTable />);
-
-    // GPT-4 usage is 8420 - rendered via toLocaleString() (locale-dependent format)
-    // Check that the value appears in the rendered output regardless of separator
+    // 8420 may render as "8,420" or "8.420" depending on locale.
     expect(container.textContent).toMatch(/8[.,\s]?420/);
+  });
+
+  it('renders loading state while query is pending', () => {
+    mocks.queryState.data = undefined;
+    mocks.queryState.isLoading = true;
+    render(<ModelsTable />);
+    expect(screen.getByText(/loading ai models/i)).toBeInTheDocument();
+  });
+
+  it('renders error row when the list query fails', () => {
+    mocks.queryState.data = undefined;
+    mocks.queryState.isError = true;
+    mocks.queryState.error = new Error('network down');
+    render(<ModelsTable />);
+    expect(screen.getByText(/failed to load ai models.*network down/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when no models exist', () => {
+    mocks.queryState.data = [];
+    render(<ModelsTable />);
+    expect(screen.getByText(/no ai models configured/i)).toBeInTheDocument();
+  });
+
+  it('calls the toggle mutation with the row id when the switch is clicked', async () => {
+    render(<ModelsTable />);
+    const toggle = screen.getByLabelText(/toggle gemini pro/i);
+    fireEvent.click(toggle);
+    await waitFor(() => expect(mocks.toggleMutateAsync).toHaveBeenCalledWith('mdl-gemini'));
+  });
+
+  it('surfaces a 409 banner when the BE rejects toggling a primary model off', () => {
+    mocks.toggleState.isError = true;
+    mocks.toggleState.error = new AdminAiModelsApiError(409, 'Primary model cannot be deactivated');
+    render(<ModelsTable />);
+    expect(screen.getByRole('alert')).toHaveTextContent(/primary model cannot be deactivated/i);
+  });
+
+  it('disables toggle button while mutation is pending', () => {
+    mocks.toggleState.isPending = true;
+    render(<ModelsTable />);
+    const toggle = screen.getByLabelText(/toggle gpt-4 turbo/i);
+    expect(toggle).toBeDisabled();
   });
 });

--- a/apps/web/src/components/admin/agents/models-table.tsx
+++ b/apps/web/src/components/admin/agents/models-table.tsx
@@ -1,75 +1,61 @@
 /* eslint-disable local/no-hardcoded-color-utility -- admin CRUD chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13c admin scope (--admin-* decision deferred to DS-15). */
 'use client';
 
-import { useState } from 'react';
-
 import { Badge } from '@/components/ui/badge';
+import { useAdminAiModels, useToggleAdminAiModel } from '@/hooks/queries/useAdminAiModels';
+import { AdminAiModelsApiError, type AiModelDto } from '@/lib/api/admin-ai-models';
 
-interface Model {
+interface ModelRow {
   id: string;
   provider: string;
   name: string;
   enabled: boolean;
+  /** Input price per 1,000 tokens, derived from `Settings.Pricing.InputPricePerMillion / 1000`. */
   costPer1k: number;
-  avgLatency: number;
+  /** Server doesn't track per-model avg latency — placeholder "—". Phase 2 BE extension tracked in #1442. */
+  avgLatency: string;
+  /** Total requests from server-side UsageStats. */
   usage: number;
 }
 
-const MOCK_MODELS: Model[] = [
-  {
-    id: '1',
-    provider: 'OpenAI',
-    name: 'GPT-4 Turbo',
-    enabled: true,
-    costPer1k: 0.01,
-    avgLatency: 1.2,
-    usage: 8420,
-  },
-  {
-    id: '2',
-    provider: 'Anthropic',
-    name: 'Claude 3.5 Sonnet',
-    enabled: true,
-    costPer1k: 0.003,
-    avgLatency: 1.5,
-    usage: 5230,
-  },
-  {
-    id: '3',
-    provider: 'OpenAI',
-    name: 'GPT-3.5 Turbo',
-    enabled: true,
-    costPer1k: 0.001,
-    avgLatency: 0.8,
-    usage: 3150,
-  },
-  {
-    id: '4',
-    provider: 'Google',
-    name: 'Gemini Pro',
-    enabled: false,
-    costPer1k: 0.00025,
-    avgLatency: 1.1,
-    usage: 420,
-  },
-  {
-    id: '5',
-    provider: 'Anthropic',
-    name: 'Claude 3 Haiku',
-    enabled: true,
-    costPer1k: 0.00025,
-    avgLatency: 0.6,
-    usage: 2840,
-  },
-];
+function mapDtoToRow(dto: AiModelDto): ModelRow {
+  return {
+    id: dto.id,
+    provider: dto.provider,
+    name: dto.displayName,
+    enabled: dto.isActive,
+    costPer1k: dto.settings.pricing.inputPricePerMillion / 1000,
+    avgLatency: '—',
+    usage: dto.usage.totalRequests,
+  };
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof AdminAiModelsApiError) {
+    return err.serverMessage;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return 'Unknown error';
+}
 
 export function ModelsTable() {
-  const [models, setModels] = useState(MOCK_MODELS);
+  const modelsQuery = useAdminAiModels();
+  const toggleMutation = useToggleAdminAiModel();
+  const rows = (modelsQuery.data ?? []).map(mapDtoToRow);
 
-  const handleToggle = (id: string) => {
-    setModels((prev) =>
-      prev.map((m) => (m.id === id ? { ...m, enabled: !m.enabled } : m))
-    );
+  const handleToggle = async (id: string) => {
+    try {
+      await toggleMutation.mutateAsync(id);
+    } catch (err) {
+      // Surface to console + (transient) UI via mutation state.
+      // The BE returns 409 when toggling a primary model off — that text
+      // is preserved on `toggleMutation.error.message` for callers that
+      // want to render it.
+
+      console.warn('Failed to toggle AI model:', describeError(err));
+    }
   };
 
   return (
@@ -79,6 +65,16 @@ export function ModelsTable() {
           AI Models
         </h2>
       </div>
+
+      {toggleMutation.isError && (
+        <div
+          role="alert"
+          className="px-6 py-3 bg-red-50/80 dark:bg-red-900/40 text-sm text-red-700 dark:text-red-200 border-b border-red-200 dark:border-red-800"
+        >
+          {describeError(toggleMutation.error)}
+        </div>
+      )}
+
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead className="bg-amber-100/50 dark:bg-zinc-900/50 border-b border-amber-200/50 dark:border-zinc-700/50">
@@ -104,10 +100,44 @@ export function ModelsTable() {
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-zinc-700">
-            {models.map((model) => (
+            {modelsQuery.isLoading && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-6 py-8 text-center text-sm text-muted-foreground dark:text-muted-foreground"
+                >
+                  Loading AI models…
+                </td>
+              </tr>
+            )}
+            {modelsQuery.isError && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-6 py-8 text-center text-sm text-red-600 dark:text-red-400"
+                  role="alert"
+                >
+                  Failed to load AI models: {describeError(modelsQuery.error)}
+                </td>
+              </tr>
+            )}
+            {!modelsQuery.isLoading && !modelsQuery.isError && rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-6 py-8 text-center text-sm text-muted-foreground dark:text-muted-foreground"
+                >
+                  No AI models configured yet.
+                </td>
+              </tr>
+            )}
+            {rows.map(model => (
               <tr key={model.id} className="hover:bg-muted/50 dark:hover:bg-zinc-900/50">
                 <td className="py-3 px-4">
-                  <Badge variant="outline" className="bg-muted text-foreground dark:bg-card dark:text-foreground">
+                  <Badge
+                    variant="outline"
+                    className="bg-muted text-foreground dark:bg-card dark:text-foreground"
+                  >
                     {model.provider}
                   </Badge>
                 </td>
@@ -116,11 +146,13 @@ export function ModelsTable() {
                 </td>
                 <td className="py-3 px-4 text-center">
                   <button
-                    onClick={() => handleToggle(model.id)}
-                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                      model.enabled
-                        ? 'bg-green-500 dark:bg-green-600'
-                        : 'bg-muted dark:bg-zinc-700'
+                    onClick={() => {
+                      void handleToggle(model.id);
+                    }}
+                    disabled={toggleMutation.isPending}
+                    aria-label={`Toggle ${model.name}`}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+                      model.enabled ? 'bg-green-500 dark:bg-green-600' : 'bg-muted dark:bg-zinc-700'
                     }`}
                   >
                     <span
@@ -135,10 +167,13 @@ export function ModelsTable() {
                   ${model.costPer1k.toFixed(4)}
                 </td>
                 <td className="py-3 px-4 text-right font-mono text-sm text-muted-foreground dark:text-muted-foreground">
-                  {model.avgLatency}s
+                  {model.avgLatency}
                 </td>
                 <td className="py-3 px-4 text-right">
-                  <Badge variant="outline" className="bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-300">
+                  <Badge
+                    variant="outline"
+                    className="bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-300"
+                  >
                     {model.usage.toLocaleString()}
                   </Badge>
                 </td>

--- a/apps/web/src/hooks/queries/useAdminAiModels.ts
+++ b/apps/web/src/hooks/queries/useAdminAiModels.ts
@@ -1,0 +1,41 @@
+/**
+ * useAdminAiModels - TanStack Query hooks for the admin AI Models surface.
+ *
+ * Issue #1442 Phase 1a — wire `models-table.tsx` to the live API.
+ * Mirrors the pattern in `useAdminCategories.ts` (#1440):
+ *   - query key: `['admin-ai-models']`
+ *   - mutation: `onSuccess` invalidates the list (no optimistic update —
+ *     `usage` / `costPer1k` are server-derived and must round-trip).
+ */
+
+import {
+  useMutation,
+  useQuery,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import { listAdminAiModels, toggleAdminAiModel, type AiModelDto } from '@/lib/api/admin-ai-models';
+import { getQueryClient } from '@/lib/queryClient';
+
+export const adminAiModelsKeys = {
+  all: ['admin-ai-models'] as const,
+};
+
+export function useAdminAiModels(): UseQueryResult<AiModelDto[], Error> {
+  return useQuery({
+    queryKey: adminAiModelsKeys.all,
+    queryFn: listAdminAiModels,
+    staleTime: 30_000,
+  });
+}
+
+export function useToggleAdminAiModel(): UseMutationResult<AiModelDto, Error, string> {
+  const queryClient = getQueryClient();
+  return useMutation({
+    mutationFn: toggleAdminAiModel,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: adminAiModelsKeys.all });
+    },
+  });
+}

--- a/apps/web/src/lib/api/admin-ai-models.ts
+++ b/apps/web/src/lib/api/admin-ai-models.ts
@@ -1,0 +1,113 @@
+/**
+ * Admin AI Models API client.
+ * Issue #1442 Phase 1a — wire `models-table.tsx` to existing BE endpoints.
+ *
+ * BE source:
+ *   apps/api/src/Api/Routing/AiModelAdminEndpoints.cs
+ *   apps/api/src/Api/BoundedContexts/SystemConfiguration/Application/DTOs/AiModelDto.cs
+ *
+ * Endpoints used in this client:
+ *   GET   /api/v1/admin/ai-models           — paginated list
+ *   PATCH /api/v1/admin/ai-models/{id}/toggle — flip IsActive
+ *
+ * Out of scope for this client (Phase 2):
+ *   POST/PUT/DELETE/PATCH-priority/tier-routing — the mockup doesn't surface them.
+ */
+
+export interface AiModelPricing {
+  inputPricePerMillion: number;
+  outputPricePerMillion: number;
+  currency: string;
+}
+
+export interface AiModelSettings {
+  maxTokens: number;
+  temperature: number;
+  pricing: AiModelPricing;
+}
+
+export interface AiModelUsage {
+  totalRequests: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokensUsed: number;
+  totalCostUsd: number;
+  lastUsedAt: string | null;
+}
+
+export interface AiModelDto {
+  id: string;
+  modelId: string;
+  displayName: string;
+  provider: string;
+  priority: number;
+  isActive: boolean;
+  isPrimary: boolean;
+  createdAt: string;
+  updatedAt: string | null;
+  settings: AiModelSettings;
+  usage: AiModelUsage;
+}
+
+export interface AiModelListDto {
+  models: AiModelDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export class AdminAiModelsApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly serverMessage: string
+  ) {
+    super(serverMessage || `HTTP ${status}`);
+    this.name = 'AdminAiModelsApiError';
+  }
+}
+
+async function rejectAs(response: Response, fallback: string): Promise<never> {
+  let message = fallback;
+  try {
+    const body = (await response.json()) as { message?: string; title?: string };
+    if (typeof body.message === 'string' && body.message.length > 0) {
+      message = body.message;
+    } else if (typeof body.title === 'string' && body.title.length > 0) {
+      message = body.title;
+    }
+  } catch {
+    // Non-JSON body — keep fallback.
+  }
+  throw new AdminAiModelsApiError(response.status, message);
+}
+
+/**
+ * Fetch the list of AI models. The mockup shows up to ~5 rows at a time;
+ * we request a large page size to render the full set without pagination
+ * controls (out of scope for Phase 1a).
+ */
+export async function listAdminAiModels(): Promise<AiModelDto[]> {
+  const response = await fetch('/api/v1/admin/ai-models?page=1&pageSize=200', {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to list AI models');
+  }
+  const list = (await response.json()) as AiModelListDto;
+  return list.models;
+}
+
+/**
+ * Toggle an AI model's `isActive` flag. The BE rejects toggling a primary
+ * model off with 409 Conflict (preserved as-is in the error surface).
+ */
+export async function toggleAdminAiModel(id: string): Promise<AiModelDto> {
+  const response = await fetch(`/api/v1/admin/ai-models/${encodeURIComponent(id)}/toggle`, {
+    method: 'PATCH',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to toggle AI model');
+  }
+  return (await response.json()) as AiModelDto;
+}


### PR DESCRIPTION
Refs #1442 (Phase 1a). Replaces hardcoded `MOCK_MODELS` in `apps/web/src/components/admin/agents/models-table.tsx` with a TanStack Query hook backed by the existing `/api/v1/admin/ai-models` endpoint (BE shipped under #2567 + #2596). Surfaced via #564 Q2 TODO/FIXME triage as drift identical to #1429 → #1440.

## Changes

- New `@/lib/api/admin-ai-models` client (list + toggle) with `AdminAiModelsApiError` preserving HTTP status (409 surfaces when toggling a primary model off)
- New `@/hooks/queries/useAdminAiModels` (1 query + 1 mutation, mirrors `useAdminCategories` from #1440)
- Refactor `models-table.tsx`: drop `MOCK_MODELS` constant + local-state `useState`, add loading/error/empty states + 409 banner + toggle disabled-while-pending

## Mapping AiModelDto → row

| BE field | FE field | Notes |
|----------|----------|-------|
| `Id` | `id` | Guid string |
| `Provider` | `provider` | as-is |
| `DisplayName` | `name` | as-is |
| `IsActive` | `enabled` | toggle endpoint mutates this |
| `Settings.Pricing.InputPricePerMillion / 1000` | `costPer1k` | derived; output price not displayed in mockup |
| `Usage.TotalRequests` | `usage` | as-is |
| **none** | `avgLatency = "—"` | BE doesn't track per-model latency — placeholder. Phase 2 tracked in #1442 |

## Tests

- 11 unit tests via `vi.mock` of the hooks module: render branches (loading/error/empty/data), DTO mapping verification (cost derivation + avgLatency placeholder + locale-aware usage formatting), toggle mutation invocation with row id, 409 banner surface, disabled-while-pending state.

## Out of scope (deferred to Phase 1b / Phase 2)

- Phase 1b: same drift sweep applied to `system-prompts-section.tsx` (PR follows in #1442)
- Add/Delete model (mockup doesn't surface it)
- Per-model avg latency BE tracking
- Tier routing UI (BE exposes endpoints, no mockup yet)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run models-table` — 11/11 pass
- [ ] CI Frontend Static green
- [ ] Manual smoke on `/admin/agents` (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)