### PR TITLE
feat(release-gate): #1444 Phase 2a — synthesize 'Release-Gate Verdict' check (kill-switched off)

### DIFF
--- a/.github/release-gates.yml
+++ b/.github/release-gates.yml
@@ -254,6 +254,26 @@ bot:
     owner: unknown
     override_path: exception-comment
 
+  # Phase 2a (#1444) — synthesize a single 'Release-Gate Verdict' check on
+  # release PRs. Read by scripts/release-gate/lib/conclusion-override.mjs +
+  # comment.mjs::publishVerdict(). When enabled, the bot posts the comment
+  # AND publishes a check-run via the Checks API:
+  #   - conclusion=success when no blocker/warning failures (informational
+  #     auto-bypassed)
+  #   - conclusion=neutral when warning-only failures
+  #   - conclusion=failure when ≥1 blocker
+  # Reviewers gate on this single check instead of N per-row noise.
+  #
+  # Dispatch gate: stays `false` until Phase 2c (#1446) accumulates 14 days
+  # of clean telemetry — see docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md.
+  # Earliest enable: 2026-06-08. Flip to `true` then; no code changes needed.
+  #
+  # Default-true semantics: when this sub-key is missing or `enabled` is
+  # absent, the bot defaults to publishing the verdict. We pin `false`
+  # explicitly here to honor the dispatch gate.
+  phase2a:
+    enabled: false
+
   # Phase 2c (#1446) — weekly Slack digest of warning-tier classifications.
   # Read by scripts/release-gate/build-digest.mjs + lib/digest-builder.mjs.
   phase2c:

--- a/.github/workflows/release-gate-comment.yml
+++ b/.github/workflows/release-gate-comment.yml
@@ -34,7 +34,10 @@ concurrency:
 permissions:
   pull-requests: write
   issues: write
-  checks: read
+  # Phase 2a (#1444): `checks: write` is needed by publishVerdict() to create
+  # the synthesized 'Release-Gate Verdict' check-run on the PR head SHA.
+  # Phase 1 only needed `checks: read` for listForRef().
+  checks: write
   contents: read
 
 jobs:

