### PR TITLE
chore(deps): BE patch/minor batch — 16 NuGet packages (10 patches + 6 OpenTelemetry/Serilog minors)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -74,9 +74,9 @@
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.4.0" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <!-- Issue #613: Polly v8 ResiliencePipeline for cache invalidation retry -->
-    <PackageReference Include="Polly.Core" Version="8.6.5" />
+    <PackageReference Include="Polly.Core" Version="8.6.6" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.14.0-beta.2" />
     <PackageReference Include="Otp.NET" Version="1.4.1" />
     <PackageReference Include="Parquet.Net" Version="5.5.0" />
@@ -90,11 +90,11 @@
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.13.1" />
     <PackageReference Include="QuestPDF" Version="2025.12.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <!-- PERF-05: HybridCache for AI/RAG response caching with L1+L2 support -->
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0" />
-    <PackageReference Include="Npgsql" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
+    <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -103,29 +103,29 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.11.1" />
     <PackageReference Include="ScottPlot" Version="5.0.47" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.1.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SlackNet" Version="0.17.9" />
+    <PackageReference Include="SlackNet" Version="0.17.10" />
     <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
     <PackageReference Include="Tesseract" Version="5.2.0" />
     <PackageReference Include="Tesseract.Drawing" Version="5.2.0" />
     <!-- OPS-02: OpenTelemetry packages -->
-    <PackageReference Include="OpenTelemetry" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.1-beta.1" />
-    <PackageReference Include="WebPush" Version="1.0.12" />
+    <PackageReference Include="WebPush" Version="1.0.13" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <!-- Security analyzers (Issue #1455: Modern analyzers replacing deprecated SecurityCodeScan) -->

--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Polly" Version="8.5.0" />
     <PackageReference Include="QuestPDF" Version="2025.12.3" />
     <PackageReference Include="ScottPlot" Version="5.1.57" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="4.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />


### PR DESCRIPTION
## Summary

Bumps 16 NuGet packages in `apps/api/src/Api/Api.csproj`. All are patch-level (Tier 1) or minor non-breaking semver (Tier 2). No Dependabot PR was open for these — discovered via `dotnet list package --outdated` during a deps-drift audit. No API surface changes expected; CI runs the full test suite to confirm.

## Tier 1 — patch bumps (10)

| Package | From | To |
|---|---|---|
| `Microsoft.Extensions.Http.Polly` | 10.0.0 | 10.0.8 |
| `Microsoft.Extensions.Caching.Memory` | 10.0.0 | 10.0.8 |
| `Microsoft.Extensions.Caching.StackExchangeRedis` | 10.0.0 | 10.0.8 |
| `System.Drawing.Common` | 10.0.0 | 10.0.8 |
| `System.Text.Json` | 10.0.0 | 10.0.8 |
| `Npgsql` | 10.0.0 | 10.0.2 |
| `Polly.Core` | 8.6.5 | 8.6.6 |
| `Serilog` | 4.3.0 | 4.3.1 |
| `SlackNet` | 0.17.9 | 0.17.10 |
| `WebPush` | 1.0.12 | 1.0.13 |

## Tier 2 — minor bumps (6)

| Package | From | To |
|---|---|---|
| `OpenTelemetry` | 1.14.0 | 1.15.3 |
| `OpenTelemetry.Extensions.Hosting` | 1.14.0 | 1.15.3 |
| `OpenTelemetry.Instrumentation.AspNetCore` | 1.14.0 | 1.15.2 |
| `OpenTelemetry.Instrumentation.Http` | 1.14.0 | 1.15.1 |
| `OpenTelemetry.Instrumentation.Runtime` | 1.14.0 | 1.15.1 |
| `Serilog.Sinks.Seq` | 9.0.0 | 9.1.0 |

## Explicitly NOT bumped (deferred for focused review)

- **Major bumps requiring .NET 10 migration**: `Microsoft.AspNetCore.OpenApi` 9.0→10.0, `Microsoft.EntityFrameworkCore` 9.0→10.0, `Npgsql.EntityFrameworkCore.PostgreSQL` 9.0→10.0
- **Major bumps requiring breaking-change review**: `AWSSDK.S3` 3.7→4.0, `Parquet.Net` 5→6 (already pinned with Snappier 1.3.1 workaround), `SixLabors.ImageSharp` 3→4, `YamlDotNet` 16→18, `Meziantou.Analyzer` 2→3
- **Large minor jumps requiring focused testing**: `Microsoft.Extensions.Caching.Hybrid` 10.0.0→10.6.0, `StackExchange.Redis` 2.10.1→2.13.1, `Quartz` 3.13→3.18, `SonarAnalyzer.CSharp` 10.16→10.26, `System.IdentityModel.Tokens.Jwt` 8.2→8.18
- **Beta/preview kept as-is**: `OpenTelemetry.Exporter.Prometheus.AspNetCore` 1.13.1-beta.1, `OpenTelemetry.Instrumentation.EntityFrameworkCore` 1.14.0-beta.2 (latest beta not found in feeds per `dotnet list package --outdated`)

## Local verification

- ✅ `dotnet restore` clean
- ✅ `dotnet build -p:SkipAnalyzers=true` (Docker production setup): 0 warnings, 0 errors in 48 s
- ✅ `dotnet build` (full analyzers): 0 warnings, 0 errors in 68 s — `TreatWarningsAsErrors=true` still green

## Test plan

- [x] Local build verde con `TreatWarningsAsErrors=true`
- [ ] CI Backend Fast (build + unit) verde
- [ ] CI Backend tests più estesi (se triggerati) verdi
- [ ] CodeQL / Semgrep / GitGuardian / SCA verdi
- [ ] No regressions in OpenTelemetry instrumentation (1.14→1.15 minor — verifica metrics flow se test E2E lo coprono)

## Risks

| Risk | Likelihood | Impact | Mitigation |
|------|------------|--------|------------|
| OpenTelemetry 1.15 introduces new [Obsolete] markers | Low | Low | TreatWarningsAsErrors=true would have failed local build; it didn't |
| Npgsql 10.0.2 connection string parsing changes | Low | Med | CI integration tests cover DB connection setup |
| Polly.Core 8.6.6 retry behavior change | Very Low | Low | Patch-only (8.6.5→8.6.6), no API change documented |
| Serilog.Sinks.Seq 9.0→9.1 log shipping format | Low | Low | Minor bump, sink interface unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)