### PR TITLE
feat(admin): wire system-prompts-section to live /admin/prompts (#1442 Phase 1b)

### DIFF
--- a/apps/web/src/components/admin/agents/__tests__/system-prompts-section.test.tsx
+++ b/apps/web/src/components/admin/agents/__tests__/system-prompts-section.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AdminPromptTemplatesApiError,
+  type PromptTemplateDto,
+} from '@/lib/api/admin-prompt-templates';
+
+const mockLoggerDebug = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    debug: (...args: unknown[]) => mockLoggerDebug(...args),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  getLogger: () => ({
+    debug: (...args: unknown[]) => mockLoggerDebug(...args),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  resetLogger: vi.fn(),
+  LogLevel: { DEBUG: 'debug', INFO: 'info', WARN: 'warn', ERROR: 'error' },
+}));
+
+const seedPrompts: PromptTemplateDto[] = [
+  {
+    id: 'tpl-rules-expert',
+    name: 'Rules Expert',
+    description: 'Specialized in explaining game rules and resolving rule disputes',
+    category: 'qa',
+    createdByUserId: 'usr-admin',
+    createdByEmail: 'admin@example.com',
+    createdAt: '2026-02-15T10:00:00Z',
+    versionCount: 3,
+    activeVersionNumber: 3,
+  },
+  {
+    id: 'tpl-strategy',
+    name: 'Strategy Advisor',
+    description: null,
+    category: null,
+    createdByUserId: 'usr-admin',
+    createdByEmail: null,
+    createdAt: '2026-02-12T09:00:00Z',
+    versionCount: 1,
+    activeVersionNumber: 1,
+  },
+];
+
+const mocks = vi.hoisted(() => ({
+  queryState: {
+    data: undefined as PromptTemplateDto[] | undefined,
+    isLoading: false,
+    isError: false,
+    error: null as unknown,
+  },
+}));
+
+vi.mock('@/hooks/queries/useAdminPromptTemplates', () => ({
+  useAdminPromptTemplates: () => ({
+    data: mocks.queryState.data,
+    isLoading: mocks.queryState.isLoading,
+    isError: mocks.queryState.isError,
+    error: mocks.queryState.error,
+  }),
+}));
+
+import { SystemPromptsSection } from '../system-prompts-section';
+
+beforeEach(() => {
+  mocks.queryState.data = seedPrompts;
+  mocks.queryState.isLoading = false;
+  mocks.queryState.isError = false;
+  mocks.queryState.error = null;
+  mockLoggerDebug.mockReset();
+});
+
+describe('SystemPromptsSection (#1442 Phase 1b — live API)', () => {
+  it('renders the section heading', () => {
+    render(<SystemPromptsSection />);
+    expect(screen.getByText('System Prompts')).toBeInTheDocument();
+  });
+
+  it('renders a card per prompt template from the server', () => {
+    render(<SystemPromptsSection />);
+    expect(screen.getByText('Rules Expert')).toBeInTheDocument();
+    expect(screen.getByText('Strategy Advisor')).toBeInTheDocument();
+  });
+
+  it('renders description text, falling back to em-dash when null', () => {
+    render(<SystemPromptsSection />);
+    expect(screen.getByText(/specialized in explaining game rules/i)).toBeInTheDocument();
+    // Strategy Advisor has a null description — em-dash appears in its card.
+    const strategyCard = screen.getByText('Strategy Advisor').closest('div')
+      ?.parentElement?.parentElement;
+    expect(strategyCard).not.toBeNull();
+    expect(strategyCard!.textContent).toContain('—');
+  });
+
+  it('renders pluralized version count badge', () => {
+    render(<SystemPromptsSection />);
+    expect(screen.getByText('3 versions')).toBeInTheDocument();
+    expect(screen.getByText('1 version')).toBeInTheDocument();
+  });
+
+  it('renders an ISO date for `Created`', () => {
+    render(<SystemPromptsSection />);
+    expect(screen.getByText(/created 2026-02-15/i)).toBeInTheDocument();
+  });
+
+  it('renders loading state when the query is loading', () => {
+    mocks.queryState.data = undefined;
+    mocks.queryState.isLoading = true;
+    render(<SystemPromptsSection />);
+    expect(screen.getByText(/loading system prompts/i)).toBeInTheDocument();
+  });
+
+  it('renders an error banner when the query fails', () => {
+    mocks.queryState.data = undefined;
+    mocks.queryState.isError = true;
+    mocks.queryState.error = new AdminPromptTemplatesApiError(500, 'database unavailable');
+    render(<SystemPromptsSection />);
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /failed to load prompts.*database unavailable/i
+    );
+  });
+
+  it('renders an empty state when no prompts exist', () => {
+    mocks.queryState.data = [];
+    render(<SystemPromptsSection />);
+    expect(screen.getByText(/no system prompts configured/i)).toBeInTheDocument();
+  });
+
+  it('logs a debug stub when the View button is clicked (Phase 1b deferred)', () => {
+    render(<SystemPromptsSection />);
+    fireEvent.click(screen.getByLabelText(/view prompt rules expert/i));
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.stringContaining('View prompt template tpl-rules-expert')
+    );
+  });
+
+  it('logs a debug stub when the Edit button is clicked (Phase 1b deferred)', () => {
+    render(<SystemPromptsSection />);
+    fireEvent.click(screen.getByLabelText(/edit prompt rules expert/i));
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      expect.stringContaining('Edit prompt template tpl-rules-expert')
+    );
+  });
+});