--- a/scripts/release-gate/README.md
+++ b/scripts/release-gate/README.md
@@ -5,7 +5,15 @@ Bot that auto-classifies CI failures on release PRs (`main-dev → main-staging`
 **Operator manual**: [`docs/for-developers/operations/release-gate-bot.md`](../../docs/for-developers/operations/release-gate-bot.md)
 **Design doc**: [`docs/for-developers/specs/2026-05-22-release-gate-spreadsheet.md`](../../docs/for-developers/specs/2026-05-22-release-gate-spreadsheet.md)
 **Phase 2 overview**: [`docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md`](../../docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md)
-**Issue**: [#1016](https://github.com/meepleAi-app/meepleai-monorepo/issues/1016) (Phase 1) · [#1446](https://github.com/meepleAi-app/meepleai-monorepo/issues/1446) (Phase 2c — weekly digest)
+**Issue**: [#1016](https://github.com/meepleAi-app/meepleai-monorepo/issues/1016) (Phase 1) · [#1444](https://github.com/meepleAi-app/meepleai-monorepo/issues/1444) (Phase 2a — verdict check) · [#1446](https://github.com/meepleAi-app/meepleai-monorepo/issues/1446) (Phase 2c — weekly digest)
+
+## Phases at a glance
+
+| Phase | Status | What it does | Toggle |
+|---|---|---|---|
+| **1** — Bot comment | ✅ live | Posts/edits a single comment on release PRs with the per-check classification table | always on |
+| **2a** — Verdict check | 🚦 dispatch-gated until 2026-06-08 | Synthesizes a single `Release-Gate Verdict` check-run (success / neutral / failure) via the Checks API so reviewers gate on one row instead of N | `bot.phase2a.enabled` in `.github/release-gates.yml` (default: `false` until dispatch gate opens, then flip to `true`) |
+| **2c** — Weekly digest | ✅ live | Monday cron posts a Slack digest of warning-tier classifications + escalation suggestions | `bot.phase2c.enabled` |
 
 ## Quick commands
 
@@ -28,18 +36,20 @@ scripts/release-gate/
 ├── comment.mjs               # CLI entry: bot (Phase 1)
 ├── build-digest.mjs          # CLI entry: weekly digest (Phase 2c, #1446)
 ├── lib/
-│   ├── classify.mjs          # pure: classify(check_name, gates)
-│   ├── format.mjs            # pure: formatComment + formatActionsSummary (Phase 1)
-│   ├── validate.mjs          # pure: validateGates + validateGatesFile
-│   ├── parse-bot-comment.mjs # pure: parseBotComment + pickLatestBotComment (Phase 2c)
-│   └── digest-builder.mjs    # pure: buildDigest + isoWeek (Phase 2c)
+│   ├── classify.mjs            # pure: classify(check_name, gates)
+│   ├── format.mjs              # pure: formatComment + formatActionsSummary (Phase 1)
+│   ├── validate.mjs            # pure: validateGates + validateGatesFile
+│   ├── conclusion-override.mjs # pure: computeVerdict (Phase 2a, #1444)
+│   ├── parse-bot-comment.mjs   # pure: parseBotComment + pickLatestBotComment (Phase 2c)
+│   └── digest-builder.mjs      # pure: buildDigest + isoWeek (Phase 2c)
 └── __tests__/
-    ├── classify.test.mjs            # 16 tests
-    ├── format.test.mjs              # 18 tests
-    ├── validate.test.mjs            # 17 tests (includes phase2c validation)
-    ├── integration.test.mjs         # 12 tests (Phase 1 nock-based)
-    ├── parse-bot-comment.test.mjs   # 15 tests (Phase 2c)
-    ├── digest-builder.test.mjs      # 15 tests (Phase 2c)
+    ├── classify.test.mjs              # 16 tests
+    ├── format.test.mjs                # 18 tests
+    ├── validate.test.mjs              # 22 tests (Phase 1 + 2c + 2a schemas)
+    ├── integration.test.mjs           # 20 tests (Phase 1 + Phase 2a publishVerdict)
+    ├── conclusion-override.test.mjs   # 22 tests (Phase 2a pure synthesizer)
+    ├── parse-bot-comment.test.mjs     # 15 tests (Phase 2c)
+    ├── digest-builder.test.mjs        # 15 tests (Phase 2c)
     └── fixtures/
         ├── release-gates-valid.yml
         ├── release-gates-invalid-version.yml

--- a/scripts/release-gate/__tests__/conclusion-override.test.mjs
+++ b/scripts/release-gate/__tests__/conclusion-override.test.mjs
@@ -1,0 +1,212 @@
+// Phase 2a (#1444) — unit tests for the pure verdict synthesizer.
+// Covers edge case matrix rows 1-5, 8, 11-12 from the spec (integration
+// rows 6, 7, 9, 10 live in integration.test.mjs).
+
+import { describe, it, expect } from "vitest";
+
+import {
+  computeVerdict,
+  VERDICT_CHECK_NAME,
+  VERDICT_EXTERNAL_ID,
+  OUTPUT_TEXT_MAX,
+} from "../lib/conclusion-override.mjs";
+
+function failure({ name, severity, is_unknown = false, owner = "backend-dev", override_path = "fix-forward", notes = null }) {
+  return { name, severity, is_unknown, owner, override_path, notes };
+}
+
+const ENABLED_GATES = { bot: { phase2a: { enabled: true } } };
+const DISABLED_GATES = { bot: { phase2a: { enabled: false } } };
+const DEFAULT_GATES = { bot: {} }; // no phase2a sub-key → default true
+
+describe("constants — AC-2 stable contract", () => {
+  it("VERDICT_CHECK_NAME is the exact public-contract string", () => {
+    expect(VERDICT_CHECK_NAME).toBe("Release-Gate Verdict");
+  });
+
+  it("VERDICT_EXTERNAL_ID is the idempotency key (AC-4)", () => {
+    expect(VERDICT_EXTERNAL_ID).toBe("release-gate-verdict-v1");
+  });
+
+  it("OUTPUT_TEXT_MAX stays under GitHub Checks API hard limit (AC-9)", () => {
+    expect(OUTPUT_TEXT_MAX).toBeLessThanOrEqual(65_535);
+    // Sanity: leave at least 5_000 chars of headroom for the footer + safety.
+    expect(65_535 - OUTPUT_TEXT_MAX).toBeGreaterThanOrEqual(5_000);
+  });
+});
+
+describe("computeVerdict — kill switch (AC-3)", () => {
+  it("returns { enabled: false } when bot.phase2a.enabled === false", () => {
+    const result = computeVerdict({ failures: [], gates: DISABLED_GATES });
+    expect(result).toEqual({ enabled: false });
+  });
+
+  it("defaults to enabled when bot.phase2a sub-key is missing", () => {
+    const result = computeVerdict({ failures: [], gates: DEFAULT_GATES });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("defaults to enabled when gates is empty object", () => {
+    const result = computeVerdict({ failures: [], gates: {} });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("defaults to enabled when gates is null/undefined", () => {
+    expect(computeVerdict({ failures: [], gates: null }).enabled).toBe(true);
+    expect(computeVerdict({ failures: [], gates: undefined }).enabled).toBe(true);
+  });
+});
+
+describe("computeVerdict — conclusion mapping (AC-5)", () => {
+  it("row 1: no failures → conclusion=success, title 0/0/0", () => {
+    const result = computeVerdict({ failures: [], gates: ENABLED_GATES });
+    expect(result.conclusion).toBe("success");
+    expect(result.title).toBe("0 blocker · 0 warning · 0 informational");
+    expect(result.counts).toEqual({ blocker: 0, warning: 0, informational: 0 });
+  });
+
+  it("row 2: informational-only → conclusion=success, title includes (auto-bypassed)", () => {
+    const result = computeVerdict({
+      failures: [failure({ name: "Lychee Link Check", severity: "informational" })],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("success");
+    expect(result.title).toBe("0 blocker · 0 warning · 1 informational (auto-bypassed)");
+  });
+
+  it("row 3: warning-only → conclusion=neutral", () => {
+    const result = computeVerdict({
+      failures: [failure({ name: "Frontend - A11y E2E", severity: "warning" })],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("neutral");
+    expect(result.title).toBe("0 blocker · 1 warning · 0 informational");
+  });
+
+  it("row 4: blocker-only → conclusion=failure", () => {
+    const result = computeVerdict({
+      failures: [failure({ name: "Backend - Unit Tests", severity: "blocker" })],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.title).toBe("1 blocker · 0 warning · 0 informational");
+  });
+
+  it("row 5: mixed blocker + warning + informational → conclusion=failure (blocker dominates)", () => {
+    const result = computeVerdict({
+      failures: [
+        failure({ name: "Backend - Unit Tests", severity: "blocker" }),
+        failure({ name: "Frontend - A11y E2E", severity: "warning" }),
+        failure({ name: "Lychee Link Check", severity: "informational" }),
+      ],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.title).toBe("1 blocker · 1 warning · 1 informational (auto-bypassed)");
+  });
+
+  it("row 12: multiple blockers (count > 1) → title shows blocker count", () => {
+    const result = computeVerdict({
+      failures: [
+        failure({ name: "Backend - Unit Tests", severity: "blocker" }),
+        failure({ name: "Backend - Integration (Core)", severity: "blocker" }),
+        failure({ name: "CodeQL", severity: "blocker" }),
+      ],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("failure");
+    expect(result.title).toBe("3 blocker · 0 warning · 0 informational");
+  });
+});
+
+describe("computeVerdict — unknown-tier fallback (AC-11, row 11)", () => {
+  it("counts is_unknown=true as warning (least-surprise default)", () => {
+    const result = computeVerdict({
+      failures: [failure({ name: "New Job", severity: "blocker", is_unknown: true })],
+      gates: ENABLED_GATES,
+    });
+    // is_unknown overrides severity → counts as warning, not blocker
+    expect(result.conclusion).toBe("neutral");
+    expect(result.counts).toEqual({ blocker: 0, warning: 1, informational: 0 });
+  });
+
+  it("rolls unrecognized severity string into warning bucket", () => {
+    const result = computeVerdict({
+      failures: [{ name: "Weird Job", severity: "critical", is_unknown: false, owner: "?", override_path: "?", notes: null }],
+      gates: ENABLED_GATES,
+    });
+    expect(result.conclusion).toBe("neutral");
+    expect(result.counts.warning).toBe(1);
+  });
+});
+
+describe("computeVerdict — output.text formatting + truncation (AC-9, row 8)", () => {
+  it("renders an empty-failures message when failures.length === 0", () => {
+    const result = computeVerdict({ failures: [], gates: ENABLED_GATES });
+    expect(result.text).toContain("No failed checks classified");
+  });
+
+  it("renders one markdown row per failure with escaped pipes/newlines", () => {
+    const result = computeVerdict({
+      failures: [
+        failure({
+          name: "Backend - Unit Tests",
+          severity: "blocker",
+          notes: "weird | note with\nnewline",
+        }),
+      ],
+      gates: ENABLED_GATES,
+    });
+    expect(result.text).toContain("| `Backend - Unit Tests` | blocker | backend-dev | fix-forward |");
+    // pipe inside notes must be escaped
+    expect(result.text).toMatch(/weird \\\| note with newline/);
+  });
+
+  it("truncates output.text past 60_000 chars and appends truncation footer", () => {
+    // synthesize 200+ failures to overflow the budget
+    const big = Array.from({ length: 600 }, (_, i) =>
+      failure({
+        name: `Synthetic Suite ${i.toString().padStart(4, "0")}`,
+        severity: i % 3 === 0 ? "blocker" : i % 3 === 1 ? "warning" : "informational",
+        notes: "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor",
+      })
+    );
+    const result = computeVerdict({ failures: big, gates: ENABLED_GATES });
+    expect(result.text.length).toBeLessThanOrEqual(OUTPUT_TEXT_MAX);
+    expect(result.text).toContain("table truncated");
+  });
+});
+
+describe("computeVerdict — output.summary includes optional comment URL", () => {
+  it("omits the comment URL when not provided", () => {
+    const result = computeVerdict({
+      failures: [failure({ name: "Backend - Unit Tests", severity: "blocker" })],
+      gates: ENABLED_GATES,
+    });
+    expect(result.summary).not.toContain("release-gate bot comment");
+  });
+
+  it("includes a markdown link to the comment URL when provided", () => {
+    const url = "https://github.com/meepleAi-app/meepleai-monorepo/pull/1234#issuecomment-9999";
+    const result = computeVerdict({
+      failures: [failure({ name: "Backend - Unit Tests", severity: "blocker" })],
+      gates: ENABLED_GATES,
+      commentUrl: url,
+    });
+    expect(result.summary).toContain(`[release-gate bot comment](${url})`);
+  });
+});
+
+describe("computeVerdict — return shape stability (AC-10)", () => {
+  it("always returns the same keys when enabled=true", () => {
+    const result = computeVerdict({ failures: [], gates: ENABLED_GATES });
+    expect(Object.keys(result).sort()).toEqual(
+      ["conclusion", "counts", "enabled", "summary", "text", "title"].sort()
+    );
+  });
+
+  it("only returns { enabled: false } when killed", () => {
+    const result = computeVerdict({ failures: [], gates: DISABLED_GATES });
+    expect(Object.keys(result)).toEqual(["enabled"]);
+  });
+});

--- a/scripts/release-gate/__tests__/fixtures/release-gates-valid.yml
+++ b/scripts/release-gate/__tests__/fixtures/release-gates-valid.yml
@@ -46,3 +46,10 @@ bot:
     severity: warning
     owner: unknown
     override_path: exception-comment
+
+  # Phase 2a (#1444) — integration tests in __tests__/integration.test.mjs
+  # expect the verdict to publish (enabled: true). The runtime config in
+  # .github/release-gates.yml pins this to false until the dispatch gate
+  # opens 2026-06-08 — see Phase 2 overview spec.
+  phase2a:
+    enabled: true

--- a/scripts/release-gate/__tests__/integration.test.mjs
+++ b/scripts/release-gate/__tests__/integration.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { loadGates } from "../lib/classify.mjs";
 import { SIGNATURE_HEADER } from "../lib/format.mjs";
 import { runBot } from "../comment.mjs";
+import { VERDICT_CHECK_NAME, VERDICT_EXTERNAL_ID } from "../lib/conclusion-override.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturePath = path.join(__dirname, "fixtures", "release-gates-valid.yml");
@@ -19,17 +20,36 @@ function makeOctokit({
   existingComments = [],
   failListComments = false,
   failCheckRuns = false,
+  // Phase 2a (#1444) — verdict mock hooks
+  checksCreateImpl = null,
+  existingVerdictRun = null,
+  checksUpdateImpl = null,
+  commentHtmlUrl = "https://github.com/x/y/pull/1#issuecomment-12345",
 } = {}) {
+  const defaultCreateImpl = async (args) => ({
+    data: { id: 7777, name: args.name, external_id: args.external_id },
+  });
+  const defaultUpdateImpl = async (args) => ({
+    data: { id: args.check_run_id, name: args.name, external_id: args.external_id },
+  });
+
   return {
     checks: {
-      listForRef: vi.fn(async () => {
+      listForRef: vi.fn(async (args) => {
         if (failCheckRuns) {
           const err = new Error("503 Service Unavailable");
           err.status = 503;
           throw err;
         }
+        // Phase 2a dedup lookup: when called with check_name=VERDICT_CHECK_NAME
+        // return the seeded existingVerdictRun (if any).
+        if (args?.check_name === VERDICT_CHECK_NAME) {
+          return { data: { check_runs: existingVerdictRun ? [existingVerdictRun] : [] } };
+        }
         return { data: { check_runs: checkRuns } };
       }),
+      create: vi.fn(checksCreateImpl ?? defaultCreateImpl),
+      update: vi.fn(checksUpdateImpl ?? defaultUpdateImpl),
     },
     pulls: {
       get: vi.fn(async () => ({ data: { head: { sha: "head1234" } } })),
@@ -42,8 +62,12 @@ function makeOctokit({
         }
         return { data: existingComments };
       }),
-      createComment: vi.fn(async (args) => ({ data: { id: 9001, body: args.body } })),
-      updateComment: vi.fn(async (args) => ({ data: { id: args.comment_id, body: args.body } })),
+      createComment: vi.fn(async (args) => ({
+        data: { id: 9001, body: args.body, html_url: commentHtmlUrl },
+      })),
+      updateComment: vi.fn(async (args) => ({
+        data: { id: args.comment_id, body: args.body, html_url: commentHtmlUrl },
+      })),
     },
   };
 }
@@ -211,12 +235,18 @@ describe("runBot — observability (AC-10)", () => {
 
     await runBot({ ...BASE_ARGS, octokit, gates, appendSummary: append });
 
-    expect(summarySink).toHaveLength(1);
+    // Two summary entries: Phase 1 classification + Phase 2a verdict.
+    expect(summarySink).toHaveLength(2);
     const summary = summarySink[0];
     expect(summary).toContain("Total checks evaluated");
     expect(summary).toContain("3"); // total
     expect(summary).toMatch(/Blocker.*1/);
     expect(summary).toMatch(/Warning.*1/);
+
+    // Phase 2a verdict appended after Phase 1 summary
+    const verdictSummary = summarySink[1];
+    expect(verdictSummary).toContain("Release-Gate Verdict (Phase 2a)");
+    expect(verdictSummary).toContain("failure"); // 1 blocker dominates → failure
   });
 });
 
@@ -254,5 +284,145 @@ describe("runBot — conclusion filtering", () => {
     });
     const result = await runBot({ ...BASE_ARGS, octokit, gates });
     expect(result.failures).toHaveLength(2);
+  });
+});
+
+// ─── Phase 2a (#1444) — publishVerdict integration ──────────────────────────
+// Spec edge-case matrix rows 6, 7, 9, 10.
+
+describe("publishVerdict — Phase 2a integration (AC-1, AC-4, AC-7, AC-8)", () => {
+  it("row 6 — idempotency: re-run on same SHA updates via external_id lookup", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Backend - Unit Tests", conclusion: "failure" }],
+      existingVerdictRun: { id: 4242, external_id: VERDICT_EXTERNAL_ID },
+      checksCreateImpl: async () => {
+        const err = new Error("a check_run with this external_id already exists");
+        err.status = 422;
+        throw err;
+      },
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.ok).toBe(true);
+    expect(result.verdict.published).toBe(true);
+    expect(result.verdict.edited).toBe(true);
+    expect(result.verdict.check_run_id).toBe(4242);
+    expect(octokit.checks.create).toHaveBeenCalledTimes(1);
+    expect(octokit.checks.update).toHaveBeenCalledTimes(1);
+    // Update call carried the verdict payload
+    const updateCallArgs = octokit.checks.update.mock.calls[0][0];
+    expect(updateCallArgs.check_run_id).toBe(4242);
+    expect(updateCallArgs.name).toBe(VERDICT_CHECK_NAME);
+    expect(updateCallArgs.conclusion).toBe("failure");
+  });
+
+  it("row 7 — kill switch: bot.phase2a.enabled=false skips checks.create entirely", async () => {
+    const gatesKilled = JSON.parse(JSON.stringify(gates));
+    gatesKilled.bot.phase2a = { enabled: false };
+
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Backend - Unit Tests", conclusion: "failure" }],
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates: gatesKilled });
+
+    expect(result.ok).toBe(true);
+    expect(result.verdict.published).toBe(false);
+    expect(result.verdict.reason).toBe("kill-switch-disabled");
+    // No checks.create or checks.update calls when kill switch is active
+    expect(octokit.checks.create).not.toHaveBeenCalled();
+    expect(octokit.checks.update).not.toHaveBeenCalled();
+    // Phase 1 comment still posted
+    expect(octokit.issues.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it("row 9 — rate-limited (429): runBot returns success, verdict soft-fails", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Backend - Unit Tests", conclusion: "failure" }],
+      checksCreateImpl: async () => {
+        const err = new Error("API rate limit exceeded");
+        err.status = 429;
+        throw err;
+      },
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.ok).toBe(true); // AC-8 soft-fail — comment IS the signal
+    expect(result.verdict.published).toBe(false);
+    expect(result.verdict.reason).toBe("publish-error");
+    expect(result.verdict.error).toContain("rate limit");
+    // Phase 1 comment still posted
+    expect(octokit.issues.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it("row 10 — 5xx server error: same soft-fail as 429", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Frontend - A11y E2E", conclusion: "failure" }],
+      checksCreateImpl: async () => {
+        const err = new Error("503 Service Unavailable");
+        err.status = 503;
+        throw err;
+      },
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.ok).toBe(true);
+    expect(result.verdict.published).toBe(false);
+    expect(result.verdict.reason).toBe("publish-error");
+    expect(result.verdict.error).toContain("503");
+  });
+
+  it("AC-2: published check carries the exact name 'Release-Gate Verdict'", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Backend - Unit Tests", conclusion: "failure" }],
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.verdict.published).toBe(true);
+    expect(octokit.checks.create).toHaveBeenCalledTimes(1);
+    const createArgs = octokit.checks.create.mock.calls[0][0];
+    expect(createArgs.name).toBe(VERDICT_CHECK_NAME);
+    expect(createArgs.external_id).toBe(VERDICT_EXTERNAL_ID);
+    expect(createArgs.head_sha).toBe(BASE_ARGS.commitSha);
+    expect(createArgs.status).toBe("completed");
+  });
+
+  it("AC-5: warning-only failure produces conclusion=neutral", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Frontend - A11y E2E", conclusion: "failure" }],
+    });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.verdict.published).toBe(true);
+    expect(result.verdict.conclusion).toBe("neutral");
+    expect(octokit.checks.create.mock.calls[0][0].conclusion).toBe("neutral");
+  });
+
+  it("AC-5: clean run (no failures) produces conclusion=success", async () => {
+    const octokit = makeOctokit({ checkRuns: [] });
+
+    const result = await runBot({ ...BASE_ARGS, octokit, gates });
+
+    expect(result.verdict.published).toBe(true);
+    expect(result.verdict.conclusion).toBe("success");
+  });
+
+  it("output.summary links to the bot comment URL when available", async () => {
+    const octokit = makeOctokit({
+      checkRuns: [{ name: "Backend - Unit Tests", conclusion: "failure" }],
+      commentHtmlUrl: "https://github.com/test/repo/pull/1#issuecomment-99",
+    });
+
+    await runBot({ ...BASE_ARGS, octokit, gates });
+
+    const createArgs = octokit.checks.create.mock.calls[0][0];
+    expect(createArgs.output.summary).toContain(
+      "https://github.com/test/repo/pull/1#issuecomment-99"
+    );
   });
 });

--- a/scripts/release-gate/__tests__/validate.test.mjs
+++ b/scripts/release-gate/__tests__/validate.test.mjs
@@ -277,3 +277,53 @@ describe("validateGatesFile (file I/O)", () => {
     expect(result.errors).toHaveLength(0);
   });
 });
