### PR TITLE
feat(game-detail): GameDetailSpecsCard + buildSpecsItems helper (#1463)

### DIFF
--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -34,7 +34,9 @@ import {
   GameDetailKpiCards,
   GameDetailRulesAccordion,
   GameDetailSessionsRail,
+  GameDetailSpecsCard,
   GameDetailTabsAnimated,
+  buildSpecsItems,
   panelIdFor,
   tabIdFor,
   type AgentsState,
@@ -384,6 +386,8 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
   const tabsConfig = buildTabsConfig(t);
   const heroMeta = buildHeroMeta(safeDetail);
   const kpiCards = buildKpiCards(safeDetail, t);
+  const specsItems = buildSpecsItems(safeDetail, t);
+  const specsTitle = t('pages.gameDetail.info.specsTitle');
 
   const heroVariant = safeDetail.libraryEntryId ? 'own' : 'community';
   const heroLabels = {
@@ -547,6 +551,7 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
         >
           <div className="flex flex-col gap-6">
             <GameDetailKpiCards cards={kpiCards} />
+            <GameDetailSpecsCard items={specsItems} title={specsTitle} />
             {/* FAQ inline preview (CTA links to subroute) */}
             <GameDetailFaqList faqs={[]} viewAllHref={`/games/${gameId}/faqs`} labels={faqLabels} />
           </div>

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -196,6 +196,17 @@ const MESSAGES: Record<string, string> = {
   'pages.gameDetail.documents.statusProcessing': 'Elaborazione',
   'pages.gameDetail.documents.statusFailed': 'Errore',
   'pages.gameDetail.documents.statsLine': 'statistiche',
+  // Issue #1463 — GameDetailSpecsCard (rendered inline in info tab)
+  'pages.gameDetail.info.specsTitle': 'Specifiche',
+  'pages.gameDetail.info.specsPlayers': 'Giocatori',
+  'pages.gameDetail.info.specsDuration': 'Durata',
+  'pages.gameDetail.info.specsAge': 'Eta',
+  'pages.gameDetail.info.specsComplexity': 'Complessita',
+  'pages.gameDetail.info.specsYear': 'Anno',
+  'pages.gameDetail.info.specsDesigner': 'Designer',
+  'pages.gameDetail.info.specsPublisher': 'Editore',
+  'pages.gameDetail.info.specsRatingBgg': 'Rating BGG',
+  'pages.gameDetail.info.specsMinutesUnit': 'min',
 };
 
 function renderWithIntl(ui: ReactElement) {

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -476,6 +476,10 @@ describe('GameDetailView — FSM integration tests (Phase 0.5 contract)', () => 
     const kpiCards = document.querySelector('[data-slot="game-detail-kpi-cards"]');
     expect(kpiCards).toBeInTheDocument();
 
+    // Specs card inside info panel (Issue #1463 — regression guard)
+    const specsCard = document.querySelector('[data-slot="game-detail-specs-card"]');
+    expect(specsCard).toBeInTheDocument();
+
     // Agents panel hidden (tab=info)
     const agentsPanel = document.querySelector('[data-slot="game-detail-panel-agents"]');
     expect(agentsPanel).toBeInTheDocument();

--- a/apps/web/src/components/features/game-detail/GameDetailSpecsCard.stories.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailSpecsCard.stories.tsx
@@ -1,0 +1,117 @@
+/**
+ * GameDetailSpecsCard Storybook Stories (Issue #1463)
+ *
+ * Visual fixtures for Chromatic / story-coverage.
+ * Covers: default full data, null cascade, empty state, custom title, long values truncation.
+ * Dark theme variant gestito globalmente via `withThemeByClassName` decorator in
+ * `apps/web/.storybook/preview.tsx` (toolbar toggle — no story dedicato necessario).
+ */
+
+import { GameDetailSpecsCard, type GameDetailSpecsItem } from './GameDetailSpecsCard';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const fullItems: ReadonlyArray<GameDetailSpecsItem> = [
+  { key: 'players', label: 'Giocatori', value: '1–5' },
+  { key: 'duration', label: 'Durata', value: '70 min' },
+  { key: 'age', label: 'Età', value: '14+' },
+  { key: 'complexity', label: 'Complessità', value: '2.4 / 5' },
+  { key: 'year', label: 'Anno', value: '2017' },
+  { key: 'designer', label: 'Designer', value: 'Stefan Feld' },
+  { key: 'publisher', label: 'Editore', value: 'Kosmos' },
+  { key: 'rating', label: 'Rating BGG', value: '8.1' },
+];
+
+const nullCascadeItems: ReadonlyArray<GameDetailSpecsItem> = [
+  { key: 'players', label: 'Giocatori', value: '1–5' },
+  { key: 'duration', label: 'Durata', value: '—' },
+  { key: 'age', label: 'Età', value: '—' },
+  { key: 'complexity', label: 'Complessità', value: '—' },
+  { key: 'year', label: 'Anno', value: '—' },
+  { key: 'designer', label: 'Designer', value: '—' },
+  { key: 'publisher', label: 'Editore', value: '—' },
+  { key: 'rating', label: 'Rating BGG', value: '—' },
+];
+
+const longValueItems: ReadonlyArray<GameDetailSpecsItem> = [
+  ...fullItems.slice(0, 5),
+  {
+    key: 'designer',
+    label: 'Designer',
+    value: 'Bruno Cathala-Antoine Bauza-Klaus Teuber',
+  },
+  {
+    key: 'publisher',
+    label: 'Editore',
+    value: 'Hans im Glück Verlags-GmbH (Germany Edition)',
+  },
+  { key: 'rating', label: 'Rating BGG', value: '8.1' },
+];
+
+const meta = {
+  title: 'Components/GameDetail/GameDetailSpecsCard',
+  component: GameDetailSpecsCard,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Presentational grid of 8 game specs items. Renders one listitem per `items` entry with uppercase mono label + display-font value. Pure component — formatting via `buildSpecsItems(detail, t)` helper sibling. DS-15 compliant.',
+      },
+    },
+    chromatic: {
+      viewports: [375, 768, 1024],
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="w-full max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GameDetailSpecsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+/** Default state — all 8 specs populated with realistic data. */
+export const Default: Story = {
+  args: {
+    items: fullItems,
+  },
+};
+
+/** Null cascade — most fields missing from BE, em-dash placeholders preserve grid layout. */
+export const WithNullables: Story = {
+  args: {
+    items: nullCascadeItems,
+  },
+};
+
+/** Edge state — empty items array still renders title + container (no listitems). */
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};
+
+/** i18n override — caller passes custom title (default fallback `'Specifiche'`). */
+export const CustomTitle: Story = {
+  args: {
+    items: fullItems,
+    title: 'Stats',
+  },
+};
+
+/** Long values truncation — `line-clamp-1` prevents overflow on designer/publisher cells. */
+export const LongDesignerName: Story = {
+  args: {
+    items: longValueItems,
+  },
+};

--- a/apps/web/src/components/features/game-detail/GameDetailSpecsCard.stories.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailSpecsCard.stories.tsx
@@ -84,6 +84,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     items: fullItems,
+    title: 'Specifiche',
   },
 };
 
@@ -91,6 +92,7 @@ export const Default: Story = {
 export const WithNullables: Story = {
   args: {
     items: nullCascadeItems,
+    title: 'Specifiche',
   },
 };
 
@@ -98,10 +100,11 @@ export const WithNullables: Story = {
 export const Empty: Story = {
   args: {
     items: [],
+    title: 'Specifiche',
   },
 };
 
-/** i18n override — caller passes custom title (default fallback `'Specifiche'`). */
+/** i18n override — caller passes a different localized title (e.g. EN locale or alternate UX label). */
 export const CustomTitle: Story = {
   args: {
     items: fullItems,
@@ -113,5 +116,6 @@ export const CustomTitle: Story = {
 export const LongDesignerName: Story = {
   args: {
     items: longValueItems,
+    title: 'Specifiche',
   },
 };

--- a/apps/web/src/components/features/game-detail/GameDetailSpecsCard.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailSpecsCard.tsx
@@ -1,0 +1,68 @@
+/**
+ * GameDetailSpecsCard - Wave C.1 follow-up (Issue #1463)
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-detail.jsx` (SpecsCard, lines 381-420).
+ * Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+ * Tracking: docs/frontend/v2-migration-matrix.md (Issue #573); design-handoff PILOT_GAP_REPORT § 2.1
+ *
+ * Pure presentational grid of N (default 8) game specs items. Each item renders a
+ * uppercase mono label + display-font value. Consumer formats `value` upstream via
+ * `buildSpecsItems(detail, t)` helper sibling (mirror `buildKpiCards()` pattern).
+ *
+ * AC: T A V (no animation, no V change beyond responsive grid).
+ * Pattern conformance vs sibling `GameDetailKpiCards.tsx` (8 invariants — see AC-3).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+const DEFAULT_TITLE = 'Specifiche';
+
+export interface GameDetailSpecsItem {
+  readonly key: string;
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface GameDetailSpecsCardProps {
+  readonly items: ReadonlyArray<GameDetailSpecsItem>;
+  readonly title?: string;
+  readonly className?: string;
+}
+
+export function GameDetailSpecsCard(props: GameDetailSpecsCardProps): ReactElement {
+  const { items, title = DEFAULT_TITLE, className } = props;
+
+  return (
+    <section
+      data-slot="game-detail-specs-card"
+      className={clsx('rounded-2xl border border-border bg-card p-[18px] shadow-sm', className)}
+    >
+      <h3 className="mb-3.5 font-display text-[15px] font-extrabold text-foreground">{title}</h3>
+      <div
+        role="list"
+        aria-label={title}
+        className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3"
+      >
+        {items.map(item => (
+          <div
+            key={item.key}
+            role="listitem"
+            data-slot="game-detail-specs-item"
+            data-spec-key={item.key}
+          >
+            <div className="mb-[3px] font-mono text-[9px] font-extrabold uppercase tracking-[0.08em] text-muted-foreground">
+              {item.label}
+            </div>
+            <div className="line-clamp-1 font-display text-[14px] font-extrabold text-foreground">
+              {item.value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-detail/GameDetailSpecsCard.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailSpecsCard.tsx
@@ -19,8 +19,6 @@ import type { ReactElement } from 'react';
 
 import clsx from 'clsx';
 
-const DEFAULT_TITLE = 'Specifiche';
-
 export interface GameDetailSpecsItem {
   readonly key: string;
   readonly label: string;
@@ -29,12 +27,17 @@ export interface GameDetailSpecsItem {
 
 export interface GameDetailSpecsCardProps {
   readonly items: ReadonlyArray<GameDetailSpecsItem>;
-  readonly title?: string;
+  /**
+   * Localized card title (e.g. via `t('pages.gameDetail.info.specsTitle')`).
+   * Required: caller MUST resolve i18n string upstream to keep the component
+   * pure and locale-agnostic (no Italian hardcoded fallback).
+   */
+  readonly title: string;
   readonly className?: string;
 }
 
 export function GameDetailSpecsCard(props: GameDetailSpecsCardProps): ReactElement {
-  const { items, title = DEFAULT_TITLE, className } = props;
+  const { items, title, className } = props;
 
   return (
     <section

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailSpecsCard.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailSpecsCard.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * GameDetailSpecsCard - Unit tests (Issue #1463).
+ *
+ * Test matrix (Crispin, T1-T6):
+ *   T1. Render baseline 8 items.
+ *   T2. data-slot + data-spec-key attributes present.
+ *   T3. role=list + aria-label localized.
+ *   T4. Custom title prop override.
+ *   T5. Empty items array (edge state).
+ *   T6. className composition.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GameDetailSpecsCard, type GameDetailSpecsItem } from '../GameDetailSpecsCard';
+
+const eightItems: ReadonlyArray<GameDetailSpecsItem> = [
+  { key: 'players', label: 'Giocatori', value: '1–5' },
+  { key: 'duration', label: 'Durata', value: '70 min' },
+  { key: 'age', label: 'Età', value: '14+' },
+  { key: 'complexity', label: 'Complessità', value: '2.4 / 5' },
+  { key: 'year', label: 'Anno', value: '2017' },
+  { key: 'designer', label: 'Designer', value: 'Stefan Feld' },
+  { key: 'publisher', label: 'Editore', value: 'Kosmos' },
+  { key: 'rating', label: 'Rating BGG', value: '8.1' },
+];
+
+describe('GameDetailSpecsCard (Issue #1463)', () => {
+  // T1
+  it('renders one listitem per entry (default 8 items)', () => {
+    render(<GameDetailSpecsCard items={eightItems} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(8);
+  });
+
+  it('renders labels and values', () => {
+    render(<GameDetailSpecsCard items={eightItems} />);
+    expect(screen.getByText('Giocatori')).toBeInTheDocument();
+    expect(screen.getByText('1–5')).toBeInTheDocument();
+    expect(screen.getByText('Rating BGG')).toBeInTheDocument();
+    expect(screen.getByText('8.1')).toBeInTheDocument();
+  });
+
+  // T2
+  it('exposes data-slot and data-spec-key for E2E selectors', () => {
+    const { container } = render(<GameDetailSpecsCard items={eightItems} />);
+    expect(container.querySelector('[data-slot="game-detail-specs-card"]')).toBeInTheDocument();
+    const itemSlots = container.querySelectorAll('[data-spec-key]');
+    expect(itemSlots).toHaveLength(8);
+    expect(container.querySelector('[data-spec-key="rating"]')).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders role=list with aria-label matching title (default)', () => {
+    render(<GameDetailSpecsCard items={eightItems} />);
+    const list = screen.getByRole('list', { name: /specifiche/i });
+    expect(list).toBeInTheDocument();
+  });
+
+  // T4
+  it('honors custom title prop and propagates to aria-label', () => {
+    render(<GameDetailSpecsCard items={eightItems} title="Stats" />);
+    expect(screen.getByRole('heading', { name: 'Stats' })).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: /stats/i })).toBeInTheDocument();
+  });
+
+  // T5
+  it('renders title but no listitems when items array is empty', () => {
+    render(<GameDetailSpecsCard items={[]} title="Empty" />);
+    expect(screen.getByRole('heading', { name: 'Empty' })).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+
+  // T6
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <GameDetailSpecsCard items={eightItems} className="extra-spacing" />
+    );
+    const section = container.querySelector('[data-slot="game-detail-specs-card"]');
+    expect(section).toHaveClass('extra-spacing');
+    // Base classes preserved
+    expect(section).toHaveClass('bg-card');
+    expect(section).toHaveClass('border-border');
+  });
+
+  it('uses DS-15 compliant semantic tokens only (text-foreground / text-muted-foreground)', () => {
+    const { container } = render(<GameDetailSpecsCard items={eightItems} />);
+    // Heading uses text-foreground
+    const heading = container.querySelector('h3');
+    expect(heading).toHaveClass('text-foreground');
+    // First label uses text-muted-foreground (mono uppercase)
+    const firstLabel = container.querySelector('[data-spec-key="players"] .font-mono');
+    expect(firstLabel).toHaveClass('text-muted-foreground');
+  });
+});

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailSpecsCard.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailSpecsCard.test.tsx
@@ -29,13 +29,13 @@ const eightItems: ReadonlyArray<GameDetailSpecsItem> = [
 describe('GameDetailSpecsCard (Issue #1463)', () => {
   // T1
   it('renders one listitem per entry (default 8 items)', () => {
-    render(<GameDetailSpecsCard items={eightItems} />);
+    render(<GameDetailSpecsCard items={eightItems} title="Specifiche" />);
     const items = screen.getAllByRole('listitem');
     expect(items).toHaveLength(8);
   });
 
   it('renders labels and values', () => {
-    render(<GameDetailSpecsCard items={eightItems} />);
+    render(<GameDetailSpecsCard items={eightItems} title="Specifiche" />);
     expect(screen.getByText('Giocatori')).toBeInTheDocument();
     expect(screen.getByText('1–5')).toBeInTheDocument();
     expect(screen.getByText('Rating BGG')).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe('GameDetailSpecsCard (Issue #1463)', () => {
 
   // T2
   it('exposes data-slot and data-spec-key for E2E selectors', () => {
-    const { container } = render(<GameDetailSpecsCard items={eightItems} />);
+    const { container } = render(<GameDetailSpecsCard items={eightItems} title="Specifiche" />);
     expect(container.querySelector('[data-slot="game-detail-specs-card"]')).toBeInTheDocument();
     const itemSlots = container.querySelectorAll('[data-spec-key]');
     expect(itemSlots).toHaveLength(8);
@@ -53,7 +53,7 @@ describe('GameDetailSpecsCard (Issue #1463)', () => {
 
   // T3
   it('renders role=list with aria-label matching title (default)', () => {
-    render(<GameDetailSpecsCard items={eightItems} />);
+    render(<GameDetailSpecsCard items={eightItems} title="Specifiche" />);
     const list = screen.getByRole('list', { name: /specifiche/i });
     expect(list).toBeInTheDocument();
   });
@@ -85,7 +85,7 @@ describe('GameDetailSpecsCard (Issue #1463)', () => {
   });
 
   it('uses DS-15 compliant semantic tokens only (text-foreground / text-muted-foreground)', () => {
-    const { container } = render(<GameDetailSpecsCard items={eightItems} />);
+    const { container } = render(<GameDetailSpecsCard items={eightItems} title="Specifiche" />);
     // Heading uses text-foreground
     const heading = container.querySelector('h3');
     expect(heading).toHaveClass('text-foreground');

--- a/apps/web/src/components/features/game-detail/__tests__/buildSpecsItems.test.ts
+++ b/apps/web/src/components/features/game-detail/__tests__/buildSpecsItems.test.ts
@@ -1,0 +1,167 @@
+/**
+ * buildSpecsItems - Unit tests (Issue #1463).
+ *
+ * Test matrix (Crispin, T7 + T8):
+ *   T7. Full data → all 8 items pre-formatted.
+ *   T8. Null cascade → 6/8 items '—' placeholder, 2/8 still formatted when present.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+
+import { buildSpecsItems } from '../buildSpecsItems';
+
+const t = (id: string): string => {
+  // Simulated i18n map mirroring `apps/web/src/locales/it.json` keys.
+  const dict: Record<string, string> = {
+    'pages.gameDetail.info.specsPlayers': 'Giocatori',
+    'pages.gameDetail.info.specsDuration': 'Durata',
+    'pages.gameDetail.info.specsAge': 'Età',
+    'pages.gameDetail.info.specsComplexity': 'Complessità',
+    'pages.gameDetail.info.specsYear': 'Anno',
+    'pages.gameDetail.info.specsDesigner': 'Designer',
+    'pages.gameDetail.info.specsPublisher': 'Editore',
+    'pages.gameDetail.info.specsRatingBgg': 'Rating BGG',
+    'pages.gameDetail.info.specsMinutesUnit': 'min',
+  };
+  return dict[id] ?? id;
+};
+
+function makeDetail(overrides: Partial<LibraryGameDetail> = {}): LibraryGameDetail {
+  return {
+    libraryEntryId: 'lib-1',
+    userId: 'user-1',
+    gameId: 'game-1',
+    addedAt: '2026-01-01T00:00:00Z',
+    notes: null,
+    isFavorite: false,
+    currentState: 'owned',
+    stateChangedAt: null,
+    stateNotes: null,
+    isAvailableForPlay: true,
+    hasCustomPdf: false,
+    hasRagAccess: false,
+    gameTitle: 'Test Game',
+    gamePublisher: null,
+    gameYearPublished: 2017,
+    gameIconUrl: null,
+    gameImageUrl: null,
+    description: null,
+    minPlayers: 1,
+    maxPlayers: 5,
+    playingTimeMinutes: 70,
+    minAge: 14,
+    complexityRating: 2.4,
+    averageRating: 8.1,
+    timesPlayed: 0,
+    lastPlayed: null,
+    winRate: null,
+    avgDuration: null,
+    designers: [{ id: 'd-1', name: 'Stefan Feld' }],
+    publishers: [{ id: 'p-1', name: 'Kosmos' }],
+    ...overrides,
+  };
+}
+
+describe('buildSpecsItems (Issue #1463)', () => {
+  // ─── T7: Full data ──────────────────────────────────────────────────────────
+  it('maps full LibraryGameDetail to 8 formatted spec items (T7)', () => {
+    const items = buildSpecsItems(makeDetail(), t);
+
+    expect(items).toHaveLength(8);
+
+    const byKey = Object.fromEntries(items.map(item => [item.key, item]));
+
+    expect(byKey.players).toEqual({ key: 'players', label: 'Giocatori', value: '1–5' });
+    expect(byKey.duration).toEqual({ key: 'duration', label: 'Durata', value: '70 min' });
+    expect(byKey.age).toEqual({ key: 'age', label: 'Età', value: '14+' });
+    expect(byKey.complexity).toEqual({
+      key: 'complexity',
+      label: 'Complessità',
+      value: '2.4 / 5',
+    });
+    expect(byKey.year).toEqual({ key: 'year', label: 'Anno', value: '2017' });
+    expect(byKey.designer).toEqual({ key: 'designer', label: 'Designer', value: 'Stefan Feld' });
+    expect(byKey.publisher).toEqual({ key: 'publisher', label: 'Editore', value: 'Kosmos' });
+    expect(byKey.rating).toEqual({ key: 'rating', label: 'Rating BGG', value: '8.1' });
+  });
+
+  it('renders players as single value when minPlayers === maxPlayers', () => {
+    const items = buildSpecsItems(makeDetail({ minPlayers: 4, maxPlayers: 4 }), t);
+    const players = items.find(item => item.key === 'players');
+    expect(players?.value).toBe('4');
+  });
+
+  it('renders only first designer when multiple co-authors present (D4 first-only)', () => {
+    const items = buildSpecsItems(
+      makeDetail({
+        designers: [
+          { id: 'd-1', name: 'Stefan Feld' },
+          { id: 'd-2', name: 'Klaus Teuber' },
+        ],
+      }),
+      t
+    );
+    const designer = items.find(item => item.key === 'designer');
+    expect(designer?.value).toBe('Stefan Feld');
+  });
+
+  it('falls back to gamePublisher when publishers array empty (D5)', () => {
+    const items = buildSpecsItems(
+      makeDetail({
+        publishers: [],
+        gamePublisher: 'Legacy Publisher Co.',
+      }),
+      t
+    );
+    const publisher = items.find(item => item.key === 'publisher');
+    expect(publisher?.value).toBe('Legacy Publisher Co.');
+  });
+
+  // ─── T8: Null cascade ───────────────────────────────────────────────────────
+  it('returns em-dash placeholder for all missing fields (T8 null cascade)', () => {
+    const items = buildSpecsItems(
+      makeDetail({
+        minPlayers: null,
+        maxPlayers: null,
+        playingTimeMinutes: null,
+        minAge: undefined,
+        complexityRating: null,
+        gameYearPublished: null,
+        designers: [],
+        publishers: [],
+        gamePublisher: null,
+        averageRating: null,
+      }),
+      t
+    );
+
+    expect(items).toHaveLength(8);
+    for (const item of items) {
+      expect(item.value).toBe('—');
+    }
+  });
+
+  it('preserves stable item order regardless of data presence (layout stability)', () => {
+    const items = buildSpecsItems(
+      makeDetail({
+        averageRating: null,
+        complexityRating: null,
+        minAge: undefined,
+      }),
+      t
+    );
+    const keys = items.map(item => item.key);
+    expect(keys).toEqual([
+      'players',
+      'duration',
+      'age',
+      'complexity',
+      'year',
+      'designer',
+      'publisher',
+      'rating',
+    ]);
+  });
+});

--- a/apps/web/src/components/features/game-detail/buildSpecsItems.ts
+++ b/apps/web/src/components/features/game-detail/buildSpecsItems.ts
@@ -1,0 +1,77 @@
+/**
+ * buildSpecsItems - Wave C.1 follow-up (Issue #1463)
+ *
+ * Helper that maps a `LibraryGameDetail` entity to the 8-item presentational
+ * shape consumed by `GameDetailSpecsCard`. Encapsulates:
+ *   - i18n label resolution via caller-provided `t()` function (react-intl wrapper)
+ *   - null cascade handling (rating/complexity/year/age/designer/publisher → '—')
+ *   - collection mapping (designers/publishers → first-only, mockup-faithful, D4)
+ *   - publisher fallback chain (D5: publishers[0] ?? gamePublisher ?? '—')
+ *
+ * Mirror of `buildKpiCards()` pattern (`apps/web/src/hooks/queries/useLibrary.ts:230`).
+ *
+ * Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
+ * Tracking: docs/frontend/v2-migration-matrix.md (Issue #573); design-handoff PILOT_GAP_REPORT § 2.1
+ */
+
+import type { GameDetailSpecsItem } from '@/components/features/game-detail/GameDetailSpecsCard';
+import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+
+type TranslateFn = (id: string) => string;
+
+const DASH = '—' as const;
+
+export function buildSpecsItems(detail: LibraryGameDetail, t: TranslateFn): GameDetailSpecsItem[] {
+  return [
+    {
+      key: 'players',
+      label: t('pages.gameDetail.info.specsPlayers'),
+      value:
+        detail.minPlayers != null && detail.maxPlayers != null
+          ? detail.minPlayers === detail.maxPlayers
+            ? String(detail.minPlayers)
+            : `${detail.minPlayers}–${detail.maxPlayers}`
+          : DASH,
+    },
+    {
+      key: 'duration',
+      label: t('pages.gameDetail.info.specsDuration'),
+      value:
+        detail.playingTimeMinutes != null
+          ? `${detail.playingTimeMinutes} ${t('pages.gameDetail.info.specsMinutesUnit')}`
+          : DASH,
+    },
+    {
+      key: 'age',
+      label: t('pages.gameDetail.info.specsAge'),
+      value: detail.minAge != null ? `${detail.minAge}+` : DASH,
+    },
+    {
+      key: 'complexity',
+      label: t('pages.gameDetail.info.specsComplexity'),
+      value: detail.complexityRating != null ? `${detail.complexityRating.toFixed(1)} / 5` : DASH,
+    },
+    {
+      key: 'year',
+      label: t('pages.gameDetail.info.specsYear'),
+      value: detail.gameYearPublished != null ? String(detail.gameYearPublished) : DASH,
+    },
+    // D4 first-only: mostra primo designer; co-autori non visibili (mockup-faithful)
+    {
+      key: 'designer',
+      label: t('pages.gameDetail.info.specsDesigner'),
+      value: detail.designers?.[0]?.name ?? DASH,
+    },
+    // D5 first-extended primary, denormalized fallback (private games path)
+    {
+      key: 'publisher',
+      label: t('pages.gameDetail.info.specsPublisher'),
+      value: detail.publishers?.[0]?.name ?? detail.gamePublisher ?? DASH,
+    },
+    {
+      key: 'rating',
+      label: t('pages.gameDetail.info.specsRatingBgg'),
+      value: detail.averageRating != null ? detail.averageRating.toFixed(1) : DASH,
+    },
+  ];
+}

--- a/apps/web/src/components/features/game-detail/buildSpecsItems.ts
+++ b/apps/web/src/components/features/game-detail/buildSpecsItems.ts
@@ -21,7 +21,10 @@ type TranslateFn = (id: string) => string;
 
 const DASH = '—' as const;
 
-export function buildSpecsItems(detail: LibraryGameDetail, t: TranslateFn): GameDetailSpecsItem[] {
+export function buildSpecsItems(
+  detail: LibraryGameDetail,
+  t: TranslateFn
+): ReadonlyArray<GameDetailSpecsItem> {
   return [
     {
       key: 'players',

--- a/apps/web/src/components/features/game-detail/index.ts
+++ b/apps/web/src/components/features/game-detail/index.ts
@@ -67,3 +67,11 @@ export type {
   GameDetailKbDocListProps,
   GameDetailKbStatus,
 } from '@/components/features/game-detail/GameDetailKbDocList';
+
+export { GameDetailSpecsCard } from '@/components/features/game-detail/GameDetailSpecsCard';
+export type {
+  GameDetailSpecsCardProps,
+  GameDetailSpecsItem,
+} from '@/components/features/game-detail/GameDetailSpecsCard';
+
+export { buildSpecsItems } from '@/components/features/game-detail/buildSpecsItems';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2322,6 +2322,11 @@
         "specsCategories": "Categories",
         "specsMechanics": "Mechanics",
         "specsBgg": "Catalog ID",
+        "specsPlayers": "Players",
+        "specsDuration": "Duration",
+        "specsComplexity": "Complexity",
+        "specsRatingBgg": "BGG Rating",
+        "specsMinutesUnit": "min",
         "noDescription": "No description available for this game."
       },
       "faqs": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2372,6 +2372,11 @@
         "specsCategories": "Categorie",
         "specsMechanics": "Meccaniche",
         "specsBgg": "Catalog ID",
+        "specsPlayers": "Giocatori",
+        "specsDuration": "Durata",
+        "specsComplexity": "Complessità",
+        "specsRatingBgg": "Rating BGG",
+        "specsMinutesUnit": "min",
         "noDescription": "Nessuna descrizione disponibile per questo gioco."
       },
       "faqs": {


### PR DESCRIPTION
Closes #1463

## Summary

Adds standalone **`GameDetailSpecsCard`** component identified as gap in
`PILOT_GAP_REPORT.md § 2.1` conformity check vs mockup `sp4-game-detail.jsx:381-420`.

Component renders 8 game specs (Giocatori / Durata / Età / Complessità / Anno /
Designer / Editore / Rating BGG) in responsive grid, integrated in `/games/[id]`
**Info tab** after `<GameDetailKpiCards />` (drill-down: 4 KPI → 8 specs).

## Architecture

| Layer | File | Responsibility |
|---|---|---|
| **Component** | `apps/web/src/components/features/game-detail/GameDetailSpecsCard.tsx` | Pure presentational. Accepts `items: ReadonlyArray<GameDetailSpecsItem>` (NOT raw entity). Mirror sibling `GameDetailKpiCards` pattern. |
| **Helper** | `apps/web/src/components/features/game-detail/buildSpecsItems.ts` | Maps `LibraryGameDetail` → 8 formatted items. Encapsulates i18n + null cascade + collection mapping. Mirror `buildKpiCards()`. |
| **Storybook** | `GameDetailSpecsCard.stories.tsx` | 5 stories: Default, WithNullables, Empty, CustomTitle, LongDesignerName. Dark theme via global `withThemeByClassName` decorator. |
| **Tests** | `__tests__/{GameDetailSpecsCard,buildSpecsItems}.test.ts(x)` | 14 scenarios total (6 helper + 8 component). |
| **Integration** | `GameDetailView.tsx` | Renders `<GameDetailSpecsCard items={specsItems} title={specsTitle} />` after KpiCards. |
| **i18n** | `locales/{it,en}.json` | 5 NEW keys extending existing `pages.gameDetail.info.specs*` namespace. |
| **Barrel** | `index.ts` | Exports `GameDetailSpecsCard`, `GameDetailSpecsCardProps`, `GameDetailSpecsItem`, `buildSpecsItems`. |

## Spec hardening (pre-impl)

Body issue hardenato via `/sc:spec-panel` 5-expert panel (Wiegers + Fowler +
Adzic + Crispin + Cockburn). Quality score **5.75/10 → 9.0/10**. 9 design
decisions ratified explicitly before any code written (pattern P69
spec-panel-pre-impl-on-stub-fresh-issue, 5° applicazione consecutiva).

See issue body + `issuecomment-4527981671` for full ratification trail.

## Deviations from hardened spec (documented, intentional)

### 1. i18n namespace — `pages.gameDetail.info.specs*` (existing) instead of new `pages.gameDetail.specs`

**Rationale**: discovery during impl revealed 5/10 target keys already exist as
dead-code scaffolding in `pages.gameDetail.info.specs*` (specsTitle,
specsDesigner, specsPublisher, specsYear, specsAge). Creating new namespace
would duplicate semantics. Extension chosen instead — 5 NEW keys added:
`specsPlayers`, `specsDuration`, `specsComplexity`, `specsRatingBgg`,
`specsMinutesUnit`. IT + EN parity. DE locale file does not exist in repo
(deferred follow-up if multi-locale gate added).

### 2. `useMemo` dropped — violated `react-hooks/rules-of-hooks`

**Rationale**: original spec proposed `const specsItems = useMemo(() =>
buildSpecsItems(safeDetail, t), [safeDetail, t])`. ESLint rule
`react-hooks/rules-of-hooks` flagged this as ERROR because `GameDetailView` has
early returns (FSM cells 1-4) BEFORE the memo line — hooks must be
unconditional. Reverted to direct call `const specsItems =
buildSpecsItems(safeDetail, t)` matching sibling `buildKpiCards(safeDetail, t)`
pattern at line 386. Helper is cheap pure function (8 string ops), no
memoization needed.

### 3. `GameDetailView.test.tsx` MESSAGES fixture extended

**Rationale**: integration introduced 10 new `t('pages.gameDetail.info.specs*')`
calls. Test uses `IntlProvider` with inline `MESSAGES` dict — missing keys
trigger `console.error('[@formatjs/intl] Missing message…')`. `vitest.setup.tsx`
console wrapper accumulates string args → eventually `RangeError: Invalid
string length` → worker timeout → 10/19 tests fail. Added 10 NEW keys to
MESSAGES dict in same test file (mirror runtime locale `it.json`).

**NEW pattern P71 captured**: i18n-test-message-sync — when adding new `t()`
calls to a component rendered by tests with mocked `IntlProvider`, the test's
MESSAGES dict MUST be extended with same keys to prevent React Intl
missing-message console.error accumulation → vitest worker overflow.

## Test Results

| Suite | Result |
|---|---|
| `buildSpecsItems` (helper) | **6/6 GREEN** (T7 full + T8 null cascade + 4 edge: players single, designer first-only D4, publisher fallback D5, layout order) |
| `GameDetailSpecsCard` (component) | **8/8 GREEN** (T1 baseline + T2 data-slot/data-spec-key + T3 a11y role/aria-label + T4 custom title + T5 empty + T6 className composition + 2 bonus: labels visible + DS-15 token check) |
| `game-detail/*` sibling family | **71/71 GREEN** (10 test files, 14 new + 57 sibling untouched) |
| `GameDetailView.test.tsx` regression | **19/19 GREEN** (post MESSAGES fixture extension) |
| `pnpm typecheck` | **PASS** |
| `pnpm lint` | **0 errors**, 51 warnings (all preexisting on other files) |

## Pattern conformance vs sibling `GameDetailKpiCards` (8 invariants)

1. ✅ JSDoc header with `mapped-from`, `spec`, `tracking` references
2. ✅ `'use client'` directive
3. ✅ `import type { ReactElement } from 'react'` + explicit return type
4. ✅ `clsx` for className composition
5. ✅ `data-slot="game-detail-specs-card"` on container (E2E selector)
6. ✅ `data-spec-key="<key>"` on each item (sub-selector)
7. ✅ `role="list"` + `role="listitem"` + `aria-label` localized
8. ✅ Font tokens: `font-mono` (label uppercase 9px) + `font-display` (value 14px extrabold)

## DS-15 compliance

ESLint rule `local/no-hardcoded-color-utility` (error mode dal 2026-05-12) PASS.
Only semantic tokens used: `bg-card`, `border-border`, `text-foreground`,
`text-muted-foreground`. No `bg-white`/`bg-slate-*`/`text-gray-*`/`border-zinc-*`.

## Effort

**Realistic ~2h 50min** (vs original body 45min estimate, vs spec-panel 2h 20min):
- Component pure + helper + 14 tests + integration + Storybook + i18n + barrel: ~2h 15min
- Root-cause investigation `GameDetailView` regression (RangeError → MESSAGES fixture): ~35min

## Visual contract preserved (mockup-faithful)

- Card: `bg-card border border-border rounded-2xl shadow-sm p-[18px]` (mockup padding 18px)
- Title: `font-display text-[15px] font-extrabold text-foreground mb-3.5`
- Grid: `grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3`
- Item label: `font-mono text-[9px] font-extrabold uppercase tracking-[0.08em] text-muted-foreground mb-[3px]`
- Item value: `font-display text-[14px] font-extrabold text-foreground line-clamp-1` (truncates long designer/publisher names)

## Out-of-scope (deferred or separate issues)

- `GameDetailHouseRulesList` — PILOT_GAP_REPORT § 2.2 (separate issue)
- `GameDetailLeaderboard` — PILOT_GAP_REPORT § 2.3 (separate issue)
- `CommunityGate` / `InfoTabLocked` — PILOT_GAP_REPORT § 1.2 hybrid (separate issue)
- Co-authors designer/publisher rendering (D4 first-only ratified)
- Wave story-coverage bulk for remaining 8 `game-detail/*` sibling without `.stories.tsx` (opportunity sub-issue)
- DE locale i18n keys (file does not exist in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
