### PR TITLE
feat(ci): #1446 Phase 2c weekly release-gate digest to Slack

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 *.ps1 text eol=lf
 *.json text eol=lf
 *.yml text eol=lf
+*.mjs text eol=lf
 
 # Generated API client files (Issue #1450)
 apps/web/src/lib/api/generated/*.ts text eol=lf

--- a/.github/release-gates.yml
+++ b/.github/release-gates.yml
@@ -253,3 +253,14 @@ bot:
     severity: warning
     owner: unknown
     override_path: exception-comment
+
+  # Phase 2c (#1446) — weekly Slack digest of warning-tier classifications.
+  # Read by scripts/release-gate/build-digest.mjs + lib/digest-builder.mjs.
+  phase2c:
+    enabled: true
+    # Number of consecutive weeks the same `warning`-tier check must appear
+    # before the digest flags it with `:warning:` "suggest reclassify to blocker".
+    escalation_threshold_weeks: 4
+    # Name of the env var bound to the Slack incoming webhook URL. The CLI
+    # reads from `process.env[<this value>]`. Kept indirect for portability.
+    slack_webhook_env: SLACK_GITNOTIFY_WEBHOOK_URL

--- a/.github/workflows/release-gate-digest.yml
+++ b/.github/workflows/release-gate-digest.yml
@@ -25,17 +25,23 @@ concurrency:
   group: release-gate-digest
   cancel-in-progress: false
 
+# Default to least-privilege at the workflow level; the digest job re-declares
+# the write permissions it needs (contents:write for the state-branch commit,
+# pull-requests:write for the state PR, issues:write for failure-issue
+# creation). Validate-only steps therefore inherit read-only credentials.
 permissions:
-  contents: write       # for state-file commit on side branch
-  pull-requests: write  # for state PR creation
-  issues: write         # for failure-issue creation
-  checks: read
+  contents: read
 
 jobs:
   digest:
     name: Build and post weekly digest
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write       # for state-file commit on side branch
+      pull-requests: write  # for state PR creation
+      issues: write         # for failure-issue creation
+      checks: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-gate-digest.yml
+++ b/.github/workflows/release-gate-digest.yml
@@ -1,0 +1,77 @@
+name: Release-gate Digest
+
+# Weekly Slack digest of `warning`-tier classifications across recent release PRs.
+# Implementation: scripts/release-gate/build-digest.mjs
+# Issue: #1446 (Phase 2c of #1016)
+# Design doc: docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md
+
+on:
+  schedule:
+    # Monday 08:00 UTC = 09:00 Europe/Rome (winter) or 10:00 Europe/Rome (summer DST).
+    # Per spec AC-1: target is Monday 09:00 Europe/Rome — exact local time varies
+    # with DST. Cron is UTC so we anchor at 08:00 UTC which is the winter-time
+    # equivalent. Summer-time will fire at 10:00 local; acceptable per spec
+    # ("Monday 09:00 Europe/Rome ±1h depending on DST").
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, print Slack payload to stdout and skip state PR"
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: release-gate-digest
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # for state-file commit on side branch
+  pull-requests: write  # for state PR creation
+  issues: write         # for failure-issue creation
+  checks: read
+
+jobs:
+  digest:
+    name: Build and post weekly digest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa  # v4
+        with:
+          version: 9
+
+      - name: Install release-gate deps
+        working-directory: scripts/release-gate
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate .github/release-gates.yml schema
+        working-directory: scripts/release-gate
+        run: node validate.mjs
+
+      - name: Build and post digest
+        id: digest
+        working-directory: scripts/release-gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_GITNOTIFY_WEBHOOK_URL: ${{ secrets.SLACK_GITNOTIFY_WEBHOOK_URL }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && '1' || '' }}
+          # GITHUB_STEP_SUMMARY is set by GH Actions automatically.
+        run: node build-digest.mjs
+        # On Slack POST failure, the CLI opens a [release-gate-digest][YYYY-Www]
+        # FAILED issue and exits 1. The job is then marked failed (visible in
+        # the run history) but does NOT auto-retry — the next cron tick is the
+        # natural retry. No continue-on-error here: failure must be visible.

--- a/.github/workflows/release-gate-digest.yml
+++ b/.github/workflows/release-gate-digest.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/scripts/release-gate/README.md
+++ b/scripts/release-gate/README.md
@@ -4,40 +4,48 @@ Bot that auto-classifies CI failures on release PRs (`main-dev → main-staging`
 
 **Operator manual**: [`docs/for-developers/operations/release-gate-bot.md`](../../docs/for-developers/operations/release-gate-bot.md)
 **Design doc**: [`docs/for-developers/specs/2026-05-22-release-gate-spreadsheet.md`](../../docs/for-developers/specs/2026-05-22-release-gate-spreadsheet.md)
-**Issue**: [#1016](https://github.com/meepleAi-app/meepleai-monorepo/issues/1016)
+**Phase 2 overview**: [`docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md`](../../docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md)
+**Issue**: [#1016](https://github.com/meepleAi-app/meepleai-monorepo/issues/1016) (Phase 1) · [#1446](https://github.com/meepleAi-app/meepleai-monorepo/issues/1446) (Phase 2c — weekly digest)
 
 ## Quick commands
 
 ```bash
-pnpm install                      # install deps
-pnpm test                         # run 56-test Vitest suite
-pnpm validate                     # validate .github/release-gates.yml schema
-DRY_RUN=1 pnpm comment            # preview comment body + summary
+pnpm install                                  # install deps
+pnpm test                                     # run 93-test Vitest suite
+pnpm validate                                 # validate .github/release-gates.yml schema
+DRY_RUN=1 pnpm comment                        # preview classification comment body
+DRY_RUN=1 pnpm digest                         # preview weekly digest Slack payload
 ```
 
 ## Files
 
 ```
 scripts/release-gate/
-├── package.json          # @meepleai/release-gate (private)
+├── package.json              # @meepleai/release-gate (private)
 ├── vitest.config.mjs
-├── README.md             # this file
-├── validate.mjs          # CLI entry: schema validator (exit 0/1/2)
-├── comment.mjs           # CLI entry: bot (octokit + classification + comment)
+├── README.md                 # this file
+├── validate.mjs              # CLI entry: schema validator (exit 0/1/2)
+├── comment.mjs               # CLI entry: bot (Phase 1)
+├── build-digest.mjs          # CLI entry: weekly digest (Phase 2c, #1446)
 ├── lib/
-│   ├── classify.mjs      # pure: classify(check_name, gates) → {severity, owner, override_path, ...}
-│   ├── format.mjs        # pure: formatComment + formatActionsSummary
-│   └── validate.mjs      # pure: validateGates + validateGatesFile
+│   ├── classify.mjs          # pure: classify(check_name, gates)
+│   ├── format.mjs            # pure: formatComment + formatActionsSummary (Phase 1)
+│   ├── validate.mjs          # pure: validateGates + validateGatesFile
+│   ├── parse-bot-comment.mjs # pure: parseBotComment + pickLatestBotComment (Phase 2c)
+│   └── digest-builder.mjs    # pure: buildDigest + isoWeek (Phase 2c)
 └── __tests__/
-    ├── classify.test.mjs
-    ├── format.test.mjs
-    ├── validate.test.mjs
-    ├── integration.test.mjs
+    ├── classify.test.mjs            # 16 tests
+    ├── format.test.mjs              # 18 tests
+    ├── validate.test.mjs            # 17 tests (includes phase2c validation)
+    ├── integration.test.mjs         # 12 tests (Phase 1 nock-based)
+    ├── parse-bot-comment.test.mjs   # 15 tests (Phase 2c)
+    ├── digest-builder.test.mjs      # 15 tests (Phase 2c)
     └── fixtures/
         ├── release-gates-valid.yml
         ├── release-gates-invalid-version.yml
         ├── release-gates-invalid-severity.yml
-        └── release-gates-missing-field.yml
+        ├── release-gates-missing-field.yml
+        └── sample-bot-comment.md    # Phase 2c parser fixture
 ```
 
 ## Env

--- a/scripts/release-gate/__tests__/digest-builder.test.mjs
+++ b/scripts/release-gate/__tests__/digest-builder.test.mjs
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+
+import { buildDigest, isoWeek, EMPTY_STATE } from "../lib/digest-builder.mjs";
+
+// Frozen "now" anchor — Monday 2026-05-25 at 09:00 Europe/Rome = ISO week 2026-W22.
+const NOW = new Date("2026-05-25T08:00:00Z");
+
+function makePr({ number, title, mergedAt, baseRef = "main-staging", botFailures = [] }) {
+  return { number, title, mergedAt, baseRef, botFailures };
+}
+
+function makeFailure(check_name, severity = "warning", owner = "qa") {
+  return {
+    check_name,
+    severity,
+    owner,
+    override_path: "exception-comment",
+    notes: "test note",
+    is_unknown: false,
+  };
+}
+
+const GATES_DEFAULT = {
+  bot: {
+    phase2c: {
+      enabled: true,
+      escalation_threshold_weeks: 4,
+    },
+  },
+};
+
+describe("buildDigest — base behavior", () => {
+  it("(matrix #1) empty window: no PRs, no warnings → 'all green' action=post, no state PR", () => {
+    const result = buildDigest({ prs: [], prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.action).toBe("post");
+    expect(result.slackMessage).toContain("No release-gate warnings this week");
+    expect(result.openStatePr).toBe(false);
+  });
+
+  it("(matrix #2) all blockers, zero warnings → 'no warnings this week', no state PR", () => {
+    const prs = [
+      makePr({
+        number: 100,
+        title: "release: X",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Backend - Unit Tests", "blocker", "backend-dev")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.action).toBe("post");
+    expect(result.slackMessage).toContain("No release-gate warnings this week");
+    expect(result.openStatePr).toBe(false);
+  });
+
+  it("filters to warning-tier ONLY (ignores informational + blocker)", () => {
+    const prs = [
+      makePr({
+        number: 101,
+        title: "release: Y",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [
+          makeFailure("Backend - Unit Tests", "blocker", "backend-dev"),
+          makeFailure("Frontend - A11y E2E", "warning", "qa"),
+          makeFailure("Lychee Link Check", "informational", "devops"),
+        ],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.action).toBe("post");
+    expect(result.slackMessage).toContain("Frontend - A11y E2E");
+    expect(result.slackMessage).not.toContain("Backend - Unit Tests");
+    expect(result.slackMessage).not.toContain("Lychee Link Check");
+  });
+});
+
+describe("buildDigest — delta tracking (AC-4)", () => {
+  it("classifies new warnings (not in prev state) as new_this_week", () => {
+    const prs = [
+      makePr({
+        number: 200,
+        title: "release Z",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Lighthouse CI", "warning", "frontend-dev")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.deltas.new_this_week).toBe(1);
+    expect(result.deltas.persisting).toBe(0);
+    expect(result.deltas.resolved_this_week).toBe(0);
+  });
+
+  it("classifies warnings present in prev state as persisting (increments weeksSeen)", () => {
+    const prevState = {
+      schemaVersion: 1,
+      lastWeekISO: "2026-W21",
+      warningsByCheck: {
+        "Frontend - A11y E2E": {
+          owner: "qa",
+          firstSeenWeek: "2026-W20",
+          weeksSeen: 2,
+          lastSeenWeek: "2026-W21",
+        },
+      },
+    };
+    const prs = [
+      makePr({
+        number: 300,
+        title: "release A",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates: GATES_DEFAULT });
+    expect(result.deltas.persisting).toBe(1);
+    expect(result.deltas.new_this_week).toBe(0);
+    expect(result.newState.warningsByCheck["Frontend - A11y E2E"].weeksSeen).toBe(3);
+  });
+
+  it("classifies warnings in prev state but NOT this week as resolved_this_week", () => {
+    const prevState = {
+      schemaVersion: 1,
+      lastWeekISO: "2026-W21",
+      warningsByCheck: {
+        "Stale Check": {
+          owner: "qa",
+          firstSeenWeek: "2026-W20",
+          weeksSeen: 2,
+          lastSeenWeek: "2026-W21",
+        },
+      },
+    };
+    const prs = [
+      makePr({
+        number: 301,
+        title: "release B",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates: GATES_DEFAULT });
+    expect(result.deltas.resolved_this_week).toBe(1);
+    expect(result.newState.warningsByCheck["Stale Check"]).toBeUndefined();
+  });
+});
+
+describe("buildDigest — escalation flag (matrix #7, AC-5)", () => {
+  it("flags warnings persisting >= escalation_threshold_weeks (default 4)", () => {
+    const prevState = {
+      schemaVersion: 1,
+      lastWeekISO: "2026-W21",
+      warningsByCheck: {
+        "Frontend - A11y E2E": {
+          owner: "qa",
+          firstSeenWeek: "2026-W18",
+          weeksSeen: 4,
+          lastSeenWeek: "2026-W21",
+        },
+      },
+    };
+    const prs = [
+      makePr({
+        number: 400,
+        title: "release C",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates: GATES_DEFAULT });
+    expect(result.escalations).toHaveLength(1);
+    expect(result.escalations[0].check_name).toBe("Frontend - A11y E2E");
+    expect(result.escalations[0].weeks_seen).toBe(5);
+    expect(result.slackMessage).toContain(":warning:");
+    expect(result.slackMessage).toContain("suggest reclassify to blocker");
+  });
+
+  it("honors a custom escalation_threshold_weeks override from gates", () => {
+    const gates = {
+      bot: { phase2c: { enabled: true, escalation_threshold_weeks: 2 } },
+    };
+    const prevState = {
+      schemaVersion: 1,
+      lastWeekISO: "2026-W21",
+      warningsByCheck: {
+        "Lighthouse CI": {
+          owner: "frontend-dev",
+          firstSeenWeek: "2026-W20",
+          weeksSeen: 2,
+          lastSeenWeek: "2026-W21",
+        },
+      },
+    };
+    const prs = [
+      makePr({
+        number: 401,
+        title: "release D",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Lighthouse CI", "warning", "frontend-dev")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates });
+    expect(result.escalations).toHaveLength(1);
+  });
+});
+
+describe("buildDigest — idempotency (matrix #6)", () => {
+  it("skips when prevState.lastWeekISO == currentWeek (action='skip')", () => {
+    const currentWeek = isoWeek(NOW);
+    const prevState = {
+      schemaVersion: 1,
+      lastWeekISO: currentWeek,
+      warningsByCheck: {},
+    };
+    const prs = [
+      makePr({
+        number: 500,
+        title: "release E",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates: GATES_DEFAULT });
+    expect(result.action).toBe("skip");
+    expect(result.reason).toBe("already-processed-this-week");
+  });
+});
+
+describe("buildDigest — kill switch (matrix #11, AC-6)", () => {
+  it("skips when gates.bot.phase2c.enabled === false", () => {
+    const gates = { bot: { phase2c: { enabled: false } } };
+    const prs = [
+      makePr({
+        number: 600,
+        title: "release F",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates });
+    expect(result.action).toBe("skip");
+    expect(result.reason).toBe("bot.phase2c.enabled=false");
+  });
+});
+
+describe("buildDigest — schema drift tolerance (matrix #10)", () => {
+  it("treats prevState with unknown schemaVersion as empty (graceful degrade)", () => {
+    const prevState = {
+      schemaVersion: 999,
+      lastWeekISO: "2026-W21",
+      warningsByCheck: { foo: { owner: "x", weeksSeen: 99 } },
+    };
+    const prs = [
+      makePr({
+        number: 700,
+        title: "release G",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState, now: NOW, gates: GATES_DEFAULT });
+    // Falls back to treating prevState as empty → warning is "new" not persisting.
+    expect(result.deltas.new_this_week).toBe(1);
+    expect(result.deltas.persisting).toBe(0);
+  });
+});
+
+describe("buildDigest — output structure", () => {
+  it("populates newState.lastWeekISO with the current ISO week", () => {
+    const result = buildDigest({ prs: [], prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.newState.lastWeekISO).toBe(isoWeek(NOW));
+  });
+
+  it("aggregates a per-check entry with frequency and owner", () => {
+    const prs = [
+      makePr({
+        number: 800,
+        title: "release H",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+      makePr({
+        number: 801,
+        title: "release I",
+        mergedAt: "2026-05-24T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.aggregates).toContainEqual(
+      expect.objectContaining({
+        check_name: "Frontend - A11y E2E",
+        owner: "qa",
+        frequency: 2,
+      })
+    );
+  });
+
+  it("opens a state PR when there is at least 1 warning to record", () => {
+    const prs = [
+      makePr({
+        number: 900,
+        title: "release J",
+        mergedAt: "2026-05-23T10:00:00Z",
+        botFailures: [makeFailure("Frontend - A11y E2E", "warning", "qa")],
+      }),
+    ];
+    const result = buildDigest({ prs, prevState: EMPTY_STATE, now: NOW, gates: GATES_DEFAULT });
+    expect(result.openStatePr).toBe(true);
+    expect(result.statePrBranchName).toMatch(/^chore\/release-gate-digest-state-2026-W22$/);
+  });
+});
+
+describe("isoWeek — utility", () => {
+  it("formats Date → 'YYYY-Www' using ISO 8601 week numbering", () => {
+    // Monday 2026-05-25 is in ISO week 22 of 2026.
+    expect(isoWeek(new Date("2026-05-25T08:00:00Z"))).toBe("2026-W22");
+    // 2026-01-01 (Thursday) is in ISO week 1 of 2026.
+    expect(isoWeek(new Date("2026-01-01T12:00:00Z"))).toBe("2026-W01");
+    // 2025-12-29 (Monday) is in ISO week 1 of 2026 by ISO 8601 rules.
+    expect(isoWeek(new Date("2025-12-29T12:00:00Z"))).toBe("2026-W01");
+  });
+});

--- a/scripts/release-gate/__tests__/digest-builder.test.mjs
+++ b/scripts/release-gate/__tests__/digest-builder.test.mjs
@@ -318,4 +318,15 @@ describe("isoWeek — utility", () => {
     // 2025-12-29 (Monday) is in ISO week 1 of 2026 by ISO 8601 rules.
     expect(isoWeek(new Date("2025-12-29T12:00:00Z"))).toBe("2026-W01");
   });
+
+  it("handles year-end without wrap (last week of same calendar year)", () => {
+    // 2026-12-28 Monday is in ISO week 53 of 2026 (Thursday 2026-12-31 stays
+    // in 2026). 2026 has 53 ISO weeks because 2026-01-01 is a Thursday.
+    expect(isoWeek(new Date("2026-12-28T12:00:00Z"))).toBe("2026-W53");
+  });
+
+  it("handles a year with 53 ISO weeks (Thursday on Dec 31)", () => {
+    // 2015 had 53 weeks: 2015-12-31 was a Thursday.
+    expect(isoWeek(new Date("2015-12-31T12:00:00Z"))).toBe("2015-W53");
+  });
 });

--- a/scripts/release-gate/__tests__/fixtures/sample-bot-comment.md
+++ b/scripts/release-gate/__tests__/fixtures/sample-bot-comment.md
@@ -1,0 +1,18 @@
+<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+Commit `abc1234` · Generated 2026-05-22T10:00:00Z
+
+**Verdict**: ⚠️ WARNING
+
+0 blocker · 3 warning · 1 informational
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|
+| `Frontend - A11y E2E` | ⚠️ warning | qa | baseline-update | ~159 known violations tracked in #1094 (Phase A→D plan). Advisory until Phase D ships. |
+| `Lighthouse CI` | ⚠️ warning | frontend-dev | exception-comment | Performance budget. Flake-prone on busy runners; retry before reverting. |
+| `codecov/patch` | ⚠️ warning | devops | baseline-update | Patch coverage threshold. Tolerated drops require updated baseline. |
+| `Lychee Link Check` | ℹ️ informational | devops | exception-comment | External link rot. Non-blocking unless docs-critical (see #1014). |
+
+<sub>Classification duration: 142 ms · PR #999</sub>

--- a/scripts/release-gate/__tests__/parse-bot-comment.test.mjs
+++ b/scripts/release-gate/__tests__/parse-bot-comment.test.mjs
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseBotComment, pickLatestBotComment } from "../lib/parse-bot-comment.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sampleFixture = readFileSync(
+  path.join(__dirname, "fixtures", "sample-bot-comment.md"),
+  "utf8"
+);
+
+describe("parseBotComment — happy path", () => {
+  it("extracts all failure rows from the markdown table", () => {
+    const rows = parseBotComment(sampleFixture);
+    expect(rows).toHaveLength(4);
+  });
+
+  it("captures check_name, severity, owner, notes per row", () => {
+    const rows = parseBotComment(sampleFixture);
+    expect(rows[0]).toMatchObject({
+      check_name: "Frontend - A11y E2E",
+      severity: "warning",
+      owner: "qa",
+    });
+    expect(rows[0].notes).toContain("#1094");
+  });
+
+  it("preserves severity tier ordering as-listed", () => {
+    const rows = parseBotComment(sampleFixture);
+    expect(rows.map((r) => r.severity)).toEqual([
+      "warning",
+      "warning",
+      "warning",
+      "informational",
+    ]);
+  });
+});
+
+describe("parseBotComment — edge cases (test matrix #3, #4, #10, #12)", () => {
+  it("returns null when SIGNATURE_HEADER is absent (test matrix #4: not a bot comment)", () => {
+    const md = "## Some random PR comment\n\nNot from the bot.";
+    expect(parseBotComment(md)).toBeNull();
+  });
+
+  it("returns [] when bot comment shows 'No failed checks classified' (test matrix #2)", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+Commit \`abc1234\` · Generated 2026-05-22T10:00:00Z
+
+✅ No failed checks classified.`;
+    expect(parseBotComment(md)).toEqual([]);
+  });
+
+  it("returns [] when bot fallback (error) comment is encountered (test matrix #3 malformed)", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+Commit \`abc1234\` · Generated 2026-05-22T10:00:00Z
+
+⚠️ **release-gate bot failed — manual triage required.**
+
+- Phase: \`fetch-check-runs\`
+- Error: \`API rate limit exceeded\``;
+    expect(parseBotComment(md)).toEqual([]);
+  });
+
+  it("returns [] when signature found but table is malformed / missing rows", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+Commit \`abc1234\` · Generated 2026-05-22T10:00:00Z
+
+**Verdict**: ⚠️ WARNING
+
+0 blocker · 3 warning · 0 informational
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|`;
+    expect(parseBotComment(md)).toEqual([]);
+  });
+
+  it("unescapes pipe characters inside check_name (escaped via \\| by formatComment)", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|
+| \`Backend - Weird \\| Pipe\` | ⚠️ warning | qa | exception-comment | x |`;
+    const rows = parseBotComment(md);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].check_name).toBe("Backend - Weird | Pipe");
+  });
+
+  it("unescapes backtick characters inside check_name (escaped via \\` by formatComment)", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|
+| \`Backend \\\`tick\\\` test\` | ⚠️ warning | qa | exception-comment | y |`;
+    const rows = parseBotComment(md);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].check_name).toBe("Backend `tick` test");
+  });
+
+  it("strips trailing 🆕 unknown tag and flags is_unknown=true", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+## Release-gate Classification
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|
+| \`New-Check-Name\` 🆕 | ⚠️ warning | unknown | exception-comment | New check detected |`;
+    const rows = parseBotComment(md);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].check_name).toBe("New-Check-Name");
+    expect(rows[0].is_unknown).toBe(true);
+  });
+
+  it("normalizes severity tokens (strips emoji prefix)", () => {
+    const md = `<!-- release-gate-bot:v1 -->
+
+| Check | Severity | Owner | Override path | Notes |
+|---|---|---|---|---|
+| \`X\` | ❌ blocker | backend-dev | fix-forward | a |
+| \`Y\` | ⚠️ warning | qa | baseline-update | b |
+| \`Z\` | ℹ️ informational | devops | exception-comment | c |`;
+    const rows = parseBotComment(md);
+    expect(rows.map((r) => r.severity)).toEqual([
+      "blocker",
+      "warning",
+      "informational",
+    ]);
+  });
+});
+
+describe("pickLatestBotComment — multi-comment ordering (test matrix #12)", () => {
+  it("returns null when no bot comment is present", () => {
+    const comments = [
+      { id: 1, body: "## Random comment", updated_at: "2026-05-22T10:00:00Z" },
+      { id: 2, body: "Another comment", updated_at: "2026-05-22T11:00:00Z" },
+    ];
+    expect(pickLatestBotComment(comments)).toBeNull();
+  });
+
+  it("returns the only bot comment when one exists", () => {
+    const comments = [
+      { id: 1, body: "## Random comment", updated_at: "2026-05-22T10:00:00Z" },
+      {
+        id: 2,
+        body: "<!-- release-gate-bot:v1 -->\n## Classification",
+        updated_at: "2026-05-22T11:00:00Z",
+      },
+    ];
+    const picked = pickLatestBotComment(comments);
+    expect(picked).not.toBeNull();
+    expect(picked.id).toBe(2);
+  });
+
+  it("returns the latest by updated_at when multiple bot comments exist", () => {
+    const comments = [
+      {
+        id: 1,
+        body: "<!-- release-gate-bot:v1 -->\n## Older",
+        updated_at: "2026-05-20T10:00:00Z",
+      },
+      {
+        id: 2,
+        body: "<!-- release-gate-bot:v1 -->\n## Newer",
+        updated_at: "2026-05-22T10:00:00Z",
+      },
+      {
+        id: 3,
+        body: "<!-- release-gate-bot:v1 -->\n## Middle",
+        updated_at: "2026-05-21T10:00:00Z",
+      },
+    ];
+    const picked = pickLatestBotComment(comments);
+    expect(picked.id).toBe(2);
+  });
+
+  it("ignores comments not starting with the signature (substring not enough)", () => {
+    const comments = [
+      {
+        id: 1,
+        body: "Some preamble\n<!-- release-gate-bot:v1 -->\n## Inline",
+        updated_at: "2026-05-22T10:00:00Z",
+      },
+    ];
+    expect(pickLatestBotComment(comments)).toBeNull();
+  });
+});

--- a/scripts/release-gate/__tests__/validate.test.mjs
+++ b/scripts/release-gate/__tests__/validate.test.mjs
@@ -159,6 +159,62 @@ describe("validateGates (in-memory)", () => {
     expect(result.errors.some((e) => /duplicate/i.test(e))).toBe(true);
   });
 
+  it("accepts a valid bot.phase2c config block (#1446)", () => {
+    const gates = {
+      version: 1,
+      checks: [],
+      bot: {
+        signature_header: "<!-- release-gate-bot:v1 -->",
+        verdict_emoji: { blocker: "X", warning: "X", informational: "X", unknown: "X" },
+        fallback_unknown: { severity: "warning", owner: "unknown", override_path: "exception-comment" },
+        phase2c: {
+          enabled: true,
+          escalation_threshold_weeks: 4,
+          slack_webhook_env: "SLACK_GITNOTIFY_WEBHOOK_URL",
+        },
+      },
+    };
+    const result = validateGates(gates);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects bot.phase2c.enabled with non-boolean type (#1446)", () => {
+    const gates = {
+      version: 1,
+      checks: [],
+      bot: {
+        signature_header: "<!-- release-gate-bot:v1 -->",
+        verdict_emoji: { blocker: "X", warning: "X", informational: "X", unknown: "X" },
+        fallback_unknown: { severity: "warning", owner: "unknown", override_path: "exception-comment" },
+        phase2c: {
+          enabled: "yes", // wrong type
+        },
+      },
+    };
+    const result = validateGates(gates);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => /phase2c\.enabled/.test(e))).toBe(true);
+  });
+
+  it("rejects bot.phase2c.escalation_threshold_weeks out of 1..52 range (#1446)", () => {
+    const gates = {
+      version: 1,
+      checks: [],
+      bot: {
+        signature_header: "<!-- release-gate-bot:v1 -->",
+        verdict_emoji: { blocker: "X", warning: "X", informational: "X", unknown: "X" },
+        fallback_unknown: { severity: "warning", owner: "unknown", override_path: "exception-comment" },
+        phase2c: {
+          enabled: true,
+          escalation_threshold_weeks: 100, // > 52
+        },
+      },
+    };
+    const result = validateGates(gates);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => /escalation_threshold_weeks/.test(e))).toBe(true);
+  });
+
   it("rejects invalid fallback_patterns regex", () => {
     const gates = {
       version: 1,

--- a/scripts/release-gate/build-digest.mjs
+++ b/scripts/release-gate/build-digest.mjs
@@ -86,9 +86,12 @@ async function fetchPrFailures({ octokit, owner, repo, prNumber }) {
 }
 
 async function postSlack({ webhookUrl, payload, fetcher = fetch }) {
-  const delays = [1000, 2000, 4000];
+  // 3 attempts with 1s/2s backoff between retries (no sleep after the final
+  // attempt — that wall-clock is wasted because the loop is about to exit).
+  const delays = [1000, 2000];
   let lastErr = null;
   for (let attempt = 0; attempt < 3; attempt++) {
+    const isLast = attempt === 2;
     try {
       const res = await fetcher(webhookUrl, {
         method: "POST",
@@ -98,14 +101,14 @@ async function postSlack({ webhookUrl, payload, fetcher = fetch }) {
       if (res.ok) return { ok: true, attempt };
       if (res.status === 429 || res.status >= 500) {
         lastErr = new Error(`Slack ${res.status}`);
-        await new Promise((r) => setTimeout(r, delays[attempt]));
+        if (!isLast) await new Promise((r) => setTimeout(r, delays[attempt]));
         continue;
       }
       const body = await res.text().catch(() => "");
       return { ok: false, error: `Slack ${res.status}: ${body.slice(0, 200)}` };
     } catch (err) {
       lastErr = err;
-      await new Promise((r) => setTimeout(r, delays[attempt]));
+      if (!isLast) await new Promise((r) => setTimeout(r, delays[attempt]));
     }
   }
   return { ok: false, error: lastErr?.message ?? "Slack POST failed after 3 retries" };
@@ -117,7 +120,10 @@ async function openStatePr({ octokit, owner, repo, branchName, stateJson, weekIS
   const baseRef = await octokit.git.getRef({ owner, repo, ref: "heads/main-dev" });
   const baseSha = baseRef.data.object.sha;
 
-  // Create branch (fail-soft if it already exists)
+  // Create branch (or reset existing one to current main-dev tip).
+  // Re-running the same week before the previous state PR was merged would
+  // otherwise leave the branch pointing at a stale base; updateRef with
+  // `force: true` ensures we always write from a fresh main-dev tip.
   try {
     await octokit.git.createRef({
       owner,
@@ -127,7 +133,16 @@ async function openStatePr({ octokit, owner, repo, branchName, stateJson, weekIS
     });
   } catch (err) {
     if (err.status !== 422) throw err;
-    // 422 = ref exists; OK, fall through to update
+    // 422 = ref exists; reset it to baseSha so the file commit lands on a
+    // fresh base. force=true is required because the existing branch tip is
+    // unrelated to baseSha (not an ancestor).
+    await octokit.git.updateRef({
+      owner,
+      repo,
+      ref: `heads/${branchName}`,
+      sha: baseSha,
+      force: true,
+    });
   }
 
   // Get current state file SHA on the branch (if present) so we can update it
@@ -283,7 +298,12 @@ async function main() {
     return;
   }
 
-  const webhookUrl = envOrThrow("SLACK_GITNOTIFY_WEBHOOK_URL");
+  // Honor `bot.phase2c.slack_webhook_env` if set; falls back to
+  // SLACK_GITNOTIFY_WEBHOOK_URL otherwise. Indirection lets operators rebind
+  // the channel without code change.
+  const webhookEnvName =
+    gates?.bot?.phase2c?.slack_webhook_env ?? "SLACK_GITNOTIFY_WEBHOOK_URL";
+  const webhookUrl = envOrThrow(webhookEnvName);
   const slackResult = await postSlack({
     webhookUrl,
     payload: { text: digest.slackMessage },

--- a/scripts/release-gate/build-digest.mjs
+++ b/scripts/release-gate/build-digest.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+// CLI entry — fetches release PRs from the past 7 days, parses bot comments,
+// builds a Slack digest, posts it, and writes a state PR with the updated
+// state/release-gate-digest.json.
+//
+// Env (all required unless noted):
+//   GITHUB_TOKEN                  Provided automatically in GH Actions
+//   GITHUB_REPOSITORY             e.g. "meepleAi-app/meepleai-monorepo"
+//   SLACK_GITNOTIFY_WEBHOOK_URL   Slack incoming webhook (required unless DRY_RUN)
+//   DRY_RUN                       If "1", print Slack payload to stdout + skip state PR
+//   RELEASE_GATES_YAML            Optional override path
+//   STATE_FILE                    Optional override path (default state/release-gate-digest.json)
+//   GITHUB_STEP_SUMMARY           Auto-set in GH Actions runner
+//
+// Tested via lib/digest-builder.test.mjs + lib/parse-bot-comment.test.mjs.
+// The CLI itself is a thin orchestrator (≤ 80 LOC of actual logic).
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
+
+import { Octokit } from "@octokit/rest";
+
+import { loadGates } from "./lib/classify.mjs";
+import { parseBotComment, pickLatestBotComment } from "./lib/parse-bot-comment.mjs";
+import { buildDigest, EMPTY_STATE } from "./lib/digest-builder.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const DEFAULT_STATE_FILE = path.join(REPO_ROOT, "state", "release-gate-digest.json");
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function envOrThrow(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env var: ${name}`);
+  return v;
+}
+
+function parseRepo() {
+  const slug = envOrThrow("GITHUB_REPOSITORY");
+  const [owner, repo] = slug.split("/");
+  if (!owner || !repo) throw new Error(`Invalid GITHUB_REPOSITORY: ${slug}`);
+  return { owner, repo };
+}
+
+function loadState(filePath) {
+  if (!existsSync(filePath)) return EMPTY_STATE;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    console.warn(`[release-gate:digest] warning — state file unreadable: ${err.message}`);
+    return EMPTY_STATE;
+  }
+}
+
+function writeState(filePath, state) {
+  const dir = path.dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, JSON.stringify(state, null, 2) + "\n", "utf8");
+}
+
+async function fetchReleasePrs({ octokit, owner, repo, since }) {
+  // List recent PRs targeting main-staging or main (open or merged).
+  // Use search API to filter by base branch + updated date.
+  const sinceISO = since.toISOString().slice(0, 10);
+  const q = `repo:${owner}/${repo} is:pr updated:>=${sinceISO} (base:main-staging OR base:main)`;
+  const res = await octokit.search.issuesAndPullRequests({ q, per_page: 50 });
+  return (res.data?.items ?? []).map((it) => ({
+    number: it.number,
+    title: it.title,
+    mergedAt: it.pull_request?.merged_at ?? null,
+    baseRef: null, // search result does not include base ref; we filter via query.
+  }));
+}
+
+async function fetchPrFailures({ octokit, owner, repo, prNumber }) {
+  const res = await octokit.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+  const latest = pickLatestBotComment(res.data ?? []);
+  if (!latest) return null;
+  return parseBotComment(latest.body) ?? null;
+}
+
+async function postSlack({ webhookUrl, payload, fetcher = fetch }) {
+  const delays = [1000, 2000, 4000];
+  let lastErr = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetcher(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) return { ok: true, attempt };
+      if (res.status === 429 || res.status >= 500) {
+        lastErr = new Error(`Slack ${res.status}`);
+        await new Promise((r) => setTimeout(r, delays[attempt]));
+        continue;
+      }
+      const body = await res.text().catch(() => "");
+      return { ok: false, error: `Slack ${res.status}: ${body.slice(0, 200)}` };
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, delays[attempt]));
+    }
+  }
+  return { ok: false, error: lastErr?.message ?? "Slack POST failed after 3 retries" };
+}
+
+async function openStatePr({ octokit, owner, repo, branchName, stateJson, weekISO, slackMessage }) {
+  // Create a branch from main-dev, write state JSON, open PR. Audit-only —
+  // does not auto-merge.
+  const baseRef = await octokit.git.getRef({ owner, repo, ref: "heads/main-dev" });
+  const baseSha = baseRef.data.object.sha;
+
+  // Create branch (fail-soft if it already exists)
+  try {
+    await octokit.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${branchName}`,
+      sha: baseSha,
+    });
+  } catch (err) {
+    if (err.status !== 422) throw err;
+    // 422 = ref exists; OK, fall through to update
+  }
+
+  // Get current state file SHA on the branch (if present) so we can update it
+  let existingSha = null;
+  try {
+    const cur = await octokit.repos.getContent({
+      owner,
+      repo,
+      path: "state/release-gate-digest.json",
+      ref: branchName,
+    });
+    existingSha = cur.data?.sha ?? null;
+  } catch (err) {
+    if (err.status !== 404) throw err;
+  }
+
+  const content = Buffer.from(JSON.stringify(stateJson, null, 2) + "\n", "utf8").toString("base64");
+  await octokit.repos.createOrUpdateFileContents({
+    owner,
+    repo,
+    path: "state/release-gate-digest.json",
+    message: `chore(release-gate): digest state ${weekISO}`,
+    content,
+    branch: branchName,
+    sha: existingSha ?? undefined,
+  });
+
+  // Open PR (idempotent: search existing)
+  const search = await octokit.pulls.list({
+    owner,
+    repo,
+    head: `${owner}:${branchName}`,
+    state: "open",
+  });
+  if (search.data && search.data.length > 0) {
+    return search.data[0].html_url;
+  }
+
+  const prBody = [
+    "Auto-generated by `.github/workflows/release-gate-digest.yml`.",
+    "",
+    `Week: \`${weekISO}\``,
+    "",
+    "## Slack digest posted",
+    "",
+    "```",
+    slackMessage,
+    "```",
+    "",
+    "**Action**: review the state diff and merge when ready. State PRs are NOT auto-merged.",
+    "",
+    "Closes (none — recurring chore).",
+  ].join("\n");
+
+  const created = await octokit.pulls.create({
+    owner,
+    repo,
+    title: `chore(release-gate): digest state ${weekISO}`,
+    head: branchName,
+    base: "main-dev",
+    body: prBody,
+  });
+  return created.data.html_url;
+}
+
+async function openFailureIssue({ octokit, owner, repo, weekISO, errorMessage }) {
+  await octokit.issues.create({
+    owner,
+    repo,
+    title: `[release-gate-digest][${weekISO}] FAILED`,
+    body: [
+      "Auto-generated by `.github/workflows/release-gate-digest.yml`.",
+      "",
+      `Week: \`${weekISO}\``,
+      `Failure: \`${errorMessage}\``,
+      "",
+      "Workflow exited soft-fail. No retry scheduled (cron is weekly).",
+    ].join("\n"),
+    labels: ["release-gate-digest", "P2"],
+  });
+}
+
+async function main() {
+  const dryRun = process.env.DRY_RUN === "1" || process.env.DRY_RUN === "true";
+  const yamlPath = process.env.RELEASE_GATES_YAML
+    ? path.resolve(process.cwd(), process.env.RELEASE_GATES_YAML)
+    : path.join(REPO_ROOT, ".github", "release-gates.yml");
+  const stateFilePath = process.env.STATE_FILE
+    ? path.resolve(process.cwd(), process.env.STATE_FILE)
+    : DEFAULT_STATE_FILE;
+
+  const gates = loadGates(yamlPath);
+  const prevState = loadState(stateFilePath);
+  const now = new Date();
+
+  let prs = [];
+  let octokit = null;
+
+  if (!dryRun) {
+    const token = envOrThrow("GITHUB_TOKEN");
+    const { owner, repo } = parseRepo();
+    octokit = new Octokit({ auth: token });
+    const since = new Date(now.getTime() - SEVEN_DAYS_MS);
+    const prSummaries = await fetchReleasePrs({ octokit, owner, repo, since });
+    prs = [];
+    for (const summary of prSummaries) {
+      const failures = await fetchPrFailures({
+        octokit,
+        owner,
+        repo,
+        prNumber: summary.number,
+      });
+      if (failures === null) continue;
+      prs.push({ ...summary, botFailures: failures });
+    }
+  } else {
+    // Dry-run: use empty PR list unless DRY_RUN_PRS is provided as JSON
+    if (process.env.DRY_RUN_PRS) {
+      try {
+        prs = JSON.parse(process.env.DRY_RUN_PRS);
+      } catch (err) {
+        console.warn(`[release-gate:digest] DRY_RUN_PRS not valid JSON: ${err.message}`);
+      }
+    }
+  }
+
+  const digest = buildDigest({ prs, prevState, now, gates });
+
+  const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+  const appendSummary = stepSummary
+    ? (s) => appendFileSync(stepSummary, s + "\n", "utf8")
+    : null;
+
+  if (digest.action === "skip") {
+    const msg = `[release-gate:digest] SKIP (${digest.reason}) week=${digest.weekISO}`;
+    console.log(msg);
+    if (appendSummary) appendSummary(`## Release-gate Digest\n\nSkipped: \`${digest.reason}\``);
+    return;
+  }
+
+  console.log(`[release-gate:digest] week=${digest.weekISO} action=post`);
+  console.log(`  aggregates=${digest.aggregates.length} escalations=${digest.escalations.length}`);
+  console.log(`  deltas: ${JSON.stringify(digest.deltas)}`);
+
+  if (dryRun) {
+    console.log("=== DRY-RUN: slack payload ===");
+    console.log(digest.slackMessage);
+    console.log("=== DRY-RUN: new state ===");
+    console.log(JSON.stringify(digest.newState, null, 2));
+    if (appendSummary) {
+      appendSummary(`## Release-gate Digest (DRY-RUN)\n\nWeek: \`${digest.weekISO}\`\n\n\`\`\`\n${digest.slackMessage}\n\`\`\``);
+    }
+    return;
+  }
+
+  const webhookUrl = envOrThrow("SLACK_GITNOTIFY_WEBHOOK_URL");
+  const slackResult = await postSlack({
+    webhookUrl,
+    payload: { text: digest.slackMessage },
+  });
+
+  if (!slackResult.ok) {
+    const { owner, repo } = parseRepo();
+    await openFailureIssue({
+      octokit,
+      owner,
+      repo,
+      weekISO: digest.weekISO,
+      errorMessage: slackResult.error,
+    });
+    console.error(`[release-gate:digest] Slack POST failed: ${slackResult.error}`);
+    process.exit(1);
+  }
+
+  if (digest.openStatePr) {
+    const { owner, repo } = parseRepo();
+    const prUrl = await openStatePr({
+      octokit,
+      owner,
+      repo,
+      branchName: digest.statePrBranchName,
+      stateJson: digest.newState,
+      weekISO: digest.weekISO,
+      slackMessage: digest.slackMessage,
+    });
+    console.log(`[release-gate:digest] state PR: ${prUrl}`);
+    if (appendSummary) {
+      appendSummary(
+        `## Release-gate Digest\n\nWeek: \`${digest.weekISO}\`\n\nSlack: posted (attempt ${slackResult.attempt + 1})\n\nState PR: ${prUrl}`
+      );
+    }
+  } else {
+    // No warnings → still write state locally for tracking (but no PR)
+    writeState(stateFilePath, digest.newState);
+    if (appendSummary) {
+      appendSummary(
+        `## Release-gate Digest\n\nWeek: \`${digest.weekISO}\`\n\nAll green — no state PR opened.`
+      );
+    }
+  }
+}
+
+// Only run if invoked directly (not imported)
+if (import.meta.url === `file://${process.argv[1].replace(/\\/g, "/")}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, "/")}`) {
+  main().catch((err) => {
+    console.error(`[release-gate:digest] CRASH: ${err.stack ?? err.message}`);
+    process.exit(2);
+  });
+}
+
+export { main, fetchReleasePrs, fetchPrFailures, postSlack, openStatePr };

--- a/scripts/release-gate/lib/digest-builder.mjs
+++ b/scripts/release-gate/lib/digest-builder.mjs
@@ -1,0 +1,222 @@
+// Pure aggregation logic — builds the weekly Slack digest payload + the next
+// state JSON from a list of release PRs (with classified failures attached)
+// and the previous state.
+// Tested by __tests__/digest-builder.test.mjs.
+
+export const STATE_SCHEMA_VERSION = 1;
+
+export const EMPTY_STATE = Object.freeze({
+  schemaVersion: STATE_SCHEMA_VERSION,
+  lastWeekISO: null,
+  warningsByCheck: {},
+});
+
+// ISO 8601 week — "YYYY-Www" (e.g. "2026-W22").
+// Implementation reference: https://en.wikipedia.org/wiki/ISO_week_date#Algorithms
+export function isoWeek(date) {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // Thursday of the current ISO week determines the year.
+  const dayNum = d.getUTCDay() === 0 ? 7 : d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  const ww = String(weekNo).padStart(2, "0");
+  return `${d.getUTCFullYear()}-W${ww}`;
+}
+
+function normalizePrevState(prevState) {
+  if (
+    !prevState ||
+    typeof prevState !== "object" ||
+    prevState.schemaVersion !== STATE_SCHEMA_VERSION ||
+    typeof prevState.warningsByCheck !== "object"
+  ) {
+    return { ...EMPTY_STATE, warningsByCheck: {} };
+  }
+  return prevState;
+}
+
+function isPhase2cEnabled(gates) {
+  if (gates?.bot?.phase2c?.enabled === false) return false;
+  return true;
+}
+
+function escalationThreshold(gates) {
+  const v = gates?.bot?.phase2c?.escalation_threshold_weeks;
+  if (typeof v === "number" && Number.isInteger(v) && v > 0) return v;
+  return 4;
+}
+
+// Format a Slack message body. Uses mrkdwn (not Block Kit) for simplicity — the
+// CLI builds Block Kit JSON when posting.
+function formatSlackMessage({ aggregates, escalations, deltas, weekISO }) {
+  if (aggregates.length === 0) {
+    return `:white_check_mark: No release-gate warnings this week (${weekISO}).`;
+  }
+
+  const lines = [];
+  lines.push(`*Release-Gate Digest — ${weekISO}*`);
+  lines.push(
+    `${deltas.new_this_week} new · ${deltas.persisting} persisting · ${deltas.resolved_this_week} resolved`
+  );
+  lines.push("");
+
+  const top = aggregates.slice(0, 3);
+  for (const entry of top) {
+    lines.push(
+      `• \`${entry.check_name}\` × ${entry.frequency} — owner @${entry.owner}`
+    );
+  }
+
+  if (escalations.length > 0) {
+    lines.push("");
+    for (const esc of escalations) {
+      lines.push(
+        `:warning: \`${esc.check_name}\` — persisting ${esc.weeks_seen} weeks, suggest reclassify to blocker`
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build the digest from this week's release PRs and prior state.
+ *
+ * @param {Object} args
+ * @param {Array<{number, title, mergedAt, baseRef, botFailures}>} args.prs
+ *   Release PRs in the 7-day window. `botFailures` is the array returned by
+ *   parse-bot-comment for the latest bot comment on each PR.
+ * @param {Object} args.prevState - state JSON loaded from state/release-gate-digest.json
+ * @param {Date} args.now - current time (frozen in tests)
+ * @param {Object} args.gates - parsed .github/release-gates.yml object
+ *
+ * @returns {Object} - { action: 'post'|'skip', reason?, slackMessage?,
+ *   aggregates, deltas, escalations, newState, openStatePr, statePrBranchName }
+ */
+export function buildDigest({ prs, prevState, now, gates }) {
+  const weekISO = isoWeek(now);
+
+  // 1. Kill switch (AC-6)
+  if (!isPhase2cEnabled(gates)) {
+    return {
+      action: "skip",
+      reason: "bot.phase2c.enabled=false",
+      weekISO,
+    };
+  }
+
+  // 2. Normalize prevState (graceful schema drift)
+  const prev = normalizePrevState(prevState);
+
+  // 3. Idempotency (AC-8 — same-week rerun)
+  if (prev.lastWeekISO === weekISO) {
+    return {
+      action: "skip",
+      reason: "already-processed-this-week",
+      weekISO,
+    };
+  }
+
+  // 4. Aggregate warning-tier failures across PRs
+  const warningsByCheck = new Map();
+  for (const pr of prs ?? []) {
+    for (const failure of pr.botFailures ?? []) {
+      if (failure.severity !== "warning") continue;
+      const key = failure.check_name;
+      if (!warningsByCheck.has(key)) {
+        warningsByCheck.set(key, {
+          check_name: failure.check_name,
+          owner: failure.owner,
+          frequency: 0,
+        });
+      }
+      warningsByCheck.get(key).frequency += 1;
+    }
+  }
+
+  const aggregates = Array.from(warningsByCheck.values()).sort(
+    (a, b) => b.frequency - a.frequency
+  );
+
+  // 5. Delta tracking + new state construction
+  const newWarnings = {};
+  let newCount = 0;
+  let persistingCount = 0;
+
+  for (const entry of aggregates) {
+    const existing = prev.warningsByCheck[entry.check_name];
+    if (existing) {
+      newWarnings[entry.check_name] = {
+        owner: entry.owner,
+        firstSeenWeek: existing.firstSeenWeek,
+        weeksSeen: (existing.weeksSeen ?? 1) + 1,
+        lastSeenWeek: weekISO,
+      };
+      persistingCount += 1;
+    } else {
+      newWarnings[entry.check_name] = {
+        owner: entry.owner,
+        firstSeenWeek: weekISO,
+        weeksSeen: 1,
+        lastSeenWeek: weekISO,
+      };
+      newCount += 1;
+    }
+  }
+
+  // Resolved = present in prev state, absent in this week
+  let resolvedCount = 0;
+  for (const prevName of Object.keys(prev.warningsByCheck ?? {})) {
+    if (!warningsByCheck.has(prevName)) {
+      resolvedCount += 1;
+    }
+  }
+
+  // 6. Escalations (AC-5)
+  const threshold = escalationThreshold(gates);
+  const escalations = [];
+  for (const [name, entry] of Object.entries(newWarnings)) {
+    if (entry.weeksSeen >= threshold) {
+      escalations.push({
+        check_name: name,
+        owner: entry.owner,
+        weeks_seen: entry.weeksSeen,
+      });
+    }
+  }
+
+  // 7. Build Slack message
+  const deltas = {
+    new_this_week: newCount,
+    persisting: persistingCount,
+    resolved_this_week: resolvedCount,
+  };
+  const slackMessage = formatSlackMessage({
+    aggregates,
+    escalations,
+    deltas,
+    weekISO,
+  });
+
+  // 8. New state + state PR decision
+  const newState = {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    lastWeekISO: weekISO,
+    warningsByCheck: newWarnings,
+  };
+  const openStatePr = aggregates.length > 0;
+  const statePrBranchName = `chore/release-gate-digest-state-${weekISO}`;
+
+  return {
+    action: "post",
+    weekISO,
+    slackMessage,
+    aggregates,
+    deltas,
+    escalations,
+    newState,
+    openStatePr,
+    statePrBranchName,
+  };
+}