+
+describe("validateGates — Phase 2a (#1444) schema", () => {
+  function gatesWith(phase2a) {
+    return {
+      version: 1,
+      checks: [
+        {
+          check_name: "X",
+          severity: "warning",
+          owner: "devops",
+          override_path: "exception-comment",
+          pre_existing_in_main_dev: false,
+        },
+      ],
+      bot: {
+        signature_header: "<!-- release-gate-bot:v1 -->",
+        verdict_emoji: { blocker: "X", warning: "X", informational: "X", unknown: "X" },
+        fallback_unknown: { severity: "warning", owner: "unknown", override_path: "exception-comment" },
+        phase2a,
+      },
+    };
+  }
+
+  it("accepts bot.phase2a.enabled=true", () => {
+    const result = validateGates(gatesWith({ enabled: true }));
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts bot.phase2a.enabled=false", () => {
+    const result = validateGates(gatesWith({ enabled: false }));
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts bot.phase2a as an empty object (enabled default-true semantics)", () => {
+    const result = validateGates(gatesWith({}));
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects non-boolean bot.phase2a.enabled", () => {
+    const result = validateGates(gatesWith({ enabled: "yes" }));
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => /bot\.phase2a\.enabled/.test(e))).toBe(true);
+  });
+
+  it("rejects bot.phase2a as a non-object", () => {
+    const result = validateGates(gatesWith("nope"));
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => /bot\.phase2a/.test(e))).toBe(true);
+  });
+});

