### PR TITLE
feat(lib): #1470 userHue + chore(lint): 49 → 0 warnings

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
@@ -27,6 +27,7 @@
 
 import { useMemo, useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
@@ -155,13 +156,13 @@ function NotFoundShell({
       </span>
       <h2 className="font-display text-[20px] font-extrabold text-foreground">{title}</h2>
       <p className="max-w-sm text-[14px] text-muted-foreground">{subtitle}</p>
-      <a
+      <Link
         href="/agents"
         data-slot="agent-detail-not-found-cta"
         className="inline-flex items-center gap-1.5 rounded-md border-none bg-violet-700 px-4 py-2.5 font-display text-[13px] font-extrabold text-white shadow-md transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {cta}
-      </a>
+      </Link>
     </div>
   );
 }
@@ -400,7 +401,10 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
   }
 
   // ── Default render — agent data guaranteed non-null (FSM cells 5-10) ───────
-  // TypeScript: effectiveKind === 'default' → real FSM ensures agentData != null
+  // TypeScript: effectiveKind === 'default' → real FSM ensures agentData != null.
+  // The non-null assertion is intentional and safe: every code path that reaches
+  // here has already validated agentData via deriveAgentDetailUiState.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FSM invariant
   const safeAgent = agentData!;
 
   // ── Tab config (variant controls locked state) ─────────────────────────────

--- a/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx
+++ b/apps/web/src/app/(authenticated)/gamebook/upload/_components/GamebookUploadClient.tsx
@@ -168,6 +168,18 @@ export function GamebookUploadClient(): JSX.Element {
   }
 
   // ── Step 2: photo upload ─────────────────────────────────────────────────
+  // Defensive guard: `step === 'upload'` always implies `gameId` is set
+  // (either from URL `initialGameId` or via `handleGameSelect`). This early
+  // return both narrows the type for `<PhotoUploader>` and protects against
+  // any future regression that would invalidate the invariant.
+  if (gameId == null) {
+    return (
+      <div className="space-y-6" data-testid="gamebook-wizard-pick">
+        <GamePicker onSelect={handleGameSelect} />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6" data-testid="gamebook-wizard-upload">
       {/* Back + game title */}
@@ -198,7 +210,7 @@ export function GamebookUploadClient(): JSX.Element {
         </p>
       </div>
 
-      <PhotoUploader gameId={gameId!} />
+      <PhotoUploader gameId={gameId} />
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -24,6 +24,7 @@
 
 import { useMemo, useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
@@ -190,13 +191,13 @@ function NotFoundShell({
       </span>
       <h2 className="font-display text-[20px] font-extrabold text-foreground">{title}</h2>
       <p className="max-w-sm text-[14px] text-muted-foreground">{subtitle}</p>
-      <a
+      <Link
         href="/games"
         data-slot="game-detail-not-found-cta"
         className="inline-flex items-center gap-1.5 rounded-md border-none bg-amber-700 px-4 py-2.5 font-display text-[13px] font-extrabold text-white shadow-md transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {cta}
-      </a>
+      </Link>
     </div>
   );
 }
@@ -379,8 +380,10 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
   }
 
   // ── Default render — detail guaranteed non-null (FSM cells 5-9) ──────────
-  // TypeScript: effectiveKind === 'default' → real FSM ensures detail != null
-  // fixture branch also guarantees detail != null
+  // TypeScript: effectiveKind === 'default' → real FSM ensures detail != null.
+  // The fixture branch also guarantees detail != null. The non-null assertion
+  // is intentional and safe: deriveGameDetailUiState has validated detail.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FSM invariant
   const safeDetail = detail!;
 
   const tabsConfig = buildTabsConfig(t);

--- a/apps/web/src/app/(authenticated)/games/[id]/chat/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/chat/page.tsx
@@ -1,10 +1,11 @@
 // TODO: implement this route (see docs/superpowers/specs/route-gap-analysis.md)
 // Mockup: sp4-game-chat-tab — AI chat tab embedded in the game detail view.
 // Redirects to the parent /games/[id] until chat is implemented as a sub-tab.
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useEffect } from 'react';
+
+import { useRouter, useParams } from 'next/navigation';
 
 export default function GameChatPlaceholderPage() {
   const router = useRouter();

--- a/apps/web/src/app/(authenticated)/knowledge-base/[id]/pdf/page.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/[id]/pdf/page.tsx
@@ -1,10 +1,11 @@
 // TODO: implement this route (see docs/superpowers/specs/route-gap-analysis.md)
 // Mockup: sp4-citation-pdf-viewer — inline PDF viewer for KB documents.
 // Redirects to the parent /knowledge-base/[id] until PDF viewer is built.
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useEffect } from 'react';
+
+import { useRouter, useParams } from 'next/navigation';
 
 export default function KbPdfPlaceholderPage() {
   const router = useRouter();
@@ -21,8 +22,7 @@ export default function KbPdfPlaceholderPage() {
     <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-8">
       <h1 className="text-2xl font-semibold text-foreground">Coming Soon</h1>
       <p className="text-muted-foreground">
-        This page is not yet implemented. Redirecting to{" "}
-        <code>/knowledge-base/{params.id}</code>...
+        This page is not yet implemented. Redirecting to <code>/knowledge-base/{params.id}</code>...
       </p>
     </main>
   );

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/GamesTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/GamesTabPanel.tsx
@@ -8,9 +8,10 @@
 
 'use client';
 
-import Link from 'next/link';
 import type { JSX } from 'react';
 import { useMemo } from 'react';
+
+import Link from 'next/link';
 
 export interface GamesTabPanelLabels {
   readonly title: string;
@@ -35,7 +36,7 @@ export function GamesTabPanel({
       Object.entries(gamePlayCounts)
         .filter(([, count]) => count > 0)
         .sort(([, a], [, b]) => b - a),
-    [gamePlayCounts],
+    [gamePlayCounts]
   );
 
   const isEmpty = ranked.length === 0;

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -35,6 +35,7 @@
 
 import { useMemo, type ReactElement } from 'react';
 
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
@@ -227,13 +228,13 @@ function NotFoundShell({
       </span>
       <h2 className="font-display text-[20px] font-extrabold text-foreground">{title}</h2>
       <p className="max-w-sm text-[14px] text-muted-foreground">{subtitle}</p>
-      <a
+      <Link
         href="/players"
         data-slot="player-detail-not-found-cta"
         className="inline-flex items-center gap-1.5 rounded-md border-none bg-violet-700 px-4 py-2.5 font-display text-[13px] font-extrabold text-white shadow-md transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {cta}
-      </a>
+      </Link>
     </div>
   );
 }
@@ -366,8 +367,10 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
   }
 
   // ── Default render — profile guaranteed non-null (FSM=default) ───────────
-  // TypeScript: effectiveKind === 'default' → real FSM ensures profile != null
-  // fixture branch also guarantees profile != null
+  // TypeScript: effectiveKind === 'default' → real FSM ensures profile != null.
+  // The fixture branch also guarantees profile != null. The non-null assertion
+  // is intentional and safe: derivePlayerDetailUiState has validated profile.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- FSM invariant
   const safeProfile = profile!;
   const safePlayerId = playerId ?? safeProfile.playerId;
 

--- a/apps/web/src/app/(authenticated)/players/[id]/_components/SessionsTabPanel.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/SessionsTabPanel.tsx
@@ -9,8 +9,9 @@
 
 'use client';
 
-import Link from 'next/link';
 import type { JSX } from 'react';
+
+import Link from 'next/link';
 
 import type { PlayerProfileFixture } from '@/lib/player-detail/player-detail-visual-test-fixture';
 

--- a/apps/web/src/app/(public)/faq-enhanced/page.tsx
+++ b/apps/web/src/app/(public)/faq-enhanced/page.tsx
@@ -1,17 +1,18 @@
 // TODO: implement this route (see docs/superpowers/specs/route-gap-analysis.md)
 // Mockup: sp3-faq-enhanced.jsx — functionality already implemented at /faq.
 // This placeholder exists so nav-map.md routes resolve; redirects to /faq.
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 export default function FaqEnhancedPlaceholderPage() {
   const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/faq");
+      router.replace('/faq');
     }, 2000);
     return () => clearTimeout(timer);
   }, [router]);

--- a/apps/web/src/app/(public)/legal/page.tsx
+++ b/apps/web/src/app/(public)/legal/page.tsx
@@ -1,17 +1,18 @@
 // TODO: implement this route (see docs/superpowers/specs/route-gap-analysis.md)
 // Mockup: sp3-legal.jsx — legal hub combining /terms and /privacy.
 // This placeholder redirects to /terms until a unified /legal hub is built.
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 export default function LegalPlaceholderPage() {
   const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/terms");
+      router.replace('/terms');
     }, 2000);
     return () => clearTimeout(timer);
   }, [router]);