--- a/scripts/release-gate/lib/parse-bot-comment.mjs
+++ b/scripts/release-gate/lib/parse-bot-comment.mjs
@@ -1,0 +1,134 @@
+// Pure parser - extracts classified failure rows from a release-gate bot
+// comment (markdown produced by lib/format.mjs::formatComment).
+// Tested by __tests__/parse-bot-comment.test.mjs.
+
+import { SIGNATURE_HEADER } from "./format.mjs";
+
+// Strip leading emoji + whitespace, normalize to lowercased severity token.
+// Accepts cells like "[red-X] blocker", "[triangle] warning", "[info]
+// informational" produced by format.mjs, or bare severity tokens.
+function normalizeSeverity(cell) {
+  const lower = cell.toLowerCase();
+  if (lower.includes("blocker")) return "blocker";
+  if (lower.includes("warning")) return "warning";
+  if (lower.includes("informational")) return "informational";
+  return "unknown";
+}
+
+// Reverse the escaping applied by format.mjs::escapeCell:
+//   backtick -> escaped backtick
+//   pipe     -> escaped pipe
+function unescapeCell(value) {
+  return String(value ?? "")
+    .replace(/\\\|/g, "|")
+    .replace(/\\`/g, "`")
+    .trim();
+}
+
+// "New check detected" tag emitted by format.mjs after the check name cell.
+// Use Unicode escape (U+1F195) so this source file stays pure ASCII for
+// portability across CI tooling.
+const UNKNOWN_TAG = "\u{1F195}";
+const SUCCESS_TICK = "✅"; // U+2705 "white heavy check mark" used by format.mjs
+
+// Strip the surrounding backticks from a check_name cell, then unescape inner
+// content. Detect and strip the "new" unknown tag, returning is_unknown flag.
+function parseCheckNameCell(cell) {
+  const raw = cell.trim();
+  const pattern = new RegExp(
+    `^\`([^\`]*(?:\\\\\`[^\`]*)*)\`\\s*(${UNKNOWN_TAG})?$`
+  );
+  const m = raw.match(pattern);
+  if (!m) {
+    return { check_name: unescapeCell(raw), is_unknown: false };
+  }
+  return {
+    check_name: unescapeCell(m[1]),
+    is_unknown: Boolean(m[2]),
+  };
+}
+
+/**
+ * Parse a release-gate bot comment markdown body and extract classified
+ * failure rows.
+ *
+ * @param {string} markdown - Comment body
+ * @returns {Array<{check_name, severity, owner, override_path, notes, is_unknown}> | null}
+ *   - null if the markdown does not start with SIGNATURE_HEADER (not a bot comment)
+ *   - [] if it IS a bot comment but contains no classifiable failures (e.g.
+ *     the "no failed checks" success path, fallback/error comment, or
+ *     malformed/empty table)
+ *   - Array of row objects otherwise. Caller is responsible for severity
+ *     filtering.
+ */
+export function parseBotComment(markdown) {
+  if (typeof markdown !== "string") return null;
+  if (!markdown.startsWith(SIGNATURE_HEADER)) return null;
+
+  // No-failures success path (format.mjs emits "U+2705 No failed checks classified.")
+  if (markdown.includes(`${SUCCESS_TICK} No failed checks classified.`)) return [];
+
+  // Fallback (bot crash) path
+  if (markdown.includes("**release-gate bot failed")) return [];
+
+  const lines = markdown.split(/\r?\n/);
+
+  // Locate the failure table header. The header row produced by formatComment
+  // is `| Check | Severity | Owner | Override path | Notes |`.
+  const headerIdx = lines.findIndex((l) =>
+    /^\|\s*Check\s*\|\s*Severity\s*\|\s*Owner\s*\|/.test(l)
+  );
+  if (headerIdx === -1) return [];
+
+  // Skip the alignment separator row (e.g. `|---|---|---|---|---|`).
+  const dataStart = headerIdx + 2;
+  const rows = [];
+  for (let i = dataStart; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith("|")) break;
+    if (/^\|\s*-+\s*\|/.test(line)) continue;
+    // Split on un-escaped pipes. Use a split-and-unescape strategy: replace
+    // escaped pipes with a sentinel, split on `|`, restore the sentinel.
+    const SENTINEL = " PIPE ";
+    const masked = line.replace(/\\\|/g, SENTINEL);
+    const cells = masked
+      .split("|")
+      .slice(1, -1)
+      .map((c) => c.replace(new RegExp(SENTINEL, "g"), "\\|"));
+    if (cells.length < 5) continue;
+
+    const { check_name, is_unknown } = parseCheckNameCell(cells[0]);
+    const severity = normalizeSeverity(cells[1]);
+    const owner = unescapeCell(cells[2]);
+    const override_path = unescapeCell(cells[3]);
+    const notes = unescapeCell(cells[4]);
+
+    if (!check_name) continue;
+    rows.push({ check_name, severity, owner, override_path, notes, is_unknown });
+  }
+
+  return rows;
+}
+
+/**
+ * From a list of GitHub issue comments, pick the latest one that is a
+ * release-gate bot comment (body starts with SIGNATURE_HEADER).
+ *
+ * @param {Array<{id, body, updated_at}>} comments
+ * @returns {{id, body, updated_at} | null}
+ */
+export function pickLatestBotComment(comments) {
+  if (!Array.isArray(comments)) return null;
+  const botComments = comments.filter(
+    (c) => typeof c?.body === "string" && c.body.startsWith(SIGNATURE_HEADER)
+  );
+  if (botComments.length === 0) return null;
+  // Sort descending by updated_at; tie-break on id (numerically higher = newer).
+  botComments.sort((a, b) => {
+    const ta = new Date(a.updated_at ?? 0).getTime();
+    const tb = new Date(b.updated_at ?? 0).getTime();
+    if (tb !== ta) return tb - ta;
+    return (b.id ?? 0) - (a.id ?? 0);
+  });
+  return botComments[0];
+}

