### PR TITLE
fix(security): patch postcss XSS (GHSA-qx2v-qp2m-jg93) via pnpm.overrides

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -277,6 +277,7 @@
       "lodash-es": ">=4.18.1",
       "markdown-it": ">=14.1.1",
       "picomatch": ">=4.0.4",
+      "postcss": ">=8.5.10",
       "protobufjs": ">=7.5.5",
       "qs": ">=6.14.2",
       "vite": ">=7.3.2",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   lodash-es: '>=4.18.1'
   markdown-it: '>=14.1.1'
   picomatch: '>=4.0.4'
+  postcss: '>=8.5.10'
   protobufjs: '>=7.5.5'
   qs: '>=6.14.2'
   vite: '>=7.3.2'
@@ -535,7 +536,7 @@ importers:
         specifier: ^0.2.6
         version: 0.2.6(@playwright/test@1.60.0)(node-fetch@2.7.0)
       postcss:
-        specifier: ^8.5.15
+        specifier: '>=8.5.10'
         version: 8.5.15
       prettier:
         specifier: ^3.8.3
@@ -5128,7 +5129,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -6883,7 +6884,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   idb@8.0.3:
     resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
@@ -8242,7 +8243,7 @@ packages:
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
-      postcss: ^7.0.0 || ^8.0.1
+      postcss: '>=8.5.10'
       webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@rspack/core':
@@ -8254,25 +8255,25 @@ packages:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   postcss-modules-local-by-default@4.2.0:
     resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   postcss-modules-scope@3.2.1:
     resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   postcss-modules-values@4.0.0:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -8280,10 +8281,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -18212,7 +18209,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
@@ -18741,12 +18738,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes GitHub Dependabot alert #33 (medium severity, CVE-2026-41305): **postcss <8.5.10 allows XSS via unescaped `</style>`** in CSS Stringify Output.

The vulnerable `postcss 8.4.31` was being pulled transitively through `next 16.2.6 > postcss`. Adds `"postcss": ">=8.5.10"` to existing `pnpm.overrides` in `apps/web/package.json` to force the patched version across the entire dep graph (Next.js included) without waiting for the next Next.js release.

## Verification

```bash
# Before
$ pnpm why postcss
dependencies:
  next 16.2.6
    └── postcss 8.4.31    ← vulnerable

$ pnpm audit --prod
1 vulnerabilities found (1 moderate)

# After
$ pnpm why postcss
dependencies:
  next 16.2.6
    └── postcss 8.5.15    ← patched

$ pnpm audit --prod
No known vulnerabilities found

$ pnpm typecheck
✓ clean
```

## Other open Dependabot alerts (NOT in scope of this PR)

| Alert | Package | Severity | Scope | Status |
|-------|---------|----------|-------|--------|
| #3 | `elliptic <=6.6.1` (GHSA-848j-6mx2-7j84) | low | **dev** (Storybook) | No upstream patch yet (`first_patched_version=null`) — accept |
| #1 | `transformers <5.0.0rc3` (GHSA-69w3-r845-3855) | medium | runtime (Python) | Vuln is in `Trainer` class, **not imported** anywhere in repo (`grep -r Trainer apps/*/`) — re-evaluate at 5.x GA |

Tracking issue for those: opening separately.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm audit --prod`: No known vulnerabilities found
- [x] `pnpm typecheck`: clean
- [ ] CI Frontend Fast (lint + typecheck + unit) verde
- [ ] CI Frontend Tests (shard 1/3, 2/3, 3/3) verdi
- [ ] CI Dependency Vulnerabilities verde

## Refs

- Alert: https://github.com/meepleAi-app/meepleai-monorepo/security/dependabot/33
- Advisory: https://github.com/advisories/GHSA-qx2v-qp2m-jg93
- CVE: CVE-2026-41305
- Upstream fix: https://github.com/postcss/postcss/releases/tag/8.5.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)