### PR TITLE
feat(mockup): Aaron core refinement + chat-fullscreen + state-matrix (Phase 1)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -6,7 +6,7 @@
 >
 > **Audience**: developers looking for "which mockup file do I need for route X?".
 >
-> **Last updated**: 2026-05-18. Keep in sync with
+> **Last updated**: 2026-05-23. Keep in sync with
 > [`docs/for-developers/frontend/v2-migration-matrix.md`](../docs/for-developers/frontend/v2-migration-matrix.md)
 > Route Index section.
 
@@ -36,6 +36,7 @@
 | `data.js` | dev-fixture | Fake dataset, 9 cross-referenced entities |
 | `mobile-app.jsx` | dev-fixture | Full mobile-app React prototype (~870 lines) |
 | `tokens.css` | dev-fixture | **Source of truth for design tokens** (port first) |
+| `state-matrix.html` | dev-fixture | State matrix cross-route (8 route × 5 stati = 40 cell) — riusabile per Phase 2/3 |
 
 ## Auth & onboarding
 
@@ -109,6 +110,12 @@
 | `sp7-game-night-transition.html` | component-mock | Modal opened from `/game-nights/[id]/live` (issue #487 screen #5) |
 | `sp7-game-night-summary.html` | page-mock | `/game-nights/[id]/summary` (issue #487 screen #6) |
 
+## Chat
+
+| File | Type | Mapped routes |
+|------|------|---------------|
+| `chat-fullscreen.html` | page-mock | `/chat/[threadId]`, `/chat/new` (empty state) |
+
 ## Nanolith — Runthrough storyboard (Aaron Iter 1)
 
 | File | Type | Mapped routes |
@@ -117,28 +124,28 @@
 | `nanolith-nav-bottom-mobile.html` | component-mock | Mobile bottom-nav primitive (global) |
 | `nanolith-nav-chat-panel.html` | component-mock | Chat slide-over panel (used globally via `useChatPanel`) |
 | `nanolith-nav-topbar.html` | component-mock | Top-bar primitive (global) |
-| `nanolith-runthrough-encounter-cheatsheet.html` | page-mock | `/library/[gameId]/play/[campaignId]/encounter` (gap-coverage 2026-05-12, PR #1056) |
-| `nanolith-runthrough-error-states.html` | component-mock | Trasversale: chat (N1/N2) · translate (N3) · encounter — stream-timeout / OCR-fail / LLM-503 / segmentation-fail (PR #1056) |
-| `nanolith-runthrough-game-detail.html` | page-mock | `/library/[gameId]` (libro variant, PR #1037) |
-| `nanolith-runthrough-game-onboarding.html` | page-mock | `/library/[gameId]` (libro variant — prereq gate, gap-coverage 2026-05-12, PR #1056) |
-| `nanolith-runthrough-glossary-editor.html` | component-mock | Glossary editor (mirror of sp6 jsx) |
-| `nanolith-runthrough-library-search.html` | component-mock | In-library search overlay (not page-level) |
-| `nanolith-runthrough-play-session.html` | page-mock | `/library/[gameId]/play/[campaignId]` |
-| `nanolith-runthrough-quota-credits.html` | component-mock | Quota/credits overlay (global) |
-| `nanolith-runthrough-resume-picker.html` | page-mock | `/library/[gameId]/play` |
-| `nanolith-runthrough-session-end.html` | page-mock | `/sessions/live/[sessionId]` (end-state) |
-| `nanolith-runthrough-setup-chat.html` | page-mock | `/chat/new`, `/chat/[threadId]` (setup variant) |
-| `nanolith-runthrough-setup-wizard.html` | page-mock | `/sessions/new`, `/library/[gameId]` campaign-setup drawer (PR #1037) |
-| `nanolith-runthrough-translate-viewer.html` | page-mock | `/library/[gameId]/play/[campaignId]/translate` |
+| `librogame-runthrough-encounter-cheatsheet.html` | page-mock | `/library/[gameId]/play/[campaignId]/encounter` (gap-coverage 2026-05-12, PR #1056) |
+| `librogame-runthrough-error-states.html` | component-mock | Trasversale: chat (N1/N2) · translate (N3) · encounter — stream-timeout / OCR-fail / LLM-503 / segmentation-fail (PR #1056) |
+| `librogame-runthrough-game-detail.html` | page-mock | `/library/[gameId]` (libro variant, PR #1037) |
+| `librogame-runthrough-game-onboarding.html` | page-mock | `/library/[gameId]` (libro variant — prereq gate, gap-coverage 2026-05-12, PR #1056) |
+| `librogame-runthrough-glossary-editor.html` | component-mock | Glossary editor (mirror of sp6 jsx) |
+| `librogame-runthrough-library-search.html` | component-mock | In-library search overlay (not page-level) |
+| `librogame-runthrough-play-session.html` | page-mock | `/library/[gameId]/play/[campaignId]` |
+| `librogame-runthrough-quota-credits.html` | component-mock | Quota/credits overlay (global) |
+| `librogame-runthrough-resume-picker.html` | page-mock | `/library/[gameId]/play` |
+| `librogame-runthrough-session-end.html` | page-mock | `/sessions/live/[sessionId]` (end-state) |
+| `librogame-runthrough-setup-chat.html` | page-mock | `/chat/new`, `/chat/[threadId]` (setup variant) |
+| `librogame-runthrough-setup-wizard.html` | page-mock | `/sessions/new`, `/library/[gameId]` campaign-setup drawer (PR #1037) |
+| `librogame-runthrough-translate-viewer.html` | page-mock | `/library/[gameId]/play/[campaignId]/translate` |
 
 ## Summary
 
 | Type | Count |
 |------|------:|
-| page-mock | 48 |
+| page-mock | 49 |
 | component-mock | 16 |
-| dev-fixture | 10 |
-| **Total** | **74** |
+| dev-fixture | 11 |
+| **Total** | **76** |
 
 > The `*.jsx` twins of `*.html` files are not double-counted (the JSX is the
 > implementation companion of the HTML reference). Listing them separately

--- a/admin-mockups/design_files/chat-fullscreen.html
+++ b/admin-mockups/design_files/chat-fullscreen.html
@@ -1,0 +1,1521 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI — Chat full-screen (B11b · /chat/[threadId] + /chat/new)</title>
+<!--
+  Mockup: chat-fullscreen
+  Routes: /chat/[threadId]   (thread esistente, 3 layout: Desktop 3-col, Mobile single-pane)
+          /chat/new          (Empty state, 3 quick-starter variants per agent type)
+  Scope:  Page-level full-screen chat — complementare a `nanolith-nav-chat-panel.html`
+          (slide-over component-mock per cross-page quick-access).
+          Chiusura parziale di issue GitHub #491 (B7 follow-up B11b, audit
+          docs/for-developers/audits/2026-05-22-mockup-gaps.md § P0).
+
+  Screen documentati (3):
+    B11b-1 · Desktop 3-col   — Sidebar sx (260px thread list) + Main (~720px stream)
+                                + Sidebar dx (260px agent info + sources + actions)
+    B11b-2 · Mobile single   — 375px, header sticky + stream + bottom composer
+                                + bottom-sheet context panel on tap header
+    B11b-3 · Empty `/chat/new` — Hero centered + 4 quick-starter cards
+                                3 variants: Libro-game (Aaron), Boardgamer, Default
+
+  Stream states (Nygard failure modes, mostra tutti e 4 nel mockup):
+    1 · idle           — composer empty, send disabled, no streaming
+    2 · streaming      — token-by-token render, typing dots, cancel CTA visibile
+    3 · stream-error   — banner "Errore stream — riprova", last user msg in composer (no perdita)
+    4 · stream-abort   — utente click cancel → "[interrotto]" badge sul message
+
+  Pattern decisions (cross-ref):
+    - Slide-over vs full-screen routing (viewport-driven):
+        Mobile/tablet (<1024px) → full-screen sempre (slide-over diventa drawer fallback)
+        Desktop (≥1024px)       → slide-over default (`nanolith-nav-chat-panel.html`),
+                                  toggle "↗ Apri full-screen" → questa route
+    - Streaming: token-by-token con AbortController — riusa `useThreadMessages` hook PR#551
+                 (apps/web/src/components/chat/shared/use-thread-messages.ts)
+    - Citations pill: click → `sp4-citation-pdf-viewer.html` overlay (RIUSO pattern, NO fork)
+    - Agent info mini-card: pattern condensato da `sp4-agent-detail.html` (Hero compatto + meta + stats)
+    - Attachment Aaron-specific: foto inline apre flow translate (Task 4) come quick-action;
+      risposta translate ritorna come citation pill in chat. Ponte chat ↔ translate
+      (`librogame-runthrough-translate-viewer.html` state-M manual + Task 4 multi-lang).
+    - Voice: UI placeholder microfono — backend Whisper integration deferita (out-of-scope v1)
+    - Quick-starter selection: agent type derivato da `agent.metadata.category`
+      (boardgame | libro-game | default). Fallback graceful a "Default" se field mancante.
+
+  Reader mode + wake-lock (coerenza con Task 2 — passive co-player Aaron sez 1.1.1):
+    - Reader mode 📖: toggle font 16pt → 24pt applicato ai message bubble agent.
+      Stessa `localStorage` key (`reader-mode-enabled`) di translate-viewer per coerenza
+      cross-route Aaron (legge regola tradotta + chiede Tutor con stesso layout passive).
+    - Wake-lock 🔆 badge: attivo durante chat con streaming attivo (riusa pattern Task 2).
+      3 stati badge: attivo (verde) · disabilitato (muted) · non-supportato (Safari <16.4).
+
+  Latency hints (token streaming targets):
+    first-token latency P50 < 500ms      (UX feel "instant", da OpenRouter+DeepSeek)
+    first-token latency P95 < 1500ms     (fallback OpenAI, network jitter)
+    inter-token latency P50 < 80ms       (50 chars/sec percepito fluido)
+    idle session timeout                  30s no token → trigger stream-error state
+    hard timeout per query                60s end-to-end → abort + user-prompt retry
+    abort latency                         <100ms (AbortController instant on user click)
+
+  Persona: Aaron (badsworm@gmail.com), narrativa "Sera con i ragazzi · Runa di Ardenel · §147"
+           (coerente con Task 1-4: error-states, translate-viewer, glossary-editor, photo-upload).
+           Plus 1 thread boardgamer (Wingspan) in thread list per multi-agent demo.
+
+  Cross-ref:
+    - issue #491 closure parziale 2026-05-20
+    - audit docs/for-developers/audits/2026-05-22-mockup-gaps.md § P0
+    - PR#551 `useThreadMessages` hook (Strangler Fig Phase 1 chat refactor)
+    - sp4-citation-pdf-viewer.html — citation pill overlay reuse (G4 v3, no fork)
+    - sp4-agent-detail.html — agent mini-card pattern compresso (Hero condensato)
+    - nanolith-nav-chat-panel.html — slide-over secondary mode (viewport ≥1024px)
+    - librogame-runthrough-translate-viewer.html — Task 2+4 translate ponte da attachment Aaron
+    - spec docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md sezione 6
+
+  Telemetry footer:
+    Ogni screen mostra footer compatto con counters (cost, latency, tokens, query/quota)
+    coerente con pattern Task 1-4 (cost transparency, telemetry).
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+
+<style>
+  body { background: var(--bg); color: var(--text); font-family: var(--f-body); margin: 0; }
+
+  /* ─── Top stage bar (mockup chrome) ─── */
+  .top {
+    position: sticky; top: 0; z-index: var(--z-sticky);
+    backdrop-filter: blur(12px); background: var(--glass-bg);
+    border-bottom: 1px solid var(--border);
+    padding: var(--s-4) var(--s-6);
+    display: flex; align-items: center; gap: var(--s-4); flex-wrap: wrap;
+  }
+  .top h1 { font-family: var(--f-display); font-size: var(--fs-lg); margin: 0; font-weight: var(--fw-bold); }
+  .top .route { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); padding: 2px var(--s-2); border-radius: var(--r-sm); background: var(--bg-muted); }
+  .top .spacer { flex: 1; }
+  .top button {
+    background: var(--bg-card); border: 1px solid var(--border); color: var(--text);
+    border-radius: var(--r-pill); padding: var(--s-1) var(--s-3);
+    font-family: var(--f-mono); font-size: var(--fs-xs); cursor: pointer;
+  }
+
+  .stage { padding: var(--s-7) var(--s-6); max-width: 1900px; margin: 0 auto; }
+
+  .state-section { margin-bottom: var(--s-10); }
+  .state-section .label {
+    display: inline-block; padding: var(--s-1) var(--s-3);
+    background: hsl(var(--c-chat) / 0.12); color: hsl(var(--c-chat));
+    border-radius: var(--r-pill);
+    font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-bold);
+    text-transform: uppercase; letter-spacing: 0.06em;
+    margin-bottom: var(--s-2);
+  }
+  .state-section .label .cmp {
+    margin-left: var(--s-2); padding: 1px var(--s-2);
+    background: var(--bg); color: hsl(var(--c-chat));
+    border-radius: var(--r-sm); font-size: 10px;
+  }
+  .state-section h2 {
+    font-family: var(--f-display); font-size: var(--fs-2xl); font-weight: var(--fw-bold);
+    margin: 0 0 var(--s-2);
+  }
+  .state-section .desc { color: var(--text-sec); margin: 0 0 var(--s-6); font-size: var(--fs-md); max-width: 920px; }
+
+  .frames { display: flex; gap: var(--s-9); flex-wrap: wrap; align-items: flex-start; }
+
+  /* ─── Phone & Desktop frames ─── */
+  .phone {
+    width: 375px; min-height: 760px; background: var(--bg);
+    border-radius: 36px; overflow: hidden;
+    border: 1px solid var(--border-strong); box-shadow: var(--shadow-lg);
+    display: flex; flex-direction: column; position: relative;
+  }
+  .desktop {
+    width: 1280px; min-height: 720px; background: var(--bg);
+    border-radius: var(--r-lg); overflow: hidden;
+    border: 1px solid var(--border-strong); box-shadow: var(--shadow-lg);
+    display: flex; flex-direction: column; position: relative;
+  }
+  .phone .frame-label, .desktop .frame-label {
+    position: absolute; top: -28px; left: 50%; transform: translateX(-50%);
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+  }
+  .desktop .frame-label { left: 0; transform: none; }
+
+  .phone-sbar {
+    height: 32px; flex-shrink: 0;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 6px 22px 0;
+    font-size: 12px; font-weight: var(--fw-bold);
+    font-family: var(--f-display); color: var(--text-sec);
+  }
+  .titlebar {
+    height: 28px; background: var(--bg-muted); flex-shrink: 0;
+    display: flex; align-items: center; padding: 0 var(--s-3); gap: 6px;
+    border-bottom: 1px solid var(--border-light);
+  }
+  .titlebar .dot { width: 10px; height: 10px; border-radius: 50%; }
+  .titlebar .dot.r { background: #ff605c; } .titlebar .dot.y { background: #ffbd44; } .titlebar .dot.g { background: #00ca4e; }
+  .titlebar .url {
+    margin-left: var(--s-3); padding: 2px var(--s-3);
+    background: var(--bg-card); border-radius: var(--r-sm);
+    font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    flex: 1;
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     B11b-1 · Desktop 3-col layout (sidebar sx + main + sidebar dx)
+     ═══════════════════════════════════════════════════════════ */
+
+  .chat-3col {
+    flex: 1; display: grid;
+    grid-template-columns: 260px 1fr 260px;
+    min-height: 0; overflow: hidden;
+  }
+
+  /* ─── Sidebar sx · Thread list ─── */
+  .sidebar-l {
+    background: var(--bg-card); border-right: 1px solid var(--border-light);
+    display: flex; flex-direction: column; overflow: hidden;
+  }
+  .sl-head {
+    padding: var(--s-3) var(--s-4); border-bottom: 1px solid var(--border-light);
+    display: flex; flex-direction: column; gap: var(--s-2); flex-shrink: 0;
+  }
+  .sl-tabs {
+    display: inline-flex; gap: 2px; padding: 2px;
+    background: var(--bg-muted); border-radius: var(--r-pill);
+    border: 1px solid var(--border-light); width: 100%;
+  }
+  .sl-tabs .tab {
+    flex: 1; padding: 4px var(--s-2);
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-sec);
+    border-radius: var(--r-pill); cursor: pointer; text-align: center;
+    border: 0; background: transparent;
+  }
+  .sl-tabs .tab.active {
+    background: var(--bg-card); color: hsl(var(--c-chat));
+    font-weight: var(--fw-bold); box-shadow: var(--shadow-xs);
+  }
+  .sl-search {
+    width: 100%; padding: var(--s-2) var(--s-3);
+    border: 1px solid var(--border); border-radius: var(--r-md);
+    background: var(--bg); font-family: var(--f-body); font-size: var(--fs-sm);
+    color: var(--text); outline: 0;
+  }
+  .sl-search:focus { border-color: hsl(var(--c-chat)); box-shadow: 0 0 0 3px hsl(var(--c-chat) / 0.15); }
+  .sl-filter {
+    display: inline-flex; align-items: center; gap: var(--s-1);
+    padding: 4px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-agent) / 0.12); color: hsl(var(--c-agent));
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-semi);
+    border: 1px solid hsl(var(--c-agent) / 0.3); cursor: pointer;
+    align-self: flex-start;
+  }
+  .sl-filter .chevron { font-size: 9px; opacity: 0.7; }
+
+  .sl-cta {
+    margin: var(--s-3) var(--s-4) var(--s-2);
+    padding: var(--s-2) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-chat)); color: #fff; border: 0;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    cursor: pointer; display: flex; align-items: center; gap: var(--s-2);
+    justify-content: center;
+  }
+
+  .sl-list {
+    flex: 1; overflow-y: auto; padding: 0 var(--s-3) var(--s-3);
+  }
+  .sl-list .group-h {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: 0.06em;
+    padding: var(--s-3) var(--s-2) var(--s-2);
+  }
+  .sl-thread {
+    display: flex; gap: var(--s-2); padding: var(--s-2) var(--s-2);
+    border-radius: var(--r-md); cursor: pointer; align-items: flex-start;
+    margin-bottom: 2px;
+  }
+  .sl-thread:hover { background: var(--bg-hover); }
+  .sl-thread.active {
+    background: hsl(var(--c-chat) / 0.1);
+    border-left: 3px solid hsl(var(--c-chat));
+    padding-left: calc(var(--s-2) - 3px);
+  }
+  .sl-thread .av {
+    width: 32px; height: 32px; border-radius: 50%;
+    background: hsl(var(--c-agent) / 0.18); color: hsl(var(--c-agent));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; flex-shrink: 0;
+  }
+  .sl-thread.libro .av { background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb)); }
+  .sl-thread.boardgame .av { background: hsl(var(--c-game) / 0.18); color: hsl(var(--c-game)); }
+  .sl-thread .info { flex: 1; min-width: 0; }
+  .sl-thread .info .ti {
+    font-family: var(--f-display); font-weight: var(--fw-semi);
+    font-size: var(--fs-sm); margin: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .sl-thread .info .pv {
+    font-size: 11px; color: var(--text-muted);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    margin-top: 2px;
+  }
+  .sl-thread .meta {
+    display: flex; flex-direction: column; align-items: flex-end;
+    gap: 2px; flex-shrink: 0;
+  }
+  .sl-thread .meta .ts { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+  .sl-thread .meta .unread {
+    min-width: 18px; height: 18px; padding: 0 5px;
+    border-radius: var(--r-pill); background: hsl(var(--c-chat)); color: #fff;
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+
+  /* ─── Main · Chat stream ─── */
+  .main-c {
+    background: var(--bg); display: flex; flex-direction: column;
+    overflow: hidden; min-width: 0;
+  }
+  .main-h {
+    padding: var(--s-3) var(--s-4);
+    border-bottom: 1px solid var(--border-light);
+    display: flex; align-items: center; gap: var(--s-3); flex-shrink: 0;
+    background: var(--bg-card);
+  }
+  .main-h .ag {
+    width: 40px; height: 40px; border-radius: 50%;
+    background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; flex-shrink: 0;
+  }
+  .main-h .ti-block { flex: 1; min-width: 0; }
+  .main-h .ti-block .ti {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-md); margin: 0;
+  }
+  .main-h .ti-block .sub {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    margin-top: 2px;
+  }
+  .main-h .actions { display: flex; gap: 4px; }
+  .main-h .icon-btn {
+    width: 32px; height: 32px; border-radius: var(--r-md);
+    background: transparent; border: 1px solid transparent;
+    color: var(--text-sec); cursor: pointer; font-size: 14px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .main-h .icon-btn:hover { background: var(--bg-muted); border-color: var(--border); }
+  .main-h .icon-btn.active { color: hsl(var(--c-chat)); background: hsl(var(--c-chat) / 0.1); }
+
+  /* Stream area */
+  .stream {
+    flex: 1; overflow-y: auto; padding: var(--s-5) var(--s-6);
+    display: flex; flex-direction: column; gap: var(--s-4);
+    max-width: 840px; width: 100%; margin: 0 auto;
+  }
+  .ts-divider {
+    align-self: center; font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-muted); padding: var(--s-1) var(--s-3);
+    background: var(--bg-muted); border-radius: var(--r-pill);
+  }
+
+  .msg-row { display: flex; gap: var(--s-3); align-items: flex-start; }
+  .msg-row.user { flex-direction: row-reverse; }
+  .msg-row .av-msg {
+    width: 32px; height: 32px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; flex-shrink: 0;
+  }
+  .msg-row.agent .av-msg { background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb)); }
+  .msg-row.user .av-msg { background: hsl(var(--c-chat) / 0.18); color: hsl(var(--c-chat)); }
+
+  .bubble {
+    max-width: 75%; padding: var(--s-3) var(--s-4);
+    border-radius: var(--r-lg); font-size: var(--fs-md);
+    line-height: var(--lh-body);
+  }
+  .bubble.user {
+    background: hsl(var(--c-chat)); color: #fff;
+    border-bottom-right-radius: var(--r-sm);
+  }
+  .bubble.agent {
+    background: var(--bg-card); color: var(--text);
+    border: 1px solid var(--border-light);
+    border-bottom-left-radius: var(--r-sm);
+  }
+  /* Reader mode: bubble agent diventa 24pt (sez 1.1.1 passive co-player Aaron) */
+  .bubble.agent.reader-on { font-size: 24px; line-height: 1.6; max-width: 65ch; }
+
+  .bubble .meta-foot {
+    margin-top: var(--s-2); padding-top: var(--s-2);
+    border-top: 1px dashed var(--border-light);
+    display: flex; align-items: center; gap: var(--s-2);
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  }
+
+  /* Citation pill — click opens sp4-citation-pdf-viewer overlay */
+  .cit-pill {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px var(--s-2); margin: 0 2px;
+    border-radius: var(--r-pill);
+    background: hsl(var(--c-info) / 0.12); color: hsl(var(--c-info));
+    font-family: var(--f-mono); font-size: 11px; font-weight: var(--fw-semi);
+    cursor: pointer; border: 1px solid hsl(var(--c-info) / 0.25);
+    text-decoration: none; vertical-align: baseline;
+  }
+  .cit-pill:hover { background: hsl(var(--c-info) / 0.22); }
+  .cit-pill .ico { font-size: 10px; opacity: 0.75; }
+
+  /* Aaron-specific: citation pill da translate flow (entity=kb book ref) */
+  .cit-pill.translate {
+    background: hsl(var(--c-kb) / 0.12); color: hsl(var(--c-kb));
+    border-color: hsl(var(--c-kb) / 0.25);
+  }
+
+  /* Confidence chip */
+  .conf-chip {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 1px 6px; border-radius: var(--r-pill);
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+  }
+  .conf-chip.high { background: hsl(var(--c-success) / 0.15); color: hsl(var(--c-success)); }
+  .conf-chip.med { background: hsl(var(--c-warning) / 0.15); color: hsl(var(--c-warning)); }
+
+  /* Typing indicator (state: streaming) */
+  .typing-dots { display: inline-flex; gap: 4px; padding: var(--s-3); }
+  .typing-dots span {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: hsl(var(--c-kb));
+    animation: typing 1.4s ease-in-out infinite;
+  }
+  .typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+  .typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes typing { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }
+
+  /* Stream cursor (during token-by-token) */
+  .stream-cursor {
+    display: inline-block; width: 8px; height: 18px;
+    background: hsl(var(--c-kb)); margin-left: 4px;
+    animation: blink 0.9s step-end infinite; vertical-align: middle;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  /* Cancel CTA during streaming */
+  .cancel-stream-cta {
+    align-self: center; margin-top: var(--s-2);
+    padding: 4px var(--s-3); border-radius: var(--r-pill);
+    background: hsl(var(--c-event) / 0.12); color: hsl(var(--c-event));
+    border: 1px solid hsl(var(--c-event) / 0.3);
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+    cursor: pointer;
+  }
+
+  /* State: stream-error banner */
+  .stream-error-banner {
+    align-self: stretch; margin: var(--s-2) 0;
+    padding: var(--s-3) var(--s-4); border-radius: var(--r-md);
+    background: hsl(var(--c-event) / 0.08);
+    border: 1px solid hsl(var(--c-event) / 0.4);
+    display: flex; align-items: center; gap: var(--s-3);
+  }
+  .stream-error-banner .ico { font-size: 18px; }
+  .stream-error-banner .info { flex: 1; }
+  .stream-error-banner .info .v { font-family: var(--f-display); font-weight: var(--fw-bold); color: hsl(var(--c-event)); font-size: var(--fs-sm); }
+  .stream-error-banner .info .s { font-family: var(--f-mono); font-size: 10px; color: var(--text-sec); margin-top: 2px; }
+  .stream-error-banner .retry {
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-event)); color: #fff; border: 0;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    cursor: pointer;
+  }
+
+  /* State: stream-abort badge */
+  .abort-badge {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 1px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-warning) / 0.15); color: hsl(var(--c-warning));
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+    margin-left: var(--s-1);
+  }
+
+  /* ─── Composer (bottom of main) ─── */
+  .composer {
+    flex-shrink: 0; padding: var(--s-3) var(--s-4) var(--s-4);
+    border-top: 1px solid var(--border-light); background: var(--bg-card);
+  }
+  .composer-row {
+    display: flex; gap: var(--s-2); align-items: flex-end;
+    max-width: 840px; width: 100%; margin: 0 auto;
+  }
+  .composer-tools {
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .tool-btn {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: var(--bg-muted); border: 1px solid var(--border-light);
+    color: var(--text-sec); cursor: pointer; font-size: 14px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .tool-btn:hover { background: var(--bg-hover); border-color: hsl(var(--c-chat) / 0.4); }
+  .tool-btn.aaron { background: hsl(var(--c-kb) / 0.12); border-color: hsl(var(--c-kb) / 0.3); color: hsl(var(--c-kb)); }
+  .tool-btn.aaron::after {
+    content: "📖"; position: absolute;
+    width: 14px; height: 14px; border-radius: 50%;
+    background: var(--bg-card); border: 1px solid var(--border);
+    font-size: 8px; margin-left: 18px; margin-top: -22px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .composer-input {
+    flex: 1; padding: var(--s-3) var(--s-4);
+    border: 1px solid var(--border); border-radius: var(--r-lg);
+    background: var(--bg); font-family: var(--f-body); font-size: var(--fs-md);
+    color: var(--text); outline: 0; resize: none;
+    min-height: 44px; max-height: 120px; line-height: var(--lh-body);
+  }
+  .composer-input:focus { border-color: hsl(var(--c-chat)); box-shadow: 0 0 0 3px hsl(var(--c-chat) / 0.15); }
+  .send-btn {
+    width: 44px; height: 44px; border-radius: 50%;
+    background: hsl(var(--c-chat)); color: #fff; border: 0;
+    font-size: 18px; cursor: pointer; flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .send-btn[disabled] { opacity: 0.4; cursor: not-allowed; }
+
+  /* ─── Sidebar dx · Agent + Sources + Suggested actions ─── */
+  .sidebar-r {
+    background: var(--bg-card); border-left: 1px solid var(--border-light);
+    display: flex; flex-direction: column; overflow-y: auto;
+  }
+
+  /* Agent mini-card (compressed sp4-agent-detail Hero pattern) */
+  .agent-mini {
+    padding: var(--s-4); border-bottom: 1px solid var(--border-light);
+    background: linear-gradient(135deg, hsl(var(--c-kb) / 0.06), transparent);
+    display: flex; flex-direction: column; gap: var(--s-2);
+  }
+  .agent-mini .row1 { display: flex; align-items: center; gap: var(--s-3); }
+  .agent-mini .av {
+    width: 56px; height: 56px; border-radius: 50%;
+    background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 26px; flex-shrink: 0;
+  }
+  .agent-mini .info { flex: 1; min-width: 0; }
+  .agent-mini .info .name { font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); }
+  .agent-mini .info .persona { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .agent-mini .stats {
+    display: flex; gap: var(--s-3); padding-top: var(--s-2);
+    border-top: 1px dashed var(--border-light);
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-sec);
+  }
+  .agent-mini .stats .s-item .v { font-weight: var(--fw-bold); color: var(--text); }
+
+  .panel-section {
+    padding: var(--s-3) var(--s-4);
+    border-bottom: 1px solid var(--border-light);
+  }
+  .panel-section h4 {
+    font-family: var(--f-mono); font-size: 10px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted); margin: 0 0 var(--s-2);
+  }
+  .panel-section .src-card {
+    display: flex; gap: var(--s-2); padding: var(--s-2);
+    border-radius: var(--r-sm);
+    background: hsl(var(--c-info) / 0.06);
+    border: 1px solid hsl(var(--c-info) / 0.2);
+    cursor: pointer; margin-bottom: var(--s-1);
+  }
+  .panel-section .src-card:hover { background: hsl(var(--c-info) / 0.12); }
+  .panel-section .src-card .ico { font-size: 14px; flex-shrink: 0; color: hsl(var(--c-info)); }
+  .panel-section .src-card .l { flex: 1; min-width: 0; }
+  .panel-section .src-card .l .v {
+    font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .panel-section .src-card .l .s {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 1px;
+  }
+
+  .panel-section .action-card {
+    display: flex; gap: var(--s-2); padding: var(--s-2) var(--s-3);
+    border-radius: var(--r-md);
+    background: var(--bg); border: 1px solid var(--border-light);
+    cursor: pointer; margin-bottom: var(--s-1); text-align: left;
+    color: var(--text); font-family: var(--f-display); font-weight: var(--fw-semi);
+    font-size: var(--fs-sm); align-items: center; width: 100%;
+  }
+  .panel-section .action-card:hover { background: var(--bg-hover); border-color: hsl(var(--c-chat) / 0.4); }
+  .panel-section .action-card .ico { font-size: 16px; }
+  .panel-section .action-card .arrow { margin-left: auto; color: var(--text-muted); }
+
+  /* ═══════════════════════════════════════════════════════════
+     Telemetry footer (cost transparency, latency, query/quota)
+     ═══════════════════════════════════════════════════════════ */
+  .telemetry-foot {
+    flex-shrink: 0; padding: var(--s-1) var(--s-3);
+    background: var(--bg-sunken); border-top: 1px solid var(--border-light);
+    display: flex; align-items: center; gap: var(--s-3); flex-wrap: wrap;
+    font-family: var(--f-mono); font-size: 9px; color: var(--text-muted);
+  }
+  .telemetry-foot .pip { display: inline-flex; align-items: center; gap: 4px; }
+  .telemetry-foot .pip .v { color: var(--text-sec); font-weight: var(--fw-bold); }
+  .telemetry-foot .pip.live .v { color: hsl(var(--c-success)); }
+  .telemetry-foot .pip.warn .v { color: hsl(var(--c-warning)); }
+  .telemetry-foot .spacer { flex: 1; }
+
+  /* Wake-lock badge (sez 1.1.1 coerenza Task 2) */
+  .wake-lock-badge {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px 6px; border-radius: var(--r-pill);
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+  }
+  .wake-lock-badge.active { background: hsl(var(--c-success) / 0.15); color: hsl(var(--c-success)); }
+  .wake-lock-badge.disabled { background: var(--bg-muted); color: var(--text-muted); }
+  .wake-lock-badge.unsupported { background: hsl(var(--c-warning) / 0.15); color: hsl(var(--c-warning)); }
+
+  /* ═══════════════════════════════════════════════════════════
+     B11b-2 · Mobile single-pane
+     ═══════════════════════════════════════════════════════════ */
+
+  .mob-h {
+    padding: var(--s-3) var(--s-3);
+    border-bottom: 1px solid var(--border-light);
+    display: flex; align-items: center; gap: var(--s-2);
+    flex-shrink: 0; background: var(--bg-card);
+    position: sticky; top: 0; z-index: 2;
+  }
+  .mob-h .back { width: 32px; height: 32px; border-radius: var(--r-md); background: var(--bg-muted); border: 0; font-size: 16px; cursor: pointer; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .mob-h .ti-block { flex: 1; min-width: 0; cursor: pointer; }
+  .mob-h .ti-block .ti { font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mob-h .ti-block .sub { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); margin-top: 2px; }
+  .mob-h .av {
+    width: 32px; height: 32px; border-radius: 50%;
+    background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb));
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; flex-shrink: 0;
+  }
+  .mob-h .kebab { width: 32px; height: 32px; border-radius: var(--r-md); background: transparent; border: 0; font-size: 16px; cursor: pointer; color: var(--text-sec); flex-shrink: 0; }
+
+  .mob-stream {
+    flex: 1; overflow-y: auto; padding: var(--s-3);
+    display: flex; flex-direction: column; gap: var(--s-3);
+  }
+  .mob-composer {
+    flex-shrink: 0; padding: var(--s-2) var(--s-3) var(--s-3);
+    border-top: 1px solid var(--border-light); background: var(--bg-card);
+  }
+  .mob-composer .composer-row { gap: var(--s-1); }
+  .mob-composer .composer-input { min-height: 40px; padding: var(--s-2) var(--s-3); font-size: var(--fs-sm); }
+  .mob-composer .tool-btn { width: 32px; height: 32px; font-size: 13px; }
+  .mob-composer .send-btn { width: 40px; height: 40px; font-size: 16px; }
+
+  /* Mobile bottom-sheet (context panel on tap header) */
+  .mob-sheet-backdrop {
+    position: absolute; inset: 0; background: rgba(0,0,0,0.45);
+    backdrop-filter: blur(4px); z-index: 10;
+  }
+  .mob-sheet {
+    position: absolute; left: 0; right: 0; bottom: 0;
+    background: var(--bg-card); border-top-left-radius: var(--r-2xl);
+    border-top-right-radius: var(--r-2xl);
+    box-shadow: var(--shadow-drawer);
+    max-height: 70%; overflow-y: auto; z-index: 11;
+    padding: var(--s-2) var(--s-3) var(--s-5);
+  }
+  .mob-sheet .grip {
+    width: 40px; height: 4px; border-radius: var(--r-pill);
+    background: var(--border-strong);
+    margin: var(--s-2) auto var(--s-3);
+  }
+
+  /* ═══════════════════════════════════════════════════════════
+     B11b-3 · Empty state /chat/new
+     ═══════════════════════════════════════════════════════════ */
+
+  .empty-shell {
+    flex: 1; padding: var(--s-9) var(--s-6);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: var(--s-5); text-align: center; overflow-y: auto;
+  }
+  .empty-shell .hero-icon {
+    font-size: 72px; line-height: 1; opacity: 0.7;
+    margin-bottom: var(--s-1);
+  }
+  .empty-shell h2 { font-family: var(--f-display); font-size: var(--fs-3xl); font-weight: var(--fw-bold); margin: 0; }
+  .empty-shell .subtitle { color: var(--text-sec); font-size: var(--fs-md); max-width: 480px; margin: 0; }
+
+  .qs-grid {
+    display: grid; gap: var(--s-3);
+    grid-template-columns: repeat(2, 1fr);
+    width: 100%; max-width: 560px;
+  }
+  .qs-grid.desk-1x4 { grid-template-columns: repeat(4, 1fr); max-width: 920px; }
+
+  .qs-card {
+    padding: var(--s-3) var(--s-4); border-radius: var(--r-md);
+    background: var(--bg-card); border: 1px solid var(--border-light);
+    text-align: left; cursor: pointer; color: var(--text);
+    font-family: var(--f-body); font-size: var(--fs-sm); line-height: var(--lh-snug);
+    display: flex; flex-direction: column; gap: var(--s-1);
+    transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out);
+  }
+  .qs-card:hover { transform: translateY(-2px); border-color: hsl(var(--c-chat) / 0.5); box-shadow: var(--shadow-sm); }
+  .qs-card .qs-ico { font-size: 18px; }
+  .qs-card .qs-cat {
+    font-family: var(--f-mono); font-size: 9px; color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: 0.06em;
+  }
+  .qs-card .qs-q { font-weight: var(--fw-semi); }
+
+  /* Variant-specific accent (libro-game vs boardgamer vs default) */
+  .qs-card.libro { border-left: 3px solid hsl(var(--c-kb)); }
+  .qs-card.libro .qs-cat { color: hsl(var(--c-kb)); }
+  .qs-card.boardgame { border-left: 3px solid hsl(var(--c-game)); }
+  .qs-card.boardgame .qs-cat { color: hsl(var(--c-game)); }
+  .qs-card.default { border-left: 3px solid hsl(var(--c-chat)); }
+  .qs-card.default .qs-cat { color: hsl(var(--c-chat)); }
+
+  /* Default variant: agent picker dropdown */
+  .agent-picker-trig {
+    padding: var(--s-3) var(--s-5); border-radius: var(--r-pill);
+    background: hsl(var(--c-chat)); color: #fff; border: 0;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md);
+    cursor: pointer; display: inline-flex; align-items: center; gap: var(--s-2);
+    box-shadow: 0 6px 16px hsl(var(--c-chat) / 0.3);
+  }
+  .agent-picker-list {
+    width: 100%; max-width: 480px;
+    background: var(--bg-card); border-radius: var(--r-lg);
+    border: 1px solid var(--border); box-shadow: var(--shadow-md);
+    padding: var(--s-2); display: flex; flex-direction: column; gap: 2px;
+    margin-top: var(--s-3);
+  }
+  .agent-picker-list .ag-item {
+    display: flex; gap: var(--s-3); padding: var(--s-2) var(--s-3);
+    border-radius: var(--r-md); cursor: pointer; align-items: center;
+    text-align: left; border: 0; background: transparent; width: 100%;
+    color: var(--text); font-family: var(--f-body); font-size: var(--fs-sm);
+  }
+  .agent-picker-list .ag-item:hover { background: var(--bg-hover); }
+  .agent-picker-list .ag-item .av { width: 36px; height: 36px; border-radius: 50%; background: hsl(var(--c-agent) / 0.18); color: hsl(var(--c-agent)); display: flex; align-items: center; justify-content: center; font-size: 16px; flex-shrink: 0; }
+  .agent-picker-list .ag-item .info { flex: 1; min-width: 0; }
+  .agent-picker-list .ag-item .info .nm { font-family: var(--f-display); font-weight: var(--fw-semi); }
+  .agent-picker-list .ag-item .info .lu { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 1px; }
+
+  /* Note callout (decisione kit) */
+  .note {
+    padding: var(--s-3); border-left: 3px solid hsl(var(--c-info));
+    background: hsl(var(--c-info) / 0.05);
+    border-radius: 0 var(--r-md) var(--r-md) 0;
+    margin-top: var(--s-4); font-size: var(--fs-sm); color: var(--text-sec);
+    max-width: 920px;
+  }
+  .note strong { color: hsl(var(--c-info)); font-family: var(--f-display); font-weight: var(--fw-bold); }
+
+  /* Cost transparency banner (coerenza Task 1-4) */
+  .cost-banner {
+    margin: var(--s-3) auto 0; max-width: 760px;
+    padding: var(--s-2) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-toolkit) / 0.06);
+    border: 1px solid hsl(var(--c-toolkit) / 0.25);
+    display: flex; align-items: center; gap: var(--s-3); flex-wrap: wrap;
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-sec);
+  }
+  .cost-banner .ico { font-size: 14px; }
+  .cost-banner .v { color: hsl(var(--c-toolkit)); font-weight: var(--fw-bold); }
+
+  /* A11y */
+  *:focus-visible { outline: 2px solid hsl(var(--c-chat)); outline-offset: 2px; }
+  @media (prefers-reduced-motion: reduce) {
+    .typing-dots span, .stream-cursor { animation: none; }
+  }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <h1>Chat full-screen · B11b (chiusura parziale #491)</h1>
+  <span class="route">/chat/[threadId] + /chat/new</span>
+  <span class="spacer"></span>
+  <button id="theme-btn" type="button" aria-label="Cambia tema">🌗 Tema</button>
+</header>
+
+<main class="stage">
+
+  <!-- ═══════════════════════════════════════════════════════════
+       SCREEN B11b-1 · DESKTOP 3-col layout
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s1">
+    <span class="label">Screen B11b-1 · Desktop 3-col<span class="cmp">ChatFullscreenDesktop · 1280px</span></span>
+    <h2 id="s1">Desktop 3-col · /chat/[threadId] · stream attivo (streaming state)</h2>
+    <p class="desc">Sidebar sx (260px) thread list con tabs · search · filter agent · CTA "+ Nuova chat". Main center (~720px) header + bubble stream user-right/agent-left + citation pills inline · typing indicator durante stream · cancel CTA visibile. Sidebar dx (260px) agent mini-card + Fonti citate + Azioni suggerite. Narrative "Sera con i ragazzi · Runa di Ardenel · §147" (coerenza Task 1-4).</p>
+
+    <div class="frames">
+      <div class="desktop" role="region" aria-label="Desktop 3-col chat full-screen — streaming state">
+        <span class="frame-label">Desktop · 1280px · /chat/thread-runa-147 · stream-state: streaming</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/chat/thread-runa-147 ← full-screen mode (toggle da slide-over)</span></div>
+
+        <div class="chat-3col">
+          <!-- ── Sidebar SX · thread list ── -->
+          <aside class="sidebar-l" aria-label="Thread list">
+            <div class="sl-head">
+              <div class="sl-tabs" role="tablist">
+                <button class="tab active" role="tab" aria-selected="true">Tutti</button>
+                <button class="tab" role="tab" aria-selected="false">Preferiti</button>
+                <button class="tab" role="tab" aria-selected="false">Archiviati</button>
+              </div>
+              <input type="text" class="sl-search" placeholder="🔍 Cerca thread…" aria-label="Cerca thread"/>
+              <button class="sl-filter" type="button" aria-label="Filtro per agent — dropdown chip">
+                <span>🧙 Tutti gli agent</span><span class="chevron">▾</span>
+              </button>
+            </div>
+            <button class="sl-cta" type="button"><span>＋</span><span>Nuova chat</span></button>
+            <div class="sl-list">
+              <div class="group-h">Oggi</div>
+              <button class="sl-thread libro active" type="button">
+                <div class="av">📕</div>
+                <div class="info">
+                  <div class="ti">Sera con i ragazzi · §147</div>
+                  <div class="pv">Aaron: Niamh affronta il Goblin Captain…</div>
+                </div>
+                <div class="meta"><span class="ts">22:34</span><span class="unread">2</span></div>
+              </button>
+              <button class="sl-thread libro" type="button">
+                <div class="av">📕</div>
+                <div class="info">
+                  <div class="ti">Runa di Ardenel · §89</div>
+                  <div class="pv">Riassumi capitolo precedente…</div>
+                </div>
+                <div class="meta"><span class="ts">14:10</span></div>
+              </button>
+              <div class="group-h">Ieri</div>
+              <button class="sl-thread boardgame" type="button">
+                <div class="av">🦅</div>
+                <div class="info">
+                  <div class="ti">Wingspan · scoring fine partita</div>
+                  <div class="pv">Bonus ornitologo come si calcola?</div>
+                </div>
+                <div class="meta"><span class="ts">ieri</span></div>
+              </button>
+              <button class="sl-thread libro" type="button">
+                <div class="av">📕</div>
+                <div class="info">
+                  <div class="ti">Press Start · setup 4 giocatori</div>
+                  <div class="pv">Press Start p.3-7 spiega che…</div>
+                </div>
+                <div class="meta"><span class="ts">ieri</span></div>
+              </button>
+              <div class="group-h">Settimana</div>
+              <button class="sl-thread boardgame" type="button">
+                <div class="av">🚂</div>
+                <div class="info">
+                  <div class="ti">Brass: Birmingham · prestiti</div>
+                  <div class="pv">I prestiti aumentano VP penalty…</div>
+                </div>
+                <div class="meta"><span class="ts">2g</span></div>
+              </button>
+            </div>
+          </aside>
+
+          <!-- ── MAIN · chat stream ── -->
+          <section class="main-c" aria-label="Conversazione attiva">
+            <div class="main-h">
+              <div class="ag">📕</div>
+              <div class="ti-block">
+                <div class="ti">Sera con i ragazzi · §147</div>
+                <div class="sub">Tutor Runa di Ardenel · DeepSeek IT · 12 query oggi · stream: streaming</div>
+              </div>
+              <div class="actions" role="toolbar" aria-label="Azioni thread">
+                <button class="icon-btn active" type="button" aria-label="Reader mode 24pt — toggle (localStorage `reader-mode-enabled`)" title="Reader mode 24pt">📖</button>
+                <button class="icon-btn" type="button" aria-label="Preferiti" title="Preferiti">⭐</button>
+                <button class="icon-btn" type="button" aria-label="Archivia" title="Archivia">📦</button>
+                <button class="icon-btn" type="button" aria-label="Altre azioni" title="Altre azioni">⋮</button>
+              </div>
+            </div>
+
+            <div class="stream" role="log" aria-live="polite" aria-relevant="additions" aria-label="Stream messaggi chat">
+              <div class="ts-divider">oggi · 22:14</div>
+
+              <div class="msg-row user">
+                <div class="av-msg">🎲</div>
+                <div class="bubble user">Niamh affronta il Goblin Captain al §147. Posso tirare 2d6 + bonus spada?</div>
+              </div>
+
+              <div class="msg-row agent">
+                <div class="av-msg">📕</div>
+                <div class="bubble agent reader-on">
+                  Sì — Niamh ha la <em>Spada Antica</em> dal §123, quindi tira <strong>2d6 + 3</strong>. Il Goblin Captain ha CD 9, quindi colpisci con 6+.
+                  Se vinci, vai al
+                  <a class="cit-pill translate" href="sp4-citation-pdf-viewer.html" target="_blank" rel="noopener" aria-label="Apri §147 in PDF viewer (citation pill)"><span class="ico">📖</span>§147</a>
+                  oppure
+                  <a class="cit-pill translate" href="sp4-citation-pdf-viewer.html" target="_blank" rel="noopener" aria-label="Apri §271 in PDF viewer (citation pill)"><span class="ico">📖</span>§271</a>
+                  per usare l'oggetto Voidstone come arma.
+                  <div class="meta-foot">
+                    <span class="conf-chip high">● alta · 94%</span>
+                    <span>· Press Start §147 · Rules p.42 §3.7</span>
+                    <span style="margin-left: auto;">22:33 · 1.2s · 412 tok · €0,0021</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="msg-row user">
+                <div class="av-msg">🎲</div>
+                <div class="bubble user">E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?</div>
+              </div>
+
+              <div class="msg-row agent">
+                <div class="av-msg">📕</div>
+                <div class="bubble agent">
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific, quindi
+                  <span class="stream-cursor"></span>
+                </div>
+              </div>
+
+              <div class="msg-row agent">
+                <div class="av-msg">📕</div>
+                <div class="typing-dots" role="status" aria-label="Tutor sta scrivendo"><span></span><span></span><span></span></div>
+              </div>
+
+              <button class="cancel-stream-cta" type="button" aria-label="Cancella streaming in corso (AbortController, riusa useThreadMessages hook PR#551)">✕ Cancella stream (4.2s)</button>
+            </div>
+
+            <div class="composer">
+              <div class="composer-row">
+                <div class="composer-tools">
+                  <button class="tool-btn aaron" type="button" title="Allega foto (Aaron: apre flow translate Task 4 — librogame-runthrough-translate-viewer.html ?mode=manual)" aria-label="Allega foto — ponte verso translate flow">📎</button>
+                  <button class="tool-btn" type="button" title="Microfono (voice — UI placeholder, Whisper deferito)" aria-label="Microfono — UI placeholder, backend Whisper deferito v1">🎤</button>
+                </div>
+                <textarea class="composer-input" placeholder="In attesa della risposta…" rows="1" disabled aria-label="Composer (disabled durante streaming)"></textarea>
+                <button class="send-btn" type="button" disabled aria-label="Invia (disabled durante streaming)">➤</button>
+              </div>
+            </div>
+
+            <div class="telemetry-foot" aria-label="Telemetria chat">
+              <span class="pip live">● <span class="v">streaming</span> · 4.2s</span>
+              <span class="pip"><span>cost:</span> <span class="v">€0,0034</span></span>
+              <span class="pip"><span>tok:</span> <span class="v">418/2k</span></span>
+              <span class="pip warn"><span>quota:</span> <span class="v">12/15 free</span></span>
+              <span class="spacer"></span>
+              <span class="wake-lock-badge active" title="Wake-lock attivo durante streaming (riusa pattern Task 2 sez 1b.C)">🔆 wake-lock attivo</span>
+              <span class="pip"><span>view:</span> <span class="v">full-screen</span></span>
+            </div>
+          </section>
+
+          <!-- ── Sidebar DX · agent + sources + actions ── -->
+          <aside class="sidebar-r" aria-label="Pannello contesto (agent, fonti, azioni)">
+            <div class="agent-mini">
+              <div class="row1">
+                <div class="av">📕</div>
+                <div class="info">
+                  <div class="name">Tutor Runa di Ardenel</div>
+                  <div class="persona">Libro-game · narratore</div>
+                </div>
+              </div>
+              <p style="margin: 0; font-size: var(--fs-xs); color: var(--text-sec); line-height: var(--lh-snug);">
+                Risponde a domande sul gamebook, ricorda decisioni narrative, traduce paragrafi EN→IT. Non spoilera scelte future.
+              </p>
+              <div class="stats">
+                <div class="s-item"><span class="v">12</span> query oggi</div>
+                <div class="s-item"><span class="v">5</span> citazioni</div>
+                <div class="s-item"><span class="v">3</span> personaggi</div>
+              </div>
+            </div>
+
+            <div class="panel-section">
+              <h4>Fonti citate · 3</h4>
+              <button class="src-card" type="button" aria-label="Apri Press Start §147 in PDF viewer">
+                <span class="ico">📖</span>
+                <div class="l">
+                  <div class="v">Press Start · §147</div>
+                  <div class="s">Goblin Captain encounter · p.42</div>
+                </div>
+              </button>
+              <button class="src-card" type="button" aria-label="Apri Rules §3.7 in PDF viewer">
+                <span class="ico">📖</span>
+                <div class="l">
+                  <div class="v">Rules · §3.7</div>
+                  <div class="s">Malus ferita + situazionali · p.42</div>
+                </div>
+              </button>
+              <button class="src-card" type="button" aria-label="Apri §271 Voidstone in PDF viewer">
+                <span class="ico">📖</span>
+                <div class="l">
+                  <div class="v">Encounter Book · §271</div>
+                  <div class="s">Voidstone · oggetto non perdibile</div>
+                </div>
+              </button>
+            </div>
+
+            <div class="panel-section">
+              <h4>Azioni suggerite</h4>
+              <button class="action-card" type="button" aria-label="Apri libro pag 42 in viewer">
+                <span class="ico">📕</span><span>Apri libro pag 42</span><span class="arrow">›</span>
+              </button>
+              <button class="action-card" type="button" aria-label="Crea play record per encounter §147">
+                <span class="ico">🎲</span><span>Crea play record (§147)</span><span class="arrow">›</span>
+              </button>
+              <button class="action-card" type="button" aria-label="Apri glossario translate-viewer Task 4">
+                <span class="ico">📖</span><span>Glossario campagna</span><span class="arrow">›</span>
+              </button>
+              <button class="action-card" type="button" aria-label="Riapri come slide-over (passa a nanolith-nav-chat-panel pattern)">
+                <span class="ico">↩</span><span>Modalità slide-over</span><span class="arrow">›</span>
+              </button>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <strong>💡 Pattern routing (slide-over ↔ full-screen):</strong> automatico per viewport. Mobile/tablet (&lt;1024px) → full-screen sempre. Desktop (≥1024px) → slide-over default (`nanolith-nav-chat-panel.html`) con toggle "↗ Apri full-screen" → questa route. Stream usa `useThreadMessages` hook PR#551 (AbortController per cancel istantaneo). Citation pill → `sp4-citation-pdf-viewer.html` overlay (RIUSO pattern, NO fork).
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       SCREEN B11b-1 · DESKTOP · stream-error state (Nygard failure mode 3)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s1err">
+    <span class="label">Screen B11b-1 · Desktop · stream-error<span class="cmp">ChatFullscreenDesktop · failure mode</span></span>
+    <h2 id="s1err">Desktop 3-col · stream-error state · last user message preserved in composer</h2>
+    <p class="desc">Nygard failure mode 3 — connection drop o timeout server. Banner "Errore stream — riprova" sopra al composer, last user message conservato in composer (NO perdita). Retry CTA invia stessa query con stesso AbortController.</p>
+
+    <div class="frames">
+      <div class="desktop" role="region" aria-label="Desktop 3-col chat — stream-error state">
+        <span class="frame-label">Desktop · 1280px · stream-state: stream-error</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/chat/thread-runa-147 ← stream-error</span></div>
+
+        <div class="chat-3col">
+          <aside class="sidebar-l" aria-label="Thread list (compressed)">
+            <div class="sl-head">
+              <div class="sl-tabs"><button class="tab active">Tutti</button><button class="tab">Preferiti</button><button class="tab">Archiviati</button></div>
+              <input type="text" class="sl-search" placeholder="🔍 Cerca…"/>
+            </div>
+            <button class="sl-cta"><span>＋</span><span>Nuova chat</span></button>
+            <div class="sl-list">
+              <div class="group-h">Oggi</div>
+              <button class="sl-thread libro active"><div class="av">📕</div><div class="info"><div class="ti">Sera con i ragazzi · §147</div><div class="pv">…malus Reaver…</div></div><div class="meta"><span class="ts">22:36</span></div></button>
+              <button class="sl-thread boardgame"><div class="av">🦅</div><div class="info"><div class="ti">Wingspan · scoring</div><div class="pv">Bonus ornitologo…</div></div><div class="meta"><span class="ts">ieri</span></div></button>
+            </div>
+          </aside>
+
+          <section class="main-c" aria-label="Conversazione attiva — stream-error">
+            <div class="main-h">
+              <div class="ag">📕</div>
+              <div class="ti-block"><div class="ti">Sera con i ragazzi · §147</div><div class="sub">stream: <strong style="color: hsl(var(--c-event));">stream-error</strong> · timeout 30s</div></div>
+              <div class="actions"><button class="icon-btn active" type="button">📖</button><button class="icon-btn">⭐</button><button class="icon-btn">⋮</button></div>
+            </div>
+            <div class="stream" role="log" aria-live="polite">
+              <div class="ts-divider">oggi · 22:33</div>
+              <div class="msg-row user"><div class="av-msg">🎲</div><div class="bubble user">E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?</div></div>
+              <div class="msg-row agent">
+                <div class="av-msg">📕</div>
+                <div class="bubble agent">
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific, quindi
+                  <span class="abort-badge" aria-label="Stream interrotto da errore">⚠ stream-error</span>
+                </div>
+              </div>
+              <div class="stream-error-banner" role="alert" aria-label="Errore stream — retry disponibile">
+                <span class="ico">⚠️</span>
+                <div class="info">
+                  <div class="v">Errore stream — connessione interrotta dopo 30s idle</div>
+                  <div class="s">Last user message conservato nel composer · click "Riprova" per re-inviare con stesso AbortController</div>
+                </div>
+                <button class="retry" type="button" aria-label="Riprova stream con stesso messaggio">↻ Riprova</button>
+              </div>
+            </div>
+            <div class="composer">
+              <div class="composer-row">
+                <div class="composer-tools">
+                  <button class="tool-btn aaron" type="button" title="Allega foto">📎</button>
+                  <button class="tool-btn" type="button" title="Microfono">🎤</button>
+                </div>
+                <textarea class="composer-input" aria-label="Composer — last user message preserved">E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?</textarea>
+                <button class="send-btn" type="button" aria-label="Invia">➤</button>
+              </div>
+            </div>
+            <div class="telemetry-foot">
+              <span class="pip warn">● <span class="v">stream-error</span> · 30.0s timeout</span>
+              <span class="pip"><span>cost:</span> <span class="v">€0,0019</span> (parziale)</span>
+              <span class="pip"><span>tok:</span> <span class="v">187/2k</span></span>
+              <span class="pip warn"><span>quota:</span> <span class="v">12/15 free</span></span>
+              <span class="spacer"></span>
+              <span class="wake-lock-badge disabled" title="Wake-lock rilasciato (stream-error termina sessione)">🔆 wake-lock off</span>
+            </div>
+          </section>
+
+          <aside class="sidebar-r" aria-label="Pannello contesto">
+            <div class="agent-mini">
+              <div class="row1"><div class="av">📕</div><div class="info"><div class="name">Tutor Runa</div><div class="persona">Libro-game</div></div></div>
+            </div>
+            <div class="panel-section"><h4>Fonti citate · 2</h4>
+              <button class="src-card"><span class="ico">📖</span><div class="l"><div class="v">Press Start · §147</div><div class="s">Goblin Captain</div></div></button>
+              <button class="src-card"><span class="ico">📖</span><div class="l"><div class="v">Rules · §3.7</div><div class="s">Malus ferita</div></div></button>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <strong>⚠️ Nygard failure mode 3 (stream-error):</strong> last user message preserved in composer protegge contro perdita lavoro su retry. Server-side timeout 30s idle (configurabile), hard timeout 60s end-to-end. AbortController già istanziato dal hook viene riusato per retry → niente race-condition.
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       SCREEN B11b-1 · DESKTOP · stream-abort state (Nygard failure mode 4)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s1abort">
+    <span class="label">Screen B11b-1 · Desktop · stream-abort<span class="cmp">ChatFullscreenDesktop · user-initiated cancel</span></span>
+    <h2 id="s1abort">Desktop 3-col · stream-abort state · user clicked cancel CTA</h2>
+    <p class="desc">Nygard failure mode 4 — utente click cancel CTA visibile durante streaming. AbortController aborts immediately (&lt;100ms). Message preserved con badge "[interrotto]" — semantics chiare per chi rilegge la conversazione.</p>
+
+    <div class="frames">
+      <div class="desktop" role="region" aria-label="Desktop 3-col chat — stream-abort state">
+        <span class="frame-label">Desktop · 1280px · stream-state: stream-abort</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/chat/thread-runa-147 ← stream-abort</span></div>
+        <div class="chat-3col">
+          <aside class="sidebar-l" aria-label="Thread list (compressed)">
+            <div class="sl-head"><div class="sl-tabs"><button class="tab active">Tutti</button><button class="tab">Preferiti</button><button class="tab">Archiviati</button></div></div>
+            <button class="sl-cta"><span>＋</span><span>Nuova chat</span></button>
+            <div class="sl-list">
+              <button class="sl-thread libro active"><div class="av">📕</div><div class="info"><div class="ti">Sera con i ragazzi · §147</div><div class="pv">…cumula malus…</div></div><div class="meta"><span class="ts">22:37</span></div></button>
+            </div>
+          </aside>
+          <section class="main-c" aria-label="Conversazione — stream-abort">
+            <div class="main-h">
+              <div class="ag">📕</div>
+              <div class="ti-block"><div class="ti">Sera con i ragazzi · §147</div><div class="sub">stream: <strong style="color: hsl(var(--c-warning));">stream-abort</strong> · user cancel @4.2s</div></div>
+              <div class="actions"><button class="icon-btn active" type="button">📖</button><button class="icon-btn">⭐</button><button class="icon-btn">⋮</button></div>
+            </div>
+            <div class="stream" role="log">
+              <div class="msg-row user"><div class="av-msg">🎲</div><div class="bubble user">E se ho 2 ferite…</div></div>
+              <div class="msg-row agent">
+                <div class="av-msg">📕</div>
+                <div class="bubble agent">
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific
+                  <span class="abort-badge" aria-label="Stream interrotto da utente">⊘ interrotto</span>
+                  <div class="meta-foot">
+                    <span class="conf-chip med">● parziale · 60%</span>
+                    <span>· 4.2s · cancelled by user · 124 tok partial</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="composer">
+              <div class="composer-row">
+                <div class="composer-tools"><button class="tool-btn aaron">📎</button><button class="tool-btn">🎤</button></div>
+                <textarea class="composer-input" placeholder="Scrivi un messaggio…" rows="1"></textarea>
+                <button class="send-btn">➤</button>
+              </div>
+            </div>
+            <div class="telemetry-foot">
+              <span class="pip"><span class="v">idle</span> · 12s da cancel</span>
+              <span class="pip"><span>cost:</span> <span class="v">€0,0011</span> (parziale)</span>
+              <span class="pip"><span>tok:</span> <span class="v">124/2k</span></span>
+              <span class="pip warn"><span>quota:</span> <span class="v">12/15 free</span></span>
+              <span class="spacer"></span>
+              <span class="wake-lock-badge disabled">🔆 wake-lock off</span>
+            </div>
+          </section>
+          <aside class="sidebar-r">
+            <div class="agent-mini"><div class="row1"><div class="av">📕</div><div class="info"><div class="name">Tutor Runa</div><div class="persona">Libro-game</div></div></div></div>
+          </aside>
+        </div>
+      </div>
+    </div>
+
+    <div class="cost-banner" aria-label="Cost transparency banner">
+      <span class="ico">💸</span>
+      <span><span class="v">Cost transparency:</span> stream-abort fattura solo i token effettivamente generati (124 tok = €0,0011). Rate-limit e quota free contati su query inviata, non su completion size.</span>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       SCREEN B11b-2 · MOBILE single-pane
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s2">
+    <span class="label">Screen B11b-2 · Mobile single-pane<span class="cmp">ChatFullscreenMobile · 375px</span></span>
+    <h2 id="s2">Mobile · /chat/[threadId] · header sticky + bottom sheet context</h2>
+    <p class="desc">Mobile single-pane: header sticky con ← back + thread title + agent avatar + kebab ⋮. Stream centrato. Bottom composer fixed con autoresize 1-row default. Tap header (ti-block) → bottom sheet con context panel (agent + sources + actions). Tap citation pill → PDF viewer overlay full-screen (sp4-citation-pdf-viewer). 4 stream states (idle, streaming, error, abort) gestiti identici desktop, solo layout diverso.</p>
+
+    <div class="frames">
+
+      <!-- Mobile · stream-state idle (composer empty, ready) -->
+      <div class="phone" role="region" aria-label="Mobile · idle state">
+        <span class="frame-label">Mobile · 375px · stream-state: idle</span>
+        <div class="phone-sbar"><span>22:14</span><span>📶 🔋 78%</span></div>
+        <div class="mob-h">
+          <button class="back" aria-label="Indietro">←</button>
+          <div class="ti-block" aria-label="Apri context panel (bottom sheet)" role="button" tabindex="0">
+            <div class="ti">Sera con i ragazzi · §147</div>
+            <div class="sub">Tutor Runa · 12 query oggi</div>
+          </div>
+          <div class="av">📕</div>
+          <button class="kebab" aria-label="Altre azioni">⋮</button>
+        </div>
+        <div class="mob-stream" role="log">
+          <div class="ts-divider">oggi · 22:14</div>
+          <div class="msg-row user"><div class="av-msg">🎲</div><div class="bubble user">Niamh affronta Goblin Captain §147. 2d6 + bonus spada?</div></div>
+          <div class="msg-row agent">
+            <div class="av-msg">📕</div>
+            <div class="bubble agent">
+              Sì — Spada Antica da §123, tira 2d6 + 3. Goblin Captain CD 9, colpisci con 6+.
+              <a class="cit-pill translate" href="sp4-citation-pdf-viewer.html"><span class="ico">📖</span>§147</a>
+              <div class="meta-foot">
+                <span class="conf-chip high">● alta · 94%</span>
+                <span style="margin-left: auto;">22:33</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mob-composer">
+          <div class="composer-row">
+            <div class="composer-tools" style="flex-direction: row;">
+              <button class="tool-btn aaron" type="button" title="Allega foto (Aaron: apre flow translate)">📎</button>
+              <button class="tool-btn" type="button" title="Microfono (UI placeholder)">🎤</button>
+            </div>
+            <textarea class="composer-input" placeholder="Scrivi al Tutor…" rows="1"></textarea>
+            <button class="send-btn" disabled aria-label="Invia (disabled — composer vuoto)">➤</button>
+          </div>
+        </div>
+        <div class="telemetry-foot">
+          <span class="pip"><span class="v">idle</span></span>
+          <span class="pip warn">quota: <span class="v">12/15</span></span>
+          <span class="spacer"></span>
+          <span class="wake-lock-badge disabled">🔆 off</span>
+        </div>
+      </div>
+
+      <!-- Mobile · stream-state streaming -->
+      <div class="phone" role="region" aria-label="Mobile · streaming state">
+        <span class="frame-label">Mobile · 375px · stream-state: streaming</span>
+        <div class="phone-sbar"><span>22:34</span><span>📶 🔋 76%</span></div>
+        <div class="mob-h">
+          <button class="back" aria-label="Indietro">←</button>
+          <div class="ti-block" role="button" tabindex="0">
+            <div class="ti">Sera con i ragazzi · §147</div>
+            <div class="sub">streaming · 4.2s</div>
+          </div>
+          <div class="av">📕</div>
+          <button class="kebab" aria-label="Altre azioni">⋮</button>
+        </div>
+        <div class="mob-stream" role="log">
+          <div class="msg-row user"><div class="av-msg">🎲</div><div class="bubble user">Se ho 2 ferite, malus −2 cumula con Reaver?</div></div>
+          <div class="msg-row agent">
+            <div class="av-msg">📕</div>
+            <div class="bubble agent">
+              I malus di ferita cumulano solo con malus situazionali (oscurità, distanza)
+              <span class="stream-cursor"></span>
+            </div>
+          </div>
+          <button class="cancel-stream-cta" type="button">✕ Cancella (4.2s)</button>
+        </div>
+        <div class="mob-composer">
+          <div class="composer-row">
+            <div class="composer-tools" style="flex-direction: row;">
+              <button class="tool-btn aaron" disabled>📎</button>
+              <button class="tool-btn" disabled>🎤</button>
+            </div>
+            <textarea class="composer-input" disabled placeholder="In attesa risposta…" rows="1"></textarea>
+            <button class="send-btn" disabled>➤</button>
+          </div>
+        </div>
+        <div class="telemetry-foot">
+          <span class="pip live">● <span class="v">streaming</span></span>
+          <span class="pip"><span>tok:</span> <span class="v">187</span></span>
+          <span class="spacer"></span>
+          <span class="wake-lock-badge active">🔆 attivo</span>
+        </div>
+      </div>
+
+      <!-- Mobile · bottom sheet open (context panel su tap header) -->
+      <div class="phone" role="region" aria-label="Mobile · bottom sheet context aperto">
+        <span class="frame-label">Mobile · 375px · bottom-sheet context</span>
+        <div class="phone-sbar"><span>22:36</span><span>📶 🔋 74%</span></div>
+        <div class="mob-h">
+          <button class="back">←</button>
+          <div class="ti-block"><div class="ti">Sera con i ragazzi · §147</div><div class="sub">tap per chiudere context</div></div>
+          <div class="av">📕</div>
+          <button class="kebab">⋮</button>
+        </div>
+        <div class="mob-stream" style="opacity: 0.4;">
+          <div class="msg-row user"><div class="av-msg">🎲</div><div class="bubble user">…2 ferite + Reaver?</div></div>
+          <div class="msg-row agent"><div class="av-msg">📕</div><div class="bubble agent">…malus situazionali…</div></div>
+        </div>
+        <div class="mob-sheet-backdrop" aria-hidden="true"></div>
+        <aside class="mob-sheet" role="dialog" aria-modal="true" aria-label="Context panel (agent · fonti · azioni)">
+          <div class="grip" aria-hidden="true"></div>
+          <div class="agent-mini" style="border-bottom: none; padding: var(--s-2) var(--s-3) var(--s-3);">
+            <div class="row1">
+              <div class="av">📕</div>
+              <div class="info"><div class="name">Tutor Runa di Ardenel</div><div class="persona">Libro-game · 12 query oggi</div></div>
+            </div>
+          </div>
+          <div class="panel-section">
+            <h4>Fonti citate · 3</h4>
+            <button class="src-card"><span class="ico">📖</span><div class="l"><div class="v">Press Start · §147</div><div class="s">Goblin Captain · p.42</div></div></button>
+            <button class="src-card"><span class="ico">📖</span><div class="l"><div class="v">Rules · §3.7</div><div class="s">Malus ferita</div></div></button>
+            <button class="src-card"><span class="ico">📖</span><div class="l"><div class="v">Encounter · §271</div><div class="s">Voidstone</div></div></button>
+          </div>
+          <div class="panel-section">
+            <h4>Azioni suggerite</h4>
+            <button class="action-card"><span class="ico">📕</span><span>Apri libro pag 42</span><span class="arrow">›</span></button>
+            <button class="action-card"><span class="ico">🎲</span><span>Crea play record</span><span class="arrow">›</span></button>
+          </div>
+        </aside>
+      </div>
+    </div>
+
+    <div class="note">
+      <strong>📱 Pattern mobile (single-pane):</strong> tap su header (ti-block) apre bottom-sheet con context panel (agent + sources + actions) — pattern condensato della sidebar dx desktop. Tap citation pill apre PDF viewer overlay full-screen (`sp4-citation-pdf-viewer.html`). Composer autoresize 1-row default → max 4 rows. Voice 🎤 UI placeholder (Whisper deferito v1). Attachment 📎 Aaron-specific apre flow translate (`librogame-runthrough-translate-viewer.html` ?mode=manual o camera).
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       SCREEN B11b-3 · EMPTY STATE /chat/new
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s3">
+    <span class="label">Screen B11b-3 · Empty state /chat/new<span class="cmp">ChatEmptyState · 3 variants per agent type</span></span>
+    <h2 id="s3">Empty state /chat/new · Hero centered + 4 quick-starter cards (3 variants)</h2>
+    <p class="desc">Hero centrato 💬 + title "Inizia una conversazione" + subtitle. 4 quick-starter cards grid 2x2 mobile, 1x4 desktop. <strong>3 variants</strong> per agent type (`agent.metadata.category`): <em>Libro-game</em> (Aaron narrative), <em>Boardgamer</em> (board game generic), <em>Default</em> (no agent — CTA picker dropdown). Fallback graceful a "Default" se field mancante.</p>
+
+    <div class="frames">
+
+      <!-- Variant 1: Libro-game (Aaron) — desktop -->
+      <div class="desktop" style="min-height: 680px;" role="region" aria-label="Desktop empty state — Libro-game variant (Aaron)">
+        <span class="frame-label">Desktop · 1280px · /chat/new?agent=tutor-runa · variant: <strong>Libro-game</strong></span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/chat/new?agent=tutor-runa-ardenel</span></div>
+        <div class="chat-3col">
+          <aside class="sidebar-l">
+            <div class="sl-head"><div class="sl-tabs"><button class="tab active">Tutti</button><button class="tab">Preferiti</button><button class="tab">Archiviati</button></div></div>
+            <button class="sl-cta"><span>＋</span><span>Nuova chat</span></button>
+            <div class="sl-list">
+              <div class="group-h">Recenti</div>
+              <button class="sl-thread libro"><div class="av">📕</div><div class="info"><div class="ti">Sera con i ragazzi · §147</div><div class="pv">…malus Reaver…</div></div><div class="meta"><span class="ts">22:37</span></div></button>
+            </div>
+          </aside>
+          <section class="main-c">
+            <div class="main-h">
+              <div class="ag">📕</div>
+              <div class="ti-block"><div class="ti">Nuova chat con Tutor Runa di Ardenel</div><div class="sub">Libro-game · agent.metadata.category=<code>libro-game</code></div></div>
+            </div>
+            <div class="empty-shell">
+              <div class="hero-icon" aria-hidden="true">💬</div>
+              <h2>Inizia una conversazione</h2>
+              <p class="subtitle">Chiedi al tuo agent una regola, una strategia, un riassunto o traduci un paragrafo del libro.</p>
+              <div class="qs-grid desk-1x4">
+                <button class="qs-card libro" type="button" aria-label="Quick starter Libro-game — regole">
+                  <span class="qs-ico">📜</span>
+                  <span class="qs-cat">Libro-game · regole</span>
+                  <span class="qs-q">Quali sono le regole di Press Start?</span>
+                </button>
+                <button class="qs-card libro" type="button" aria-label="Quick starter Libro-game — encounter">
+                  <span class="qs-ico">⚔️</span>
+                  <span class="qs-cat">Libro-game · encounter</span>
+                  <span class="qs-q">Spiega questa Encounter (foto §147)</span>
+                </button>
+                <button class="qs-card libro" type="button" aria-label="Quick starter Libro-game — riassunto">
+                  <span class="qs-ico">📖</span>
+                  <span class="qs-cat">Libro-game · riassunto</span>
+                  <span class="qs-q">Riassumi paragrafo 42 in italiano</span>
+                </button>
+                <button class="qs-card libro" type="button" aria-label="Quick starter Libro-game — personaggi">
+                  <span class="qs-ico">🧙</span>
+                  <span class="qs-cat">Libro-game · personaggi</span>
+                  <span class="qs-q">Lista personaggi nella campagna</span>
+                </button>
+              </div>
+              <div class="cost-banner" style="margin-top: var(--s-5);">
+                <span class="ico">💸</span>
+                <span><span class="v">Cost-aware suggestion:</span> ogni quick-starter usa Tutor cache hit quando possibile (paragrafi già tradotti → 0 cost). Foto Encounter scatena flow translate Task 4 (~€0,01 per re-OCR).</span>
+              </div>
+            </div>
+            <div class="composer">
+              <div class="composer-row">
+                <div class="composer-tools">
+                  <button class="tool-btn aaron" title="Allega foto (Aaron: apre flow translate)">📎</button>
+                  <button class="tool-btn" title="Microfono (UI placeholder)">🎤</button>
+                </div>
+                <textarea class="composer-input" placeholder="Scrivi al Tutor…" rows="1"></textarea>
+                <button class="send-btn" disabled>➤</button>
+              </div>
+            </div>
+            <div class="telemetry-foot">
+              <span class="pip"><span class="v">idle · /chat/new</span></span>
+              <span class="pip"><span>variant:</span> <span class="v">libro-game</span></span>
+              <span class="pip warn"><span>quota:</span> <span class="v">12/15 free</span></span>
+              <span class="spacer"></span>
+              <span class="wake-lock-badge disabled">🔆 off</span>
+            </div>
+          </section>
+          <aside class="sidebar-r">
+            <div class="agent-mini">
+              <div class="row1">
+                <div class="av">📕</div>
+                <div class="info"><div class="name">Tutor Runa di Ardenel</div><div class="persona">Libro-game · narratore</div></div>
+              </div>
+              <p style="margin: 0; font-size: var(--fs-xs); color: var(--text-sec); line-height: var(--lh-snug);">Specializzato in gamebook narrative. Traduce paragrafi, gestisce glossario campagna, ricorda decisioni narrative cross-session.</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <!-- Variant 2: Boardgamer — mobile -->
+      <div class="phone" role="region" aria-label="Mobile empty state — Boardgamer variant">
+        <span class="frame-label">Mobile · 375px · /chat/new · variant: <strong>Boardgamer</strong></span>
+        <div class="phone-sbar"><span>21:05</span><span>📶 🔋 84%</span></div>
+        <div class="mob-h">
+          <button class="back">←</button>
+          <div class="ti-block"><div class="ti">Nuova chat · Mago di Wingspan</div><div class="sub">Boardgamer · meta.category=boardgame</div></div>
+          <div class="av" style="background: hsl(var(--c-game) / 0.18); color: hsl(var(--c-game));">🦅</div>
+        </div>
+        <div class="empty-shell" style="padding: var(--s-7) var(--s-4);">
+          <div class="hero-icon" aria-hidden="true">💬</div>
+          <h2 style="font-size: var(--fs-xl);">Inizia con Wingspan</h2>
+          <p class="subtitle">Setup, regole edge case, strategie comuni o FAQ del gioco.</p>
+          <div class="qs-grid">
+            <button class="qs-card boardgame" type="button" aria-label="Quick starter Boardgamer — setup">
+              <span class="qs-ico">🎲</span>
+              <span class="qs-cat">Boardgamer · setup</span>
+              <span class="qs-q">Setup iniziale Wingspan 3 giocatori</span>
+            </button>
+            <button class="qs-card boardgame" type="button" aria-label="Quick starter Boardgamer — edge case">
+              <span class="qs-ico">⚖️</span>
+              <span class="qs-cat">Boardgamer · regole</span>
+              <span class="qs-q">Regole edge case (predatore + jolly)</span>
+            </button>
+            <button class="qs-card boardgame" type="button" aria-label="Quick starter Boardgamer — strategie">
+              <span class="qs-ico">🧠</span>
+              <span class="qs-cat">Boardgamer · strategia</span>
+              <span class="qs-q">Strategie comuni habitat foresta</span>
+            </button>
+            <button class="qs-card boardgame" type="button" aria-label="Quick starter Boardgamer — FAQ">
+              <span class="qs-ico">❓</span>
+              <span class="qs-cat">Boardgamer · FAQ</span>
+              <span class="qs-q">FAQ ufficiali del gioco</span>
+            </button>
+          </div>
+        </div>
+        <div class="mob-composer">
+          <div class="composer-row">
+            <div class="composer-tools" style="flex-direction: row;">
+              <button class="tool-btn" title="Allega regolamento">📎</button>
+              <button class="tool-btn" title="Microfono (UI placeholder)">🎤</button>
+            </div>
+            <textarea class="composer-input" placeholder="Scrivi al Mago…" rows="1"></textarea>
+            <button class="send-btn" disabled>➤</button>
+          </div>
+        </div>
+        <div class="telemetry-foot">
+          <span class="pip"><span class="v">idle</span></span>
+          <span class="pip"><span>variant:</span> <span class="v">boardgame</span></span>
+          <span class="spacer"></span>
+          <span class="wake-lock-badge disabled">🔆 off</span>
+        </div>
+      </div>
+
+      <!-- Variant 3: Default (no agent) — mobile picker -->
+      <div class="phone" role="region" aria-label="Mobile empty state — Default variant (no agent)">
+        <span class="frame-label">Mobile · 375px · /chat/new · variant: <strong>Default</strong> (no agent · fallback)</span>
+        <div class="phone-sbar"><span>21:08</span><span>📶 🔋 82%</span></div>
+        <div class="mob-h">
+          <button class="back">←</button>
+          <div class="ti-block"><div class="ti">Nuova chat</div><div class="sub">Default · nessun agent selezionato · fallback graceful (meta.category mancante o &quot;default&quot;)</div></div>
+        </div>
+        <div class="empty-shell" style="padding: var(--s-7) var(--s-4);">
+          <div class="hero-icon" aria-hidden="true">💬</div>
+          <h2 style="font-size: var(--fs-xl);">Scegli un agent</h2>
+          <p class="subtitle">Non hai ancora selezionato un agent. Sceglilo dalla lista o crea una nuova chat dall'index agent.</p>
+          <button class="agent-picker-trig" type="button" aria-label="Apri agent picker dropdown">
+            <span>🧙</span><span>Scegli agent</span><span style="opacity: 0.7;">▾</span>
+          </button>
+          <div class="agent-picker-list" role="listbox" aria-label="Lista agent disponibili">
+            <button class="ag-item" role="option" aria-selected="false">
+              <div class="av" style="background: hsl(var(--c-kb) / 0.18); color: hsl(var(--c-kb));">📕</div>
+              <div class="info"><div class="nm">Tutor Runa di Ardenel</div><div class="lu">libro-game · last used 5min fa</div></div>
+            </button>
+            <button class="ag-item" role="option" aria-selected="false">
+              <div class="av" style="background: hsl(var(--c-game) / 0.18); color: hsl(var(--c-game));">🦅</div>
+              <div class="info"><div class="nm">Mago di Wingspan</div><div class="lu">boardgame · last used 2h fa</div></div>
+            </button>
+            <button class="ag-item" role="option" aria-selected="false">
+              <div class="av" style="background: hsl(var(--c-game) / 0.18); color: hsl(var(--c-game));">🚂</div>
+              <div class="info"><div class="nm">Brass: Birmingham Tutor</div><div class="lu">boardgame · last used 2g fa</div></div>
+            </button>
+          </div>
+        </div>
+        <div class="telemetry-foot">
+          <span class="pip"><span class="v">idle · no agent</span></span>
+          <span class="pip"><span>variant:</span> <span class="v">default</span></span>
+          <span class="spacer"></span>
+          <span class="wake-lock-badge disabled">🔆 off</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <strong>💡 Quick-starter selection logic:</strong> agent type derivato da `agent.metadata.category` field (verificato a runtime). Tre branch: <code>libro-game</code> → 4 prompts narrative gamebook (regole · encounter · riassunto · personaggi); <code>boardgame</code> → 4 prompts board game generici (setup · edge case · strategie · FAQ); altri valori o field mancante → <code>Default</code> variant con agent picker dropdown CTA. <strong>Fallback graceful:</strong> mai broken-state, l'utente vede sempre qualcosa di utilizzabile.
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       PATTERN DECISIONS (riepilogo finale)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="s4">
+    <span class="label">Pattern decisions · riepilogo<span class="cmp">cross-ref Task 1-4 + PR#551 + sp4-*</span></span>
+    <h2 id="s4">Pattern decisions consolidati</h2>
+    <p class="desc">Riepilogo decisioni che differenziano la chat full-screen rispetto allo slide-over component-mock e ai pattern di reference.</p>
+
+    <div class="frames" style="flex-direction: column; max-width: 920px;">
+      <div class="note">
+        <strong>🪟 Slide-over ↔ full-screen routing (viewport-driven):</strong><br/>
+        Mobile/tablet (&lt;1024px) → <em>full-screen sempre</em> (slide-over diventa drawer fallback)<br/>
+        Desktop (≥1024px) → <em>slide-over default</em> (`nanolith-nav-chat-panel.html`), toggle "↗ Apri full-screen" → questa route (`/chat/[threadId]`)
+      </div>
+      <div class="note">
+        <strong>⚡ Streaming (riusa hook PR#551):</strong><br/>
+        Token-by-token con AbortController via `useThreadMessages` hook. Cancel istantaneo &lt;100ms.<br/>
+        Stati Nygard failure modes (tutti e 4 mostrati nel mockup): <code>idle · streaming · stream-error · stream-abort</code>.<br/>
+        Latency targets: first-token P50&lt;500ms, P95&lt;1500ms, idle 30s, hard timeout 60s.
+      </div>
+      <div class="note">
+        <strong>📖 Citation pill (RIUSO `sp4-citation-pdf-viewer`):</strong><br/>
+        Click pill → PDF viewer overlay (G4 v3 pattern, ownership-gated). NO fork.<br/>
+        Variant Aaron: pill `.cit-pill.translate` (color `--c-kb`) per citation da translate flow.
+      </div>
+      <div class="note">
+        <strong>📷 Attachment Aaron-specific (ponte chat ↔ translate):</strong><br/>
+        Tool 📎 in composer apre flow translate (`librogame-runthrough-translate-viewer.html` ?mode=manual o camera).<br/>
+        Risposta translate ritorna come citation pill `.cit-pill.translate` in chat (paragrafo §123 IT).<br/>
+        Voice 🎤 = UI placeholder (Whisper integration deferita v1).
+      </div>
+      <div class="note">
+        <strong>📖 Reader mode + 🔆 wake-lock (coerenza Task 2 sez 1.1.1):</strong><br/>
+        Toggle 📖 nell'header attiva font 24pt sui bubble agent (`localStorage 'reader-mode-enabled'`).<br/>
+        Stessa key del translate-viewer (Task 2 sez 1b.B) → cross-route consistency Aaron passive co-player.<br/>
+        Badge wake-lock 🔆 nel telemetry footer durante streaming (3 stati: attivo · disabilitato · non-supportato).
+      </div>
+      <div class="note">
+        <strong>💸 Cost transparency (coerenza Task 1-4):</strong><br/>
+        Telemetry footer mostra cost real-time (€0,xxxx) · tok consumati · quota residua · stato wake-lock.<br/>
+        stream-abort fattura solo token effettivi (124 tok = €0,0011, non query intera).<br/>
+        Cost-aware suggestions in empty state: cache hit paragrafi → 0 cost; Encounter re-OCR ~€0,01.
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+  document.getElementById('theme-btn').addEventListener('click', () => {
+    const r = document.documentElement;
+    r.dataset.theme = r.dataset.theme === 'dark' ? 'light' : 'dark';
+  });
+</script>
+</body>
+</html>

--- a/admin-mockups/design_files/chat-fullscreen.jsx
+++ b/admin-mockups/design_files/chat-fullscreen.jsx
@@ -1,0 +1,1062 @@
+/* MeepleAI · Chat full-screen mockup (B11b · chiusura parziale issue #491)
+   Routes: /chat/[threadId]   (3 screen: Desktop 3-col, Mobile single-pane)
+           /chat/new          (Empty state, 3 quick-starter variants per agent type)
+   File: admin-mockups/design_files/chat-fullscreen.{html,jsx}
+
+   ─── Twin React-style del HTML ───
+   Component naming match HTML pattern:
+     - ChatFullscreenDesktop  → Screen B11b-1 (3-col layout)
+     - ChatFullscreenMobile   → Screen B11b-2 (single-pane)
+     - ChatEmptyState         → Screen B11b-3 (/chat/new hero + quick-starters)
+   Sub-components:
+     - ThreadList             (sidebar sx desktop, group-by oggi/ieri/settimana)
+     - ChatComposer           (textarea autoresize + attachment + voice + send)
+     - MessageBubble          (user / agent variant, reader-mode 24pt support)
+     - CitationPill           (click → sp4-citation-pdf-viewer overlay, RIUSO)
+     - AgentInfoMiniCard      (compressed sp4-agent-detail Hero pattern)
+     - SuggestedActions       (sidebar dx, "apri libro pag X", "crea play record")
+     - QuickStarterCard       (variant per agent type: libro-game/boardgame/default)
+     - TelemetryFooter        (cost transparency, latency, quota — coerenza Task 1-4)
+     - StreamErrorBanner      (Nygard failure mode 3 — last user msg preserved)
+
+   ─── Pattern decisions ───
+   - Slide-over ↔ full-screen routing: viewport-driven (<1024px → full-screen sempre)
+   - Streaming: token-by-token via `useThreadMessages` hook (PR#551)
+                AbortController per cancel istantaneo <100ms
+   - Citation pill: click → sp4-citation-pdf-viewer overlay (NO fork)
+   - Attachment Aaron-specific: foto inline apre flow translate (Task 4)
+                                librogame-runthrough-translate-viewer.html ?mode=manual o camera
+   - Voice 🎤: UI placeholder, backend Whisper integration deferita v1
+   - Quick-starter: derivato da agent.metadata.category (libro-game|boardgame|default)
+                    Fallback graceful a "default" se field mancante
+
+   ─── Reader mode + wake-lock (coerenza Task 2 sez 1.1.1) ───
+   - Toggle 📖 → bubble agent font 24pt (localStorage `reader-mode-enabled`)
+   - Wake-lock 🔆 badge nel telemetry footer durante streaming
+     3 stati: active | disabled | unsupported (Safari <16.4)
+
+   ─── Stream states (Nygard failure modes) ───
+   1. idle           — composer empty, send disabled
+   2. streaming      — token-by-token, typing dots, cancel CTA visibile
+   3. stream-error   — banner errore + retry, last user msg preserved nel composer
+   4. stream-abort   — message preserved con badge "[interrotto]", cost parziale fatturato
+
+   ─── Cross-ref ───
+   - PR#551 useThreadMessages hook → apps/web/src/components/chat/shared/use-thread-messages.ts
+   - sp4-citation-pdf-viewer.html → citation pill overlay reuse (G4 v3, NO fork)
+   - sp4-agent-detail.html → AgentInfoMiniCard pattern compresso
+   - nanolith-nav-chat-panel.html → slide-over secondary mode (viewport ≥1024px)
+   - librogame-runthrough-translate-viewer.html → Task 2+4 translate ponte
+   - audit docs/for-developers/audits/2026-05-22-mockup-gaps.md § P0
+   - spec docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md sez 6
+
+   Persona: Aaron (badsworm@gmail.com), narrative "Sera con i ragazzi · Runa di Ardenel · §147"
+            (coerenza Task 1-4). 1 thread Boardgamer (Wingspan) per multi-agent demo.
+*/
+
+const { useState, useEffect, useRef, useCallback } = React;
+
+// ─── Reader mode persistence (sez 1.1.1 coerenza Task 2 sez 1b.B) ───────
+// IMPORTANT: stessa key del translate-viewer per cross-route consistency Aaron
+const READER_MODE_KEY = 'reader-mode-enabled';
+
+const useReaderMode = () => {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    try { return window.localStorage.getItem(READER_MODE_KEY) === 'true'; }
+    catch { return false; }
+  });
+  const toggle = useCallback(() => {
+    setEnabled(prev => {
+      const next = !prev;
+      try { window.localStorage.setItem(READER_MODE_KEY, String(next)); } catch {}
+      return next;
+    });
+  }, []);
+  return [enabled, toggle];
+};
+
+// ─── Wake-lock badge (sez 1.1.1 coerenza Task 2 sez 1b.C) ───────────────
+const useWakeLock = (active) => {
+  // 'active' | 'disabled' | 'unsupported'
+  const [status, setStatus] = useState('disabled');
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('wakeLock' in navigator)) {
+      setStatus('unsupported');
+      return;
+    }
+    let lock = null;
+    if (active) {
+      navigator.wakeLock.request('screen')
+        .then(l => { lock = l; setStatus('active'); })
+        .catch(() => setStatus('disabled'));
+    } else {
+      setStatus('disabled');
+    }
+    return () => { if (lock) lock.release().catch(() => {}); };
+  }, [active]);
+  return status;
+};
+
+// ─── Sample data (narrative "Sera con i ragazzi · Runa di Ardenel · §147") ──
+const THREADS = [
+  { id: 't1', group: 'Oggi', kind: 'libro', avatar: '📕', title: 'Sera con i ragazzi · §147', preview: 'Aaron: Niamh affronta il Goblin Captain…', ts: '22:34', unread: 2, active: true },
+  { id: 't2', group: 'Oggi', kind: 'libro', avatar: '📕', title: 'Runa di Ardenel · §89', preview: 'Riassumi capitolo precedente…', ts: '14:10' },
+  { id: 't3', group: 'Ieri', kind: 'boardgame', avatar: '🦅', title: 'Wingspan · scoring fine partita', preview: 'Bonus ornitologo come si calcola?', ts: 'ieri' },
+  { id: 't4', group: 'Ieri', kind: 'libro', avatar: '📕', title: 'Press Start · setup 4 giocatori', preview: 'Press Start p.3-7 spiega che…', ts: 'ieri' },
+  { id: 't5', group: 'Settimana', kind: 'boardgame', avatar: '🚂', title: 'Brass: Birmingham · prestiti', preview: 'I prestiti aumentano VP penalty…', ts: '2g' },
+];
+
+const AGENT_RUNA = {
+  id: 'tutor-runa-ardenel',
+  name: 'Tutor Runa di Ardenel',
+  persona: 'Libro-game · narratore',
+  avatar: '📕',
+  category: 'libro-game',
+  description: 'Risponde a domande sul gamebook, ricorda decisioni narrative, traduce paragrafi EN→IT. Non spoilera scelte future.',
+  stats: { queries: 12, citations: 5, characters: 3 },
+};
+
+const AGENT_WINGSPAN = {
+  id: 'wingspan-mago',
+  name: 'Mago di Wingspan',
+  persona: 'Boardgamer · strategia',
+  avatar: '🦅',
+  category: 'boardgame',
+};
+
+// ─── Quick-starter variants (3 per agent.metadata.category) ──────────────
+const QUICK_STARTERS = {
+  'libro-game': [
+    { icon: '📜', cat: 'Libro-game · regole', q: 'Quali sono le regole di Press Start?' },
+    { icon: '⚔️', cat: 'Libro-game · encounter', q: 'Spiega questa Encounter (foto §147)' },
+    { icon: '📖', cat: 'Libro-game · riassunto', q: 'Riassumi paragrafo 42 in italiano' },
+    { icon: '🧙', cat: 'Libro-game · personaggi', q: 'Lista personaggi nella campagna' },
+  ],
+  'boardgame': [
+    { icon: '🎲', cat: 'Boardgamer · setup', q: 'Setup iniziale Wingspan 3 giocatori' },
+    { icon: '⚖️', cat: 'Boardgamer · regole', q: 'Regole edge case (predatore + jolly)' },
+    { icon: '🧠', cat: 'Boardgamer · strategia', q: 'Strategie comuni habitat foresta' },
+    { icon: '❓', cat: 'Boardgamer · FAQ', q: 'FAQ ufficiali del gioco' },
+  ],
+  'default': null, // → agent picker dropdown CTA invece di quick-starters
+};
+
+// Fallback graceful: agent senza metadata.category → 'default' variant
+const resolveQuickStarters = (agent) => {
+  if (!agent || !agent.category) return QUICK_STARTERS['default'];
+  return QUICK_STARTERS[agent.category] || QUICK_STARTERS['default'];
+};
+
+const SAMPLE_AGENTS = [
+  { id: 'tutor-runa-ardenel', name: 'Tutor Runa di Ardenel', avatar: '📕', category: 'libro-game', lastUsed: '5min fa' },
+  { id: 'wingspan-mago', name: 'Mago di Wingspan', avatar: '🦅', category: 'boardgame', lastUsed: '2h fa' },
+  { id: 'brass-tutor', name: 'Brass: Birmingham Tutor', avatar: '🚂', category: 'boardgame', lastUsed: '2g fa' },
+];
+
+// ─── Sub-component · ThreadList (sidebar sx desktop) ──────────────────────
+const ThreadList = ({ threads, activeId, onSelect }) => {
+  const groups = threads.reduce((acc, t) => {
+    acc[t.group] = acc[t.group] || [];
+    acc[t.group].push(t);
+    return acc;
+  }, {});
+  return (
+    <div className="sl-list">
+      {Object.entries(groups).map(([group, items]) => (
+        <React.Fragment key={group}>
+          <div className="group-h">{group}</div>
+          {items.map(t => (
+            <button
+              key={t.id}
+              type="button"
+              className={`sl-thread ${t.kind} ${t.id === activeId ? 'active' : ''}`}
+              onClick={() => onSelect && onSelect(t.id)}
+              aria-current={t.id === activeId ? 'true' : undefined}
+            >
+              <div className="av">{t.avatar}</div>
+              <div className="info">
+                <div className="ti">{t.title}</div>
+                <div className="pv">{t.preview}</div>
+              </div>
+              <div className="meta">
+                <span className="ts">{t.ts}</span>
+                {t.unread ? <span className="unread">{t.unread}</span> : null}
+              </div>
+            </button>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+// ─── Sub-component · CitationPill (click → sp4-citation-pdf-viewer overlay) ──
+const CitationPill = ({ paragraph, variant = 'default', onOpen }) => {
+  // variant: 'default' (kb generic) | 'translate' (Aaron flow translate, color --c-kb)
+  const className = `cit-pill${variant === 'translate' ? ' translate' : ''}`;
+  return (
+    <a
+      className={className}
+      href="sp4-citation-pdf-viewer.html"
+      target="_blank"
+      rel="noopener"
+      onClick={(e) => { if (onOpen) { e.preventDefault(); onOpen(paragraph); } }}
+      aria-label={`Apri ${paragraph} in PDF viewer (citation pill)`}
+    >
+      <span className="ico">📖</span>{paragraph}
+    </a>
+  );
+};
+
+// ─── Sub-component · MessageBubble (user/agent, reader-mode support) ─────
+const MessageBubble = ({ role, children, readerMode, meta, abortBadge, isStreaming }) => {
+  const isAgent = role === 'agent';
+  const cls = `bubble ${role}${isAgent && readerMode ? ' reader-on' : ''}`;
+  return (
+    <div className={`msg-row ${role}`}>
+      <div className="av-msg">{isAgent ? '📕' : '🎲'}</div>
+      <div className={cls}>
+        {children}
+        {isStreaming && <span className="stream-cursor" aria-hidden="true"></span>}
+        {abortBadge && (
+          <span className="abort-badge" aria-label={`Stream interrotto: ${abortBadge}`}>
+            {abortBadge === 'user' ? '⊘ interrotto' : '⚠ stream-error'}
+          </span>
+        )}
+        {meta && (
+          <div className="meta-foot">
+            {meta.confidence && (
+              <span className={`conf-chip ${meta.confidenceLevel || 'high'}`}>
+                ● {meta.confidence}
+              </span>
+            )}
+            {meta.source && <span>· {meta.source}</span>}
+            {meta.timestamp && <span style={{ marginLeft: 'auto' }}>{meta.timestamp}</span>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── Sub-component · ChatComposer (textarea + attachment + voice + send) ──
+const ChatComposer = ({
+  value,
+  onChange,
+  onSend,
+  disabled,
+  isStreaming,
+  onAttach,    // Aaron-specific: apre flow translate
+  onVoice,     // UI placeholder, Whisper deferita
+  mobile = false,
+}) => {
+  const inputRef = useRef(null);
+
+  // Autoresize 1-row default → max 4 rows
+  useEffect(() => {
+    if (!inputRef.current) return;
+    inputRef.current.style.height = 'auto';
+    const lines = Math.min((value || '').split('\n').length, 4);
+    inputRef.current.style.height = `${44 + (lines - 1) * 22}px`;
+  }, [value]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey && !disabled && !isStreaming) {
+      e.preventDefault();
+      onSend && onSend(value);
+    }
+  };
+
+  return (
+    <div className={mobile ? 'mob-composer' : 'composer'}>
+      <div className="composer-row">
+        <div className="composer-tools" style={mobile ? { flexDirection: 'row' } : {}}>
+          <button
+            type="button"
+            className="tool-btn aaron"
+            disabled={disabled || isStreaming}
+            onClick={onAttach}
+            title="Allega foto (Aaron: apre flow translate — librogame-runthrough-translate-viewer.html)"
+            aria-label="Allega foto — ponte verso translate flow Task 4"
+          >📎</button>
+          <button
+            type="button"
+            className="tool-btn"
+            disabled={disabled || isStreaming}
+            onClick={onVoice}
+            title="Microfono (voice — UI placeholder, Whisper backend deferito v1)"
+            aria-label="Microfono — UI placeholder, backend Whisper deferito"
+          >🎤</button>
+        </div>
+        <textarea
+          ref={inputRef}
+          className="composer-input"
+          placeholder={isStreaming ? 'In attesa della risposta…' : disabled ? '' : 'Scrivi un messaggio…'}
+          value={value || ''}
+          onChange={(e) => onChange && onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          disabled={disabled || isStreaming}
+          aria-label={isStreaming ? 'Composer (disabled durante streaming)' : 'Composer'}
+        />
+        <button
+          type="button"
+          className="send-btn"
+          disabled={disabled || isStreaming || !(value || '').trim()}
+          onClick={() => onSend && onSend(value)}
+          aria-label={isStreaming ? 'Invia (disabled durante streaming)' : 'Invia messaggio'}
+        >➤</button>
+      </div>
+    </div>
+  );
+};
+
+// ─── Sub-component · StreamErrorBanner (Nygard failure mode 3) ────────────
+const StreamErrorBanner = ({ message, timeout, onRetry }) => (
+  <div className="stream-error-banner" role="alert" aria-label="Errore stream — retry disponibile">
+    <span className="ico">⚠️</span>
+    <div className="info">
+      <div className="v">Errore stream — connessione interrotta dopo {timeout}s idle</div>
+      <div className="s">Last user message conservato nel composer · click "Riprova" per re-inviare con stesso AbortController</div>
+    </div>
+    <button className="retry" type="button" onClick={onRetry} aria-label="Riprova stream con stesso messaggio">
+      ↻ Riprova
+    </button>
+  </div>
+);
+
+// ─── Sub-component · AgentInfoMiniCard (compressed sp4-agent-detail Hero) ──
+const AgentInfoMiniCard = ({ agent }) => (
+  <div className="agent-mini">
+    <div className="row1">
+      <div className="av">{agent.avatar}</div>
+      <div className="info">
+        <div className="name">{agent.name}</div>
+        <div className="persona">{agent.persona}</div>
+      </div>
+    </div>
+    {agent.description && (
+      <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: 'var(--text-sec)', lineHeight: 'var(--lh-snug)' }}>
+        {agent.description}
+      </p>
+    )}
+    {agent.stats && (
+      <div className="stats">
+        <div className="s-item"><span className="v">{agent.stats.queries}</span> query oggi</div>
+        <div className="s-item"><span className="v">{agent.stats.citations}</span> citazioni</div>
+        <div className="s-item"><span className="v">{agent.stats.characters}</span> personaggi</div>
+      </div>
+    )}
+  </div>
+);
+
+// ─── Sub-component · SuggestedActions (sidebar dx, contestuali) ───────────
+const SuggestedActions = ({ actions }) => (
+  <div className="panel-section">
+    <h4>Azioni suggerite</h4>
+    {actions.map((a, i) => (
+      <button key={i} className="action-card" type="button" aria-label={a.label} onClick={a.onClick}>
+        <span className="ico">{a.icon}</span>
+        <span>{a.label}</span>
+        <span className="arrow">›</span>
+      </button>
+    ))}
+  </div>
+);
+
+// ─── Sub-component · QuickStarterCard (variant per agent type) ────────────
+const QuickStarterCard = ({ icon, cat, question, variant, onClick }) => (
+  <button
+    type="button"
+    className={`qs-card ${variant}`}
+    onClick={onClick}
+    aria-label={`Quick starter ${cat} — ${question}`}
+  >
+    <span className="qs-ico">{icon}</span>
+    <span className="qs-cat">{cat}</span>
+    <span className="qs-q">{question}</span>
+  </button>
+);
+
+// ─── Sub-component · TelemetryFooter (cost, latency, quota, wake-lock) ────
+const TelemetryFooter = ({
+  streamState,    // 'idle' | 'streaming' | 'stream-error' | 'stream-abort'
+  cost,
+  tokens,
+  quota,
+  wakeLockStatus, // 'active' | 'disabled' | 'unsupported'
+  viewMode = 'full-screen',
+  variant,        // for /chat/new empty state
+}) => {
+  const wakeLockLabel = {
+    active: '🔆 wake-lock attivo',
+    disabled: '🔆 wake-lock off',
+    unsupported: '🔆 non supportato',
+  }[wakeLockStatus] || '🔆 off';
+
+  const statePip = {
+    idle: { cls: '', label: 'idle' },
+    streaming: { cls: 'live', label: 'streaming' },
+    'stream-error': { cls: 'warn', label: 'stream-error' },
+    'stream-abort': { cls: 'warn', label: 'stream-abort' },
+  }[streamState] || { cls: '', label: streamState };
+
+  return (
+    <div className="telemetry-foot" aria-label="Telemetria chat">
+      <span className={`pip ${statePip.cls}`}>
+        {statePip.cls === 'live' ? '●' : ''} <span className="v">{statePip.label}</span>
+      </span>
+      {cost && <span className="pip"><span>cost:</span> <span className="v">€{cost}</span></span>}
+      {tokens && <span className="pip"><span>tok:</span> <span className="v">{tokens}</span></span>}
+      {quota && <span className="pip warn"><span>quota:</span> <span className="v">{quota}</span></span>}
+      {variant && <span className="pip"><span>variant:</span> <span className="v">{variant}</span></span>}
+      <span className="spacer"></span>
+      <span className={`wake-lock-badge ${wakeLockStatus}`} title={`Wake-lock ${wakeLockStatus} (sez 1.1.1 coerenza Task 2 sez 1b.C)`}>
+        {wakeLockLabel}
+      </span>
+      {viewMode && <span className="pip"><span>view:</span> <span className="v">{viewMode}</span></span>}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// SCREEN B11b-1 · ChatFullscreenDesktop (3-col layout, 1280px)
+// ═══════════════════════════════════════════════════════════════════════
+const ChatFullscreenDesktop = ({
+  threadId = 't1',
+  agent = AGENT_RUNA,
+  streamState = 'streaming',  // demo: idle | streaming | stream-error | stream-abort
+}) => {
+  const [readerMode, toggleReader] = useReaderMode();
+  const wakeLockStatus = useWakeLock(streamState === 'streaming');
+  const [composerValue, setComposerValue] = useState(
+    streamState === 'stream-error' ? 'E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?' : ''
+  );
+  const [activeThread, setActiveThread] = useState(threadId);
+  const abortRef = useRef(null);
+
+  // Riusa pattern useThreadMessages hook PR#551 (AbortController per cancel istantaneo)
+  const handleCancel = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  const handleAttach = useCallback(() => {
+    // Aaron-specific: apre flow translate (Task 4)
+    // librogame-runthrough-translate-viewer.html ?mode=manual o camera
+    window.open('librogame-runthrough-translate-viewer.html?mode=manual', '_blank');
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    // Riusa stesso AbortController dal hook — preview last user message preservato
+    abortRef.current = new AbortController();
+    // … fetch streaming endpoint with abortRef.current.signal
+  }, []);
+
+  const suggestedActions = [
+    { icon: '📕', label: 'Apri libro pag 42', onClick: () => {} },
+    { icon: '🎲', label: 'Crea play record (§147)', onClick: () => {} },
+    { icon: '📖', label: 'Glossario campagna', onClick: () => {} },
+    { icon: '↩', label: 'Modalità slide-over', onClick: () => {} }, // → nanolith-nav-chat-panel
+  ];
+
+  return (
+    <div className="desktop" role="region" aria-label="Desktop 3-col chat full-screen">
+      <div className="titlebar">
+        <span className="dot r"></span><span className="dot y"></span><span className="dot g"></span>
+        <span className="url">meepleai.app/chat/{activeThread} ← full-screen mode</span>
+      </div>
+      <div className="chat-3col">
+        {/* ── Sidebar SX · Thread list ── */}
+        <aside className="sidebar-l" aria-label="Thread list">
+          <div className="sl-head">
+            <div className="sl-tabs" role="tablist">
+              <button className="tab active" role="tab" aria-selected="true">Tutti</button>
+              <button className="tab" role="tab" aria-selected="false">Preferiti</button>
+              <button className="tab" role="tab" aria-selected="false">Archiviati</button>
+            </div>
+            <input type="text" className="sl-search" placeholder="🔍 Cerca thread…" aria-label="Cerca thread"/>
+            <button className="sl-filter" type="button" aria-label="Filtro per agent (dropdown chip)">
+              <span>🧙 Tutti gli agent</span><span className="chevron">▾</span>
+            </button>
+          </div>
+          <button className="sl-cta" type="button">
+            <span>＋</span><span>Nuova chat</span>
+          </button>
+          <ThreadList threads={THREADS} activeId={activeThread} onSelect={setActiveThread} />
+        </aside>
+
+        {/* ── MAIN · Chat stream ── */}
+        <section className="main-c" aria-label="Conversazione attiva">
+          <div className="main-h">
+            <div className="ag">{agent.avatar}</div>
+            <div className="ti-block">
+              <div className="ti">Sera con i ragazzi · §147</div>
+              <div className="sub">
+                {agent.name} · DeepSeek IT · 12 query oggi · stream: <strong>{streamState}</strong>
+              </div>
+            </div>
+            <div className="actions" role="toolbar" aria-label="Azioni thread">
+              <button
+                className={`icon-btn ${readerMode ? 'active' : ''}`}
+                type="button"
+                onClick={toggleReader}
+                aria-pressed={readerMode}
+                aria-label="Reader mode 24pt (localStorage `reader-mode-enabled`, coerenza Task 2)"
+                title="Reader mode 24pt"
+              >📖</button>
+              <button className="icon-btn" type="button" aria-label="Preferiti" title="Preferiti">⭐</button>
+              <button className="icon-btn" type="button" aria-label="Archivia" title="Archivia">📦</button>
+              <button className="icon-btn" type="button" aria-label="Altre azioni" title="Altre azioni">⋮</button>
+            </div>
+          </div>
+
+          <div className="stream" role="log" aria-live="polite" aria-relevant="additions" aria-label="Stream messaggi chat">
+            <div className="ts-divider">oggi · 22:14</div>
+
+            <MessageBubble role="user">
+              Niamh affronta il Goblin Captain al §147. Posso tirare 2d6 + bonus spada?
+            </MessageBubble>
+
+            <MessageBubble
+              role="agent"
+              readerMode={readerMode}
+              meta={{ confidence: 'alta · 94%', confidenceLevel: 'high', source: 'Press Start §147 · Rules p.42 §3.7', timestamp: '22:33 · 1.2s · 412 tok · €0,0021' }}
+            >
+              Sì — Niamh ha la <em>Spada Antica</em> dal §123, quindi tira <strong>2d6 + 3</strong>.
+              Il Goblin Captain ha CD 9, quindi colpisci con 6+. Se vinci, vai al{' '}
+              <CitationPill paragraph="§147" variant="translate" />{' '}oppure{' '}
+              <CitationPill paragraph="§271" variant="translate" />{' '}per usare l'oggetto Voidstone come arma.
+            </MessageBubble>
+
+            {streamState === 'streaming' && (
+              <>
+                <MessageBubble role="user">
+                  E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?
+                </MessageBubble>
+                <MessageBubble role="agent" readerMode={readerMode} isStreaming>
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific, quindi
+                </MessageBubble>
+                <div className="msg-row agent">
+                  <div className="av-msg">📕</div>
+                  <div className="typing-dots" role="status" aria-label="Tutor sta scrivendo">
+                    <span></span><span></span><span></span>
+                  </div>
+                </div>
+                <button
+                  className="cancel-stream-cta"
+                  type="button"
+                  onClick={handleCancel}
+                  aria-label="Cancella streaming in corso (AbortController, riusa useThreadMessages hook PR#551)"
+                >
+                  ✕ Cancella stream (4.2s)
+                </button>
+              </>
+            )}
+
+            {streamState === 'stream-error' && (
+              <>
+                <MessageBubble role="user">
+                  E se ho 2 ferite, il malus −2 si cumula con quello del Reaver?
+                </MessageBubble>
+                <MessageBubble role="agent" abortBadge="error">
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific, quindi
+                </MessageBubble>
+                <StreamErrorBanner message="" timeout={30} onRetry={handleRetry} />
+              </>
+            )}
+
+            {streamState === 'stream-abort' && (
+              <>
+                <MessageBubble role="user">E se ho 2 ferite…</MessageBubble>
+                <MessageBubble
+                  role="agent"
+                  abortBadge="user"
+                  meta={{ confidence: 'parziale · 60%', confidenceLevel: 'med', source: '4.2s · cancelled by user · 124 tok partial' }}
+                >
+                  I malus di ferita cumulano solo con malus situazionali (oscurità, distanza). Il Reaver impone un malus combat-specific
+                </MessageBubble>
+              </>
+            )}
+          </div>
+
+          <ChatComposer
+            value={composerValue}
+            onChange={setComposerValue}
+            disabled={streamState === 'streaming'}
+            isStreaming={streamState === 'streaming'}
+            onAttach={handleAttach}
+          />
+
+          <TelemetryFooter
+            streamState={streamState}
+            cost={streamState === 'streaming' ? '0,0034' : streamState === 'stream-error' ? '0,0019' : streamState === 'stream-abort' ? '0,0011' : null}
+            tokens={streamState === 'streaming' ? '418/2k' : streamState === 'stream-error' ? '187/2k' : streamState === 'stream-abort' ? '124/2k' : null}
+            quota="12/15 free"
+            wakeLockStatus={wakeLockStatus}
+            viewMode="full-screen"
+          />
+        </section>
+
+        {/* ── Sidebar DX · Agent info + Sources + Suggested actions ── */}
+        <aside className="sidebar-r" aria-label="Pannello contesto (agent, fonti, azioni)">
+          <AgentInfoMiniCard agent={agent} />
+          <div className="panel-section">
+            <h4>Fonti citate · 3</h4>
+            <button className="src-card" type="button" aria-label="Apri Press Start §147 in PDF viewer">
+              <span className="ico">📖</span>
+              <div className="l"><div className="v">Press Start · §147</div><div className="s">Goblin Captain encounter · p.42</div></div>
+            </button>
+            <button className="src-card" type="button" aria-label="Apri Rules §3.7 in PDF viewer">
+              <span className="ico">📖</span>
+              <div className="l"><div className="v">Rules · §3.7</div><div className="s">Malus ferita + situazionali · p.42</div></div>
+            </button>
+            <button className="src-card" type="button" aria-label="Apri Encounter §271 in PDF viewer">
+              <span className="ico">📖</span>
+              <div className="l"><div className="v">Encounter Book · §271</div><div className="s">Voidstone · oggetto non perdibile</div></div>
+            </button>
+          </div>
+          <SuggestedActions actions={suggestedActions} />
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// SCREEN B11b-2 · ChatFullscreenMobile (single-pane, 375px)
+// ═══════════════════════════════════════════════════════════════════════
+const ChatFullscreenMobile = ({
+  agent = AGENT_RUNA,
+  streamState = 'idle',
+  showContextSheet = false,
+}) => {
+  const [readerMode] = useReaderMode();
+  const wakeLockStatus = useWakeLock(streamState === 'streaming');
+  const [sheetOpen, setSheetOpen] = useState(showContextSheet);
+  const [composerValue, setComposerValue] = useState('');
+
+  const handleAttach = useCallback(() => {
+    // Aaron-specific: foto inline apre flow translate Task 4
+    window.open('librogame-runthrough-translate-viewer.html?mode=manual', '_blank');
+  }, []);
+
+  return (
+    <div className="phone" role="region" aria-label="Mobile chat full-screen">
+      <div className="phone-sbar"><span>22:14</span><span>📶 🔋 78%</span></div>
+
+      <div className="mob-h">
+        <button className="back" aria-label="Indietro">←</button>
+        <div
+          className="ti-block"
+          aria-label="Apri context panel (bottom sheet)"
+          role="button"
+          tabIndex={0}
+          onClick={() => setSheetOpen(true)}
+        >
+          <div className="ti">Sera con i ragazzi · §147</div>
+          <div className="sub">{agent.name} · 12 query oggi</div>
+        </div>
+        <div className="av">{agent.avatar}</div>
+        <button className="kebab" aria-label="Altre azioni">⋮</button>
+      </div>
+
+      <div className="mob-stream" role="log">
+        <div className="ts-divider">oggi · 22:14</div>
+        <MessageBubble role="user">Niamh affronta Goblin Captain §147. 2d6 + bonus spada?</MessageBubble>
+        <MessageBubble
+          role="agent"
+          readerMode={readerMode}
+          meta={{ confidence: 'alta · 94%', confidenceLevel: 'high', timestamp: '22:33' }}
+        >
+          Sì — Spada Antica da §123, tira 2d6 + 3. Goblin Captain CD 9, colpisci con 6+.{' '}
+          <CitationPill paragraph="§147" variant="translate" />
+        </MessageBubble>
+        {streamState === 'streaming' && (
+          <>
+            <MessageBubble role="user">Se ho 2 ferite, malus −2 cumula con Reaver?</MessageBubble>
+            <MessageBubble role="agent" readerMode={readerMode} isStreaming>
+              I malus di ferita cumulano solo con malus situazionali (oscurità, distanza)
+            </MessageBubble>
+            <button className="cancel-stream-cta" type="button" aria-label="Cancella stream">
+              ✕ Cancella (4.2s)
+            </button>
+          </>
+        )}
+      </div>
+
+      <ChatComposer
+        value={composerValue}
+        onChange={setComposerValue}
+        disabled={streamState === 'streaming'}
+        isStreaming={streamState === 'streaming'}
+        onAttach={handleAttach}
+        mobile
+      />
+
+      <TelemetryFooter
+        streamState={streamState}
+        tokens={streamState === 'streaming' ? '187' : null}
+        quota="12/15"
+        wakeLockStatus={wakeLockStatus}
+      />
+
+      {/* Bottom sheet context panel (tap header → open) */}
+      {sheetOpen && (
+        <>
+          <div className="mob-sheet-backdrop" onClick={() => setSheetOpen(false)} aria-hidden="true" />
+          <aside className="mob-sheet" role="dialog" aria-modal="true" aria-label="Context panel (agent · fonti · azioni)">
+            <div className="grip" aria-hidden="true" />
+            <AgentInfoMiniCard agent={agent} />
+            <div className="panel-section">
+              <h4>Fonti citate · 3</h4>
+              <button className="src-card"><span className="ico">📖</span><div className="l"><div className="v">Press Start · §147</div><div className="s">Goblin Captain · p.42</div></div></button>
+              <button className="src-card"><span className="ico">📖</span><div className="l"><div className="v">Rules · §3.7</div><div className="s">Malus ferita</div></div></button>
+              <button className="src-card"><span className="ico">📖</span><div className="l"><div className="v">Encounter · §271</div><div className="s">Voidstone</div></div></button>
+            </div>
+            <SuggestedActions actions={[
+              { icon: '📕', label: 'Apri libro pag 42', onClick: () => {} },
+              { icon: '🎲', label: 'Crea play record', onClick: () => {} },
+            ]}/>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// SCREEN B11b-3 · ChatEmptyState (/chat/new, 3 quick-starter variants)
+// ═══════════════════════════════════════════════════════════════════════
+const ChatEmptyState = ({
+  agent = AGENT_RUNA,    // null → default variant (no agent)
+  mobile = false,
+  onStartChat,           // callback su click quick-starter o picker
+}) => {
+  const wakeLockStatus = useWakeLock(false);
+
+  // Quick-starter selection logic (sez 6 spec)
+  // agent.metadata.category → libro-game | boardgame | default
+  // Fallback graceful: agent senza category → default variant
+  const starters = resolveQuickStarters(agent);
+  const variantName = agent?.category || 'default';
+
+  // No agent → Default variant (CTA picker dropdown)
+  if (!agent || starters === null) {
+    return (
+      <div className={mobile ? 'phone' : 'desktop'} role="region" aria-label="Empty state — Default variant (no agent)">
+        {mobile ? (
+          <>
+            <div className="phone-sbar"><span>21:08</span><span>📶 🔋 82%</span></div>
+            <div className="mob-h">
+              <button className="back">←</button>
+              <div className="ti-block">
+                <div className="ti">Nuova chat</div>
+                <div className="sub">Default · nessun agent selezionato · fallback graceful</div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="titlebar">
+            <span className="dot r"></span><span className="dot y"></span><span className="dot g"></span>
+            <span className="url">meepleai.app/chat/new</span>
+          </div>
+        )}
+        <div className="empty-shell" style={mobile ? { padding: 'var(--s-7) var(--s-4)' } : {}}>
+          <div className="hero-icon" aria-hidden="true">💬</div>
+          <h2 style={mobile ? { fontSize: 'var(--fs-xl)' } : {}}>Scegli un agent</h2>
+          <p className="subtitle">
+            Non hai ancora selezionato un agent. Sceglilo dalla lista o crea una nuova chat dall'index agent.
+          </p>
+          <button className="agent-picker-trig" type="button" aria-label="Apri agent picker dropdown">
+            <span>🧙</span><span>Scegli agent</span><span style={{ opacity: 0.7 }}>▾</span>
+          </button>
+          <div className="agent-picker-list" role="listbox" aria-label="Lista agent disponibili">
+            {SAMPLE_AGENTS.map(a => (
+              <button
+                key={a.id}
+                className="ag-item"
+                role="option"
+                aria-selected="false"
+                onClick={() => onStartChat && onStartChat(a)}
+              >
+                <div
+                  className="av"
+                  style={a.category === 'libro-game'
+                    ? { background: 'hsl(var(--c-kb) / 0.18)', color: 'hsl(var(--c-kb))' }
+                    : { background: 'hsl(var(--c-game) / 0.18)', color: 'hsl(var(--c-game))' }}
+                >{a.avatar}</div>
+                <div className="info">
+                  <div className="nm">{a.name}</div>
+                  <div className="lu">{a.category} · last used {a.lastUsed}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+        <TelemetryFooter streamState="idle" variant="default" wakeLockStatus={wakeLockStatus} />
+      </div>
+    );
+  }
+
+  // Agent presente → Libro-game o Boardgamer variant (quick-starter cards)
+  const gridCls = mobile ? 'qs-grid' : 'qs-grid desk-1x4';
+
+  if (mobile) {
+    return (
+      <div className="phone" role="region" aria-label={`Empty state — ${variantName} variant`}>
+        <div className="phone-sbar"><span>21:05</span><span>📶 🔋 84%</span></div>
+        <div className="mob-h">
+          <button className="back">←</button>
+          <div className="ti-block">
+            <div className="ti">Nuova chat · {agent.name}</div>
+            <div className="sub">{variantName === 'libro-game' ? 'Libro-game' : 'Boardgamer'} · meta.category={variantName}</div>
+          </div>
+          <div
+            className="av"
+            style={variantName === 'libro-game'
+              ? { background: 'hsl(var(--c-kb) / 0.18)', color: 'hsl(var(--c-kb))' }
+              : { background: 'hsl(var(--c-game) / 0.18)', color: 'hsl(var(--c-game))' }}
+          >{agent.avatar}</div>
+        </div>
+        <div className="empty-shell" style={{ padding: 'var(--s-7) var(--s-4)' }}>
+          <div className="hero-icon" aria-hidden="true">💬</div>
+          <h2 style={{ fontSize: 'var(--fs-xl)' }}>
+            {variantName === 'libro-game' ? 'Inizia una conversazione' : `Inizia con ${agent.name.replace('Mago di ', '')}`}
+          </h2>
+          <p className="subtitle">
+            {variantName === 'libro-game'
+              ? 'Chiedi al tuo agent una regola, una strategia, un riassunto o traduci un paragrafo del libro.'
+              : 'Setup, regole edge case, strategie comuni o FAQ del gioco.'}
+          </p>
+          <div className={gridCls}>
+            {starters.map((s, i) => (
+              <QuickStarterCard
+                key={i}
+                icon={s.icon}
+                cat={s.cat}
+                question={s.q}
+                variant={variantName}
+                onClick={() => onStartChat && onStartChat({ agent, prompt: s.q })}
+              />
+            ))}
+          </div>
+        </div>
+        <ChatComposer
+          value=""
+          onChange={() => {}}
+          disabled={false}
+          isStreaming={false}
+          mobile
+        />
+        <TelemetryFooter streamState="idle" variant={variantName} quota="12/15" wakeLockStatus={wakeLockStatus} />
+      </div>
+    );
+  }
+
+  // Desktop empty state
+  return (
+    <div className="desktop" style={{ minHeight: 680 }} role="region" aria-label={`Empty state — ${variantName} variant (desktop)`}>
+      <div className="titlebar">
+        <span className="dot r"></span><span className="dot y"></span><span className="dot g"></span>
+        <span className="url">meepleai.app/chat/new?agent={agent.id}</span>
+      </div>
+      <div className="chat-3col">
+        <aside className="sidebar-l">
+          <div className="sl-head">
+            <div className="sl-tabs">
+              <button className="tab active">Tutti</button>
+              <button className="tab">Preferiti</button>
+              <button className="tab">Archiviati</button>
+            </div>
+          </div>
+          <button className="sl-cta"><span>＋</span><span>Nuova chat</span></button>
+          <div className="sl-list">
+            <div className="group-h">Recenti</div>
+            <button className="sl-thread libro">
+              <div className="av">📕</div>
+              <div className="info"><div className="ti">Sera con i ragazzi · §147</div><div className="pv">…malus Reaver…</div></div>
+              <div className="meta"><span className="ts">22:37</span></div>
+            </button>
+          </div>
+        </aside>
+
+        <section className="main-c">
+          <div className="main-h">
+            <div className="ag">{agent.avatar}</div>
+            <div className="ti-block">
+              <div className="ti">Nuova chat con {agent.name}</div>
+              <div className="sub">Libro-game · agent.metadata.category=<code>{variantName}</code></div>
+            </div>
+          </div>
+          <div className="empty-shell">
+            <div className="hero-icon" aria-hidden="true">💬</div>
+            <h2>Inizia una conversazione</h2>
+            <p className="subtitle">
+              Chiedi al tuo agent una regola, una strategia, un riassunto o traduci un paragrafo del libro.
+            </p>
+            <div className={gridCls}>
+              {starters.map((s, i) => (
+                <QuickStarterCard
+                  key={i}
+                  icon={s.icon}
+                  cat={s.cat}
+                  question={s.q}
+                  variant={variantName}
+                  onClick={() => onStartChat && onStartChat({ agent, prompt: s.q })}
+                />
+              ))}
+            </div>
+            <div className="cost-banner" style={{ marginTop: 'var(--s-5)' }}>
+              <span className="ico">💸</span>
+              <span>
+                <span className="v">Cost-aware suggestion:</span> ogni quick-starter usa Tutor cache hit quando possibile
+                (paragrafi già tradotti → 0 cost). Foto Encounter scatena flow translate Task 4 (~€0,01 per re-OCR).
+              </span>
+            </div>
+          </div>
+          <ChatComposer value="" onChange={() => {}} disabled={false} isStreaming={false} />
+          <TelemetryFooter streamState="idle" variant={variantName} quota="12/15 free" wakeLockStatus={wakeLockStatus} />
+        </section>
+
+        <aside className="sidebar-r">
+          <AgentInfoMiniCard agent={agent} />
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// ROOT · demo all screens (Desktop 3-col 4 states + Mobile 3 states + Empty 3 variants)
+// ═══════════════════════════════════════════════════════════════════════
+const Root = () => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  return (
+    <>
+      <header className="top">
+        <h1>Chat full-screen · B11b (chiusura parziale #491)</h1>
+        <span className="route">/chat/[threadId] + /chat/new</span>
+        <span className="spacer"></span>
+        <button onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')} aria-label="Cambia tema">🌗 Tema</button>
+      </header>
+      <main className="stage">
+
+        <section className="state-section">
+          <span className="label">
+            Screen B11b-1 · Desktop 3-col · streaming
+            <span className="cmp">ChatFullscreenDesktop</span>
+          </span>
+          <h2>Desktop 3-col · /chat/[threadId] · stream attivo (streaming state)</h2>
+          <div className="frames">
+            <ChatFullscreenDesktop streamState="streaming" />
+          </div>
+        </section>
+
+        <section className="state-section">
+          <span className="label">
+            Screen B11b-1 · Desktop · stream-error
+            <span className="cmp">ChatFullscreenDesktop · Nygard failure mode 3</span>
+          </span>
+          <h2>Desktop 3-col · stream-error · last user message preserved in composer</h2>
+          <div className="frames">
+            <ChatFullscreenDesktop streamState="stream-error" />
+          </div>
+        </section>
+
+        <section className="state-section">
+          <span className="label">
+            Screen B11b-1 · Desktop · stream-abort
+            <span className="cmp">ChatFullscreenDesktop · user cancel</span>
+          </span>
+          <h2>Desktop 3-col · stream-abort · message preserved con badge "[interrotto]"</h2>
+          <div className="frames">
+            <ChatFullscreenDesktop streamState="stream-abort" />
+          </div>
+        </section>
+
+        <section className="state-section">
+          <span className="label">
+            Screen B11b-2 · Mobile single-pane
+            <span className="cmp">ChatFullscreenMobile · 375px</span>
+          </span>
+          <h2>Mobile · /chat/[threadId] · 3 states (idle, streaming, bottom sheet)</h2>
+          <div className="frames">
+            <ChatFullscreenMobile streamState="idle" />
+            <ChatFullscreenMobile streamState="streaming" />
+            <ChatFullscreenMobile streamState="idle" showContextSheet={true} />
+          </div>
+        </section>
+
+        <section className="state-section">
+          <span className="label">
+            Screen B11b-3 · Empty state /chat/new
+            <span className="cmp">ChatEmptyState · 3 variants (libro-game · boardgame · default)</span>
+          </span>
+          <h2>Empty state /chat/new · 4 quick-starter cards · 3 agent type variants</h2>
+          <div className="frames">
+            {/* Variant 1: Libro-game (Aaron) desktop */}
+            <ChatEmptyState agent={AGENT_RUNA} mobile={false} />
+            {/* Variant 2: Boardgamer mobile */}
+            <ChatEmptyState agent={AGENT_WINGSPAN} mobile={true} />
+            {/* Variant 3: Default (no agent → CTA picker) mobile */}
+            <ChatEmptyState agent={null} mobile={true} />
+          </div>
+        </section>
+
+      </main>
+    </>
+  );
+};
+
+// Render root if React DOM available (mockup standalone)
+if (typeof ReactDOM !== 'undefined') {
+  const container = document.getElementById('root');
+  if (container) {
+    const root = ReactDOM.createRoot
+      ? ReactDOM.createRoot(container)
+      : null;
+    if (root) {
+      root.render(<Root />);
+    } else if (ReactDOM.render) {
+      ReactDOM.render(<Root />, container);
+    }
+  }
+}
+
+// Named exports per consumo programmatic (TypeScript-friendly)
+window.ChatFullscreenMockup = {
+  Root,
+  ChatFullscreenDesktop,
+  ChatFullscreenMobile,
+  ChatEmptyState,
+  // Sub-components
+  ThreadList,
+  ChatComposer,
+  MessageBubble,
+  CitationPill,
+  AgentInfoMiniCard,
+  SuggestedActions,
+  QuickStarterCard,
+  TelemetryFooter,
+  StreamErrorBanner,
+  // Hooks
+  useReaderMode,
+  useWakeLock,
+  // Data
+  THREADS,
+  AGENT_RUNA,
+  AGENT_WINGSPAN,
+  QUICK_STARTERS,
+  SAMPLE_AGENTS,
+  resolveQuickStarters,
+  READER_MODE_KEY,
+};

--- a/admin-mockups/design_files/librogame-runthrough-error-states.html
+++ b/admin-mockups/design_files/librogame-runthrough-error-states.html
@@ -6,15 +6,25 @@
 <title>MeepleAI — Librogame Runthrough · Error States</title>
 <!--
   Mockup: librogame-runthrough-error-states
-  Route:  trasversale ai 4 goal (chat N1/N2, photo-translate N3)
-  Scope:  Phase A runthrough — gap coverage error states tecnici NON coperti da low-confidence
-  Stati:  A · stream-timeout      (chat agente N2: nessun token > 30s · retry/cambia agent/copy)
-          B · ocr-fail             (foto pagina: OCR conf < 0.3 → testo illeggibile · rifotografa/manuale/cancella)
-          C · llm-503              (provider down · 3 retry exponential backoff · fallback offline regole base)
-          D · segmentation-fail    (OCR ok ma niente § rilevati · inserisci numero § manuale · alt: range)
+  Route:  trasversale ai 4 goal (chat N1/N2, photo-translate N3 — /library/[gameId]/play/[campaignId]/translate)
+  Scope:  Phase A runthrough — error states tecnici puntuali OCR/AI (gap coverage low-confidence)
+  Spec:   docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md (sezione 1a)
+  Stati:  A · stream-timeout                (chat agente N2: nessun token > 30s · retry/cambia agent/copy)
+          B · ocr-fail                       (foto pagina: OCR conf < 0.3 → testo illeggibile · rifotografa/manuale/cancella)
+          C · llm-503                        (provider down · 3 retry exponential backoff · fallback offline regole base)
+          D · segmentation-fail              (OCR ok ma niente § rilevati · inserisci numero § manuale · alt: range)
+          E · ocr-low-confidence             (conf 0.5-0.7 · highlight regioni dubbie in giallo · ritocca/procedi)
+          F · photo-blur-pre-ocr             (autofocus < threshold client-side · reject in-camera · zero roundtrip)
+          G · translation-timeout            (AI translate abort > 20s · banner + retry/edit manuale)
+          H · source-lang-unknown            (LLM confidence_lang < 0.5 · dialog conferma lingua · 5 opzioni)
+          I · network-mid-ocr                (loss connection upload · save locale · retry on-reconnect)
+          J · quota-exhausted-mid-stream     (token quota esaurita · bridge a quota-credits overlay · retain OCR text)
   Vincolo: ogni error state mostra (a) cosa è successo in linguaggio Aaron-friendly, (b) cosa NON
-           verrà addebitato (cost transparency), (c) ≥ 2 azioni di recupero, (d) link a "telemetria
-           invia" per dogfood iter feedback. Pattern banner riuso da translate-viewer state-F + extension.
+           verrà addebitato (cost transparency), (c) ≥ 2 azioni di recupero non-distruttive (MAI dead-end),
+           (d) link a "telemetria invia" per dogfood iter feedback. Pattern banner riuso da translate-viewer state-F + extension.
+  Retry granularity: OCR-fail/low-conf → retry solo OCR step (foto in cache); LLM-503/timeout → retry solo AI step.
+                     MAI retry-from-scratch automatico.
+  Confidence threshold: low-confidence default 0.7 (futuro configurabile in /settings/preferences).
   Mobile-first 375px. Desktop 880px.
 -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -302,10 +312,308 @@
     cursor: pointer; text-decoration: underline; text-underline-offset: 2px;
   }
 
+  /* ──────────────────────────────────────────────────────────
+     Stati E–J · extension components
+     ────────────────────────────────────────────────────────── */
+
+  /* State E · OCR low-confidence highlight overlay */
+  .ocr-page-preview {
+    position: relative; width: 100%; max-width: 280px; aspect-ratio: 3/4;
+    background: linear-gradient(180deg, #fdf8f0, #f4ead8);
+    border: 1px solid var(--border); border-radius: var(--r-md);
+    padding: var(--s-3);
+    font-family: var(--f-mono); font-size: 10px; line-height: 1.6;
+    color: #3a2f1e; overflow: hidden;
+    flex-shrink: 0;
+  }
+  .ocr-page-preview .line { display: block; }
+  .ocr-page-preview .line.confident { color: #3a2f1e; }
+  .ocr-page-preview .line.uncertain {
+    background: hsl(var(--c-warning) / 0.32);
+    box-shadow: 0 0 0 2px hsl(var(--c-warning) / 0.55);
+    border-radius: 3px;
+    padding: 0 2px;
+    color: #2a1e07;
+  }
+  .ocr-page-preview .pn {
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: 13px;
+    color: hsl(var(--c-kb)); display: block; margin-bottom: var(--s-1);
+  }
+  .ocr-page-preview .legend {
+    position: absolute; bottom: var(--s-2); right: var(--s-2);
+    background: rgba(255,255,255,0.9);
+    padding: 2px var(--s-2); border-radius: var(--r-sm);
+    font-size: 9px; color: var(--text-muted);
+    display: flex; align-items: center; gap: 4px;
+  }
+  .ocr-page-preview .legend .swatch {
+    width: 10px; height: 10px; border-radius: 2px;
+    background: hsl(var(--c-warning) / 0.55);
+  }
+
+  .conf-strip {
+    display: flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-2) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-warning) / 0.06);
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-sec);
+    margin-bottom: var(--s-3);
+  }
+  .conf-strip .bar {
+    flex: 1; height: 6px; background: var(--bg-muted); border-radius: 999px;
+    overflow: hidden; position: relative;
+  }
+  .conf-strip .bar .fill {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 64%;
+    background: linear-gradient(90deg, hsl(var(--c-danger)), hsl(var(--c-warning)) 50%, hsl(var(--c-success)));
+    border-radius: 999px;
+  }
+  .conf-strip .bar .marker {
+    position: absolute; left: 70%; top: -3px; bottom: -3px; width: 2px;
+    background: var(--text); opacity: 0.4;
+  }
+  .conf-strip .val { font-weight: var(--fw-bold); color: hsl(var(--c-warning)); }
+
+  /* State F · camera viewfinder (pre-OCR client-side reject) */
+  .viewfinder {
+    width: 100%; max-width: 260px; aspect-ratio: 3/4; flex-shrink: 0;
+    background:
+      linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)),
+      repeating-linear-gradient(0deg, transparent, transparent 14px, rgba(0,0,0,0.04) 14px, rgba(0,0,0,0.04) 15px),
+      linear-gradient(135deg, #1f1810, #0e0a06);
+    border-radius: var(--r-md); position: relative;
+    display: flex; align-items: center; justify-content: center;
+    overflow: hidden;
+    filter: blur(3.5px);
+  }
+  .viewfinder::after {
+    content: '';
+    position: absolute; inset: 0;
+    border: 2px dashed hsl(var(--c-danger) / 0.7);
+    border-radius: var(--r-md);
+    filter: none;
+  }
+  .viewfinder .reticle {
+    position: absolute; inset: 0;
+    background:
+      linear-gradient(90deg, transparent calc(50% - 1px), hsl(var(--c-danger) / 0.4) 50%, transparent calc(50% + 1px)),
+      linear-gradient(0deg,  transparent calc(50% - 1px), hsl(var(--c-danger) / 0.4) 50%, transparent calc(50% + 1px));
+    filter: none;
+  }
+  .viewfinder .focus-warn {
+    position: absolute; bottom: var(--s-3); left: 50%; transform: translateX(-50%);
+    background: hsl(var(--c-danger));
+    color: #fff; font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-bold);
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    white-space: nowrap; text-transform: uppercase; letter-spacing: 0.06em;
+    filter: none;
+    display: flex; align-items: center; gap: 4px;
+  }
+  .camera-shutter {
+    width: 64px; height: 64px; border-radius: 50%;
+    background: var(--bg-card); border: 4px solid var(--border-strong);
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; flex-shrink: 0;
+    opacity: 0.4; pointer-events: none;
+  }
+  .camera-shutter::after {
+    content: ''; width: 48px; height: 48px; border-radius: 50%;
+    background: hsl(var(--c-danger) / 0.4);
+  }
+  .focus-meter {
+    display: flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-2) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-danger) / 0.08); border: 1px solid hsl(var(--c-danger) / 0.3);
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-sec);
+    margin-bottom: var(--s-3);
+  }
+  .focus-meter .bar {
+    flex: 1; height: 8px; background: var(--bg-muted); border-radius: 999px; overflow: hidden;
+    position: relative;
+  }
+  .focus-meter .bar .fill {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 28%;
+    background: hsl(var(--c-danger));
+    border-radius: 999px;
+  }
+  .focus-meter .bar .threshold {
+    position: absolute; left: 60%; top: -3px; bottom: -3px; width: 2px;
+    background: var(--text); opacity: 0.4;
+  }
+  .focus-meter .val { font-weight: var(--fw-bold); color: hsl(var(--c-danger)); }
+
+  /* State H · lang-unknown dialog */
+  .lang-dialog {
+    background: var(--bg-card); border-radius: var(--r-lg);
+    border: 1px solid hsl(var(--c-danger) / 0.4); box-shadow: var(--shadow-lg);
+    padding: var(--s-5); margin: var(--s-4);
+    max-width: 340px;
+  }
+  .lang-dialog .head {
+    display: flex; align-items: center; gap: var(--s-2); margin-bottom: var(--s-3);
+  }
+  .lang-dialog .head .ico {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: hsl(var(--c-danger) / 0.12); color: hsl(var(--c-danger));
+    display: flex; align-items: center; justify-content: center; font-size: 20px;
+  }
+  .lang-dialog .head .title {
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md);
+  }
+  .lang-dialog .desc {
+    font-size: var(--fs-sm); color: var(--text-sec); margin: 0 0 var(--s-3); line-height: var(--lh-snug);
+  }
+  .lang-grid {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--s-2);
+    margin-bottom: var(--s-3);
+  }
+  .lang-opt {
+    padding: var(--s-3); border-radius: var(--r-md);
+    background: var(--bg); border: 1.5px solid var(--border);
+    cursor: pointer; text-align: left;
+    display: flex; align-items: center; gap: var(--s-2);
+    font-family: var(--f-display); font-size: var(--fs-sm); color: var(--text);
+  }
+  .lang-opt.selected {
+    background: hsl(var(--c-kb) / 0.08); border-color: hsl(var(--c-kb)); color: hsl(var(--c-kb));
+    font-weight: var(--fw-bold);
+  }
+  .lang-opt .flag { font-size: 18px; flex-shrink: 0; }
+  .lang-opt .meta { display: block; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; font-weight: var(--fw-reg); }
+  .lang-opt.selected .meta { color: hsl(var(--c-kb) / 0.8); }
+
+  /* State I · network offline banner / queue */
+  .net-strip {
+    margin: var(--s-4); padding: var(--s-3) var(--s-4);
+    background: linear-gradient(90deg, hsl(var(--c-danger) / 0.95), hsl(var(--c-danger) / 0.7));
+    color: #fff; border-radius: var(--r-md);
+    display: flex; align-items: center; gap: var(--s-3);
+    font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm);
+  }
+  .net-strip .pulse {
+    width: 10px; height: 10px; border-radius: 50%; background: #fff; flex-shrink: 0;
+    animation: net-pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes net-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(255,255,255,0.7); opacity: 0.9; }
+    50%      { box-shadow: 0 0 0 8px rgba(255,255,255, 0); opacity: 0.5; }
+  }
+  .net-strip .lbl { flex: 1; }
+  .net-strip .meta {
+    font-family: var(--f-mono); font-size: 10px; opacity: 0.85; font-weight: var(--fw-reg);
+  }
+
+  .queue-card {
+    margin: 0 var(--s-4) var(--s-4); padding: var(--s-3) var(--s-4);
+    background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--r-md);
+  }
+  .queue-card .head {
+    display: flex; align-items: center; gap: var(--s-2);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    margin-bottom: var(--s-2);
+  }
+  .queue-card .head .badge {
+    background: hsl(var(--c-warning) / 0.18); color: hsl(var(--c-warning));
+    padding: 2px var(--s-2); border-radius: var(--r-pill);
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+  }
+  .queue-item {
+    display: flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-2) 0; border-bottom: 1px dashed var(--border-light);
+    font-size: var(--fs-sm); color: var(--text-sec);
+  }
+  .queue-item:last-child { border-bottom: 0; }
+  .queue-item .thumb {
+    width: 36px; height: 48px; flex-shrink: 0;
+    border-radius: var(--r-sm); background: linear-gradient(135deg, #2a2218, #1a140d);
+    display: flex; align-items: center; justify-content: center; color: rgba(255,255,255,0.5); font-size: 10px;
+  }
+  .queue-item .info { flex: 1; }
+  .queue-item .info .v { display: block; font-family: var(--f-display); font-weight: var(--fw-semi); color: var(--text); }
+  .queue-item .info .s { display: block; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .queue-item .status {
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+    padding: 2px var(--s-2); border-radius: var(--r-pill);
+  }
+  .queue-item .status.wait { background: hsl(var(--c-warning) / 0.15); color: hsl(var(--c-warning)); }
+  .queue-item .status.ok   { background: hsl(var(--c-success) / 0.15); color: hsl(var(--c-success)); }
+
+  /* State J · quota bridge */
+  .quota-bridge {
+    margin: var(--s-4); padding: var(--s-5); border-radius: var(--r-lg);
+    background: linear-gradient(135deg, hsl(var(--c-warning) / 0.16), hsl(var(--c-danger) / 0.1));
+    border: 1px solid hsl(var(--c-warning) / 0.5);
+  }
+  .quota-bridge .head { display: flex; align-items: center; gap: var(--s-2); margin-bottom: var(--s-3); }
+  .quota-bridge .head .ico {
+    width: 40px; height: 40px; border-radius: 50%;
+    background: hsl(var(--c-warning)); color: #fff;
+    display: flex; align-items: center; justify-content: center; font-size: 22px;
+  }
+  .quota-bridge .head .title {
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-lg);
+    color: hsl(var(--c-warning));
+  }
+  .quota-bridge .desc {
+    font-size: var(--fs-sm); color: var(--text); margin: 0 0 var(--s-3); line-height: var(--lh-snug);
+  }
+  .quota-meter {
+    margin-bottom: var(--s-3); padding: var(--s-3); border-radius: var(--r-md);
+    background: rgba(255,255,255,0.4);
+  }
+  .quota-meter .meter-head {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-sec); margin-bottom: var(--s-2);
+    text-transform: uppercase; letter-spacing: 0.06em; font-weight: var(--fw-bold);
+  }
+  .quota-meter .meter-head .val { color: hsl(var(--c-danger)); }
+  .quota-meter .bar {
+    height: 8px; background: var(--bg-muted); border-radius: 999px; overflow: hidden;
+    position: relative;
+  }
+  .quota-meter .bar .fill {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 100%;
+    background: hsl(var(--c-danger));
+    border-radius: 999px;
+  }
+  .fallback-preserve {
+    margin-top: var(--s-3); padding: var(--s-3); border-radius: var(--r-md);
+    background: rgba(255,255,255,0.5); border: 1px dashed hsl(var(--c-success) / 0.4);
+  }
+  .fallback-preserve .lbl {
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold); color: hsl(var(--c-success));
+    text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: var(--s-2);
+    display: flex; align-items: center; gap: var(--s-1);
+  }
+  .fallback-preserve .text {
+    font-family: var(--f-body); font-size: var(--fs-sm); color: var(--text); line-height: var(--lh-snug);
+    font-style: italic;
+  }
+
+  /* Edit-manual textarea (state G fallback) */
+  .manual-edit {
+    margin-top: var(--s-3); padding: var(--s-3); border-radius: var(--r-md);
+    background: var(--bg-card); border: 1px solid var(--border);
+  }
+  .manual-edit .lbl {
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    margin-bottom: var(--s-2); display: block;
+  }
+  .manual-edit textarea {
+    width: 100%; box-sizing: border-box;
+    min-height: 90px; padding: var(--s-3); border: 1px solid var(--border);
+    border-radius: var(--r-sm); background: var(--bg); color: var(--text);
+    font-family: var(--f-body); font-size: var(--fs-sm); line-height: var(--lh-snug);
+    resize: vertical;
+  }
+  .manual-edit textarea:focus {
+    outline: 2px solid hsl(var(--c-warning)); border-color: hsl(var(--c-warning));
+  }
+
   *:focus-visible { outline: 2px solid hsl(var(--c-danger)); outline-offset: 2px; }
   @media (prefers-reduced-motion: reduce) {
     .retry-strip .pip.try { animation: none; }
     .chat-msg .stalled-dots .dot { animation: none; opacity: 0.7; }
+    .net-strip .pulse { animation: none; }
   }
 </style>
 </head>
@@ -314,7 +622,7 @@
 
 <header class="top">
   <h1>Librogame Runthrough · Error States</h1>
-  <span class="route">trasversale · 4 stati</span>
+  <span class="route">trasversale · 10 stati</span>
   <span class="spacer"></span>
   <button id="theme-btn" type="button" aria-label="Cambia tema">🌗 Tema</button>
 </header>
@@ -703,6 +1011,668 @@
               <span class="ico">→</span>
               <span class="l"><span class="v">Conferma e traduci</span><span class="s">N3 standard · ~6 s · 0,01 €</span></span>
             </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO E · OCR LOW CONFIDENCE (conf 0.5-0.7 · regioni dubbie)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section warn" id="s5" aria-labelledby="se">
+    <span class="label">Stato E · OCR Low Confidence · 0.5–0.7</span>
+    <h2 id="se">Testo letto, ma alcune parole sono poco chiare</h2>
+    <p class="desc">A metà strada tra OCR-fail (illeggibile) e OCR-ok: confidence aggregata 0.64, ma ≥1 regione sotto soglia 0.7. Aaron vede inline le parole dubbie evidenziate in giallo, può ritoccare la foto (luce migliore) oppure procedere comunque accettando il rischio di errori. Soglia 0.7 (default, futuro configurabile in /settings/preferences).</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – ocr low confidence">
+        <span class="frame-label">Mobile · 375px</span>
+        <div class="phone-sbar"><span>22:27</span><span>📶 🔋 69%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Foto §147 · controllo</span>
+          <button class="right-tool">⋯</button>
+        </div>
+        <div style="flex: 1; overflow-y: auto; padding: var(--s-4); display: flex; flex-direction: column; gap: var(--s-3); align-items: center;">
+          <div class="ocr-page-preview" aria-label="Anteprima OCR con regioni dubbie evidenziate">
+            <span class="pn">§ 147</span>
+            <span class="line confident">Il guardiano della soglia</span>
+            <span class="line"><span class="confident">ti osserva con occhi </span><span class="uncertain">ferrigni</span><span class="confident">.</span></span>
+            <span class="line"><span class="confident">"Solo chi possiede la </span><span class="uncertain">runa</span><span class="confident"> potrà</span></span>
+            <span class="line confident">passare oltre", sussurra.</span>
+            <span class="line">&nbsp;</span>
+            <span class="line"><span class="confident">Hai con te la </span><span class="uncertain">Runa di Ardenel</span><span class="confident">?</span></span>
+            <span class="line confident">→ Sì, mostrala (vai a § 152)</span>
+            <span class="line"><span class="confident">→ No, prova a forzare il pa</span><span class="uncertain">ssaggio</span></span>
+            <span class="line confident">&nbsp;&nbsp;&nbsp;(vai a § 198)</span>
+            <span class="legend"><span class="swatch"></span>dubbio</span>
+          </div>
+          <div class="err-banner warn" style="margin: 0; width: 100%;" role="alert">
+            <div class="head"><span class="badge">🔎 0.64</span><span class="title">Testo letto, 4 parole sono poco chiare</span></div>
+            <p class="msg">Confidence media 64% (soglia minima 70%). Le parti evidenziate in giallo potrebbero essere lette male — ho indovinato in base al contesto ma non sono sicuro al 100%.</p>
+            <div class="conf-strip" aria-label="Confidence indicator">
+              <span>conf</span>
+              <span class="bar"><span class="fill"></span><span class="marker" title="soglia 0.70"></span></span>
+              <span class="val">0.64</span>
+            </div>
+            <div class="cost-note">💰 <span><strong>Solo OCR addebitato</strong> · traduzione N3 non ancora partita</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus>
+                <span class="ico">📷</span>
+                <span class="l"><span class="v">Ritocca foto</span><span class="s">consigliato · più luce · nuovo OCR gratis</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">⚠</span>
+                <span class="l"><span class="v">Procedi comunque</span><span class="s">accetto rischio errori sulle parole dubbie</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">✏</span>
+                <span class="l"><span class="v">Correggi manualmente</span><span class="s">tap sulle parole gialle per editare</span></span>
+              </button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">OCR conf</span><span class="v">0.64</span>
+              <span class="lbl">soglia</span><span class="v">0.70</span>
+              <span class="lbl">regioni low</span><span class="v">4 di 32</span>
+              <span class="lbl">tokens</span><span class="v">~210</span>
+            </div>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 telemetry: ocr_low_confidence · 4 regions</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – ocr low confidence">
+        <span class="frame-label">Desktop · 1440px</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?conf=0.64</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · OCR §147 · 4 regioni dubbie</span></div>
+        <div style="flex: 1; padding: var(--s-6); display: grid; grid-template-columns: 320px 1fr; gap: var(--s-6); overflow-y: auto; align-items: start;">
+          <div class="ocr-page-preview" style="max-width: 320px;" aria-label="Anteprima OCR con regioni dubbie">
+            <span class="pn">§ 147</span>
+            <span class="line confident">Il guardiano della soglia ti</span>
+            <span class="line"><span class="confident">osserva con occhi </span><span class="uncertain">ferrigni</span><span class="confident">.</span></span>
+            <span class="line"><span class="confident">"Solo chi possiede la </span><span class="uncertain">runa</span></span>
+            <span class="line confident">potrà passare oltre",</span>
+            <span class="line confident">sussurra.</span>
+            <span class="line">&nbsp;</span>
+            <span class="line"><span class="confident">Hai con te la </span><span class="uncertain">Runa di Ardenel</span><span class="confident">?</span></span>
+            <span class="line confident">→ Sì, mostrala (vai a § 152)</span>
+            <span class="line"><span class="confident">→ No, forza il pa</span><span class="uncertain">ssaggio</span></span>
+            <span class="line confident">&nbsp;&nbsp;&nbsp;(vai a § 198)</span>
+            <span class="legend"><span class="swatch"></span>dubbio · tap per editare</span>
+          </div>
+          <div class="err-banner warn" style="margin: 0;" role="alert">
+            <div class="head"><span class="badge">🔎 0.64</span><span class="title">4 parole con confidence sotto soglia</span></div>
+            <p class="msg">OCR completato (32 token estratti) ma 4 regioni sono sotto la soglia minima 70%. "ferrigni", "runa", "Runa di Ardenel" e "ssaggio" potrebbero essere lette male. Posso procedere con la traduzione N3 accettando il rischio, oppure puoi ritoccare la foto per migliorare la qualità (nuovo OCR gratis: la foto resta in cache).</p>
+            <div class="conf-strip" aria-label="Confidence indicator">
+              <span>conf aggregata</span>
+              <span class="bar"><span class="fill"></span><span class="marker" title="soglia 0.70"></span></span>
+              <span class="val">0.64</span>
+              <span style="margin-left: var(--s-3);">soglia 0.70 · futuro configurabile in /settings/preferences</span>
+            </div>
+            <div class="cost-note">💰 <span><strong>Solo OCR addebitato</strong> · ~0,002 € · traduzione N3 ancora non partita · retry OCR gratis</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus><span class="ico">📷</span><span class="l"><span class="v">Ritocca foto (consigliato)</span><span class="s">illumina meglio · nuovo OCR gratis · foto in cache locale</span></span></button>
+              <button class="err-action" type="button"><span class="ico">⚠</span><span class="l"><span class="v">Procedi comunque</span><span class="s">traduco con le parole dubbie così come sono · ~6 s · ~0,01 €</span></span></button>
+              <button class="err-action" type="button"><span class="ico">✏</span><span class="l"><span class="v">Correggi manualmente</span><span class="s">click sulle parole gialle nell'anteprima a sinistra per editare</span></span></button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">OCR conf</span><span class="v">0.64</span>
+              <span class="lbl">soglia</span><span class="v">0.70</span>
+              <span class="lbl">regioni low</span><span class="v">4 di 32 (12.5%)</span>
+              <span class="lbl">tokens estratti</span><span class="v">~210</span>
+              <span class="lbl">cache foto</span><span class="v">photo_cache_e8a3 · 380 KB</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO F · PHOTO BLUR PRE-OCR (autofocus < threshold · client-side reject)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section warn" id="s6" aria-labelledby="sf">
+    <span class="label">Stato F · Photo Blur · pre-OCR client-side</span>
+    <h2 id="sf">Foto sfocata — rifiutata prima dell'upload</h2>
+    <p class="desc">Reject in-camera client-side: autofocus score &lt; threshold viene rilevato dal browser PRIMA dell'upload server. Zero roundtrip, zero token consumati, zero costo. Aaron vede shutter disabilitato + feedback warning "tieni fermo" — flusso ottimale per UX in piedi al tavolo.</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – photo blur pre-OCR">
+        <span class="frame-label">Mobile · 375px (camera viewport)</span>
+        <div class="phone-sbar"><span>22:18</span><span>📶 🔋 70%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Scatta foto §</span>
+          <button class="right-tool">💡</button>
+        </div>
+        <div style="flex: 1; display: flex; flex-direction: column; align-items: center; gap: var(--s-4); padding: var(--s-4); background: #0a0805;">
+          <div class="viewfinder" aria-label="Viewfinder fotocamera · foto sfocata">
+            <span class="reticle"></span>
+            <span class="focus-warn">⚠ FUORI FUOCO</span>
+          </div>
+          <div class="camera-shutter" aria-label="Shutter disabilitato" aria-disabled="true"></div>
+          <div class="err-banner warn" style="margin: 0; width: 100%;" role="alert">
+            <div class="head"><span class="badge">🌀 Blur</span><span class="title">Tieni fermo il telefono</span></div>
+            <p class="msg">Lo scatto è sfocato. Non lo invio nemmeno — risparmio tempo e costi. Aspetta che il riquadro diventi nitido e riprova.</p>
+            <div class="focus-meter" aria-label="Focus score live">
+              <span>focus</span>
+              <span class="bar"><span class="fill"></span><span class="threshold" title="soglia 0.60"></span></span>
+              <span class="val">0.28</span>
+            </div>
+            <div class="cost-note">💰 <span><strong>Niente addebitato</strong> · reject client-side · 0 byte inviati, 0 token</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus>
+                <span class="ico">🔄</span>
+                <span class="l"><span class="v">Riprova</span><span class="s">attendi che il riquadro sia nitido</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">💡</span>
+                <span class="l"><span class="v">Attiva flash</span><span class="s">migliora luce · riduce mosso</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">🔢</span>
+                <span class="l"><span class="v">Salta: inserisci § manuale</span><span class="s">se conosci il paragrafo</span></span>
+              </button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">focus</span><span class="v">0.28</span>
+              <span class="lbl">soglia</span><span class="v">0.60</span>
+              <span class="lbl">round-trip</span><span class="v">0 ms (skip server)</span>
+              <span class="lbl">device</span><span class="v">user-agent camera</span>
+            </div>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 telemetry: photo_blur_reject · client-side</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – photo blur pre-OCR">
+        <span class="frame-label">Desktop · 1440px (preview camera modal)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?camera=blur</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Scatto rigettato · client-side</span></div>
+        <div style="flex: 1; padding: var(--s-6); display: grid; grid-template-columns: 360px 1fr; gap: var(--s-6); overflow-y: auto; align-items: start;">
+          <div style="display: flex; flex-direction: column; align-items: center; gap: var(--s-4); padding: var(--s-4); background: #0a0805; border-radius: var(--r-lg);">
+            <div class="viewfinder" style="max-width: 320px;" aria-label="Viewfinder camera · sfocata">
+              <span class="reticle"></span>
+              <span class="focus-warn">⚠ FUORI FUOCO</span>
+            </div>
+            <div class="camera-shutter" aria-label="Shutter disabilitato" aria-disabled="true"></div>
+            <span style="font-family: var(--f-mono); font-size: var(--fs-xs); color: rgba(255,255,255,0.7);">scatto disabilitato finché focus &lt; 0.60</span>
+          </div>
+          <div class="err-banner warn" style="margin: 0;" role="alert">
+            <div class="head"><span class="badge">🌀 Blur</span><span class="title">Foto sfocata · rifiutata in-camera</span></div>
+            <p class="msg">Lo scatto non supera la soglia di nitidezza (focus 0.28 vs 0.60 minimo). Il browser intercetta la sfocatura via Camera API <code>getCapabilities()</code> e disabilita lo shutter <em>prima</em> di inviare i byte al server. Risultato: zero token consumati, zero costo, nessun roundtrip — ottimo per UX in piedi al tavolo dove la mano trema.</p>
+            <div class="focus-meter" aria-label="Focus score live">
+              <span>focus score live</span>
+              <span class="bar"><span class="fill"></span><span class="threshold" title="soglia 0.60"></span></span>
+              <span class="val">0.28</span>
+              <span style="margin-left: var(--s-3);">soglia 0.60</span>
+            </div>
+            <div class="cost-note">💰 <span><strong>Niente addebitato</strong> · client-side reject · 0 byte inviati, 0 OCR, 0 traduzione</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus><span class="ico">🔄</span><span class="l"><span class="v">Riprova</span><span class="s">attendi che il riquadro diventi nitido · shutter si riattiva automatico</span></span></button>
+              <button class="err-action" type="button"><span class="ico">💡</span><span class="l"><span class="v">Attiva flash / torcia</span><span class="s">più luce = focus più rapido · riduce micro-mosso</span></span></button>
+              <button class="err-action" type="button"><span class="ico">🔢</span><span class="l"><span class="v">Salta foto · inserisci § manuale</span><span class="s">bypassa OCR · digita direttamente "§ 147"</span></span></button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">focus</span><span class="v">0.28</span>
+              <span class="lbl">soglia</span><span class="v">0.60</span>
+              <span class="lbl">round-trip</span><span class="v">0 ms (skip server entirely)</span>
+              <span class="lbl">camera</span><span class="v">user-facing · autofocus continuous</span>
+              <span class="lbl">events</span><span class="v">camera.focuschange listener</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO G · TRANSLATION TIMEOUT (AI translate abort > 20s)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section warn" id="s7" aria-labelledby="sg">
+    <span class="label">Stato G · Translation Timeout · &gt; 20 s</span>
+    <h2 id="sg">Traduzione lenta — riprova o modifica manualmente</h2>
+    <p class="desc">OCR completato con successo (testo pronto), ma la chiamata AI di traduzione si è bloccata oltre 20 s. Distinto dallo Stato A (chat stream-timeout): qui non c'è stream parziale, è una request/response. Aaron ha sempre il testo originale OCR-decoded come fallback non-distruttivo, può ri-tentare o editare la traduzione a mano.</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – translation timeout">
+        <span class="frame-label">Mobile · 375px</span>
+        <div class="phone-sbar"><span>22:42</span><span>📶 🔋 67%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Traduco §147</span>
+          <button class="right-tool">⋯</button>
+        </div>
+        <div style="flex: 1; overflow-y: auto;">
+          <div class="err-banner warn" role="alert">
+            <div class="head">
+              <span class="badge">⏱ 22 s</span>
+              <span class="title">La traduzione è lenta</span>
+            </div>
+            <p class="msg">Ho aspettato 22 s ma l'AI non ha ancora risposto. Probabile traffico provider. Il testo originale è già pronto qui sotto — puoi tradurlo a mano oppure ritentare.</p>
+            <div class="cost-note">💰 <span><strong>Non addebitato</strong> · request abortita = 0 token traduzione</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus>
+                <span class="ico">🔄</span>
+                <span class="l"><span class="v">Riprova traduzione</span><span class="s">stesso testo · nuovo tentativo · ~5 s</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">✏</span>
+                <span class="l"><span class="v">Traduci a mano</span><span class="s">testo originale qui sotto, edita liberamente</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">↩</span>
+                <span class="l"><span class="v">Continua in lingua originale</span><span class="s">salta traduzione, mostra testo OCR</span></span>
+              </button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">req-id</span><span class="v">tr_e8a3b1c</span>
+              <span class="lbl">timeout</span><span class="v">20.0 s</span>
+              <span class="lbl">model</span><span class="v">openrouter:gemini-pro</span>
+            </div>
+          </div>
+          <div class="manual-edit" style="margin: 0 var(--s-4) var(--s-4);">
+            <label class="lbl" for="manual-tr">Testo originale OCR (puoi tradurre qui)</label>
+            <textarea id="manual-tr" placeholder="Inserisci traduzione…">The guardian of the threshold watches you with iron eyes. "Only the rune-bearer shall pass," he whispers.
+
+Do you have the Rune of Ardenel?
+→ Yes, show it (go to § 152)
+→ No, force the passage (go to § 198)</textarea>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 telemetry: translation_timeout · 22.4 s</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – translation timeout">
+        <span class="frame-label">Desktop · 1440px</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?req=tr_e8a3b1c&timeout=22.4s</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Traduzione lenta · §147</span></div>
+        <div style="flex: 1; padding: var(--s-6); display: grid; grid-template-columns: 1fr 380px; gap: var(--s-6); overflow-y: auto; align-items: start;">
+          <div>
+            <div class="err-banner warn" style="margin: 0;" role="alert">
+              <div class="head"><span class="badge">⏱ 22 s</span><span class="title">AI translate non risponde · request abortita</span></div>
+              <p class="msg">Ho lanciato la traduzione 22.4 s fa, soglia di timeout 20 s superata. La chiamata è stata abortita lato client (AbortController) — niente token consumati. Il testo originale OCR è già pronto e disponibile per editing manuale. Puoi ritentare con un altro provider, scriverla tu, o continuare la sessione in lingua originale.</p>
+              <div class="cost-note">💰 <span><strong>Non addebitato</strong> · AbortController firework · 0 token traduzione · OCR già pagato e conservato</span></div>
+              <div class="err-debug">
+                <span class="lbl">req</span><span class="v">tr_e8a3b1c</span>
+                <span class="lbl">timeout</span><span class="v">20.0 s (cutoff)</span>
+                <span class="lbl">elapsed</span><span class="v">22.4 s (abortito)</span>
+                <span class="lbl">model</span><span class="v">openrouter:gemini-pro</span>
+                <span class="lbl">fallback model</span><span class="v">deepseek-chat (al retry)</span>
+              </div>
+            </div>
+            <div class="manual-edit" style="margin-top: var(--s-4);">
+              <label class="lbl" for="manual-tr-d">Testo OCR originale (EN) · pronto per edit / traduzione manuale</label>
+              <textarea id="manual-tr-d" placeholder="Inserisci la tua traduzione qui…">The guardian of the threshold watches you with iron eyes. "Only the rune-bearer shall pass," he whispers.
+
+Do you have the Rune of Ardenel?
+→ Yes, show it (go to § 152)
+→ No, force the passage (go to § 198)</textarea>
+              <div style="margin-top: var(--s-2); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);">
+                ✏ edit live · auto-save sessione · markdown supportato
+              </div>
+            </div>
+          </div>
+          <div class="err-actions" style="margin: 0;">
+            <button class="err-action primary-warn" type="button" autofocus><span class="ico">🔄</span><span class="l"><span class="v">Riprova traduzione</span><span class="s">stesso testo · prova provider alternativo · ~5 s · ~0,01 €</span></span></button>
+            <button class="err-action" type="button"><span class="ico">✏</span><span class="l"><span class="v">Traduci a mano</span><span class="s">scrivi nell'area testo a fianco · auto-save</span></span></button>
+            <button class="err-action" type="button"><span class="ico">↩</span><span class="l"><span class="v">Continua in EN</span><span class="s">salta traduzione · prosegui con testo originale OCR</span></span></button>
+            <button class="err-action" type="button"><span class="ico">⏰</span><span class="l"><span class="v">Notificami al ritorno</span><span class="s">push browser appena AI risponde · sessione resta aperta</span></span></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO H · SOURCE LANG UNKNOWN (LLM confidence_lang < 0.5)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" id="s8" aria-labelledby="sh">
+    <span class="label">Stato H · Source Lang Unknown · conf &lt; 0.5</span>
+    <h2 id="sh">Non riconosco la lingua del testo — conferma quale</h2>
+    <p class="desc">L'LLM rileva la lingua del testo OCR ma con confidence &lt; 0.5 (sotto soglia critica). Tipico in libro-game multilingua, glossari fantasy con neologismi, o testi misti EN/IT. Dialog blocking con dropdown 5 opzioni (EN, FR, DE, ES, IT). Pattern danger-colored perché richiede input prima di proseguire.</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – source lang unknown">
+        <span class="frame-label">Mobile · 375px (dialog overlay)</span>
+        <div class="phone-sbar"><span>22:38</span><span>📶 🔋 68%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Lingua testo · §147</span>
+          <button class="right-tool">⋯</button>
+        </div>
+        <div style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: var(--s-3); background: hsl(var(--c-danger) / 0.04);">
+          <div class="lang-dialog" role="dialog" aria-modal="true" aria-labelledby="lang-h-title">
+            <div class="head">
+              <span class="ico">🌐</span>
+              <span class="title" id="lang-h-title">Quale lingua è questa?</span>
+            </div>
+            <p class="desc">Confidence lingua 38% (sotto soglia 50%). Il testo OCR contiene neologismi fantasy che confondono l'auto-detect. Conferma tu così procedo con la traduzione corretta.</p>
+            <div class="lang-grid" role="radiogroup" aria-label="Seleziona lingua sorgente">
+              <button class="lang-opt selected" type="button" role="radio" aria-checked="true">
+                <span class="flag">🇬🇧</span>
+                <span><span style="display: block;">English</span><span class="meta">conf 38% · proposta</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇮🇹</span>
+                <span><span style="display: block;">Italiano</span><span class="meta">conf 24%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇫🇷</span>
+                <span><span style="display: block;">Français</span><span class="meta">conf 11%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇩🇪</span>
+                <span><span style="display: block;">Deutsch</span><span class="meta">conf 9%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false" style="grid-column: span 2;">
+                <span class="flag">🇪🇸</span>
+                <span><span style="display: block;">Español</span><span class="meta">conf 7%</span></span>
+              </button>
+            </div>
+            <div class="cost-note">💰 <span><strong>Solo OCR addebitato</strong> · lang-detect free · traduzione N3 dopo conferma</span></div>
+            <div class="err-actions">
+              <button class="err-action primary" type="button" autofocus>
+                <span class="ico">→</span>
+                <span class="l"><span class="v">Conferma "English"</span><span class="s">e traduci in italiano · ~6 s · ~0,01 €</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">↩</span>
+                <span class="l"><span class="v">Annulla</span><span class="s">salta traduzione, mostra testo OCR così com'è</span></span>
+              </button>
+            </div>
+            <div class="err-debug" style="margin-top: var(--s-3);">
+              <span class="lbl">lang-conf</span><span class="v">0.38</span>
+              <span class="lbl">soglia</span><span class="v">0.50</span>
+              <span class="lbl">tokens</span><span class="v">~210</span>
+            </div>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 telemetry: source_lang_unknown · 0.38</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – source lang unknown">
+        <span class="frame-label">Desktop · 1440px (modal centrato)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?lang=unknown</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Conferma lingua sorgente · §147</span></div>
+        <div style="flex: 1; padding: var(--s-6); display: flex; justify-content: center; align-items: flex-start; background: hsl(var(--c-danger) / 0.03);">
+          <div class="lang-dialog" style="max-width: 480px; margin: 0;" role="dialog" aria-modal="true" aria-labelledby="lang-h-title-d">
+            <div class="head">
+              <span class="ico">🌐</span>
+              <span class="title" id="lang-h-title-d">Conferma la lingua del testo originale</span>
+            </div>
+            <p class="desc">L'auto-detect ha restituito "English" con confidence solo 38%, sotto la soglia critica del 50%. Probabile causa: neologismi fantasy (Ardenel, rune-bearer, threshold-guardian) e alternanza inglese arcaico/moderno. Scegli tu la lingua sorgente per procedere con la traduzione N3 verso italiano.</p>
+            <div class="lang-grid" role="radiogroup" aria-label="Seleziona lingua sorgente">
+              <button class="lang-opt selected" type="button" role="radio" aria-checked="true">
+                <span class="flag">🇬🇧</span>
+                <span><span style="display: block;">English</span><span class="meta">conf 38% · proposta auto-detect</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇮🇹</span>
+                <span><span style="display: block;">Italiano</span><span class="meta">conf 24%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇫🇷</span>
+                <span><span style="display: block;">Français</span><span class="meta">conf 11%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false">
+                <span class="flag">🇩🇪</span>
+                <span><span style="display: block;">Deutsch</span><span class="meta">conf 9%</span></span>
+              </button>
+              <button class="lang-opt" type="button" role="radio" aria-checked="false" style="grid-column: span 2;">
+                <span class="flag">🇪🇸</span>
+                <span><span style="display: block;">Español</span><span class="meta">conf 7%</span></span>
+              </button>
+            </div>
+            <div class="cost-note">💰 <span><strong>Solo OCR addebitato finora</strong> · ~0,002 € · lang-detect gratuito · traduzione N3 parte dopo conferma · ~0,01 €</span></div>
+            <div class="err-actions">
+              <button class="err-action primary" type="button" autofocus><span class="ico">→</span><span class="l"><span class="v">Conferma "English" e traduci</span><span class="s">avvia N3 verso italiano · ~6 s · costo stimato ~0,01 €</span></span></button>
+              <button class="err-action" type="button"><span class="ico">↩</span><span class="l"><span class="v">Annulla traduzione</span><span class="s">mostra testo OCR originale così com'è (no traduzione)</span></span></button>
+              <button class="err-action" type="button"><span class="ico">📖</span><span class="l"><span class="v">Mostra testo OCR</span><span class="s">verifica visivamente prima di scegliere lingua</span></span></button>
+            </div>
+            <div class="err-debug" style="margin-top: var(--s-3);">
+              <span class="lbl">lang-conf top</span><span class="v">0.38 (EN)</span>
+              <span class="lbl">soglia</span><span class="v">0.50</span>
+              <span class="lbl">model</span><span class="v">cld3-language-detector</span>
+              <span class="lbl">tokens</span><span class="v">~210 estratti</span>
+              <span class="lbl">retry-free</span><span class="v">cambia lingua = nuova traduzione gratis</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO I · NETWORK MID-OCR (loss connection · save locale · retry on-reconnect)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" id="s9" aria-labelledby="si">
+    <span class="label">Stato I · Network Loss · mid-OCR</span>
+    <h2 id="si">Connessione persa — foto salvata localmente</h2>
+    <p class="desc">Aaron carica la foto, l'upload parte, poi connessione cellulare drop (treno, cantina, wi-fi instabile). Strategia: persist locale in IndexedDB + queue + retry automatico on-reconnect. Banner persistent top, NO modal blocking (Aaron continua a usare l'app offline: glossario + setup tutorial cached). Pattern danger-colored ma non bloccante.</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – network loss mid-OCR">
+        <span class="frame-label">Mobile · 375px</span>
+        <div class="phone-sbar"><span>22:47</span><span>✈ 🔋 65%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Offline · 1 in coda</span>
+          <button class="right-tool">⚡</button>
+        </div>
+        <div class="net-strip" role="status" aria-live="polite">
+          <span class="pulse" aria-hidden="true"></span>
+          <span class="lbl">Offline · 1 foto in coda<br/><span class="meta">retry automatico appena torni online</span></span>
+        </div>
+        <div class="queue-card">
+          <div class="head">
+            <span>📥 Foto in upload</span>
+            <span class="badge">1 in attesa</span>
+          </div>
+          <div class="queue-item">
+            <div class="thumb">§147</div>
+            <div class="info">
+              <span class="v">Foto §147</span>
+              <span class="s">salvata locale · 380 KB · in attesa rete</span>
+            </div>
+            <span class="status wait">⏳ attesa</span>
+          </div>
+        </div>
+        <div style="flex: 1; padding: 0 var(--s-4); overflow-y: auto;">
+          <div class="err-banner danger" style="margin: 0;" role="alert">
+            <div class="head">
+              <span class="badge">📶 Offline</span>
+              <span class="title">Niente rete</span>
+            </div>
+            <p class="msg">L'upload della foto si è interrotto a metà. Niente paura: ho salvato lo scatto sul tuo telefono e riprovo da solo appena la rete torna. Puoi continuare a usare l'app offline: il glossario campagna è disponibile.</p>
+            <div class="cost-note">💰 <span><strong>Non addebitato</strong> · upload incompleto = 0 byte ricevuti server-side</span></div>
+            <div class="err-actions">
+              <button class="err-action" type="button" autofocus>
+                <span class="ico">🔄</span>
+                <span class="l"><span class="v">Riprova subito</span><span class="s">forza retry · utile se rete è tornata ora</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">📒</span>
+                <span class="l"><span class="v">Vai a Glossario offline</span><span class="s">32 termini campagna cached · accesso istantaneo</span></span>
+              </button>
+              <button class="err-action" type="button">
+                <span class="ico">🗑</span>
+                <span class="l"><span class="v">Cancella coda</span><span class="s">elimina foto in attesa (irrecuperabile)</span></span>
+              </button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">err</span><span class="v">net::ERR_NETWORK_CHANGED</span>
+              <span class="lbl">salvato</span><span class="v">IndexedDB · photo_queue_b3a</span>
+              <span class="lbl">retry</span><span class="v">on connectivity-change</span>
+            </div>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 in attesa retry · telemetry posticipata</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – network loss mid-OCR">
+        <span class="frame-label">Desktop · 1440px</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?offline=1</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Connessione persa · 1 upload in coda</span></div>
+        <div class="net-strip" style="margin: var(--s-5);" role="status" aria-live="polite">
+          <span class="pulse" aria-hidden="true"></span>
+          <span class="lbl">Connessione persa · 1 foto salvata localmente in attesa retry automatico<br/><span class="meta">net::ERR_NETWORK_CHANGED · 22:47:13 · auto-retry on connectivity-change event</span></span>
+        </div>
+        <div style="flex: 1; padding: 0 var(--s-6) var(--s-6); display: grid; grid-template-columns: 1fr 380px; gap: var(--s-6); overflow-y: auto; align-items: start;">
+          <div class="err-banner danger" style="margin: 0;" role="alert">
+            <div class="head"><span class="badge">📶 Offline</span><span class="title">Upload interrotto · foto in cache locale</span></div>
+            <p class="msg">L'upload della foto §147 si è bloccato a metà del trasferimento (220/380 KB inviati). Ho persistito lo scatto in IndexedDB del browser (chiave <code>photo_queue_b3a</code>) — quando la rete torna, riprende automaticamente da zero senza che tu debba fare nulla. Nel frattempo l'app rimane usabile: glossario campagna, setup tutorial Press Start e stato sessione sono tutti disponibili offline.</p>
+            <div class="cost-note">💰 <span><strong>Non addebitato</strong> · upload parziale (220 KB) scartato server-side · 0 OCR, 0 traduzione</span></div>
+            <div class="err-actions">
+              <button class="err-action" type="button" autofocus><span class="ico">🔄</span><span class="l"><span class="v">Riprova subito</span><span class="s">forza retry manuale · utile se la rete è appena tornata</span></span></button>
+              <button class="err-action" type="button"><span class="ico">📒</span><span class="l"><span class="v">Glossario offline</span><span class="s">32 termini campagna cached · accesso istantaneo</span></span></button>
+              <button class="err-action" type="button"><span class="ico">📋</span><span class="l"><span class="v">Setup tutorial offline</span><span class="s">Press Start completo · 24 pagine cached</span></span></button>
+              <button class="err-action" type="button"><span class="ico">🗑</span><span class="l"><span class="v">Cancella coda</span><span class="s">elimina foto in attesa · azione irrecuperabile</span></span></button>
+            </div>
+            <div class="err-debug">
+              <span class="lbl">err</span><span class="v">net::ERR_NETWORK_CHANGED</span>
+              <span class="lbl">progress</span><span class="v">220/380 KB (57%)</span>
+              <span class="lbl">storage</span><span class="v">IndexedDB · photo_queue_b3a · 380 KB</span>
+              <span class="lbl">retry</span><span class="v">listener navigator.onLine + connectivity-change</span>
+              <span class="lbl">offline-ok</span><span class="v">glossary + tutorial + sessione</span>
+            </div>
+          </div>
+          <div class="queue-card" style="margin: 0;">
+            <div class="head">
+              <span>📥 Coda upload offline</span>
+              <span class="badge">1 in attesa</span>
+            </div>
+            <div class="queue-item">
+              <div class="thumb">§147</div>
+              <div class="info">
+                <span class="v">Foto §147 · pagina libro</span>
+                <span class="s">22:47:08 · 380 KB · salvata IndexedDB · retry auto</span>
+              </div>
+              <span class="status wait">⏳ in coda</span>
+            </div>
+            <div style="margin-top: var(--s-3); padding-top: var(--s-3); border-top: 1px dashed var(--border-light); font-size: var(--fs-xs); color: var(--text-muted); font-family: var(--f-mono);">
+              Sessione + paragrafo corrente conservati. Quando rete torna online, l'OCR riparte automatico e ricevi notifica banner.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO J · QUOTA EXHAUSTED MID-STREAM (token quota termina · bridge a quota-credits · retain OCR text)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" id="s10" aria-labelledby="sj">
+    <span class="label">Stato J · Quota Exhausted · mid-stream</span>
+    <h2 id="sj">Crediti esauriti durante la traduzione</h2>
+    <p class="desc">La quota token termina mentre l'AI sta traducendo (probabile sessione lunga + glossario fantasy verbose). Bridge a `librogame-runthrough-quota-credits` overlay, ma il testo OCR-decoded resta come fallback non-distruttivo (Aaron NON perde il paragrafo già decodificato, niente token aggiuntivi addebitati per mostrarlo). Pattern danger-colored con tonalità "soft" (warning amber) perché non è un errore tecnico, è un limite di piano.</p>
+
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – quota exhausted">
+        <span class="frame-label">Mobile · 375px</span>
+        <div class="phone-sbar"><span>22:54</span><span>📶 🔋 64%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Crediti finiti</span>
+          <button class="right-tool">⋯</button>
+        </div>
+        <div class="quota-bridge" role="alert">
+          <div class="head">
+            <span class="ico">⚡</span>
+            <span class="title">Crediti finiti mid-traduzione</span>
+          </div>
+          <p class="desc">La traduzione si è fermata a metà — i tuoi crediti del piano "Esploratore" sono esauriti per oggi. Il testo originale del paragrafo è qui sotto: leggilo in lingua originale senza spendere altro, oppure ricarica crediti.</p>
+          <div class="quota-meter">
+            <div class="meter-head"><span>token quota giornaliera</span><span class="val">100% · 8 470 / 8 470</span></div>
+            <div class="bar"><span class="fill"></span></div>
+          </div>
+          <div class="cost-note">💰 <span><strong>Solo OCR + traduzione parziale addebitati</strong> · ~0,008 € · mostrare testo originale = 0 token extra</span></div>
+          <div class="err-actions">
+            <button class="err-action primary-warn" type="button" autofocus>
+              <span class="ico">💎</span>
+              <span class="l"><span class="v">Ricarica crediti</span><span class="s">+5 000 token · 1,99 € · sblocca subito</span></span>
+            </button>
+            <button class="err-action" type="button">
+              <span class="ico">📖</span>
+              <span class="l"><span class="v">Leggi in lingua originale</span><span class="s">testo OCR qui sotto · 0 token extra</span></span>
+            </button>
+            <button class="err-action" type="button">
+              <span class="ico">⏰</span>
+              <span class="l"><span class="v">Aspetta reset domani</span><span class="s">quota si ricarica alle 00:00 · gratis</span></span>
+            </button>
+          </div>
+          <div class="fallback-preserve">
+            <div class="lbl">✓ Testo OCR conservato · 0 token extra</div>
+            <div class="text">"The guardian of the threshold watches you with iron eyes. Only the rune-bearer shall pass…"</div>
+          </div>
+          <div class="err-debug" style="margin-top: var(--s-3);">
+            <span class="lbl">quota</span><span class="v">8470/8470 (100%)</span>
+            <span class="lbl">reset</span><span class="v">00:00 UTC+1</span>
+            <span class="lbl">parziale</span><span class="v">42 / ~210 tokens</span>
+          </div>
+        </div>
+        <div class="telemetry">
+          <span>📡 quota_exhausted · piano esploratore</span>
+          <button class="send" type="button">+ nota dogfood</button>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – quota exhausted mid-stream">
+        <span class="frame-label">Desktop · 1440px (bridge a quota-credits overlay)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?quota=exhausted&plan=explorer</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Quota crediti esaurita · bridge a /credits</span></div>
+        <div style="flex: 1; padding: var(--s-6); display: grid; grid-template-columns: 1fr 380px; gap: var(--s-6); overflow-y: auto; align-items: start;">
+          <div class="quota-bridge" style="margin: 0;" role="alert">
+            <div class="head">
+              <span class="ico">⚡</span>
+              <span class="title">Crediti esauriti mentre traducevo</span>
+            </div>
+            <p class="desc">Hai finito i token del piano "Esploratore" durante la traduzione del §147. Il sistema si è fermato dopo 42 token su ~210 attesi — la quota era a 99.5%, ho preferito non andare in negativo. Il testo OCR è preservato non-distruttivamente nel pannello a destra: puoi continuare a leggere in lingua originale senza spendere altro, oppure ricaricare crediti per riprendere la traduzione automatica.</p>
+            <div class="quota-meter">
+              <div class="meter-head"><span>token quota giornaliera · piano "Esploratore"</span><span class="val">100% · 8 470 / 8 470 consumati</span></div>
+              <div class="bar"><span class="fill"></span></div>
+              <div style="margin-top: var(--s-2); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; justify-content: space-between;">
+                <span>reset automatico · 00:00 UTC+1 (tra 1h 06m)</span>
+                <span>upgrade Adventurer: 50 000 token/giorno · 4,99 €/mese</span>
+              </div>
+            </div>
+            <div class="cost-note">💰 <span><strong>Tracciamento puntuale</strong> · OCR ~0,002 € · traduzione parziale (42 tok) ~0,006 € · totale ~0,008 € · mostrare OCR cached = 0 token extra</span></div>
+            <div class="err-actions">
+              <button class="err-action primary-warn" type="button" autofocus><span class="ico">💎</span><span class="l"><span class="v">Ricarica crediti istant.</span><span class="s">+5 000 token one-shot · 1,99 € · sblocca subito · paga e riprendi</span></span></button>
+              <button class="err-action" type="button"><span class="ico">⭐</span><span class="l"><span class="v">Upgrade piano Adventurer</span><span class="s">50 000 token/giorno · 4,99 €/mese · 6x più capacity</span></span></button>
+              <button class="err-action" type="button"><span class="ico">📖</span><span class="l"><span class="v">Leggi in lingua originale</span><span class="s">testo OCR cached qui a destra · 0 token consumati</span></span></button>
+              <button class="err-action" type="button"><span class="ico">⏰</span><span class="l"><span class="v">Aspetta reset domani</span><span class="s">quota si ricarica alle 00:00 UTC+1 · gratuita · piano resta Esploratore</span></span></button>
+            </div>
+            <div class="err-debug" style="margin-top: var(--s-3);">
+              <span class="lbl">quota</span><span class="v">8 470/8 470 (100%)</span>
+              <span class="lbl">reset</span><span class="v">2026-05-24 00:00 UTC+1</span>
+              <span class="lbl">parziale</span><span class="v">42 / ~210 tokens (20%)</span>
+              <span class="lbl">piano</span><span class="v">Esploratore (free tier · 8 470/giorno)</span>
+              <span class="lbl">cache OCR</span><span class="v">preservato · 0 token extra per render</span>
+            </div>
+          </div>
+          <div class="fallback-preserve" style="margin: 0; padding: var(--s-4);">
+            <div class="lbl">✓ Testo OCR conservato · zero costo aggiuntivo</div>
+            <div class="text">"The guardian of the threshold watches you with iron eyes. 'Only the rune-bearer shall pass,' he whispers.<br/><br/>Do you have the Rune of Ardenel?<br/>→ Yes, show it (go to § 152)<br/>→ No, force the passage (go to § 198)"</div>
+            <div style="margin-top: var(--s-3); padding-top: var(--s-3); border-top: 1px dashed hsl(var(--c-success) / 0.35); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);">
+              Foto + OCR già pagati. Rileggere/copiare/incollare = gratis. Solo la <em>traduzione AI</em> richiede token.
+            </div>
           </div>
         </div>
       </div>

--- a/admin-mockups/design_files/librogame-runthrough-error-states.html
+++ b/admin-mockups/design_files/librogame-runthrough-error-states.html
@@ -1177,6 +1177,10 @@
                 <span class="ico">🔢</span>
                 <span class="l"><span class="v">Salta: inserisci § manuale</span><span class="s">se conosci il paragrafo</span></span>
               </button>
+              <button class="err-action" type="button" onclick="location.href='/library/librogame/play/cmp-1234/translate?mode=manual'">
+                <span class="ico">⌨</span>
+                <span class="l"><span class="v">Digita manualmente</span><span class="s">trascrivi il paragrafo · skip OCR · vedi translate-viewer state-M</span></span>
+              </button>
             </div>
             <div class="err-debug">
               <span class="lbl">focus</span><span class="v">0.28</span>
@@ -1219,6 +1223,7 @@
               <button class="err-action primary-warn" type="button" autofocus><span class="ico">🔄</span><span class="l"><span class="v">Riprova</span><span class="s">attendi che il riquadro diventi nitido · shutter si riattiva automatico</span></span></button>
               <button class="err-action" type="button"><span class="ico">💡</span><span class="l"><span class="v">Attiva flash / torcia</span><span class="s">più luce = focus più rapido · riduce micro-mosso</span></span></button>
               <button class="err-action" type="button"><span class="ico">🔢</span><span class="l"><span class="v">Salta foto · inserisci § manuale</span><span class="s">bypassa OCR · digita direttamente "§ 147"</span></span></button>
+              <button class="err-action" type="button" onclick="location.href='/library/librogame/play/cmp-1234/translate?mode=manual'"><span class="ico">⌨</span><span class="l"><span class="v">Digita manualmente</span><span class="s">trascrivi il paragrafo completo · vedi state-M manual-input-mode in translate-viewer · skip OCR · entry-point #1 del triple-entry pattern (sez 1d)</span></span></button>
             </div>
             <div class="err-debug">
               <span class="lbl">focus</span><span class="v">0.28</span>

--- a/admin-mockups/design_files/librogame-runthrough-glossary-editor.html
+++ b/admin-mockups/design_files/librogame-runthrough-glossary-editor.html
@@ -8,15 +8,98 @@
           play-session quando Aaron tappa una glossary pill nel testo.
           Migrato da sp6-libro-game-glossary-editor.html (persona Sara → Aaron,
           route /gamebook/* → /library/*/play, issue #871 chiusa).
-  Stati:  state-01-edit-pristine    — Voidstone → Pietra del Vuoto, Salva disabled
-          state-02-edited           — input dirty → "Pietra del Caos", Salva enabled
-          state-03-save-error       — banner amber + Retry, value preservato
-          state-04-collision        — banner red, [Sovrascrivi] + [Cambia traduzione]
-          state-01-desktop          — modal centered 480px
-          state-04-desktop-conflict — modal centered + pannello laterale "Goblin → Razziatore"
+
+  Narrative cluster: "Sera con i ragazzi · Runa di Ardenel · §147" (coerente
+                     con Task 1 error-states + Task 2 translate-viewer).
+                     Termini esempio: sentinel, ferrigni, runa, threshold.
+                     Books esempio: Press Start + Rules Game.
+
+  Stati base:  state-01-edit-pristine    — Sentinel → soldato di guardia, Salva disabled
+               state-02-edited           — input dirty → "punto di osservazione strategica"
+               state-03-save-error       — banner amber + Retry, value preservato
+               state-04-collision        — banner red, [Sovrascrivi] + [Cambia traduzione]
+               state-01-desktop          — modal centered 480px
+               state-04-desktop-conflict — modal centered + pannello laterale "Ferrigni → Razziatori"
+
+  ─────────────────────────────────────────────────────────────────────
+  NUOVI sub-screen (spec sezione 1c — context-aware glossary):
+  ─────────────────────────────────────────────────────────────────────
+    state-05-conflict-dialog       — Modal: parola già nel glossario con
+                                     context_similarity < 0.85.
+                                     Body: definizione esistente vs nuova
+                                     side-by-side. 3 CTA radio:
+                                       ① "Mantieni esistente" (default soft-CTA)
+                                       ② "Sostituisci"
+                                       ③ "Aggiungi variante per [book name]"
+                                     Footer: [Conferma] / [Annulla].
+
+    state-06-bulk-import-card      — Inline card sotto traduzione quando
+                                     OCR trova ≥3 parole nuove non-glossario
+                                     in un paragrafo. Title "N nuove parole
+                                     rilevate" + chip preview termini.
+                                     2 CTA: ["Aggiungi tutte" 1-click] /
+                                     ["Rivedi" → modal multi-select w/
+                                     checkbox + edit definition inline].
+
+    state-07-variant-expansion     — Glossary index row con contexts.length > 1.
+                                     Default collapsed. Click → expand mostra
+                                     N varianti, ognuna con:
+                                       · book badge "📖 Press Start" / "📖 Rules Game"
+                                       · definition specifica (o "(usa base)"
+                                         se context.definition is null)
+                                       · first_seen link "Vedi paragrafo originale"
+                                       · delete variant button
+                                     ChevronDown icon ruota su expand.
+
+    state-08-filter-strip          — Header glossary index sempre visibile:
+                                       · search input "Cerca per termine,
+                                         definizione, libro…"
+                                       · filter by book chip multi-select
+                                       · filter toggle "Solo con varianti"
+                                     Ogni term row mostra context badges
+                                     inline (📖 Press Start + 📖 Rules Game)
+                                     accanto al term name.
+
+  ─────────────────────────────────────────────────────────────────────
+  Modello dati GlossaryEntry (proposto, implica schema migration backend):
+  ─────────────────────────────────────────────────────────────────────
+    GlossaryEntry {
+      term: "sentinel",
+      base_definition: "soldato di guardia",          ← primary
+      contexts: [
+        { book_id: "press-start",
+          definition: null,                            ← uses base
+          first_seen: paragraph_id_X },
+        { book_id: "rules-game",
+          definition: "punto di osservazione strategica",  ← variant
+          first_seen: paragraph_id_Y }
+      ]
+    }
+
+  Pattern decisions (sezione 1c — Fowler/Adzic):
+    · context_similarity threshold: 0.85 (server-side via embedding cosine,
+      riusa IEmbeddingService). Auto-keep silenzioso se ≥ 0.85; mostra
+      conflict-dialog solo se < 0.85.
+    · bulk-import trigger: ≥3 parole (NON ≥1, evita card-fatigue su
+      paragrafi corti).
+    · default conflict resolution: "Mantieni esistente" (soft CTA, no
+      destructive default — protegge da double-tap accidentali).
+    · variant deletion: utente può eliminare singola variante; se elimina
+      l'ultima variante non-base, term torna single-context (no orphan).
+
+  Decisione architetturale incidentale (Fowler):
+    Il modello GlossaryEntry con `contexts[]` richiede schema migration
+    backend su tabella `glossary_entries` (oggi single-context). Il mockup
+    propone il modello; la spec backend è separata (issue/spec a parte,
+    non in questo mockup).
+
   UI:     entityHsl() o var(--c-toolkit) tokens. MeepleCard + ManaPips compatibili.
-  Persona: Aaron (badsworm@gmail.com), durante sessione gruppo A.
-  Issue:  #952 (FE implementation pending).
+  A11y:   role="dialog" + aria-modal su conflict-dialog · role="radiogroup"
+          per 3 CTA · role="listbox" + aria-multiselectable per bulk modal
+          multi-select · aria-expanded su variant-expansion chevron.
+  Persona: Aaron (badsworm@gmail.com), durante sessione "Sera con i ragazzi".
+  Issue:  #952 (FE implementation pending). Spec: 2026-05-23-mockup-refinement
+          -aaron-core-design.md sezione 1c.
   ===================================================================
 -->
 <html lang="it" data-theme="light">
@@ -209,22 +292,29 @@
 <div class="gl-stage">
   <div class="gl-wrap">
     <div class="gl-head">
-      <h1>SP6 · H · Glossary editor — Libro game</h1>
+      <h1>SP6 · H · Glossary editor — Libro game · context-aware</h1>
       <p class="lead">
         Modale che si apre SOPRA il viewer D <code>translation-viewer</code>
         quando Aaron tappa una glossary pill cliccabile inline al testo.
-        Persona <strong>Aaron (badsworm@gmail.com)</strong> in dogfooding.
-        4 stati mobile (fullscreen sheet) + 2 desktop variants (centered overlay 480px).
-        Coverage scenario <strong>N3.5</strong> del design doc 2026-05-07.
+        Persona <strong>Aaron (badsworm@gmail.com)</strong> in dogfooding,
+        narrative <em>"Sera con i ragazzi · Runa di Ardenel · §147"</em>.
+        4 stati base (modal edit) + 4 NUOVI sub-screen <em>context-aware</em>:
+        conflict-dialog · bulk-import-card · variant-expansion · filter-strip.
+        Coverage scenario <strong>N3.5</strong> + spec <strong>sezione 1c</strong>
+        (modello <code>GlossaryEntry.contexts[]</code>, threshold
+        <code>context_similarity 0.85</code>, bulk threshold <code>≥3</code>).
       </p>
       <div class="meta-row">
         <span class="tag">@N3.5 inline pill edit</span>
+        <span class="tag">@1c context-aware</span>
         <span class="tag kb">entity=kb (glossary domain)</span>
         <span class="tag warn">var(--c-warning) save error</span>
         <span class="tag danger">var(--c-event) collision</span>
+        <span class="tag muted">conflict-dialog (sim &lt; 0.85)</span>
+        <span class="tag muted">bulk-import-card (≥3 nuove)</span>
+        <span class="tag muted">variant-expansion (contexts.length &gt; 1)</span>
+        <span class="tag muted">filter-strip + context-badges</span>
         <span class="tag muted">FREEZE v2 #807/#808 compliant</span>
-        <span class="tag muted">.gl-phone fullscreen sheet</span>
-        <span class="tag muted">desktop modal 480px</span>
       </div>
     </div>
 
@@ -249,6 +339,10 @@
       <option value="state-02">02 Edited</option>
       <option value="state-03">03 Save error</option>
       <option value="state-04">04 Collision</option>
+      <option value="state-05">05 Conflict dialog (sim &lt; 0.85)</option>
+      <option value="state-06">06 Bulk import card (≥3 nuove)</option>
+      <option value="state-07">07 Variant expansion</option>
+      <option value="state-08">08 Filter strip + context badges</option>
     </select>
   </label>
   <label>

--- a/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
+++ b/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
@@ -14,8 +14,23 @@
           D · translating     (streaming primo token IT, progress)
           E · fullscreen-viewer (testo IT 26px line-height 1.6 max-width 60ch + glossary pill)
           F · low-confidence  (banner amber + 3 azioni Rifotografa/Numero § manuale/Procedi)
+          G · loading-4step   (Caricamento foto → OCR → Traduzione → Glossario, abort CTA, skeleton+shimmer)  ← Task 2 (spec 1b.A)
+          H · reader-mode     (toggle 16pt↔24pt, localStorage 'reader-mode-enabled', split-view)              ← Task 2 (spec 1b.B)
+          I · wake-lock       (badge sticky bottom-right, 3 stati: attivo/disabilitato/non-supportato)        ← Task 2 (spec 1b.C)
+          J · contrasto-aaa   (paragrafo tradotto ≥7:1 contrast, max-width 65ch centrato)                     ← Task 2 (spec 1b.D)
   Vincolo: SMART N3 — segmentation accuracy ≥ 90%, OCR confidence ≥ 0.7, latency P95 < 8s end-to-end.
-  Mobile-first 375px CANONICAL (Aaron al tavolo). Desktop full parity.
+  Latency targets (sequenza loading 4-step Aaron):
+          step1 (Caricamento foto)        < 2s   (0-2s,  upload + EXIF strip)
+          step2 (OCR — Sto leggendo)      < 5s   (2-7s,  smoldocling extraction)
+          step3 (Sto traducendo)          < 10s  (7-15s, AI translation token-by-token streaming)
+          step4 (Cerco parole glossario)  < 2s   (15-17s, glossary check + badge ⊕ progressive highlight)
+          total                           < 17s
+          hard timeout                    20s    → trigger state-G `translation-timeout` in librogame-runthrough-error-states.html
+  Reader mode:    localStorage key `reader-mode-enabled` (boolean). Persistito cross-session, applicato a skeleton + paragrafo finale.
+  Wake-lock:      Web Wake Lock API (Safari < 16.4 fallback "Non supportato"). Override manuale via badge click.
+  Contrasto AAA:  paragrafo tradotto usa `--c-text-high-contrast` (≥7:1 vs background), centrato, max-width 65ch.
+  Mobile-first 375px CANONICAL (Aaron al tavolo). Desktop full parity (1280px breakpoint).
+  Narrative coherent: "Sera con i ragazzi · Runa di Ardenel · §147" — same campaign as librogame-runthrough-error-states.html (Task 1).
 -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -402,9 +417,287 @@
     color: rgba(255,255,255,0.6); font-family: var(--f-mono); font-size: var(--fs-xs);
   }
 
+  /* ═══════════════════════════════════════════════════════════
+     STATI G/H/I/J · Task 2 — Loading 4-step + Reader + Wake-lock + AAA
+     ═══════════════════════════════════════════════════════════ */
+
+  /* Fallback CSS variable per contrasto AAA-target (≥7:1).
+     Definito locale se non presente in tokens.css. In light mode usa quasi-nero,
+     in dark mode bianco pieno. Compatibile con bg cream `--bg` mockup. */
+  :root {
+    --c-text-high-contrast: #0f0a05;   /* light: quasi-nero vs cream bg = ~15:1 */
+  }
+  [data-theme="dark"] {
+    --c-text-high-contrast: #ffffff;   /* dark: bianco pieno vs dark bg = ~18:1 */
+  }
+
+  /* ─── G: Loading 4-step shell ─── */
+  .loading-4step {
+    flex: 1; display: flex; flex-direction: column; padding: var(--s-5);
+    gap: var(--s-4); overflow-y: auto;
+  }
+  .loading-4step .step-thumbnail {
+    width: 96px; aspect-ratio: 3/4; flex-shrink: 0;
+    border-radius: var(--r-md); overflow: hidden;
+    background:
+      repeating-linear-gradient(0deg, transparent, transparent 8px, rgba(0,0,0,0.04) 8px, rgba(0,0,0,0.04) 9px),
+      linear-gradient(135deg, #f4ead7, #e9dcc1);
+    border: 1px solid var(--border);
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--f-mono); font-size: 9px; color: var(--text-muted);
+    text-align: center;
+  }
+  .loading-4step .step-thumb-row {
+    display: flex; align-items: center; gap: var(--s-3);
+    padding: var(--s-3); background: var(--bg-card);
+    border: 1px solid var(--border-light); border-radius: var(--r-md);
+  }
+  .loading-4step .step-thumb-row .info { flex: 1; min-width: 0; }
+  .loading-4step .step-thumb-row .info .v { font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); }
+  .loading-4step .step-thumb-row .info .s { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin-top: 2px; }
+
+  /* Step list mobile = verticale stack | desktop = orizzontale breadcrumb (vedi .step-list-h) */
+  .step-list-v {
+    display: flex; flex-direction: column; gap: var(--s-2);
+  }
+  .step-list-h {
+    display: flex; flex-direction: row; gap: var(--s-2); align-items: center;
+    padding: var(--s-3) var(--s-4); background: var(--bg-card);
+    border-radius: var(--r-md); border: 1px solid var(--border-light);
+    overflow-x: auto;
+  }
+  .step-list-h .step-pill {
+    display: inline-flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    background: var(--bg-muted); flex-shrink: 0;
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+  }
+  .step-list-h .step-pill.done { background: hsl(var(--c-success) / 0.12); color: hsl(var(--c-success)); }
+  .step-list-h .step-pill.active { background: hsl(var(--c-kb) / 0.15); color: hsl(var(--c-kb)); font-weight: var(--fw-bold); }
+  .step-list-h .arrow { color: var(--text-muted); font-size: 12px; flex-shrink: 0; }
+
+  /* Linear progress bar (step 1 — upload %) */
+  .linear-progress {
+    width: 100%; height: 6px; background: var(--bg-muted);
+    border-radius: var(--r-pill); overflow: hidden; position: relative;
+  }
+  .linear-progress .fill-pct {
+    position: absolute; left: 0; top: 0; bottom: 0;
+    background: linear-gradient(90deg, hsl(var(--c-kb)), hsl(var(--c-game)));
+    border-radius: var(--r-pill);
+  }
+  .pct-label {
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+    font-variant-numeric: tabular-nums; margin-top: var(--s-1);
+  }
+
+  /* Skeleton paragraph (step 2 — OCR) — 3 righe + shimmer-sweep gradient */
+  .skeleton-paragraph {
+    display: flex; flex-direction: column; gap: var(--s-2);
+    padding: var(--s-4); background: var(--bg-card);
+    border: 1px solid var(--border-light); border-radius: var(--r-md);
+  }
+  .skeleton-line {
+    height: 18px; border-radius: var(--r-sm);
+    background: linear-gradient(
+      90deg,
+      var(--bg-muted) 0%,
+      hsl(var(--c-kb) / 0.08) 50%,
+      var(--bg-muted) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer-sweep 1.8s ease-in-out infinite;
+  }
+  .skeleton-line.w-100 { width: 100%; }
+  .skeleton-line.w-92 { width: 92%; }
+  .skeleton-line.w-65 { width: 65%; }
+  @keyframes shimmer-sweep {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  /* Step 3 — paragrafo OCR 60% opacity SOPRA + traduzione token-by-token SOTTO */
+  .ocr-overlay {
+    padding: var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-kb) / 0.04); border: 1px dashed hsl(var(--c-kb) / 0.25);
+    font-family: 'Georgia', serif; font-style: italic; font-size: var(--fs-sm);
+    color: var(--text-sec); opacity: 0.6; line-height: var(--lh-body);
+  }
+  .ocr-overlay .badge-en {
+    display: inline-block; padding: 1px var(--s-2); border-radius: var(--r-sm);
+    background: var(--bg-muted); color: var(--text-muted); margin-right: var(--s-2);
+    font-family: var(--f-mono); font-size: 10px; font-style: normal; font-weight: var(--fw-bold);
+  }
+  .translation-stream {
+    padding: var(--s-4); border-radius: var(--r-md);
+    background: var(--bg-card); border: 1px solid hsl(var(--c-game) / 0.3);
+    font-family: var(--f-body); font-size: 18px; line-height: 1.55; color: var(--text);
+  }
+  .translation-stream .token { animation: token-in 0.18s ease-out; display: inline; }
+  @keyframes token-in {
+    from { opacity: 0; transform: translateY(2px); }
+    to { opacity: 1; transform: none; }
+  }
+  .translation-stream .cursor {
+    display: inline-block; width: 8px; height: 18px;
+    background: hsl(var(--c-game)); margin-left: 3px; vertical-align: text-bottom;
+    animation: blink 0.9s step-end infinite;
+  }
+
+  /* Step 4 — Highlight progressivo parole nuove (badge ⊕) */
+  .glossary-check {
+    padding: var(--s-4); border-radius: var(--r-md);
+    background: hsl(var(--c-agent) / 0.05); border: 1px solid hsl(var(--c-agent) / 0.25);
+    font-family: var(--f-body); font-size: 16px; line-height: 1.55;
+  }
+  .glossary-check .new-word {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 1px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-agent) / 0.18); color: hsl(var(--c-agent));
+    font-weight: var(--fw-semi); animation: glossary-pop 0.4s ease-out;
+  }
+  .glossary-check .new-word::after { content: "⊕"; font-size: 11px; margin-left: 2px; }
+  @keyframes glossary-pop {
+    0% { transform: scale(0.8); opacity: 0; }
+    60% { transform: scale(1.08); opacity: 1; }
+    100% { transform: scale(1); }
+  }
+
+  /* Abort CTA (step 2+) */
+  .abort-bar {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: var(--s-3); padding: var(--s-3); margin-top: var(--s-2);
+    background: var(--bg-muted); border-radius: var(--r-md);
+    border: 1px solid var(--border-light);
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+  }
+  .abort-bar .abort-btn {
+    padding: var(--s-2) var(--s-4); border-radius: var(--r-md);
+    background: var(--bg-card); border: 1px solid var(--border);
+    color: var(--text); font-family: var(--f-display); font-weight: var(--fw-semi);
+    font-size: var(--fs-sm); cursor: pointer;
+  }
+  .abort-bar .abort-btn:hover { background: hsl(var(--c-warning) / 0.08); border-color: hsl(var(--c-warning) / 0.4); color: hsl(var(--c-warning)); }
+  .abort-fab {
+    position: absolute; right: var(--s-4); bottom: var(--s-7);
+    width: 52px; height: 52px; border-radius: 50%;
+    background: hsl(var(--c-warning)); color: #fff; border: 0;
+    box-shadow: var(--shadow-lg); cursor: pointer; font-size: 22px;
+    display: flex; align-items: center; justify-content: center;
+    z-index: 5;
+  }
+
+  /* Cost transparency banner inline per ogni step */
+  .cost-inline {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-success) / 0.12); color: hsl(var(--c-success));
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+  }
+  .cost-inline.paid { background: hsl(var(--c-kb) / 0.12); color: hsl(var(--c-kb)); }
+
+  /* Telemetry footer per phone frame */
+  .telemetry-footer {
+    padding: var(--s-2) var(--s-3); border-top: 1px solid var(--border-light);
+    background: var(--bg-muted); flex-shrink: 0;
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    display: flex; align-items: center; justify-content: space-between; gap: var(--s-2);
+  }
+
+  /* ─── H: Reader Mode toggle classes ─── */
+  /* Default mode = 16pt | Reader mode = 24pt + line-height 1.7 + padding aumentato + max-width 65ch */
+  .reader-mode-content {
+    font-family: var(--f-body); font-size: 16px; line-height: 1.55;
+    color: var(--text); padding: var(--s-3); max-width: 60ch;
+  }
+  .reader-mode-content.reader-mode {
+    font-size: 24px; line-height: 1.7; padding: var(--s-6);
+    max-width: 65ch; margin: 0 auto;
+  }
+  .reader-mode-toggle {
+    display: inline-flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    background: var(--bg-card); border: 1px solid var(--border);
+    color: var(--text); font-family: var(--f-mono); font-size: var(--fs-xs);
+    cursor: pointer;
+  }
+  .reader-mode-toggle.active {
+    background: hsl(var(--c-kb) / 0.15); border-color: hsl(var(--c-kb)); color: hsl(var(--c-kb));
+    font-weight: var(--fw-bold);
+  }
+  .reader-mode-toggle .ico { font-size: 14px; }
+
+  /* Quando reader mode è attivo, lo skeleton si ridimensiona di pari passo */
+  .skeleton-paragraph.reader-mode .skeleton-line { height: 26px; }
+
+  /* Demo split-view per mostrare default vs reader side-by-side */
+  .reader-split-view {
+    display: flex; gap: var(--s-4); align-items: flex-start;
+  }
+  .reader-split-view > * { flex: 1; min-width: 0; }
+  .reader-split-view .variant-label {
+    display: inline-block; padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    background: var(--bg-muted); color: var(--text-sec);
+    font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-bold);
+    margin-bottom: var(--s-2);
+  }
+  .reader-split-view .variant-label.reader { background: hsl(var(--c-kb) / 0.15); color: hsl(var(--c-kb)); }
+
+  /* ─── I: Wake-Lock sticky badge ─── */
+  .wake-lock-indicator {
+    position: absolute; right: var(--s-3); bottom: 70px;
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    background: rgba(0,0,0,0.65); color: rgba(255,255,255,0.85);
+    backdrop-filter: blur(8px); font-family: var(--f-mono); font-size: 11px;
+    cursor: pointer; box-shadow: var(--shadow-md);
+    z-index: 4;
+  }
+  .wake-lock-indicator.disabled {
+    background: rgba(0,0,0,0.45); color: rgba(255,255,255,0.55);
+  }
+  .wake-lock-indicator.unsupported {
+    background: hsl(var(--c-warning) / 0.85); color: #fff;
+  }
+  .wake-lock-indicator .ico { font-size: 14px; }
+  .wake-lock-toast {
+    position: absolute; left: 50%; bottom: 130px; transform: translateX(-50%);
+    padding: var(--s-2) var(--s-4); border-radius: var(--r-md);
+    background: rgba(0,0,0,0.8); color: #fff;
+    font-family: var(--f-display); font-size: var(--fs-sm); font-weight: var(--fw-semi);
+    box-shadow: var(--shadow-lg); z-index: 5;
+  }
+
+  /* ─── J: Contrasto AAA (≥7:1) ─── */
+  .viewer-text.aaa {
+    color: var(--c-text-high-contrast);
+    max-width: 65ch; margin: 0 auto;
+    text-align: left;
+  }
+  .viewer-text.aaa em {
+    color: var(--c-text-high-contrast); opacity: 0.92;
+    font-style: italic;
+  }
+  .contrast-badge {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-success) / 0.15); color: hsl(var(--c-success));
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+  }
+
   *:focus-visible { outline: 2px solid hsl(var(--c-kb)); outline-offset: 2px; }
   @media (prefers-reduced-motion: reduce) {
-    .photo-preview .scan, .stream-text .cursor, .translation-progress .bar .fill { animation: none; }
+    .photo-preview .scan,
+    .stream-text .cursor,
+    .translation-progress .bar .fill,
+    .skeleton-line,
+    .translation-stream .token,
+    .translation-stream .cursor,
+    .glossary-check .new-word { animation: none; }
+    /* prefers-reduced-motion: skeleton statico (no shimmer-sweep) */
+    .skeleton-line {
+      background: var(--bg-muted);
+    }
   }
 </style>
 </head>
@@ -739,6 +1032,596 @@
             </div>
           </div>
           <button class="nav-btn primary">Letto, vai a §148 →</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO G · LOADING MULTI-STEP (4 step nominati con label IT)
+       Task 2 spec 1b.A — sequence Caricamento foto → OCR → Traduzione → Glossario
+       Latency targets: step1<2s, step2<5s, step3<10s, step4<2s, total<17s, timeout 20s
+       Abort CTA visibile da step 2 in poi → retake con foto preservata
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sg">
+    <span class="label">Stato G · Loading 4-step</span>
+    <h2 id="sg">Sequenza loading multi-step — Aaron vede ogni passaggio</h2>
+    <p class="desc">4 step nominati in italiano: <strong>Caricamento foto</strong> (0-2s, %) → <strong>Sto leggendo il libro</strong> (2-7s, skeleton+shimmer) → <strong>Sto traducendo</strong> (7-15s, token-by-token con OCR overlay 60%) → <strong>Cerco parole nel glossario</strong> (15-17s, badge ⊕ progressivo). Hard timeout 20s → trigger `translation-timeout` (vedi librogame-runthrough-error-states.html). Mobile: step list verticale + abort FAB. Desktop: step list orizzontale breadcrumb + abort inline.</p>
+
+    <!-- ───── STEP 1 · Caricamento foto (0-2s) ───── -->
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Step 1 / 4 · "Caricamento foto…" (0-2s)</h3>
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – step 1 upload" aria-busy="true">
+        <span class="frame-label">Mobile · 375px · step 1</span>
+        <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Runa di Ardenel · §147</span>
+        </div>
+        <div class="loading-4step">
+          <div class="step-list-v" role="status" aria-live="polite">
+            <div class="stage-row active">
+              <span class="ico">⏳</span><span class="lbl">Caricamento foto…</span><span class="meta">0.8s / 2s</span>
+            </div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Sto leggendo il libro…</span><span class="meta">in attesa</span></div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Sto traducendo…</span><span class="meta">in attesa</span></div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Cerco parole nel glossario…</span><span class="meta">in attesa</span></div>
+          </div>
+          <div class="step-thumb-row">
+            <div class="step-thumbnail">📷<br/>photo-1234.jpg</div>
+            <div class="info">
+              <div class="v">photo-1234.jpg</div>
+              <div class="s">320 KB · upload in corso</div>
+              <div class="linear-progress" style="margin-top: 6px;"><div class="fill-pct" style="width: 42%;"></div></div>
+              <div class="pct-label">42% · ETA 1.2s</div>
+            </div>
+          </div>
+          <div style="display: flex; align-items: center; gap: var(--s-2); margin-top: var(--s-2);">
+            <span class="cost-inline">🆓 0 € · upload free</span>
+            <span style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);">EXIF GPS verrà rimosso</span>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>step=upload · t=0.8s</span>
+          <span>budget 2s · 40% used</span>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – step 1 upload" aria-busy="true">
+        <span class="frame-label">Desktop · 1280px · step 1 (breadcrumb)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Runa di Ardenel · §147 · Elaborazione</span></div>
+        <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
+          <!-- Step list orizzontale breadcrumb -->
+          <div class="step-list-h" role="status" aria-live="polite">
+            <span class="step-pill active"><span>⏳</span>1 · Caricamento foto…</span>
+            <span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>2 · Sto leggendo</span>
+            <span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>3 · Sto traducendo</span>
+            <span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>4 · Glossario</span>
+          </div>
+          <div style="display: flex; gap: var(--s-7); align-items: flex-start;">
+            <div class="step-thumbnail" style="width: 200px; height: 260px;">📷<br/>photo-1234.jpg<br/>320 KB</div>
+            <div style="flex: 1;">
+              <h3 style="font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-bold); margin: 0 0 var(--s-2);">Caricamento foto…</h3>
+              <p style="color: var(--text-sec); margin: 0 0 var(--s-4); font-size: var(--fs-md);">Sto caricando la foto sul server. EXIF GPS viene rimosso automaticamente per privacy.</p>
+              <div class="linear-progress"><div class="fill-pct" style="width: 42%;"></div></div>
+              <div class="pct-label">42% · ETA 1.2s · budget 2s</div>
+              <div style="margin-top: var(--s-4);"><span class="cost-inline">🆓 0 € · upload free</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ───── STEP 2 · OCR (2-7s) ───── -->
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Step 2 / 4 · "Sto leggendo il libro…" (2-7s · skeleton+shimmer, abort CTA da qui)</h3>
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – step 2 OCR" aria-busy="true">
+        <span class="frame-label">Mobile · 375px · step 2 + abort FAB</span>
+        <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · Sto leggendo il libro…</span>
+        </div>
+        <div class="loading-4step">
+          <div class="step-list-v" role="status" aria-live="polite">
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Caricamento foto</span><span class="meta">1.6s</span></div>
+            <div class="stage-row active"><span class="ico">⏳</span><span class="lbl">Sto leggendo il libro…</span><span class="meta">3.2s / 5s</span></div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Sto traducendo…</span><span class="meta">in attesa</span></div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Cerco parole nel glossario…</span><span class="meta">in attesa</span></div>
+          </div>
+          <!-- Skeleton paragraph 3 righe + shimmer-sweep gradient -->
+          <div class="skeleton-paragraph" aria-hidden="true">
+            <div class="skeleton-line w-100"></div>
+            <div class="skeleton-line w-92"></div>
+            <div class="skeleton-line w-65"></div>
+          </div>
+          <div style="margin-top: var(--s-2);"><span class="cost-inline">🆓 0 € · OCR local</span></div>
+        </div>
+        <!-- Abort FAB bottom-right (mobile only) -->
+        <button class="abort-fab" type="button" aria-label="Annulla elaborazione e torna alla camera con foto preservata">✕</button>
+        <div class="telemetry-footer">
+          <span>step=ocr · t=3.2s</span>
+          <span>smoldocling · cum 4.8s</span>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – step 2 OCR" aria-busy="true">
+        <span class="frame-label">Desktop · 1280px · step 2 + abort inline</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>§147</strong> · Sto leggendo il libro…</span></div>
+        <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
+          <div class="step-list-h" role="status" aria-live="polite">
+            <span class="step-pill done"><span>✓</span>1 · Caricato</span><span class="arrow">→</span>
+            <span class="step-pill active"><span>⏳</span>2 · Sto leggendo</span><span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>3 · Sto traducendo</span><span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>4 · Glossario</span>
+          </div>
+          <div style="display: flex; gap: var(--s-7); align-items: flex-start;">
+            <div class="step-thumbnail" style="width: 200px; height: 260px;">📷<br/>photo-1234.jpg<br/>OCR in corso</div>
+            <div style="flex: 1;">
+              <h3 style="font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-bold); margin: 0 0 var(--s-2);">Sto leggendo il libro…</h3>
+              <p style="color: var(--text-sec); margin: 0 0 var(--s-4); font-size: var(--fs-md);">smoldocling sta estraendo il testo. Budget 5s.</p>
+              <div class="skeleton-paragraph" aria-hidden="true">
+                <div class="skeleton-line w-100"></div>
+                <div class="skeleton-line w-92"></div>
+                <div class="skeleton-line w-65"></div>
+              </div>
+              <div class="abort-bar" style="margin-top: var(--s-4);">
+                <span>⏱ 3.2s / 5s budget · cum 4.8s</span>
+                <button class="abort-btn" type="button" aria-label="Annulla elaborazione">✕ Annulla</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ───── STEP 3 · AI Translation streaming (7-15s) ───── -->
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Step 3 / 4 · "Sto traducendo…" (7-15s · OCR overlay 60% sopra + token-by-token sotto)</h3>
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – step 3 AI translation" aria-busy="true">
+        <span class="frame-label">Mobile · 375px · step 3 streaming</span>
+        <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · Sto traducendo…</span>
+        </div>
+        <div class="loading-4step">
+          <div class="step-list-v" role="status" aria-live="polite">
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Caricamento foto</span><span class="meta">1.6s</span></div>
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Sto leggendo il libro</span><span class="meta">4.8s</span></div>
+            <div class="stage-row active"><span class="ico">⏳</span><span class="lbl">Sto traducendo…</span><span class="meta">3.1s / 10s</span></div>
+            <div class="stage-row"><span class="ico" style="opacity: 0.4;">○</span><span class="lbl" style="opacity: 0.5;">Cerco parole nel glossario…</span><span class="meta">in attesa</span></div>
+          </div>
+          <!-- OCR text sopra (60% opacity) -->
+          <div class="ocr-overlay" aria-hidden="true">
+            <span class="badge-en">EN · OCR</span>"As Niamh approached the altar, the air grew thick with whispers. The Goblin guards drew their blades, eyes gleaming with bloodlust…"
+          </div>
+          <!-- Traduzione token-by-token streaming -->
+          <div class="translation-stream" aria-live="polite">
+            <span class="token">Mentre</span> <span class="token">Niamh</span> <span class="token">si</span> <span class="token">avvicinava</span> <span class="token">all'altare,</span> <span class="token">l'aria</span> <span class="token">si</span> <span class="token">fece</span> <span class="token">densa</span> <span class="token">di</span> <span class="token">sussurri.</span> <span class="token">Le</span> <span class="token">guardie</span><span class="cursor" aria-hidden="true"></span>
+          </div>
+          <div style="margin-top: var(--s-2); display: flex; gap: var(--s-2); align-items: center;">
+            <span class="cost-inline paid">💰 ~0,01 € · DeepSeek AI</span>
+            <span style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);">SSE stream · 35%</span>
+          </div>
+        </div>
+        <button class="abort-fab" type="button" aria-label="Annulla traduzione">✕</button>
+        <div class="telemetry-footer">
+          <span>step=ai-translate · t=3.1s</span>
+          <span>deepseek · cum 7.9s</span>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – step 3 AI translation" aria-busy="true">
+        <span class="frame-label">Desktop · 1280px · step 3 streaming</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>§147</strong> · Sto traducendo…</span></div>
+        <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
+          <div class="step-list-h" role="status" aria-live="polite">
+            <span class="step-pill done"><span>✓</span>1 · Caricato</span><span class="arrow">→</span>
+            <span class="step-pill done"><span>✓</span>2 · Letto</span><span class="arrow">→</span>
+            <span class="step-pill active"><span>⏳</span>3 · Sto traducendo</span><span class="arrow">→</span>
+            <span class="step-pill"><span>○</span>4 · Glossario</span>
+          </div>
+          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--s-5);">
+            <div>
+              <h4 style="font-family: var(--f-display); font-weight: var(--fw-bold); margin: 0 0 var(--s-2); color: var(--text-muted); font-size: var(--fs-sm);">📖 Testo originale (OCR)</h4>
+              <div class="ocr-overlay" aria-hidden="true">
+                <span class="badge-en">EN · OCR</span>"As Niamh approached the altar, the air grew thick with whispers. The Goblin guards drew their blades, eyes gleaming with bloodlust…"
+              </div>
+            </div>
+            <div>
+              <h4 style="font-family: var(--f-display); font-weight: var(--fw-bold); margin: 0 0 var(--s-2); color: hsl(var(--c-game)); font-size: var(--fs-sm);">🌍 Traduzione IT (streaming token-by-token)</h4>
+              <div class="translation-stream" aria-live="polite">
+                <span class="token">Mentre</span> <span class="token">Niamh</span> <span class="token">si</span> <span class="token">avvicinava</span> <span class="token">all'altare,</span> <span class="token">l'aria</span> <span class="token">si</span> <span class="token">fece</span> <span class="token">densa</span> <span class="token">di</span> <span class="token">sussurri.</span> <span class="token">Le</span> <span class="token">guardie</span> <span class="token">Goblin</span> <span class="token">sguainarono</span><span class="cursor"></span>
+              </div>
+            </div>
+          </div>
+          <div class="abort-bar">
+            <span>⏱ 3.1s / 10s budget · cum 7.9s · 💰 ~0,01 € DeepSeek</span>
+            <button class="abort-btn" type="button">✕ Annulla traduzione</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ───── STEP 4 · Glossary check (15-17s) ───── -->
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Step 4 / 4 · "Cerco parole nel glossario…" (15-17s · badge ⊕ progressive highlight)</h3>
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – step 4 glossary check" aria-busy="true">
+        <span class="frame-label">Mobile · 375px · step 4 glossario</span>
+        <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · Cerco parole nel glossario…</span>
+        </div>
+        <div class="loading-4step">
+          <div class="step-list-v" role="status" aria-live="polite">
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Caricamento foto</span><span class="meta">1.6s</span></div>
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Sto leggendo il libro</span><span class="meta">4.8s</span></div>
+            <div class="stage-row done"><span class="ico">✓</span><span class="lbl">Sto traducendo</span><span class="meta">9.4s</span></div>
+            <div class="stage-row active"><span class="ico">⏳</span><span class="lbl">Cerco parole nel glossario…</span><span class="meta">0.8s / 2s</span></div>
+          </div>
+          <!-- Highlight progressivo parole nuove con badge ⊕ -->
+          <div class="glossary-check" aria-live="polite">
+            Mentre <span class="new-word">Niamh</span> si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie <span class="new-word">Goblin</span> sguainarono le lame, gli occhi che brillavano di sete di sangue, mentre la <span class="new-word">Pietra del Vuoto</span> pulsava di una luce malata.
+          </div>
+          <div style="margin-top: var(--s-2); display: flex; gap: var(--s-2); align-items: center; flex-wrap: wrap;">
+            <span class="cost-inline">🆓 0 € · lookup KB</span>
+            <span style="font-family: var(--f-mono); font-size: var(--fs-xs); color: hsl(var(--c-agent));">3 termini trovati</span>
+          </div>
+        </div>
+        <button class="abort-fab" type="button" aria-label="Annulla">✕</button>
+        <div class="telemetry-footer">
+          <span>step=glossary · t=0.8s</span>
+          <span>cum 16.6s / 17s budget</span>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – step 4 glossary check" aria-busy="true">
+        <span class="frame-label">Desktop · 1280px · step 4 glossario</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>§147</strong> · Cerco parole nel glossario…</span></div>
+        <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
+          <div class="step-list-h" role="status" aria-live="polite">
+            <span class="step-pill done"><span>✓</span>1 · Caricato</span><span class="arrow">→</span>
+            <span class="step-pill done"><span>✓</span>2 · Letto</span><span class="arrow">→</span>
+            <span class="step-pill done"><span>✓</span>3 · Tradotto</span><span class="arrow">→</span>
+            <span class="step-pill active"><span>⏳</span>4 · Cerco glossario</span>
+          </div>
+          <div style="display: flex; gap: var(--s-7); align-items: flex-start;">
+            <div style="flex: 1;">
+              <h3 style="font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-bold); margin: 0 0 var(--s-2);">Cerco parole nel glossario…</h3>
+              <p style="color: var(--text-sec); margin: 0 0 var(--s-4); font-size: var(--fs-md);">Identifico nomi propri, termini di gioco e parole già nel tuo glossario.</p>
+              <div class="glossary-check" aria-live="polite">
+                Mentre <span class="new-word">Niamh</span> si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie <span class="new-word">Goblin</span> sguainarono le lame, gli occhi che brillavano di sete di sangue, mentre la <span class="new-word">Pietra del Vuoto</span> pulsava di una luce malata sulla pietra dell'altare.
+              </div>
+              <div class="abort-bar" style="margin-top: var(--s-4);">
+                <span>⏱ 0.8s / 2s budget · cum 16.6s / 17s · 3 termini glossario</span>
+                <button class="abort-btn" type="button">✕ Annulla</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO H · READER MODE TOGGLE (16pt ↔ 24pt, persistito localStorage)
+       Task 2 spec 1b.B — passive co-player Aaron variant
+       localStorage key: `reader-mode-enabled` (boolean)
+       Quando attivo: font 24pt + line-height 1.7 + padding maggiore + max-width 65ch + centrato
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sh">
+    <span class="label">Stato H · Reader Mode</span>
+    <h2 id="sh">Toggle 📖 Reader Mode — Aaron passa la app a Marco co-player</h2>
+    <p class="desc">Button <strong>📖</strong> nell'header (top-right). Click → font body 16pt → 24pt + line-height +30% + padding maggiore sul container + max-width 65ch centrato. Stato persistito in <code>localStorage</code> con key <code>reader-mode-enabled</code> (boolean). Applicato sia allo skeleton (step 2 loading) che al paragrafo finale.</p>
+
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Default mode vs Reader mode · side-by-side comparison</h3>
+    <div class="reader-split-view">
+      <!-- VARIANT 1 · Default mode (16pt) -->
+      <div class="phone" role="region" aria-label="Mobile – default mode 16pt">
+        <span class="frame-label">Default · body 16pt</span>
+        <div class="phone-sbar"><span>21:42</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · traduzione</span>
+          <button class="reader-mode-toggle" type="button" aria-pressed="false" aria-label="Attiva Reader Mode">
+            <span class="ico">📖</span><span>Reader</span>
+          </button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="reader-mode-content" aria-live="polite">
+            <span class="variant-label">Default mode (16pt · line-height 1.55)</span>
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie Goblin sguainarono le lame, gli occhi che brillavano di sete di sangue, mentre la Pietra del Vuoto pulsava di una luce malata sulla pietra.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano.</em></p>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>reader-mode: false</span>
+          <span>font 16pt · width 60ch</span>
+        </div>
+      </div>
+
+      <!-- VARIANT 2 · Reader mode (24pt) -->
+      <div class="phone" role="region" aria-label="Mobile – reader mode 24pt attivo">
+        <span class="frame-label">Reader Mode ON · body 24pt</span>
+        <div class="phone-sbar"><span>21:42</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · traduzione</span>
+          <button class="reader-mode-toggle active" type="button" aria-pressed="true" aria-label="Disattiva Reader Mode">
+            <span class="ico">📖</span><span>Reader ✓</span>
+          </button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="reader-mode-content reader-mode" aria-live="polite">
+            <span class="variant-label reader">Reader mode (24pt · line-height 1.7 · max-width 65ch)</span>
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie Goblin sguainarono le lame, gli occhi che brillavano di sete di sangue.</p>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>reader-mode: true (localStorage)</span>
+          <span>font 24pt · width 65ch</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Skeleton applicato a reader-mode (step 2 con toggle ON) -->
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Reader Mode applicato anche allo skeleton (step 2 loading)</h3>
+    <div class="frames">
+      <div class="phone" role="region" aria-label="Mobile – skeleton reader-mode">
+        <span class="frame-label">Mobile · 375px · skeleton reader-mode</span>
+        <div class="phone-sbar"><span>21:42</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · Sto leggendo…</span>
+          <button class="reader-mode-toggle active" type="button" aria-pressed="true"><span class="ico">📖</span><span>Reader ✓</span></button>
+        </div>
+        <div class="loading-4step">
+          <div class="skeleton-paragraph reader-mode" aria-hidden="true">
+            <div class="skeleton-line w-100"></div>
+            <div class="skeleton-line w-92"></div>
+            <div class="skeleton-line w-65"></div>
+          </div>
+          <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); text-align: center;">Le righe skeleton hanno altezza 26px (vs 18px default) per matchare il font 24pt finale.</p>
+        </div>
+      </div>
+
+      <div class="desktop" role="region" aria-label="Desktop – reader mode comparison">
+        <span class="frame-label">Desktop · 1280px · split comparison</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?p=147</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · confronto reader mode</span>
+          <button class="reader-mode-toggle active" type="button" aria-pressed="true"><span class="ico">📖</span><span>Reader ON</span></button>
+        </div>
+        <div style="flex: 1; padding: var(--s-5); display: grid; grid-template-columns: 1fr 1fr; gap: var(--s-5); overflow-y: auto;">
+          <div style="border-right: 1px dashed var(--border); padding-right: var(--s-5);">
+            <span class="variant-label">Default · 16pt</span>
+            <div class="reader-mode-content">
+              <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            </div>
+          </div>
+          <div>
+            <span class="variant-label reader">Reader Mode · 24pt</span>
+            <div class="reader-mode-content reader-mode">
+              <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO I · WAKE-LOCK INDICATOR (badge sticky bottom-right, 3 stati)
+       Task 2 spec 1b.C — passive co-player UX
+       3 variants: 🔆 attivo · 🔅 disabilitato · 🔆 non-supportato (Safari < 16.4)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="si">
+    <span class="label">Stato I · Wake-Lock Indicator</span>
+    <h2 id="si">Badge 🔆 sticky bottom-right — override manuale screen-on</h2>
+    <p class="desc">Quando Aaron passa la app a Marco co-player, il telefono non deve bloccarsi durante la lettura. Web Wake Lock API attivo di default → badge <strong>🔆 Schermo attivo</strong> bottom-right. Click → disable wake-lock + toast feedback. Safari &lt; 16.4 → variant <strong>Non supportato</strong> con tooltip.</p>
+
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">3 stati del badge wake-lock</h3>
+    <div class="frames">
+
+      <!-- VARIANT 1 · Wake-lock ATTIVO (default) -->
+      <div class="phone" role="region" aria-label="Mobile – wake-lock attivo">
+        <span class="frame-label">Stato 1 · Wake-lock ATTIVO (default)</span>
+        <div class="phone-sbar"><span>21:42</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · lettura</span>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="viewer-text">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano.</em></p>
+          </div>
+        </div>
+        <div class="viewer-toolbar">
+          <button class="nav-btn">← §146</button>
+          <button class="nav-btn primary">§148 →</button>
+        </div>
+        <!-- Wake-lock badge ATTIVO -->
+        <button class="wake-lock-indicator" type="button" aria-pressed="true" aria-label="Disattiva blocco schermo">
+          <span class="ico">🔆</span><span>Schermo attivo</span>
+        </button>
+        <div class="telemetry-footer">
+          <span>wake-lock: active</span>
+          <span>API: navigator.wakeLock</span>
+        </div>
+      </div>
+
+      <!-- VARIANT 2 · Wake-lock DISABILITATO (dopo click) -->
+      <div class="phone" role="region" aria-label="Mobile – wake-lock disabilitato">
+        <span class="frame-label">Stato 2 · Disabilitato + toast</span>
+        <div class="phone-sbar"><span>21:43</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · lettura</span>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="viewer-text">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano.</em></p>
+          </div>
+        </div>
+        <div class="viewer-toolbar">
+          <button class="nav-btn">← §146</button>
+          <button class="nav-btn primary">§148 →</button>
+        </div>
+        <!-- Toast feedback dopo click -->
+        <div class="wake-lock-toast" role="status" aria-live="polite">Schermo torna alla normalità</div>
+        <!-- Wake-lock badge DISABILITATO -->
+        <button class="wake-lock-indicator disabled" type="button" aria-pressed="false" aria-label="Riattiva blocco schermo">
+          <span class="ico">🔅</span><span>Auto-blocco attivo</span>
+        </button>
+        <div class="telemetry-footer">
+          <span>wake-lock: released</span>
+          <span>release() called</span>
+        </div>
+      </div>
+
+      <!-- VARIANT 3 · NON SUPPORTATO (Safari < 16.4) -->
+      <div class="phone" role="region" aria-label="Mobile – wake-lock non supportato">
+        <span class="frame-label">Stato 3 · Non supportato (Safari &lt; 16.4)</span>
+        <div class="phone-sbar"><span>21:44</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · lettura</span>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="viewer-text">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano.</em></p>
+          </div>
+        </div>
+        <div class="viewer-toolbar">
+          <button class="nav-btn">← §146</button>
+          <button class="nav-btn primary">§148 →</button>
+        </div>
+        <!-- Badge unsupported con tooltip -->
+        <button class="wake-lock-indicator unsupported" type="button" aria-label="Web Wake Lock non supportato — disattiva auto-blocco nelle impostazioni del telefono"
+                title="Disattiva auto-blocco nelle impostazioni del telefono">
+          <span class="ico">🔆</span><span>Non supportato</span>
+        </button>
+        <div class="telemetry-footer">
+          <span>wake-lock: unavailable</span>
+          <span>Safari &lt; 16.4 fallback</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO J · CONTRASTO AAA (paragrafo tradotto ≥7:1)
+       Task 2 spec 1b.D — readability target WCAG AAA (vs AA 4.5:1)
+       Usa `--c-text-high-contrast` (definito locale come fallback)
+       Centrato, max-width 65ch
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sj">
+    <span class="label">Stato J · Contrasto AAA</span>
+    <h2 id="sj">Paragrafo finale con contrasto ≥7:1 — readability massima</h2>
+    <p class="desc">Il paragrafo tradotto usa <code>--c-text-high-contrast</code> (light: <code>#0f0a05</code> quasi-nero vs cream bg ≈15:1; dark: <code>#ffffff</code> bianco pieno vs dark bg ≈18:1). Centrato con <code>max-width 65ch</code> per ottimal line-length. Supera lo standard WCAG AAA di 7:1 con margine confortevole.</p>
+
+    <div class="frames">
+      <!-- Mobile · AAA contrast -->
+      <div class="phone" role="region" aria-label="Mobile – AAA contrast">
+        <span class="frame-label">Mobile · 375px · contrasto AAA</span>
+        <div class="phone-sbar"><span>21:42</span><span>📶 🔋 76%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · traduzione</span>
+          <button class="right-tool" aria-label="Menu">⋯</button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+            <span class="contrast-badge" style="margin-top: var(--s-2);">✓ AAA ≥7:1</span>
+          </header>
+          <!-- Paragrafo con classe .aaa -->
+          <div class="viewer-text aaa" aria-live="polite">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie Goblin sguainarono le lame, gli occhi che brillavano di sete di sangue, mentre la <span class="glossary-pill" role="button" tabindex="0">📒 Pietra del Vuoto</span> pulsava di una luce malata sulla pietra.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano. «Questo luogo non è per voi.»</em></p>
+          </div>
+          <div class="glossary-footnote"><strong>📒 Glossario:</strong> Pietra del Vuoto · Niamh · Goblin</div>
+        </div>
+        <div class="viewer-toolbar">
+          <button class="nav-btn">← §146</button>
+          <button class="nav-btn primary">§148 →</button>
+        </div>
+        <div class="telemetry-footer">
+          <span>contrast: ≥15:1 (light)</span>
+          <span>WCAG AAA · max-width 65ch</span>
+        </div>
+      </div>
+
+      <!-- Desktop · AAA contrast con misurazione esplicita -->
+      <div class="desktop" role="region" aria-label="Desktop – AAA contrast detailed">
+        <span class="frame-label">Desktop · 1280px · contrasto AAA + misurazione</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?p=147&amp;contrast=aaa</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs">§147 · traduzione · readability AAA</span>
+          <button class="right-tool" aria-label="Menu">⋯</button>
+        </div>
+        <div class="viewer-page" style="padding: var(--s-7);">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big" style="font-size: 56px;">§147</div>
+            <div style="display: flex; gap: var(--s-2); justify-content: center; margin-top: var(--s-2);">
+              <span class="contrast-badge">✓ AAA ≥7:1</span>
+              <span class="contrast-badge" style="background: hsl(var(--c-kb) / 0.15); color: hsl(var(--c-kb));">📏 65ch line-length</span>
+              <span class="contrast-badge" style="background: hsl(var(--c-agent) / 0.15); color: hsl(var(--c-agent));">📖 reader optimal</span>
+            </div>
+          </header>
+          <div class="viewer-text aaa">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie Goblin sguainarono le lame, gli occhi che brillavano di sete di sangue, mentre la <span class="glossary-pill" role="button" tabindex="0">📒 Pietra del Vuoto</span> pulsava di una luce malata sulla pietra.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano. «Questo luogo non è per voi.»</em></p>
+            <p>Niamh strinse l'elsa della spada, sentendo l'eco di antichi giuramenti vibrare nell'acciaio.</p>
+          </div>
+          <div class="glossary-footnote"><strong>📒 Glossario applicato:</strong> Pietra del Vuoto · Niamh · Goblin</div>
+        </div>
+        <div class="viewer-toolbar">
+          <button class="nav-btn">← §146</button>
+          <div style="display: flex; gap: var(--s-2); align-items: center;">
+            <span style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);">contrast: <strong style="color: hsl(var(--c-success));">15:1 ✓ AAA</strong> · width <strong>65ch</strong> · font 26px</span>
+            <div class="a11y-tools">
+              <button class="a11y-btn">A−</button><button class="a11y-btn">A</button><button class="a11y-btn">A+</button>
+              <button class="a11y-btn" aria-label="Tema">🌗</button>
+            </div>
+          </div>
+          <button class="nav-btn primary">§148 →</button>
         </div>
       </div>
     </div>

--- a/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
+++ b/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
@@ -18,6 +18,9 @@
           H · reader-mode     (toggle 16pt↔24pt, localStorage 'reader-mode-enabled', split-view)              ← Task 2 (spec 1b.B)
           I · wake-lock       (badge sticky bottom-right, 3 stati: attivo/disabilitato/non-supportato)        ← Task 2 (spec 1b.C)
           J · contrasto-aaa   (paragrafo tradotto ≥7:1 contrast, max-width 65ch centrato)                     ← Task 2 (spec 1b.D)
+          K · lang-detection-badge (header pill post OCR, 3 variants confidence >0.8 / 0.5-0.8 / <0.5)        ← Task 4 (spec 1d)
+          L · lang-override-modal  (modal radio group 5 lingue EN·FR·DE·ES·IT + CTA Conferma e ritraduci)     ← Task 4 (spec 1d)
+          M · manual-input-mode    (textarea fallback, ?mode=manual, no foto, max 2000 char + counter)        ← Task 4 (spec 1d)
   Vincolo: SMART N3 — segmentation accuracy ≥ 90%, OCR confidence ≥ 0.7, latency P95 < 8s end-to-end.
   Latency targets (sequenza loading 4-step Aaron):
           step1 (Caricamento foto)        < 2s   (0-2s,  upload + EXIF strip)
@@ -29,6 +32,43 @@
   Reader mode:    localStorage key `reader-mode-enabled` (boolean). Persistito cross-session, applicato a skeleton + paragrafo finale.
   Wake-lock:      Web Wake Lock API (Safari < 16.4 fallback "Non supportato"). Override manuale via badge click.
   Contrasto AAA:  paragrafo tradotto usa `--c-text-high-contrast` (≥7:1 vs background), centrato, max-width 65ch.
+
+  ─── Task 4 · Sezione 1d — Multi-language source + Manual input fallback ───
+  Source language model:
+    - Auto-detected dal LLM sul risultato OCR (stessa call AI translation, no overhead extra).
+    - confidence > 0.8 → badge informativo "Sorgente: EN" (no friction, dismissable).
+    - confidence 0.5-0.8 → badge tap-to-confirm "Sorgente: EN · Conferma o cambia" PRIMA di translate (blocking).
+    - confidence < 0.5 → trigger state-H `source-lang-unknown` in librogame-runthrough-error-states.html (forza override).
+  Lingue supportate v1: 5 sorgenti EN · FR · DE · ES · IT — copre ~95% libri-game europei.
+    Bandiere: 🇬🇧 English (EN) · 🇫🇷 Français (FR) · 🇩🇪 Deutsch (DE) · 🇪🇸 Español (ES) · 🇮🇹 Italiano (IT).
+  Target lingua: IT fisso v1 (derivato da setting profilo utente). Multi-target out-of-scope v1.
+    Target dropdown NON visibile nella UI v1.
+  Override re-translate behavior:
+    - Lang change da badge/modal preserva OCR result (cache hit) → re-translate solo step 3 (AI translation).
+    - NO re-OCR cost (smoldocling cache key `(photo_hash, page)` invariante).
+  Manual input mode (state M):
+    - Trigger via query param `?mode=manual` (UI-only, NO sub-route backend distinta).
+    - Triple-entry discoverability (3 punti di ingresso):
+        1. CTA "Digita manualmente" in error state `photo-blur-pre-ocr` (sezione 1a, state-F di error-states.html)
+        2. Kebab menu ⋮ del camera step (sp6-libro-game-photo-upload.html, top-right + voce "Digita manualmente")
+        3. Empty state quando /translate aperto senza foto: card "Libro non a portata? Digita il paragrafo"
+    - Layout: header sticky ("Inserimento manuale" + back + lang dropdown pre-filled last-used)
+              + textarea multiline (max 2000 char + counter visibile bottom-right + auto-shrink hint)
+              + book ref pre-filled (read-only chip current campaign book)
+              + CTA submit "Traduci" → skip step 2 OCR, va a step 3 (AI translation) della loading sequence (state-G)
+    - Parity: stessi step 3-4 della loading sequence Task 2 (vedere state-G); unica differenza = step 2 OCR
+              sostituito da textarea content come `source_text` direttamente.
+  Stato tracking:
+    - `source_method: "ocr" | "manual"` campo nello state della sessione (commento backend).
+      Distingue analytics + glossary edge cases (manual = no OCR confidence, no auto retake CTA).
+    - `source_lang: "en" | "fr" | "de" | "es" | "it"` (locked dopo conferma utente).
+    - `lang_detection_confidence: 0.0-1.0` (solo per source_method=ocr).
+  Cross-ref:
+    - state-H `source-lang-unknown` in librogame-runthrough-error-states.html (sez 1a Task 1) — confidence < 0.5
+    - state-F `photo-blur-pre-ocr` in librogame-runthrough-error-states.html — entry-point CTA "Digita manualmente"
+    - state-G loading 4-step (sez 1b Task 2) — manual input riusa step 3-4
+    - sp6-libro-game-photo-upload.html — kebab ⋮ "Digita manualmente" (sez 1d Task 4)
+
   Mobile-first 375px CANONICAL (Aaron al tavolo). Desktop full parity (1280px breakpoint).
   Narrative coherent: "Sera con i ragazzi · Runa di Ardenel · §147" — same campaign as librogame-runthrough-error-states.html (Task 1).
 -->
@@ -685,6 +725,327 @@
     font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
   }
 
+  /* ═══════════════════════════════════════════════════════════
+     STATI K/L/M · Task 4 — Multi-language source + Manual input
+     ═══════════════════════════════════════════════════════════ */
+
+  /* ─── K: Lang detection badge (pill nell'header) ─── */
+  .lang-detect-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: var(--s-1) var(--s-3); border-radius: var(--r-pill);
+    background: hsl(var(--c-info, var(--c-kb)) / 0.15);
+    color: hsl(var(--c-info, var(--c-kb)));
+    font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-semi);
+    cursor: pointer; border: 1px solid hsl(var(--c-info, var(--c-kb)) / 0.3);
+    transition: background var(--dur-sm) var(--ease-out);
+    white-space: nowrap;
+  }
+  .lang-detect-badge:hover { background: hsl(var(--c-info, var(--c-kb)) / 0.25); }
+  .lang-detect-badge .flag { font-size: 14px; }
+  .lang-detect-badge .conf {
+    padding: 0 4px; border-radius: var(--r-sm);
+    background: var(--bg-card); color: var(--text-sec);
+    font-size: 10px; font-variant-numeric: tabular-nums;
+  }
+  .lang-detect-badge .hint { font-style: italic; color: var(--text-sec); }
+
+  /* Variant: high confidence (>0.8) — informativo, no friction */
+  .lang-detect-badge.high {
+    background: hsl(var(--c-success) / 0.12); color: hsl(var(--c-success));
+    border-color: hsl(var(--c-success) / 0.3);
+  }
+  .lang-detect-badge.high:hover { background: hsl(var(--c-success) / 0.2); }
+
+  /* Variant: medium confidence (0.5-0.8) — tap-to-confirm */
+  .lang-detect-badge.medium {
+    background: hsl(var(--c-warning) / 0.15); color: hsl(var(--c-warning));
+    border-color: hsl(var(--c-warning) / 0.4);
+  }
+  .lang-detect-badge.medium:hover { background: hsl(var(--c-warning) / 0.25); }
+  .lang-detect-badge.medium::after {
+    content: "·  Conferma o cambia";
+    font-weight: var(--fw-reg); margin-left: 2px;
+  }
+
+  /* Variant: low confidence (<0.5) — error/critical, cross-link state-H */
+  .lang-detect-badge.low {
+    background: hsl(var(--c-danger, 0 70% 50%) / 0.15);
+    color: hsl(var(--c-danger, 0 70% 50%));
+    border-color: hsl(var(--c-danger, 0 70% 50%) / 0.4);
+    animation: pulse-low 1.8s ease-in-out infinite;
+  }
+  @keyframes pulse-low {
+    0%, 100% { box-shadow: 0 0 0 0 hsl(var(--c-danger, 0 70% 50%) / 0.0); }
+    50%      { box-shadow: 0 0 0 4px hsl(var(--c-danger, 0 70% 50%) / 0.15); }
+  }
+
+  /* ─── L: Lang override modal ─── */
+  .lang-modal-backdrop {
+    position: absolute; inset: 0;
+    background: rgba(15, 10, 5, 0.55);
+    backdrop-filter: blur(4px);
+    display: flex; align-items: center; justify-content: center;
+    padding: var(--s-4); z-index: 10;
+  }
+  .lang-modal {
+    width: 100%; max-width: 360px;
+    background: var(--bg-card); border-radius: var(--r-lg);
+    border: 1px solid var(--border); box-shadow: var(--shadow-lg);
+    overflow: hidden;
+  }
+  .lang-modal-head {
+    padding: var(--s-4) var(--s-5) var(--s-3);
+    border-bottom: 1px solid var(--border-light);
+  }
+  .lang-modal-head h3 {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-lg); margin: 0 0 var(--s-1);
+  }
+  .lang-modal-head p {
+    font-family: var(--f-mono); font-size: var(--fs-xs);
+    color: var(--text-muted); margin: 0;
+  }
+  .lang-modal-body { padding: var(--s-3) var(--s-4); }
+  .lang-radio-list {
+    display: flex; flex-direction: column; gap: var(--s-1);
+    list-style: none; padding: 0; margin: 0;
+  }
+  .lang-radio-item {
+    display: flex; align-items: center; gap: var(--s-3);
+    padding: var(--s-3); border-radius: var(--r-md);
+    background: var(--bg); border: 1px solid var(--border-light);
+    cursor: pointer; transition: background var(--dur-sm) var(--ease-out);
+  }
+  .lang-radio-item:hover { background: var(--bg-hover); border-color: hsl(var(--c-kb) / 0.4); }
+  .lang-radio-item.selected {
+    background: hsl(var(--c-kb) / 0.08);
+    border-color: hsl(var(--c-kb));
+    box-shadow: 0 0 0 2px hsl(var(--c-kb) / 0.15);
+  }
+  .lang-radio-item .flag { font-size: 22px; flex-shrink: 0; }
+  .lang-radio-item .l { flex: 1; min-width: 0; }
+  .lang-radio-item .l .v {
+    font-family: var(--f-display); font-weight: var(--fw-semi);
+    font-size: var(--fs-md); display: block;
+  }
+  .lang-radio-item .l .s {
+    font-family: var(--f-mono); font-size: var(--fs-xs);
+    color: var(--text-muted); margin-top: 1px; display: block;
+  }
+  .lang-radio-item .radio {
+    width: 18px; height: 18px; border-radius: 50%;
+    border: 2px solid var(--border); flex-shrink: 0; position: relative;
+  }
+  .lang-radio-item.selected .radio { border-color: hsl(var(--c-kb)); }
+  .lang-radio-item.selected .radio::after {
+    content: ""; position: absolute; inset: 3px;
+    background: hsl(var(--c-kb)); border-radius: 50%;
+  }
+  .lang-radio-item .auto-tag {
+    padding: 1px var(--s-2); border-radius: var(--r-sm);
+    background: hsl(var(--c-agent) / 0.15); color: hsl(var(--c-agent));
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .lang-modal-foot {
+    padding: var(--s-3) var(--s-4) var(--s-4);
+    display: flex; gap: var(--s-2); flex-direction: column;
+    border-top: 1px solid var(--border-light); background: var(--bg-muted);
+  }
+  .lang-modal-foot .cta-primary {
+    padding: var(--s-3) var(--s-4); border-radius: var(--r-md);
+    background: hsl(var(--c-kb)); color: #fff; border: 0;
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-md); cursor: pointer;
+  }
+  .lang-modal-foot .cta-secondary {
+    padding: var(--s-2) var(--s-4); border-radius: var(--r-md);
+    background: transparent; color: var(--text-sec);
+    border: 1px solid var(--border);
+    font-family: var(--f-display); font-weight: var(--fw-semi);
+    font-size: var(--fs-sm); cursor: pointer;
+  }
+  .lang-modal-foot .cache-hint {
+    font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-muted); text-align: center; margin: 0;
+  }
+  .lang-modal-foot .cache-hint strong { color: hsl(var(--c-success)); }
+
+  /* ─── M: Manual input mode (textarea fallback, no foto) ─── */
+  .manual-input-shell {
+    flex: 1; display: flex; flex-direction: column;
+    overflow-y: auto;
+  }
+  .manual-input-head {
+    padding: var(--s-4) var(--s-4) var(--s-3);
+    border-bottom: 1px solid var(--border-light);
+    background: var(--bg);
+    display: flex; flex-direction: column; gap: var(--s-2);
+    position: sticky; top: 0; z-index: 2;
+  }
+  .manual-input-head .title-row {
+    display: flex; align-items: center; gap: var(--s-2);
+  }
+  .manual-input-head h2 {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-lg); margin: 0; flex: 1;
+  }
+  .manual-input-head .badge-manual {
+    padding: 2px var(--s-2); border-radius: var(--r-pill);
+    background: hsl(var(--c-agent) / 0.15); color: hsl(var(--c-agent));
+    font-family: var(--f-mono); font-size: 9px; font-weight: var(--fw-bold);
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .manual-input-head .meta-row {
+    display: flex; align-items: center; gap: var(--s-2); flex-wrap: wrap;
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+  }
+  .manual-lang-dropdown {
+    display: inline-flex; align-items: center; gap: var(--s-2);
+    padding: 4px var(--s-2); border-radius: var(--r-pill);
+    background: var(--bg-card); border: 1px solid var(--border);
+    cursor: pointer;
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text);
+  }
+  .manual-lang-dropdown .flag { font-size: 13px; }
+  .manual-lang-dropdown .chevron { color: var(--text-muted); font-size: 10px; }
+  .book-ref-chip {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 3px var(--s-2); border-radius: var(--r-sm);
+    background: hsl(var(--c-game) / 0.1); color: hsl(var(--c-game));
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+  }
+  .book-ref-chip .lock { font-size: 9px; opacity: 0.7; }
+
+  .manual-input-body {
+    flex: 1; padding: var(--s-4);
+    display: flex; flex-direction: column; gap: var(--s-3);
+  }
+  .manual-textarea-shell {
+    position: relative;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    transition: border-color var(--dur-sm) var(--ease-out);
+  }
+  .manual-textarea-shell:focus-within {
+    border-color: hsl(var(--c-kb));
+    box-shadow: 0 0 0 3px hsl(var(--c-kb) / 0.15);
+  }
+  .manual-textarea {
+    width: 100%; min-height: 200px;
+    padding: var(--s-3) var(--s-4) var(--s-7);
+    border: 0; background: transparent; resize: vertical;
+    font-family: 'Georgia', serif; font-size: 15px; line-height: 1.55;
+    color: var(--text); outline: none;
+    box-sizing: border-box;
+  }
+  .manual-textarea::placeholder {
+    color: var(--text-muted); font-style: italic;
+  }
+  .manual-char-counter {
+    position: absolute; right: var(--s-3); bottom: var(--s-2);
+    padding: 2px var(--s-2); border-radius: var(--r-sm);
+    background: var(--bg-muted); color: var(--text-muted);
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-semi);
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+  }
+  .manual-char-counter.warn { color: hsl(var(--c-warning)); }
+  .manual-char-counter.over { color: hsl(var(--c-danger, 0 70% 50%)); background: hsl(var(--c-danger, 0 70% 50%) / 0.1); }
+  .manual-char-counter .max { color: var(--text-muted); font-weight: var(--fw-reg); }
+
+  .manual-hint {
+    padding: var(--s-2) var(--s-3); border-radius: var(--r-md);
+    background: hsl(var(--c-info, var(--c-kb)) / 0.06);
+    border: 1px dashed hsl(var(--c-info, var(--c-kb)) / 0.25);
+    font-family: var(--f-mono); font-size: var(--fs-xs);
+    color: var(--text-sec); line-height: 1.5;
+  }
+  .manual-hint strong { color: hsl(var(--c-info, var(--c-kb))); }
+
+  .manual-input-foot {
+    padding: var(--s-3) var(--s-4) var(--s-5);
+    border-top: 1px solid var(--border-light);
+    background: var(--bg-muted);
+    display: flex; flex-direction: column; gap: var(--s-2);
+  }
+  .manual-cta-primary {
+    padding: var(--s-3) var(--s-5); border-radius: var(--r-md);
+    background: hsl(var(--c-kb)); border: 0; color: #fff;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md);
+    cursor: pointer; display: flex; align-items: center; justify-content: center; gap: var(--s-2);
+  }
+  .manual-cta-primary:disabled {
+    background: var(--border); cursor: not-allowed; opacity: 0.55;
+  }
+  .manual-cta-primary .arrow { font-size: 16px; }
+  .manual-flow-note {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    text-align: center; margin: 0;
+  }
+  .manual-flow-note strong { color: hsl(var(--c-success)); }
+
+  /* Empty state entry-point card (terzo punto triple-entry) */
+  .manual-empty-card {
+    margin: var(--s-4); padding: var(--s-4);
+    border-radius: var(--r-lg);
+    background: hsl(var(--c-agent) / 0.06);
+    border: 1px dashed hsl(var(--c-agent) / 0.35);
+    display: flex; align-items: center; gap: var(--s-3);
+    cursor: pointer; transition: background var(--dur-sm) var(--ease-out);
+  }
+  .manual-empty-card:hover { background: hsl(var(--c-agent) / 0.12); }
+  .manual-empty-card .icon { font-size: 26px; flex-shrink: 0; }
+  .manual-empty-card .l { flex: 1; }
+  .manual-empty-card .l .v {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-md); display: block; color: var(--text);
+  }
+  .manual-empty-card .l .s {
+    font-family: var(--f-mono); font-size: var(--fs-xs);
+    color: var(--text-muted); margin-top: 2px; display: block;
+  }
+  .manual-empty-card .arrow {
+    color: hsl(var(--c-agent)); font-weight: var(--fw-bold); font-size: 18px;
+  }
+
+  /* Discovery diagram for triple-entry visualization (docs only) */
+  .triple-entry-diagram {
+    margin: var(--s-4) 0;
+    padding: var(--s-5);
+    border-radius: var(--r-lg);
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--s-4);
+  }
+  .triple-entry-diagram .entry {
+    padding: var(--s-3); border-radius: var(--r-md);
+    background: var(--bg); border: 1px solid var(--border-light);
+    display: flex; flex-direction: column; gap: var(--s-1);
+    text-align: center;
+  }
+  .triple-entry-diagram .entry .num {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: hsl(var(--c-agent)); color: #fff;
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-md); margin: 0 auto;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .triple-entry-diagram .entry .where {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-sm); color: var(--text);
+  }
+  .triple-entry-diagram .entry .file {
+    font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-muted);
+  }
+  @media (max-width: 720px) {
+    .triple-entry-diagram { grid-template-columns: 1fr; }
+  }
+
   *:focus-visible { outline: 2px solid hsl(var(--c-kb)); outline-offset: 2px; }
   @media (prefers-reduced-motion: reduce) {
     .photo-preview .scan,
@@ -693,7 +1054,8 @@
     .skeleton-line,
     .translation-stream .token,
     .translation-stream .cursor,
-    .glossary-check .new-word { animation: none; }
+    .glossary-check .new-word,
+    .lang-detect-badge.low { animation: none; }
     /* prefers-reduced-motion: skeleton statico (no shimmer-sweep) */
     .skeleton-line {
       background: var(--bg-muted);
@@ -1622,6 +1984,509 @@
             </div>
           </div>
           <button class="nav-btn primary">§148 →</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO K · LANG DETECTION BADGE (header pill post OCR)
+       Task 4 spec 1d — multi-language source EN·FR·DE·ES·IT
+       3 variants confidence-driven:
+         · high   (>0.8)   → badge informativo (no friction)
+         · medium (0.5-0.8)→ tap-to-confirm prima di translate (blocking)
+         · low    (<0.5)   → cross-link state-H source-lang-unknown in librogame-runthrough-error-states.html
+       Click → apre lang-override-modal (stato L)
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sk">
+    <span class="label">Stato K · Lang Detection Badge</span>
+    <h2 id="sk">Badge sorgente lingua nell'header — 3 variants confidence-driven</h2>
+    <p class="desc">Post step 2 OCR (sequenza loading 4-step Task 2 sez 1b), LLM auto-detect lingua sorgente con stessa call AI translation (no overhead). Pill nel header top-right "Sorgente: EN · 🌐". Click → apre <strong>lang-override-modal</strong> (stato L). Cross-ref: <code>&lt;0.5</code> trigger <code>source-lang-unknown</code> in <code>librogame-runthrough-error-states.html</code>.</p>
+
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">3 variants del badge · side-by-side</h3>
+    <div class="frames">
+
+      <!-- VARIANT 1 · High confidence (>0.8) — informativo -->
+      <div class="phone" role="region" aria-label="Mobile – lang-detection high confidence">
+        <span class="frame-label">Stato K.1 · confidence 0.92 (high · informativo)</span>
+        <div class="phone-sbar"><span>21:36</span><span>📶 🔋 77%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · post OCR</span>
+          <!-- Badge high confidence — no friction, dismissable -->
+          <button class="lang-detect-badge high" type="button" aria-label="Sorgente rilevata: English (alta affidabilità) — tap per cambiare">
+            <span class="flag">🇬🇧</span><span>EN</span><span class="conf">0.92</span>
+          </button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="pn-big">§147</div>
+          </header>
+          <div class="viewer-text" aria-live="polite">
+            <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri. Le guardie Goblin sguainarono le lame, gli occhi che brillavano di sete di sangue.</p>
+            <p><em>«Tornate indietro, mortali» sibilò il capitano.</em></p>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>source_method: ocr</span>
+          <span>source_lang: en · conf 0.92</span>
+        </div>
+      </div>
+
+      <!-- VARIANT 2 · Medium confidence (0.5-0.8) — tap-to-confirm blocking -->
+      <div class="phone" role="region" aria-label="Mobile – lang-detection medium confidence">
+        <span class="frame-label">Stato K.2 · confidence 0.67 (medium · tap-to-confirm)</span>
+        <div class="phone-sbar"><span>21:36</span><span>📶 🔋 77%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · conferma lingua</span>
+          <!-- Badge medium — tap-to-confirm blocking PRIMA di translate -->
+          <button class="lang-detect-badge medium" type="button" aria-label="Sorgente probabile: French — conferma o cambia prima di tradurre">
+            <span class="flag">🇫🇷</span><span>FR</span><span class="conf">0.67</span>
+          </button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch">⏸ Traduzione in pausa</div>
+            <div class="pn-big" style="font-size: 32px;">Conferma lingua</div>
+          </header>
+          <div style="padding: var(--s-4); text-align: center;">
+            <p style="font-family: var(--f-body); font-size: var(--fs-md); color: var(--text-sec); line-height: 1.55; margin: 0 0 var(--s-3);">
+              Non sono sicuro al 100% che la sorgente sia <strong style="color: hsl(var(--c-warning));">Francese</strong>. Tappa il badge sopra per confermare o cambiare prima di procedere.
+            </p>
+            <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin: 0;">
+              confidence 0.67 · soglia tap-to-confirm 0.5-0.8
+            </p>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>source_method: ocr · BLOCKED</span>
+          <span>requires user confirm</span>
+        </div>
+      </div>
+
+      <!-- VARIANT 3 · Low confidence (<0.5) — cross-link a state-H source-lang-unknown -->
+      <div class="phone" role="region" aria-label="Mobile – lang-detection low confidence cross-link">
+        <span class="frame-label">Stato K.3 · confidence 0.31 (low · cross-link state-H)</span>
+        <div class="phone-sbar"><span>21:37</span><span>📶 🔋 77%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · lingua sconosciuta</span>
+          <!-- Badge low — forza override, animazione pulse -->
+          <button class="lang-detect-badge low" type="button" aria-label="Lingua non riconosciuta — scegli manualmente"
+                  onclick="window.location.href='librogame-runthrough-error-states.html#state-H'" /* DEMO-NAV: cross-ref */>
+            <span class="flag">⚠️</span><span>?</span><span class="conf">0.31</span>
+          </button>
+        </div>
+        <div class="viewer-page" role="main">
+          <header class="viewer-header">
+            <div class="ch" style="color: hsl(var(--c-danger, 0 70% 50%));">⚠️ Lingua non riconosciuta</div>
+          </header>
+          <div style="padding: var(--s-4); text-align: center;">
+            <p style="font-family: var(--f-body); font-size: var(--fs-md); color: var(--text); line-height: 1.55; margin: 0 0 var(--s-3);">
+              Non riesco a determinare in che lingua è scritto il libro. Devi scegliere manualmente prima di procedere.
+            </p>
+            <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin: 0 0 var(--s-3);">
+              confidence 0.31 · trigger <code>source-lang-unknown</code>
+            </p>
+            <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: hsl(var(--c-kb));">
+              → Vedi <strong>state-H</strong> in <code>librogame-runthrough-error-states.html</code>
+            </p>
+          </div>
+        </div>
+        <div class="telemetry-footer">
+          <span>source_method: ocr · UNKNOWN</span>
+          <span>→ state-H cross-link</span>
+        </div>
+      </div>
+
+      <!-- Desktop · varianti badge in header -->
+      <div class="desktop" role="region" aria-label="Desktop – lang detection badge variants">
+        <span class="frame-label">Desktop · 1280px · 3 variants in toolbar</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?p=147&amp;source=auto</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · post OCR · lingua sorgente</span>
+          <button class="lang-detect-badge high" type="button"><span class="flag">🇬🇧</span><span>EN</span><span class="conf">0.92</span></button>
+        </div>
+        <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
+          <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--s-5);">
+            <div style="padding: var(--s-4); border: 1px dashed var(--border); border-radius: var(--r-md); text-align: center;">
+              <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin: 0 0 var(--s-2);">High (&gt;0.8) · informativo</p>
+              <button class="lang-detect-badge high" type="button"><span class="flag">🇬🇧</span><span>EN</span><span class="conf">0.92</span></button>
+              <p style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin: var(--s-2) 0 0;">no friction · auto-proceed</p>
+            </div>
+            <div style="padding: var(--s-4); border: 1px dashed var(--border); border-radius: var(--r-md); text-align: center;">
+              <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin: 0 0 var(--s-2);">Medium (0.5-0.8) · tap-to-confirm</p>
+              <button class="lang-detect-badge medium" type="button"><span class="flag">🇫🇷</span><span>FR</span><span class="conf">0.67</span></button>
+              <p style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin: var(--s-2) 0 0;">blocking · user confirm</p>
+            </div>
+            <div style="padding: var(--s-4); border: 1px dashed var(--border); border-radius: var(--r-md); text-align: center;">
+              <p style="font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin: 0 0 var(--s-2);">Low (&lt;0.5) · forza override</p>
+              <button class="lang-detect-badge low" type="button"><span class="flag">⚠️</span><span>?</span><span class="conf">0.31</span></button>
+              <p style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-kb)); margin: var(--s-2) 0 0;">→ state-H error-states.html</p>
+            </div>
+          </div>
+          <div style="padding: var(--s-3); background: var(--bg-muted); border-radius: var(--r-md); font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-sec);">
+            <strong>Lingue v1:</strong> 🇬🇧 EN (English) · 🇫🇷 FR (Français) · 🇩🇪 DE (Deutsch) · 🇪🇸 ES (Español) · 🇮🇹 IT (Italiano) — copertura ~95% libri-game europei. Target IT fisso (derivato da setting profilo). Multi-target out-of-scope v1.
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO L · LANG OVERRIDE MODAL (5 lingue radio + CTA ritraduci)
+       Task 4 spec 1d — re-trigger AI translation, skip step 2 OCR (cache hit)
+       Pre-selected: lingua auto-detected dal badge K
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sl">
+    <span class="label">Stato L · Lang Override Modal</span>
+    <h2 id="sl">Modal "Lingua sorgente del libro" — radio group 5 lingue v1</h2>
+    <p class="desc">Aaron tappa il badge K (qualunque variant). Modal con title "Lingua sorgente del libro" + radio group 5 lingue (🇬🇧 EN · 🇫🇷 FR · 🇩🇪 DE · 🇪🇸 ES · 🇮🇹 IT) + CTA primary "Conferma e ritraduci" + secondary "Annulla". Pre-selected: lingua auto-detected. Override behavior: <strong>OCR result preservato</strong> (cache hit, smoldocling key <code>(photo_hash, page)</code>); re-trigger solo step 3 AI translation della loading sequence (state-G).</p>
+
+    <div class="frames">
+      <!-- Mobile · modal con FR pre-selected (from badge K.2) -->
+      <div class="phone" role="region" aria-label="Mobile – lang override modal">
+        <span class="frame-label">Mobile · 375px · modal FR pre-selected</span>
+        <div class="phone-sbar"><span>21:36</span><span>📶 🔋 77%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · scegli lingua</span>
+          <button class="lang-detect-badge medium" type="button"><span class="flag">🇫🇷</span><span>FR</span><span class="conf">0.67</span></button>
+        </div>
+        <div class="viewer-page" role="main" aria-hidden="true" style="opacity: 0.45;">
+          <header class="viewer-header">
+            <div class="ch">Capitolo 4</div>
+            <div class="pn-big">§147</div>
+          </header>
+        </div>
+        <!-- Modal backdrop + content -->
+        <div class="lang-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="lang-modal-title">
+          <div class="lang-modal">
+            <div class="lang-modal-head">
+              <h3 id="lang-modal-title">Lingua sorgente del libro</h3>
+              <p>5 lingue v1 supportate · target IT fisso</p>
+            </div>
+            <div class="lang-modal-body">
+              <ul class="lang-radio-list">
+                <li class="lang-radio-item" role="button" tabindex="0">
+                  <span class="flag">🇬🇧</span>
+                  <span class="l"><span class="v">English</span><span class="s">EN · uk · us</span></span>
+                  <span class="radio" aria-hidden="true"></span>
+                </li>
+                <li class="lang-radio-item selected" role="button" tabindex="0" aria-current="true">
+                  <span class="flag">🇫🇷</span>
+                  <span class="l"><span class="v">Français</span><span class="s">FR · fr · be · ca</span></span>
+                  <span class="auto-tag">Auto</span>
+                  <span class="radio" aria-hidden="true"></span>
+                </li>
+                <li class="lang-radio-item" role="button" tabindex="0">
+                  <span class="flag">🇩🇪</span>
+                  <span class="l"><span class="v">Deutsch</span><span class="s">DE · de · at · ch</span></span>
+                  <span class="radio" aria-hidden="true"></span>
+                </li>
+                <li class="lang-radio-item" role="button" tabindex="0">
+                  <span class="flag">🇪🇸</span>
+                  <span class="l"><span class="v">Español</span><span class="s">ES · es · mx · ar</span></span>
+                  <span class="radio" aria-hidden="true"></span>
+                </li>
+                <li class="lang-radio-item" role="button" tabindex="0">
+                  <span class="flag">🇮🇹</span>
+                  <span class="l"><span class="v">Italiano</span><span class="s">IT · it · ch · sm</span></span>
+                  <span class="radio" aria-hidden="true"></span>
+                </li>
+              </ul>
+            </div>
+            <div class="lang-modal-foot">
+              <button class="cta-primary" type="button" autofocus>Conferma e ritraduci</button>
+              <button class="cta-secondary" type="button">Annulla</button>
+              <p class="cache-hint">
+                <strong>✓ OCR preservato</strong> · re-translate solo step 3 (skip OCR cache hit)
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · modal centrato + side info -->
+      <div class="desktop" role="region" aria-label="Desktop – lang override modal">
+        <span class="frame-label">Desktop · 1280px · modal + info pannello</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate?p=147&amp;override-lang=open</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>§147</strong> · override lingua sorgente</span>
+          <button class="lang-detect-badge medium" type="button"><span class="flag">🇫🇷</span><span>FR</span><span class="conf">0.67</span></button>
+        </div>
+        <div style="flex: 1; position: relative; padding: var(--s-7);">
+          <!-- Faded viewer content sotto -->
+          <div style="opacity: 0.3; pointer-events: none;">
+            <div class="viewer-text">
+              <p>Mentre Niamh si avvicinava all'altare, l'aria si fece densa di sussurri.</p>
+            </div>
+          </div>
+          <!-- Modal centrato sopra -->
+          <div class="lang-modal-backdrop" style="position: absolute;">
+            <div class="lang-modal" style="max-width: 480px;">
+              <div class="lang-modal-head">
+                <h3>Lingua sorgente del libro</h3>
+                <p>5 lingue v1 · 🇬🇧 EN · 🇫🇷 FR · 🇩🇪 DE · 🇪🇸 ES · 🇮🇹 IT — target IT fisso</p>
+              </div>
+              <div class="lang-modal-body">
+                <ul class="lang-radio-list">
+                  <li class="lang-radio-item" role="button" tabindex="0"><span class="flag">🇬🇧</span><span class="l"><span class="v">English (EN)</span></span><span class="radio"></span></li>
+                  <li class="lang-radio-item selected" role="button" tabindex="0"><span class="flag">🇫🇷</span><span class="l"><span class="v">Français (FR)</span></span><span class="auto-tag">Auto</span><span class="radio"></span></li>
+                  <li class="lang-radio-item" role="button" tabindex="0"><span class="flag">🇩🇪</span><span class="l"><span class="v">Deutsch (DE)</span></span><span class="radio"></span></li>
+                  <li class="lang-radio-item" role="button" tabindex="0"><span class="flag">🇪🇸</span><span class="l"><span class="v">Español (ES)</span></span><span class="radio"></span></li>
+                  <li class="lang-radio-item" role="button" tabindex="0"><span class="flag">🇮🇹</span><span class="l"><span class="v">Italiano (IT)</span></span><span class="radio"></span></li>
+                </ul>
+              </div>
+              <div class="lang-modal-foot" style="flex-direction: row;">
+                <button class="cta-secondary" type="button" style="flex: 1;">Annulla</button>
+                <button class="cta-primary" type="button" style="flex: 2;">Conferma e ritraduci →</button>
+              </div>
+              <div style="padding: var(--s-2) var(--s-4) var(--s-3); border-top: 1px dashed var(--border); background: var(--bg);">
+                <p class="cache-hint" style="text-align: left;">
+                  <strong>✓ OCR result preservato</strong> (smoldocling cache key invariante)<br/>
+                  → re-trigger solo step 3 AI translation (vedi state-G loading 4-step Task 2)<br/>
+                  → cost: solo DeepSeek (~0,01 €), no smoldocling recompute
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════
+       STATO M · MANUAL INPUT MODE (textarea fallback, no foto)
+       Task 4 spec 1d — ?mode=manual query param
+       Triple-entry discoverability (3 punti di ingresso visualizzati)
+       Layout: header sticky + textarea (max 2000 char + counter) + book ref chip + CTA Traduci
+       Skip step 2 OCR, va a step 3 (AI translation) della loading sequence Task 2
+       ═══════════════════════════════════════════════════════════ -->
+  <section class="state-section" aria-labelledby="sm">
+    <span class="label">Stato M · Manual Input Mode</span>
+    <h2 id="sm">Inserimento manuale — fallback senza foto (<code>?mode=manual</code>)</h2>
+    <p class="desc">Aaron non ha il libro a portata (es. Marco ce l'ha) o foto sfocata. Trigger via query param <code>?mode=manual</code> (UI-only, NO sub-route backend). Layout senza foto: header sticky + textarea multiline (max 2000 char + counter visibile) + lang dropdown pre-filled (last-used) + book ref chip pre-filled (current campaign book). CTA "Traduci" → skip step 2 OCR, va direttamente a step 3 (AI translation) della loading sequence Task 2 (state-G). Parity: stessi step 3-4; differenza = step 2 sostituito da textarea content come <code>source_text</code>. <code>source_method: "manual"</code> nello state.</p>
+
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Triple-entry discoverability (3 punti di ingresso)</h3>
+    <div class="triple-entry-diagram" role="figure" aria-label="3 punti di ingresso a manual-input-mode">
+      <div class="entry">
+        <span class="num">1</span>
+        <span class="where">CTA "Digita manualmente"</span>
+        <span class="file">in state-F <code>photo-blur-pre-ocr</code><br/>(librogame-runthrough-error-states.html sez 1a)</span>
+      </div>
+      <div class="entry">
+        <span class="num">2</span>
+        <span class="where">Kebab menu ⋮ del camera step</span>
+        <span class="file">in <code>sp6-libro-game-photo-upload.html</code><br/>(top-right + voce "Digita manualmente")</span>
+      </div>
+      <div class="entry">
+        <span class="num">3</span>
+        <span class="where">Empty state card</span>
+        <span class="file">card "Libro non a portata? Digita il paragrafo"<br/>(quando /translate aperto senza foto)</span>
+      </div>
+    </div>
+
+    <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); margin: var(--s-7) 0 var(--s-3); color: var(--text-sec);">Layout manual-input-mode · phone + desktop</h3>
+    <div class="frames">
+
+      <!-- Mobile · manual-input-mode (state principale) -->
+      <div class="phone" role="region" aria-label="Mobile – manual input mode">
+        <span class="frame-label">Mobile · 375px · ?mode=manual · 247/2000 char</span>
+        <!-- Browser URL frame mostra il query param -->
+        <div style="padding: 4px var(--s-3); background: var(--bg-muted); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); border-bottom: 1px solid var(--border-light); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+          🌐 /play/cmp-1234/translate<strong style="color: hsl(var(--c-agent));">?mode=manual</strong>
+        </div>
+        <div class="phone-sbar"><span>21:38</span><span>📶 🔋 76%</span></div>
+        <div class="manual-input-shell">
+          <!-- Header sticky -->
+          <div class="manual-input-head">
+            <div class="title-row">
+              <button class="back" aria-label="Indietro">←</button>
+              <h2>Inserimento manuale</h2>
+              <span class="badge-manual">Manual</span>
+            </div>
+            <div class="meta-row">
+              <!-- Lang dropdown pre-filled last-used -->
+              <button class="manual-lang-dropdown" type="button" aria-label="Lingua sorgente — cambia">
+                <span class="flag">🇬🇧</span><span>EN</span><span class="chevron">▾</span>
+              </button>
+              <!-- Book ref chip pre-filled -->
+              <span class="book-ref-chip" aria-label="Libro corrente — Runa di Ardenel">
+                <span class="lock">🔒</span>📕 Runa di Ardenel
+              </span>
+            </div>
+          </div>
+
+          <!-- Body: textarea + counter + hint -->
+          <div class="manual-input-body">
+            <div class="manual-textarea-shell">
+              <textarea class="manual-textarea" placeholder="Incolla o digita il paragrafo del libro…&#10;&#10;Es: «As Niamh approached the altar, the air grew thick with whispers…»" aria-label="Testo paragrafo da tradurre" maxlength="2000">As Niamh approached the altar, the air grew thick with whispers. The Goblin guards drew their blades, eyes gleaming with bloodlust, while the Voidstone pulsed with sickly light upon the dais.</textarea>
+              <!-- Counter visibile bottom-right -->
+              <span class="manual-char-counter" aria-live="polite" aria-label="247 caratteri su 2000 massimi">
+                247 <span class="max">/ 2000</span>
+              </span>
+            </div>
+            <div class="manual-hint">
+              <strong>💡 Suggerimento:</strong> Incolla esattamente il paragrafo dal libro. Salta step 2 OCR e va direttamente alla traduzione. Glossario applicato in step 4.
+            </div>
+          </div>
+
+          <!-- Footer sticky con CTA -->
+          <div class="manual-input-foot">
+            <button class="manual-cta-primary" type="button" aria-label="Traduci il testo manuale">
+              <span>Traduci</span><span class="arrow">→</span>
+            </button>
+            <p class="manual-flow-note">
+              <strong>→ step 3 streaming</strong> (skip OCR) · ~10s · 💰 ~0,01 €
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · counter warning state (over limit) -->
+      <div class="phone" role="region" aria-label="Mobile – manual input warning over-limit">
+        <span class="frame-label">Mobile · 375px · 1856/2000 (warn) e disabled state</span>
+        <div style="padding: 4px var(--s-3); background: var(--bg-muted); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); border-bottom: 1px solid var(--border-light); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+          🌐 /play/cmp-1234/translate<strong style="color: hsl(var(--c-agent));">?mode=manual</strong>
+        </div>
+        <div class="phone-sbar"><span>21:38</span><span>📶 🔋 76%</span></div>
+        <div class="manual-input-shell">
+          <div class="manual-input-head">
+            <div class="title-row">
+              <button class="back" aria-label="Indietro">←</button>
+              <h2>Inserimento manuale</h2>
+              <span class="badge-manual">Manual</span>
+            </div>
+            <div class="meta-row">
+              <button class="manual-lang-dropdown" type="button"><span class="flag">🇩🇪</span><span>DE</span><span class="chevron">▾</span></button>
+              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Runa di Ardenel</span>
+            </div>
+          </div>
+          <div class="manual-input-body">
+            <div class="manual-textarea-shell">
+              <textarea class="manual-textarea" maxlength="2000" placeholder="Incolla o digita il paragrafo…">Als Niamh sich dem Altar näherte, wurde die Luft dicht von Geflüster. Die Goblin-Wachen zogen ihre Klingen, die Augen funkelten vor Blutlust, während der Leerenstein mit krankem Licht auf dem Podest pulsierte. Niamh umklammerte den Schwertgriff fester und fühlte das Echo alter Eide im Stahl schwingen. Sie hatte zwei Möglichkeiten zur Wahl... [paragrafo lungo continua per altre 1400+ caratteri inclusi dettagli combattimento, descrizioni ambientali, e dialogo del capitano Goblin che minaccia la compagnia di avventurieri]</textarea>
+              <span class="manual-char-counter warn" aria-live="polite">
+                1856 <span class="max">/ 2000</span>
+              </span>
+            </div>
+            <div class="manual-hint" style="background: hsl(var(--c-warning) / 0.08); border-color: hsl(var(--c-warning) / 0.3);">
+              <strong style="color: hsl(var(--c-warning));">⚠️ Quasi al limite:</strong> 144 caratteri rimanenti. Paragrafi più lunghi vanno divisi in due richieste.
+            </div>
+          </div>
+          <div class="manual-input-foot">
+            <button class="manual-cta-primary" type="button">
+              <span>Traduci 1856 caratteri</span><span class="arrow">→</span>
+            </button>
+            <p class="manual-flow-note">paragrafo lungo · ~12s stimati</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · manual-input-mode full layout -->
+      <div class="desktop" role="region" aria-label="Desktop – manual input mode">
+        <span class="frame-label">Desktop · 1280px · ?mode=manual · layout esteso</span>
+        <div class="titlebar">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="url">meepleai.app/library/librogame/play/cmp-1234/translate<strong style="color: hsl(var(--c-agent));">?mode=manual</strong></span>
+        </div>
+        <div class="manual-input-shell" style="flex-direction: column;">
+          <div class="manual-input-head" style="padding: var(--s-5) var(--s-7) var(--s-4);">
+            <div class="title-row">
+              <button class="back" aria-label="Indietro">←</button>
+              <h2 style="font-size: var(--fs-xl);">Inserimento manuale</h2>
+              <span class="badge-manual">Manual · skip OCR</span>
+            </div>
+            <div class="meta-row">
+              <button class="manual-lang-dropdown" type="button" aria-label="Lingua sorgente — 5 lingue v1: EN · FR · DE · ES · IT">
+                <span class="flag">🇬🇧</span><span>English (EN)</span><span class="chevron">▾</span>
+              </button>
+              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Runa di Ardenel · Sera con i ragazzi</span>
+              <span style="margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);">
+                Target lingua: <strong style="color: hsl(var(--c-game));">🇮🇹 IT</strong> (da profilo · v1 fixed)
+              </span>
+            </div>
+          </div>
+          <div class="manual-input-body" style="padding: var(--s-7); flex-direction: row; gap: var(--s-7);">
+            <!-- Col sinistra: textarea + counter -->
+            <div style="flex: 2;">
+              <div class="manual-textarea-shell" style="min-height: 280px;">
+                <textarea class="manual-textarea" maxlength="2000" style="min-height: 280px; font-size: 17px;" placeholder="Incolla o digita il paragrafo dal libro…">As Niamh approached the altar, the air grew thick with whispers. The Goblin guards drew their blades, eyes gleaming with bloodlust, while the Voidstone pulsed with sickly light upon the dais.
+
+"Turn back, mortals" hissed the captain. "This place is not for you."
+
+Niamh tightened her grip on the sword's hilt, feeling the echo of ancient oaths thrumming in the steel. She had two choices.</textarea>
+                <span class="manual-char-counter" aria-live="polite">412 <span class="max">/ 2000</span></span>
+              </div>
+            </div>
+            <!-- Col destra: hints + flow note -->
+            <div style="flex: 1; display: flex; flex-direction: column; gap: var(--s-3);">
+              <div class="manual-hint">
+                <strong>💡 Quando usare:</strong>
+                <ul style="margin: var(--s-2) 0 0; padding-left: var(--s-4); font-size: 11px; line-height: 1.5;">
+                  <li>Libro non a portata di mano</li>
+                  <li>Foto sfocata o luce bassa (state-F)</li>
+                  <li>Vuoi correggere errori OCR</li>
+                </ul>
+              </div>
+              <div class="manual-hint" style="background: hsl(var(--c-success) / 0.06); border-color: hsl(var(--c-success) / 0.3);">
+                <strong style="color: hsl(var(--c-success));">✓ Parity flow:</strong>
+                <p style="margin: var(--s-1) 0 0; font-size: 11px; line-height: 1.5;">Step 3 (AI translate) + step 4 (glossario) identici alla loading sequence Task 2. Solo step 2 OCR sostituito da textarea content.</p>
+              </div>
+              <div class="manual-hint" style="background: var(--bg-card); border-color: var(--border); border-style: solid;">
+                <strong>🧾 Cost:</strong>
+                <p style="margin: var(--s-1) 0 0; font-size: 11px; font-family: var(--f-mono);">~0,01 € (DeepSeek)<br/>Latency: ~10s (skip OCR ~5s)</p>
+              </div>
+            </div>
+          </div>
+          <div class="manual-input-foot" style="padding: var(--s-4) var(--s-7) var(--s-5); flex-direction: row; align-items: center; gap: var(--s-4);">
+            <p class="manual-flow-note" style="text-align: left; flex: 1; margin: 0;">
+              <strong>→ step 3 streaming</strong> (skip OCR cache hit) · source_method: <code>manual</code> · source_lang: <code>en</code>
+            </p>
+            <button class="manual-cta-primary" type="button" style="min-width: 220px;">
+              <span>Traduci</span><span class="arrow">→</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · empty state card (terzo punto triple-entry) -->
+      <div class="phone" role="region" aria-label="Mobile – empty state /translate senza foto">
+        <span class="frame-label">Stato M.3 · empty state (entry-point 3 di 3)</span>
+        <div style="padding: 4px var(--s-3); background: var(--bg-muted); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); border-bottom: 1px solid var(--border-light); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+          🌐 /play/cmp-1234/translate <em>(no foto)</em>
+        </div>
+        <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
+        <div class="appbar">
+          <button class="back">←</button>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · §147</span>
+        </div>
+        <!-- Empty state principale: camera CTA + manual entry card -->
+        <div style="flex: 1; padding: var(--s-4); display: flex; flex-direction: column; gap: var(--s-3);">
+          <div style="text-align: center; padding: var(--s-5) var(--s-3);">
+            <div style="font-size: 56px; opacity: 0.4; margin-bottom: var(--s-2);">📷</div>
+            <h3 style="font-family: var(--f-display); font-size: var(--fs-lg); font-weight: var(--fw-bold); margin: 0 0 var(--s-2);">Fotografa il paragrafo</h3>
+            <p style="color: var(--text-sec); margin: 0 0 var(--s-4); font-size: var(--fs-sm);">Inquadra il numero del paragrafo (es. §147) e il testo. OCR + traduzione automatica.</p>
+            <button class="btn-sm-fill" style="padding: var(--s-3) var(--s-5);">📷 Apri fotocamera</button>
+          </div>
+          <!-- Manual entry card (terzo punto triple-entry) -->
+          <div class="manual-empty-card" role="button" tabindex="0"
+               aria-label="Libro non a portata? Digita il paragrafo manualmente"
+               onclick="window.location.href='librogame-runthrough-translate-viewer.html?mode=manual'" /* DEMO-NAV: triple-entry #3 */>
+            <span class="icon">⌨️</span>
+            <div class="l">
+              <span class="v">Libro non a portata?</span>
+              <span class="s">Digita manualmente il paragrafo · skip foto</span>
+            </div>
+            <span class="arrow">›</span>
+          </div>
+          <p style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: center; margin: 0;">
+            Entry-point 3 di 3 · vedi anche state-F error-states + kebab ⋮ camera step
+          </p>
         </div>
       </div>
     </div>

--- a/admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
@@ -1,16 +1,56 @@
 /* ===================================================================
    SP6 Libro Game — Glossary Editor (sp6-libro-game-glossary-editor.jsx)
-   Coverage: scenario N3.5 inline pill edit (design doc 2026-05-07).
+   Coverage: scenario N3.5 inline pill edit (design doc 2026-05-07)
+             + spec sezione 1c context-aware glossary (2026-05-23).
    Modal sopra il viewer D translation-viewer quando Aaron tappa una
    glossary pill cliccabile inline al testo del paragrafo §147.
 
-   Stati:
-     state-01-edit-pristine     — Voidstone → Pietra del Vuoto, Salva disabled
-     state-02-edited            — input dirty → "Pietra del Caos", Salva enabled
+   Narrative: "Sera con i ragazzi · Runa di Ardenel · §147"
+   Books esempio: Press Start + Rules Game
+
+   Stati base:
+     state-01-edit-pristine     — Sentinel → soldato di guardia, Salva disabled
+     state-02-edited            — input dirty → "punto di osservazione strategica"
      state-03-save-error        — banner amber + Retry, value preservato
      state-04-collision         — banner red, [Sovrascrivi] + [Cambia traduzione]
      state-01-desktop           — modal centered 480px
-     state-04-desktop-conflict  — modal centered + side panel 200px "Reaver → Razziatore"
+     state-04-desktop-conflict  — modal centered + side panel 200px "Ferrigni → Razziatori"
+
+   ─────────────────────────────────────────────────────────────────────
+   NUOVI sub-screen (sezione 1c context-aware glossary):
+   ─────────────────────────────────────────────────────────────────────
+     state-05-conflict-dialog       — Modal w/ 3-CTA radiogroup, side-by-side
+                                       definitions (esistente vs nuova)
+     state-06-bulk-import-card      — Inline card + multi-select review modal
+     state-07-variant-expansion     — Glossary index term row collapsed/expanded
+     state-08-filter-strip          — Header search + book filter chips +
+                                       "solo con varianti" toggle + context badges
+                                       inline su ogni term row
+
+   ─────────────────────────────────────────────────────────────────────
+   Modello dati GlossaryEntry (proposto, implica schema migration backend):
+   ─────────────────────────────────────────────────────────────────────
+     GlossaryEntry {
+       term: "sentinel",
+       base_definition: "soldato di guardia",          // primary
+       contexts: [
+         { book_id: "press-start", definition: null,    // uses base
+           first_seen: paragraph_id_X },
+         { book_id: "rules-game",
+           definition: "punto di osservazione strategica",  // variant
+           first_seen: paragraph_id_Y }
+       ]
+     }
+
+   Pattern decisions:
+     · context_similarity threshold: 0.85 (server embedding cosine);
+       auto-keep silenzioso se ≥ 0.85, conflict-dialog se < 0.85
+     · bulk-import trigger: ≥3 parole (evita card-fatigue)
+     · default conflict resolution: "Mantieni esistente" (soft, no destructive)
+     · variant deletion: ultima variante non-base eliminata → torna single-context
+
+   Decisione architetturale incidentale (Fowler): schema migration backend
+   su `glossary_entries` per contexts[]. Spec backend separata.
 
    Vincolo FREEZE v2 #807/#808: solo entityHsl(entity, alpha) o token semantici.
    =================================================================== */
@@ -711,6 +751,1055 @@ function ActionRow({ primary, secondary, caption, vertical }) {
 }
 
 /* =====================================================================
+   NUOVO sub-screen 05 — ConflictDialog
+   ─────────────────────────────────────────────────────────────────────
+   OCR trova parola "sentinel" già nel glossario base con definizione
+   "soldato di guardia", ma il nuovo paragrafo §147 di "Rules Game"
+   suggerisce "punto di osservazione strategica" (context_similarity = 0.62
+   < 0.85 threshold → mostra dialog).
+
+   Layout: dialog role="dialog" aria-modal="true"
+           body: definizioni side-by-side (esistente | nuova) con badge book
+           CTA radiogroup verticale (3 opzioni)
+           footer: [Annulla] + [Conferma] (CTA primaria game)
+
+   Default selection: "Mantieni esistente" (soft CTA, evita destructive default).
+   ===================================================================== */
+
+function ConflictDialog({ desktop = false }) {
+  const existingDef = 'soldato di guardia';
+  const newDef = 'punto di osservazione strategica';
+  const similarity = 0.62;
+  const term = 'sentinel';
+
+  const radioOptions = [
+    {
+      id: 'keep',
+      label: 'Mantieni esistente',
+      sublabel: 'Nessun cambiamento — il glossario rimane invariato',
+      isDefault: true,
+    },
+    {
+      id: 'replace',
+      label: 'Sostituisci',
+      sublabel: 'La nuova definizione rimpiazza ovunque la base',
+      accent: 'warning',
+    },
+    {
+      id: 'variant',
+      label: 'Aggiungi variante per Rules Game',
+      sublabel: 'Tieni base + variante book-specific (consigliato)',
+      accent: 'game',
+    },
+  ];
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'rgba(0, 0, 0, 0.55)',
+      backdropFilter: 'blur(3px)',
+      display: 'flex',
+      alignItems: desktop ? 'center' : 'flex-end',
+      justifyContent: 'center',
+      padding: desktop ? 24 : 0,
+      zIndex: 10,
+    }}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="conflict-dialog-title"
+        aria-describedby="conflict-dialog-desc"
+        style={{
+          width: desktop ? 540 : '100%',
+          maxWidth: '100%',
+          height: desktop ? 'auto' : '100%',
+          background: 'var(--bg-card)',
+          borderRadius: desktop ? 'var(--r-2xl)' : 'var(--r-2xl) var(--r-2xl) 0 0',
+          boxShadow: desktop
+            ? '0 24px 60px rgba(0,0,0,.18), 0 8px 16px rgba(0,0,0,.08)'
+            : 'none',
+          border: '1px solid var(--border)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}>
+        {/* Drag handle (mobile sheet) */}
+        {!desktop && (
+          <div style={{
+            display: 'flex', justifyContent: 'center',
+            paddingTop: 8, paddingBottom: 4, flexShrink: 0,
+          }}>
+            <span style={{
+              width: 36, height: 4, borderRadius: 2,
+              background: 'var(--border-strong)', opacity: 0.6,
+            }} />
+          </div>
+        )}
+
+        {/* Header */}
+        <div style={{ padding: desktop ? '20px 24px 14px' : '8px 18px 14px', flexShrink: 0 }}>
+          <div style={{
+            display: 'inline-flex', alignItems: 'center', gap: 8,
+            padding: '4px 10px',
+            borderRadius: 'var(--r-pill)',
+            background: entityHsl('event', 0.12),
+            color: entityHsl('event'),
+            fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+            border: `1px solid ${entityHsl('event', 0.28)}`,
+            marginBottom: 12,
+          }}>
+            <span style={{ fontSize: 11, lineHeight: 1 }}>⚠</span>
+            Conflitto · similarità {similarity.toFixed(2)} &lt; 0.85
+          </div>
+          <h2
+            id="conflict-dialog-title"
+            style={{
+              fontFamily: 'var(--f-display)', fontWeight: 700,
+              fontSize: 20, lineHeight: 1.25, color: 'var(--text)',
+              letterSpacing: '-0.01em', margin: '0 0 4px',
+            }}>
+            La parola "<span style={{ color: entityHsl('kb') }}>{term}</span>" è già nel glossario
+          </h2>
+          <p
+            id="conflict-dialog-desc"
+            style={{
+              margin: 0, fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.5,
+            }}>
+            Le due definizioni sono troppo diverse per fonderle automaticamente.
+            Scegli come procedere.
+          </p>
+        </div>
+
+        {/* Side-by-side definitions */}
+        <div style={{
+          padding: desktop ? '0 24px 14px' : '0 18px 14px',
+          flexShrink: 0,
+        }}>
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: desktop ? '1fr 1fr' : '1fr',
+            gap: 10,
+          }}>
+            {/* Existing */}
+            <div style={{
+              padding: '12px 14px',
+              borderRadius: 'var(--r-md)',
+              border: '1px solid var(--border-light)',
+              background: 'var(--bg-muted)',
+            }}>
+              <div style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6,
+                fontFamily: 'var(--f-mono)', fontSize: 9.5,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase', letterSpacing: '0.07em',
+                fontWeight: 700, marginBottom: 8,
+              }}>
+                <span>📖</span> Press Start · esistente
+              </div>
+              <div style={{
+                fontFamily: 'var(--f-display)', fontWeight: 600,
+                fontSize: 14, color: 'var(--text)', lineHeight: 1.45,
+              }}>{existingDef}</div>
+              <div style={{
+                marginTop: 8,
+                fontFamily: 'var(--f-mono)', fontSize: 10,
+                color: 'var(--text-muted)',
+              }}>prima vista §72 · usato 3 volte</div>
+            </div>
+            {/* New */}
+            <div style={{
+              padding: '12px 14px',
+              borderRadius: 'var(--r-md)',
+              border: `1.5px solid ${entityHsl('game', 0.42)}`,
+              background: entityHsl('game', 0.06),
+            }}>
+              <div style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6,
+                fontFamily: 'var(--f-mono)', fontSize: 9.5,
+                color: entityHsl('game'),
+                textTransform: 'uppercase', letterSpacing: '0.07em',
+                fontWeight: 700, marginBottom: 8,
+              }}>
+                <span>📖</span> Rules Game · nuova proposta
+              </div>
+              <div style={{
+                fontFamily: 'var(--f-display)', fontWeight: 600,
+                fontSize: 14, color: 'var(--text)', lineHeight: 1.45,
+              }}>{newDef}</div>
+              <div style={{
+                marginTop: 8,
+                fontFamily: 'var(--f-mono)', fontSize: 10,
+                color: 'var(--text-muted)',
+              }}>vista in §147 · primo uso</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Radio group — 3 CTA */}
+        <div
+          role="radiogroup"
+          aria-label="Come risolvere il conflitto"
+          style={{
+            padding: desktop ? '0 24px 14px' : '0 18px 14px',
+            flex: desktop ? 'unset' : 1,
+            overflowY: desktop ? 'visible' : 'auto',
+            display: 'flex', flexDirection: 'column', gap: 8,
+          }}>
+          {radioOptions.map(opt => (
+            <ConflictRadioOption key={opt.id} option={opt} />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: desktop ? '14px 24px 20px' : '12px 18px 18px',
+          borderTop: '1px solid var(--border-light)',
+          background: 'var(--bg-card)',
+          flexShrink: 0,
+          display: 'flex', gap: 8,
+        }}>
+          <button style={{
+            flex: 1,
+            padding: '11px 18px',
+            borderRadius: 'var(--r-md)',
+            border: '1px solid var(--border-strong)',
+            background: 'transparent',
+            color: 'var(--text-sec)',
+            fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 14,
+            cursor: 'pointer',
+          }}>Annulla</button>
+          <button style={{
+            flex: 1,
+            padding: '11px 18px',
+            borderRadius: 'var(--r-md)',
+            border: 'none',
+            background: entityHsl('game'),
+            color: '#fff',
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14,
+            boxShadow: `0 4px 14px ${entityHsl('game', 0.30)}`,
+            cursor: 'pointer',
+            letterSpacing: '-0.005em',
+          }}>Conferma</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConflictRadioOption({ option }) {
+  const accent = option.accent || 'kb';
+  const isDefault = option.isDefault;
+
+  return (
+    <label style={{
+      display: 'flex', alignItems: 'flex-start', gap: 12,
+      padding: '12px 14px',
+      borderRadius: 'var(--r-md)',
+      border: isDefault
+        ? `1.5px solid ${entityHsl(accent, 0.42)}`
+        : '1px solid var(--border-light)',
+      background: isDefault ? entityHsl(accent, 0.04) : 'var(--bg)',
+      cursor: 'pointer',
+      transition: 'background 120ms var(--ease-out, ease-out)',
+    }}>
+      <span
+        role="radio"
+        aria-checked={isDefault}
+        style={{
+          width: 18, height: 18, borderRadius: '50%',
+          border: `2px solid ${isDefault ? entityHsl(accent) : 'var(--border-strong)'}`,
+          background: 'var(--bg)',
+          flexShrink: 0,
+          marginTop: 2,
+          display: 'inline-flex',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+        {isDefault && (
+          <span style={{
+            width: 8, height: 8, borderRadius: '50%',
+            background: entityHsl(accent),
+          }} />
+        )}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily: 'var(--f-display)', fontWeight: 700,
+          fontSize: 14, color: 'var(--text)', lineHeight: 1.35,
+          marginBottom: 2,
+        }}>
+          {option.label}
+          {isDefault && (
+            <span style={{
+              marginLeft: 8,
+              padding: '1px 7px', borderRadius: 'var(--r-sm)',
+              fontFamily: 'var(--f-mono)', fontSize: 9, fontWeight: 700,
+              background: entityHsl(accent, 0.18),
+              color: entityHsl(accent),
+              textTransform: 'uppercase', letterSpacing: '0.06em',
+              verticalAlign: 'middle',
+            }}>default</span>
+          )}
+        </div>
+        <div style={{
+          fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.5,
+        }}>{option.sublabel}</div>
+      </div>
+    </label>
+  );
+}
+
+/* =====================================================================
+   NUOVO sub-screen 06 — BulkImportCard
+   ─────────────────────────────────────────────────────────────────────
+   OCR trova ≥3 parole nuove (threshold ≥3, NON ≥1 per evitare
+   card-fatigue). Card inline sotto traduzione di §147.
+
+   Layout: inline card sopra il viewer (NO scrim — non bloccante)
+           title "5 nuove parole rilevate"
+           chip preview (5 termini cliccabili)
+           2 CTA: ["Aggiungi tutte" 1-click] / ["Rivedi" → multi-select modal]
+
+   Multi-select modal: per-term checkbox + edit definition inline
+                       role="listbox" aria-multiselectable="true"
+   ===================================================================== */
+
+function BulkImportCard({ variant = 'inline', desktop = false }) {
+  // 5 termini esempio coerenti con narrative "Runa di Ardenel · §147"
+  const newWords = [
+    { term: 'ferrigni', proposedDef: 'razziatori di pietra-ferro' },
+    { term: 'runa', proposedDef: 'simbolo magico inciso' },
+    { term: 'threshold', proposedDef: 'soglia mistica del cerchio' },
+    { term: 'veglia cava', proposedDef: 'spirito dormiente del bosco' },
+    { term: 'ardenel', proposedDef: 'antica casata di custodi' },
+  ];
+
+  if (variant === 'inline') {
+    return <BulkImportInlineCard newWords={newWords} desktop={desktop} />;
+  }
+  return <BulkImportReviewModal newWords={newWords} desktop={desktop} />;
+}
+
+function BulkImportInlineCard({ newWords, desktop }) {
+  return (
+    <div style={{
+      position: 'absolute',
+      left: desktop ? '50%' : 12,
+      right: desktop ? 'auto' : 12,
+      top: desktop ? 'auto' : 'auto',
+      bottom: desktop ? 32 : 32,
+      transform: desktop ? 'translateX(-50%)' : 'none',
+      width: desktop ? 560 : 'auto',
+      maxWidth: '100%',
+      padding: '14px 16px',
+      borderRadius: 'var(--r-lg)',
+      background: 'var(--bg-card)',
+      border: `1.5px solid ${entityHsl('kb', 0.42)}`,
+      boxShadow: '0 16px 40px rgba(0,0,0,.16)',
+      zIndex: 10,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 10,
+      }}>
+        <span style={{
+          width: 30, height: 30, borderRadius: '50%',
+          background: entityHsl('kb', 0.16),
+          color: entityHsl('kb'),
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 15, fontWeight: 800, flexShrink: 0,
+        }}>⊕</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14,
+            color: 'var(--text)', marginBottom: 2,
+          }}>
+            {newWords.length} nuove parole rilevate
+          </div>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 10,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>
+            in §147 · libro "Runa di Ardenel" · trigger ≥3
+          </div>
+        </div>
+      </div>
+
+      {/* Chip preview */}
+      <div style={{
+        display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12,
+      }}>
+        {newWords.map(w => (
+          <span key={w.term} style={{
+            padding: '4px 10px',
+            borderRadius: 'var(--r-pill)',
+            background: entityHsl('kb', 0.10),
+            color: entityHsl('kb'),
+            fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 600,
+            border: `1px solid ${entityHsl('kb', 0.24)}`,
+            whiteSpace: 'nowrap',
+          }}>{w.term}</span>
+        ))}
+      </div>
+
+      {/* CTA row */}
+      <div style={{
+        display: 'flex', gap: 8,
+      }}>
+        <button style={{
+          flex: 1,
+          padding: '10px 16px',
+          borderRadius: 'var(--r-md)',
+          border: '1px solid var(--border-strong)',
+          background: 'transparent',
+          color: 'var(--text-sec)',
+          fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 13,
+          cursor: 'pointer',
+        }}>Rivedi</button>
+        <button style={{
+          flex: 1.4,
+          padding: '10px 16px',
+          borderRadius: 'var(--r-md)',
+          border: 'none',
+          background: entityHsl('kb'),
+          color: '#fff',
+          fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 13,
+          boxShadow: `0 4px 14px ${entityHsl('kb', 0.30)}`,
+          cursor: 'pointer',
+          letterSpacing: '-0.005em',
+        }}>Aggiungi tutte ({newWords.length})</button>
+      </div>
+    </div>
+  );
+}
+
+function BulkImportReviewModal({ newWords, desktop }) {
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'rgba(0, 0, 0, 0.55)',
+      backdropFilter: 'blur(3px)',
+      display: 'flex',
+      alignItems: desktop ? 'center' : 'flex-end',
+      justifyContent: 'center',
+      padding: desktop ? 24 : 0,
+      zIndex: 10,
+    }}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-review-title"
+        style={{
+          width: desktop ? 560 : '100%',
+          maxWidth: '100%',
+          height: desktop ? 'auto' : '100%',
+          maxHeight: desktop ? '85vh' : '100%',
+          background: 'var(--bg-card)',
+          borderRadius: desktop ? 'var(--r-2xl)' : 'var(--r-2xl) var(--r-2xl) 0 0',
+          boxShadow: desktop
+            ? '0 24px 60px rgba(0,0,0,.18), 0 8px 16px rgba(0,0,0,.08)'
+            : 'none',
+          border: '1px solid var(--border)',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}>
+        {!desktop && (
+          <div style={{
+            display: 'flex', justifyContent: 'center',
+            paddingTop: 8, paddingBottom: 4, flexShrink: 0,
+          }}>
+            <span style={{
+              width: 36, height: 4, borderRadius: 2,
+              background: 'var(--border-strong)', opacity: 0.6,
+            }} />
+          </div>
+        )}
+
+        {/* Header */}
+        <div style={{ padding: desktop ? '20px 24px 14px' : '8px 18px 14px', flexShrink: 0 }}>
+          <h2
+            id="bulk-review-title"
+            style={{
+              fontFamily: 'var(--f-display)', fontWeight: 700,
+              fontSize: 20, lineHeight: 1.25, color: 'var(--text)',
+              letterSpacing: '-0.01em', margin: '0 0 4px',
+            }}>
+            Rivedi le nuove parole
+          </h2>
+          <p style={{
+            margin: 0, fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.5,
+          }}>
+            Spunta le parole da aggiungere al glossario. Puoi editare le
+            definizioni proposte inline.
+          </p>
+        </div>
+
+        {/* List */}
+        <div
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label="Nuove parole da importare"
+          style={{
+            padding: desktop ? '0 24px 14px' : '0 18px 14px',
+            flex: 1,
+            overflowY: 'auto',
+            display: 'flex', flexDirection: 'column', gap: 8,
+          }}>
+          {newWords.map((w, idx) => (
+            <BulkReviewRow key={w.term} word={w} checked={idx !== 2} />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: desktop ? '14px 24px 20px' : '12px 18px 18px',
+          borderTop: '1px solid var(--border-light)',
+          background: 'var(--bg-card)',
+          flexShrink: 0,
+          display: 'flex', flexDirection: 'column', gap: 10,
+        }}>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 10,
+            color: 'var(--text-muted)',
+            textAlign: 'center',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>
+            4 di {newWords.length} selezionate
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button style={{
+              flex: 1,
+              padding: '11px 18px',
+              borderRadius: 'var(--r-md)',
+              border: '1px solid var(--border-strong)',
+              background: 'transparent',
+              color: 'var(--text-sec)',
+              fontFamily: 'var(--f-display)', fontWeight: 600, fontSize: 14,
+              cursor: 'pointer',
+            }}>Annulla</button>
+            <button style={{
+              flex: 1,
+              padding: '11px 18px',
+              borderRadius: 'var(--r-md)',
+              border: 'none',
+              background: entityHsl('kb'),
+              color: '#fff',
+              fontFamily: 'var(--f-display)', fontWeight: 700, fontSize: 14,
+              boxShadow: `0 4px 14px ${entityHsl('kb', 0.30)}`,
+              cursor: 'pointer',
+            }}>Aggiungi 4 parole</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BulkReviewRow({ word, checked }) {
+  return (
+    <div
+      role="option"
+      aria-selected={checked}
+      style={{
+        display: 'flex', alignItems: 'flex-start', gap: 12,
+        padding: '11px 12px',
+        borderRadius: 'var(--r-md)',
+        border: checked
+          ? `1.5px solid ${entityHsl('kb', 0.36)}`
+          : '1px solid var(--border-light)',
+        background: checked ? entityHsl('kb', 0.05) : 'var(--bg)',
+      }}>
+      {/* Checkbox */}
+      <span style={{
+        width: 18, height: 18, borderRadius: 'var(--r-sm)',
+        border: `2px solid ${checked ? entityHsl('kb') : 'var(--border-strong)'}`,
+        background: checked ? entityHsl('kb') : 'var(--bg)',
+        flexShrink: 0,
+        marginTop: 2,
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        color: '#fff', fontSize: 11, fontWeight: 800,
+      }}>
+        {checked && '✓'}
+      </span>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8,
+          marginBottom: 4,
+        }}>
+          <span style={{
+            fontFamily: 'var(--f-display)', fontWeight: 700,
+            fontSize: 14, color: 'var(--text)',
+          }}>{word.term}</span>
+          <span style={{
+            fontFamily: 'var(--f-mono)', fontSize: 9.5,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>EN → IT</span>
+        </div>
+        {/* Inline-editable definition */}
+        <div style={{
+          padding: '7px 10px',
+          borderRadius: 'var(--r-sm)',
+          border: '1px solid var(--border-light)',
+          background: 'var(--bg)',
+          fontSize: 12.5, color: 'var(--text-sec)', lineHeight: 1.45,
+          fontFamily: 'var(--f-display)',
+        }}>
+          {word.proposedDef}
+          <span style={{
+            marginLeft: 8,
+            fontFamily: 'var(--f-mono)', fontSize: 9.5,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+            fontWeight: 700,
+          }}>✏ tap per editare</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* =====================================================================
+   NUOVO sub-screen 07 — VariantExpansion
+   ─────────────────────────────────────────────────────────────────────
+   Glossary index term row con contexts.length > 1.
+   Default collapsed. Click → expand mostra varianti per book.
+
+   Layout: term row con chevron + term name + base_definition truncated
+           click → aria-expanded="true", row espande mostrando N varianti:
+             · book badge "📖 Press Start" / "📖 Rules Game"
+             · definition specifica (o "(usa base)" se context.definition null)
+             · first_seen link "Vedi paragrafo §X"
+             · delete variant button
+   ===================================================================== */
+
+function VariantExpansionList({ desktop = false }) {
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'var(--bg)',
+      overflowY: 'auto',
+      padding: desktop ? '16px 28px' : '12px 14px',
+    }}>
+      {/* Page header */}
+      <div style={{
+        marginBottom: 14,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      }}>
+        <div>
+          <h2 style={{
+            margin: '0 0 2px',
+            fontFamily: 'var(--f-display)', fontWeight: 700,
+            fontSize: 18, color: 'var(--text)',
+          }}>Glossario · Runa di Ardenel</h2>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 10,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+          }}>
+            12 termini · 3 con varianti per book
+          </div>
+        </div>
+      </div>
+
+      {/* List of term rows — 1 collapsed, 1 expanded */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <TermRow
+          term="ferrigni"
+          baseDef="razziatori di pietra-ferro"
+          contextCount={1}
+          expanded={false}
+        />
+        <TermRow
+          term="sentinel"
+          baseDef="soldato di guardia"
+          contextCount={2}
+          expanded={true}
+          variants={[
+            {
+              bookId: 'press-start',
+              bookLabel: 'Press Start',
+              definition: null,
+              firstSeen: '§72',
+            },
+            {
+              bookId: 'rules-game',
+              bookLabel: 'Rules Game',
+              definition: 'punto di osservazione strategica',
+              firstSeen: '§147',
+            },
+          ]}
+        />
+        <TermRow
+          term="runa"
+          baseDef="simbolo magico inciso"
+          contextCount={1}
+          expanded={false}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TermRow({ term, baseDef, contextCount, expanded, variants }) {
+  const hasVariants = contextCount > 1;
+
+  return (
+    <div style={{
+      borderRadius: 'var(--r-lg)',
+      border: expanded
+        ? `1.5px solid ${entityHsl('kb', 0.36)}`
+        : '1px solid var(--border-light)',
+      background: expanded ? entityHsl('kb', 0.04) : 'var(--bg-card)',
+      overflow: 'hidden',
+    }}>
+      {/* Collapsible row header */}
+      <button
+        aria-expanded={expanded}
+        aria-controls={`variants-${term}`}
+        style={{
+          width: '100%',
+          display: 'flex', alignItems: 'center', gap: 10,
+          padding: '12px 14px',
+          border: 'none', background: 'transparent',
+          textAlign: 'left',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}>
+        {/* Chevron icon (rotates on expand) */}
+        <span style={{
+          display: 'inline-flex',
+          width: 18, height: 18, flexShrink: 0,
+          alignItems: 'center', justifyContent: 'center',
+          color: 'var(--text-muted)',
+          transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+          transition: 'transform 160ms var(--ease-out, ease-out)',
+          fontSize: 14, fontWeight: 800, lineHeight: 1,
+        }}>›</span>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            display: 'flex', alignItems: 'baseline', gap: 8,
+            marginBottom: 2, flexWrap: 'wrap',
+          }}>
+            <span style={{
+              fontFamily: 'var(--f-display)', fontWeight: 700,
+              fontSize: 15, color: 'var(--text)',
+            }}>{term}</span>
+            {hasVariants && (
+              <span style={{
+                padding: '1px 7px',
+                borderRadius: 'var(--r-sm)',
+                background: entityHsl('game', 0.14),
+                color: entityHsl('game'),
+                fontFamily: 'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+                textTransform: 'uppercase', letterSpacing: '0.06em',
+              }}>{contextCount} varianti</span>
+            )}
+          </div>
+          <div style={{
+            fontSize: 12.5, color: 'var(--text-sec)', lineHeight: 1.4,
+            overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>{baseDef}</div>
+        </div>
+      </button>
+
+      {/* Expanded variants list */}
+      {expanded && variants && (
+        <div
+          id={`variants-${term}`}
+          style={{
+            padding: '4px 14px 14px',
+            borderTop: `1px dashed ${entityHsl('kb', 0.22)}`,
+            display: 'flex', flexDirection: 'column', gap: 8,
+            marginTop: 4,
+          }}>
+          <div style={{
+            fontFamily: 'var(--f-mono)', fontSize: 9.5,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase', letterSpacing: '0.07em',
+            fontWeight: 700,
+            marginTop: 10, marginBottom: 4,
+          }}>
+            Varianti per libro
+          </div>
+          {variants.map(v => (
+            <VariantRow key={v.bookId} variant={v} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VariantRow({ variant }) {
+  const usesBase = variant.definition == null;
+
+  return (
+    <div style={{
+      padding: '10px 12px',
+      borderRadius: 'var(--r-md)',
+      border: '1px solid var(--border-light)',
+      background: 'var(--bg)',
+      display: 'flex', alignItems: 'flex-start', gap: 10,
+    }}>
+      {/* Book badge */}
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5,
+        padding: '3px 9px',
+        borderRadius: 'var(--r-pill)',
+        background: entityHsl('kb', 0.12),
+        color: entityHsl('kb'),
+        fontFamily: 'var(--f-mono)', fontSize: 10, fontWeight: 700,
+        border: `1px solid ${entityHsl('kb', 0.28)}`,
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+      }}>
+        <span>📖</span>{variant.bookLabel}
+      </span>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 13, color: 'var(--text)', lineHeight: 1.45,
+          fontFamily: 'var(--f-display)',
+          fontStyle: usesBase ? 'italic' : 'normal',
+          opacity: usesBase ? 0.7 : 1,
+        }}>
+          {usesBase ? '(usa definizione base)' : variant.definition}
+        </div>
+        <div style={{
+          marginTop: 5,
+          display: 'flex', alignItems: 'center', gap: 10,
+          fontFamily: 'var(--f-mono)', fontSize: 10,
+          color: 'var(--text-muted)',
+        }}>
+          <a href="#" style={{
+            color: entityHsl('game'),
+            textDecoration: 'underline',
+            textDecorationStyle: 'dotted',
+            fontWeight: 700,
+          }}>Vedi paragrafo originale {variant.firstSeen}</a>
+        </div>
+      </div>
+
+      {/* Delete variant */}
+      <button
+        aria-label={`Elimina variante ${variant.bookLabel}`}
+        style={{
+          width: 26, height: 26,
+          borderRadius: 'var(--r-sm)',
+          border: '1px solid var(--border-light)',
+          background: 'transparent',
+          color: 'var(--text-muted)',
+          fontSize: 13, lineHeight: 1, padding: 0,
+          cursor: 'pointer',
+          flexShrink: 0,
+        }}>🗑</button>
+    </div>
+  );
+}
+
+/* =====================================================================
+   NUOVO sub-screen 08 — FilterStrip + ContextBadges
+   ─────────────────────────────────────────────────────────────────────
+   Header glossary index sempre visibile:
+     · search input (term/definition/book)
+     · filter by book chip multi-select
+     · toggle "Solo con varianti"
+   Ogni term row mostra context badges inline (📖 Press Start + 📖 Rules Game).
+   ===================================================================== */
+
+function FilterStripGlossaryIndex({ desktop = false }) {
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      background: 'var(--bg)',
+      overflowY: 'auto',
+      padding: desktop ? '16px 28px' : '12px 14px',
+    }}>
+      <div style={{
+        marginBottom: 14,
+      }}>
+        <h2 style={{
+          margin: '0 0 8px',
+          fontFamily: 'var(--f-display)', fontWeight: 700,
+          fontSize: 18, color: 'var(--text)',
+        }}>Glossario · 12 termini</h2>
+      </div>
+
+      {/* Search input */}
+      <div style={{
+        position: 'relative',
+        marginBottom: 10,
+      }}>
+        <span style={{
+          position: 'absolute',
+          left: 12, top: '50%',
+          transform: 'translateY(-50%)',
+          color: 'var(--text-muted)',
+          fontSize: 14,
+          pointerEvents: 'none',
+        }}>🔍</span>
+        <div
+          role="searchbox"
+          aria-label="Cerca nel glossario"
+          style={{
+            padding: '10px 12px 10px 38px',
+            borderRadius: 'var(--r-md)',
+            border: '1px solid var(--border-light)',
+            background: 'var(--bg-card)',
+            color: 'var(--text-muted)',
+            fontFamily: 'var(--f-display)', fontSize: 13.5,
+          }}>
+          Cerca per termine, definizione, libro…
+        </div>
+      </div>
+
+      {/* Filter chips: book multi-select */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap',
+        marginBottom: 8,
+      }}>
+        <span style={{
+          fontFamily: 'var(--f-mono)', fontSize: 10,
+          color: 'var(--text-muted)',
+          textTransform: 'uppercase', letterSpacing: '0.06em',
+          fontWeight: 700,
+          marginRight: 4,
+        }}>Libri:</span>
+        <FilterChip label="📖 Press Start" active />
+        <FilterChip label="📖 Rules Game" active />
+        <FilterChip label="📖 Encounter Book" />
+      </div>
+
+      {/* Toggle: solo con varianti */}
+      <label style={{
+        display: 'inline-flex', alignItems: 'center', gap: 8,
+        padding: '6px 12px',
+        borderRadius: 'var(--r-pill)',
+        background: entityHsl('game', 0.08),
+        border: `1px solid ${entityHsl('game', 0.28)}`,
+        cursor: 'pointer',
+        marginBottom: 16,
+      }}>
+        <span
+          role="switch"
+          aria-checked="true"
+          style={{
+            width: 28, height: 16, borderRadius: 999,
+            background: entityHsl('game'),
+            position: 'relative',
+            flexShrink: 0,
+          }}>
+          <span style={{
+            position: 'absolute',
+            right: 2, top: 2,
+            width: 12, height: 12, borderRadius: '50%',
+            background: '#fff',
+          }} />
+        </span>
+        <span style={{
+          fontFamily: 'var(--f-display)', fontSize: 12.5, fontWeight: 600,
+          color: entityHsl('game'),
+        }}>Solo con varianti</span>
+      </label>
+
+      {/* Term rows with context badges */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <TermRowWithBadges
+          term="sentinel"
+          baseDef="soldato di guardia"
+          books={['Press Start', 'Rules Game']}
+        />
+        <TermRowWithBadges
+          term="ferrigni"
+          baseDef="razziatori di pietra-ferro"
+          books={['Press Start', 'Rules Game', 'Encounter Book']}
+        />
+        <TermRowWithBadges
+          term="runa"
+          baseDef="simbolo magico inciso"
+          books={['Press Start']}
+        />
+        <TermRowWithBadges
+          term="threshold"
+          baseDef="soglia mistica del cerchio"
+          books={['Rules Game', 'Encounter Book']}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({ label, active }) {
+  return (
+    <button style={{
+      padding: '4px 10px',
+      borderRadius: 'var(--r-pill)',
+      border: active
+        ? `1.5px solid ${entityHsl('kb', 0.42)}`
+        : '1px solid var(--border-light)',
+      background: active ? entityHsl('kb', 0.12) : 'var(--bg-card)',
+      color: active ? entityHsl('kb') : 'var(--text-sec)',
+      fontFamily: 'var(--f-display)', fontSize: 12, fontWeight: 600,
+      cursor: 'pointer',
+      whiteSpace: 'nowrap',
+    }}>{label}</button>
+  );
+}
+
+function TermRowWithBadges({ term, baseDef, books }) {
+  const hasMultiContext = books.length > 1;
+
+  return (
+    <div style={{
+      padding: '11px 12px',
+      borderRadius: 'var(--r-lg)',
+      border: '1px solid var(--border-light)',
+      background: 'var(--bg-card)',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        flexWrap: 'wrap',
+        marginBottom: 4,
+      }}>
+        <span style={{
+          fontFamily: 'var(--f-display)', fontWeight: 700,
+          fontSize: 14, color: 'var(--text)',
+        }}>{term}</span>
+        {/* Context badges inline */}
+        {books.map(book => (
+          <span key={book} style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            padding: '1px 7px',
+            borderRadius: 'var(--r-sm)',
+            background: entityHsl('kb', 0.10),
+            color: entityHsl('kb'),
+            fontFamily: 'var(--f-mono)', fontSize: 9.5, fontWeight: 700,
+            border: `1px solid ${entityHsl('kb', 0.22)}`,
+            textTransform: 'none', letterSpacing: 0,
+          }}>📖 {book}</span>
+        ))}
+        {hasMultiContext && (
+          <span style={{
+            marginLeft: 'auto',
+            fontFamily: 'var(--f-mono)', fontSize: 9.5,
+            color: entityHsl('game'),
+            textTransform: 'uppercase', letterSpacing: '0.06em',
+            fontWeight: 700,
+          }}>{books.length} varianti</span>
+        )}
+      </div>
+      <div style={{
+        fontSize: 12.5, color: 'var(--text-sec)', lineHeight: 1.4,
+      }}>{baseDef}</div>
+    </div>
+  );
+}
+
+/* =====================================================================
    Phone + Desktop frames
    ===================================================================== */
 
@@ -898,6 +1987,187 @@ function App() {
           <DesktopFrame url="/library/games/nanolith/play/§147">
             <FauxViewerBackdrop withScrim={false} />
             <GlossaryEditorModal variant="collision" desktop withConflictPanel />
+          </DesktopFrame>
+        </StateBlock>
+      )}
+
+      {/* =====================================================================
+          NUOVI sub-screen sezione 1c — context-aware glossary
+          ===================================================================== */}
+
+      {/* 05 · Conflict dialog — context_similarity < 0.85 */}
+      {showState('state-05') && showMobile && (
+        <StateBlock
+          id="state-05-conflict-dialog-mobile"
+          title="05 · Conflict dialog mobile — 'sentinel' già nel glossario · sim 0.62 < 0.85"
+          gherkin="@1c context-similarity threshold"
+          frame="mobile · 375 × 780 · fullscreen sheet"
+        >
+          <div className="gl-frame-caption">
+            Side-by-side: Press Start "soldato di guardia" vs Rules Game "punto di osservazione strategica" · 3 CTA radio · default "Mantieni esistente" (soft, no destructive)
+            <span className="theme-tag">role=radiogroup</span>
+            <span className="theme-tag">sim 0.62 &lt; 0.85</span>
+          </div>
+          <div className="gl-state-grid">
+            <PhoneFrame>
+              <FauxViewerBackdrop />
+              <ConflictDialog />
+            </PhoneFrame>
+          </div>
+        </StateBlock>
+      )}
+
+      {showState('state-05') && showDesktop && (
+        <StateBlock
+          id="state-05-conflict-dialog-desktop"
+          title="05 · Conflict dialog desktop — modal 540px centered"
+          gherkin="@1c context-aware"
+          frame="desktop · 1280 × 720 · centered overlay"
+        >
+          <div className="gl-frame-caption">
+            Definizioni side-by-side in grid 2-col · radio CTA visibili immediate · threshold context_similarity = 0.85 annotato in header
+            <span className="theme-tag">grid 2-col</span>
+          </div>
+          <DesktopFrame url="/library/runa-ardenel/play/§147?glossary=conflict">
+            <FauxViewerBackdrop withScrim={false} />
+            <ConflictDialog desktop />
+          </DesktopFrame>
+        </StateBlock>
+      )}
+
+      {/* 06 · Bulk import card — ≥3 nuove parole rilevate */}
+      {showState('state-06') && showMobile && (
+        <StateBlock
+          id="state-06-bulk-import-inline-mobile"
+          title="06a · Bulk import inline card — 5 nuove parole in §147"
+          gherkin="@1c bulk-import threshold ≥3"
+          frame="mobile · 375 × 780 · inline card sopra viewer"
+        >
+          <div className="gl-frame-caption">
+            Card inline bottom · 5 chip preview (ferrigni, runa, threshold, veglia cava, ardenel) · 2 CTA: "Rivedi" + "Aggiungi tutte (5)" · trigger ≥3 (NO ≥1, evita fatigue)
+            <span className="theme-tag">non-blocking</span>
+            <span className="theme-tag">threshold ≥3</span>
+          </div>
+          <div className="gl-state-grid">
+            <PhoneFrame>
+              <FauxViewerBackdrop withScrim={false} />
+              <BulkImportCard variant="inline" />
+            </PhoneFrame>
+          </div>
+        </StateBlock>
+      )}
+
+      {showState('state-06') && showMobile && (
+        <StateBlock
+          id="state-06-bulk-import-review-mobile"
+          title="06b · Bulk import review modal — multi-select w/ inline edit"
+          gherkin="@1c bulk-import review"
+          frame="mobile · 375 × 780 · fullscreen sheet"
+        >
+          <div className="gl-frame-caption">
+            Click "Rivedi" → modal multi-select · 5 row con checkbox + def inline-editable · listbox aria-multiselectable="true" · footer "Aggiungi 4 parole"
+            <span className="theme-tag">role=listbox</span>
+            <span className="theme-tag">aria-multiselectable</span>
+          </div>
+          <div className="gl-state-grid">
+            <PhoneFrame>
+              <FauxViewerBackdrop />
+              <BulkImportCard variant="review" />
+            </PhoneFrame>
+          </div>
+        </StateBlock>
+      )}
+
+      {showState('state-06') && showDesktop && (
+        <StateBlock
+          id="state-06-bulk-import-desktop"
+          title="06 · Bulk import desktop — inline card centered + review modal"
+          gherkin="@1c bulk-import desktop"
+          frame="desktop · 1280 × 720"
+        >
+          <div className="gl-frame-caption">
+            Card 560px max-width centered bottom · non-blocking · stesso pattern del mobile ma con padding maggiore
+            <span className="theme-tag">light</span>
+          </div>
+          <DesktopFrame url="/library/runa-ardenel/play/§147?glossary=bulk">
+            <FauxViewerBackdrop withScrim={false} />
+            <BulkImportCard variant="inline" desktop />
+          </DesktopFrame>
+        </StateBlock>
+      )}
+
+      {/* 07 · Variant expansion — term row collapsed vs expanded */}
+      {showState('state-07') && showMobile && (
+        <StateBlock
+          id="state-07-variant-expansion-mobile"
+          title="07 · Variant expansion — 'sentinel' con 2 contexts per book"
+          gherkin="@1c contexts.length > 1"
+          frame="mobile · 375 × 780 · glossary index"
+        >
+          <div className="gl-frame-caption">
+            3 term rows: ferrigni (collapsed, 1 context) · sentinel (expanded, 2 varianti per "Press Start" usa-base + "Rules Game" definition specifica) · runa (collapsed) · chevron ruota su expand · aria-expanded + aria-controls
+            <span className="theme-tag">aria-expanded</span>
+            <span className="theme-tag">chevron rotate</span>
+          </div>
+          <div className="gl-state-grid">
+            <PhoneFrame>
+              <VariantExpansionList />
+            </PhoneFrame>
+          </div>
+        </StateBlock>
+      )}
+
+      {showState('state-07') && showDesktop && (
+        <StateBlock
+          id="state-07-variant-expansion-desktop"
+          title="07 · Variant expansion desktop — glossary index w/ expanded row"
+          gherkin="@1c variant deletion"
+          frame="desktop · 1280 × 720 · glossary index"
+        >
+          <div className="gl-frame-caption">
+            Click row → expand varianti per book · ogni variante: book badge "📖 Press Start"/"📖 Rules Game" + definition (o "(usa base)" se null) + link first_seen + delete button · last variant deletion → term torna single-context
+            <span className="theme-tag">variant delete</span>
+          </div>
+          <DesktopFrame url="/library/runa-ardenel/glossary">
+            <VariantExpansionList desktop />
+          </DesktopFrame>
+        </StateBlock>
+      )}
+
+      {/* 08 · Filter strip + context badges */}
+      {showState('state-08') && showMobile && (
+        <StateBlock
+          id="state-08-filter-strip-mobile"
+          title="08 · Filter strip + context badges — glossary index header"
+          gherkin="@1c filter + badges"
+          frame="mobile · 375 × 780 · glossary index"
+        >
+          <div className="gl-frame-caption">
+            Search input "Cerca per termine, definizione, libro…" · filter chips multi-select per book (Press Start + Rules Game attivi, Encounter Book disattivo) · toggle "Solo con varianti" ON · ogni term row mostra context badges inline (📖 Press Start + 📖 Rules Game)
+            <span className="theme-tag">multi-select</span>
+            <span className="theme-tag">role=switch</span>
+          </div>
+          <div className="gl-state-grid">
+            <PhoneFrame>
+              <FilterStripGlossaryIndex />
+            </PhoneFrame>
+          </div>
+        </StateBlock>
+      )}
+
+      {showState('state-08') && showDesktop && (
+        <StateBlock
+          id="state-08-filter-strip-desktop"
+          title="08 · Filter strip desktop — search + chips + toggle + badges inline"
+          gherkin="@1c filter-strip desktop"
+          frame="desktop · 1280 × 720 · glossary index"
+        >
+          <div className="gl-frame-caption">
+            Stesso layout mobile ma con padding orizzontale maggiore · 4 term rows demo con varianti count badge a destra "N varianti" quando books.length &gt; 1
+            <span className="theme-tag">context badges inline</span>
+          </div>
+          <DesktopFrame url="/library/runa-ardenel/glossary?filter=multi-context">
+            <FilterStripGlossaryIndex desktop />
           </DesktopFrame>
         </StateBlock>
       )}

--- a/admin-mockups/design_files/sp6-libro-game-photo-upload.html
+++ b/admin-mockups/design_files/sp6-libro-game-photo-upload.html
@@ -4,6 +4,23 @@
   Route: /gamebook/upload
   Descrizione: Wizard fotografare manuale: scegli gioco → scatta pagine → indicizzazione.
   Persona: Sara, 32, casual italian gamer / GM al tavolo (mobile-first, camera nativa).
+
+  ─── Task 4 · Sezione 1d update (2026-05-23) — Kebab menu "Digita manualmente" ───
+  Camera step (Step 2) top toolbar ora include kebab menu ⋮ (top-right) con voce primaria
+  "Digita manualmente" che naviga a `librogame-runthrough-translate-viewer.html?mode=manual`.
+
+  Questo è il punto di ingresso #2 della triple-entry discoverability per manual-input-mode:
+    1. CTA "Digita manualmente" in state-F `photo-blur-pre-ocr`
+       (librogame-runthrough-error-states.html sez 1a)
+    2. Kebab menu ⋮ del camera step (qui · sp6-libro-game-photo-upload.html sez 1d) ← THIS FILE
+    3. Empty state card "Libro non a portata? Digita il paragrafo"
+       (librogame-runthrough-translate-viewer.html state-M, sez 1d)
+
+  Cross-ref: vedi state-M `manual-input-mode` in librogame-runthrough-translate-viewer.html
+  per layout completo (textarea max 2000 char + counter + lang dropdown + book ref chip).
+
+  Quando Sara è nel camera step ma non può fotografare (libro non a portata, camera permission
+  negata, foto sempre sfocate) → kebab ⋮ → "Digita manualmente" → translate?mode=manual.
 -->
 <html lang="it" data-theme="light">
 <head>
@@ -155,7 +172,7 @@
     <h1 style="font-size:var(--fs-3xl);margin-bottom:var(--s-2);">SP6 · B · Photo Upload — 3-step wizard</h1>
     <p style="color:var(--text-sec);font-size:var(--fs-md);max-width:760px;margin-bottom:var(--s-7);">
       Step 1 scegli gioco · Step 2 scatta pagine · Step 3 indicizzazione.
-      11 stati totali. Mobile 375 canonical + desktop 1440 (drag-drop fallback).
+      12 stati totali (incl. Task 4 sez 1d kebab "Digita manualmente"). Mobile 375 canonical + desktop 1440 (drag-drop fallback).
     </p>
 
     <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:32px;">
@@ -264,8 +281,10 @@
    Descrizione: Wizard 3-step per fotografare manuale (scegli gioco → scatta pagine → indicizzazione).
    Persona: Sara, 32, casual italian gamer / GM al tavolo (mobile-first, camera nativa).
 
-   Stati: 11 totali distribuiti su 3 step, vedi STATES array in fondo file.
-   Gherkin coperti: G1.2, G1.3, G1.4, G1.5, G1.6
+   Stati: 12 totali distribuiti su 3 step, vedi STATES array in fondo file.
+   Gherkin coperti: G1.2, G1.3, G1.4, G1.5, G1.6 · TASK4-1d (kebab "Digita manualmente")
+   Task 4 sez 1d (2026-05-23): nuovo state `2-kebab` con kebab menu ⋮ + voce primaria
+   "Digita manualmente" che naviga a `translate-viewer.html?mode=manual` (triple-entry #2).
    =================================================================== */
 
 const { useState, useEffect } = React;
@@ -531,12 +550,15 @@ function Step1_BGGLoading() {
    STEP 2 — Scatta pagine
    ─────────────────────────────────────────────────────────────── */
 
-function CameraViewfinder({ variant, capturedCount }) {
-  // variant: ready | low-light | detection-failed | denied
+function CameraViewfinder({ variant, capturedCount, kebabOpen = false }) {
+  // variant: ready | low-light | detection-failed | denied | kebab-open
   // Real impl: getUserMedia / native file picker
-  const isOk = variant === 'ready';
-  const isLow = variant === 'low-light';
-  const isFailed = variant === 'detection-failed';
+  // kebabOpen: Task 4 sez 1d — mostra menu "Digita manualmente" → ?mode=manual
+  const showKebab = variant === 'kebab-open' || kebabOpen;
+  const effectiveVariant = variant === 'kebab-open' ? 'ready' : variant;
+  const isOk = effectiveVariant === 'ready';
+  const isLow = effectiveVariant === 'low-light';
+  const isFailed = effectiveVariant === 'detection-failed';
 
   return (
     <div className="pu-camera">
@@ -547,7 +569,61 @@ function CameraViewfinder({ variant, capturedCount }) {
           <span aria-hidden="true">📸</span>
           <span style={{ fontVariantNumeric: 'tabular-nums' }}>{capturedCount} / 50</span>
         </div>
-        <button type="button" className="pu-cam-icon" aria-label="Flash">⚡</button>
+        {/* Right cluster: flash + kebab menu (Task 4 sez 1d entry-point #2/3 manual-input) */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button type="button" className="pu-cam-icon" aria-label="Flash">⚡</button>
+          <div className="pu-cam-kebab-wrap">
+            <button
+              type="button"
+              className="pu-cam-kebab"
+              aria-label="Altre azioni"
+              aria-haspopup="menu"
+              aria-expanded={showKebab}
+            >
+              ⋮
+            </button>
+            {showKebab && (
+              <div className="pu-cam-kebab-menu" role="menu" aria-label="Altre azioni camera">
+                {/* Primary entry — Task 4 sez 1d manual-input-mode entry-point #2 */}
+                <button
+                  type="button"
+                  className="pu-cam-kebab-item primary shortcut"
+                  role="menuitem"
+                  onClick={() => { window.location.href = 'librogame-runthrough-translate-viewer.html?mode=manual'; /* DEMO-NAV: triple-entry #2 → ?mode=manual */ }}
+                >
+                  <span className="icon">⌨️</span>
+                  <span className="l">
+                    <span className="v">Digita manualmente</span>
+                    <span className="s">Salta foto · vai a ?mode=manual</span>
+                  </span>
+                </button>
+                <div className="pu-cam-kebab-divider" />
+                <button type="button" className="pu-cam-kebab-item" role="menuitem">
+                  <span className="icon">🖼️</span>
+                  <span className="l">
+                    <span className="v">Carica dalla galleria</span>
+                    <span className="s">Scegli foto già scattate</span>
+                  </span>
+                </button>
+                <button type="button" className="pu-cam-kebab-item" role="menuitem">
+                  <span className="icon">⚙️</span>
+                  <span className="l">
+                    <span className="v">Impostazioni camera</span>
+                    <span className="s">Risoluzione · auto-focus</span>
+                  </span>
+                </button>
+                <div className="pu-cam-kebab-divider" />
+                <button type="button" className="pu-cam-kebab-item" role="menuitem">
+                  <span className="icon">❓</span>
+                  <span className="l">
+                    <span className="v">Aiuto</span>
+                    <span className="s">Suggerimenti per foto migliori</span>
+                  </span>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
 
       {/* Viewfinder */}
@@ -667,10 +743,12 @@ function CameraViewfinder({ variant, capturedCount }) {
   );
 }
 
-function Step2_Ready()   { return <CameraViewfinder variant="ready" capturedCount={0}/>; }
+function Step2_Ready()    { return <CameraViewfinder variant="ready" capturedCount={0}/>; }
 function Step2_Capturing(){ return <CameraViewfinder variant="ready" capturedCount={8}/>; }
 function Step2_LowLight() { return <CameraViewfinder variant="low-light" capturedCount={3}/>; }
 function Step2_Failed()   { return <CameraViewfinder variant="detection-failed" capturedCount={2}/>; }
+/* Task 4 sez 1d · kebab menu aperto con "Digita manualmente" → ?mode=manual */
+function Step2_KebabOpen(){ return <CameraViewfinder variant="kebab-open" capturedCount={3}/>; }
 
 function Step2_Denied() {
   return (
@@ -925,6 +1003,7 @@ function Screen({ stateId, desktop }) {
   else if (stateId === '2-low-light') content = desktop ? <DesktopDropFallback step={2}/> : <Step2_LowLight/>;
   else if (stateId === '2-failed') content = desktop ? <DesktopDropFallback step={2}/> : <Step2_Failed/>;
   else if (stateId === '2-denied') content = <Step2_Denied/>;
+  else if (stateId === '2-kebab') content = desktop ? <DesktopDropFallback step={2}/> : <Step2_KebabOpen/>;
   else if (stateId === '3-progress') content = <IndexingScreen variant="in-progress"/>;
   else if (stateId === '3-partial') content = <IndexingScreen variant="partial-fail"/>;
   else if (stateId === '3-complete') content = <IndexingScreen variant="complete"/>;
@@ -998,6 +1077,8 @@ const STATES = [
   { id: '2-low-light',   label: 'Step 2 · Light meter low',     step: 2, gherkin: 'G1.3' },
   { id: '2-failed',      label: 'Step 2 · Page detection failed', step: 2, gherkin: 'G1.3' },
   { id: '2-denied',      label: 'Step 2 · Permission denied',   step: 2 },
+  /* Task 4 sez 1d · kebab menu "Digita manualmente" → ?mode=manual (triple-entry #2) */
+  { id: '2-kebab',       label: 'Step 2 · Kebab menu · "Digita manualmente"', step: 2, gherkin: 'TASK4-1d' },
   // Step 3
   { id: '3-progress',    label: 'Step 3 · Indexing 24/50 mixed',step: 3 },
   { id: '3-partial',     label: 'Step 3 · Partial fail (3 retake)', step: 3 },
@@ -1268,6 +1349,51 @@ styleEl.textContent = `
     display: inline-flex; align-items: center; gap: 6px;
     padding: 6px 12px; border-radius: var(--r-pill);
     font-family: var(--f-mono); font-weight: 700; font-size: 12px; color: #fff;
+  }
+
+  /* Kebab menu (Task 4 sez 1d · top-right "Digita manualmente" entry-point #2/3) */
+  .pu-cam-kebab-wrap {
+    position: relative; display: inline-block;
+  }
+  .pu-cam-kebab {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: rgba(0,0,0,.5); border: none; color: #fff;
+    cursor: pointer; font-size: 20px; line-height: 1;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .pu-cam-kebab-menu {
+    position: absolute; top: 44px; right: 0;
+    min-width: 240px; padding: 6px;
+    background: rgba(20, 18, 14, 0.96); backdrop-filter: blur(12px);
+    border: 1px solid rgba(255,255,255,.12);
+    border-radius: var(--r-md); box-shadow: 0 12px 32px rgba(0,0,0,.5);
+    z-index: 10;
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .pu-cam-kebab-item {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 12px; border-radius: var(--r-sm);
+    background: transparent; border: none; color: #fff;
+    font-family: var(--f-display); font-weight: var(--fw-semi); font-size: 13px;
+    cursor: pointer; text-align: left; width: 100%;
+  }
+  .pu-cam-kebab-item:hover { background: rgba(255,255,255,.08); }
+  .pu-cam-kebab-item.primary { color: hsl(38 95% 68%); }
+  .pu-cam-kebab-item.primary:hover { background: hsl(38 92% 50% / 0.18); }
+  .pu-cam-kebab-item .icon { font-size: 16px; flex-shrink: 0; }
+  .pu-cam-kebab-item .l { flex: 1; min-width: 0; display: block; }
+  .pu-cam-kebab-item .l .v { display: block; }
+  .pu-cam-kebab-item .l .s {
+    display: block; font-family: var(--f-mono);
+    font-size: 10px; font-weight: var(--fw-reg);
+    color: rgba(255,255,255,.55); margin-top: 2px;
+  }
+  .pu-cam-kebab-item.shortcut::after {
+    content: "→"; color: rgba(255,255,255,.45); font-size: 14px;
+  }
+  .pu-cam-kebab-divider {
+    height: 1px; background: rgba(255,255,255,.1);
+    margin: 4px 8px;
   }
 
   .pu-cam-vf {

--- a/admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
@@ -4,6 +4,41 @@
    Anchor id su ogni screen wrapper (state-NN-…) + Gherkin tag (G4.4 / G4.7).
    Reading-body: 26px Nunito assoluto, line-height 1.6, max-width 60ch — DEVIAZIONE brief L519.
    prefers-reduced-motion guard ereditato (mai-shimmer / mai-spinner / mai-pulse).
+
+   ─── Task 4 · Sezione 1d update (2026-05-23) — Multi-language source + Manual input ───
+   Nuovi componenti aggiunti (parity con sezione K/L/M in librogame-runthrough-translate-viewer.html):
+     · LangDetectionBadge — header pill post OCR, 3 variants confidence-driven
+         · high   (>0.8)   → badge informativo (no friction)
+         · medium (0.5-0.8)→ tap-to-confirm prima di translate (blocking)
+         · low    (<0.5)   → cross-link state-H source-lang-unknown (error-states.html)
+     · LangOverrideModal — modal radio group 5 lingue v1 (EN·FR·DE·ES·IT)
+         · CTA "Conferma e ritraduci" → re-trigger AI translation (skip OCR cache hit)
+         · OCR result preservato (smoldocling cache key `(photo_hash, page)` invariante)
+     · ManualInputMode — textarea fallback senza foto (?mode=manual query param UI-only)
+         · max 2000 char + counter visibile + lang dropdown pre-filled + book ref chip
+         · Skip step 2 OCR, va a step 3 (AI translate) loading sequence Task 2
+
+   Lingue v1: 🇬🇧 EN · 🇫🇷 FR · 🇩🇪 DE · 🇪🇸 ES · 🇮🇹 IT — copre ~95% libri-game europei.
+   Target lingua: IT fisso v1 (da setting profilo). Target dropdown NON visibile.
+
+   Triple-entry discoverability per manual-input-mode (3 punti di ingresso):
+     1. CTA "Digita manualmente" in state-F `photo-blur-pre-ocr`
+        (librogame-runthrough-error-states.html sez 1a Task 1)
+     2. Kebab menu ⋮ del camera step
+        (sp6-libro-game-photo-upload.html, top-right + voce "Digita manualmente")
+     3. Empty state card "Libro non a portata? Digita il paragrafo"
+        (librogame-runthrough-translate-viewer.html state-M, sez 1d Task 4)
+
+   State tracking nello session model (commento backend):
+     · source_method: "ocr" | "manual"
+     · source_lang: "en" | "fr" | "de" | "es" | "it" (locked dopo conferma utente)
+     · lang_detection_confidence: 0.0-1.0 (solo per source_method=ocr)
+
+   Cross-ref:
+     · state-H source-lang-unknown → librogame-runthrough-error-states.html (sez 1a Task 1)
+     · state-F photo-blur-pre-ocr → librogame-runthrough-error-states.html
+     · state-G loading 4-step → librogame-runthrough-translate-viewer.html (sez 1b Task 2)
+     · kebab "Digita manualmente" → sp6-libro-game-photo-upload.html
 */
 
 const { useState } = React;
@@ -274,6 +309,231 @@ function BottomControls({
           🎙️ Leggi tu <span className="v2">v2</span>
         </span>
       </div>
+    </div>
+  );
+}
+
+/* ────────────────────────── TASK 4 sez 1d — LANG DETECTION + MANUAL INPUT ────────────────────────── */
+
+/* Languages v1: 5 supportate · target IT fisso (NO target dropdown UI) */
+const SUPPORTED_LANGS = [
+  { code: 'EN', flag: '🇬🇧', label: 'English',  sub: 'EN · uk · us' },
+  { code: 'FR', flag: '🇫🇷', label: 'Français', sub: 'FR · fr · be · ca' },
+  { code: 'DE', flag: '🇩🇪', label: 'Deutsch',  sub: 'DE · de · at · ch' },
+  { code: 'ES', flag: '🇪🇸', label: 'Español',  sub: 'ES · es · mx · ar' },
+  { code: 'IT', flag: '🇮🇹', label: 'Italiano', sub: 'IT · it · ch · sm' },
+];
+
+/**
+ * LangDetectionBadge — Header pill post OCR (state K).
+ *
+ * 3 variants confidence-driven:
+ *   - high   (>0.8)   → informativo, no friction (success color)
+ *   - medium (0.5-0.8)→ tap-to-confirm BLOCKING prima di translate (warning color)
+ *   - low    (<0.5)   → cross-link state-H source-lang-unknown (danger color, animated pulse)
+ *
+ * onClick → apre <LangOverrideModal/> (state L).
+ * Cross-ref: state-H in librogame-runthrough-error-states.html (sez 1a Task 1).
+ */
+function LangDetectionBadge({ langCode = 'EN', confidence = 0.92, onClick }) {
+  const lang = SUPPORTED_LANGS.find(l => l.code === langCode) || SUPPORTED_LANGS[0];
+  let variant = 'high';
+  if (confidence < 0.5) variant = 'low';
+  else if (confidence < 0.8) variant = 'medium';
+
+  const ariaLabel = variant === 'high'
+    ? `Sorgente rilevata: ${lang.label} (alta affidabilità ${confidence.toFixed(2)}) — tap per cambiare`
+    : variant === 'medium'
+      ? `Sorgente probabile: ${lang.label} (confidence ${confidence.toFixed(2)}) — conferma o cambia prima di tradurre`
+      : `Lingua non riconosciuta (confidence ${confidence.toFixed(2)}) — scegli manualmente`;
+
+  return (
+    <button
+      type="button"
+      className={`lang-detect-badge ${variant}`}
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
+      <span className="flag">{variant === 'low' ? '⚠️' : lang.flag}</span>
+      <span>{variant === 'low' ? '?' : lang.code}</span>
+      <span className="conf">{confidence.toFixed(2)}</span>
+    </button>
+  );
+}
+
+/**
+ * LangOverrideModal — Modal radio group (state L).
+ *
+ * Tap sul badge K → modal con 5 lingue v1.
+ * CTA "Conferma e ritraduci" → re-trigger AI translation step 3 (skip step 2 OCR cache hit).
+ * Pre-selected: lingua auto-detected dal badge.
+ *
+ * Behavior:
+ *   - OCR result preservato (smoldocling cache key (photo_hash, page) invariante)
+ *   - Re-translate solo step 3 della loading sequence Task 2
+ *   - Cost: solo DeepSeek (~0,01 €), no smoldocling recompute
+ */
+function LangOverrideModal({
+  selectedCode = 'FR',
+  autoDetectedCode = 'FR',
+  onConfirm = () => {},
+  onCancel = () => {},
+}) {
+  return (
+    <div className="lang-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="lang-modal-title">
+      <div className="lang-modal">
+        <div className="lang-modal-head">
+          <h3 id="lang-modal-title">Lingua sorgente del libro</h3>
+          <p>5 lingue v1 supportate · target IT fisso</p>
+        </div>
+        <div className="lang-modal-body">
+          <ul className="lang-radio-list">
+            {SUPPORTED_LANGS.map(l => {
+              const isSelected = l.code === selectedCode;
+              const isAuto = l.code === autoDetectedCode;
+              return (
+                <li
+                  key={l.code}
+                  className={`lang-radio-item ${isSelected ? 'selected' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-current={isSelected ? 'true' : undefined}
+                >
+                  <span className="flag">{l.flag}</span>
+                  <span className="l">
+                    <span className="v">{l.label}</span>
+                    <span className="s">{l.sub}</span>
+                  </span>
+                  {isAuto && <span className="auto-tag">Auto</span>}
+                  <span className="radio" aria-hidden="true" />
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <div className="lang-modal-foot">
+          <button className="cta-primary" type="button" autoFocus onClick={onConfirm}>
+            Conferma e ritraduci
+          </button>
+          <button className="cta-secondary" type="button" onClick={onCancel}>
+            Annulla
+          </button>
+          <p className="cache-hint">
+            <strong>✓ OCR preservato</strong> · re-translate solo step 3 (skip OCR cache hit)
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ManualInputMode — Layout fallback senza foto (state M).
+ *
+ * Trigger via query param `?mode=manual` (UI-only, NO sub-route backend).
+ * Triple-entry discoverability:
+ *   1. CTA "Digita manualmente" in state-F photo-blur-pre-ocr (error-states.html)
+ *   2. Kebab menu ⋮ del camera step (sp6-libro-game-photo-upload.html)
+ *   3. Empty state card "Libro non a portata?" (qui · default route /translate)
+ *
+ * Layout: header sticky (title + back + lang dropdown + book ref chip)
+ *       + textarea multiline (max 2000 char + counter visibile bottom-right)
+ *       + CTA "Traduci" → skip step 2 OCR, va a step 3 AI translation (loading state-G)
+ *
+ * State: source_method = "manual", source_lang locked dopo conferma, lang_detection_confidence = null.
+ * Parity: stessi step 3-4 della loading sequence Task 2. Diff = step 2 OCR sostituito da textarea content.
+ */
+function ManualInputMode({
+  initialText = '',
+  initialLang = 'EN',
+  bookRef = 'Runa di Ardenel',
+  maxChars = 2000,
+}) {
+  const [text, setText] = useState(initialText);
+  const [lang, setLang] = useState(initialLang);
+  const langInfo = SUPPORTED_LANGS.find(l => l.code === lang) || SUPPORTED_LANGS[0];
+  const charCount = text.length;
+  const counterClass =
+    charCount > maxChars ? 'over' :
+    charCount > maxChars * 0.9 ? 'warn' : '';
+  const disabled = charCount === 0 || charCount > maxChars;
+
+  return (
+    <div className="manual-input-shell">
+      {/* Header sticky */}
+      <div className="manual-input-head">
+        <div className="title-row">
+          <button className="back" aria-label="Indietro">←</button>
+          <h2>Inserimento manuale</h2>
+          <span className="badge-manual">Manual</span>
+        </div>
+        <div className="meta-row">
+          {/* Lang dropdown pre-filled last-used */}
+          <button className="manual-lang-dropdown" type="button" aria-label={`Lingua sorgente: ${langInfo.label} — cambia`}>
+            <span className="flag">{langInfo.flag}</span>
+            <span>{langInfo.code}</span>
+            <span className="chevron">▾</span>
+          </button>
+          {/* Book ref chip pre-filled current campaign book */}
+          <span className="book-ref-chip" aria-label={`Libro corrente — ${bookRef}`}>
+            <span className="lock">🔒</span>📕 {bookRef}
+          </span>
+        </div>
+      </div>
+
+      {/* Body: textarea + counter + hint */}
+      <div className="manual-input-body">
+        <div className="manual-textarea-shell">
+          <textarea
+            className="manual-textarea"
+            placeholder="Incolla o digita il paragrafo del libro…"
+            aria-label="Testo paragrafo da tradurre"
+            maxLength={maxChars}
+            value={text}
+            onChange={e => setText(e.target.value)}
+          />
+          <span className={`manual-char-counter ${counterClass}`} aria-live="polite" aria-label={`${charCount} caratteri su ${maxChars} massimi`}>
+            {charCount} <span className="max">/ {maxChars}</span>
+          </span>
+        </div>
+        <div className="manual-hint">
+          <strong>💡 Suggerimento:</strong> Incolla esattamente il paragrafo dal libro. Salta step 2 OCR e va direttamente alla traduzione. Glossario applicato in step 4.
+        </div>
+      </div>
+
+      {/* Footer sticky con CTA */}
+      <div className="manual-input-foot">
+        <button className="manual-cta-primary" type="button" disabled={disabled} aria-label="Traduci il testo manuale">
+          <span>Traduci</span><span className="arrow">→</span>
+        </button>
+        <p className="manual-flow-note">
+          <strong>→ step 3 streaming</strong> (skip OCR) · ~10s · 💰 ~0,01 €
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ManualEntryCard — Empty state card (state M entry-point #3 di 3).
+ * Render quando /translate aperto senza foto.
+ * Click → naviga a ?mode=manual.
+ */
+function ManualEntryCard() {
+  return (
+    <div
+      className="manual-empty-card"
+      role="button"
+      tabIndex={0}
+      aria-label="Libro non a portata? Digita il paragrafo manualmente"
+      onClick={() => { window.location.href = 'librogame-runthrough-translate-viewer.html?mode=manual'; /* DEMO-NAV: triple-entry #3 */ }}
+    >
+      <span className="icon">⌨️</span>
+      <div className="l">
+        <span className="v">Libro non a portata?</span>
+        <span className="s">Digita manualmente il paragrafo · skip foto</span>
+      </div>
+      <span className="arrow">›</span>
     </div>
   );
 }
@@ -571,6 +831,209 @@ function AidsSection() {
   );
 }
 
+/* ────────────────────────── TASK 4 SEZ 1d · MULTI-LANG + MANUAL INPUT SECTION ────────────────────────── */
+
+/**
+ * MultiLangSection — Stati K (badge), L (modal), M (manual input).
+ *
+ * Demonstra:
+ *   · 3 variants di LangDetectionBadge (high / medium / low)
+ *   · LangOverrideModal con FR pre-selected (from medium badge)
+ *   · ManualInputMode con textarea pre-filled
+ *   · ManualEntryCard (empty state entry-point #3)
+ *
+ * Lingue v1: 🇬🇧 EN · 🇫🇷 FR · 🇩🇪 DE · 🇪🇸 ES · 🇮🇹 IT.
+ * Cross-ref: librogame-runthrough-translate-viewer.html stati K/L/M (sez 1d Task 4).
+ */
+function MultiLangSection() {
+  const items = [
+    {
+      id: 'state-K1-lang-detect-high',
+      label: 'K.1 · LangDetectionBadge — high confidence (>0.8)',
+      gherkin: '@TASK4-1d badge-high',
+      sub: 'EN 0.92 · informativo · no friction · success color',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <div className="tv-topbar">
+              <button className="icon-btn" aria-label="Indietro">←</button>
+              <div className="center">§147</div>
+              <LangDetectionBadge langCode="EN" confidence={0.92} />
+            </div>
+            <div className="tv-body mai-noscroll">
+              <BodyHead pnum="§147" />
+              <ReadingBodyIT fs="md" lh="default" />
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-K2-lang-detect-medium',
+      label: 'K.2 · LangDetectionBadge — medium confidence (0.5-0.8)',
+      gherkin: '@TASK4-1d badge-medium',
+      sub: 'FR 0.67 · tap-to-confirm · BLOCKING prima di translate · warning color',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <div className="tv-topbar">
+              <button className="icon-btn" aria-label="Indietro">←</button>
+              <div className="center">§147</div>
+              <LangDetectionBadge langCode="FR" confidence={0.67} />
+            </div>
+            <div className="tv-body mai-noscroll">
+              <BodyHead pnum="§147" />
+              <p style={{
+                padding: '20px',
+                fontSize: '14px',
+                color: 'var(--text-sec)',
+                textAlign: 'center',
+                fontStyle: 'italic',
+              }}>
+                ⏸ Traduzione in pausa — tappa il badge per confermare la lingua sorgente prima di procedere.
+              </p>
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-K3-lang-detect-low',
+      label: 'K.3 · LangDetectionBadge — low confidence (<0.5) · cross-link state-H',
+      gherkin: '@TASK4-1d badge-low',
+      sub: '? 0.31 · cross-link state-H source-lang-unknown (error-states.html sez 1a)',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <div className="tv-topbar">
+              <button className="icon-btn" aria-label="Indietro">←</button>
+              <div className="center">§147</div>
+              <LangDetectionBadge langCode="EN" confidence={0.31} />
+            </div>
+            <div className="tv-body mai-noscroll">
+              <p style={{
+                padding: '20px',
+                fontSize: '14px',
+                color: 'var(--text)',
+                textAlign: 'center',
+                lineHeight: 1.55,
+              }}>
+                ⚠️ Lingua non riconosciuta. Devi scegliere manualmente prima di procedere.
+                <br /><br />
+                <span style={{ fontSize: '12px', color: 'hsl(var(--c-kb))', fontFamily: 'var(--f-mono)' }}>
+                  → state-H source-lang-unknown<br/>in <code>librogame-runthrough-error-states.html</code>
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-L-lang-override-modal',
+      label: 'L · LangOverrideModal — radio group 5 lingue v1 (EN·FR·DE·ES·IT)',
+      gherkin: '@TASK4-1d modal',
+      sub: 'FR pre-selected (Auto tag) · CTA "Conferma e ritraduci" · OCR preservato (cache hit)',
+      screen: (
+        <div className="phone-sp6" data-theme="light" style={{ position: 'relative' }}>
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <div className="tv-topbar">
+              <button className="icon-btn" aria-label="Indietro">←</button>
+              <div className="center">§147</div>
+              <LangDetectionBadge langCode="FR" confidence={0.67} />
+            </div>
+            <div className="tv-body mai-noscroll" style={{ opacity: 0.4 }}>
+              <BodyHead pnum="§147" />
+            </div>
+            <LangOverrideModal selectedCode="FR" autoDetectedCode="FR" />
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-M-manual-input-mode',
+      label: 'M · ManualInputMode — textarea fallback (?mode=manual) · 247/2000 char',
+      gherkin: '@TASK4-1d manual-input',
+      sub: 'No foto · lang dropdown EN pre-filled · book ref chip Runa di Ardenel · counter 247/2000',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <ManualInputMode
+              initialText="As Niamh approached the altar, the air grew thick with whispers. The Goblin guards drew their blades, eyes gleaming with bloodlust, while the Voidstone pulsed with sickly light upon the dais."
+              initialLang="EN"
+              bookRef="Runa di Ardenel"
+            />
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-M-manual-input-warn',
+      label: 'M · ManualInputMode — counter warn (1856/2000)',
+      gherkin: '@TASK4-1d manual-input-warn',
+      sub: 'DE lang · counter > 90% (yellow warn) · paragrafo lungo',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <ManualInputMode
+              initialText={'Als Niamh sich dem Altar näherte, wurde die Luft dicht von Geflüster. Die Goblin-Wachen zogen ihre Klingen, die Augen funkelten vor Blutlust, während der Leerenstein mit krankem Licht auf dem Podest pulsierte. Niamh umklammerte den Schwertgriff fester und fühlte das Echo alter Eide im Stahl schwingen. Sie hatte zwei Möglichkeiten zur Wahl... [paragrafo lungo continua per altre 1400+ caratteri inclusi dettagli combattimento, descrizioni ambientali, e dialogo del capitano Goblin che minaccia la compagnia di avventurieri]'.padEnd(1856, ' ')}
+              initialLang="DE"
+              bookRef="Runa di Ardenel"
+            />
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'state-M-empty-card',
+      label: 'M.3 · ManualEntryCard — empty state (entry-point #3 di 3)',
+      gherkin: '@TASK4-1d empty-card',
+      sub: '/translate aperto senza foto · card "Libro non a portata?" → ?mode=manual',
+      screen: (
+        <div className="phone-sp6" data-theme="light">
+          <StatusBar />
+          <div className="phone-screen" style={{ background: 'var(--bg)' }}>
+            <div className="tv-topbar">
+              <button className="icon-btn" aria-label="Indietro">←</button>
+              <div className="center">§147</div>
+              <button className="icon-btn" aria-label="Altre azioni">⋯</button>
+            </div>
+            <div className="tv-body mai-noscroll" style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 16 }}>
+              <div style={{ textAlign: 'center', padding: '20px 12px' }}>
+                <div style={{ fontSize: 56, opacity: 0.4, marginBottom: 8 }}>📷</div>
+                <h3 style={{ fontFamily: 'var(--f-display)', fontSize: 18, fontWeight: 700, margin: '0 0 8px' }}>Fotografa il paragrafo</h3>
+                <p style={{ color: 'var(--text-sec)', margin: '0 0 16px', fontSize: 13 }}>OCR + traduzione automatica.</p>
+                <button className="nav-btn primary" type="button" style={{ padding: '10px 20px' }}>📷 Apri fotocamera</button>
+              </div>
+              <ManualEntryCard />
+              <p style={{ fontFamily: 'var(--f-mono)', fontSize: 10, color: 'var(--text-muted)', textAlign: 'center', margin: 0 }}>
+                Entry-point 3 di 3 · vedi state-F error-states + kebab ⋮ camera step
+              </p>
+            </div>
+          </div>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      {items.map(it => (
+        <div className="frame-cell" id={it.id} key={it.id}>
+          <FrameMeta anchor={it.id} gherkin={it.gherkin} label={it.label} sub={it.sub} />
+          {it.screen}
+        </div>
+      ))}
+    </>
+  );
+}
+
 /* ────────────────────────── BOOT ────────────────────────── */
 
 const ReactDOMClient = ReactDOM;
@@ -578,3 +1041,8 @@ ReactDOMClient.createRoot(document.getElementById('mount-mobile')).render(<Mobil
 ReactDOMClient.createRoot(document.getElementById('mount-desktop')).render(<DesktopSection />);
 ReactDOMClient.createRoot(document.getElementById('mount-themes')).render(<ThemesSection />);
 ReactDOMClient.createRoot(document.getElementById('mount-aids')).render(<AidsSection />);
+/* Task 4 sez 1d · mount opzionale per nuova section (host page deve avere <div id="mount-multilang"/>) */
+const multilangMount = document.getElementById('mount-multilang');
+if (multilangMount) {
+  ReactDOMClient.createRoot(multilangMount).render(<MultiLangSection />);
+}

--- a/admin-mockups/design_files/state-matrix.html
+++ b/admin-mockups/design_files/state-matrix.html
@@ -1,0 +1,1020 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI — State Matrix · 8 route × 5 stati</title>
+<!--
+  Mockup: state-matrix
+  Type:   dev-fixture (companion a 01-screens.html)
+  Scope:  cross-route state coverage per i 3 segmenti attivi
+          (Aaron libro-game + boardgamer + casual browser)
+  Spec:   docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md sezione 3 (B18)
+  Audit:  docs/for-developers/audits/2026-05-22-mockup-gaps.md § P3 state matrix
+
+  Grid: 8 route × 5 stati = 40 cell (35 effettive + 5 skip).
+  Permission-denied applicato SOLO a 3 route (translate, chat, sessions/live).
+  Mobile-only viewport 375 (come 01-screens.html). Light + dark inline toggle.
+
+  ROUTE MAPPING (segmento + entity color):
+  - /library/[gameId]/play/[campaignId]/translate  Aaron CORE     --c-game (orange)
+  - /library/[gameId]/play                          Aaron resume   --c-game (orange)
+  - /chat/[threadId]                                Aaron+boardg   --c-agent (purple)
+  - /game-nights                                    boardgamer     --c-session (rose)
+  - /sessions/live/[sessionId]                      boardgamer     --c-session (rose)
+  - /shared-games                                   browser        --c-toolkit (teal)
+  - /discover                                       browser cross  --c-toolkit (teal)
+  - /notifications                                  cross-cutting  --c-kb (blue)
+
+  PATTERN SOURCES (reuse trace):
+  - Empty:      pattern stand-alone (icon 96px + tagline + CTA)
+  - Error:      see librogame-runthrough-error-states.html (icon + message + retry)
+  - Loading:    see librogame-runthrough-translate-viewer.html (Task 2 sez 1b 4-step skeleton)
+  - Permission: tier-locked pattern (future B13 /pricing — link dead-end finché B13 ships)
+  - Offline:    pattern stand-alone (banner top persistent + cache 80% opacity)
+
+  ILLUSTRATION ECONOMY (~5 unique tematici):
+  - "book"     translate + play
+  - "speak"    chat + notifications
+  - "calendar" game-nights + sessions-live
+  - "compass"  shared-games + discover
+
+  CROSS-REFS:
+  - 01-screens.html (companion dev-fixture, 24 mobile happy-path screens)
+  - librogame-runthrough-error-states.html (Task 1, 10 error sub-states)
+  - librogame-runthrough-translate-viewer.html (Task 2 + 4, loading + reader-mode + multi-lang)
+  - chat-fullscreen.html (Task 5, B11b #491)
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+
+<style>
+  body { background: var(--bg); color: var(--text); font-family: var(--f-body); margin: 0; }
+
+  .top {
+    position: sticky; top: 0; z-index: var(--z-sticky);
+    backdrop-filter: blur(12px); background: var(--glass-bg);
+    border-bottom: 1px solid var(--border);
+    padding: var(--s-4) var(--s-6);
+    display: flex; align-items: center; gap: var(--s-4); flex-wrap: wrap;
+  }
+  .top h1 { font-family: var(--f-display); font-size: var(--fs-lg); margin: 0; font-weight: var(--fw-bold); }
+  .top .meta { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); padding: 2px var(--s-2); border-radius: var(--r-sm); background: var(--bg-muted); }
+  .top .spacer { flex: 1; }
+  .top button {
+    background: var(--bg-card); border: 1px solid var(--border); color: var(--text);
+    border-radius: var(--r-pill); padding: var(--s-1) var(--s-3);
+    font-family: var(--f-mono); font-size: var(--fs-xs); cursor: pointer;
+  }
+
+  .stage { padding: var(--s-7) var(--s-6); max-width: 1700px; margin: 0 auto; }
+
+  /* Matrix grid 8 rows × 6 cols (1 header + 5 stati) */
+  .matrix {
+    display: grid;
+    grid-template-columns: 200px repeat(5, minmax(220px, 1fr));
+    gap: var(--s-4);
+    align-items: start;
+  }
+  .matrix .hdr-state {
+    position: sticky; top: 72px; z-index: 9;
+    background: var(--bg);
+    padding: var(--s-3) var(--s-2);
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-md); color: var(--text);
+    text-align: center;
+    border-bottom: 2px solid var(--border-strong);
+  }
+  .matrix .hdr-state .ico { font-size: var(--fs-lg); display: block; margin-bottom: 2px; }
+  .matrix .hdr-corner { background: var(--bg); border-bottom: 2px solid var(--border-strong); }
+
+  .matrix .hdr-route {
+    padding: var(--s-3) var(--s-3);
+    display: flex; flex-direction: column; gap: var(--s-2);
+    border-right: 2px solid var(--border-strong);
+    position: sticky; left: 0; z-index: 5;
+    background: var(--bg);
+  }
+  .matrix .hdr-route .path {
+    font-family: var(--f-mono); font-size: 11px; color: var(--text);
+    font-weight: var(--fw-bold); line-height: 1.3;
+    word-break: break-all;
+  }
+  .matrix .hdr-route .seg {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: 0.06em;
+  }
+  .matrix .hdr-route .entity-dot {
+    width: 12px; height: 12px; border-radius: 50%;
+    display: inline-block; margin-right: var(--s-1);
+  }
+
+  /* Phone mini frame: 220×440 vs 375×740 standard */
+  .frame {
+    width: 220px; min-height: 440px;
+    background: var(--bg); border-radius: 22px;
+    border: 1px solid var(--border-strong); box-shadow: var(--shadow-md);
+    overflow: hidden; display: flex; flex-direction: column;
+    position: relative; margin: 0 auto;
+  }
+  .frame.skip {
+    background: var(--bg-muted); border-style: dashed;
+    align-items: center; justify-content: center;
+    min-height: 200px; padding: var(--s-4); text-align: center;
+  }
+  .frame.skip .skip-msg {
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .frame .sbar {
+    height: 22px; flex-shrink: 0;
+    padding: 4px 14px 0;
+    display: flex; justify-content: space-between;
+    font-size: 9px; font-weight: var(--fw-bold); color: var(--text-sec);
+  }
+  .frame .app-bar {
+    height: 32px; padding: 0 var(--s-3); flex-shrink: 0;
+    display: flex; align-items: center; gap: var(--s-2);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-card);
+  }
+  .frame .app-bar .back { font-size: 14px; color: var(--text-sec); }
+  .frame .app-bar .title { font-size: 11px; font-weight: var(--fw-bold); color: var(--text); flex: 1; }
+  .frame .body {
+    flex: 1; padding: var(--s-3);
+    display: flex; flex-direction: column; gap: var(--s-3);
+    overflow: hidden;
+  }
+
+  /* --- Empty state pattern (centered icon + tagline + CTA) --- */
+  .empty {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: var(--s-3); padding: var(--s-3); text-align: center;
+  }
+  .empty .icon {
+    font-size: 48px; line-height: 1;
+    width: 80px; height: 80px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    background: var(--entity-grad, hsl(var(--c-kb) / 0.12));
+  }
+  .empty .title {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: 13px; color: var(--text); line-height: 1.3;
+  }
+  .empty .desc {
+    font-size: 10px; color: var(--text-sec); line-height: 1.4;
+  }
+  .empty .cta {
+    margin-top: var(--s-2);
+    padding: 6px 14px; border-radius: var(--r-pill);
+    background: var(--entity-color, hsl(var(--c-kb)));
+    color: #fff; font-weight: var(--fw-bold); font-size: 10px;
+    border: none; cursor: pointer;
+  }
+
+  /* --- Error state pattern (banner + retry) --- */
+  .err-banner {
+    background: hsl(var(--c-danger) / 0.08);
+    border: 1px solid hsl(var(--c-danger) / 0.25);
+    border-radius: var(--r-md);
+    padding: var(--s-3);
+    display: flex; flex-direction: column; gap: var(--s-2);
+  }
+  .err-banner .head {
+    display: flex; align-items: center; gap: var(--s-2);
+    font-size: 11px; font-weight: var(--fw-bold); color: hsl(var(--c-danger));
+  }
+  .err-banner .msg {
+    font-size: 10px; color: var(--text-sec); line-height: 1.4;
+  }
+  .err-banner .actions {
+    display: flex; gap: var(--s-2);
+  }
+  .err-banner .actions button {
+    flex: 1; padding: 4px 8px; border-radius: var(--r-sm);
+    font-size: 10px; font-weight: var(--fw-bold);
+    border: 1px solid hsl(var(--c-danger) / 0.4);
+    background: var(--bg-card); color: hsl(var(--c-danger));
+    cursor: pointer;
+  }
+  .err-banner .actions .primary {
+    background: hsl(var(--c-danger));
+    color: #fff; border-color: hsl(var(--c-danger));
+  }
+  .err-banner .actions .secondary {
+    background: transparent; color: var(--text-muted); border-color: var(--border);
+  }
+  .ref-note {
+    font-size: 9px; color: var(--text-muted); font-family: var(--f-mono);
+    margin-top: var(--s-2); padding-top: var(--s-2);
+    border-top: 1px dashed var(--border);
+  }
+
+  /* --- Loading skeleton + shimmer --- */
+  .skeleton { background: var(--bg-muted); border-radius: var(--r-sm); position: relative; overflow: hidden; }
+  .skeleton::after {
+    content: '';
+    position: absolute; inset: 0;
+    background: linear-gradient(90deg, transparent, hsl(0 0% 100% / 0.4), transparent);
+    animation: shimmer 1.6s ease-in-out infinite;
+  }
+  @keyframes shimmer { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton::after { animation: none; background: var(--bg-muted); }
+  }
+  .skeleton-card { height: 60px; }
+  .skeleton-line { height: 12px; margin-bottom: var(--s-2); }
+  .skeleton-line.w70 { width: 70%; }
+  .skeleton-line.w50 { width: 50%; }
+  .skeleton-line.w85 { width: 85%; }
+
+  /* --- Loading 4-step pattern (Task 2 sez 1b ref) --- */
+  .load-steps {
+    display: flex; flex-direction: column; gap: var(--s-2);
+  }
+  .load-steps .step {
+    display: flex; align-items: center; gap: var(--s-2);
+    font-size: 10px; color: var(--text-sec);
+    padding: 4px 8px; border-radius: var(--r-sm);
+  }
+  .load-steps .step.active {
+    background: hsl(var(--c-game) / 0.08);
+    color: hsl(var(--c-game)); font-weight: var(--fw-bold);
+  }
+  .load-steps .step .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--border-strong);
+  }
+  .load-steps .step.active .dot {
+    background: hsl(var(--c-game)); animation: pulse 1s ease-in-out infinite;
+  }
+  .load-steps .step.done .dot { background: hsl(var(--c-success)); }
+  @keyframes pulse { 50% { transform: scale(1.3); } }
+  @media (prefers-reduced-motion: reduce) {
+    .load-steps .step.active .dot { animation: none; }
+  }
+
+  /* --- Permission-denied pattern (tier-locked) --- */
+  .perm-locked {
+    flex: 1;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: var(--s-3); padding: var(--s-3); text-align: center;
+  }
+  .perm-locked .lock {
+    font-size: 36px; line-height: 1;
+    color: hsl(var(--c-warning));
+  }
+  .perm-locked .tier-badge {
+    display: inline-block;
+    padding: 3px 10px; border-radius: var(--r-pill);
+    background: hsl(var(--c-warning) / 0.18);
+    color: hsl(var(--c-warning));
+    font-family: var(--f-mono); font-size: 10px; font-weight: var(--fw-bold);
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .perm-locked .title {
+    font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: 12px; color: var(--text); line-height: 1.3;
+  }
+  .perm-locked .desc {
+    font-size: 10px; color: var(--text-sec); line-height: 1.4;
+  }
+  .perm-locked .cta-row {
+    display: flex; flex-direction: column; gap: var(--s-2); margin-top: var(--s-2); width: 100%;
+  }
+  .perm-locked .cta-primary {
+    padding: 6px 14px; border-radius: var(--r-pill);
+    background: hsl(var(--c-warning)); color: #fff;
+    font-weight: var(--fw-bold); font-size: 10px; border: none; cursor: pointer;
+  }
+  .perm-locked .cta-secondary {
+    padding: 4px 12px; border-radius: var(--r-sm);
+    background: transparent; color: var(--text-muted);
+    font-size: 10px; border: 1px solid var(--border); cursor: pointer;
+  }
+
+  /* --- Offline banner + cache-stale --- */
+  .offline-banner {
+    background: hsl(var(--c-info) / 0.12);
+    border: 1px solid hsl(var(--c-info) / 0.3);
+    border-radius: var(--r-md);
+    padding: var(--s-2) var(--s-3);
+    font-size: 10px; color: hsl(var(--c-info));
+    display: flex; align-items: center; gap: var(--s-2);
+    font-weight: var(--fw-bold);
+  }
+  .offline-banner .retry {
+    margin-left: auto; padding: 2px 8px; border-radius: var(--r-sm);
+    background: hsl(var(--c-info)); color: #fff;
+    font-size: 9px; border: none; cursor: pointer;
+  }
+  .cached-data {
+    opacity: 0.8;
+    display: flex; flex-direction: column; gap: var(--s-2);
+    flex: 1;
+  }
+  .cached-data .cached-card {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: var(--r-sm); padding: var(--s-2);
+    font-size: 10px; color: var(--text);
+  }
+  .cached-data .cached-card .meta { font-size: 9px; color: var(--text-muted); margin-top: 2px; }
+
+  /* Entity color presets (CSS class for empty bg) */
+  .ec-game { --entity-color: hsl(var(--c-game)); --entity-grad: linear-gradient(135deg, hsl(var(--c-game) / 0.18), hsl(var(--c-game) / 0.06)); }
+  .ec-agent { --entity-color: hsl(var(--c-agent)); --entity-grad: linear-gradient(135deg, hsl(var(--c-agent) / 0.18), hsl(var(--c-agent) / 0.06)); }
+  .ec-session { --entity-color: hsl(var(--c-session)); --entity-grad: linear-gradient(135deg, hsl(var(--c-session) / 0.18), hsl(var(--c-session) / 0.06)); }
+  .ec-toolkit { --entity-color: hsl(var(--c-toolkit)); --entity-grad: linear-gradient(135deg, hsl(var(--c-toolkit) / 0.18), hsl(var(--c-toolkit) / 0.06)); }
+  .ec-kb { --entity-color: hsl(var(--c-kb)); --entity-grad: linear-gradient(135deg, hsl(var(--c-kb) / 0.18), hsl(var(--c-kb) / 0.06)); }
+
+  /* Misc inline elements */
+  .typing-dots { display: inline-flex; gap: 3px; }
+  .typing-dots span { width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); animation: typing 1.4s infinite; }
+  .typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+  .typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes typing { 0%, 60%, 100% { opacity: 0.3; } 30% { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) { .typing-dots span { animation: none; } }
+
+  .calendar-mini {
+    display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px;
+    font-size: 9px; color: var(--text-sec);
+  }
+  .calendar-mini .cd { aspect-ratio: 1; display: flex; align-items: center; justify-content: center; background: var(--bg-muted); border-radius: var(--r-sm); }
+  .calendar-mini .cd.has { background: hsl(var(--c-session) / 0.2); color: hsl(var(--c-session)); font-weight: var(--fw-bold); }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <h1>🎯 State Matrix</h1>
+  <span class="meta">dev-fixture · 8 route × 5 stati · mobile 375</span>
+  <span class="spacer"></span>
+  <span class="meta">Spec: 2026-05-23 § B18</span>
+  <button onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'">☀/☾ toggle</button>
+</header>
+
+<main class="stage">
+
+  <p style="font-size: 13px; color: var(--text-sec); margin: 0 0 var(--s-6); max-width: 70ch;">
+    Matrix di coverage 8 route critiche × 5 stati canonici (Empty · Error · Loading · Permission · Offline).
+    Permission-denied applicato solo a 3 route tier-locked (translate · chat · sessions/live).
+    Le cell con <code>—</code> sono universally accessible (no permission gate). Ogni stato ha pattern documentato
+    riusabile, con reuse trace nei commenti HTML head. Foundation per Phase 2-3 raffinamenti.
+  </p>
+
+  <div class="matrix">
+    <!-- Header row -->
+    <div class="hdr-corner"></div>
+    <div class="hdr-state"><span class="ico">⊘</span>Empty</div>
+    <div class="hdr-state"><span class="ico">⚠</span>Error</div>
+    <div class="hdr-state"><span class="ico">⏳</span>Loading</div>
+    <div class="hdr-state"><span class="ico">🔒</span>Permission</div>
+    <div class="hdr-state"><span class="ico">📡</span>Offline</div>
+
+    <!-- ════════ ROUTE A: /library/[gameId]/play/[campaignId]/translate ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-game))"></span>
+      <span class="seg">Aaron CORE</span>
+      <span class="path">/library/[gameId]/play/[campaignId]/translate</span>
+    </div>
+
+    <!-- A1 translate Empty -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera con i ragazzi · §</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">📷</div>
+          <div class="title">Fotografa una pagina</div>
+          <div class="desc">Inquadra il libro fisico per tradurre il paragrafo corrente.</div>
+          <button class="cta">Apri camera</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- A2 translate Error -->
+    <!-- pattern: see librogame-runthrough-error-states.html state-B ocr-fail -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · OCR errore</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>📷</span><span>OCR illeggibile</span></div>
+          <div class="msg">Confidence 0.18 — testo troppo sfocato per essere letto.</div>
+          <div class="actions">
+            <button class="primary">Rifotografa</button>
+            <button class="secondary">Manuale</button>
+          </div>
+          <div class="ref-note">💰 0 token consumati · ref state-B</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- A3 translate Loading -->
+    <!-- pattern: see librogame-runthrough-translate-viewer.html Task 2 sez 1b 4-step -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · §147 traduco</span></div>
+      <div class="body">
+        <div class="load-steps">
+          <div class="step done"><span class="dot"></span><span>Caricamento foto…</span></div>
+          <div class="step done"><span class="dot"></span><span>Sto leggendo il libro…</span></div>
+          <div class="step active"><span class="dot"></span><span>Sto traducendo…</span></div>
+          <div class="step"><span class="dot"></span><span>Cerco parole nel glossario…</span></div>
+        </div>
+        <div class="skeleton skeleton-line w85"></div>
+        <div class="skeleton skeleton-line w70"></div>
+        <div class="skeleton skeleton-line w50"></div>
+      </div>
+    </div>
+
+    <!-- A4 translate Permission -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · quota</span></div>
+      <div class="body">
+        <div class="perm-locked">
+          <div class="lock">🔒</div>
+          <div class="tier-badge">Pro</div>
+          <div class="title">Quota OCR esaurita</div>
+          <div class="desc">Hai usato 50/50 traduzioni questo mese. Passa a Pro per illimitate.</div>
+          <div class="cta-row">
+            <button class="cta-primary">Esplora piani →</button>
+            <button class="cta-secondary">Torna indietro</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- A5 translate Offline -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · §147</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline — dati salvati<button class="retry">Riprova</button></div>
+        <div class="cached-data">
+          <div class="cached-card">
+            <div><strong>§ 147 · last cached</strong></div>
+            <div style="margin-top: 4px;">"Il guardiano della soglia ti osserva con occhi ferrigni…"</div>
+            <div class="meta">cached 18 min fa · tradotto IT</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE B: /library/[gameId]/play ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-game))"></span>
+      <span class="seg">Aaron resume</span>
+      <span class="path">/library/[gameId]/play</span>
+    </div>
+
+    <!-- B1 play Empty -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Press Start · campagne</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">📖</div>
+          <div class="title">Nessuna campagna</div>
+          <div class="desc">Inizia un libro-game per creare la tua prima sessione.</div>
+          <button class="cta">Sfoglia libreria</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- B2 play Error -->
+    <!-- pattern: see librogame-runthrough-error-states.html -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Press Start</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Errore caricamento</span></div>
+          <div class="msg">Non riesco a caricare le tue campagne. Verifica la connessione.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Segnala</button>
+          </div>
+          <div class="ref-note">ref error-states pattern</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- B3 play Loading -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Press Start</span></div>
+      <div class="body">
+        <div class="skeleton skeleton-card"></div>
+        <div class="skeleton skeleton-card"></div>
+        <div class="skeleton skeleton-card"></div>
+      </div>
+    </div>
+
+    <!-- B4 skip — universally accessible -->
+    <div class="frame skip" role="img" aria-label="Skip: universally accessible">
+      <div class="skip-msg">— <br>Universally<br>accessible</div>
+    </div>
+
+    <!-- B5 play Offline -->
+    <div class="frame ec-game">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Press Start</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline<button class="retry">Riprova</button></div>
+        <div class="cached-data">
+          <div class="cached-card">
+            <strong>Sera con i ragazzi</strong>
+            <div style="margin-top: 4px;">§ 147 · resume</div>
+            <div class="meta">last sync 24h fa</div>
+          </div>
+          <div class="cached-card">
+            <strong>Run solo</strong>
+            <div style="margin-top: 4px;">§ 38 · resume</div>
+            <div class="meta">last sync 3g fa</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE C: /chat/[threadId] ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-agent))"></span>
+      <span class="seg">Aaron + boardgamer</span>
+      <span class="path">/chat/[threadId]</span>
+    </div>
+
+    <!-- C1 chat Empty (riusa quick-starter Aaron variant) -->
+    <!-- pattern: see chat-fullscreen.html B11b-3 -->
+    <div class="frame ec-agent">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Nuova chat</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">💬</div>
+          <div class="title">Inizia una conversazione</div>
+          <div class="desc">Chiedi al tuo agent una regola, una strategia o un riassunto.</div>
+          <button class="cta">Quali sono le regole di Press Start?</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- C2 chat Error -->
+    <!-- pattern: see chat-fullscreen.html stream-error state -->
+    <div class="frame ec-agent">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · chat</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Errore stream</span></div>
+          <div class="msg">La risposta è stata interrotta. Il tuo messaggio è preservato.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Cambia agent</button>
+          </div>
+          <div class="ref-note">last user msg in composer</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- C3 chat Loading (typing indicator + skeleton bubble) -->
+    <div class="frame ec-agent">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · chat</span></div>
+      <div class="body">
+        <div style="background: hsl(var(--c-agent) / 0.08); border-radius: var(--r-md); padding: var(--s-3); font-size: 10px; color: var(--text-sec); align-self: flex-start; max-width: 80%;">
+          <div style="display: flex; align-items: center; gap: var(--s-2);">
+            <span class="typing-dots"><span></span><span></span><span></span></span>
+            <span style="font-size: 9px; color: var(--text-muted);">Sto pensando…</span>
+          </div>
+        </div>
+        <div class="skeleton skeleton-line w85"></div>
+        <div class="skeleton skeleton-line w70"></div>
+      </div>
+    </div>
+
+    <!-- C4 chat Permission -->
+    <div class="frame ec-agent">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">chat · quota</span></div>
+      <div class="body">
+        <div class="perm-locked">
+          <div class="lock">🔒</div>
+          <div class="tier-badge">Pro</div>
+          <div class="title">Quota chat esaurita</div>
+          <div class="desc">100/100 messaggi questo mese. Passa a Pro per illimitate.</div>
+          <div class="cta-row">
+            <button class="cta-primary">Esplora piani →</button>
+            <button class="cta-secondary">Torna indietro</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- C5 chat Offline -->
+    <div class="frame ec-agent">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sera · chat</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline — msg history cached<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card">
+            <strong>Aaron:</strong> Come si risolve §147?
+            <div class="meta">22:08 · synced</div>
+          </div>
+          <div class="cached-card">
+            <strong>Agent:</strong> "Il guardiano richiede la Runa…"
+            <div class="meta">22:08 · synced</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE D: /game-nights ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-session))"></span>
+      <span class="seg">boardgamer</span>
+      <span class="path">/game-nights</span>
+    </div>
+
+    <!-- D1 game-nights Empty -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Serate</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">🎲</div>
+          <div class="title">Crea la prima serata</div>
+          <div class="desc">Pianifica una serata, invita amici, scegli i giochi.</div>
+          <button class="cta">+ Nuova serata</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- D2 game-nights Error -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Serate</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Calendar non disponibile</span></div>
+          <div class="msg">Non riesco a caricare il calendario serate.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Segnala</button>
+          </div>
+          <div class="ref-note">ref error-states pattern</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- D3 game-nights Loading (calendar skeleton 7-day) -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Serate</span></div>
+      <div class="body">
+        <div style="font-size: 10px; color: var(--text-muted); margin-bottom: 4px;">Maggio 2026</div>
+        <div class="calendar-mini">
+          <div class="cd skeleton">L</div><div class="cd skeleton">M</div><div class="cd skeleton">M</div><div class="cd skeleton">G</div><div class="cd skeleton">V</div><div class="cd skeleton">S</div><div class="cd skeleton">D</div>
+          <div class="cd skeleton"></div><div class="cd skeleton"></div><div class="cd skeleton"></div><div class="cd skeleton"></div><div class="cd skeleton"></div><div class="cd skeleton"></div><div class="cd skeleton"></div>
+        </div>
+        <div class="skeleton skeleton-card" style="margin-top: var(--s-3);"></div>
+      </div>
+    </div>
+
+    <!-- D4 skip — universally accessible -->
+    <div class="frame skip">
+      <div class="skip-msg">— <br>Universally<br>accessible</div>
+    </div>
+
+    <!-- D5 game-nights Offline -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Serate</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card">
+            <strong>Sab 18 Mag · Casa Marco</strong>
+            <div style="margin-top: 4px;">Wingspan + Carcassonne · 4 pax</div>
+            <div class="meta">RSVP confermati: 3/4</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE E: /sessions/live/[sessionId] ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-session))"></span>
+      <span class="seg">boardgamer</span>
+      <span class="path">/sessions/live/[sessionId]</span>
+    </div>
+
+    <!-- E1 sessions-live Empty -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sessione live</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">⏳</div>
+          <div class="title">Aspetta che host inizi</div>
+          <div class="desc">L'host non ha ancora avviato la sessione. Riceverai una notifica.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- E2 sessions-live Error (SSE disconnect) -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sessione live</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>📡</span><span>Connessione persa</span></div>
+          <div class="msg">SSE disconnesso. Riconnessione automatica in corso…</div>
+          <div class="actions">
+            <button class="primary">Riconnetti ora</button>
+            <button class="secondary">Modalità local</button>
+          </div>
+          <div class="ref-note">retry exponential backoff · 3 tentativi</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- E3 sessions-live Loading -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Sessione live</span></div>
+      <div class="body">
+        <div style="display: flex; flex-direction: column; align-items: center; gap: var(--s-3); flex: 1; justify-content: center;">
+          <div style="width: 80px; height: 100px; background: var(--bg-muted); border-radius: var(--r-md); border: 1px solid var(--border);"></div>
+          <div class="typing-dots"><span></span><span></span><span></span></div>
+          <div style="font-size: 10px; color: var(--text-muted);">Inizializzo sessione…</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- E4 sessions-live Permission (host-only) -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">live · host-only</span></div>
+      <div class="body">
+        <div class="perm-locked">
+          <div class="lock">🔒</div>
+          <div class="tier-badge">Host-only</div>
+          <div class="title">Solo l'host può iniziare</div>
+          <div class="desc">Aspetta che la sessione si attivi. Marco (host) verrà notificato.</div>
+          <div class="cta-row">
+            <button class="cta-secondary">Torna alla serata</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- E5 sessions-live Offline (local-only mode) -->
+    <div class="frame ec-session">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">live · local</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline — local-only<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card">
+            <strong>Wingspan · Turn 4</strong>
+            <div style="margin-top: 4px;">Aaron: 12 pt · Marco: 18 pt</div>
+            <div class="meta">salvataggio locale · sync on reconnect</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE F: /shared-games ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-toolkit))"></span>
+      <span class="seg">browser</span>
+      <span class="path">/shared-games</span>
+    </div>
+
+    <!-- F1 shared-games Empty (improbabile) -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Catalogo</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">📚</div>
+          <div class="title">Catalog vuoto</div>
+          <div class="desc">Riprova fra qualche minuto — stiamo importando.</div>
+          <button class="cta">Riprova</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- F2 shared-games Error -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Catalogo</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Catalogo non disponibile</span></div>
+          <div class="msg">Non riesco a caricare i giochi condivisi.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Segnala</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- F3 shared-games Loading (card-grid 6-skeleton) -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Catalogo</span></div>
+      <div class="body">
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--s-2);">
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="aspect-ratio: 3/4;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- F4 skip — universally accessible (public catalog) -->
+    <div class="frame skip">
+      <div class="skip-msg">— <br>Public<br>catalog</div>
+    </div>
+
+    <!-- F5 shared-games Offline -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Catalogo</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline · cached<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card"><strong>Wingspan</strong><div class="meta">1-5p · 40min · cached</div></div>
+          <div class="cached-card"><strong>Carcassonne</strong><div class="meta">2-5p · 30min · cached</div></div>
+          <div class="cached-card"><strong>Press Start</strong><div class="meta">solo · 90min · cached</div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE G: /discover ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-toolkit))"></span>
+      <span class="seg">browser cross</span>
+      <span class="path">/discover</span>
+    </div>
+
+    <!-- G1 discover Empty -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Scopri</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">🧭</div>
+          <div class="title">Nessun consiglio ora</div>
+          <div class="desc">Stiamo lavorando ai tuoi suggerimenti — torna fra poco.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- G2 discover Error -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Scopri</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Discovery offline</span></div>
+          <div class="msg">Il motore di raccomandazione non risponde.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Segnala</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- G3 discover Loading (rail skeleton 3-row) -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Scopri</span></div>
+      <div class="body">
+        <div class="skeleton skeleton-line w50"></div>
+        <div style="display: flex; gap: var(--s-2);">
+          <div class="skeleton" style="width: 60px; aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="width: 60px; aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="width: 60px; aspect-ratio: 3/4;"></div>
+        </div>
+        <div class="skeleton skeleton-line w50" style="margin-top: var(--s-2);"></div>
+        <div style="display: flex; gap: var(--s-2);">
+          <div class="skeleton" style="width: 60px; aspect-ratio: 3/4;"></div>
+          <div class="skeleton" style="width: 60px; aspect-ratio: 3/4;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- G4 skip — universally accessible -->
+    <div class="frame skip">
+      <div class="skip-msg">— <br>Universally<br>accessible</div>
+    </div>
+
+    <!-- G5 discover Offline -->
+    <div class="frame ec-toolkit">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Scopri</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline · cached<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card"><strong>📍 Per te (cached)</strong><div class="meta">Press Start · Brass · Wingspan</div></div>
+          <div class="cached-card"><strong>📍 Nuovi (cached)</strong><div class="meta">3 nuovi titoli · 24h fa</div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ════════ ROUTE H: /notifications ════════ -->
+    <div class="hdr-route">
+      <span class="entity-dot" style="background: hsl(var(--c-kb))"></span>
+      <span class="seg">cross-cutting</span>
+      <span class="path">/notifications</span>
+    </div>
+
+    <!-- H1 notifications Empty -->
+    <div class="frame ec-kb">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Notifiche</span></div>
+      <div class="body">
+        <div class="empty">
+          <div class="icon">🎉</div>
+          <div class="title">Sei in pari!</div>
+          <div class="desc">Nessuna notifica nuova. Goditi la pace.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- H2 notifications Error -->
+    <div class="frame ec-kb">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Notifiche</span></div>
+      <div class="body">
+        <div class="err-banner">
+          <div class="head"><span>⚠</span><span>Errore caricamento</span></div>
+          <div class="msg">Non riesco a caricare le notifiche.</div>
+          <div class="actions">
+            <button class="primary">Riprova</button>
+            <button class="secondary">Segnala</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- H3 notifications Loading -->
+    <div class="frame ec-kb">
+      <div class="sbar"><span>22:14</span><span>📶 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Notifiche</span></div>
+      <div class="body">
+        <div class="skeleton skeleton-card" style="height: 50px;"></div>
+        <div class="skeleton skeleton-card" style="height: 50px;"></div>
+        <div class="skeleton skeleton-card" style="height: 50px;"></div>
+      </div>
+    </div>
+
+    <!-- H4 skip — universally accessible -->
+    <div class="frame skip">
+      <div class="skip-msg">— <br>Universally<br>accessible</div>
+    </div>
+
+    <!-- H5 notifications Offline -->
+    <div class="frame ec-kb">
+      <div class="sbar"><span>22:14</span><span>📵 🔋 72%</span></div>
+      <div class="app-bar"><span class="back">←</span><span class="title">Notifiche</span></div>
+      <div class="body">
+        <div class="offline-banner">📡 Offline · cached<button class="retry">Sync</button></div>
+        <div class="cached-data">
+          <div class="cached-card"><strong>Marco ti invita</strong><div class="meta">Sera 18 Mag · cached</div></div>
+          <div class="cached-card"><strong>Press Start §147 tradotto</strong><div class="meta">2h fa · cached</div></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <footer style="margin-top: var(--s-10); padding-top: var(--s-6); border-top: 1px solid var(--border); font-size: 12px; color: var(--text-muted);">
+    <p><strong>Cross-references:</strong>
+      <code>librogame-runthrough-error-states.html</code> (Task 1, 10 error sub-states) ·
+      <code>librogame-runthrough-translate-viewer.html</code> (Task 2+4, loading + multi-lang) ·
+      <code>chat-fullscreen.html</code> (Task 5, B11b chiusura #491) ·
+      <code>01-screens.html</code> (companion dev-fixture happy-path).
+    </p>
+    <p><strong>Permission-denied scope:</strong> applicato solo a 3 route tier-locked (translate · chat · sessions/live). Le altre 5 route (play, game-nights, shared-games, discover, notifications) sono universally accessible.</p>
+    <p><strong>Future:</strong> il CTA "Esplora piani" punta a <code>/pricing</code> (route esistente ma senza mockup canonico — vedi audit gap, B13 future).</p>
+  </footer>
+
+</main>
+
+</body>
+</html>

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -1,0 +1,254 @@
+# Mockup Gaps Audit — 2026-05-22
+
+**Scope**: user-reachable routes (escluse `admin/(dashboard)/**`) prive di mockup
+canonico in `admin-mockups/design_files/`.
+
+**Method**: cross-reference fra le 96 route in `apps/web/src/app/(authenticated)/**` e
+`apps/web/src/app/(public)/**`, l'inventario `admin-mockups/MOCKUPS_INDEX.md` e
+la sezione *Route → Mockup index* di
+[`v2-migration-matrix.md`](../frontend/v2-migration-matrix.md).
+
+**Aggiorna**: [`2026-05-12-mockup-gaps.md`](./2026-05-12-mockup-gaps.md) (stale —
+chiusura batch 2026-05-20 di #491/#492 ha invalidato gap #1 e #2, e l'audit
+elencava 3 route `/library/playlists/*` che non esistono nel codebase).
+
+**Total gaps confermati**: 9 cluster (di cui 2 da closure false-positive,
+5 nuovi, 2 carry-over dall'audit precedente).
+
+## Diff vs audit 2026-05-12
+
+| # | Cluster | Stato 2026-05-12 | Stato 2026-05-22 | Δ |
+|---|---|---|---|---|
+| 1 | `/dashboard` (#491) | gap OPEN | **closure parziale** — `sp4-dashboard.html` consegnato, chat full-screen NO | ⚠️ ridotto |
+| 2 | `/profile/*` (#492) | gap OPEN | **closure false-positive** — `community.jsx + .html` non esistono | ⚠️ riaprire |
+| 3 | `/play-records/*` | gap, no issue | invariato — confermo gap, route esistono | = |
+| 4 | `/library/playlists/*` | gap, no issue | **route inesistenti** → rimosso dall'audit | ✗ |
+| 5 | `/pricing` | gap, no issue | route `(public)/pricing` esiste, gap commerciale invariato | = (fuori scope authenticated) |
+| 6 | `/editor/agent-proposals/*` | non auditato | **gap nuovo P1** — 5 route user-facing AI Agent System | + |
+| 7 | `/toolkit/{history,stats,templates,play}` | non auditato | **gap nuovo P1** — sub-route coperte solo da mapping generico in MOCKUPS_INDEX | + |
+| 8 | `/private-games/[id]` vs `/library/private/[privateGameId]` | non auditato | **routing conflict P2** — co-esistenza non documentata | + |
+| 9 | `/library/wishlist` | non auditato | **gap nuovo P2** — impl attiva (`MeepleWishlistCard`) senza mockup | + |
+| 10 | `/games/[id]/{reviews,rules,strategies}` | non auditato | **gap nuovo P2** — sub-route oltre tabs `sp4-game-detail` | + |
+| 11 | `/sessions/[id]/{scoreboard,notes,join,players}` + `/sessions/live/[sessionId]/{scores,photos,agent,players}` | non auditato | **gap nuovo P2** — 8 sub-route con scope distinto | + |
+
+## Decision policy
+
+> Stessa policy dell'audit 2026-05-12: documentare i gap qui, proporre azioni
+> sulle issue esistenti, non aprire automaticamente nuove issue. Il maintainer
+> (badsworm@gmail.com) decide il routing.
+>
+> **Numerazione B-series**: B1-B10 tutti CLOSED. Le nuove issue partono da
+> **B11**.
+
+## P0 — Gap critici (chiusura false-positive da correggere)
+
+### #492 — Community / players / friends / achievements
+
+- **Issue**: [#492](https://github.com/meepleAi-app/meepleai-monorepo/issues/492)
+  *[Design v1 · B8] Mockup Community (player profile, friends, shared games)*
+- **Stato**: CLOSED COMPLETED 2026-05-20
+- **AC dichiarati**: `admin-mockups/design_files/community.jsx + .html` + link in
+  `00-hub.html` + light/dark mode
+- **AC reali**: nessun file `community*`, `friend*`, `achievement*` esiste in
+  `design_files/`. Solo `sp4-player-detail.html` (preesistente Wave 3,
+  PR #724) e `sp4-players-index.html`.
+- **Route impattate** (5):
+  - `/profile` — own profile (variant editable mancante)
+  - `/profile/achievements` — achievements grid + detail sheets
+  - `/players/[id]` — copertura partial via `sp4-player-detail` ma manca friends
+    e activity feed
+  - `/players/[id]/{achievements,games,sessions,stats}` — sub-tab coperti
+    nominalmente, achievement detail sheet NO
+- **Azione**: **riaprire #492** con scope ridotto ai 4 screen non consegnati
+  (own-editable variant · friend list · shared-games marketplace · achievement
+  detail sheet) oppure aprire **B11a follow-up**.
+
+### #491 — Dashboard + Chat full-screen
+
+- **Issue**: [#491](https://github.com/meepleAi-app/meepleai-monorepo/issues/491)
+  *[Design v1 · B7] Mockup Dashboard desktop + Chat full-screen*
+- **Stato**: CLOSED COMPLETED 2026-05-20
+- **AC dichiarati**: `dashboard-chat.jsx + .html` + 5 screen (dashboard 3-col ·
+  dashboard empty · chat full-screen desktop · chat mobile · chat empty) +
+  light/dark mode
+- **AC reali**: `sp4-dashboard.html` esiste (file naming differente, dashboard
+  3-col coperto). Chat full-screen desktop NO — solo
+  `nanolith-nav-chat-panel.html` che è component-mock (slide-over), non
+  full-page.
+- **Route impattate** (2):
+  - `/dashboard` — coperta da `sp4-dashboard.html` ✓ (verificare dark mode e
+    empty state)
+  - `/chat/[threadId]` full-screen desktop — coperto solo come slide-over
+    (`nanolith-nav-chat-panel`); il design originale prevedeva 3-col full-screen
+- **Azione**: **riaprire #491** con scope ridotto al chat full-screen (3 screen:
+  desktop 3-col · mobile · empty state) oppure aprire **B11b follow-up**.
+
+## P1 — Gap nuovi bloccanti sprint corrente
+
+### Gap N1 — `/editor/agent-proposals/*`
+
+- **Route impattate** (5):
+  - `/editor` — index editor user-facing
+  - `/editor/agent-proposals` — index proposals
+  - `/editor/agent-proposals/create` — create flow
+  - `/editor/agent-proposals/[id]/edit` — edit detail
+  - `/editor/agent-proposals/[id]/test` — playground test
+- **Impatto**: feature attiva (Epic AI Agent System) senza UX spec → impl
+  scollegato dal design system.
+- **Existing**: nessuna issue dedicata. Search "mockup editor / agent-proposals"
+  → 0 hit.
+- **Tier suggerito**: M (proposal index = S, create/edit = M, test = M con stream).
+- **Recommendation**: aprire `[Design v1 · B14] Mockup Editor user-facing
+  (agent proposals)`.
+
+### Gap N2 — `/play-records/*`
+
+- **Route impattate** (4):
+  - `/play-records` (index)
+  - `/play-records/new`
+  - `/play-records/[id]`
+  - `/play-records/[id]/edit`
+  - `/play-records/stats`
+- **Impatto**: bloccante **US-32 (P1 sprint Core Game Loop)**.
+- **Existing**: nessuna issue dedicata (carry-over audit 2026-05-12 #3).
+- **Tier suggerito**: S (index + new + stats), M ([id] detail con timeline).
+- **Recommendation**: aprire `[Design v1 · B11] Mockup Play Records (index,
+  new, detail, edit, stats)`.
+
+### Gap N3 — `/toolkit/{history,stats,templates,play}`
+
+- **Route impattate** (4):
+  - `/toolkit/history` — paginated list
+  - `/toolkit/stats` — KPI dashboard
+  - `/toolkit/templates` — gallery + filter
+  - `/toolkit/play` — live session toolkit panel
+- **Impatto**: `sp4-toolkit-detail.html` mappa generico "+ sub-routes" ma
+  ognuna ha dati e interazioni distinte. Mancano esempi concreti (Adzic).
+- **Existing**: nessuna. `sp4-toolkit-detail` copre `[sessionId]` detail solo.
+- **Tier suggerito**: S (per ognuna).
+- **Recommendation**: aprire `[Design v1 · B15] Mockup Toolkit sub-pages
+  (history, stats, templates, play)`.
+
+## P2 — Gap secondari / IA conflict
+
+### Gap N4 — `/private-games/[id]` vs `/library/private/[privateGameId]`
+
+- **Stato**: **routing conflict** — entrambe le route esistono in
+  `(authenticated)/`:
+  - `/private-games/[id]/page.tsx` → `PrivateGameDetailClient` (origine
+    tracking commento Issue #3664, non in GH)
+  - `/library/private/[privateGameId]/page.tsx`
+- **Mockup attuale**: `sp4-game-detail.html` mappato a "/games/[id],
+  /library/[gameId], /private-games/[id]" — usa la prima route stale.
+- **Impatto**: confusione utente + manutenzione doppia. Cockburn: chi è
+  l'attore primario per quale route?
+- **Recommendation**: **decisione architetturale, non mockup**. Stabilire la
+  route canonica (probabilmente `/library/private/[privateGameId]`) e deprecare
+  l'altra con `redirect()` Next.js. Aggiornare il mapping
+  in `MOCKUPS_INDEX.md` e in `v2-migration-matrix.md`.
+
+### Gap N5 — `/library/wishlist`
+
+- **Stato**: route esistente, codice impl attivo (`MeepleWishlistCard`,
+  `AddToWishlistDialog`, `useWishlist`).
+- **Mockup attuale**: nessuno dedicato. Riusa `MeepleCard` + Dialog primitives.
+- **Impatto**: layout/empty state/add-dialog UX non specificati centralmente.
+- **Tier**: S.
+- **Recommendation**: estendere `sp4-library-desktop.html` con variant
+  wishlist OR aprire `[Design v1 · B16] Mockup Library Wishlist standalone`.
+
+### Gap N6 — `/games/[id]/{reviews,rules,strategies}`
+
+- **Route impattate** (3): tre route fisicamente separate da `/games/[id]` index.
+- **Mockup attuale**: `sp4-game-detail.html` ha tabs interne; non chiaro se
+  ogni tab fosse pensata come sub-state o sub-route.
+- **Impatto**: Fowler — interface design coherence. Decidere pattern
+  uniforme tabs-as-state vs tabs-as-route.
+- **Recommendation**: decisione architetturale + estensione `sp4-game-detail`
+  con 3 screen sub-route OR ridurre fisicamente le route (Next.js routes →
+  query params).
+
+### Gap N7 — `/sessions/[id]/*` e `/sessions/live/[sessionId]/*` sub-routes
+
+- **Route impattate** (8):
+  - `/sessions/[id]/scoreboard` — vista standalone scoreboard
+  - `/sessions/[id]/notes` — post-session notes editor
+  - `/sessions/[id]/join` — join flow (sp3-join reuse?)
+  - `/sessions/[id]/players` — players list management
+  - `/sessions/live/[sessionId]/scores` — live scores entry
+  - `/sessions/live/[sessionId]/photos` — photo gallery in-session
+  - `/sessions/live/[sessionId]/agent` — agent panel in-session
+  - `/sessions/live/[sessionId]/players` — players management live
+- **Mockup attuale**: `sp4-session-live.html` (live aggregate) +
+  `sp4-session-summary.html` (post-game). Le sub-route specifiche non distinte.
+- **Recommendation**: aprire `[Design v1 · B17] Mockup Sessions sub-pages`
+  (8 screen) OR consolidare sub-route in tabs interne dei mockup esistenti.
+
+## P3 — Coverage stati (cross-cutting, Adzic)
+
+Il fixture `01-screens.html` documenta 24 mobile screen, ma per le **route
+reali** la coverage di stati canonici è disomogenea:
+
+| Stato | Coverage attuale | Gap principali |
+|---|---|---|
+| **Empty state** | `/library`, `/library/wishlist`, `/discover` ✓ | mancano: `/play-records`, `/editor/agent-proposals`, `/notifications`, `/toolkit/history` |
+| **Error state** | `nanolith-runthrough-error-states` (chat/translate/encounter only) | mancano: `/sessions/live` SSE-disconnect, `/upload` PDF-corrupt, `/games/[id]` no-data |
+| **Loading skeleton** | Componenti impl (es. `WishlistSkeleton`), non specificati in mockup | discrepanza spec/impl globale — Wiegers traceability |
+| **Permission-denied** | `auth-flow.html` (login only) | mancano: tier-locked features, suspended-account, expired-session inline |
+| **Network-offline** | `nanolith-runthrough-error-states` parziale | mancano: offline cache per `/library`, `/play-records`, `/notifications` |
+
+**Recommendation**: aprire `[Design v1 · B18] Mockup State Matrix
+(empty/error/loading/permission/offline cross-route)` come fixture di tipo
+`01-screens.html` ma orientata agli stati.
+
+## Periferia (P3) — verifica scope
+
+| Route | Stato | Azione |
+|---|---|---|
+| `/n8n` | esiste in `(authenticated)/` | Verificare se user-facing o vestigial admin-tool. Se admin → spostare sotto `admin/(dashboard)/` |
+| `/pipeline-builder` | esiste in `(authenticated)/` | Idem — se admin-only, riposizionare |
+| `/versions` | esiste in `(authenticated)/` | System info, low-priority, P3 |
+| `/setup` | esiste, coperto da `onboarding.html` ✓ | nessuna azione |
+| `/agents` | coperta da `sp4-agents-index` ✓ | nessuna azione |
+
+## Sommario azioni per maintainer
+
+### Issue da riaprire / aprire
+
+1. **Riaprire #492** con scope ridotto (4 screen community) → o aprire B11a
+2. **Riaprire #491** con scope ridotto (3 screen chat full-screen) → o aprire B11b
+3. **Aprire B11** `Mockup Play Records` — bloccante US-32
+4. **Aprire B14** `Mockup Editor user-facing (agent proposals)`
+5. **Aprire B15** `Mockup Toolkit sub-pages`
+6. **Aprire B16** `Mockup Library Wishlist standalone` (estensione)
+7. **Aprire B17** `Mockup Sessions sub-pages` (estensione)
+8. **Aprire B18** `Mockup State Matrix cross-route`
+
+### Decisioni architetturali (non-mockup)
+
+9. **N4** — decidere route canonica `/library/private/[privateGameId]` vs
+   `/private-games/[id]`; deprecare l'altra
+10. **N6** — decidere pattern tabs-as-state vs tabs-as-route per `/games/[id]/*`
+11. **N7** — decidere consolidamento sub-route sessions in tabs vs route fisiche
+
+### Manutenzione audit
+
+12. **Aggiornare `MOCKUPS_INDEX.md`** dopo merge della riapertura #491/#492
+13. **Stabilire CI check** route-vs-mockup (un drift simile al gap #4 dell'audit
+    precedente — playlists route inesistente — non deve ripresentarsi).
+    Suggerimento: script che fa `grep -r "page.tsx" apps/web/src/app/(authenticated)/`
+    e diffa contro `MOCKUPS_INDEX.md`.
+
+## Cross-references
+
+- [`docs/for-developers/audits/2026-05-12-mockup-gaps.md`](./2026-05-12-mockup-gaps.md) — audit precedente (stale)
+- [`docs/for-developers/frontend/v2-migration-matrix.md`](../frontend/v2-migration-matrix.md) — Route → Mockup index
+- [`admin-mockups/MOCKUPS_INDEX.md`](../../../admin-mockups/MOCKUPS_INDEX.md) — File classification
+- Issue umbrella #1023 — Design System De-versioning & Mockup-Faithful Convergence
+- Issue #492 (closure false-positive) · #491 (closure parziale)
+
+## Reminder
+
+> Questo audit **non crea automaticamente** nuove issue (policy ereditata
+> dall'audit 2026-05-12). Le proposte alle voci 1-8 vanno applicate dal
+> maintainer via GH UI / `gh` CLI.

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -15,6 +15,23 @@ elencava 3 route `/library/playlists/*` che non esistono nel codebase).
 **Total gaps confermati**: 9 cluster (di cui 2 da closure false-positive,
 5 nuovi, 2 carry-over dall'audit precedente).
 
+## Status (2026-05-23 update)
+
+**Phase 1 in implementation** (branch `feature/mockup-refinement-aaron-design`):
+- ✅ Closure parziale #491 chat full-screen → mockup `chat-fullscreen.html` creato (Sezione 2)
+- ⚠️ Closure false-positive #492 community follow-up → ancora da riaprire
+  (sezione B11a non in scope Approccio B di questa Phase 1)
+- ✅ Cluster translate Aaron CORE → 4 sezioni 1a/1b/1c/1d implementate
+- ✅ B18 state-matrix cross-route → mockup `state-matrix.html` creato (Sezione 3)
+
+**Spec di riferimento**:
+`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`
+
+**Out of scope Phase 1** (deferiti a Phase 2/3):
+B11 play-records · B11a community follow-up · B14 editor agent-proposals
+(parcheggiato) · B15 toolkit sub-pages · B16 wishlist · B17 sessions
+sub-pages · nodi architetturali N4/N6/N7.
+
 ## Diff vs audit 2026-05-12
 
 | # | Cluster | Stato 2026-05-12 | Stato 2026-05-22 | Δ |
@@ -215,14 +232,14 @@ reali** la coverage di stati canonici è disomogenea:
 
 ### Issue da riaprire / aprire
 
-1. **Riaprire #492** con scope ridotto (4 screen community) → o aprire B11a
-2. **Riaprire #491** con scope ridotto (3 screen chat full-screen) → o aprire B11b
+1. ⚠️ **Riaprire #492** con scope ridotto (4 screen community) → o aprire B11a — STILL TODO (non in scope Phase 1)
+2. ✅ **Riaprire #491** con scope ridotto (3 screen chat full-screen) → consegnato via `chat-fullscreen.html` (Phase 1, 2026-05-23)
 3. **Aprire B11** `Mockup Play Records` — bloccante US-32
 4. **Aprire B14** `Mockup Editor user-facing (agent proposals)`
 5. **Aprire B15** `Mockup Toolkit sub-pages`
 6. **Aprire B16** `Mockup Library Wishlist standalone` (estensione)
 7. **Aprire B17** `Mockup Sessions sub-pages` (estensione)
-8. **Aprire B18** `Mockup State Matrix cross-route`
+8. ✅ **Aprire B18** `Mockup State Matrix cross-route` → consegnato via `state-matrix.html` (Phase 1, 2026-05-23)
 
 ### Decisioni architetturali (non-mockup)
 

--- a/docs/for-developers/audits/2026-05-22-mockup-gaps.md
+++ b/docs/for-developers/audits/2026-05-22-mockup-gaps.md
@@ -192,10 +192,10 @@ reali** la coverage di stati canonici è disomogenea:
 | Stato | Coverage attuale | Gap principali |
 |---|---|---|
 | **Empty state** | `/library`, `/library/wishlist`, `/discover` ✓ | mancano: `/play-records`, `/editor/agent-proposals`, `/notifications`, `/toolkit/history` |
-| **Error state** | `nanolith-runthrough-error-states` (chat/translate/encounter only) | mancano: `/sessions/live` SSE-disconnect, `/upload` PDF-corrupt, `/games/[id]` no-data |
+| **Error state** | `librogame-runthrough-error-states` (chat/translate/encounter only) | mancano: `/sessions/live` SSE-disconnect, `/upload` PDF-corrupt, `/games/[id]` no-data |
 | **Loading skeleton** | Componenti impl (es. `WishlistSkeleton`), non specificati in mockup | discrepanza spec/impl globale — Wiegers traceability |
 | **Permission-denied** | `auth-flow.html` (login only) | mancano: tier-locked features, suspended-account, expired-session inline |
-| **Network-offline** | `nanolith-runthrough-error-states` parziale | mancano: offline cache per `/library`, `/play-records`, `/notifications` |
+| **Network-offline** | `librogame-runthrough-error-states` parziale | mancano: offline cache per `/library`, `/play-records`, `/notifications` |
 
 **Recommendation**: aprire `[Design v1 · B18] Mockup State Matrix
 (empty/error/loading/permission/offline cross-route)` come fixture di tipo

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -53,6 +53,14 @@ ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch st
 > da Tier S blanket erroneo a Tier L (3 hook indipendenti). `MOCKUPS_INDEX.md` synced
 > (page-mock 44→46, component-mock 14→15, Total 68→71).
 
+> **Updated 2026-05-23** (Mockup refinement Aaron core + cross-cutting, Phase 1):
+> added `chat-fullscreen.html` (page-mock, `/chat/[threadId]` + `/chat/new`),
+> `state-matrix.html` (dev-fixture, cross-route states 8×5), e estese 4 mockup
+> esistenti per cluster translate (error-states +6 stati, translate-viewer
+> +loading+reader-mode+multi-lang, glossary-editor +context-aware,
+> photo-upload +manual-mode entry). Spec:
+> `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`.
+
 ## Scope and ground rules
 
 - **In scope**: 83 feature components extracted from `admin-mockups/design_files/sp4-*.jsx`
@@ -127,8 +135,8 @@ Each route is classified by **Tier** (S/M/L) which gates implementation strategy
 | `/toolkits/[id]` | **M** | `sp4-toolkit-detail.html` | Toolkit summary + version timeline | pending |
 | `/gamebook` | **M** | `sp6-libro-game-index.html` | Libro-game index: Hero + QuotaWidget + Card grid + EmptyState | ✅ done (SP6 Phase B, PR #792) |
 | `/gamebook/upload` | **L** | `sp4-upload-wizard-extended.html` + `sp6-libro-game-photo-upload.html` | 3-step wizard: game search + camera + indexing — 14-state FSM + camera permission matrix + offline retry | ✅ done (SP6 Phase C, contract PR #794 + Foundation PR #796 + Interactions PR #800) — [`contracts/gamebook-upload-hooks.md`](contracts/gamebook-upload-hooks.md) |
-| `/library/[gameId]/play/[campaignId]/translate` | **S** | `nanolith-runthrough-translate-viewer.html` | Nanolith demo — paragraph translate via chat-stream workaround. Route consolidated from `/library/games/[gameId]/translate` under campaign in IA refactor #871. | ✅ done (SP6 Phase A, PR #790; route refactored in #871) |
-| `/library/[gameId]/play/[campaignId]/encounter` | **S** | `nanolith-runthrough-encounter-cheatsheet.html` | Nanolith dogfood — Encounter Book photo→cheatsheet on-demand (4 stati: entry-from-story · segmenting · cheatsheet-rendered · resolved-back). Ephemeral parse (no long-term cache, §9.1). Single hook `useEncounterParse`, linear FSM. | pending (post-Stage-2 unfreeze) |
+| `/library/[gameId]/play/[campaignId]/translate` | **S** | `librogame-runthrough-translate-viewer.html` | Nanolith demo — paragraph translate via chat-stream workaround. Route consolidated from `/library/games/[gameId]/translate` under campaign in IA refactor #871. | ✅ done (SP6 Phase A, PR #790; route refactored in #871) |
+| `/library/[gameId]/play/[campaignId]/encounter` | **S** | `librogame-runthrough-encounter-cheatsheet.html` | Nanolith dogfood — Encounter Book photo→cheatsheet on-demand (4 stati: entry-from-story · segmenting · cheatsheet-rendered · resolved-back). Ephemeral parse (no long-term cache, §9.1). Single hook `useEncounterParse`, linear FSM. | pending (post-Stage-2 unfreeze) |
 | `/kb/[id]` | **M** | `sp4-kb-detail.html` | KB header + chunks + search | **deferred** — pivot legale 2026-05-10, vedi `2026-05-10-citation-pdf-viewer-design.md` (G4 v3) |
 
 **Anti-pattern**: dispatchare implementation subagent senza Phase 0.5 per route Tier L. Wave C.1 PR #697 ha esattamente questo come root cause (vedi [post-mortem](../specs/2026-04-26-v2-design-migration.md#34-phase-05--sub-hook-contract-per-tier-l-routes-only)).
@@ -433,8 +441,8 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `nanolith-runthrough-game-detail.html` | `LibroGameDetailView` | `apps/web/src/components/v2/gamebook/LibroGameDetailView.tsx` | `/library/[gameId]` (libro variant) | done | #1037 | T A V | — |
-| `nanolith-runthrough-setup-wizard.html` | `CampaignSetupDrawer` | `apps/web/src/components/v2/gamebook/CampaignSetupDrawer.tsx` | `/library/[gameId]` (libro variant — drawer) | done | #1037 | T A V | — |
+| `librogame-runthrough-game-detail.html` | `LibroGameDetailView` | `apps/web/src/components/v2/gamebook/LibroGameDetailView.tsx` | `/library/[gameId]` (libro variant) | done | #1037 | T A V | — |
+| `librogame-runthrough-setup-wizard.html` | `CampaignSetupDrawer` | `apps/web/src/components/v2/gamebook/CampaignSetupDrawer.tsx` | `/library/[gameId]` (libro variant — drawer) | done | #1037 | T A V | — |
 
 ### Libro-game checkout flow — `/gamebook` (embedded modal) — 2 components — **Tier M**
 
@@ -471,9 +479,9 @@ the PR review.
 
 | Mockup | Component | Tier | Path | Route | Status | PR | AC |
 |--------|-----------|------|------|-------|--------|----|----|
-| `nanolith-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | **S** | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | pending | — | T A M V |
-| `nanolith-runthrough-game-onboarding.html` | `LibroGameOnboardingPanel` | **L** ⚠️ | `apps/web/src/components/features/gamebook/LibroGameOnboardingPanel.tsx` | `/library/[gameId]` (libro variant — prereq gate) | pending | — | T A M V |
-| `nanolith-runthrough-error-states.html` | `GamebookErrorBanner` | **S** (primitive-like) | `apps/web/src/components/features/gamebook/GamebookErrorBanner.tsx` | cross-cutting (chat, translate, encounter) | pending | — | T A V |
+| `librogame-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | **S** | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | pending | — | T A M V |
+| `librogame-runthrough-game-onboarding.html` | `LibroGameOnboardingPanel` | **L** ⚠️ | `apps/web/src/components/features/gamebook/LibroGameOnboardingPanel.tsx` | `/library/[gameId]` (libro variant — prereq gate) | pending | — | T A M V |
+| `librogame-runthrough-error-states.html` | `GamebookErrorBanner` | **S** (primitive-like) | `apps/web/src/components/features/gamebook/GamebookErrorBanner.tsx` | cross-cutting (chat, translate, encounter) | pending | — | T A V |
 
 **Stato di copertura** (4 stati ciascuno, mobile + desktop parity):
 
@@ -643,12 +651,12 @@ instead.
 | `/library/private` · `/add` · `/[id]` | `sp4-add-game-pdf-dedup.html` + `sp4-upload-wizard-extended.html` [partial] | — |
 | `/library/private/[id]/toolkit/configure` | `sp4-toolkit-detail.html` ↻ | — |
 | `/library/proposals` · `/propose` | `sp4-add-game-bgg-step.html` | Ingestion proposta |
-| `/library/[gameId]` | `sp4-game-detail.html` + `nanolith-runthrough-game-detail.html` + `nanolith-runthrough-game-onboarding.html` | IA closes #871 (PR #1037); onboarding gap-coverage 2026-05-12 (pending Stage-2) |
+| `/library/[gameId]` | `sp4-game-detail.html` + `librogame-runthrough-game-detail.html` + `librogame-runthrough-game-onboarding.html` | IA closes #871 (PR #1037); onboarding gap-coverage 2026-05-12 (pending Stage-2) |
 | `/library/[gameId]/agent` | `sp4-agent-detail.html` + `sp4-game-chat-tab.html` | — |
-| `/library/[gameId]/play` | `nanolith-runthrough-resume-picker.html` + `sp6-libro-game-resume-state.html` | Libro-game |
-| `/library/[gameId]/play/[campaignId]` | `nanolith-runthrough-play-session.html` + `sp6-libro-game-index.html` | — |
-| `/library/[gameId]/play/[campaignId]/translate` | `nanolith-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` | Tier S done (PR #790) |
-| `/library/[gameId]/play/[campaignId]/encounter` | `nanolith-runthrough-encounter-cheatsheet.html` | Tier S pending (BLOCKER §9.1 gap-coverage 2026-05-12) |
+| `/library/[gameId]/play` | `librogame-runthrough-resume-picker.html` + `sp6-libro-game-resume-state.html` | Libro-game |
+| `/library/[gameId]/play/[campaignId]` | `librogame-runthrough-play-session.html` + `sp6-libro-game-index.html` | — |
+| `/library/[gameId]/play/[campaignId]/translate` | `librogame-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` | Tier S done (PR #790) |
+| `/library/[gameId]/play/[campaignId]/encounter` | `librogame-runthrough-encounter-cheatsheet.html` | Tier S pending (BLOCKER §9.1 gap-coverage 2026-05-12) |
 | `/library/[gameId]/toolbox` · `/toolkit` · `/toolkit/[sessionId]` | `sp4-toolkit-detail.html` ↻ | — |
 
 > **Note**: `/library/v2` decommissionata 2026-05-12 (era demo orfana con SEED hard-coded).
@@ -671,12 +679,12 @@ instead.
 | Route | Mockup | Note |
 |-------|--------|------|
 | `/sessions` | `sp4-sessions-index.html` | — |
-| `/sessions/new` | `nanolith-runthrough-setup-wizard.html` | — |
+| `/sessions/new` | `librogame-runthrough-setup-wizard.html` | — |
 | `/sessions/join` | `sp3-join.html` ↻ | Reuse |
 | `/sessions/[id]` | `sp4-session-summary.html` | Tier M-L done (PR #762) |
 | `/sessions/[id]/live` | `sp4-session-live.html` | Tier L+ pending |
 | `/sessions/[id]/{play,notes,players,scoreboard,join}` | `sp4-session-live.html` [partial] | Sub-views |
-| `/sessions/live/[id]` (+ `/agent`, `/photos`, `/players`, `/scores`) | `sp4-session-live.html` + `nanolith-runthrough-session-end.html` | — |
+| `/sessions/live/[id]` (+ `/agent`, `/photos`, `/players`, `/scores`) | `sp4-session-live.html` + `librogame-runthrough-session-end.html` | — |
 | `/game-nights` | `sp4-game-nights-index.html` | Tier L pending |
 | `/game-nights/new` | `sp7-game-night-create.html` | Tier L+ DONE (PR #1297 components, PR #1302 orchestrator, PR #1305 W4 E2E + a11y + conformity entry); baseline PNGs auto-generated post-merge via bootstrap workflows |
 | `/game-nights/[id]` · `/[id]/edit` | `sp7-game-night-detail-rsvp.html` + `nanolith-game-night-storyboard.html` | Tier M done (PR #1171, RSVP cluster); tabbed/host surfaces pending |
@@ -697,7 +705,7 @@ instead.
 
 | Route | Mockup | Note |
 |-------|--------|------|
-| `/chat` · `/chat/new` · `/chat/[threadId]` | `sp4-game-chat-tab.html` + `nanolith-runthrough-setup-chat.html` + `nanolith-nav-chat-panel.html` | — |
+| `/chat` · `/chat/new` · `/chat/[threadId]` | `chat-fullscreen.html` (page-mock) + `sp4-game-chat-tab.html` + `librogame-runthrough-setup-chat.html` + `nanolith-nav-chat-panel.html` | chat-fullscreen done (#491 partial, 2026-05-23) |
 | `/chat/agents/create` | `sp4-agents-index.html` [partial] | gap dedicato per "create flow" |
 
 ### Power-user / editor (utente avanzato, non admin)
@@ -719,6 +727,13 @@ Routes senza mockup con **alta priorità user-journey** (audit 2026-05-12):
 5. **`/pricing`** — landing commerciale assente
 
 Status di queste 5 lacune è tracciato in `docs/for-developers/audits/2026-05-12-mockup-gaps.md`.
+
+### Cross-route state coverage (dev-fixture)
+
+> `state-matrix.html` (dev-fixture, 2026-05-23) mappa gli stati
+> Empty/Error/Loading/Permission/Offline per 8 route critiche (translate, play, chat,
+> game-nights, sessions/live, shared-games, discover, notifications) — 8×5 = 40 cell.
+> Riferimento cross-cutting per Phase 2/3; non page-level, non sostituisce i page-mock per route.
 
 ## References
 

--- a/docs/superpowers/plans/2026-05-23-mockup-refinement-aaron-core.md
+++ b/docs/superpowers/plans/2026-05-23-mockup-refinement-aaron-core.md
@@ -1,0 +1,1263 @@
+# Mockup Refinement — Aaron Core + Cross-cutting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raffinare i mockup del cluster libro-game (CORE Aaron) + creare `chat-fullscreen.html` (B11b) + creare `state-matrix.html` (B18), incluse 2 actor variations (passive co-player + phone-passing).
+
+**Architecture:** Workflow ibrido per mockup HTML: (1) engineer prepara brief contestualizzato dalla spec, (2) user esegue Claude Design Web producendo HTML, (3) engineer integra output nel file target (`admin-mockups/design_files/`), valida acceptance criteria via grep + visual inspection, committa. Pattern "extend existing" per `error-states`, `translate-viewer`, `glossary-editor`, `photo-upload` (preserva continuità); pattern "create new" per `chat-fullscreen.html` e `state-matrix.html`.
+
+**Tech Stack:** HTML + CSS (componenti già presenti in `admin-mockups/design_files/components.css`), JSX twins per i mockup principali, design tokens canonici da `tokens.css`. Nessuna build step — i file sono statici. Riuso di pattern da `nanolith-runthrough-*`, `sp6-libro-game-*`, `sp4-citation-pdf-viewer`.
+
+**Spec sorgente**: [`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`](../specs/2026-05-23-mockup-refinement-aaron-core-design.md)
+
+**Branching**: feature branch `feature/mockup-refinement-aaron-design` da `main-dev`, PR target `main-dev`.
+
+---
+
+## File Structure
+
+### Files da modificare (extend existing)
+
+| File | Sezione spec | Cosa cambia |
+|---|---|---|
+| `admin-mockups/design_files/nanolith-runthrough-error-states.html` | 1a | + 6 nuovi stati OCR/AI (ocr-low-confidence, photo-blur-pre-ocr, translation-timeout, source-lang-unknown, network-mid-ocr, quota-exhausted-mid-stream) |
+| `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` | 1b + 1d | + 4-step loading sequence, reader mode toggle 📖, wake-lock indicator 🔆, contrasto AAA, 3 sub-screen multi-lang (lang-detection-badge, lang-override-modal, manual-input-mode) |
+| `admin-mockups/design_files/sp6-libro-game-photo-upload.html` | 1d | + kebab menu *"Digita manualmente"* entry point per manual-input-mode |
+| `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html` | 1c | + 4 sub-screen (conflict-dialog, bulk-import-card, variant-expansion, filter-strip+context-badges) + commento modello dati `GlossaryEntry` |
+| `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx` | 1c | Sync .jsx twin con HTML modificato |
+| `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx` | 1b + 1d | Sync .jsx twin con HTML modificato |
+| `admin-mockups/MOCKUPS_INDEX.md` | 9 (AC globali) | Aggiornare count (page-mock 48→49, dev-fixture 10→11) + nuovi entry |
+| `docs/for-developers/frontend/v2-migration-matrix.md` | 9 (AC globali) | Aggiornare route mapping per `/chat/[threadId]` (chat-fullscreen) + entry stati |
+| `docs/for-developers/audits/2026-05-22-mockup-gaps.md` | 9 (AC globali) | Marcare Phase 1 in implementation |
+
+### Files da creare (new)
+
+| File | Sezione spec | Tipo MOCKUPS_INDEX |
+|---|---|---|
+| `admin-mockups/design_files/chat-fullscreen.html` | 2 (B11b) | page-mock |
+| `admin-mockups/design_files/chat-fullscreen.jsx` | 2 (B11b) | twin jsx |
+| `admin-mockups/design_files/state-matrix.html` | 3 (B18) | dev-fixture |
+
+---
+
+## Workflow per ogni task mockup
+
+Ogni task mockup segue questo pattern (~30-60 min totali):
+
+1. **Read target file** — capire lo stato attuale (Read tool)
+2. **Prepare brief** — scrivere prompt strutturato per Claude Design Web (mostrato inline nel plan, copy-paste ready)
+3. **User executes Claude Design Web** — produce HTML/JSX output. Engineer pausa e aspetta.
+4. **Integrate output** — engineer applica il contenuto al file target (Edit/Write tool)
+5. **Validate AC** — grep per termini chiave + visual review browser
+6. **Commit** — branch feature, conventional commit message
+
+---
+
+## Task 0: Setup branch + verifica baseline
+
+**Files:**
+- No file changes, only git ops + verification
+
+- [ ] **Step 0.1: Verifica branch corrente è clean su main-dev**
+
+Run:
+```bash
+git status
+git branch --show-current
+git pull --ff-only
+```
+
+Expected: branch `main-dev`, working tree clean, no divergence.
+
+- [ ] **Step 0.2: Crea feature branch**
+
+Run:
+```bash
+git checkout -b feature/mockup-refinement-aaron-design
+git config branch.feature/mockup-refinement-aaron-design.parent main-dev
+```
+
+Expected: `Switched to a new branch 'feature/mockup-refinement-aaron-design'`
+
+- [ ] **Step 0.3: Verifica spec + audit committati (da sessione precedente)**
+
+Run:
+```bash
+git log --oneline -3
+ls docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md
+ls docs/for-developers/audits/2026-05-22-mockup-gaps.md
+```
+
+Expected: entrambi i file presenti. Se non committati, fare commit prima:
+```bash
+git add docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md docs/for-developers/audits/2026-05-22-mockup-gaps.md
+git commit -m "docs(design): mockup refinement spec + audit 2026-05-22"
+```
+
+- [ ] **Step 0.4: Push branch**
+
+Run:
+```bash
+git push -u origin feature/mockup-refinement-aaron-design
+```
+
+---
+
+## Task 1: Sezione 1a — `nanolith-runthrough-error-states.html` (+ 6 stati)
+
+**Files:**
+- Modify: `admin-mockups/design_files/nanolith-runthrough-error-states.html`
+
+- [ ] **Step 1.1: Read existing file**
+
+Run via Read tool: `admin-mockups/design_files/nanolith-runthrough-error-states.html`
+
+Identificare:
+- Pattern attuale per le 4 cellule esistenti (stream-timeout, OCR-fail, LLM-503, segmentation-fail)
+- Sezione `<head>` con design tokens link
+- Struttura grid contenente le cellule
+
+- [ ] **Step 1.2: Prepare Claude Design Web brief**
+
+Brief da copia-incollare in Claude Design Web:
+
+```
+Contesto: sto estendendo il mockup HTML esistente
+`admin-mockups/design_files/nanolith-runthrough-error-states.html` aggiungendo
+6 nuovi stati di errore al pattern cross-cutting già usato per le 4 celle
+esistenti (stream-timeout, OCR-fail, LLM-503, segmentation-fail).
+
+Mantieni STILE IDENTICO al pattern esistente: stesso layout grid, stessi token
+CSS, stessa struttura per ogni cellula (icon + message + 2 CTA: retry +
+secondary).
+
+Aggiungi queste 6 cellule (NEL FILE esistente, NON nuovo file):
+
+1. `ocr-low-confidence` — Icon ⚠️ giallo · Title "Testo poco chiaro" ·
+   Message "Alcune regioni della foto sono difficili da leggere
+   (confidence < 0.7)" · CTA primary "Ritocca foto" · CTA secondary
+   "Procedi comunque"
+
+2. `photo-blur-pre-ocr` — Icon 📷 · Title "Foto sfocata" · Message
+   "L'autofocus non ha agganciato il libro. Riprova mantenendo il
+   telefono fermo." · CTA primary "Riprova" (no roundtrip server) · NO
+   CTA secondary (è rilevazione client-side)
+
+3. `translation-timeout` — Icon ⏱️ · Title "Traduzione lenta" · Message
+   "L'AI ci sta mettendo più di 20 secondi. Probabilmente sovraccarico
+   del modello." · CTA primary "Riprova" · CTA secondary "Digita
+   manualmente"
+
+4. `source-lang-unknown` — Icon ❓ · Title "Lingua non riconosciuta" ·
+   Message "Non riesco a capire la lingua del libro. Confermala
+   manualmente." · UI inline: dropdown con 5 lingue (EN, FR, DE, ES, IT)
+   · CTA primary "Conferma e ritraduci"
+
+5. `network-mid-ocr` — Icon 📡 · Title "Connessione persa" · Message
+   "Foto salvata in locale. Riprova quando torni online." · banner
+   persistent · CTA primary "Riprova ora"
+
+6. `quota-exhausted-mid-stream` — Icon ⚡ · Title "Token esauriti" ·
+   Message "La traduzione AI non è disponibile. Hai il testo OCR già
+   pronto." · Bridge a quota-credits overlay · CTA primary "Esplora
+   piani" · CTA secondary "Usa solo testo OCR" (no token aggiuntivi)
+
+Aggiungi commento HTML head per ogni cellula con:
+- trigger condition (precisa)
+- recovery action (cosa fa l'utente)
+- fallback path (cosa succede se recovery fail)
+
+Light + dark mode (usa CSS variabili già definite in tokens.css).
+Mobile + desktop (mantieni grid responsive esistente).
+```
+
+- [ ] **Step 1.3: User executes Claude Design Web**
+
+Engineer pause. User esegue brief, riceve HTML output integrato nel file
+esistente.
+
+- [ ] **Step 1.4: Integrate HTML output**
+
+Engineer usa Edit tool per inserire le 6 nuove cellule prima della chiusura
+del grid container. Verifica preservazione delle 4 cellule esistenti.
+
+- [ ] **Step 1.5: Validate AC via grep**
+
+Run:
+```bash
+grep -c "ocr-low-confidence\|photo-blur-pre-ocr\|translation-timeout\|source-lang-unknown\|network-mid-ocr\|quota-exhausted-mid-stream" admin-mockups/design_files/nanolith-runthrough-error-states.html
+```
+
+Expected: `6` (un match per stato).
+
+```bash
+grep -c "stream-timeout\|OCR-fail\|LLM-503\|segmentation-fail" admin-mockups/design_files/nanolith-runthrough-error-states.html
+```
+
+Expected: `4` (preservazione cellule esistenti).
+
+- [ ] **Step 1.6: Visual review**
+
+Aprire `admin-mockups/design_files/nanolith-runthrough-error-states.html` nel browser. Verificare:
+- 10 cellule totali visibili (4 esistenti + 6 nuove)
+- Light + dark toggle funziona su tutte
+- Mobile 375 + desktop 1280 (resize browser)
+- Ogni cellula ha icon + message + CTA primary (+ secondary dove applicabile)
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add admin-mockups/design_files/nanolith-runthrough-error-states.html
+git commit -m "feat(mockup): sezione 1a — 6 nuovi stati OCR/AI in error-states (#491-follow-up)"
+```
+
+---
+
+## Task 2: Sezione 1b — `nanolith-runthrough-translate-viewer.html` (+ loading multi-step + reader mode + wake-lock)
+
+**Files:**
+- Modify: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`
+
+- [ ] **Step 2.1: Read existing file**
+
+Run via Read tool: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`
+
+Identificare:
+- Layout principale (header, body translate, footer)
+- Stato attuale "happy-path" (foto + paragrafo tradotto)
+- Token CSS usati
+
+- [ ] **Step 2.2: Prepare Claude Design Web brief**
+
+```
+Contesto: estendo il mockup esistente
+`admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` con:
+A) Loading sequence multi-step
+B) Reader mode toggle
+C) Wake-lock indicator
+D) Contrasto AAA-target sul paragrafo
+
+A) LOADING SEQUENCE (4 step nominati, label IT):
+
+   1. "Caricamento foto..."     (0-2s)  — linear progress bar + thumbnail
+   2. "Sto leggendo il libro..." (2-7s) — skeleton paragrafo 3-righe +
+                                          shimmer-sweep gradient
+   3. "Sto traducendo..."        (7-15s) — paragrafo OCR @ 60% opacity sopra
+                                          + overlay tradotto token-by-token
+   4. "Cerco parole nel glossario..." (15-17s) — highlight progressivo
+                                                 parole nuove (badge ⊕)
+
+   Pattern: ogni step ha un'icon spinner + label IT + percentuale (solo step 1)
+   o "Sto..." progressivo (step 2-4).
+
+   Abort CTA visibile dal step 2 in poi (FAB bottom-right mobile, top-right
+   desktop). Click abort → torna a camera step.
+
+   Skeleton size: 3 righe @ 16pt body (default font size). Se reader mode
+   attivo (vedi B), scala a 24pt.
+
+   `prefers-reduced-motion` → fallback statico (no shimmer).
+
+B) READER MODE TOGGLE:
+
+   Pulsante 📖 nel header (top-right, accanto a hamburger menu se esiste).
+   Click → switch font body 16pt → 24pt, line-height +30%, padding maggiore
+   sul container del paragrafo.
+
+   Stato persistito in `localStorage` con key `reader-mode-enabled` (boolean).
+
+   Quando attivo, applicare la scala anche al skeleton (step 2 del loading).
+
+   Visivamente nel mockup: mostrare 2 varianti side-by-side o tab toggle:
+   - "Default mode": body 16pt
+   - "Reader mode": body 24pt, paragrafo centrato max-width 65ch
+
+C) WAKE-LOCK INDICATOR:
+
+   Badge 🔆 *"Schermo attivo"* in bottom-right (sticky), color subtle
+   (`--c-muted-fg`). Click → disable wake-lock con toast feedback "Schermo
+   torna alla normalità".
+
+   Quando wake-lock disabilitato, badge cambia in 🔅 *"Auto-blocco attivo"*
+   (stesso click toggle).
+
+   NOTA: per browser senza Web Wake Lock API support (Safari < 16.4),
+   mostrare variant del badge: 🔆 *"Non supportato"* con tooltip
+   "Disattiva auto-blocco nelle impostazioni del telefono."
+
+D) CONTRASTO AAA-TARGET:
+
+   Paragrafo tradotto (main content) usa coppia colore con contrast ratio
+   ≥7:1 (vs AA standard 4.5:1). Centrato, max-width 65ch. Usa CSS variable
+   `--c-text-high-contrast` (definire in tokens.css fallback se non esiste).
+
+Variants viewport:
+- Mobile 375: step list verticale stack, paragrafo sotto, abort FAB
+  bottom-right, reader toggle in hamburger menu
+- Desktop 1280: step list orizzontale top breadcrumb, paragrafo central,
+  abort top-right, reader toggle visibile in header
+
+Latency targets (commenti HTML head):
+- Step 1 < 2s · Step 2 < 5s · Step 3 < 10s · Step 4 < 2s · Total < 17s
+- Hard timeout 20s totale → trigger `translation-timeout` (vedi
+  nanolith-runthrough-error-states.html)
+
+Light + dark mode. Preservare stato happy-path attuale (foto + paragrafo
+tradotto) come "step finale dopo loading".
+```
+
+- [ ] **Step 2.3: User executes Claude Design Web**
+
+Engineer pause.
+
+- [ ] **Step 2.4: Integrate HTML output**
+
+Edit tool per integrare: loading sequence + reader mode + wake-lock +
+contrasto AAA. Preservare happy-path esistente.
+
+- [ ] **Step 2.5: Validate AC via grep**
+
+Run:
+```bash
+grep -c "Caricamento foto\|Sto leggendo\|Sto traducendo\|Cerco parole" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+```
+
+Expected: `4` (un match per label step).
+
+```bash
+grep -c "reader-mode-enabled\|wake-lock\|max-width.*65ch" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+```
+
+Expected: `≥3` (almeno un match per ognuno dei 3 pattern).
+
+```bash
+grep "prefers-reduced-motion" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+```
+
+Expected: almeno 1 occorrenza.
+
+- [ ] **Step 2.6: Visual review**
+
+Browser apre file. Verificare:
+- Loading 4 step visibili (mostrati progressivamente o in tab/state switch)
+- Reader mode toggle funziona (font cambia 16pt ↔ 24pt)
+- Wake-lock badge presente
+- Light + dark + mobile + desktop tutti coerenti
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+git commit -m "feat(mockup): sezione 1b — loading multi-step + reader mode + wake-lock in translate-viewer"
+```
+
+---
+
+## Task 3: Sezione 1c — `nanolith-runthrough-glossary-editor.html` + jsx twin (+ 4 sub-screen)
+
+**Files:**
+- Modify: `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html`
+- Modify: `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx`
+
+- [ ] **Step 3.1: Read existing files**
+
+Run via Read tool su entrambi:
+- `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html`
+- `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx`
+
+Identificare: layout glossary index attuale, edit/add patterns.
+
+- [ ] **Step 3.2: Prepare Claude Design Web brief**
+
+```
+Contesto: estendo il mockup esistente
+`admin-mockups/design_files/nanolith-runthrough-glossary-editor.html` (e il
+twin jsx `sp6-libro-game-glossary-editor.jsx`) per supportare context-aware
+glossary entries.
+
+MODELLO DATI (da inserire come commento HTML head + commento jsx top):
+
+GlossaryEntry {
+  term: "sentinel"
+  base_definition: "soldato di guardia"          ← primary
+  contexts: [
+    { book_id: "press-start", definition: null,  ← uses base
+      first_seen: paragraph_id_X },
+    { book_id: "rules-game", definition: "punto di osservazione strategica",
+      first_seen: paragraph_id_Y }
+  ]
+}
+
+AGGIUNGI 4 SUB-SCREEN:
+
+1. `conflict-dialog` (Modal):
+   Trigger: OCR trova parola già nel glossario con
+   `context_similarity < 0.85`.
+   UI: Modal con title "La parola 'sentinel' è già nel glossario" + body
+   mostra entrambe le definizioni side-by-side (esistente + nuova) +
+   3 CTA radio:
+   ① "Mantieni esistente" (default, soft-CTA)
+   ② "Sostituisci"
+   ③ "Aggiungi variante per Rules Game"
+   + footer CTA "Conferma" / "Annulla".
+
+2. `bulk-import-card` (Inline card):
+   Trigger: OCR trova ≥3 parole nuove non-glossario in un paragrafo.
+   UI: Card inline sotto la traduzione (translate-viewer page) con title
+   "5 nuove parole rilevate" + chip preview dei 5 termini + 2 CTA:
+   ① "Aggiungi tutte" (1-click bulk save)
+   ② "Rivedi" → apre modal multi-select con per-term checkbox
+              + edit definition inline.
+
+3. `variant-expansion` (Row expand):
+   Trigger: Click su term row con `contexts.length > 1`.
+   UI: Row glossary index espande mostrando N varianti, ognuna con:
+   - book badge "📖 Press Start" / "📖 Rules Game"
+   - definition specifica (o "(usa base)" se context.definition is null)
+   - first_seen link "Vedi paragrafo originale"
+   - delete variant button
+   Collapse by default. Click row → expand. ChevronDown icon che ruota.
+
+4. `filter-strip + context-badges` (Sempre visibile in glossary index):
+   Header glossary index con:
+   - search input "Cerca per termine, definizione, libro..."
+   - filter by book: chip multi-select con tutti i book della collection
+   - filter toggle "Solo con varianti" (boolean)
+   Ogni term row mostra context badges inline (📖 Press Start +
+   📖 Rules Game) accanto al term name.
+
+PATTERN DECISIONS (commenti HTML):
+- Default conflict resolution: auto-keep esistente se
+  `context_similarity ≥ 0.85` (silenzioso); mostra dialog solo `< 0.85`.
+- Context similarity: server-side via embedding cosine (riusa
+  `IEmbeddingService`); threshold `0.85`.
+- Bulk import trigger: `≥3` parole, non `≥1`.
+- Variant deletion: se elimina l'ultima variante non-base, term torna
+  single-context.
+
+DECISIONE ARCHITETTURALE INCIDENTALE (commento HTML head):
+"Il modello GlossaryEntry con contexts[] richiede schema migration backend
+su tabella glossary_entries. Spec backend separata, non in questo mockup."
+
+Light + dark + mobile + desktop. Sync .jsx twin con HTML modificato.
+```
+
+- [ ] **Step 3.3: User executes Claude Design Web (HTML + jsx)**
+
+Engineer pause. User esegue brief 2 volte (HTML + jsx) o una volta con output
+diviso.
+
+- [ ] **Step 3.4: Integrate HTML output**
+
+Edit tool su `nanolith-runthrough-glossary-editor.html` per aggiungere 4
+sub-screen + commento modello dati.
+
+- [ ] **Step 3.5: Integrate jsx output**
+
+Edit tool su `sp6-libro-game-glossary-editor.jsx` per sync.
+
+- [ ] **Step 3.6: Validate AC via grep**
+
+Run:
+```bash
+grep -c "conflict-dialog\|bulk-import-card\|variant-expansion\|filter-strip" admin-mockups/design_files/nanolith-runthrough-glossary-editor.html
+```
+
+Expected: `≥4`.
+
+```bash
+grep "context_similarity\|0.85\|contexts:" admin-mockups/design_files/nanolith-runthrough-glossary-editor.html
+```
+
+Expected: ≥3 occorrenze.
+
+```bash
+grep "GlossaryEntry\|contexts" admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
+```
+
+Expected: ≥1 occorrenza in jsx.
+
+- [ ] **Step 3.7: Visual review**
+
+Browser apre HTML. Verifica:
+- 4 sub-screen presenti
+- Conflict dialog mostra 3 CTA radio
+- Bulk import card mostra chip preview
+- Variant expansion ha chevron + book badges
+- Filter strip presente
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add admin-mockups/design_files/nanolith-runthrough-glossary-editor.html admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
+git commit -m "feat(mockup): sezione 1c — glossary context-aware (conflict/merge/variants) + jsx sync"
+```
+
+---
+
+## Task 4: Sezione 1d — `translate-viewer.html` (multi-lang) + `photo-upload.html` (entry point manual) + jsx twin
+
+**Files:**
+- Modify: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` (estende Task 2)
+- Modify: `admin-mockups/design_files/sp6-libro-game-photo-upload.html`
+- Modify: `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx`
+
+- [ ] **Step 4.1: Read existing files**
+
+Run via Read tool su:
+- `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` (post Task 2)
+- `admin-mockups/design_files/sp6-libro-game-photo-upload.html`
+- `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx`
+
+- [ ] **Step 4.2: Prepare Claude Design Web brief**
+
+```
+Contesto: estendo `nanolith-runthrough-translate-viewer.html` (post Task 2
+con loading sequence) aggiungendo support per multi-language source +
+manual input fallback. Estendo anche `sp6-libro-game-photo-upload.html`
+con entry-point al manual mode.
+
+AGGIUNGI 3 SUB-SCREEN AL translate-viewer.html:
+
+1. `lang-detection-badge` (Header pill):
+   Trigger: post OCR step 2 completato.
+   UI: pill nel header top-right "Sorgente: EN · Conferma o cambia" con
+   icon 🌐. Color: `--c-info` background, `--c-info-fg` text.
+   Behavior:
+   - confidence > 0.8 → badge informativo (no friction)
+   - confidence 0.5-0.8 → badge tap-to-confirm prima di translate
+   - confidence < 0.5 → trigger source-lang-unknown error state
+   Click → apre lang-override-modal (sub-screen 2).
+
+2. `lang-override-modal` (Modal):
+   Trigger: Tap sul lang-detection-badge.
+   UI: Modal con title "Lingua sorgente del libro" + radio group 5 lingue:
+   - 🇬🇧 English (EN)
+   - 🇫🇷 Français (FR)
+   - 🇩🇪 Deutsch (DE)
+   - 🇪🇸 Español (ES)
+   - 🇮🇹 Italiano (IT)
+   + CTA primary "Conferma e ritraduci" + secondary "Annulla".
+   Re-trigger AI translation step 3 (skip step 2 OCR cache hit).
+   Pre-selected: lingua auto-detected.
+
+3. `manual-input-mode` (Layout variant):
+   Trigger: query param `?mode=manual` (deeplink/share) OR triple-entry
+   discoverability (vedi sotto).
+   UI: layout translate-viewer SENZA foto thumbnail. Componenti:
+   - Header sticky con title "Inserimento manuale" + back button + lang
+     dropdown pre-filled last-used
+   - Textarea multiline (max 2000 char + counter visibile bottom-right)
+   - Book ref pre-filled current campaign book (read-only chip)
+   - CTA submit "Traduci" → skip OCR, va direttamente a step 3 (AI
+     translation) della loading sequence del Task 2
+
+TRIPLE-ENTRY DISCOVERABILITY (commento HTML head):
+1. CTA "Digita manualmente" in error state `photo-blur-pre-ocr` (sezione 1a)
+2. Kebab menu ⋮ del camera step (sp6-libro-game-photo-upload.html — vedi
+   sotto)
+3. Empty state quando /translate aperto senza foto: card "Libro non a
+   portata? Digita il paragrafo"
+
+AGGIUNGI AL `sp6-libro-game-photo-upload.html`:
+
+- Kebab menu ⋮ top-right nel camera UI con voce:
+  "Digita manualmente" → naviga a `/translate?mode=manual`
+
+PATTERN DECISIONS (commenti HTML):
+- Target lang fixed IT v1 (target dropdown NON visibile)
+- 5 lingue v1 (EN, FR, DE, ES, IT) copre ~95% libri-game europei
+- Manual mode parity: stessi step 3-4 della loading sequence; unica diff =
+  step 2 OCR sostituito da textarea
+- `source_method: "ocr" | "manual"` tracked nello stato (commento)
+- Override re-translate: lang change preserva OCR result (cache hit) —
+  re-translate solo step AI
+- `?mode=manual` query param vs sub-route: scelto query param (UI-only,
+  no backend route distinta)
+
+Sync `sp6-libro-game-translation-viewer.jsx` con i cambi HTML.
+
+Light + dark + mobile + desktop.
+```
+
+- [ ] **Step 4.3: User executes Claude Design Web**
+
+Engineer pause.
+
+- [ ] **Step 4.4: Integrate HTML/JSX output**
+
+3 file da modificare:
+- `nanolith-runthrough-translate-viewer.html` (+ 3 sub-screen)
+- `sp6-libro-game-photo-upload.html` (+ kebab menu)
+- `sp6-libro-game-translation-viewer.jsx` (sync)
+
+- [ ] **Step 4.5: Validate AC via grep**
+
+Run:
+```bash
+grep -c "lang-detection-badge\|lang-override-modal\|manual-input-mode" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+```
+
+Expected: `≥3`.
+
+```bash
+grep -c "EN\|FR\|DE\|ES\|IT" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+```
+
+Expected: ≥5 occorrenze.
+
+```bash
+grep "?mode=manual\|mode=manual" admin-mockups/design_files/sp6-libro-game-photo-upload.html
+```
+
+Expected: ≥1.
+
+```bash
+grep "Digita manualmente" admin-mockups/design_files/sp6-libro-game-photo-upload.html
+```
+
+Expected: 1 match.
+
+- [ ] **Step 4.6: Visual review**
+
+Browser su entrambi i file. Verifica:
+- translate-viewer: 3 sub-screen presenti (badge + modal + manual layout)
+- photo-upload: kebab menu con "Digita manualmente"
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add admin-mockups/design_files/nanolith-runthrough-translate-viewer.html admin-mockups/design_files/sp6-libro-game-photo-upload.html admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
+git commit -m "feat(mockup): sezione 1d — multi-lang source + manual input fallback + jsx sync"
+```
+
+---
+
+## Task 5: Sezione 2 — Creare `chat-fullscreen.html` + jsx (B11b carry-over #491)
+
+**Files:**
+- Create: `admin-mockups/design_files/chat-fullscreen.html`
+- Create: `admin-mockups/design_files/chat-fullscreen.jsx`
+
+- [ ] **Step 5.1: Read reference files**
+
+Run via Read tool su:
+- `admin-mockups/design_files/nanolith-nav-chat-panel.html` (slide-over, riferimento)
+- `admin-mockups/design_files/sp4-citation-pdf-viewer.html` (citation overlay riuso)
+- `admin-mockups/design_files/sp4-agent-detail.html` (agent mini-card riuso)
+- `admin-mockups/design_files/components.css` (CSS shared)
+
+- [ ] **Step 5.2: Prepare Claude Design Web brief**
+
+```
+Contesto: creo un NUOVO mockup `admin-mockups/design_files/chat-fullscreen.html`
+(+ twin jsx) per la chat full-screen page-level. NON estendere
+nanolith-nav-chat-panel.html (che resta component-mock slide-over per
+cross-page quick-access).
+
+Route impattate: /chat/[threadId] (page principale) · /chat/new (empty state)
+
+3 SCREEN DA CREARE:
+
+SCREEN B11b-1: Desktop 3-col (1280px)
+
+Layout:
+- Sidebar sx (260px):
+  • Tabs orizzontali: Tutti / Preferiti / Archiviati
+  • Search input "Cerca conversazioni..."
+  • Filter by agent: chip dropdown
+  • CTA "+ Nuova chat" prominente
+  • Thread list: avatar + title + last-msg-preview + timestamp + unread
+    badge
+
+- Main center (~720px):
+  • Header: thread title + agent avatar + actions (star, archive, delete
+    kebab menu)
+  • Chat stream bubble (user-right, agent-left con avatar)
+  • Citations pills inline ai messaggi agent (style: pill rounded, color
+    `--c-info-soft`, click apre PDF overlay)
+  • Typing indicator (3 dots animate) durante stream
+  • Cancel CTA visibile durante stream attivo
+  • Composer bottom: textarea multiline autoresize (1-row default,
+    expand-on-content) + attachment button (paperclip) + voice button
+    (microphone, placeholder) + send button (paper plane)
+
+- Sidebar dx (260px):
+  • Agent info mini-card (riuso pattern sp4-agent-detail mini)
+  • Sezione "Fonti citate" — list cards delle citation referenced nei
+    msgs del thread (click → PDF overlay)
+  • Sezione "Azioni suggerite" — CTA contestuali (es. "Apri il libro
+    a pag 42", "Crea play record", ecc.)
+
+SCREEN B11b-2: Mobile (375)
+
+Layout single-pane:
+- Header sticky: ← back + thread title + agent avatar + kebab menu ⋮
+- Message stream scroll fluido
+- Bottom composer fixed (autoresize 1-row default)
+- Tap header → bottom sheet con context panel (agent + sources + actions)
+- Tap citation pill → PDF viewer overlay full-screen
+
+SCREEN B11b-3: Empty state (/chat/new)
+
+Hero centrato:
+- Icon 💬 grande
+- Title "Inizia una conversazione"
+- Subtitle "Chiedi al tuo agent una regola, una strategia o un riassunto."
+- 4 quick-starter cards (grid 2x2 mobile, 1x4 desktop) — VARIANTI:
+
+  Variant LIBRO-GAME (Aaron):
+  • "Quali sono le regole di Press Start?"
+  • "Spiega questa Encounter"
+  • "Riassumi paragrafo 42"
+  • "Lista personaggi nella campagna"
+
+  Variant BOARDGAMER:
+  • "Setup iniziale"
+  • "Regole edge case"
+  • "Strategie comuni"
+  • "FAQ del gioco"
+
+  Variant DEFAULT (no agent):
+  • CTA "Scegli un agent" + dropdown picker prominent (lista agent
+    disponibili con avatar + name + last-used)
+
+PATTERN DECISIONS (commenti HTML):
+- Slide-over vs full-screen routing: automatico per viewport
+  • Mobile/tablet (<1024px) → full-screen sempre (slide-over diventa
+    drawer fallback)
+  • Desktop (≥1024px) → slide-over default, toggle "View as full-screen"
+    nel slide-over header per immersive mode
+- Streaming token-by-token con AbortController (riusa useThreadMessages
+  pattern PR#551)
+- Citations: pill click → sp4-citation-pdf-viewer overlay (NO fork)
+- Attachment Aaron-specific: foto inline apre flow translate come
+  quick-action; risposta translate ritorna come citation pill nella chat
+- Voice: UI placeholder, backend Whisper integration deferita
+- Quick-starter selection: agent type da agent.metadata.category
+  (verificare esistenza field; fallback graceful a "Default" se mancante)
+
+READER MODE + WAKE-LOCK (per passive co-player):
+- Stesso toggle 📖 della sezione 1b (translate viewer) — applicabile a
+  bubble dei messaggi (font 16pt → 24pt)
+- Stessa `localStorage` key (`reader-mode-enabled`) per coerenza
+  cross-route Aaron
+- Wake-lock 🔆 badge attivo durante chat con streaming attivo
+
+STATI DI STREAM (mostra tutti e 4 nel mockup):
+- `idle` — empty composer
+- `streaming` — token-by-token + cancel CTA visibile
+- `stream-error` — banner "Errore stream — riprova" + last user message
+  conservato in composer (no perdita)
+- `stream-abort` — utente click cancel → message preservato come
+  "[interrotto]" badge
+
+Crea anche twin jsx con stesso layout React-style.
+
+Light + dark + mobile + desktop. Riuso pattern: nanolith-nav-chat-panel
+(slide-over secondary) · sp4-citation-pdf-viewer (overlay) ·
+sp4-agent-detail (mini agent card).
+```
+
+- [ ] **Step 5.3: User executes Claude Design Web**
+
+Engineer pause.
+
+- [ ] **Step 5.4: Integrate HTML output**
+
+Write tool per creare `admin-mockups/design_files/chat-fullscreen.html`.
+
+- [ ] **Step 5.5: Integrate jsx output**
+
+Write tool per creare `admin-mockups/design_files/chat-fullscreen.jsx`.
+
+- [ ] **Step 5.6: Validate AC via grep**
+
+Run:
+```bash
+grep -c "Desktop 3-col\|Mobile\|Empty state\|/chat/new\|/chat/\[threadId\]" admin-mockups/design_files/chat-fullscreen.html
+```
+
+Expected: ≥3 (almeno una occorrenza per dimensione).
+
+```bash
+grep -c "idle\|streaming\|stream-error\|stream-abort" admin-mockups/design_files/chat-fullscreen.html
+```
+
+Expected: `4` (un match per stato).
+
+```bash
+grep "reader-mode-enabled\|wake-lock" admin-mockups/design_files/chat-fullscreen.html
+```
+
+Expected: ≥2 occorrenze.
+
+```bash
+grep "Libro-game\|Boardgamer\|Default" admin-mockups/design_files/chat-fullscreen.html
+```
+
+Expected: ≥3 (3 varianti quick-starter).
+
+- [ ] **Step 5.7: Visual review**
+
+Browser apre file. Verifica:
+- 3 screen visibili (desktop 3-col, mobile, empty state)
+- Stream states 4 mostrati
+- Reader mode + wake-lock visible
+- Quick-starter 3 varianti
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add admin-mockups/design_files/chat-fullscreen.html admin-mockups/design_files/chat-fullscreen.jsx
+git commit -m "feat(mockup): sezione 2 (B11b) — chat-fullscreen page-mock + jsx (closes #491 partial)"
+```
+
+---
+
+## Task 6: Sezione 3 — Creare `state-matrix.html` (B18)
+
+**Files:**
+- Create: `admin-mockups/design_files/state-matrix.html`
+
+- [ ] **Step 6.1: Read reference file**
+
+Run via Read tool su:
+- `admin-mockups/design_files/01-screens.html` (riferimento dev-fixture matrix
+  phone-frame grid)
+- `admin-mockups/design_files/nanolith-runthrough-error-states.html` (post
+  Task 1, riferimento pattern errors)
+
+- [ ] **Step 6.2: Prepare Claude Design Web brief**
+
+```
+Contesto: creo NUOVO mockup `admin-mockups/design_files/state-matrix.html`
+come dev-fixture (stile 01-screens.html — phone-frame matrix grid).
+Asse verticale: 8 route critiche · asse orizzontale: 5 stati. Totale
+40 cell (alcune `—` = skip).
+
+Layout: grid 8 rows x 6 cols (1 col header + 5 cols stati).
+Mobile-only viewport (375 phone-frame per cell, come 01-screens.html).
+
+ROUTE × STATI (riempi ogni cell con phone-frame mockup):
+
+| Route                                              | Empty | Error | Loading | Permission | Offline |
+|----------------------------------------------------|-------|-------|---------|------------|---------|
+| /library/[gameId]/play/[campaignId]/translate      | A1    | A2    | A3      | A4         | A5      |
+| /library/[gameId]/play                             | B1    | B2    | B3      | —          | B5      |
+| /chat/[threadId]                                   | C1    | C2    | C3      | C4         | C5      |
+| /game-nights                                       | D1    | D2    | D3      | —          | D5      |
+| /sessions/live/[sessionId]                         | E1    | E2    | E3      | E4         | E5      |
+| /shared-games                                      | F1    | F2    | F3      | —          | F5      |
+| /discover                                          | G1    | G2    | G3      | —          | G5      |
+| /notifications                                     | H1    | H2    | H3      | —          | H5      |
+
+Contenuto per cell (testi IT, no placeholder generici):
+
+A1 (translate empty): icon 📷 + "Fotografa una pagina" + CTA "Apri camera"
+A2 (translate error): riusa pattern nanolith-runthrough-error-states ocr-fail
+A3 (translate loading): 4-step skeleton (riusa Task 2 sezione 1b)
+A4 (translate permission): 🔒 + "Quota OCR esaurita" + tier badge "Pro" +
+   CTA "Esplora piani"
+A5 (translate offline): banner 📡 + last-translation cached @ 80% opacity
+
+B1 (play empty): icon 📖 + "Nessuna campagna" + CTA "Sfoglia libreria"
+B2 (play error): "Errore caricamento — riprova" + retry button
+B3 (play loading): 3 campaign card skeleton
+B5 (play offline): banner + campagne cached visibili
+
+C1 (chat empty): icon 💬 + "Inizia conversazione" + quick-starters
+   (riusa sezione 2 / Task 5 variant libro-game)
+C2 (chat error): banner "Errore stream — riprova"
+C3 (chat loading): typing indicator + skeleton bubble
+C4 (chat permission): 🔒 + "Quota chat esaurita" + tier badge + CTA
+C5 (chat offline): banner + msg history cached
+
+D1 (game-nights empty): icon 🎲 + "Crea prima serata" + CTA "+ Nuova
+   serata"
+D2 (game-nights error): "Calendar non disponibile"
+D3 (game-nights loading): calendar skeleton 7-day grid
+D5 (game-nights offline): banner + serate cached
+
+E1 (sessions-live empty): icon ⏳ + "Aspetta che host inizi"
+E2 (sessions-live error): SSE disconnect banner + "Riconnessione..."
+E3 (sessions-live loading): spinner + game cover thumbnail
+E4 (sessions-live permission): 🔒 + "Solo l'host può iniziare — aspetta
+   che la sessione si attivi"
+E5 (sessions-live offline): banner — modalità local-only
+
+F1 (shared-games empty): icon 📚 + "Catalog vuoto — riprova" (improbabile)
+F2 (shared-games error): "Catalogo non disponibile"
+F3 (shared-games loading): card-grid 6-skeleton
+F5 (shared-games offline): banner + cached results
+
+G1 (discover empty): icon 🧭 + "Nessun consiglio ora"
+G2 (discover error): "Discovery offline"
+G3 (discover loading): rail skeleton 3-row
+G5 (discover offline): banner + cached
+
+H1 (notifications empty): icon 🎉 + "Sei in pari!"
+H2 (notifications error): "Errore caricamento notifiche"
+H3 (notifications loading): list skeleton
+H5 (notifications offline): banner + cached
+
+PATTERN UNIFICATI (riusa nello stesso file):
+
+Empty: icon 96px centrale + gradient bg entity color (color depende dalla
+       route, mapping: translate/play → orange Aaron · chat → purple ·
+       game-nights/sessions → rose · shared-games/discover → teal ·
+       notifications → blue) + tagline IT + primary CTA per uscire.
+
+Error: riuso pattern nanolith-runthrough-error-states (icon + message
+       umano + retry + report-bug). Annota in commento HTML head
+       `<!-- error: see nanolith-runthrough-error-states -->`.
+
+Loading skeleton: 3-row card dimensionato al contenuto reale. Shimmer-sweep
+                  gradient. `prefers-reduced-motion` → fallback statico.
+
+Permission-denied: 🔒 lock + tier badge "Pro"/"Premium" + tagline
+                   "Disponibile nei piani Pro/Premium" + primary CTA
+                   "Esplora piani" → /pricing (route esistente ma senza
+                   mockup canonico — vedi audit gap; link sarà dead-end
+                   visivo) + secondary "Torna indietro".
+
+Offline: banner top persistent (📡 + "Offline — sto usando dati salvati")
+         + cache-stale data sotto a 80% opacity + retry inline nel banner.
+
+LIGHT/DARK TOGGLE: button top destro inline (no 2 file paralleli).
+
+ILLUSTRATION ECONOMY: ~5 illustration uniche riusabili (tema):
+- "book": translate+play
+- "speak": chat+notifications
+- "calendar": game-nights+sessions-live
+- "compass": shared-games+discover
+
+REUSE TRACE: commento HTML head per ogni pattern che linka all'origine
+(es. `<!-- pattern: see nanolith-runthrough-translate-viewer.html -->`).
+```
+
+- [ ] **Step 6.3: User executes Claude Design Web**
+
+Engineer pause. Output sarà denso (40 cell phone-frame).
+
+- [ ] **Step 6.4: Integrate HTML output**
+
+Write tool per creare `admin-mockups/design_files/state-matrix.html`.
+
+- [ ] **Step 6.5: Validate AC via grep**
+
+Run:
+```bash
+grep -c "phone-frame" admin-mockups/design_files/state-matrix.html
+```
+
+Expected: `≥40` (1 per cell).
+
+```bash
+grep -c "Empty\|Error\|Loading\|Permission\|Offline" admin-mockups/design_files/state-matrix.html
+```
+
+Expected: ≥40 (5 stati × 8 route con `—` skip = 35 effettivi + headers).
+
+```bash
+grep "translate\|play\|chat\|game-nights\|sessions/live\|shared-games\|discover\|notifications" admin-mockups/design_files/state-matrix.html | wc -l
+```
+
+Expected: ≥8 occorrenze (1 per route).
+
+```bash
+grep "prefers-reduced-motion" admin-mockups/design_files/state-matrix.html
+```
+
+Expected: ≥1 match.
+
+- [ ] **Step 6.6: Visual review**
+
+Browser apre file. Verifica:
+- Grid 8×5 visibile (alcune cell `—`)
+- Light + dark toggle funziona
+- Tutte le tagline sono IT route-specific
+- Permission-denied appare solo su 3 route (translate, chat, sessions-live)
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add admin-mockups/design_files/state-matrix.html
+git commit -m "feat(mockup): sezione 3 (B18) — state-matrix cross-route dev-fixture (8x5 grid)"
+```
+
+---
+
+## Task 7: Aggiornare `MOCKUPS_INDEX.md`
+
+**Files:**
+- Modify: `admin-mockups/MOCKUPS_INDEX.md`
+
+- [ ] **Step 7.1: Read MOCKUPS_INDEX.md attuale**
+
+Run via Read tool: `admin-mockups/MOCKUPS_INDEX.md`
+
+Verificare summary count attuale (riga ~134): page-mock 48, component-mock 16, dev-fixture 10, Total 74.
+
+- [ ] **Step 7.2: Aggiornare summary count**
+
+Edit tool per cambiare la tabella summary:
+- page-mock: 48 → **49** (+ `chat-fullscreen.html`)
+- component-mock: 16 → **16** (invariato — `error-states`, `glossary-editor`, `translate-viewer`, `photo-upload` sono *modifiche*, non nuovi file)
+- dev-fixture: 10 → **11** (+ `state-matrix.html`)
+- Total: 74 → **76**
+
+- [ ] **Step 7.3: Aggiungere entry SP6 / Auth & onboarding / dev-fixture sections**
+
+Edit tool su sezioni rilevanti:
+
+**Auth & onboarding** (aggiungere nuova riga se non esiste sezione Chat):
+```markdown
+| `chat-fullscreen.html` | page-mock | `/chat/[threadId]`, `/chat/new` (empty state) |
+```
+
+(in alternativa: creare nuova sezione "Chat" se la struttura lo permette).
+
+**Dev fixtures** (aggiungere riga):
+```markdown
+| `state-matrix.html` | dev-fixture | State matrix cross-route (8 route × 5 stati) — riusabile per Phase 2/3 |
+```
+
+- [ ] **Step 7.4: Aggiornare data "Last updated"**
+
+Edit tool: cambia "Last updated: 2026-05-18" → "Last updated: 2026-05-23"
+(riga ~9).
+
+- [ ] **Step 7.5: Validate AC via grep**
+
+Run:
+```bash
+grep "chat-fullscreen\|state-matrix" admin-mockups/MOCKUPS_INDEX.md
+```
+
+Expected: ≥2 occorrenze (1 per file).
+
+```bash
+grep "\*\*76\*\*" admin-mockups/MOCKUPS_INDEX.md
+```
+
+Expected: 1 match (total aggiornato).
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add admin-mockups/MOCKUPS_INDEX.md
+git commit -m "docs(mockup): aggiorna MOCKUPS_INDEX — +chat-fullscreen +state-matrix (76 total)"
+```
+
+---
+
+## Task 8: Aggiornare `v2-migration-matrix.md`
+
+**Files:**
+- Modify: `docs/for-developers/frontend/v2-migration-matrix.md`
+
+- [ ] **Step 8.1: Read sezione Route → Mockup index**
+
+Run via Grep:
+```bash
+grep -n "Route.*Mockup index\|chat/\[threadId\]\|/chat/" docs/for-developers/frontend/v2-migration-matrix.md
+```
+
+Identificare sezione e righe da modificare.
+
+- [ ] **Step 8.2: Aggiornare route mapping per /chat/[threadId]**
+
+Edit tool: aggiornare riga esistente o aggiungere riga per
+`chat-fullscreen.html` → `/chat/[threadId]`, `/chat/new`.
+
+Pattern proposto (sezione "Chat" o "Communication"):
+```markdown
+| `chat-fullscreen.html` | page-mock | `/chat/[threadId]`, `/chat/new` | done — PR <questa> | T A M V |
+```
+
+- [ ] **Step 8.3: Aggiornare entry state-matrix come dev-fixture**
+
+Edit tool: aggiungere sezione/riga per `state-matrix.html` come dev-fixture
+riferimento, route cross-cutting.
+
+- [ ] **Step 8.4: Aggiornare il banner update notes (top del file)**
+
+Edit tool: aggiungere paragrafo "Updated 2026-05-23" simile al pattern
+esistente:
+
+```markdown
+> **Updated 2026-05-23** (Mockup refinement Aaron core + cross-cutting PR <N>):
+> added `chat-fullscreen.html` (page-mock, /chat/[threadId]+/chat/new),
+> `state-matrix.html` (dev-fixture, cross-route states), e estese 4 mockup
+> esistenti per cluster translate (error-states +6 stati, translate-viewer
+> +loading+reader-mode+multi-lang, glossary-editor +context-aware,
+> photo-upload +manual-mode entry). Spec:
+> `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`.
+```
+
+- [ ] **Step 8.5: Validate AC via grep**
+
+Run:
+```bash
+grep -c "chat-fullscreen\|state-matrix\|2026-05-23" docs/for-developers/frontend/v2-migration-matrix.md
+```
+
+Expected: ≥3 occorrenze.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add docs/for-developers/frontend/v2-migration-matrix.md
+git commit -m "docs(matrix): v2-migration-matrix +chat-fullscreen +state-matrix routes"
+```
+
+---
+
+## Task 9: Aggiornare audit `2026-05-22-mockup-gaps.md`
+
+**Files:**
+- Modify: `docs/for-developers/audits/2026-05-22-mockup-gaps.md`
+
+- [ ] **Step 9.1: Read sezione corrente**
+
+Run via Read tool su file completo. Identificare sezioni P0 (#491, #492)
+che vanno marcate come "Phase 1 in implementation".
+
+- [ ] **Step 9.2: Aggiungere status banner top del file**
+
+Edit tool: dopo la riga "Total gaps confermati:..." aggiungere:
+
+```markdown
+## Status (2026-05-23 update)
+
+**Phase 1 in implementation** (PR <questa>):
+- ✅ Closure parziale #491 chat full-screen → mockup `chat-fullscreen.html` creato (Sezione 2)
+- ⚠️ Closure false-positive #492 community follow-up → ancora da riaprire
+  (sezione B11a non in scope Approccio B di questa Phase 1)
+- ✅ Cluster translate Aaron CORE → 4 sezioni 1a/1b/1c/1d implementate
+- ✅ B18 state-matrix cross-route → mockup `state-matrix.html` creato (Sezione 3)
+
+**Spec di riferimento**:
+`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`
+
+**Out of scope Phase 1** (deferiti a Phase 2/3):
+B11 play-records · B11a community follow-up · B14 editor agent-proposals
+(parcheggiato) · B15 toolkit sub-pages · B16 wishlist · B17 sessions
+sub-pages · nodi architetturali N4/N6/N7.
+```
+
+- [ ] **Step 9.3: Update sezione "Sommario azioni per maintainer"**
+
+Edit tool: marcare con ✅ le voci consegnate, lasciare ⚠️/⏸️ per le
+deferite.
+
+Esempio:
+```markdown
+1. ⚠️ **Riaprire #492** con scope ridotto (4 screen community) → o aprire B11a — STILL TODO
+2. ✅ **Riaprire #491** con scope ridotto (3 screen chat full-screen) →  consegnato via `chat-fullscreen.html` (PR <questa>)
+...
+```
+
+- [ ] **Step 9.4: Validate AC via grep**
+
+Run:
+```bash
+grep "Phase 1 in implementation\|2026-05-23" docs/for-developers/audits/2026-05-22-mockup-gaps.md
+```
+
+Expected: ≥2 occorrenze.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add docs/for-developers/audits/2026-05-22-mockup-gaps.md
+git commit -m "docs(audit): mockup-gaps Phase 1 in implementation (Aaron core consegnato)"
+```
+
+---
+
+## Task 10: Push + Pull Request
+
+**Files:**
+- No file changes
+
+- [ ] **Step 10.1: Push tutti i commit**
+
+Run:
+```bash
+git push origin feature/mockup-refinement-aaron-design
+```
+
+- [ ] **Step 10.2: Verifica diff completo prima di PR**
+
+Run:
+```bash
+git diff main-dev...HEAD --stat
+git log main-dev..HEAD --oneline
+```
+
+Expected: ~9 commit visibili, ~10 file modificati/creati totali.
+
+- [ ] **Step 10.3: Crea PR target main-dev**
+
+Run:
+```bash
+gh pr create --base main-dev --title "feat(mockup): Aaron core refinement + chat-fullscreen + state-matrix (Phase 1)" --body "$(cat <<'EOF'
+## Summary
+
+Implementazione Phase 1 del piano di raffinamento mockup secondo l'Approccio B (Aaron core + cross-cutting foundation):
+
+- **Sezione 1a-1d** — cluster translate (Aaron JTBD #1): 4 mockup estesi con failure modes (6 nuovi stati), loading multi-step + reader mode + wake-lock, glossary context-aware, multi-language source + manual fallback
+- **Sezione 2 (B11b)** — nuovo `chat-fullscreen.html` (3 screen: desktop 3-col + mobile + empty) — chiude parzialmente #491
+- **Sezione 3 (B18)** — nuovo `state-matrix.html` (8 route × 5 stati = 40 cell, foundation per Phase 2/3)
+- **Documentazione** — MOCKUPS_INDEX +2 entry, v2-migration-matrix aggiornata, audit `2026-05-22-mockup-gaps` marcato Phase 1 in implementation
+
+## Spec di riferimento
+
+`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`
+
+## Out of scope
+
+B11 play-records · B11a community follow-up · B14 editor agent-proposals · B15 toolkit sub-pages · B16 wishlist · B17 sessions sub-pages — deferiti a Phase 2/3.
+
+## Test plan
+
+- [ ] Visual review mockup nel browser: light + dark + mobile 375 + desktop 1280
+- [ ] Verifica `prefers-reduced-motion` rispettato (skeleton shimmer fallback)
+- [ ] Verifica reader mode toggle persistito in localStorage
+- [ ] Verifica wake-lock indicator graceful degradation Safari <16.4
+- [ ] Verifica contrasto AAA (≥7:1) sui paragrafi tradotti (axe / DevTools)
+- [ ] Verifica reference cross-linking nei commenti HTML head
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 10.4: Verifica CI checks**
+
+Aspetta che GitHub Actions completi. Se fail, investigare e fixare prima del merge.
+
+- [ ] **Step 10.5: Stop here**
+
+Plan termina. Merge della PR e cleanup branch sono al di fuori dello scope (decisione user).
+
+---
+
+## Self-Review checklist (post-plan)
+
+Da eseguire dopo la scrittura del plan:
+
+- [ ] **Spec coverage**: ogni sezione spec (1a/1b/1c/1d/2/3/8/9/10) ha task corrispondente?
+  - Sezione 1a → Task 1 ✓
+  - Sezione 1b → Task 2 ✓
+  - Sezione 1c → Task 3 ✓
+  - Sezione 1d → Task 4 ✓
+  - Sezione 2 (B11b) → Task 5 ✓
+  - Sezione 3 (B18) → Task 6 ✓
+  - Sezione 9 (AC globali) → Task 7+8+9 ✓
+  - Sezione 10 (decisioni archi) → coperte come commenti HTML nei brief
+- [ ] **Placeholder scan**: nessun TBD/TODO/"add appropriate" nei step?
+- [ ] **Type consistency**: nomi file, route, label coerenti cross-task?
+- [ ] **Branching**: Task 0 setup + Task 10 push/PR coerenti con CLAUDE.md project rules (feature branch → main-dev)

--- a/docs/superpowers/plans/2026-05-23-mockup-refinement-aaron-core.md
+++ b/docs/superpowers/plans/2026-05-23-mockup-refinement-aaron-core.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Workflow ibrido per mockup HTML: (1) engineer prepara brief contestualizzato dalla spec, (2) user esegue Claude Design Web producendo HTML, (3) engineer integra output nel file target (`admin-mockups/design_files/`), valida acceptance criteria via grep + visual inspection, committa. Pattern "extend existing" per `error-states`, `translate-viewer`, `glossary-editor`, `photo-upload` (preserva continuità); pattern "create new" per `chat-fullscreen.html` e `state-matrix.html`.
 
-**Tech Stack:** HTML + CSS (componenti già presenti in `admin-mockups/design_files/components.css`), JSX twins per i mockup principali, design tokens canonici da `tokens.css`. Nessuna build step — i file sono statici. Riuso di pattern da `nanolith-runthrough-*`, `sp6-libro-game-*`, `sp4-citation-pdf-viewer`.
+**Tech Stack:** HTML + CSS (componenti già presenti in `admin-mockups/design_files/components.css`), JSX twins per i mockup principali, design tokens canonici da `tokens.css`. Nessuna build step — i file sono statici. Riuso di pattern da `librogame-runthrough-*`, `sp6-libro-game-*`, `sp4-citation-pdf-viewer`.
 
 **Spec sorgente**: [`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`](../specs/2026-05-23-mockup-refinement-aaron-core-design.md)
 
@@ -20,10 +20,10 @@
 
 | File | Sezione spec | Cosa cambia |
 |---|---|---|
-| `admin-mockups/design_files/nanolith-runthrough-error-states.html` | 1a | + 6 nuovi stati OCR/AI (ocr-low-confidence, photo-blur-pre-ocr, translation-timeout, source-lang-unknown, network-mid-ocr, quota-exhausted-mid-stream) |
-| `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` | 1b + 1d | + 4-step loading sequence, reader mode toggle 📖, wake-lock indicator 🔆, contrasto AAA, 3 sub-screen multi-lang (lang-detection-badge, lang-override-modal, manual-input-mode) |
+| `admin-mockups/design_files/librogame-runthrough-error-states.html` | 1a | + 6 nuovi stati OCR/AI (ocr-low-confidence, photo-blur-pre-ocr, translation-timeout, source-lang-unknown, network-mid-ocr, quota-exhausted-mid-stream) |
+| `admin-mockups/design_files/librogame-runthrough-translate-viewer.html` | 1b + 1d | + 4-step loading sequence, reader mode toggle 📖, wake-lock indicator 🔆, contrasto AAA, 3 sub-screen multi-lang (lang-detection-badge, lang-override-modal, manual-input-mode) |
 | `admin-mockups/design_files/sp6-libro-game-photo-upload.html` | 1d | + kebab menu *"Digita manualmente"* entry point per manual-input-mode |
-| `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html` | 1c | + 4 sub-screen (conflict-dialog, bulk-import-card, variant-expansion, filter-strip+context-badges) + commento modello dati `GlossaryEntry` |
+| `admin-mockups/design_files/librogame-runthrough-glossary-editor.html` | 1c | + 4 sub-screen (conflict-dialog, bulk-import-card, variant-expansion, filter-strip+context-badges) + commento modello dati `GlossaryEntry` |
 | `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx` | 1c | Sync .jsx twin con HTML modificato |
 | `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx` | 1b + 1d | Sync .jsx twin con HTML modificato |
 | `admin-mockups/MOCKUPS_INDEX.md` | 9 (AC globali) | Aggiornare count (page-mock 48→49, dev-fixture 10→11) + nuovi entry |
@@ -103,14 +103,14 @@ git push -u origin feature/mockup-refinement-aaron-design
 
 ---
 
-## Task 1: Sezione 1a — `nanolith-runthrough-error-states.html` (+ 6 stati)
+## Task 1: Sezione 1a — `librogame-runthrough-error-states.html` (+ 6 stati)
 
 **Files:**
-- Modify: `admin-mockups/design_files/nanolith-runthrough-error-states.html`
+- Modify: `admin-mockups/design_files/librogame-runthrough-error-states.html`
 
 - [ ] **Step 1.1: Read existing file**
 
-Run via Read tool: `admin-mockups/design_files/nanolith-runthrough-error-states.html`
+Run via Read tool: `admin-mockups/design_files/librogame-runthrough-error-states.html`
 
 Identificare:
 - Pattern attuale per le 4 cellule esistenti (stream-timeout, OCR-fail, LLM-503, segmentation-fail)
@@ -123,7 +123,7 @@ Brief da copia-incollare in Claude Design Web:
 
 ```
 Contesto: sto estendendo il mockup HTML esistente
-`admin-mockups/design_files/nanolith-runthrough-error-states.html` aggiungendo
+`admin-mockups/design_files/librogame-runthrough-error-states.html` aggiungendo
 6 nuovi stati di errore al pattern cross-cutting già usato per le 4 celle
 esistenti (stream-timeout, OCR-fail, LLM-503, segmentation-fail).
 
@@ -185,20 +185,20 @@ del grid container. Verifica preservazione delle 4 cellule esistenti.
 
 Run:
 ```bash
-grep -c "ocr-low-confidence\|photo-blur-pre-ocr\|translation-timeout\|source-lang-unknown\|network-mid-ocr\|quota-exhausted-mid-stream" admin-mockups/design_files/nanolith-runthrough-error-states.html
+grep -c "ocr-low-confidence\|photo-blur-pre-ocr\|translation-timeout\|source-lang-unknown\|network-mid-ocr\|quota-exhausted-mid-stream" admin-mockups/design_files/librogame-runthrough-error-states.html
 ```
 
 Expected: `6` (un match per stato).
 
 ```bash
-grep -c "stream-timeout\|OCR-fail\|LLM-503\|segmentation-fail" admin-mockups/design_files/nanolith-runthrough-error-states.html
+grep -c "stream-timeout\|OCR-fail\|LLM-503\|segmentation-fail" admin-mockups/design_files/librogame-runthrough-error-states.html
 ```
 
 Expected: `4` (preservazione cellule esistenti).
 
 - [ ] **Step 1.6: Visual review**
 
-Aprire `admin-mockups/design_files/nanolith-runthrough-error-states.html` nel browser. Verificare:
+Aprire `admin-mockups/design_files/librogame-runthrough-error-states.html` nel browser. Verificare:
 - 10 cellule totali visibili (4 esistenti + 6 nuove)
 - Light + dark toggle funziona su tutte
 - Mobile 375 + desktop 1280 (resize browser)
@@ -207,20 +207,20 @@ Aprire `admin-mockups/design_files/nanolith-runthrough-error-states.html` nel br
 - [ ] **Step 1.7: Commit**
 
 ```bash
-git add admin-mockups/design_files/nanolith-runthrough-error-states.html
+git add admin-mockups/design_files/librogame-runthrough-error-states.html
 git commit -m "feat(mockup): sezione 1a — 6 nuovi stati OCR/AI in error-states (#491-follow-up)"
 ```
 
 ---
 
-## Task 2: Sezione 1b — `nanolith-runthrough-translate-viewer.html` (+ loading multi-step + reader mode + wake-lock)
+## Task 2: Sezione 1b — `librogame-runthrough-translate-viewer.html` (+ loading multi-step + reader mode + wake-lock)
 
 **Files:**
-- Modify: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`
+- Modify: `admin-mockups/design_files/librogame-runthrough-translate-viewer.html`
 
 - [ ] **Step 2.1: Read existing file**
 
-Run via Read tool: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`
+Run via Read tool: `admin-mockups/design_files/librogame-runthrough-translate-viewer.html`
 
 Identificare:
 - Layout principale (header, body translate, footer)
@@ -231,7 +231,7 @@ Identificare:
 
 ```
 Contesto: estendo il mockup esistente
-`admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` con:
+`admin-mockups/design_files/librogame-runthrough-translate-viewer.html` con:
 A) Loading sequence multi-step
 B) Reader mode toggle
 C) Wake-lock indicator
@@ -300,7 +300,7 @@ Variants viewport:
 Latency targets (commenti HTML head):
 - Step 1 < 2s · Step 2 < 5s · Step 3 < 10s · Step 4 < 2s · Total < 17s
 - Hard timeout 20s totale → trigger `translation-timeout` (vedi
-  nanolith-runthrough-error-states.html)
+  librogame-runthrough-error-states.html)
 
 Light + dark mode. Preservare stato happy-path attuale (foto + paragrafo
 tradotto) come "step finale dopo loading".
@@ -319,19 +319,19 @@ contrasto AAA. Preservare happy-path esistente.
 
 Run:
 ```bash
-grep -c "Caricamento foto\|Sto leggendo\|Sto traducendo\|Cerco parole" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+grep -c "Caricamento foto\|Sto leggendo\|Sto traducendo\|Cerco parole" admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 ```
 
 Expected: `4` (un match per label step).
 
 ```bash
-grep -c "reader-mode-enabled\|wake-lock\|max-width.*65ch" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+grep -c "reader-mode-enabled\|wake-lock\|max-width.*65ch" admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 ```
 
 Expected: `≥3` (almeno un match per ognuno dei 3 pattern).
 
 ```bash
-grep "prefers-reduced-motion" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+grep "prefers-reduced-motion" admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 ```
 
 Expected: almeno 1 occorrenza.
@@ -347,22 +347,22 @@ Browser apre file. Verificare:
 - [ ] **Step 2.7: Commit**
 
 ```bash
-git add admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+git add admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 git commit -m "feat(mockup): sezione 1b — loading multi-step + reader mode + wake-lock in translate-viewer"
 ```
 
 ---
 
-## Task 3: Sezione 1c — `nanolith-runthrough-glossary-editor.html` + jsx twin (+ 4 sub-screen)
+## Task 3: Sezione 1c — `librogame-runthrough-glossary-editor.html` + jsx twin (+ 4 sub-screen)
 
 **Files:**
-- Modify: `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html`
+- Modify: `admin-mockups/design_files/librogame-runthrough-glossary-editor.html`
 - Modify: `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx`
 
 - [ ] **Step 3.1: Read existing files**
 
 Run via Read tool su entrambi:
-- `admin-mockups/design_files/nanolith-runthrough-glossary-editor.html`
+- `admin-mockups/design_files/librogame-runthrough-glossary-editor.html`
 - `admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx`
 
 Identificare: layout glossary index attuale, edit/add patterns.
@@ -371,7 +371,7 @@ Identificare: layout glossary index attuale, edit/add patterns.
 
 ```
 Contesto: estendo il mockup esistente
-`admin-mockups/design_files/nanolith-runthrough-glossary-editor.html` (e il
+`admin-mockups/design_files/librogame-runthrough-glossary-editor.html` (e il
 twin jsx `sp6-libro-game-glossary-editor.jsx`) per supportare context-aware
 glossary entries.
 
@@ -449,7 +449,7 @@ diviso.
 
 - [ ] **Step 3.4: Integrate HTML output**
 
-Edit tool su `nanolith-runthrough-glossary-editor.html` per aggiungere 4
+Edit tool su `librogame-runthrough-glossary-editor.html` per aggiungere 4
 sub-screen + commento modello dati.
 
 - [ ] **Step 3.5: Integrate jsx output**
@@ -460,13 +460,13 @@ Edit tool su `sp6-libro-game-glossary-editor.jsx` per sync.
 
 Run:
 ```bash
-grep -c "conflict-dialog\|bulk-import-card\|variant-expansion\|filter-strip" admin-mockups/design_files/nanolith-runthrough-glossary-editor.html
+grep -c "conflict-dialog\|bulk-import-card\|variant-expansion\|filter-strip" admin-mockups/design_files/librogame-runthrough-glossary-editor.html
 ```
 
 Expected: `≥4`.
 
 ```bash
-grep "context_similarity\|0.85\|contexts:" admin-mockups/design_files/nanolith-runthrough-glossary-editor.html
+grep "context_similarity\|0.85\|contexts:" admin-mockups/design_files/librogame-runthrough-glossary-editor.html
 ```
 
 Expected: ≥3 occorrenze.
@@ -489,7 +489,7 @@ Browser apre HTML. Verifica:
 - [ ] **Step 3.8: Commit**
 
 ```bash
-git add admin-mockups/design_files/nanolith-runthrough-glossary-editor.html admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
+git add admin-mockups/design_files/librogame-runthrough-glossary-editor.html admin-mockups/design_files/sp6-libro-game-glossary-editor.jsx
 git commit -m "feat(mockup): sezione 1c — glossary context-aware (conflict/merge/variants) + jsx sync"
 ```
 
@@ -498,21 +498,21 @@ git commit -m "feat(mockup): sezione 1c — glossary context-aware (conflict/mer
 ## Task 4: Sezione 1d — `translate-viewer.html` (multi-lang) + `photo-upload.html` (entry point manual) + jsx twin
 
 **Files:**
-- Modify: `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` (estende Task 2)
+- Modify: `admin-mockups/design_files/librogame-runthrough-translate-viewer.html` (estende Task 2)
 - Modify: `admin-mockups/design_files/sp6-libro-game-photo-upload.html`
 - Modify: `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx`
 
 - [ ] **Step 4.1: Read existing files**
 
 Run via Read tool su:
-- `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html` (post Task 2)
+- `admin-mockups/design_files/librogame-runthrough-translate-viewer.html` (post Task 2)
 - `admin-mockups/design_files/sp6-libro-game-photo-upload.html`
 - `admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx`
 
 - [ ] **Step 4.2: Prepare Claude Design Web brief**
 
 ```
-Contesto: estendo `nanolith-runthrough-translate-viewer.html` (post Task 2
+Contesto: estendo `librogame-runthrough-translate-viewer.html` (post Task 2
 con loading sequence) aggiungendo support per multi-language source +
 manual input fallback. Estendo anche `sp6-libro-game-photo-upload.html`
 con entry-point al manual mode.
@@ -587,7 +587,7 @@ Engineer pause.
 - [ ] **Step 4.4: Integrate HTML/JSX output**
 
 3 file da modificare:
-- `nanolith-runthrough-translate-viewer.html` (+ 3 sub-screen)
+- `librogame-runthrough-translate-viewer.html` (+ 3 sub-screen)
 - `sp6-libro-game-photo-upload.html` (+ kebab menu)
 - `sp6-libro-game-translation-viewer.jsx` (sync)
 
@@ -595,13 +595,13 @@ Engineer pause.
 
 Run:
 ```bash
-grep -c "lang-detection-badge\|lang-override-modal\|manual-input-mode" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+grep -c "lang-detection-badge\|lang-override-modal\|manual-input-mode" admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 ```
 
 Expected: `≥3`.
 
 ```bash
-grep -c "EN\|FR\|DE\|ES\|IT" admin-mockups/design_files/nanolith-runthrough-translate-viewer.html
+grep -c "EN\|FR\|DE\|ES\|IT" admin-mockups/design_files/librogame-runthrough-translate-viewer.html
 ```
 
 Expected: ≥5 occorrenze.
@@ -627,7 +627,7 @@ Browser su entrambi i file. Verifica:
 - [ ] **Step 4.7: Commit**
 
 ```bash
-git add admin-mockups/design_files/nanolith-runthrough-translate-viewer.html admin-mockups/design_files/sp6-libro-game-photo-upload.html admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
+git add admin-mockups/design_files/librogame-runthrough-translate-viewer.html admin-mockups/design_files/sp6-libro-game-photo-upload.html admin-mockups/design_files/sp6-libro-game-translation-viewer.jsx
 git commit -m "feat(mockup): sezione 1d — multi-lang source + manual input fallback + jsx sync"
 ```
 
@@ -825,7 +825,7 @@ git commit -m "feat(mockup): sezione 2 (B11b) — chat-fullscreen page-mock + js
 Run via Read tool su:
 - `admin-mockups/design_files/01-screens.html` (riferimento dev-fixture matrix
   phone-frame grid)
-- `admin-mockups/design_files/nanolith-runthrough-error-states.html` (post
+- `admin-mockups/design_files/librogame-runthrough-error-states.html` (post
   Task 1, riferimento pattern errors)
 
 - [ ] **Step 6.2: Prepare Claude Design Web brief**
@@ -855,7 +855,7 @@ ROUTE × STATI (riempi ogni cell con phone-frame mockup):
 Contenuto per cell (testi IT, no placeholder generici):
 
 A1 (translate empty): icon 📷 + "Fotografa una pagina" + CTA "Apri camera"
-A2 (translate error): riusa pattern nanolith-runthrough-error-states ocr-fail
+A2 (translate error): riusa pattern librogame-runthrough-error-states ocr-fail
 A3 (translate loading): 4-step skeleton (riusa Task 2 sezione 1b)
 A4 (translate permission): 🔒 + "Quota OCR esaurita" + tier badge "Pro" +
    CTA "Esplora piani"
@@ -908,9 +908,9 @@ Empty: icon 96px centrale + gradient bg entity color (color depende dalla
        game-nights/sessions → rose · shared-games/discover → teal ·
        notifications → blue) + tagline IT + primary CTA per uscire.
 
-Error: riuso pattern nanolith-runthrough-error-states (icon + message
+Error: riuso pattern librogame-runthrough-error-states (icon + message
        umano + retry + report-bug). Annota in commento HTML head
-       `<!-- error: see nanolith-runthrough-error-states -->`.
+       `<!-- error: see librogame-runthrough-error-states -->`.
 
 Loading skeleton: 3-row card dimensionato al contenuto reale. Shimmer-sweep
                   gradient. `prefers-reduced-motion` → fallback statico.
@@ -933,7 +933,7 @@ ILLUSTRATION ECONOMY: ~5 illustration uniche riusabili (tema):
 - "compass": shared-games+discover
 
 REUSE TRACE: commento HTML head per ogni pattern che linka all'origine
-(es. `<!-- pattern: see nanolith-runthrough-translate-viewer.html -->`).
+(es. `<!-- pattern: see librogame-runthrough-translate-viewer.html -->`).
 ```
 
 - [ ] **Step 6.3: User executes Claude Design Web**
@@ -1028,6 +1028,29 @@ Edit tool su sezioni rilevanti:
 Edit tool: cambia "Last updated: 2026-05-18" → "Last updated: 2026-05-23"
 (riga ~9).
 
+- [ ] **Step 7.4b: Fix debito naming preesistente nanolith → librogame**
+
+I file `librogame-runthrough-*.html` (13 file) sono elencati erroneamente in
+MOCKUPS_INDEX righe 120-132 come `nanolith-runthrough-*`. Il filesystem ha
+i nomi corretti `librogame-*` (eccezione: `nanolith-nav-{bottom-mobile,
+chat-panel,topbar}.html` esistono come tali).
+
+Run:
+```bash
+grep -c "nanolith-runthrough" admin-mockups/MOCKUPS_INDEX.md
+```
+
+Expected: `13` prima del fix.
+
+Edit tool con `replace_all=true`: `nanolith-runthrough` → `librogame-runthrough`.
+
+Validate:
+```bash
+grep -c "nanolith-runthrough" admin-mockups/MOCKUPS_INDEX.md
+```
+
+Expected: `0` dopo il fix.
+
 - [ ] **Step 7.5: Validate AC via grep**
 
 Run:
@@ -1096,7 +1119,28 @@ esistente:
 > `docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`.
 ```
 
-- [ ] **Step 8.5: Validate AC via grep**
+- [ ] **Step 8.5: Fix debito naming preesistente nanolith → librogame**
+
+Stesso debito di Task 7 Step 7.4b. La matrix ha 15 occorrenze di
+`nanolith-runthrough` da rimappare.
+
+Run:
+```bash
+grep -c "nanolith-runthrough" docs/for-developers/frontend/v2-migration-matrix.md
+```
+
+Expected: `15` prima del fix.
+
+Edit tool con `replace_all=true`: `nanolith-runthrough` → `librogame-runthrough`.
+
+Validate:
+```bash
+grep -c "nanolith-runthrough" docs/for-developers/frontend/v2-migration-matrix.md
+```
+
+Expected: `0` dopo il fix.
+
+- [ ] **Step 8.6: Validate AC via grep**
 
 Run:
 ```bash
@@ -1105,7 +1149,7 @@ grep -c "chat-fullscreen\|state-matrix\|2026-05-23" docs/for-developers/frontend
 
 Expected: ≥3 occorrenze.
 
-- [ ] **Step 8.6: Commit**
+- [ ] **Step 8.7: Commit**
 
 ```bash
 git add docs/for-developers/frontend/v2-migration-matrix.md

--- a/docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md
+++ b/docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md
@@ -42,14 +42,14 @@ Aaron non è isolato. Le actor variations attive influenzano i mockup:
 **Tradurre paragrafo da foto** del libro fisico.
 
 Cluster di mockup critici per il JTBD #1:
-- `nanolith-runthrough-translate-viewer.html` (page-mock)
+- `librogame-runthrough-translate-viewer.html` (page-mock)
 - `sp6-libro-game-photo-upload.html` (camera step)
-- `nanolith-runthrough-glossary-editor.html` (glossary overlay)
+- `librogame-runthrough-glossary-editor.html` (glossary overlay)
 - `sp6-libro-game-translation-viewer.jsx` + `sp6-libro-game-glossary-editor.jsx` (twin jsx)
 
 ### 1.3 Gap identificati (4 aree)
 
-1. **Failure modes OCR/AI puntuali** — `nanolith-runthrough-error-states` copre solo OCR-fail/LLM-503 generici; mancano 6 stati specifici.
+1. **Failure modes OCR/AI puntuali** — `librogame-runthrough-error-states` copre solo OCR-fail/LLM-503 generici; mancano 6 stati specifici.
 2. **Loading + progress durante elaborazione** — mockup attuali non mostrano stato intermedio durante i ~17s di OCR+translate; rischio di hot-reload utente.
 3. **Glossario conflict / merge / context** — modello dati attuale non supporta varianti per book; manca conflict resolution UI e bulk import.
 4. **Multi-language source + manual fallback** — mockup assumono sorgente EN; nessun supporto per FR/DE/ES/IT o per manual text input quando foto fallisce.
@@ -68,7 +68,7 @@ Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US
 
 ## 2. Section 1a — Failure modes OCR/AI puntuali
 
-**File target**: estensione di `admin-mockups/design_files/nanolith-runthrough-error-states.html` (NO nuovo file — preserva pattern cross-cutting PR #1056).
+**File target**: estensione di `admin-mockups/design_files/librogame-runthrough-error-states.html` (NO nuovo file — preserva pattern cross-cutting PR #1056).
 
 **Route impattata**: `/library/[gameId]/play/[campaignId]/translate`
 
@@ -81,7 +81,7 @@ Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US
 | `translation-timeout` | AI translate abort dopo 20s | Banner *"Traduzione lenta — riprova o modifica manualmente"* + 2 CTA |
 | `source-lang-unknown` | LLM ritorna `confidence_lang < 0.5` | Dialog *"Lingua non riconosciuta. Conferma:"* + dropdown 5 lingue |
 | `network-mid-ocr` | Loss connection durante upload foto | Banner persistent *"Connessione persa — foto salvata localmente, riprova quando torni online"* |
-| `quota-exhausted-mid-stream` | Token quota termina durante AI translate | Bridge a `nanolith-runthrough-quota-credits` overlay + retain OCR-decoded paragraph come fallback (no token aggiuntivi consumati) |
+| `quota-exhausted-mid-stream` | Token quota termina durante AI translate | Bridge a `librogame-runthrough-quota-credits` overlay + retain OCR-decoded paragraph come fallback (no token aggiuntivi consumati) |
 
 **Pattern decisions**:
 - **Retry granularity**: per `OCR-fail` → retry solo OCR step (foto in cache locale); per `LLM-503` → retry solo AI step (OCR result conservato). MAI retry-from-scratch automatico.
@@ -89,7 +89,7 @@ Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US
 - **Fallback path**: ogni failure ha minimo 1 fallback non-distruttivo (manual input, save-and-retry, alternative provider). MAI dead-end.
 
 **Acceptance criteria**:
-- [ ] 6 nuove cellule nel `nanolith-runthrough-error-states.html`
+- [ ] 6 nuove cellule nel `librogame-runthrough-error-states.html`
 - [ ] Ogni cellula documenta: trigger condition, recovery action, fallback path
 - [ ] Light + dark mode
 - [ ] MOCKUPS_INDEX resta `component-mock`
@@ -98,7 +98,7 @@ Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US
 
 ## 3. Section 1b — Loading + progress durante elaborazione
 
-**File target**: estensione di `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`.
+**File target**: estensione di `admin-mockups/design_files/librogame-runthrough-translate-viewer.html`.
 
 **Loading sequence multi-step** (4 step nominati, non % anonima):
 
@@ -144,7 +144,7 @@ Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US
 
 ## 4. Section 1c — Glossario conflict / merge / context
 
-**File target**: estensione di `nanolith-runthrough-glossary-editor.html` (component-mock) + twin `sp6-libro-game-glossary-editor.jsx`.
+**File target**: estensione di `librogame-runthrough-glossary-editor.html` (component-mock) + twin `sp6-libro-game-glossary-editor.jsx`.
 
 **Modello dati proposto** (riflesso nei mockup):
 
@@ -191,7 +191,7 @@ GlossaryEntry {
 
 ## 5. Section 1d — Multi-language source + manual fallback
 
-**File target**: estensione di `nanolith-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` + twin `sp6-libro-game-translation-viewer.jsx`.
+**File target**: estensione di `librogame-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` + twin `sp6-libro-game-translation-viewer.jsx`.
 
 **Source language model**:
 
@@ -327,7 +327,7 @@ Hero *"Inizia una conversazione"* + 4 quick-starter cards **adattate per agent t
 
 **Empty**: icon 96px centrale + gradient bg entity color + tagline IT route-specific + primary CTA per uscire (mai dead-end).
 
-**Error**: riuso `nanolith-runthrough-error-states` (icon + message umano + retry + report-bug). Annotato in commento HTML head per traceability.
+**Error**: riuso `librogame-runthrough-error-states` (icon + message umano + retry + report-bug). Annotato in commento HTML head per traceability.
 
 **Loading skeleton**: 3-row card dimensionato al contenuto reale (3 game-cards per `/shared-games`, 7-day calendar per `/game-nights`, ecc.). Shimmer-sweep gradient. `prefers-reduced-motion` → fallback statico.
 
@@ -379,7 +379,7 @@ Hero *"Inizia una conversazione"* + 4 quick-starter cards **adattate per agent t
 ## 9. Acceptance criteria globali
 
 - [ ] 6 sezioni mockup-work consegnate (1a, 1b, 1c, 1d, 2, 3)
-- [ ] 3 file modificati: `nanolith-runthrough-error-states.html`, `nanolith-runthrough-translate-viewer.html`, `nanolith-runthrough-glossary-editor.html` + 2 twin jsx aggiornati
+- [ ] 3 file modificati: `librogame-runthrough-error-states.html`, `librogame-runthrough-translate-viewer.html`, `librogame-runthrough-glossary-editor.html` + 2 twin jsx aggiornati
 - [ ] 2 file nuovi: `chat-fullscreen.html`, `state-matrix.html` (+ jsx twins)
 - [ ] `admin-mockups/MOCKUPS_INDEX.md` aggiornato (count: 48 page-mock → 49, 16 component-mock invariato, 10 dev-fixture → 11)
 - [ ] `docs/for-developers/frontend/v2-migration-matrix.md` route mapping aggiornato
@@ -413,4 +413,4 @@ Le seguenti decisioni emergono dal design mockup ma richiedono follow-up impleme
 - [`docs/for-developers/frontend/v2-migration-matrix.md`](../../for-developers/frontend/v2-migration-matrix.md) — route→mockup matrix
 - [`docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md`](./2026-05-07-libro-game-nanolith-demo-design.md) — Iter 1 design Aaron persona
 - Issue #491 (closure parziale chat full-screen) · #492 (closure false-positive community)
-- PR #1056 (`nanolith-runthrough-error-states` pattern) · PR #551 (`useThreadMessages` hook)
+- PR #1056 (`librogame-runthrough-error-states` pattern) · PR #551 (`useThreadMessages` hook)

--- a/docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md
+++ b/docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md
@@ -1,0 +1,416 @@
+# Mockup Refinement — Aaron Core + Cross-cutting (Approccio B)
+
+**Date**: 2026-05-23
+**Status**: design — pending implementation plan
+**Author**: socratic refinement session (Cockburn / Wiegers / Adzic / Fowler / Nygard)
+**Scope**: raffinamento mockup cluster libro-game (CORE Aaron) + chat full-screen (B11b) + state matrix cross-route (B18)
+**Out of scope**: B11/B11a/B14/B15/B16/B17 (deferred to Phase 2-3, vedi sezione *Out of scope*)
+**Related audit**: [`docs/for-developers/audits/2026-05-22-mockup-gaps.md`](../../for-developers/audits/2026-05-22-mockup-gaps.md)
+
+---
+
+## 1. Context
+
+### 1.1 North-star + segmenti attivi
+
+**North-star**: **Aaron libro-game enthusiast** (multi-segment ma Aaron prioritario).
+
+**Segmenti attivi al 2026-05-23**:
+
+| Segmento | Status | Pagine principali |
+|---|---|---|
+| Libro-game enthusiast (Aaron) | ✅ ATTIVO PRIMARY | `/library/[gameId]/play/[campaignId]/translate`, `/gamebook`, `/chat/[threadId]` |
+| Boardgamer host + player | ✅ ATTIVO secondary | `/game-nights`, `/sessions/live/[sessionId]`, `/play-records` |
+| Casual browser pre-registrazione | ✅ ATTIVO secondary | `/shared-games`, `/discover`, `/faq` |
+| AI builder / KB curator | ⏸️ PARCHEGGIATO (strategy ambigua) | `/editor/agent-proposals/*`, `/agents/*`, `/knowledge-base/*` |
+
+#### 1.1.1 Aaron actor variations (supporting actors)
+
+Aaron non è isolato. Le actor variations attive influenzano i mockup:
+
+| Variation | Comportamento | Design impact |
+|---|---|---|
+| **Passive co-player** (compagna/partner che osserva) | Legge lo schermo a distanza ~50cm, non tocca il telefono | • **Reader mode**: toggle font 16pt → 24pt nel translate viewer + chat (vedi sezioni 1b e 6.4)<br>• **Wake-lock**: durante `/translate`, `/play/[campaignId]`, `/chat/[threadId]` lo schermo non si auto-blocca<br>• Indicator visibile: badge 🔆 *"Schermo attivo"* con override manuale<br>• Contrasto: AA elevated (target AAA dove possibile) |
+| **Phone-passing** (entrambi toccano lo stesso device, stesso account) | Aaron passa il telefono alla compagna che fotografa, lui legge la risposta, lei aggiunge parola al glossario | • **No actor attribution**: glossary entries, history, chat messages NON taggate per autore (coerente con sezione 1c `contexts[]` che ha solo `book_id`)<br>• **Session state preserved**: navigazione tra `/translate` ↔ `/chat` ↔ `/glossary` mantiene state senza re-login né reload (allinea con `?mode=manual` deeplink, sezione 1d) |
+
+**Out of scope** (actor variations non selezionate):
+- Own-device co-player con account separato (multi-user campaign sync) — feature parcheggiata
+- Bambino spectator con TTS — TTS UI placeholder ma backend deferito
+
+### 1.2 JTBD #1 di Aaron
+
+**Tradurre paragrafo da foto** del libro fisico.
+
+Cluster di mockup critici per il JTBD #1:
+- `nanolith-runthrough-translate-viewer.html` (page-mock)
+- `sp6-libro-game-photo-upload.html` (camera step)
+- `nanolith-runthrough-glossary-editor.html` (glossary overlay)
+- `sp6-libro-game-translation-viewer.jsx` + `sp6-libro-game-glossary-editor.jsx` (twin jsx)
+
+### 1.3 Gap identificati (4 aree)
+
+1. **Failure modes OCR/AI puntuali** — `nanolith-runthrough-error-states` copre solo OCR-fail/LLM-503 generici; mancano 6 stati specifici.
+2. **Loading + progress durante elaborazione** — mockup attuali non mostrano stato intermedio durante i ~17s di OCR+translate; rischio di hot-reload utente.
+3. **Glossario conflict / merge / context** — modello dati attuale non supporta varianti per book; manca conflict resolution UI e bulk import.
+4. **Multi-language source + manual fallback** — mockup assumono sorgente EN; nessun supporto per FR/DE/ES/IT o per manual text input quando foto fallisce.
+
+### 1.4 Approccio selezionato — Opzione B
+
+**Aaron-core + cross-cutting foundation** (~3 settimane mockup work):
+
+- Cluster translate raffinato (4 sezioni 1a-1d)
+- B11b chat full-screen (carry-over closure parziale #491, Aaron-relevant)
+- B18 state matrix cross-route (foundation per Fase 2-3)
+
+Trade-off accettato: boardgamer game-night gap (B11/B17) restano non coperti; US-32 ancora bloccante. Razionale: Aaron è north-star + B18 ammortizza su tutti i raffinamenti futuri.
+
+---
+
+## 2. Section 1a — Failure modes OCR/AI puntuali
+
+**File target**: estensione di `admin-mockups/design_files/nanolith-runthrough-error-states.html` (NO nuovo file — preserva pattern cross-cutting PR #1056).
+
+**Route impattata**: `/library/[gameId]/play/[campaignId]/translate`
+
+**6 stati nuovi (oltre ai 4 esistenti)**:
+
+| Stato | Trigger | UX |
+|---|---|---|
+| `ocr-low-confidence` | OCR completato, `confidence < 0.7` su ≥1 regione | Inline highlight regioni dubbie (giallo) + CTA *"Ritocca foto"* / *"Procedi comunque"* |
+| `photo-blur-pre-ocr` | Autofocus score < threshold (client-side, pre-upload) | Reject in-camera prima di upload + CTA *"Riprova"* (zero roundtrip server) |
+| `translation-timeout` | AI translate abort dopo 20s | Banner *"Traduzione lenta — riprova o modifica manualmente"* + 2 CTA |
+| `source-lang-unknown` | LLM ritorna `confidence_lang < 0.5` | Dialog *"Lingua non riconosciuta. Conferma:"* + dropdown 5 lingue |
+| `network-mid-ocr` | Loss connection durante upload foto | Banner persistent *"Connessione persa — foto salvata localmente, riprova quando torni online"* |
+| `quota-exhausted-mid-stream` | Token quota termina durante AI translate | Bridge a `nanolith-runthrough-quota-credits` overlay + retain OCR-decoded paragraph come fallback (no token aggiuntivi consumati) |
+
+**Pattern decisions**:
+- **Retry granularity**: per `OCR-fail` → retry solo OCR step (foto in cache locale); per `LLM-503` → retry solo AI step (OCR result conservato). MAI retry-from-scratch automatico.
+- **Confidence threshold**: low-confidence default `0.7` (futuro configurabile in `/settings/preferences`).
+- **Fallback path**: ogni failure ha minimo 1 fallback non-distruttivo (manual input, save-and-retry, alternative provider). MAI dead-end.
+
+**Acceptance criteria**:
+- [ ] 6 nuove cellule nel `nanolith-runthrough-error-states.html`
+- [ ] Ogni cellula documenta: trigger condition, recovery action, fallback path
+- [ ] Light + dark mode
+- [ ] MOCKUPS_INDEX resta `component-mock`
+
+---
+
+## 3. Section 1b — Loading + progress durante elaborazione
+
+**File target**: estensione di `admin-mockups/design_files/nanolith-runthrough-translate-viewer.html`.
+
+**Loading sequence multi-step** (4 step nominati, non % anonima):
+
+| Step | Durata target | UI | Label IT |
+|---|---|---|---|
+| 1. Upload foto | 0-2s | Linear progress bar percentage + thumbnail | *"Caricamento foto…"* |
+| 2. OCR (lettura) | 2-7s | Skeleton paragrafo 3-righe + shimmer-sweep | *"Sto leggendo il libro…"* |
+| 3. AI translation | 7-15s | Paragrafo OCR in 60% opacity sopra + overlay tradotto token-by-token | *"Sto traducendo…"* |
+| 4. Glossary check | 15-17s | Highlight progressivo parole nuove (badge ⊕) | *"Cerco parole nel glossario…"* |
+
+**Pattern decisions**:
+- **Multi-step vs single-phase**: scelto multi-step per trasparenza diagnostica.
+- **Abort CTA**: visibile dal step 2 in poi. Click → torna a camera step con foto preservata per retake.
+- **Skeleton sizing**: 3 righe dimensionate al paragrafo medio (~150 char), shimmer-sweep gradient.
+- **Token-by-token vs final**: step 3 streaming token-by-token, allinea `useThreadMessages` pattern (PR#551).
+
+**Variants viewport**:
+- Mobile 375: step list verticale stack, paragrafo sotto, abort FAB bottom-right
+- Desktop 1280: step list orizzontale top breadcrumb, paragrafo central, abort top-right
+
+**Latency targets** (Wiegers measurability):
+- Step 1 < 2s · Step 2 < 5s · Step 3 < 10s · Step 4 < 2s · Total < 17s
+- Hard timeout 20s totale → trigger `translation-timeout` di sezione 1a
+- Documentati nei commenti HTML head
+
+**Reader mode + wake-lock** (per passive co-player, sezione 1.1.1):
+- **Reader mode toggle**: button 📖 nel header translate-viewer, switch font body 16pt → 24pt + line-height +30% + padding maggiore. Stato persistito in `localStorage` per sessione. Visibile anche durante step di loading (skeleton scala al font scelto).
+- **Wake-lock indicator**: badge 🔆 *"Schermo attivo"* visibile bottom-right durante translate viewer + play session attivi. Click → disable wake-lock con feedback toast *"Schermo torna alla normalità"*. Auto-re-enable su nuova foto/azione.
+- **Contrasto AAA-targeting**: paragrafo tradotto usa coppia colore con ratio ≥7:1 (vs AA standard 4.5:1), centrato, max-width 65ch per leggibilità.
+
+**Acceptance criteria**:
+- [ ] 4 step espliciti, label IT
+- [ ] Skeleton dimensionato + shimmer animato + `prefers-reduced-motion` fallback statico
+- [ ] Abort visibile da step 2
+- [ ] Token-by-token rendering in step 3
+- [ ] Latency targets nei commenti HTML
+- [ ] Reader mode toggle (16pt ↔ 24pt) persistito + applicato a skeleton + paragrafo finale
+- [ ] Wake-lock indicator 🔆 con override manuale
+- [ ] Contrasto paragrafo tradotto AAA-target (≥7:1)
+- [ ] Light + dark + mobile + desktop
+
+---
+
+## 4. Section 1c — Glossario conflict / merge / context
+
+**File target**: estensione di `nanolith-runthrough-glossary-editor.html` (component-mock) + twin `sp6-libro-game-glossary-editor.jsx`.
+
+**Modello dati proposto** (riflesso nei mockup):
+
+```
+GlossaryEntry {
+  term: "sentinel"
+  base_definition: "soldato di guardia"          ← primary
+  contexts: [
+    { book_id: "press-start", definition: null,  ← uses base
+      first_seen: paragraph_id_X },
+    { book_id: "rules-game", definition: "punto di osservazione strategica",  ← variant
+      first_seen: paragraph_id_Y }
+  ]
+}
+```
+
+**4 sub-screen da aggiungere**:
+
+| Sub-screen | Trigger | UI |
+|---|---|---|
+| `conflict-dialog` | OCR trova parola già nel glossario con `context_similarity < 0.85` | Modal con 3 CTA: ① *"Mantieni esistente"* (default) · ② *"Sostituisci"* · ③ *"Aggiungi variante"* |
+| `bulk-import-card` | OCR trova ≥3 parole nuove non-glossario in un paragrafo | Inline card sotto traduzione: *"5 nuove parole rilevate"* + chip preview + CTA *"Aggiungi tutte"* / *"Rivedi"* (modal multi-select) |
+| `variant-expansion` | Click su term con `contexts.length > 1` | Row espande mostrando N varianti con book badge + definition specifica. Collapse-by-default per density |
+| `filter-strip + context-badges` | Sempre visibile in glossary index | Header con: search by term/def/book · filter by book (chip multi-select) · filter "solo con varianti" toggle · ogni term row mostra `📖 Press Start` + `📖 Rules Game` badges |
+
+**Pattern decisions**:
+- **Default conflict resolution**: auto-keep esistente se `context_similarity ≥ 0.85` (silenzioso); mostra dialog solo `< 0.85`.
+- **Context similarity**: server-side via embedding cosine (riusa `IEmbeddingService`); threshold `0.85` documentato.
+- **Bulk import trigger**: `≥3` parole, non `≥1` — evita card-fatigue su paragrafi corti.
+- **Variant deletion**: utente può eliminare singola variante; se elimina l'ultima, term torna single-context.
+
+**Decisione architetturale incidentale** (Fowler): il modello `GlossaryEntry` con `contexts[]` implica backend schema migration su `glossary_entries`. Il mockup *propone* il modello; l'implementazione backend è separata (issue/spec a parte, non in questo design).
+
+**Acceptance criteria**:
+- [ ] 4 sub-screen documentate
+- [ ] Threshold `context-similarity = 0.85` annotato
+- [ ] Bulk import threshold `≥3` annotato
+- [ ] Variant expansion/collapse + filter strip + context badges
+- [ ] Twin `.jsx` aggiornato di pari passo
+- [ ] Light + dark + mobile + desktop
+- [ ] MOCKUPS_INDEX resta `component-mock`
+
+---
+
+## 5. Section 1d — Multi-language source + manual fallback
+
+**File target**: estensione di `nanolith-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` + twin `sp6-libro-game-translation-viewer.jsx`.
+
+**Source language model**:
+
+- Auto-detect via LLM su OCR result (riusa stessa call di AI translation)
+- `confidence < 0.5` → trigger `source-lang-unknown` di sezione 1a (forza override)
+- `confidence 0.5-0.8` → badge tap-to-confirm prima di translate
+- `confidence > 0.8` → badge informativo, no friction
+
+**Lingue supportate v1**: EN · FR · DE · ES · IT (sorgente). Target = **IT fisso** (derivato da setting profilo). Multi-target out-of-scope v1.
+
+**3 sub-screen da aggiungere**:
+
+| Sub-screen | Trigger | UI |
+|---|---|---|
+| `lang-detection-badge` | Post OCR step 2 | Header pill *"Sorgente: EN · Conferma o cambia"* (top-right). Click → dropdown override |
+| `lang-override-modal` | Tap su badge | Modal radio 5 lingue + CTA *"Conferma e ritraduci"* (re-trigger step 3, skip step 2 OCR cache hit) |
+| `manual-input-mode` | Triple-entry (vedi sotto) | Layout translate-viewer SENZA foto thumbnail: textarea multiline (max 2000 char + counter) · lang dropdown pre-filled last-used · book ref pre-filled current campaign · CTA submit → skip OCR, va direttamente step 3 |
+
+**Manual mode — triple-entry discoverability** (Cockburn: actor variations):
+1. CTA *"Digita manualmente"* in error state `photo-blur-pre-ocr` (sezione 1a)
+2. Kebab menu `⋮` del camera step
+3. Empty state quando `/translate` aperto senza foto: card *"Libro non a portata? Digita il paragrafo"*
+
+Route invariata, query param `?mode=manual` per deeplink/share.
+
+**Pattern decisions**:
+- **Target lang fixed IT v1**: scope-cut intenzionale (multi-target = lang pairs N², complessità esponenziale).
+- **5 lingue v1**: copre ~95% libri-game europei.
+- **Manual mode parity**: stessi step 3-4 della sezione 1b. Unica diff = step 2 OCR sostituito da textarea.
+- **Source method tracking**: ogni traduzione persistita con `source_method: "ocr" | "manual"` per analytics futuro.
+- **Override re-translate**: lang change post-fact preserva OCR result (cache hit) — re-translate solo step AI. Token saving.
+
+**Decisione architetturale incidentale** (Fowler): `?mode=manual` come query param vs sub-route `/translate/manual` — scelto **query param** perché stato `manual` è UI-only (no backend distinto) e mantiene `useThreadMessages` deeplink-friendly.
+
+**Acceptance criteria**:
+- [ ] 3 sub-screen documentate
+- [ ] 5 lingue sorgente (EN, FR, DE, ES, IT) · target IT fisso v1
+- [ ] Manual mode con triple-entry discoverability
+- [ ] Length limit 2000 char + counter
+- [ ] `source_method` tracked nello stato
+- [ ] OCR result preservato su lang override (no re-OCR)
+- [ ] `?mode=manual` query param per deeplink
+- [ ] Twin `.jsx` aggiornato
+- [ ] MOCKUPS_INDEX resta `page-mock`
+- [ ] Light + dark + mobile + desktop
+
+---
+
+## 6. Section 2 — B11b Chat full-screen (carry-over #491)
+
+**File target**: nuovo `admin-mockups/design_files/chat-fullscreen.html` + twin `.jsx`.
+**NOTA**: NON estendere `nanolith-nav-chat-panel.html` (resta `component-mock` slide-over per cross-page quick-access).
+
+**Route impattate**: `/chat/[threadId]` (page-mock principale) · `/chat/new` (empty state)
+
+### 6.1 Screen B11b-1 — Desktop 3-col (1280px)
+
+| Colonna | Width | Contenuto |
+|---|---|---|
+| Sidebar sx | 260px | Thread list tabs (`Tutti`/`Preferiti`/`Archiviati`) + search + new-thread CTA + filter by agent |
+| Main center | ~720px | Chat stream bubble + typing indicator + composer multiline autoresize bottom |
+| Sidebar dx | 260px | Context panel: agent info mini-card + cited sources list + suggested actions |
+
+### 6.2 Screen B11b-2 — Mobile (375)
+
+- Header sticky: ← back + thread title + agent avatar
+- Message stream scroll
+- Bottom composer fixed (collapse autoresize 1-row default)
+- Tap header → bottom sheet context panel
+- Tap citation pill → PDF viewer overlay full-screen
+
+### 6.3 Screen B11b-3 — Empty state (`/chat/new`)
+
+Hero *"Inizia una conversazione"* + 4 quick-starter cards **adattate per agent type**:
+
+| Agent type | Quick-starters |
+|---|---|
+| Libro-game (Aaron) | *"Quali sono le regole di [game]?"* · *"Spiega questa Encounter"* · *"Riassumi paragrafo X"* · *"Lista personaggi"* |
+| Boardgamer game-rules | *"Setup iniziale"* · *"Regole edge case"* · *"Strategie comuni"* · *"FAQ"* |
+| Default (no agent) | CTA *"Scegli un agent"* + dropdown picker prominent |
+
+### 6.4 Pattern decisions
+
+- **Slide-over vs full-screen routing**: automatico per viewport. Mobile/tablet (<1024px) → sempre full-screen (slide-over diventa drawer fallback). Desktop (≥1024px) → slide-over default, toggle *"View as full-screen"* nello slide-over header per immersive mode.
+- **Streaming**: token-by-token con AbortController, riusa `useThreadMessages` (PR#551). Cancel CTA visibile durante stream attivo.
+- **Citations**: pill click → `sp4-citation-pdf-viewer` overlay (reuse, NO fork).
+- **Attachment Aaron-specific**: foto inline apre flow translate (sezione 1b/1d) come quick-action; risposta translate ritorna come citation pill. Ponte chat ↔ translate.
+- **Voice**: UI placeholder, backend integration Whisper deferita (out of scope mockup).
+- **Quick-starter selection**: agent type da `agent.metadata.category` (verificare esistenza campo in `AgentDefinition` durante impl; se mancante, fallback graceful a *"Default (no agent)"* quick-starters).
+- **Reader mode + wake-lock** (per passive co-player, sezione 1.1.1): stesso toggle 📖 della sezione 3 (translate viewer) — applicabile a bubble dei messaggi (font 16pt → 24pt). Stessa `localStorage` key (`reader-mode-enabled`) → coerenza cross-route Aaron. Wake-lock attivo durante chat con streaming attivo.
+
+### 6.5 Stati di stream (Nygard — failure modes)
+
+- `idle` — empty composer
+- `streaming` — token-by-token + cancel CTA visibile
+- `stream-error` — banner *"Errore stream — riprova"* + last user message conservato in composer (no perdita)
+- `stream-abort` — utente click cancel → message preservato come *"[interrotto]"* badge
+
+**Acceptance criteria**:
+- [ ] 3 screen documentati (desktop 3-col, mobile, empty)
+- [ ] 4 stream stati (idle/streaming/error/abort) visibili
+- [ ] Citation pill → PDF overlay (sp4-citation-pdf-viewer reuse)
+- [ ] Quick-starter contestualizzati per agent type
+- [ ] Slide-over ↔ full-screen routing automatico per viewport
+- [ ] Attachment Aaron quick-translate bridge documentato
+- [ ] Voice come placeholder UI
+- [ ] Reader mode toggle 📖 (16pt ↔ 24pt) coerente con sezione 1b (stessa `localStorage` key)
+- [ ] Wake-lock attivo durante stream + override manuale
+- [ ] Reuse: `nanolith-nav-chat-panel` (slide-over secondary) · `sp4-citation-pdf-viewer` · `sp4-agent-detail` (mini)
+- [ ] Light + dark + mobile + desktop
+- [ ] MOCKUPS_INDEX nuovo entry `chat-fullscreen.html` (page-mock)
+
+---
+
+## 7. Section 3 — B18 State Matrix cross-route
+
+**File target**: nuovo `admin-mockups/design_files/state-matrix.html` (classificato `dev-fixture` come `01-screens.html`).
+
+### 7.1 Route × Stati grid (8 × 5)
+
+| Route | Segmento | Empty | Error | Loading | Permission | Offline |
+|---|---|---|---|---|---|---|
+| `/library/[gameId]/play/[campaignId]/translate` | Aaron CORE | "Fotografa una pagina" + camera CTA | sez 1a riuso | sez 1b 4-step skeleton | Tier-locked OCR quota | banner + last-translation cache |
+| `/library/[gameId]/play` | Aaron resume | "Nessuna campagna — inizia un libro" + library CTA | "Errore caricamento — riprova" | 3-card skeleton | — | banner + campagne cached |
+| `/chat/[threadId]` | Aaron + boardgamer | "Inizia conversazione" + quick-starters (sez 2) | sez 2 stream-error | typing indicator + skeleton bubble | Tier-locked chat quota | banner + msg history cached |
+| `/game-nights` | boardgamer | "Crea la prima serata" + new-night CTA | "Calendar non disponibile" | calendar skeleton 7d | — | banner + serate cached |
+| `/sessions/live/[sessionId]` | boardgamer | "Aspetta che host inizi" | SSE disconnect banner + reconnecting | spinner + game cover | "Solo l'host può iniziare — aspetta che la sessione si attivi" | banner — modalità local-only |
+| `/shared-games` | browser | "Catalog vuoto — riprova" | "Catalogo non disponibile" | card-grid 6-skeleton | — | banner + cached results |
+| `/discover` | browser cross | "Nessun consiglio ora" | "Discovery offline" | rail skeleton 3-row | — | banner + cached |
+| `/notifications` | cross-cutting | "Sei in pari!" | "Errore caricamento notifiche" | list skeleton | — | banner + cached |
+
+### 7.2 Pattern per stato (riusabili)
+
+**Empty**: icon 96px centrale + gradient bg entity color + tagline IT route-specific + primary CTA per uscire (mai dead-end).
+
+**Error**: riuso `nanolith-runthrough-error-states` (icon + message umano + retry + report-bug). Annotato in commento HTML head per traceability.
+
+**Loading skeleton**: 3-row card dimensionato al contenuto reale (3 game-cards per `/shared-games`, 7-day calendar per `/game-nights`, ecc.). Shimmer-sweep gradient. `prefers-reduced-motion` → fallback statico.
+
+**Permission-denied**: 🔒 lock + tier badge *"Pro"*/*"Premium"* + tagline *"Disponibile nei piani Pro/Premium"* + primary CTA *"Esplora piani"* → `/pricing` (route esistente ma senza mockup canonico — vedi audit gap; il link sarà dead-end visivo finché B13 non viene aperto) + secondary *"Torna indietro"*.
+
+**Offline**: banner top persistent (📡 WiFi-off + *"Offline — sto usando dati salvati"*) + cache-stale data a 80% opacity + retry inline.
+
+### 7.3 Pattern decisions
+
+- **Singolo matrix vs files separati**: **singolo file**. Density + visibility cross-route consistency batte file-fatigue. ~40 phone-frames in grid 8×5 scrollable.
+- **Mobile-only viewport**: come `01-screens.html`. Desktop pattern emerge nei page-mock dedicati. Burden ridotto a 40 vs 80 cell.
+- **Light/dark inline toggle**: button top destro swap mode. Evita 2 file paralleli.
+- **Illustration economy**: ~5 illustration uniche con sub-set tematici riusabili (*"book"*: translate+play · *"speak"*: chat+notifications · *"calendar"*: game-nights+sessions-live · *"compass"*: shared-games+discover).
+- **Permission-denied dummy**: solo 3 route ne hanno bisogno (translate, chat, sessions-live host-only); altre 5 = `—` (skip cell).
+- **Reuse trace**: ogni cell linka via commento HTML al pattern di origine.
+
+**Cross-segment value**: investimento mockup state-matrix ammortizza su tutti i raffinamenti futuri (Fase 2 boardgamer, Fase 3 community/wishlist). Foundation cross-cutting.
+
+**Acceptance criteria**:
+- [ ] 40 cell visibili in grid 8×5 phone-frame mobile 375
+- [ ] Light + dark toggle inline
+- [ ] 5 pattern per stato documentati riusabili
+- [ ] Tagline IT route-specific (no placeholder generici)
+- [ ] Reuse trace nei commenti HTML head per ogni pattern
+- [ ] Permission-denied applicato solo a 3 route
+- [ ] `prefers-reduced-motion` fallback per skeleton shimmer
+- [ ] MOCKUPS_INDEX nuovo entry `state-matrix.html` come `dev-fixture`
+
+---
+
+## 8. Out of scope
+
+| Brief | Razionale esclusione | Phase ripristino |
+|---|---|---|
+| B11 Play Records | Bloccante US-32 boardgamer, ma north-star = Aaron. Boardgamer riposizionato come secondary. | Phase 2 post-validazione demo Iter 1 |
+| B11a Community follow-up | Segmento community è secondary; #492 closure false-positive non blocca Aaron. | Phase 2 |
+| B14 Editor agent-proposals | Segmento AI builder parcheggiato (strategy ambigua). | Gated on AI builder strategy decision (no scheduled phase) |
+| B15 Toolkit sub-pages | Toolkit non-CORE per Aaron; boardgamer secondary. | Phase 3 |
+| B16 Library Wishlist | Cross-segment low-priority; impl attiva ma non bloccante. | Phase 3 |
+| B17 Sessions sub-pages | Boardgamer secondary + IA nodo N7 (consolidation decision) ancora aperto. | Phase 2 con prior N7 decision |
+
+**Nodi architetturali deferiti** (Phase 3):
+- N4 — routing duplicate `/private-games/[id]` vs `/library/private/[privateGameId]`
+- N6 — tabs vs routes per `/games/[id]/*`
+- N7 — sessions sub-route consolidation
+
+---
+
+## 9. Acceptance criteria globali
+
+- [ ] 6 sezioni mockup-work consegnate (1a, 1b, 1c, 1d, 2, 3)
+- [ ] 3 file modificati: `nanolith-runthrough-error-states.html`, `nanolith-runthrough-translate-viewer.html`, `nanolith-runthrough-glossary-editor.html` + 2 twin jsx aggiornati
+- [ ] 2 file nuovi: `chat-fullscreen.html`, `state-matrix.html` (+ jsx twins)
+- [ ] `admin-mockups/MOCKUPS_INDEX.md` aggiornato (count: 48 page-mock → 49, 16 component-mock invariato, 10 dev-fixture → 11)
+- [ ] `docs/for-developers/frontend/v2-migration-matrix.md` route mapping aggiornato
+- [ ] Tutti i mockup: light + dark mode, mobile 375 + desktop 1280, `prefers-reduced-motion` rispettato
+- [ ] Audit `2026-05-22-mockup-gaps.md` aggiornato a *"Phase 1 in implementation"* per le sezioni coperte
+- [ ] **Aaron actor variations** (sezione 1.1.1): reader mode toggle 📖 e wake-lock 🔆 coerenti cross-route (`translate-viewer`, `chat-fullscreen`, eventualmente `play-session`). Stessa `localStorage` key `reader-mode-enabled` per persistence.
+- [ ] **Contrasto AAA-target** sui paragrafi tradotti (≥7:1) — verificare con axe a livello mockup.
+
+## 10. Dependencies / decisioni architetturali incidentali
+
+Le seguenti decisioni emergono dal design mockup ma richiedono follow-up implementazione separato:
+
+1. **GlossaryEntry contexts model** (sezione 1c) — schema migration backend per supportare `contexts: []`. Spec backend separata, non in questo design.
+2. **Context similarity service** (sezione 1c) — `IEmbeddingService` riuso per cosine similarity threshold 0.85 — verificare costo token + latency.
+3. **`?mode=manual` query param** (sezione 1d) — pattern UI-only, no backend route distinta. Documentato come decisione esplicita.
+4. **Slide-over ↔ full-screen viewport routing** (sezione 2) — breakpoint 1024px hard-coded vs configurabile? Per ora hard-coded; reviewing post-implementazione.
+5. **Web Wake Lock API** (sezione 1.1.1 + 1b) — supportata: Chrome 84+, Safari 16.4+, Firefox 126+, Edge 84+. Su browser più vecchi (es. Safari < 16.4 su iPhone con iOS < 16.4) fallback graceful: badge 🔆 mostra *"Funzione non supportata — tieni schermo acceso manualmente"* + link a guida `prefers-reduced-motion`/auto-lock settings. Documentare nel mockup come edge case esplicito.
+6. **Reader mode `localStorage` key** (sezione 1.1.1 + 1b + 6.4) — `reader-mode-enabled` boolean, scope per-device (no sync server-side v1). Future: sync via `user_preferences` table se Aaron usa multi-device.
+
+## 11. Next steps
+
+1. **User review** di questo spec doc.
+2. **Writing-plans skill** → piano di implementazione dettagliato (file-by-file, ordine, agenti coinvolti).
+3. **Workflow design produzione mockup**: Claude Design web (Approccio B descritto in audit 2026-05-22 — brief estratti dalle sezioni 1-3 di questo doc).
+4. **Phase 2 trigger**: post-validazione demo Iter 1 → re-evaluate boardgamer priority → decidere se sbloccare B11/B17.
+
+## 12. References
+
+- [`docs/for-developers/audits/2026-05-22-mockup-gaps.md`](../../for-developers/audits/2026-05-22-mockup-gaps.md) — audit fonte
+- [`admin-mockups/MOCKUPS_INDEX.md`](../../../admin-mockups/MOCKUPS_INDEX.md) — inventario mockup
+- [`docs/for-developers/frontend/v2-migration-matrix.md`](../../for-developers/frontend/v2-migration-matrix.md) — route→mockup matrix
+- [`docs/superpowers/specs/2026-05-07-libro-game-nanolith-demo-design.md`](./2026-05-07-libro-game-nanolith-demo-design.md) — Iter 1 design Aaron persona
+- Issue #491 (closure parziale chat full-screen) · #492 (closure false-positive community)
+- PR #1056 (`nanolith-runthrough-error-states` pattern) · PR #551 (`useThreadMessages` hook)


### PR DESCRIPTION
## Summary

Implementazione Phase 1 del piano di raffinamento mockup secondo l'Approccio B (Aaron core + cross-cutting foundation):

- **Sezione 1a-1d** — cluster translate (Aaron JTBD #1): 4 mockup estesi con failure modes (6 nuovi stati), loading multi-step + reader mode + wake-lock, glossary context-aware, multi-language source + manual fallback
- **Sezione 2 (B11b)** — nuovo `chat-fullscreen.html` (3 screen: desktop 3-col + mobile + empty) — chiude parzialmente #491
- **Sezione 3 (B18)** — nuovo `state-matrix.html` (8 route × 5 stati = 40 cell, foundation per Phase 2/3)
- **Documentazione** — MOCKUPS_INDEX +2 entry (76 total), v2-migration-matrix aggiornata, audit `2026-05-22-mockup-gaps` marcato Phase 1 in implementation; fix naming `nanolith-runthrough` → `librogame-runthrough` (index + matrix)

## Spec di riferimento

`docs/superpowers/specs/2026-05-23-mockup-refinement-aaron-core-design.md`

## Out of scope

B11 play-records · B11a community follow-up · B14 editor agent-proposals · B15 toolkit sub-pages · B16 wishlist · B17 sessions sub-pages — deferiti a Phase 2/3.

## Note di implementazione

- `state-matrix.html` usa `class="frame ec-*"` (entity-color) per le 40 celle, non `phone-frame` (termine descrittivo del piano, mai usato come classe nel codebase). Griglia 8×5 verificata: 40 frame, 5 stati, toggle tema, `prefers-reduced-motion`.

## Test plan

- [ ] Visual review mockup nel browser: light + dark + mobile 375 + desktop 1280
- [ ] Verifica `prefers-reduced-motion` rispettato (skeleton shimmer fallback)
- [ ] Verifica reader mode toggle persistito in localStorage
- [ ] Verifica wake-lock indicator graceful degradation Safari <16.4
- [ ] Verifica contrasto AAA (≥7:1) sui paragrafi tradotti (axe / DevTools)
- [ ] Verifica reference cross-linking nei commenti HTML head

🤖 Generated with [Claude Code](https://claude.com/claude-code)