--- a/scripts/release-gate/lib/validate.mjs
+++ b/scripts/release-gate/lib/validate.mjs
@@ -105,6 +105,29 @@ export function validateGates(gates) {
     if (!OVERRIDE_PATHS.has(fb.override_path)) {
       errors.push(`bot.fallback_unknown.override_path: must be a valid override_path, got "${fb.override_path}"`);
     }
+
+    // Phase 2c (#1446) — optional sub-key; validate only if present.
+    if (gates.bot.phase2c !== undefined) {
+      const p2c = gates.bot.phase2c;
+      if (!p2c || typeof p2c !== "object") {
+        errors.push("bot.phase2c: must be an object when present");
+      } else {
+        if (p2c.enabled !== undefined && typeof p2c.enabled !== "boolean") {
+          errors.push(`bot.phase2c.enabled: must be boolean when present, got "${typeof p2c.enabled}"`);
+        }
+        if (p2c.escalation_threshold_weeks !== undefined) {
+          const v = p2c.escalation_threshold_weeks;
+          if (!Number.isInteger(v) || v < 1 || v > 52) {
+            errors.push(
+              `bot.phase2c.escalation_threshold_weeks: must be an integer 1..52, got "${v}"`
+            );
+          }
+        }
+        if (p2c.slack_webhook_env !== undefined && typeof p2c.slack_webhook_env !== "string") {
+          errors.push("bot.phase2c.slack_webhook_env: must be a string when present");
+        }
+      }
+    }
   }
 
   return { ok: errors.length === 0, errors };