--- a/apps/web/src/app/(public)/shared-game-detail/page.tsx
+++ b/apps/web/src/app/(public)/shared-game-detail/page.tsx
@@ -2,17 +2,18 @@
 // Mockup: sp3-shared-game-detail — public detail view for a shared game.
 // Canonically implemented at /shared-games/[id]; this slug-less variant
 // is a legacy mockup route. Redirects to /shared-games until an id is resolved.
-"use client";
+'use client';
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 export default function SharedGameDetailPlaceholderPage() {
   const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/shared-games");
+      router.replace('/shared-games');
     }, 2000);
     return () => clearTimeout(timer);
   }, [router]);

--- a/apps/web/src/app/admin/(dashboard)/agents/usage/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/agents/usage/page.tsx
@@ -26,6 +26,13 @@ import {
   RecentRequestsTable,
   type RecentRequestsFilters,
 } from '@/components/admin/usage/RecentRequestsTable';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
+import { Button } from '@/components/ui/primitives/button';
+import { createAdminClient } from '@/lib/api/clients/adminClient';
+import { isNotFoundError } from '@/lib/api/core/errors';
+import { HttpClient } from '@/lib/api/core/httpClient';
+
+import { TokenBalanceTab } from './token-balance-tab';
 
 const CostBreakdownPanel = dynamic(
   () => import('@/components/admin/usage/CostBreakdownPanel').then(m => m.CostBreakdownPanel),
@@ -35,13 +42,6 @@ const RequestTimelineChart = dynamic(
   () => import('@/components/admin/usage/RequestTimelineChart').then(m => m.RequestTimelineChart),
   { ssr: false, loading: () => <div className="h-48 animate-pulse rounded-lg bg-muted" /> }
 );
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
-import { Button } from '@/components/ui/primitives/button';
-import { createAdminClient } from '@/lib/api/clients/adminClient';
-import { isNotFoundError } from '@/lib/api/core/errors';
-import { HttpClient } from '@/lib/api/core/httpClient';
-
-import { TokenBalanceTab } from './token-balance-tab';
 
 // ─── Module-level client (stable reference, avoids re-creation on every render) ─
 

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -210,8 +210,11 @@ export default function MechanicAnalysesPage() {
   });
 
   // ========== Polling: analysis status ==========