--- a/apps/web/src/components/admin/agents/system-prompts-section.tsx
+++ b/apps/web/src/components/admin/agents/system-prompts-section.tsx
@@ -5,40 +5,101 @@ import { EyeIcon, PencilIcon } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/primitives/button';
+import { useAdminPromptTemplates } from '@/hooks/queries/useAdminPromptTemplates';
+import {
+  AdminPromptTemplatesApiError,
+  type PromptTemplateDto,
+} from '@/lib/api/admin-prompt-templates';
+import { logger } from '@/lib/logger';
 
-interface SystemPrompt {
-  id: string;
-  title: string;
-  description: string;
-  tokenCount: number;
-  lastUpdated: string;
+function describeError(err: unknown): string {
+  if (err instanceof AdminPromptTemplatesApiError) {
+    return err.serverMessage;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return 'Unknown error';
 }
 
-const MOCK_PROMPTS: SystemPrompt[] = [
-  {
-    id: '1',
-    title: 'Rules Expert',
-    description: 'Specialized in explaining game rules and resolving rule disputes',
-    tokenCount: 2847,
-    lastUpdated: '2026-02-15',
-  },
-  {
-    id: '2',
-    title: 'Strategy Advisor',
-    description: 'Provides tactical advice and strategic recommendations for competitive play',
-    tokenCount: 3102,
-    lastUpdated: '2026-02-12',
-  },
-  {
-    id: '3',
-    title: 'Game Recommender',
-    description: 'Suggests games based on player preferences, group size, and complexity',
-    tokenCount: 2654,
-    lastUpdated: '2026-02-10',
-  },
-];
+function formatCreatedAt(iso: string): string {
+  try {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+      return iso;
+    }
+    return date.toISOString().slice(0, 10); // YYYY-MM-DD (locale-independent for test stability)
+  } catch {
+    return iso;
+  }
+}
+
+interface PromptCardProps {
+  readonly prompt: PromptTemplateDto;
+}
+
+function PromptCard({ prompt }: PromptCardProps) {
+  // tokenCount placeholder: BE doesn't expose the active version content on
+  // the list query (would require a per-row round-trip via
+  // `GET /admin/prompts/{id}/versions`). Phase 1b shows `versionCount` as a
+  // proxy until the dedicated editor surface lands.
+  const versionLabel = prompt.versionCount === 1 ? '1 version' : `${prompt.versionCount} versions`;
+
+  return (
+    <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border/50 dark:border-zinc-700/50">
+      <div className="flex items-start justify-between mb-3">
+        <h3 className="font-quicksand text-lg font-bold text-foreground dark:text-zinc-100">
+          {prompt.name}
+        </h3>
+        <Badge
+          variant="outline"
+          className="bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300"
+        >
+          {versionLabel}
+        </Badge>
+      </div>
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground mb-4">
+        {prompt.description ?? '—'}
+      </p>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground dark:text-muted-foreground">
+          Created {formatCreatedAt(prompt.createdAt)}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => {
+              // Phase 1b stub — dedicated editor surface tracked in #1442 Phase 2.
+              logger.debug(`View prompt template ${prompt.id} (Phase 1b stub)`);
+            }}
+            aria-label={`View prompt ${prompt.name}`}
+          >
+            <EyeIcon className="h-4 w-4" />
+            <span className="sr-only">View prompt</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => {
+              logger.debug(`Edit prompt template ${prompt.id} (Phase 1b stub)`);
+            }}
+            aria-label={`Edit prompt ${prompt.name}`}
+          >
+            <PencilIcon className="h-4 w-4" />
+            <span className="sr-only">Edit prompt</span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function SystemPromptsSection() {
+  const promptsQuery = useAdminPromptTemplates();
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -47,40 +108,32 @@ export function SystemPromptsSection() {
         </h2>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {MOCK_PROMPTS.map(prompt => (
-          <div
-            key={prompt.id}
-            className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border/50 dark:border-zinc-700/50"
-          >
-            <div className="flex items-start justify-between mb-3">
-              <h3 className="font-quicksand text-lg font-bold text-foreground dark:text-zinc-100">
-                {prompt.title}
-              </h3>
-              <Badge
-                variant="outline"
-                className="bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300"
-              >
-                {prompt.tokenCount} tokens
-              </Badge>
-            </div>
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground mb-4">{prompt.description}</p>
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-muted-foreground dark:text-muted-foreground">
-                Updated {prompt.lastUpdated}
-              </span>
-              <div className="flex gap-2">
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                  <EyeIcon className="h-4 w-4" />
-                  <span className="sr-only">View prompt</span>
-                </Button>
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                  <PencilIcon className="h-4 w-4" />
-                  <span className="sr-only">Edit prompt</span>
-                </Button>
-              </div>
-            </div>
+      {promptsQuery.isLoading && (
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground py-8 text-center">
+          Loading system prompts…
+        </div>
+      )}
+
+      {promptsQuery.isError && (
+        <div
+          role="alert"
+          className="rounded-md border border-red-200 dark:border-red-800 bg-red-50/80 dark:bg-red-900/40 px-4 py-3 text-sm text-red-700 dark:text-red-200"
+        >
+          Failed to load prompts: {describeError(promptsQuery.error)}
+        </div>
+      )}
+
+      {!promptsQuery.isLoading &&
+        !promptsQuery.isError &&
+        (promptsQuery.data?.length ?? 0) === 0 && (
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground py-8 text-center">
+            No system prompts configured yet.
           </div>
+        )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {(promptsQuery.data ?? []).map(prompt => (
+          <PromptCard key={prompt.id} prompt={prompt} />
         ))}
       </div>
     </div>

--- a/apps/web/src/hooks/queries/useAdminPromptTemplates.ts
+++ b/apps/web/src/hooks/queries/useAdminPromptTemplates.ts
@@ -1,0 +1,22 @@
+/**
+ * useAdminPromptTemplates - TanStack Query hook for the admin Prompts surface.
+ *
+ * Issue #1442 Phase 1b — read-only wiring; no mutations in this iteration
+ * (View / Edit buttons remain stubs until the dedicated editor lands).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { listAdminPromptTemplates, type PromptTemplateDto } from '@/lib/api/admin-prompt-templates';
+
+export const adminPromptTemplatesKeys = {
+  all: ['admin-prompt-templates'] as const,
+};
+
+export function useAdminPromptTemplates(): UseQueryResult<PromptTemplateDto[], Error> {
+  return useQuery({
+    queryKey: adminPromptTemplatesKeys.all,
+    queryFn: listAdminPromptTemplates,
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/lib/api/admin-prompt-templates.ts
+++ b/apps/web/src/lib/api/admin-prompt-templates.ts
@@ -1,0 +1,77 @@
+/**
+ * Admin Prompt Templates API client.
+ * Issue #1442 Phase 1b — wire `system-prompts-section.tsx` to existing BE.
+ *
+ * BE source:
+ *   apps/api/src/Api/Routing/PromptManagementEndpoints.cs
+ *   apps/api/src/Api/Models/PromptManagementDto.cs (PromptTemplateDto)
+ *
+ * Endpoint used in this client (read-only for Phase 1b):
+ *   GET /api/v1/admin/prompts — paginated list (returns PagedResult<PromptTemplateDto>)
+ *
+ * Out of scope for Phase 1b:
+ *   POST/GET-by-id/versions/activate/evaluate — mockup only shows the card grid,
+ *   the View/Edit actions remain stub buttons until a dedicated editor surface
+ *   ships in a follow-up epic.
+ */
+
+export interface PromptTemplateDto {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string | null;
+  createdByUserId: string;
+  createdByEmail: string | null;
+  createdAt: string;
+  versionCount: number;
+  activeVersionNumber: number | null;
+}
+
+export interface PagedPromptTemplatesDto {
+  items: PromptTemplateDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export class AdminPromptTemplatesApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly serverMessage: string
+  ) {
+    super(serverMessage || `HTTP ${status}`);
+    this.name = 'AdminPromptTemplatesApiError';
+  }
+}
+
+async function rejectAs(response: Response, fallback: string): Promise<never> {
+  let message = fallback;
+  try {
+    const body = (await response.json()) as { message?: string; title?: string };
+    if (typeof body.message === 'string' && body.message.length > 0) {
+      message = body.message;
+    } else if (typeof body.title === 'string' && body.title.length > 0) {
+      message = body.title;
+    }
+  } catch {
+    // Non-JSON body — keep fallback.
+  }
+  throw new AdminPromptTemplatesApiError(response.status, message);
+}
+
+/**
+ * Fetch the prompt templates. The endpoint returns a generic `PagedResult`
+ * wrapper (`{ items, totalCount, page, pageSize }`). The card grid renders
+ * a small, bounded set so we request `pageSize=200` and ignore pagination
+ * controls for Phase 1b.
+ */
+export async function listAdminPromptTemplates(): Promise<PromptTemplateDto[]> {
+  const response = await fetch('/api/v1/admin/prompts?page=1&limit=200', {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    await rejectAs(response, 'Failed to list prompt templates');
+  }
+  const payload = (await response.json()) as PagedPromptTemplatesDto;
+  return payload.items;
+}


### PR DESCRIPTION
Refs #1442 (Phase 1b). Replaces hardcoded `MOCK_PROMPTS` in `apps/web/src/components/admin/agents/system-prompts-section.tsx` with a TanStack Query hook backed by the existing `/api/v1/admin/prompts` endpoint. Read-only; View/Edit buttons remain as logging stubs until the dedicated editor surface lands.

## Changes

- New `@/lib/api/admin-prompt-templates` (list-only) with `AdminPromptTemplatesApiError`. Endpoint returns `PagedResult<PromptTemplateDto>` from `Models/PromptManagementDto.cs`.
- New `@/hooks/queries/useAdminPromptTemplates` (read-only query).
- Refactor `system-prompts-section.tsx`: drop `MOCK_PROMPTS`, extract `PromptCard` subcomponent, add loading/error/empty states.

## Mapping PromptTemplateDto → card

| BE field | FE rendering | Notes |
|----------|--------------|-------|
| `Name` | card header | as-is |
| `Description` | body paragraph | null → em-dash placeholder |
| `VersionCount` | badge | "1 version" / "N versions" — proxy for tokenCount (deferred) |
| `CreatedAt` | "Created YYYY-MM-DD" | ISO format for locale-independent test stability |
| **View button** | `logger.debug` stub | Phase 2 editor surface |
| **Edit button** | `logger.debug` stub | Phase 2 editor surface |

## Tests

- 10 unit tests via `vi.mock` of the hook: heading, render-per-row, description em-dash fallback, pluralized version label (1 vs N), ISO date display, loading/error/empty branches, View/Edit stub logging.

## Out of scope (intentional)

- `tokenCount` badge — would require a per-row round-trip via `GET /admin/prompts/{id}/versions` (deferred)
- View / Edit action implementations — separate editor surface epic
- Mutations (Create/Update/Delete/Versioning) — out of mockup scope
- Pagination controls — small bounded set

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run system-prompts-section` — 10/10 pass
- [ ] CI Frontend Static green
- [ ] Manual smoke on `/admin/agents` (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)