--- a/scripts/release-gate/comment.mjs
+++ b/scripts/release-gate/comment.mjs
@@ -19,6 +19,11 @@ import { Octokit } from "@octokit/rest";
 
 import { loadGates, classify } from "./lib/classify.mjs";
 import { formatComment, formatActionsSummary, SIGNATURE_HEADER } from "./lib/format.mjs";
+import {
+  computeVerdict,
+  VERDICT_CHECK_NAME,
+  VERDICT_EXTERNAL_ID,
+} from "./lib/conclusion-override.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
@@ -136,29 +141,65 @@ export async function runBot({
   }
 
   // 5. Post or edit
+  let commentResult = null;
   if (existingId) {
-    await octokit.issues.updateComment({
+    commentResult = await octokit.issues.updateComment({
       owner,
       repo,
       comment_id: existingId,
       body,
     });
   } else {
-    await octokit.issues.createComment({
+    commentResult = await octokit.issues.createComment({
       owner,
       repo,
       issue_number: prNumber,
       body,
     });
   }
+  const commentUrl = commentResult?.data?.html_url ?? null;
 
-  // 6. Observability — GH Actions summary
+  // 6. Phase 2a (#1444) — synthesize the verdict check-run on the head SHA.
+  // Soft-fail per AC-8: any error here logs and continues — the Phase 1
+  // comment posted above is the canonical durable signal.
+  const verdictResult = await publishVerdict({
+    octokit,
+    owner,
+    repo,
+    sha: commitSha,
+    failures,
+    gates,
+    commentUrl,
+    startedAt: started,
+  });
+
+  // 7. Observability — GH Actions summary
   if (appendSummary) {
     appendSummary(formatActionsSummary({
       failures,
       total_checks: checkRuns.length,
       meta,
     }));
+    if (verdictResult.published) {
+      appendSummary(
+        `\n## Release-Gate Verdict (Phase 2a)\n\n` +
+          `- Conclusion: \`${verdictResult.conclusion}\`\n` +
+          `- Check-run id: \`${verdictResult.check_run_id ?? "?"}\`\n` +
+          `- Latency: \`${verdictResult.latency_ms}\` ms\n` +
+          `- Mode: \`${verdictResult.edited ? "updated" : "created"}\`\n`
+      );
+    } else if (verdictResult.reason === "kill-switch-disabled") {
+      appendSummary(`\n## Release-Gate Verdict (Phase 2a)\n\nbot.phase2a.enabled=false → verdict skipped.\n`);
+    } else if (verdictResult.reason === "no-sha") {
+      appendSummary(`\n## Release-Gate Verdict (Phase 2a)\n\nNo head SHA available — verdict skipped.\n`);
+    } else {
+      appendSummary(
+        `\n## Release-Gate Verdict (Phase 2a) — FAILED\n\n` +
+          `- Reason: \`${verdictResult.reason}\`\n` +
+          `- Error: \`${verdictResult.error ?? "n/a"}\`\n` +
+          `- Phase 1 comment was posted; verdict publish is an enhancement.\n`
+      );
+    }
   }
 
   return {
@@ -167,7 +208,103 @@ export async function runBot({
     total_checks: checkRuns.length,
     existing_comment_id: existingId,
     edited: existingId !== null,
+    verdict: verdictResult,
   };
+}
+
+// Phase 2a (#1444) — internal helper. Pure-core (computeVerdict) +
+// imperative-shell (octokit.checks.create). Idempotent via external_id.
+async function publishVerdict({ octokit, owner, repo, sha, failures, gates, commentUrl, startedAt }) {
+  const verdict = computeVerdict({ failures, gates, commentUrl });
+
+  if (!verdict.enabled) {
+    return { published: false, reason: "kill-switch-disabled" };
+  }
+
+  if (!sha) {
+    // Defensive: without a head SHA, the Checks API has nothing to target.
+    // Phase 1 comment is unaffected.
+    return { published: false, reason: "no-sha" };
+  }
+
+  const payload = {
+    owner,
+    repo,
+    name: VERDICT_CHECK_NAME,
+    head_sha: sha,
+    external_id: VERDICT_EXTERNAL_ID,
+    status: "completed",
+    conclusion: verdict.conclusion,
+    completed_at: new Date().toISOString(),
+    output: {
+      title: verdict.title,
+      summary: verdict.summary,
+      text: verdict.text,
+    },
+  };
+
+  // AC-4 idempotency: the Checks API treats external_id as the lookup key on
+  // the same SHA, so re-running the bot updates rather than duplicates. To
+  // keep the implementation minimal, we attempt `checks.create` first; if it
+  // fails with a 422 ("a check with the same external_id already exists"),
+  // we look up the existing run and update it.
+  try {
+    const created = await octokit.checks.create(payload);
+    return {
+      published: true,
+      conclusion: verdict.conclusion,
+      check_run_id: created.data?.id ?? null,
+      edited: false,
+      latency_ms: Date.now() - startedAt,
+    };
+  } catch (err) {
+    // 422 unprocessable typically signals duplicate external_id on the SHA
+    const isDuplicate =
+      err?.status === 422 ||
+      (err?.message && /already exists/i.test(err.message)) ||
+      (err?.message && /duplicate/i.test(err.message));
+    if (isDuplicate) {
+      try {
+        const existing = await octokit.checks.listForRef({
+          owner,
+          repo,
+          ref: sha,
+          check_name: VERDICT_CHECK_NAME,
+          per_page: 100,
+        });
+        const found = (existing.data?.check_runs ?? []).find(
+          (c) => c.external_id === VERDICT_EXTERNAL_ID
+        );
+        if (found) {
+          const updated = await octokit.checks.update({
+            owner,
+            repo,
+            check_run_id: found.id,
+            ...payload,
+          });
+          return {
+            published: true,
+            conclusion: verdict.conclusion,
+            check_run_id: updated.data?.id ?? found.id,
+            edited: true,
+            latency_ms: Date.now() - startedAt,
+          };
+        }
+      } catch (lookupErr) {
+        // AC-8 soft-fail: log and return, comment IS the durable signal.
+        console.error(
+          `[release-gate:verdict] dedup lookup failed after create-422: ${lookupErr.message}`
+        );
+      }
+    }
+    // AC-8 soft-fail on any non-recoverable error.
+    console.error(`[release-gate:verdict] publish failed: ${err.message}`);
+    return {
+      published: false,
+      reason: "publish-error",
+      error: err.message,
+    };
+  }
 }
 
 async function postFallback({

--- a/scripts/release-gate/lib/conclusion-override.mjs
+++ b/scripts/release-gate/lib/conclusion-override.mjs
@@ -1,0 +1,125 @@
+// Phase 2a (#1444) — pure verdict synthesizer.
+// Computes a single GH Checks API conclusion from classified failures so
+// reviewers can gate on one row instead of N per-tier rows.
+//
+// Pure: no I/O, no octokit. Tested by __tests__/conclusion-override.test.mjs.
+
+export const VERDICT_CHECK_NAME = "Release-Gate Verdict";
+export const VERDICT_EXTERNAL_ID = "release-gate-verdict-v1";
+
+// AC-9: GitHub Checks API output.text hard limit is 65_535 chars; we cap at
+// 60_000 to leave 5_535 chars of headroom for the truncation footer + safety.
+export const OUTPUT_TEXT_MAX = 60_000;
+
+const TRUNC_FOOTER = "\n\n_... (table truncated — see release-gate bot comment for the full classification)_";
+
+function isPhase2aEnabled(gates) {
+  // Default-true semantics so the bot ships behaviorally on by adding the
+  // sub-key; existing release-gates.yml files without phase2a still get the
+  // verdict published. Operators opt OUT explicitly with `enabled: false`.
+  if (!gates || typeof gates !== "object") return true;
+  const p2a = gates.bot?.phase2a;
+  if (!p2a || typeof p2a !== "object") return true;
+  return p2a.enabled !== false;
+}
+
+function countByTier(failures) {
+  // AC-11 (edge case matrix row 11): unknown / unrecognized severity rolls into
+  // `warning` (least-surprise default — neutral conclusion, not silently passing).
+  const counts = { blocker: 0, warning: 0, informational: 0 };
+  for (const f of failures) {
+    if (f?.is_unknown) {
+      counts.warning += 1;
+      continue;
+    }
+    const sev = f?.severity;
+    if (sev === "blocker" || sev === "warning" || sev === "informational") {
+      counts[sev] += 1;
+    } else {
+      counts.warning += 1;
+    }
+  }
+  return counts;
+}
+
+function pickConclusion(counts) {
+  // AC-5: blocker dominates → failure; warning-only → neutral; otherwise success.
+  // Informational-only counts as success (auto-bypassed) per Scenario 1.
+  if (counts.blocker > 0) return "failure";
+  if (counts.warning > 0) return "neutral";
+  return "success";
+}
+
+function buildTitle(counts) {
+  const suffix = counts.informational > 0 ? " (auto-bypassed)" : "";
+  return `${counts.blocker} blocker · ${counts.warning} warning · ${counts.informational} informational${suffix}`;
+}
+
+function buildSummary({ conclusion, title, commentUrl }) {
+  const lines = [];
+  lines.push(`**Verdict conclusion**: \`${conclusion}\``);
+  lines.push("");
+  lines.push(title);
+  if (commentUrl) {
+    lines.push("");
+    lines.push(`See [release-gate bot comment](${commentUrl}) for the per-check classification table.`);
+  }
+  return lines.join("\n");
+}
+
+function escapeCell(value) {
+  return String(value ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
+}
+
+function buildText(failures) {
+  if (!failures || failures.length === 0) {
+    return "_No failed checks classified — verdict synthesized from a clean run._";
+  }
+
+  const header = [
+    "| Check | Severity | Owner | Override path | Notes |",
+    "|---|---|---|---|---|",
+  ];
+  const rows = failures.map((f) => {
+    const sevLabel = f.is_unknown ? "warning (was unknown)" : escapeCell(f.severity);
+    const name = escapeCell(f.name);
+    const owner = escapeCell(f.owner);
+    const override = escapeCell(f.override_path);
+    const notes = escapeCell(f.notes ?? "");
+    return `| \`${name}\` | ${sevLabel} | ${owner} | ${override} | ${notes} |`;
+  });
+
+  let body = [...header, ...rows].join("\n");
+
+  if (body.length > OUTPUT_TEXT_MAX) {
+    // AC-9: truncate, preserve footer.
+    body = body.slice(0, OUTPUT_TEXT_MAX - TRUNC_FOOTER.length) + TRUNC_FOOTER;
+  }
+
+  return body;
+}
+
+export function computeVerdict({ failures = [], gates = {}, commentUrl = null } = {}) {
+  // AC-3: kill switch — when disabled, surface a shape callers can branch on
+  // without calling the octokit Checks API.
+  if (!isPhase2aEnabled(gates)) {
+    return { enabled: false };
+  }
+
+  const counts = countByTier(failures);
+  const conclusion = pickConclusion(counts);
+  const title = buildTitle(counts);
+  const summary = buildSummary({ conclusion, title, commentUrl });
+  const text = buildText(failures);
+
+  return {
+    enabled: true,
+    conclusion,
+    title,
+    summary,
+    text,
+    counts,
+  };
+}

--- a/scripts/release-gate/lib/validate.mjs
+++ b/scripts/release-gate/lib/validate.mjs
@@ -106,6 +106,18 @@ export function validateGates(gates) {
       errors.push(`bot.fallback_unknown.override_path: must be a valid override_path, got "${fb.override_path}"`);
     }
 
+    // Phase 2a (#1444) — optional sub-key; validate only if present.
+    // Schema is intentionally minimal (just `enabled`) so future Phase 2a
+    // tuning can extend without breaking older release-gates.yml files.
+    if (gates.bot.phase2a !== undefined) {
+      const p2a = gates.bot.phase2a;
+      if (!p2a || typeof p2a !== "object") {
+        errors.push("bot.phase2a: must be an object when present");
+      } else if (p2a.enabled !== undefined && typeof p2a.enabled !== "boolean") {
+        errors.push(`bot.phase2a.enabled: must be boolean when present, got "${typeof p2a.enabled}"`);
+      }
+    }
+
     // Phase 2c (#1446) — optional sub-key; validate only if present.
     if (gates.bot.phase2c !== undefined) {
       const p2c = gates.bot.phase2c;


### PR DESCRIPTION
## Summary

Adds the Phase 2a verdict layer per the [Phase 2 overview spec](../blob/main-dev/docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md). Bot publishes a single `Release-Gate Verdict` check-run on the release PR head SHA so reviewers gate on **one row** instead of N per-tier rows.

**Closes #1444** — deploy gated until 2026-06-08 dispatch window opens. Merge unblocks gate-flip readiness; no behavioral change until operator flips `bot.phase2a.enabled` to `true`.

## Verdict mapping (AC-5)

| Failures present | Conclusion |
|---|---|
| (none) | `success` |
| informational-only | `success` (auto-bypassed) |
| warning-only | `neutral` |
| ≥1 blocker | `failure` |

## Dispatch gate

`bot.phase2a.enabled: false` pinned in `.github/release-gates.yml`. Per the spec, this stays off until #1446 Phase 2c (cron live at commit `b704b7693` 2026-05-22T21:33:22Z) accumulates 14 days of clean telemetry — earliest enable **2026-06-08**.

Default-true semantics in `computeVerdict()` mean: when the sub-key is missing entirely, the bot will still publish — we pin `false` explicitly here to honor the gate.

## What changed

| File | Change |
|---|---|
| `scripts/release-gate/lib/conclusion-override.mjs` | **NEW** — pure `computeVerdict()` (no I/O) |
| `scripts/release-gate/comment.mjs` | extends `runBot()` with `publishVerdict()` (imperative shell, AC-8 soft-fail) |
| `.github/release-gates.yml` | adds `bot.phase2a.enabled: false` sub-key |
| `scripts/release-gate/lib/validate.mjs` | adds phase2a schema validation |
| `.github/workflows/release-gate-comment.yml` | `checks: read` → `checks: write` |
| `scripts/release-gate/__tests__/conclusion-override.test.mjs` | **NEW** — 22 unit tests (matrix rows 1-5, 8, 11-12) |
| `scripts/release-gate/__tests__/integration.test.mjs` | +8 integration tests (matrix rows 6, 7, 9, 10 + contract assertions) |
| `scripts/release-gate/__tests__/validate.test.mjs` | +5 phase2a schema tests |
| `scripts/release-gate/README.md` | "Phases at a glance" matrix + updated file inventory |

**+766 / -20 LOC** · 1 PR · single session per spec's "Tier S ~3h" estimate.

## SMART AC coverage

| AC | Coverage |
|---|---|
| AC-1 latency | `verdictResult.latency_ms` logged to step summary |
| AC-2 name contract | `VERDICT_CHECK_NAME` constant + test asserts exact match |
| AC-3 kill switch | `bot.phase2a.enabled=false` default; integration row 7 verifies no `checks.create` call |
| AC-4 idempotency | `external_id='release-gate-verdict-v1'` + create-then-update-on-422 fallback; integration row 6 |
| AC-5 conclusion matrix | 7 unit tests across all 4 outcomes |
| AC-6 (14d telemetry) | **dispatch gate**, not a deliverable AC — tracked separately |
| AC-7 permissions | workflow updated to `checks: write` |
| AC-8 soft-fail | integration rows 9 + 10 verify `runBot()` returns `ok=true` on 429/503 |
| AC-9 output budget | unit row 8 with 600 synthetic failures truncates within budget |
| AC-10 backward compat | existing 86 tests still pass; only "appends summary" test adapted for 2-entry summary |
| AC-11 unknown-tier | `is_unknown` rolls into `warning` bucket (least-surprise) |
| AC-12 multi-blocker | unit test covers 3-blocker title |

## Local verification

```
$ cd scripts/release-gate
$ pnpm test                                     # 130/130 ✅
$ node validate.mjs                             # OK — 20 checks + 7 fallback valid (schema v1)
$ DRY_RUN=1 PR_NUMBER=1444 node comment.mjs     # Phase 1 dry-run unchanged
```

## Test plan

- [x] Unit tests `__tests__/conclusion-override.test.mjs` 22/22
- [x] Integration tests `__tests__/integration.test.mjs` 20/20 (incl 8 new for Phase 2a)
- [x] Validator tests `__tests__/validate.test.mjs` 22/22 (incl 5 new for phase2a schema)
- [x] Full suite 130/130 ✅
- [x] `node validate.mjs` accepts the authoritative `.github/release-gates.yml`
- [x] `DRY_RUN=1` smoke test prints Phase 1 comment body + actions summary
- [ ] CI release-gate validator step passes
- [ ] CI full test suite green

## Out of scope

- Modifying branch protection (separate operator runbook task — `docs/for-developers/operations/release-gate-bot.md` extension deferred)
- Suppressing informational rows from the bot comment (verdict is the abstraction layer, not the comment)
- Email/Slack notification on verdict (Phase 2c digest already covers warning aggregate)
- Auto-merge when verdict=success (manual review still required)

## Refs

- Closes #1444
- Parent: #1016 Phase 2 overview (CLOSED)
- Phase 1: PR #1435 (`cf20f65f8`)
- Phase 2c: PR #1450 (`b704b7693`)
- Sibling: #1445 Phase 2b Auto-revert (gated on this +14d → 2026-06-22)
- Spec: [`docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md`](../blob/main-dev/docs/for-developers/specs/2026-05-22-release-gate-phase2-overview.md)
- GitHub Checks API: https://docs.github.com/en/rest/checks/runs#create-a-check-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)