+  // The queryFn only runs when `enabled: !!analysisId` is true; the non-null
+  // assertion is gated by that invariant.
   const statusQuery = useQuery<MechanicAnalysisStatusDto | null>({
     queryKey: ['mechanic-analysis', analysisId],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled: !!analysisId` gates execution
     queryFn: () => adminClient.getMechanicAnalysisStatus(analysisId!),
     enabled: !!analysisId,
     // Poll every 2s while the pipeline is running.
@@ -251,7 +254,12 @@ export default function MechanicAnalysesPage() {
   });
 
   const submitReviewMutation = useMutation({
-    mutationFn: () => adminClient.submitMechanicAnalysisForReview(analysisId!),
+    mutationFn: () => {
+      if (analysisId == null) {
+        throw new Error('analysisId is required to submit for review');
+      }
+      return adminClient.submitMechanicAnalysisForReview(analysisId);
+    },
     onSuccess: () => {
       setLifecycleError(null);
       queryClient.invalidateQueries({ queryKey: ['mechanic-analysis', analysisId] });
@@ -262,7 +270,12 @@ export default function MechanicAnalysesPage() {
   });
 
   const approveMutation = useMutation({
-    mutationFn: () => adminClient.approveMechanicAnalysis(analysisId!),
+    mutationFn: () => {
+      if (analysisId == null) {
+        throw new Error('analysisId is required to approve');
+      }
+      return adminClient.approveMechanicAnalysis(analysisId);
+    },
     onSuccess: () => {
       setLifecycleError(null);
       queryClient.invalidateQueries({ queryKey: ['mechanic-analysis', analysisId] });
@@ -273,11 +286,15 @@ export default function MechanicAnalysesPage() {
   });
 
   const suppressMutation = useMutation({
-    mutationFn: () =>
-      adminClient.suppressMechanicAnalysis(analysisId!, {
+    mutationFn: () => {
+      if (analysisId == null) {
+        throw new Error('analysisId is required to suppress');
+      }
+      return adminClient.suppressMechanicAnalysis(analysisId, {
         reason: suppressReason,
         requestSource: suppressSource,
-      }),
+      });
+    },
     onSuccess: () => {
       setLifecycleError(null);
       setSuppressOpen(false);

--- a/apps/web/src/components/admin/agent-builder/PromptEditorStep.tsx
+++ b/apps/web/src/components/admin/agent-builder/PromptEditorStep.tsx
@@ -7,13 +7,8 @@
 
 import { useState } from 'react';
 
-import dynamic from 'next/dynamic';
-
-const Editor = dynamic(() => import('@monaco-editor/react'), {
-  ssr: false,
-  loading: () => <div className="h-64 animate-pulse rounded-lg bg-muted" />,
-});
 import { Plus, Trash2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
 import {
@@ -25,6 +20,11 @@ import {
 } from '@/components/ui/overlays/select';
 import { Label } from '@/components/ui/primitives/label';
 import type { AgentForm, PromptTemplate } from '@/lib/schemas/agent-definition-schema';
+
+const Editor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+  loading: () => <div className="h-64 animate-pulse rounded-lg bg-muted" />,
+});
 
 interface PromptEditorStepProps {
   agent: AgentForm;

--- a/apps/web/src/components/chat-unified/ChatMessageList.tsx
+++ b/apps/web/src/components/chat-unified/ChatMessageList.tsx
@@ -227,13 +227,22 @@ export function ChatMessageList({
                   />
                 )}
 
-                {/* Continue button — when backend signals truncated response */}
-                {msg.role === 'assistant' && msg.continuationToken && onContinue && (
-                  <ContinueButton
-                    onContinue={() => onContinue(msg.continuationToken!)}
-                    isLoading={isSending ?? false}
-                  />
-                )}
+                {/* Continue button — when backend signals truncated response.
+                    Bind the token to a const so the arrow callback below
+                    captures a guaranteed non-null value (TS can't preserve
+                    the `msg.continuationToken` narrow into the closure). */}
+                {msg.role === 'assistant' &&
+                  msg.continuationToken &&
+                  onContinue &&
+                  (() => {
+                    const token = msg.continuationToken;
+                    return (
+                      <ContinueButton
+                        onContinue={() => onContinue(token)}
+                        isLoading={isSending ?? false}
+                      />
+                    );
+                  })()}
 
                 {/* Strategy tier badge — only on last assistant message, not streaming */}
                 {isLastAssistant && streamState.strategyTier && (

--- a/apps/web/src/components/chat-unified/ChatMobile.tsx
+++ b/apps/web/src/components/chat-unified/ChatMobile.tsx
@@ -16,7 +16,12 @@ import { useRouter } from 'next/navigation';
 import { MobileHeader } from '@/components/ui/navigation/MobileHeader';
 import { useAgentChatStream } from '@/hooks/useAgentChatStream';
 import { api } from '@/lib/api';
-import { qaStream, QA_EVENT_TYPES, type InlineCitationMatch, type ContinuationData } from '@/lib/api/clients/chatClient';
+import {
+  qaStream,
+  QA_EVENT_TYPES,
+  type InlineCitationMatch,
+  type ContinuationData,
+} from '@/lib/api/clients/chatClient';
 import type { ChatThreadDto, ChatThreadMessageDto } from '@/lib/api/schemas/chat.schemas';
 import { cn } from '@/lib/utils';
 
@@ -105,13 +110,18 @@ function MessageBubble({
             excludeIndices={new Set(message.inlineCitations?.map(c => c.snippetIndex) ?? [])}
           />
         )}
-        {/* Continue button */}
-        {!isUser && message.continuationToken && onContinue && (
-          <ContinueButton
-            onContinue={() => onContinue(message.continuationToken!)}
-            isLoading={isSending ?? false}
-          />
-        )}
+        {/* Continue button — bind the token to a const so the closure captures
+            a non-null value (TypeScript can't preserve the narrow into the
+            arrow function body). */}
+        {!isUser &&
+          message.continuationToken &&
+          onContinue &&
+          (() => {
+            const token = message.continuationToken;
+            return (
+              <ContinueButton onContinue={() => onContinue(token)} isLoading={isSending ?? false} />
+            );
+          })()}
       </div>
     </div>
   );
@@ -266,18 +276,24 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
             abortController.signal
           )) {
             if (event.type === QA_EVENT_TYPES.TOKEN) {
-              const token = typeof event.data === 'string' ? event.data : ((event.data as { token?: string })?.token ?? '');
+              const token =
+                typeof event.data === 'string'
+                  ? event.data
+                  : ((event.data as { token?: string })?.token ?? '');
               if (token) {
                 appendedContent += token;
                 const content = appendedContent;
                 setMessages(prev =>
-                  prev.map(m => m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m)
+                  prev.map(m =>
+                    m.id === lastAssistant.id ? { ...m, content, continuationToken: undefined } : m
+                  )
                 );
               }
             }
           }
-        } catch { /* handled */ }
-        finally {
+        } catch {
+          /* handled */
+        } finally {
           setIsSending(false);
           qaAbortRef.current = null;
         }
@@ -311,6 +327,10 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
 
       // QA stream path: game context available → use RAG QA streaming
       if (thread?.gameId) {
+        // Capture gameId in a const so the async closure below preserves the
+        // narrow (TypeScript can't keep the `thread?.gameId` narrow alive
+        // across the async IIFE boundary).
+        const gameId = thread.gameId;
         setIsSending(true);
         const assistantMsgId = `assistant-${Date.now()}`;
         setMessages(prev => [
@@ -333,7 +353,7 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
             await api.chat.addMessage(threadId, { content: text, role: 'user' });
 
             for await (const event of qaStream(
-              { gameId: thread.gameId!, query: text, chatId: threadId, responseStyle: 'concise' },
+              { gameId, query: text, chatId: threadId, responseStyle: 'concise' },
               abortController.signal
             )) {
               switch (event.type) {
@@ -341,7 +361,9 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                   const data = event.data as { citations: InlineCitationMatch[] };
                   if (data.citations) {
                     setMessages(prev =>
-                      prev.map(m => m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m)
+                      prev.map(m =>
+                        m.id === assistantMsgId ? { ...m, inlineCitations: data.citations } : m
+                      )
                     );
                   }
                   break;
@@ -350,16 +372,30 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
                   const data = event.data as ContinuationData;
                   if (data.continuationToken) {
                     setMessages(prev =>
-                      prev.map(m => m.id === assistantMsgId ? { ...m, continuationToken: data.continuationToken } : m)
+                      prev.map(m =>
+                        m.id === assistantMsgId
+                          ? { ...m, continuationToken: data.continuationToken }
+                          : m
+                      )
                     );
                   }
                   break;
                 }
                 case QA_EVENT_TYPES.CITATIONS: {
-                  const data = event.data as { citations?: Array<{ text: string; source: string; page: number; line: number; score: number }> };
+                  const data = event.data as {
+                    citations?: Array<{
+                      text: string;
+                      source: string;
+                      page: number;
+                      line: number;
+                      score: number;
+                    }>;
+                  };
                   if (data.citations) {
                     setMessages(prev =>
-                      prev.map(m => m.id === assistantMsgId ? { ...m, snippets: data.citations } : m)
+                      prev.map(m =>
+                        m.id === assistantMsgId ? { ...m, snippets: data.citations } : m
+                      )
                     );
                   }
                   break;
@@ -527,7 +563,12 @@ export function ChatMobile({ threadId }: ChatMobileProps) {
         )}
 
         {messages.map(msg => (
-          <MessageBubble key={msg.id} message={msg} onContinue={handleContinue} isSending={isSending} />
+          <MessageBubble
+            key={msg.id}
+            message={msg}
+            onContinue={handleContinue}
+            isSending={isSending}
+          />
         ))}
 
         {/* Streaming states */}

--- a/apps/web/src/components/chat/panel/ChatInputBar.tsx
+++ b/apps/web/src/components/chat/panel/ChatInputBar.tsx
@@ -67,6 +67,7 @@ export function ChatInputBar({
         <div className="mb-3 flex flex-wrap gap-2">
           {images.map((img, idx) => (
             <div key={img.previewUrl} className="group relative">
+              {/* eslint-disable-next-line @next/next/no-img-element -- previewUrl is a local blob: URL from URL.createObjectURL(); next/image cannot consume blob URLs (no loader support) */}
               <img
                 src={img.previewUrl}
                 alt={`Allegato ${idx + 1}`}

--- a/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
+++ b/apps/web/src/components/chat/panel/ChatMessageBubble.tsx
@@ -107,9 +107,7 @@ export function ChatMessageBubble({
       </div>
       <div className={cn('flex min-w-0 flex-1 flex-col gap-2', isUser && 'items-end')}>
         <div className="flex items-center gap-2 text-[0.66rem] font-semibold text-[var(--text-muted)]">
-          <span className="font-quicksand font-extrabold text-[var(--text-sec)]">
-            {authorName}
-          </span>
+          <span className="font-quicksand font-extrabold text-[var(--text-sec)]">{authorName}</span>
           <span>· {timestamp}</span>
         </div>
         <div
@@ -133,6 +131,7 @@ export function ChatMessageBubble({
             <div className="mb-2 flex flex-wrap gap-2">
               {imageUrls.map((url, idx) => (
                 <a key={idx} href={url} target="_blank" rel="noopener noreferrer" className="block">
+                  {/* eslint-disable-next-line @next/next/no-img-element -- chat image URLs may be blob: URLs (live previews) or arbitrary remote hosts not whitelisted in next.config.js images.domains; using next/image would break either case */}
                   <img
                     src={url}
                     alt={`Immagine ${idx + 1}`}

--- a/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+++ b/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
@@ -22,11 +22,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ReactElement } from 'react';
 
+import clsx from 'clsx';
 import { Document, Page, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
-
-import clsx from 'clsx';
 
 import { CitationOwnershipUpsell } from '@/components/features/game-chat/CitationOwnershipUpsell';
 import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';

--- a/apps/web/src/components/features/gamebook/CheckoutModal.tsx
+++ b/apps/web/src/components/features/gamebook/CheckoutModal.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState, type ReactElement } from 'react';
 
 import { Dialog, DialogContent } from '@/components/ui/overlays/dialog';
-import { CHECKOUT_PACKS, formatEur, type CheckoutPackId } from '@/lib/gamebook/checkout-packs';
+import { formatEur, getCheckoutPack, type CheckoutPackId } from '@/lib/gamebook/checkout-packs';
 
 import { CheckoutStepIndicator } from './checkout/CheckoutStepIndicator';
 import { Step1QuotaReached, type Step1Labels } from './checkout/Step1QuotaReached';
@@ -82,7 +82,7 @@ export function CheckoutModal({
   const [selectedPack, setSelectedPack] = useState<CheckoutPackId>('starter');
   const [paymentSubState, setPaymentSubState] = useState<Step3SubState>('filled');
 
-  const pack = CHECKOUT_PACKS.find((p) => p.id === selectedPack)!;
+  const pack = getCheckoutPack(selectedPack);
   const priceEurString = formatEur(pack.priceEur);
 
   const handleOpenChange = useCallback(

--- a/apps/web/src/components/features/gamebook/checkout/Step2PackPicker.tsx
+++ b/apps/web/src/components/features/gamebook/checkout/Step2PackPicker.tsx
@@ -6,7 +6,12 @@ import type { ReactElement } from 'react';
 
 import clsx from 'clsx';
 
-import { CHECKOUT_PACKS, formatEur, type CheckoutPackId } from '@/lib/gamebook/checkout-packs';
+import {
+  CHECKOUT_PACKS,
+  formatEur,
+  getCheckoutPack,
+  type CheckoutPackId,
+} from '@/lib/gamebook/checkout-packs';
 
 export interface Step2Labels {
   readonly heading: string;
@@ -33,7 +38,7 @@ export function Step2PackPicker({
   onSelect,
   onContinue,
 }: Step2PackPickerProps): ReactElement {
-  const selectedPack = CHECKOUT_PACKS.find((p) => p.id === selectedId)!;
+  const selectedPack = getCheckoutPack(selectedId);
   return (
     <div data-slot="checkout-step-2" className="flex flex-col gap-4 p-5">
       <div className="flex flex-col gap-1">
@@ -45,7 +50,7 @@ export function Step2PackPicker({
         aria-label="Scelta pacchetto crediti"
         className="flex flex-col gap-2.5"
       >
-        {CHECKOUT_PACKS.map((pack) => {
+        {CHECKOUT_PACKS.map(pack => {
           const selected = pack.id === selectedId;
           const badgeKind = pack.badge;
           const badgeLabel = badgeKind ? labels.packBadges[badgeKind] : null;
@@ -100,7 +105,9 @@ export function Step2PackPicker({
                 aria-hidden="true"
                 className={clsx(
                   'col-start-3 row-span-3 flex h-5 w-5 items-center justify-center self-center justify-self-end rounded-full border-2 transition-colors',
-                  selected ? 'border-entity-toolkit bg-entity-toolkit' : 'border-border bg-transparent'
+                  selected
+                    ? 'border-entity-toolkit bg-entity-toolkit'
+                    : 'border-border bg-transparent'
                 )}
               >
                 {selected && <span className="h-2 w-2 rounded-full bg-white" />}

--- a/apps/web/src/components/features/gamebook/checkout/Step4Success.tsx
+++ b/apps/web/src/components/features/gamebook/checkout/Step4Success.tsx
@@ -116,9 +116,16 @@ export function Step4Success({
         >
           {labels.backToGameCta}
         </button>
-        <a href="#" className="self-center text-xs text-muted-foreground hover:text-foreground">
+        <button
+          type="button"
+          className="self-center text-xs text-muted-foreground hover:text-foreground"
+          // TODO(#953): wire to receipt download endpoint once checkout BE is implemented.
+          onClick={() => {
+            // no-op placeholder — checkout flow is currently 100% frontend (no real Stripe).
+          }}
+        >
           {labels.receiptLink}
-        </a>
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -39,16 +39,13 @@ export function PageHeader({
   activeTabId,
   className,
 }: PageHeaderProps) {
-  const showBackLink = Boolean(parentHref && parentLabel);
-  const hasTabs = tabs && tabs.length > 0;
-
   return (
     <div className={cn('w-full', className)}>
-      {/* Back link */}
-      {showBackLink && (
+      {/* Back link — both parentHref and parentLabel must be present */}
+      {parentHref && parentLabel && (
         <div className="mb-1">
           <Link
-            href={parentHref!}
+            href={parentHref}
             className="inline-flex items-center gap-1 text-sm font-medium"
             style={{ color: 'hsl(var(--c-kb-text))' }}
           >
@@ -81,9 +78,9 @@ export function PageHeader({
       </div>
 
       {/* Tabs */}
-      {hasTabs && (
+      {tabs && tabs.length > 0 && (
         <nav className="mt-4 flex gap-0 border-b border-border" aria-label="Page tabs">
-          {tabs!.map(tab => {
+          {tabs.map(tab => {
             const isActive = tab.id === activeTabId;
             return (
               <Link

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/entities/SessionDrawerContent.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/entities/SessionDrawerContent.tsx
@@ -85,7 +85,9 @@ export function SessionDrawerContent({ entityId, initialTabId }: SessionDrawerCo
     },
   ];
 
-  const hasToolkit = data.toolkit != null;
+  // Bind to a local so TypeScript narrows inside `{toolkit && ...}` blocks
+  // and we avoid `data.toolkit!` non-null assertions in the JSX below.
+  const toolkit = data.toolkit;
 
   return (
     <div className="flex flex-1 flex-col">
@@ -109,7 +111,7 @@ export function SessionDrawerContent({ entityId, initialTabId }: SessionDrawerCo
             label="Live"
             activeAccent={colors.activeAccent}
           />
-          {hasToolkit && (
+          {toolkit && (
             <EntityTabTrigger
               value="toolkit"
               icon={Wrench}
@@ -180,33 +182,31 @@ export function SessionDrawerContent({ entityId, initialTabId }: SessionDrawerCo
           </TabsContent>
 
           {/* Toolkit tab */}
-          {hasToolkit && (
+          {toolkit && (
             <TabsContent value="toolkit" className="mt-0">
               <div className="space-y-3">
                 <div className="rounded-lg bg-indigo-50/50 border border-indigo-200/40 p-3">
                   <p className="font-nunito text-[10px] text-indigo-500 uppercase tracking-wider">
                     Toolkit
                   </p>
-                  <p className="font-quicksand text-sm font-bold text-indigo-700">
-                    {data.toolkit!.name}
-                  </p>
+                  <p className="font-quicksand text-sm font-bold text-indigo-700">{toolkit.name}</p>
                 </div>
                 <div className="grid grid-cols-3 gap-2">
                   <div className="rounded-lg bg-card/50 border border-border/40 p-2.5 text-center">
                     <p className="font-quicksand text-lg font-bold text-indigo-700">
-                      {data.toolkit!.diceTools.length}
+                      {toolkit.diceTools.length}
                     </p>
                     <p className="font-nunito text-[10px] text-muted-foreground">Dadi</p>
                   </div>
                   <div className="rounded-lg bg-card/50 border border-border/40 p-2.5 text-center">
                     <p className="font-quicksand text-lg font-bold text-indigo-700">
-                      {data.toolkit!.cardTools.length}
+                      {toolkit.cardTools.length}
                     </p>
                     <p className="font-nunito text-[10px] text-muted-foreground">Carte</p>
                   </div>
                   <div className="rounded-lg bg-card/50 border border-border/40 p-2.5 text-center">
                     <p className="font-quicksand text-lg font-bold text-indigo-700">
-                      {data.toolkit!.timerTools.length}
+                      {toolkit.timerTools.length}
                     </p>
                     <p className="font-nunito text-[10px] text-muted-foreground">Timer</p>
                   </div>
@@ -232,7 +232,9 @@ export function SessionDrawerContent({ entityId, initialTabId }: SessionDrawerCo
                       <p className="font-nunito text-xs font-medium text-foreground truncate">
                         {event.label ?? event.description}
                       </p>
-                      <p className="font-nunito text-[10px] text-muted-foreground">{event.timestamp}</p>
+                      <p className="font-nunito text-[10px] text-muted-foreground">
+                        {event.timestamp}
+                      </p>
                     </div>
                   </div>
                 ))

--- a/apps/web/src/components/ui/settings-row/settings-row.tsx
+++ b/apps/web/src/components/ui/settings-row/settings-row.tsx
@@ -119,13 +119,17 @@ export function SettingsRow({
           {body}
         </button>
       ) : useLink ? (
-        <a
-          href={disabled ? undefined : href}
-          className={innerClasses}
-          aria-disabled={disabled || undefined}
-        >
-          {body}
-        </a>
+        disabled ? (
+          // When the row is disabled, render a non-interactive <span> so that
+          // we never emit an <a> without an href (jsx-a11y/anchor-is-valid).
+          <span className={innerClasses} aria-disabled="true">
+            {body}
+          </span>
+        ) : (
+          <a href={href} className={innerClasses}>
+            {body}
+          </a>
+        )
       ) : (
         <div className={innerClasses}>{body}</div>
       )}

--- a/apps/web/src/hooks/useSessionInlineChat.ts
+++ b/apps/web/src/hooks/useSessionInlineChat.ts
@@ -37,14 +37,15 @@ export function useSessionInlineChat(
 
       try {
         let thread;
-        if (!threadIdRef.current) {
+        const currentThreadId = threadIdRef.current;
+        if (!currentThreadId) {
           thread = await api.chat.createThread({
             gameId: gameId ?? null,
             initialMessage: text,
           });
           threadIdRef.current = thread.id;
         } else {
-          thread = await api.chat.addMessage(threadIdRef.current!, { content: text, role: 'user' });
+          thread = await api.chat.addMessage(currentThreadId, { content: text, role: 'user' });
         }
 
         // Extract the last assistant message from the returned thread

--- a/apps/web/src/lib/colors/__tests__/user-hue.test.ts
+++ b/apps/web/src/lib/colors/__tests__/user-hue.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { userHsl, userHue } from '../user-hue';
+
+describe('userHue', () => {
+  it('returns a deterministic value for the same userId across calls', () => {
+    const a = userHue('p-marco');
+    const b = userHue('p-marco');
+    expect(a).toBe(b);
+  });
+
+  it('always returns a value in [0, 360)', () => {
+    const inputs = [
+      'p-marco',
+      'p-elisa',
+      'p-1',
+      'a-very-long-user-id-12345-with-extras',
+      '00000000-0000-0000-0000-000000000001',
+      'unicode-utente-àèìòù',
+    ];
+    for (const v of inputs) {
+      const h = userHue(v);
+      expect(h).toBeGreaterThanOrEqual(0);
+      expect(h).toBeLessThan(360);
+      expect(Number.isInteger(h)).toBe(true);
+    }
+  });
+
+  it('returns different hues for different userIds (statistical distribution)', () => {
+    // 8 distinct userIds should map to ≥6 distinct hues with overwhelming
+    // probability under uniform hash distribution (collision rate ≪ 1%).
+    const ids = ['alice', 'bob', 'charlie', 'dave', 'erin', 'frank', 'grace', 'heidi'];
+    const hues = new Set(ids.map(id => userHue(id)));
+    expect(hues.size).toBeGreaterThanOrEqual(6);
+  });
+
+  it('returns 0 for empty userId (edge case)', () => {
+    expect(userHue('')).toBe(0);
+  });
+
+  it('distinguishes Guid-format userIds that differ by a single character', () => {
+    const a = userHue('00000000-0000-0000-0000-000000000001');
+    const b = userHue('00000000-0000-0000-0000-000000000002');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('userHsl', () => {
+  it('returns a valid hsl() string with default saturation/lightness when alpha is omitted', () => {
+    const s = userHsl('p-marco');
+    expect(s).toMatch(/^hsl\(\d{1,3}, 60%, 55%\)$/);
+  });
+
+  it('returns a valid hsla() string when alpha is provided', () => {
+    const s = userHsl('p-marco', 0.3);
+    expect(s).toMatch(/^hsla\(\d{1,3}, 60%, 55%, 0\.3\)$/);
+  });
+
+  it('accepts alpha = 0 and alpha = 1 boundary values', () => {
+    expect(userHsl('p-marco', 0)).toMatch(/^hsla\(\d{1,3}, 60%, 55%, 0\)$/);
+    expect(userHsl('p-marco', 1)).toMatch(/^hsla\(\d{1,3}, 60%, 55%, 1\)$/);
+  });
+
+  it('produces stable output across calls for the same userId', () => {
+    expect(userHsl('p-marco')).toBe(userHsl('p-marco'));
+    expect(userHsl('p-marco', 0.5)).toBe(userHsl('p-marco', 0.5));
+  });
+
+  it('produces hsl() (not hsla()) when alpha is undefined explicitly', () => {
+    const s = userHsl('p-marco', undefined);
+    expect(s.startsWith('hsl(')).toBe(true);
+    expect(s.startsWith('hsla(')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/colors/user-hue.ts
+++ b/apps/web/src/lib/colors/user-hue.ts
@@ -1,0 +1,65 @@
+/**
+ * Deterministic color utility for users when BE doesn't expose `User.AccentHue`.
+ *
+ * Uses FNV-1a 32-bit hash for fast, deterministic, well-distributed mapping
+ * `userId` → `hue` ∈ [0, 360). Purely visual — no security implications,
+ * no crypto guarantees.
+ *
+ * Motivation: the mockup `admin-mockups/design_files/sp4-game-detail.jsx`
+ * (function `Leaderboard`) uses `p.color : number` (hue 0-360) for avatar
+ * background colors. The BE `User` entity does not currently expose an
+ * `AccentHue` field (verified 2026-05-24 PM via `PILOT_GAP_REPORT.md § 3.5`
+ * decision #5). This module provides a client-side stable replacement so
+ * the same user gets the same color across sessions and devices.
+ *
+ * @see docs `admin-mockups/design_handoff/PILOT_GAP_REPORT.md` decision #5
+ * @see issue #1470
+ * @module
+ */
+
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+/**
+ * Returns a deterministic hue (0-359) for a given user identifier.
+ * Same input → same output across sessions and platforms.
+ *
+ * Empty `userId` returns `0` so consumers can handle "unknown user"
+ * uniformly without branching.
+ *
+ * @example
+ *   userHue('p-marco')                                  // → stable hue ∈ [0, 360)
+ *   userHue('00000000-0000-0000-0000-000000000001')     // → stable hue ∈ [0, 360)
+ *   userHue('')                                         // → 0
+ */
+export function userHue(userId: string): number {
+  if (!userId) return 0;
+  let hash = FNV_OFFSET_BASIS;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+  // `hash` is a signed 32-bit integer after `Math.imul`; mod 360 of its
+  // absolute value yields a value in [0, 360).
+  return Math.abs(hash) % 360;
+}
+
+/**
+ * Returns a full HSL color string for the given user identifier.
+ *
+ * Saturation 60% and Lightness 55% are tuned for AA contrast on the project's
+ * light background (`--bg-base` = `#f7f3ee`) and remain readable on the dark
+ * variant. Override via CSS custom properties if a specific contrast target
+ * is required.
+ *
+ * @param userId — see {@link userHue}
+ * @param alpha — optional alpha channel ∈ [0, 1]; when set, returns `hsla()`
+ *
+ * @example
+ *   userHsl('p-marco')           // → 'hsl(123, 60%, 55%)' (example)
+ *   userHsl('p-marco', 0.3)      // → 'hsla(123, 60%, 55%, 0.3)'
+ */
+export function userHsl(userId: string, alpha?: number): string {
+  const h = userHue(userId);
+  return alpha !== undefined ? `hsla(${h}, 60%, 55%, ${alpha})` : `hsl(${h}, 60%, 55%)`;
+}

--- a/apps/web/src/lib/faq/search.ts
+++ b/apps/web/src/lib/faq/search.ts
@@ -28,6 +28,10 @@ function escapeRegex(input: string): string {
 export function highlight(text: string, query: string): ReactNode {
   if (!query || !query.trim()) return text;
   const q = query.trim();
+  // The dynamic argument to RegExp is fully escaped upstream by `escapeRegex`,
+  // so every metacharacter becomes a literal — no ReDoS / pattern-injection
+  // risk remains. The eslint rule cannot follow the escape, hence the disable.
+  // eslint-disable-next-line security/detect-non-literal-regexp -- input sanitized by escapeRegex
   const re = new RegExp(`(${escapeRegex(q)})`, 'gi');
   const parts = text.split(re);
   return createElement(

--- a/apps/web/src/lib/gamebook/checkout-packs.ts
+++ b/apps/web/src/lib/gamebook/checkout-packs.ts
@@ -21,10 +21,32 @@ export interface CheckoutPack {
 }
 
 export const CHECKOUT_PACKS: readonly CheckoutPack[] = [
-  { id: 'starter', name: 'Starter', priceEur: 5, credits: 100, perParagraphEur: 0.05, badge: 'popular' },
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceEur: 5,
+    credits: 100,
+    perParagraphEur: 0.05,
+    badge: 'popular',
+  },
   { id: 'mid', name: 'Mid', priceEur: 20, credits: 500, perParagraphEur: 0.04, badge: null },
   { id: 'pro', name: 'Pro', priceEur: 35, credits: 1000, perParagraphEur: 0.035, badge: 'save' },
 ] as const;
+
+/**
+ * Resolve a {@link CheckoutPack} by id. Since `CheckoutPackId` is the exact
+ * union of `CHECKOUT_PACKS[*].id`, this lookup is total by construction — the
+ * throw is a defensive guard against future config drift (e.g. removing a pack
+ * id from `CHECKOUT_PACKS` without removing the corresponding `CheckoutPackId`
+ * variant).
+ */
+export function getCheckoutPack(id: CheckoutPackId): CheckoutPack {
+  const pack = CHECKOUT_PACKS.find(p => p.id === id);
+  if (!pack) {
+    throw new Error(`Checkout pack "${id}" not found in CHECKOUT_PACKS — config drift`);
+  }
+  return pack;
+}
 
 /**
  * Format EUR value using Italian locale. Integer values render without decimals

--- a/apps/web/src/lib/gamebook/hooks/useCampaignProgress.ts
+++ b/apps/web/src/lib/gamebook/hooks/useCampaignProgress.ts
@@ -20,6 +20,8 @@ export function useCampaignProgress(campaignId: string | undefined) {
     queryKey: campaignId
       ? campaignProgressKeys.byCampaign(campaignId)
       : ['gamebook', 'campaigns', 'noop', 'progress'],
+    // `enabled: !!campaignId` guarantees queryFn only runs when campaignId is set.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
     queryFn: () => getCampaignProgress(campaignId!),
     enabled: !!campaignId,
   });

--- a/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
+++ b/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
@@ -9,6 +9,8 @@ export const gamebookCampaignKeys = {
 export function useGamebookCampaign(id: string | undefined) {
   return useQuery<GamebookCampaign>({
     queryKey: id ? gamebookCampaignKeys.detail(id) : ['gamebook', 'campaigns', 'noop'],
+    // `enabled: !!id` guarantees queryFn only runs when id is set.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
     queryFn: () => getCampaign(id!),
     enabled: !!id,
   });

--- a/apps/web/src/lib/gamebook/hooks/useGetParagraph.ts
+++ b/apps/web/src/lib/gamebook/hooks/useGetParagraph.ts
@@ -169,10 +169,14 @@ export function useGetParagraph(
 
   return useQuery<Paragraph, Error>({
     queryKey,
+    // `enabled: !!batchId && ...` gates the queryFn — the non-null assertions
+    // on batchId are safe under that invariant.
     queryFn: () =>
       paragraphRef.type === 'page'
-        ? getParagraph(batchId!, paragraphRef.value, hint)
-        : getParagraphByParagraphNumber(batchId!, paragraphRef.value, hint),
+        ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
+          getParagraph(batchId!, paragraphRef.value, hint)
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
+          getParagraphByParagraphNumber(batchId!, paragraphRef.value, hint),
     enabled: enabled && !!batchId && paragraphRef.value > 0,
     staleTime: 5 * 60_000,
     retry: false,

--- a/apps/web/src/lib/invites/visual-test-fixture.ts
+++ b/apps/web/src/lib/invites/visual-test-fixture.ts
@@ -112,6 +112,10 @@ export function tryLoadVisualTestFixture(
   variant?: 'pending' | 'accepted' | 'declined'
 ): PublicGameNightInvitation | null {
   if (!IS_VISUAL_TEST_BUILD) return null;
+  // Visual-test fixtures are gated behind a build-time flag (IS_VISUAL_TEST_BUILD)
+  // and the sentinel token is hardcoded in this file; this is dev/CI tooling,
+  // not a real authentication path, so timing-safe comparison is not warranted.
+  // eslint-disable-next-line security/detect-possible-timing-attacks -- visual-test sentinel, not a real auth token
   if (token !== VISUAL_TEST_FIXTURE_TOKEN) return null;
   if (variant === 'accepted') return FIXTURE_ALREADY_ACCEPTED;
   if (variant === 'declined') return FIXTURE_ALREADY_DECLINED;

--- a/apps/web/src/lib/stores/cascade-navigation-store.ts
+++ b/apps/web/src/lib/stores/cascade-navigation-store.ts
@@ -163,7 +163,14 @@ export const useCascadeNavigationStore = create<CascadeNavigationState>()(
           return;
         }
         const stack = [...current.drawerStack];
-        const prev = stack.pop()!;
+        const prev = stack.pop();
+        if (!prev) {
+          // Defensive: the length check above (`drawerStack.length === 0`)
+          // already guarantees the stack is non-empty, but TypeScript can't
+          // preserve that invariant across the copy. Bail out gracefully
+          // instead of crashing the popDrawer action.
+          return;
+        }
         set(
           {
             state: 'drawer',

--- a/apps/web/src/stores/toolkit-timer-store.ts
+++ b/apps/web/src/stores/toolkit-timer-store.ts
@@ -65,71 +65,71 @@ function clearTimerInterval(gameId: string) {
  * Safe to call multiple times — always returns the same instance.
  */
 export function getTimerStore(gameId: string): UseBoundStore<StoreApi<TimerStore>> {
-  if (!storeRegistry.has(gameId)) {
-    const store = create<TimerStore>()((set, get) => ({
-      totalSeconds: 60,
-      remaining: 60,
-      status: 'idle',
-      autoResetOnTurn: false,
+  const existing = storeRegistry.get(gameId);
+  if (existing) return existing;
 
-      start() {
-        const { status, remaining } = get();
-        if (status === 'running' || remaining <= 0) return;
+  const store = create<TimerStore>()((set, get) => ({
+    totalSeconds: 60,
+    remaining: 60,
+    status: 'idle',
+    autoResetOnTurn: false,
 
-        set({ status: 'running' });
-        clearTimerInterval(gameId); // guard against double-start
+    start() {
+      const { status, remaining } = get();
+      if (status === 'running' || remaining <= 0) return;
 
-        const id = setInterval(() => {
-          const { remaining: rem } = get();
-          if (rem <= 1) {
-            clearTimerInterval(gameId);
-            set({ remaining: 0, status: 'ended' });
-            if (typeof window !== 'undefined') {
-              window.dispatchEvent(new CustomEvent('toolkit:timer-end', { detail: { gameId } }));
-            }
-          } else {
-            set({ remaining: rem - 1 });
+      set({ status: 'running' });
+      clearTimerInterval(gameId); // guard against double-start
+
+      const id = setInterval(() => {
+        const { remaining: rem } = get();
+        if (rem <= 1) {
+          clearTimerInterval(gameId);
+          set({ remaining: 0, status: 'ended' });
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('toolkit:timer-end', { detail: { gameId } }));
           }
-        }, 1000);
+        } else {
+          set({ remaining: rem - 1 });
+        }
+      }, 1000);
 
-        intervalRegistry.set(gameId, id);
-      },
+      intervalRegistry.set(gameId, id);
+    },
 
-      pause() {
-        if (get().status !== 'running') return;
-        clearTimerInterval(gameId);
-        set({ status: 'paused' });
-      },
+    pause() {
+      if (get().status !== 'running') return;
+      clearTimerInterval(gameId);
+      set({ status: 'paused' });
+    },
 
-      reset() {
-        clearTimerInterval(gameId);
-        set(s => ({ remaining: s.totalSeconds, status: 'idle' }));
-      },
+    reset() {
+      clearTimerInterval(gameId);
+      set(s => ({ remaining: s.totalSeconds, status: 'idle' }));
+    },
 
-      setDuration(seconds: number) {
-        clearTimerInterval(gameId);
-        // Clamp: 5 s – 99m59s
-        const clamped = Math.max(5, Math.min(seconds, 5999));
-        set({ totalSeconds: clamped, remaining: clamped, status: 'idle' });
-      },
+    setDuration(seconds: number) {
+      clearTimerInterval(gameId);
+      // Clamp: 5 s – 99m59s
+      const clamped = Math.max(5, Math.min(seconds, 5999));
+      set({ totalSeconds: clamped, remaining: clamped, status: 'idle' });
+    },
 
-      adjustTime(deltaSec: number) {
-        set(s => {
-          const newRemaining = Math.max(0, Math.min(s.remaining + deltaSec, 5999));
-          const newStatus = s.status === 'ended' && newRemaining > 0 ? 'paused' : s.status;
-          return { remaining: newRemaining, status: newStatus };
-        });
-      },
+    adjustTime(deltaSec: number) {
+      set(s => {
+        const newRemaining = Math.max(0, Math.min(s.remaining + deltaSec, 5999));
+        const newStatus = s.status === 'ended' && newRemaining > 0 ? 'paused' : s.status;
+        return { remaining: newRemaining, status: newStatus };
+      });
+    },
 
-      setAutoResetOnTurn(enabled: boolean) {
-        set({ autoResetOnTurn: enabled });
-      },
-    }));
+    setAutoResetOnTurn(enabled: boolean) {
+      set({ autoResetOnTurn: enabled });
+    },
+  }));
 
-    storeRegistry.set(gameId, store);
-  }
-
-  return storeRegistry.get(gameId)!;
+  storeRegistry.set(gameId, store);
+  return store;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Closes #1470** — `userHue(userId)` deterministic color utility (Phase 1 foundation primitive from [`PILOT_GAP_REPORT.md`](../admin-mockups/design_handoff/PILOT_GAP_REPORT.md) decision #5).

This PR ships the small primitive **and** clears the entire pre-existing ESLint warning backlog (49 → 0) in a single reviewable change. Both deliverables landed as **two atomic commits** so they can be reviewed (and reverted) independently.

## Commit 1 — `feat(lib): #1470 userHue deterministic color utility`

| Aspect | Value |
|---|---|
| Path | `apps/web/src/lib/colors/user-hue.ts` |
| Tests | `apps/web/src/lib/colors/__tests__/user-hue.test.ts` (10 scenarios) |
| Hash | FNV-1a 32-bit → `Math.abs(hash) % 360` |
| Exports | `userHue(userId: string): number`, `userHsl(userId: string, alpha?: number): string` |
| Edge cases | empty userId → 0; alpha=0 / alpha=1 boundaries |
| LOC | +139 (2 files) |

### Motivation

The `sp4-game-detail.jsx` mockup (Leaderboard, lines 759-812) uses `p.color : number` for avatar background colors. The BE `User` entity does **not** expose an `AccentHue` field (verified 2026-05-24 PM in `PILOT_GAP_REPORT.md § 3.5` decision #5). This client-side utility provides visual stability across sessions/devices without requiring a BE schema change.

Used as a building block by upcoming **#1468** (`GameDetailLeaderboard` component).

## Commit 2 — `chore(lint): clear 49 pre-existing ESLint warnings → 0`

Brought `pnpm lint` warnings from **49** (well under the 510 budget) down to **0** without touching production semantics. Companion cleanup applied alongside the feature.

### Breakdown (49 warnings)

| # | Rule | Approach |
|---|---|---|
| 9 | `import/order` (auto) | `eslint --fix` — pure cosmetic reformat |
| 5 | `import/order` (manual) | consolidated split import groups around `dynamic()` blocks |
| 3 | `@next/next/no-html-link-for-pages` | `<a href="/{plural}">` → `<Link>` for `not-found` CTAs in {Agent,Game,Player}DetailView |
| 2 | `jsx-a11y/anchor-is-valid` | (a) `<a href="#">` placeholder in Step4Success → `<button>` with TODO for #953 receipt endpoint; (b) `<a href={undefined when disabled}>` in `SettingsRow` → `<span aria-disabled="true">` |
| 2 | `@next/next/no-img-element` | `eslint-disable` with rationale: ChatInputBar uses `blob:` URLs from `URL.createObjectURL()` (next/image cannot consume); ChatMessageBubble URLs may be blob or non-whitelisted remote hosts |
| 2 | `security/*` | `eslint-disable` with rationale: `faq/search` already escapes via `escapeRegex()`; `invites/visual-test-fixture` is dev-only sentinel comparison |
| 26 | `@typescript-eslint/no-non-null-assertion` | case-by-case refactor (see below) |

### Non-null assertion refactors — case by case

Each removal is either backed by a tighter guard, refactored into a total function, or documented via `eslint-disable` with a rationale identifying the actual invariant.

| Count | File(s) | Strategy |
|---|---|---|
| 3 | `{Agent,Game,Player}DetailView.tsx` | FSM-enforced (`deriveXxxUiState`): `eslint-disable` with explicit pointer to the cell guards |
| 1 | `GamebookUploadClient.tsx` | added explicit `if (gameId == null) return <GamePicker />` guard preserving the wizard fallback |
| 4 | `mechanic-extractor/analyses/page.tsx` (mutations) | replaced `analysisId!` with up-front `throw new Error(…)` inside `mutationFn` |
| 1 | `mechanic-extractor/analyses/page.tsx` (statusQuery) | `eslint-disable` — gated by `enabled: !!analysisId` |
| 4 | `SessionDrawerContent.tsx` | rebound `data.toolkit` to a local `toolkit` so TypeScript narrows under `{toolkit && …}` |
| 2 | `PageHeader.tsx` | replaced derived booleans with inline conditions that preserve the narrow (`{tabs && tabs.length > 0 && …}`) |
| 3 | `ChatMobile.tsx` / `ChatMessageList.tsx` | bound `continuationToken` to a `const` inside an IIFE so the closure captures a guaranteed non-null; same trick for `thread.gameId` on the async QA branch |
| 4 | `gamebook/hooks/{useCampaignProgress,useGamebookCampaign,useGetParagraph}.ts` | `eslint-disable` with "gated by `enabled`" comment (TanStack query pattern) |
| 1 | `useSessionInlineChat.ts` | extracted `const currentThreadId = threadIdRef.current` to preserve the narrow across the `else` branch |
| 1 | `cascade-navigation-store.ts` | replaced `stack.pop()!` with explicit guard returning early — upstream length check guarantees non-empty but TS can't preserve the invariant across `[...drawerStack]` |
| 1 | `toolkit-timer-store.ts` | restructured the factory to read-then-create-then-return so the returned store is narrowed |
| 2 | `Step2PackPicker.tsx` / `CheckoutModal.tsx` | added shared helper `getCheckoutPack(id)` in `lib/gamebook/checkout-packs.ts` with explicit throw on missing id (config-drift guard) — both callsites now total |

### Verification

| Check | Before | After |
|---|---|---|
| `pnpm lint` | 49 warnings (0 errors) | **0 warnings, 0 errors** |
| `pnpm typecheck` | pass | **pass** |
| `pnpm test` (full vitest suite) | 18313 pass / 28 skip / 0 fail | **18313 pass / 28 skip / 0 fail** (625.66s) |

No production semantics changed.

## Files changed

```
36 files changed, 482 insertions(+), 274 deletions(-)
```

2 new files (utility + tests), 34 modified files (cleanup).

## Trade-offs and pushback note

I initially recommended (Option A) splitting the warning cleanup into a separate issue, since it widened scope from a 2-file primitive into 24+ touched files and carried meaningful risk on the 26 `non-null-assertion` rewrites. The maintainer explicitly chose to bundle them (Option C of the AskUserQuestion). The full test suite passing after the refactor is the empirical guard against the risk we accepted.

For follow-ups that would further harden some of the `eslint-disable` choices into stronger invariants (e.g. moving the TanStack `enabled+ID!` pattern into a typed wrapper, or threading `User.AccentHue` through the BE so `userHue` becomes a pure fallback), I'd recommend separate tickets rather than expanding this PR further.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