--- a/scripts/release-gate/package.json
+++ b/scripts/release-gate/package.json
@@ -7,9 +7,11 @@
   "scripts": {
     "validate": "node validate.mjs",
     "comment": "node comment.mjs",
+    "digest": "node build-digest.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:dry": "DRY_RUN=1 node comment.mjs"
+    "test:dry": "DRY_RUN=1 node comment.mjs",
+    "digest:dry": "DRY_RUN=1 node build-digest.mjs"
   },
   "dependencies": {
     "@octokit/rest": "^21.0.2",

--- a/state/README.md
+++ b/state/README.md
@@ -1,0 +1,57 @@
+# `state/` — auto-generated workflow state
+
+This directory contains JSON files written by recurring GitHub Actions
+workflows. Files here are **committed to source control on purpose**: the diff
+is the audit trail.
+
+## Files
+
+### `release-gate-digest.json`
+
+Persistent state for `.github/workflows/release-gate-digest.yml` (issue #1446,
+Phase 2c of #1016). Tracks `warning`-tier checks that have appeared in release
+PRs week-over-week so the digest can compute deltas (`new` / `persisting` /
+`resolved`) and trigger escalation flags after ≥ 4 consecutive weeks.
+
+#### Schema (v1)
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "lastWeekISO": "2026-W22",   // null on first run; ISO 8601 "YYYY-Www"
+  "warningsByCheck": {
+    "Frontend - A11y E2E": {
+      "owner": "qa",
+      "firstSeenWeek": "2026-W20",
+      "weeksSeen": 3,
+      "lastSeenWeek": "2026-W22"
+    }
+  }
+}
+```
+
+#### Update flow
+
+1. Cron fires at Monday 08:00 UTC (`scripts/release-gate/build-digest.mjs`).
+2. CLI loads this file into memory.
+3. CLI fetches release PRs from the last 7 days, parses bot comments, builds
+   the digest via `lib/digest-builder.mjs`.
+4. CLI posts the Slack message.
+5. CLI opens a **state PR** on branch `chore/release-gate-digest-state-{weekISO}`
+   that updates this file with the new state.
+6. **A human maintainer merges the state PR** — no auto-merge.
+
+The PR-not-direct-commit pattern is deliberate: it preserves an audit trail
+(reviewer can spot drift) and avoids a race with concurrent release branches.
+
+#### Schema drift policy
+
+If `schemaVersion` here is older or newer than what the CLI expects, the CLI
+treats the file as empty (graceful degrade) and emits a `[WARN]` log. Backfill
+is not attempted; the next week's run reseeds the file with the current week's
+data.
+
+#### Backfill notes
+
+This file was seeded empty on `2026-05-22` with PR #1446. Earlier weeks of
+release PR warnings are not represented here.

--- a/state/release-gate-digest.json
+++ b/state/release-gate-digest.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "lastWeekISO": null,
+  "warningsByCheck": {}
+}


### PR DESCRIPTION
## Summary

Implements **Phase 2c of #1016 (release-gate epic)** — a weekly cron workflow that aggregates `warning`-tier classifications from recent release PRs and posts a digest to Slack, tracking week-over-week deltas and flagging persisting warnings for reclassification.

**First in Phase 2 sequence** (per [overview doc](../blob/main-dev/docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md)) — produces the telemetry that will gate 2a + 2b.

- **3 new lib modules** (pure functions): `parse-bot-comment.mjs`, `digest-builder.mjs`, `validate.mjs` extension
- **1 new CLI**: `build-digest.mjs` (thin shell, Octokit + native `fetch`)
- **1 new workflow**: `.github/workflows/release-gate-digest.yml` (cron `0 8 * * 1` UTC + `workflow_dispatch` for dry-run)
- **2 new state files**: `state/release-gate-digest.json` + `state/README.md` (committed for audit trail)
- **+33 unit tests** (15 parse-bot-comment + 15 digest-builder + 3 validate phase2c) — `93/93 green`, Phase 1 60 tests preserved unchanged

Closes #1446

## Spec-panel hardening pre-impl

Issue #1446 body raised **6.0 → 8.5/10** via panel review (Wiegers · Nygard · Crispin · Fowler · Newman · Cockburn). [Changelog comment](https://github.com/meepleAi-app/meepleai-monorepo/issues/1446#issuecomment-4521469954) on the issue captures the 8 modifications + 6 design decisions taken pre-impl:

1. State persistence via auto-PR branch (NOT direct commit) — audit-friendly + no release-branch race
2. Slack via native `fetch` (Node 20+) — zero new deps
3. Kill switch in YAML (`bot.phase2c.enabled`) — consistent with Phase 1 pattern
4. Escalation threshold configurable (`bot.phase2c.escalation_threshold_weeks`, default 4)
5. No auto-merge of state PR — humans review every state diff
6. Schema versioning forward-compat — graceful degrade to empty on drift

## Test plan

- [x] `pnpm test` in `scripts/release-gate/` — 93/93 green (60 Phase 1 + 33 new)
- [x] `pnpm validate` — `.github/release-gates.yml` valid (20 checks + 7 fallback patterns + new `bot.phase2c.*` block)
- [x] `DRY_RUN=1 pnpm digest` smoke test — empty PR list returns "all green" message
- [x] `DRY_RUN_PRS='[…]' pnpm digest` with 2 warning fixtures — produces correct Slack message + state JSON
- [x] Phase 1 56-test regression check — `format` (18) + `validate` (14→17) + `integration` (12) + `classify` (16) all green
- [ ] **Post-merge**: maintainer triggers `workflow_dispatch` with `dry_run=true` once before first cron tick (Monday 2026-05-25 08:00 UTC) to verify Slack channel binding
- [ ] **2026-06-08** (14d post-launch): AC-7 telemetry gate cleared → 2a can begin

## Edge cases covered

| # | Scenario | Test |
|---|----------|------|
| 1 | Empty window | `digest-builder.test.mjs` |
| 2 | All blockers, zero warnings | `digest-builder.test.mjs` |
| 3 | Malformed bot comment | `parse-bot-comment.test.mjs` |
| 4 | PR with no bot comment | CLI layer |
| 5 | New week + new state | `digest-builder.test.mjs` |
| 6 | Same-week rerun (idempotent) | `digest-builder.test.mjs` |
| 7 | Persisting escalation flag (>=4 weeks) | `digest-builder.test.mjs` |
| 8 | Slack 429 retry | CLI (build-digest.mjs::postSlack) |
| 9 | Slack 5xx all retries fail → GH issue + soft-fail | CLI |
| 10 | State file schema drift | `digest-builder.test.mjs` |
| 11 | `bot.phase2c.enabled=false` kill switch | `digest-builder.test.mjs` |
| 12 | Multi-comment ordering | `parse-bot-comment.test.mjs` |

## References

- Parent: #1016 (epic, CLOSED — shipped 2026-05-22)
- Phase 2 overview: [`docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md`](../blob/main-dev/docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md)
- Phase 1: PR #1435 (`cf20f65f8`)
- Sister sub-issues (timing-gated): #1444 Phase 2a Synthesize Verdict · #1445 Phase 2b Auto-revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
