### PR TITLE
docs(admin): SP5 admin console - design handoff + consolidation spec

### DIFF
--- a/admin-mockups/design_handoff_admin/ADMIN_AUDIT.md
+++ b/admin-mockups/design_handoff_admin/ADMIN_AUDIT.md
@@ -1,0 +1,271 @@
+# ADMIN_AUDIT.md — Audit codebase vs handoff Admin Console SP5
+
+> **Scope**: audit **read-only** del monorepo MeepleAI per valutare l'integrazione dei 18 mockup admin SP5 (`design_handoff_admin/admin/`). Nessun file di codice è stato modificato.
+> **Data**: 2026-05-24 · **Branch**: `main-dev` · **Metodo**: lettura dei 5 doc di handoff + analisi mirata di backend (`apps/api/src/Api/`) e frontend (`apps/web/`).
+> **Nota nome file**: il `README.md` chiede `CODEBASE_AUDIT.md`, mentre `QUICK_START.md` chiede `ADMIN_AUDIT.md`. Uso `ADMIN_AUDIT.md` (istruzione esplicita). Incoerenza interna al handoff da sanare.
+
+---
+
+## 0. TL;DR — Verdetto
+
+**Questo NON è un greenfield.** MeepleAI ha già una **console admin estremamente estesa**, più ampia dei 18 mockup SP5:
+
+- **Frontend**: ~90 `page.tsx` sotto `apps/web/src/app/admin/(dashboard)/` con shell admin, navigazione, SSE, ~220 componenti in `apps/web/src/components/admin/**`.
+- **Backend**: bounded context `Administration` completo + ~70 file `Routing/Admin*Endpoints.cs`, con **audit log, impersonate, 2FA TOTP, gate RBAC superadmin già implementati**.
+
+Di conseguenza il lavoro reale **non è "costruire da zero"**, ma un **delta mirato**: (a) re-skin/allineamento al look-and-feel SP5, (b) colmare gap specifici (moderation, step-up 2FA, schema audit, alcune route/endpoint), (c) riconciliare divergenze di architettura (ruoli, routing, convenzioni API).
+
+Il handoff sovrastima massicciamente lo sforzo: dei ~38 componenti "nuovi", **~33-36 sono già coperti** da riuso/adattamento; solo **~2-3 sono realmente da creare**.
+
+**Premessa critica al handoff**: il modello a 4 ruoli `user`/`premium`/`admin`/`superadmin` **non corrisponde** al modello reale (`user`/`editor`/`creator`/`admin`/`superadmin`, con `premium` modellato come *tier* di subscription, non come ruolo). Va riconciliato prima di toccare l'RBAC.
+
+---
+
+## 1. Risposte rapide alle domande di handoff
+
+### README.md (5 domande)
+
+| # | Domanda | Risposta sintetica |
+|---|---|---|
+| 1 | Esiste già una sezione admin? Dove/quali pagine | **Sì, estesa**. `apps/web/src/app/admin/(dashboard)/`: overview, users, ai, agents (~25 route), analytics, config, content, knowledge-base, monitor, catalog-ingestion, shared-games, rag-quality, providers, notifications. |
+| 2 | Modello RBAC oggi? Compatibile con user/admin/superadmin? | **Parzialmente**. Esistono `user`/`admin`/`superadmin` (✅) ma anche `editor`/`creator`; **`premium` NON esiste come ruolo** (è `UserTier`). Gate admin+superadmin già attivo. |
+| 3 | Esistono `AdminDataTable`, `KPISparkline`, `LiveEventLog`? | `DataTable` ✅ (`ui/data-display/data-table.tsx`, senza pagination/virtualization); KPI cards ✅ (no "Sparkline" dedicato, Recharts disponibile); LiveEventLog 🟡 (infra SSE + `job-step-timeline`, UI log da assemblare). |
+| 4 | Quali endpoint admin esistono / mancano? | Vasta copertura sotto `/api/v1/admin/*`. **Mancano**: moderation (0%), editor/versions generico, SSE `events/live` globale, `force-logout`, `flag-hallucination`, `kb/tree`, `idempotency-check`. Dettaglio §5. |
+| 5 | Schermata pilota? | **A1 Overview** (P0, già full, basso rischio → valida shell + design-system SP5), poi **A2 Users** come stress-test sicurezza. §10. |
+
+### QUICK_START.md (7 domande)
+
+| # | Domanda | Risposta |
+|---|---|---|
+| 1 | Sezione `/admin/*` esiste? Lista pagine | Sì — vedi §6 per l'albero completo. |
+| 2 | Ruoli: come gestiti, quali esistono | VO `Role` (string) in `apps/api/src/Api/SharedKernel/Domain/ValueObjects/Role.cs` + enum `UserRole` in `apps/api/src/Api/Infrastructure/Entities/Authentication/UserRole.cs`. Valori: `user`, `editor`, `creator`, `admin`, `superadmin`. §2. |
+| 3 | Audit log esiste? Schema | **Sì**, tabella `audit_logs`. Schema **insufficiente** vs handoff (manca `impersonated_user_id`, `before_json`, `after_json`, `step_up_token_id`). §3. |
+| 4 | Endpoint `/api/admin/*` esistenti? | Sì, ~70 file di routing. Prefisso reale `/api/v1/admin/*`. §5. |
+| 5 | Permission middleware/decorator? Path | `apps/api/src/Api/Filters/RequireAdminSessionFilter.cs` + `apps/api/src/Api/Extensions/SessionValidationExtensions.cs` + policy in `apps/api/src/Api/Extensions/AuthenticationServiceExtensions.cs`. §2. |
+| 6 | "Danger zone" pattern (delete user…)? Path | Sì — `RequiresConfirmationAttribute` + `ConfirmationLevel.Level2` (BE), `AdminConfirmationDialog` typed-confirm (FE, `apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx`). §3/§7. |
+| 7 | SSE/WebSocket admin? | **Sì, maturo**: ≥10 hook SSE FE + SignalR per chat. Manca solo un bus SSE **globale** `events/live` (oggi SSE per-feature). §8. |
+
+---
+
+## 2. RBAC, ruoli e gate di autorizzazione
+
+### Stato attuale
+
+- **Doppia rappresentazione del ruolo** (da riconciliare):
+  - Value Object `Role` (stringa) — `apps/api/src/Api/SharedKernel/Domain/ValueObjects/Role.cs`. `ValidRoles = { user, editor, creator, admin, superadmin }`. Usato dall'aggregate `User` (`apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs`).
+  - Enum `UserRole` — `apps/api/src/Api/Infrastructure/Entities/Authentication/UserRole.cs` (`Admin=0, Editor=1, User=2, SuperAdmin=3, Creator=4`). Usato dal gate RBAC.
+- **`superadmin` già completo e corretto**: seeded, non assegnabile a runtime (`User.AssignRole` lo vieta), immutabile, `IsSuperAdmin()`. Semantica Aaron/cofounder già rispettata.
+- **`premium` NON esiste come ruolo**. Esiste `UserTier` (`User.Tier`, default `Free`) come concetto separato di subscription. **Il handoff confonde ruolo e tier.**
+- **Gate admin/superadmin già distinti** (riusabili as-is):
+  - Imperativo (per-endpoint): `RequireAdminSession()`, `RequireSuperAdminSession()` (Issue #3696), `RequireAdminOrEditorSession()` in `apps/api/src/Api/Extensions/SessionValidationExtensions.cs`. Gerarchia `SuperAdmin(4) > Admin(3) > Editor(2) > Creator(1) > User(0)`.
+  - Dichiarativo (policy): `RequireSuperAdmin`, `RequireAdminOrAbove`, `RequireEditorOrAbove` in `apps/api/src/Api/Extensions/AuthenticationServiceExtensions.cs:44-57`, usate con `.RequireAuthorization(...)`.
+  - Filter: `apps/api/src/Api/Filters/RequireAdminSessionFilter.cs`.
+- **Sessioni**: **cookie + session table server-side (NO JWT)**. Token hashato in DB, lifetime default **30 giorni**. Middleware `apps/api/src/Api/Middleware/SessionAuthenticationMiddleware.cs`; entity `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/Session.cs`. Sessione validata propagata in `HttpContext.Items[SessionStatusDto]`.
+
+### Gap RBAC
+
+| Aspetto | Handoff richiede | Realtà | Azione |
+|---|---|---|---|
+| Ruolo `premium` | 4° ruolo | Non esiste (è `UserTier`) | **Decisione**: mappare `premium` → `UserTier.Premium` (consigliato) o aggiungere ruolo. |
+| Ruoli extra | solo 4 | `editor`+`creator` presenti | Mantenere; la matrice RBAC SP5 va estesa a 5 ruoli. |
+| Doppio tipo ruolo | — | VO `Role` + enum `UserRole` | Riconciliare/documentare; non introdurre un terzo. |
+| Gate superadmin | nuovo | **Già esiste** | Riusare `RequireSuperAdminSession()` + policy. |
+| Doppio meccanismo gate | — | imperativo vs policy | Standardizzare per i nuovi endpoint admin. |
+
+---
+
+## 3. Audit log
+
+### Stato attuale
+
+- **Tabella `audit_logs`** — entity `apps/api/src/Api/Infrastructure/Entities/Administration/AuditLogEntity.cs`, config `…/Infrastructure/EntityConfigurations/Administration/AuditLogEntityConfiguration.cs`, dominio `apps/api/src/Api/BoundedContexts/Administration/Domain/Entities/AuditLog.cs` (immutabile).
+- **Scrittura su due strade**:
+  1. **Automatica** via MediatR `AuditLoggingBehavior` (`…/Administration/Application/Behaviors/AuditLoggingBehavior.cs`), opt-in per comando con attributo `[AuditableAction]` — applicato a **soli ~8 comandi** (Suspend/ChangeRole/Delete/UpdateTier/UpdateAiConsent/ExportData/DeleteLlmData/DeleteOwnAccount).
+  2. **Manuale** nei handler (es. impersonate). Repo `…/Administration/Infrastructure/Persistence/AuditLogRepository.cs` (Update/Delete lanciano eccezione → immutabilità).
+- **Read endpoints**: `apps/api/src/Api/Routing/AdminAuditLogEndpoints.cs` (`GET /admin/audit-log`, `…/export`, `GET /admin/users/{id}/audit-log`).
+- ❌ **Nessun middleware globale** "logga ogni mutazione `/admin/*`". La copertura è frammentaria.
+
+### Schema attuale vs richiesto
+
+| Campo handoff | Colonna reale | Stato |
+|---|---|---|
+| `actor_id` | `UserId` | ✅ (rinominare semanticamente) |
+| `action` | `Action` (maxlen 64) | ✅ |
+| `target_type` | `Resource` (maxlen 128) | ✅ |
+| `target_id` | `ResourceId` | ✅ |
+| `ip` | `IpAddress` | ✅ |
+| `user_agent` | `UserAgent` | ✅ |
+| `created_at` | `CreatedAt` (indexed) | ✅ |
+| `impersonated_user_id` | — | ❌ manca |
+| `before_json` | — (solo `Details` blob, **max 1024 char**) | ❌ manca |
+| `after_json` | — | ❌ manca |
+| `step_up_token_id` | — | ❌ manca |
+
+### Gap audit
+
+1. **Estendere lo schema**: aggiungere `impersonated_user_id`, `before_json`, `after_json`, `step_up_token_id`; allargare/sostituire `Details` (1024 char insufficiente per before+after).
+2. **Cattura before/after**: oggi il behavior serializza solo le proprietà del *comando*, non lo stato dell'entità. Serve catturare pre/post nei handler.
+3. **Sistematizzare**: estendere `[AuditableAction]` a tutti gli handler admin (o un wrapper più generale) per soddisfare il requisito "ogni mutazione admin logga".
+4. ⚠️ **Rischio — doppia entità AuditLog**: esiste anche `apps/api/src/Api/BoundedContexts/SecurityAudit/Infrastructure/Entities/AuditLogEntity.cs` con config propria. **Chiarire quale è canonica** (`Administration` è quella effettivamente usata) prima di estendere lo schema, per non costruire sul ramo morto.
+
+---
+
+## 4. Impersonate e 2FA / step-up
+
+### Impersonate — esiste, ma non conforme al token model
+
+- **Esiste** end-to-end: `ImpersonateUserCommandHandler` (`…/Administration/Application/Commands/`), endpoint `POST /admin/users/{userId}/impersonate` (`apps/api/src/Api/Routing/Admin/AdminUserActivityDetailEndpoints.cs:152`, SuperAdmin-gated + `RequiresConfirmationAttribute`), end via `POST /admin/impersonation/end`. Guard sui target privilegiati (no impersonate di admin/superadmin), audit start/end doppio.
+- ❌ **Gap**: usa **session cookie a 30 giorni** invece di JWT/token **15 min**; **nessun claim `actor`** (l'admin originale vive solo in audit, non nel token) → manca data-source affidabile per il **banner persistente**.
+- **Raccomandazione**: estendere la `Session` entity con `ImpersonatedByUserId` + `ImpersonatedUntil` + lifetime override 15 min (più coerente dell'introdurre JWT), sfruttando `SessionStatusDto` già propagato al FE per il banner.
+
+### 2FA / Step-up — TOTP esiste, step-up NO
+
+- **2FA TOTP completo**: enrollment (`GenerateTotpSetupCommand`), anti-replay (`UsedTotpCodeEntity`), backup codes; su `User` (`IsTwoFactorEnabled`, `TotpSecret`). Tipo TOTP (no SMS).
+- ❌ **Step-up assente**: `TwoFactorEnforcementBehavior` (`…/Authentication/Application/Behaviors/`) è in **shadow mode** — logga e **prosegue, non blocca**. `MaxAgeMinutes=30` (handoff chiede 5). **Nessun header `X-StepUp-Token`** (0 occorrenze in `apps/api/src`). Manca `LastTotpVerifiedAt` sulla `Session` (esplicitamente previsto nei commenti del behavior).
+- **Riusabile**: tutta l'infra TOTP; `RequireTwoFactorAttribute` (già su Impersonate/Delete/Suspend/ChangeRole); `ConfirmationLevel.Level2` come base del typed-confirm UI.
+- **Gap per lo step-up del handoff**: (1) `LastTotpVerifiedAt` su Session; (2) endpoint challenge che emette `step_up_token` (→ `audit.step_up_token_id`); (3) header `X-StepUp-Token` + validazione; (4) behavior shadow→strict (403 `STEP_UP_REQUIRED`, MaxAge 30→5); (5) coprire trigger mancanti (rotate API key, emergency shutdown, mass delete>5, change flag prod, promote→superadmin).
+
+---
+
+## 5. Endpoint backend — copertura per gruppo
+
+> Prefisso globale reale **`/api/v1`** (`apps/api/src/Api/Program.cs:700`): un path di design `/api/admin/x` corrisponde a `/api/v1/admin/x`. ⚠️ Esiste **duplicazione** dei file user (`Routing/AdminUser*.cs` legacy vs `Routing/Admin/AdminUser*.cs` — registrati questi ultimi).
+
+| Gruppo | Copertura | Gap principali |
+|---|---|---|
+| Overview/monitor/health | ~55% | manca **SSE `events/live` globale**; `metrics` frammentato per dominio (no `?range=`); health non sotto `/admin` |
+| Users | ~85% | manca **`force-logout`** (esiste `unlock`≠) e **`GET .../sessions`**; PATCH→**PUT**; paginazione **page/limit** (non cursor) |
+| **Content moderation** | **0%** | **gruppo interamente assente** (queue/approve/reject/delete-comment/mute). Nessun aggregate riusabile |
+| AI/RAG | ~70% | manca **`flag-hallucination`** e **`queries?sort=worst`**; path `agents/*` invece di `ai/*`; drill via `rag-executions/{id}/replay` (SSE) |
+| KB | ~75% | manca **`kb/tree`**, **`docs/{id}/chunks`**, **`idempotency-check`**; upload OK ma progress SSE su endpoint separato (`/admin/queue/{jobId}/stream`) |
+| Catalog | ~90% | coperto (BGG queue + ingestion); "runs" storici non come da design |
+| Config/Flags | ~80% | path `feature-flags`; PATCH→PUT/toggle; no `apply` esplicito (modifiche inline) |
+| Notifications | ~70% | solo canale email-template; `test-send` reale incerto (esiste `preview`); broadcast = `POST /admin/notifications/send` |
+| **Editor/Versions** | ~25% | **nessun editor/versioning generico**; frammentato per dominio (email-template, config history/rollback, RuleSpec) |
+| Pipeline/n8n | ~70% | n8n configs+templates+test OK; **no `rotate` key dedicato**; webhooks = error-log workflow |
+| Upload avanzato | ~80% | bulk+queue OK; `upload/history` solo come `recently-processed` |
+| Play records | ~80% | path **`/play-records`** (non `/me/...`); **manca `DELETE`** |
+| Private games | ~75% | path **`/private-games`** (non `/me/...`); **manca `publish-checklist`**; submit-for-review solo via "propose-to-catalog"/toolkit |
+
+**Gap backend più critici**: (1) Content Moderation 100% assente; (2) bus SSE admin globale `events/live`; (3) Editor/Versions generico; (4) Users `force-logout`+`sessions`; (5) AI `flag-hallucination`; (6) personal endpoints su `/play-records` e `/private-games` (non `/me`), con `DELETE`/`publish-checklist` mancanti.
+
+**Aree admin EXTRA non previste dai 18 mockup** (il backend è più ricco del design): Mechanic Extractor, LLM/Provider ops (OpenRouter, circuit-breaker, emergency), Docker/Infra ops, Slack, business stats, secrets, database-sync, staging-allowlist, A/B test, sandbox, RAG backup.
+
+---
+
+## 6. Frontend — 18 schermate SP5 vs realtà
+
+### Shell e navigazione (diverge dal design)
+
+- Layout: `apps/web/src/app/admin/(dashboard)/layout.tsx` → guard (`view_mode` cookie + `RequireRole ['Admin']`) → `AdminShell`.
+- `AdminShell` (`apps/web/src/components/layout/AdminShell/AdminShell.tsx`) = **`TopBar` (riusata da UserShell, `adminMode`) + `AdminSideDrawer` off-canvas (overlay 280px) + SearchOverlay**. **NON** è una sidebar persistente + topbar fissa come implica SP5.
+- Navigazione (`AdminSideDrawer.tsx`): ~20 voci curate, ma esistono ~90 page.tsx admin → gran parte delle route non è in nav primaria.
+
+### Mappa schermate
+
+| ID | Funzione | Stato | Route reale / file |
+|---|---|---|---|
+| A1 Overview | KPI+activity+alerts+charts | ✅ | `admin/(dashboard)/overview/page.tsx` (+`activity/`, `system/`) |
+| A2 Users | lista+drill+impersonate+suspend+delete | 🟡 | `users/page.tsx` + `users/[id]/page.tsx` (impersonate endpoint BE ✅; wiring FE delete/impersonate **da verificare**) |
+| A3 Content moderation | queue approve/reject | 🟡 | `content/page.tsx` è gestione giochi/KB, **non** moderation queue |
+| A4 AI/RAG quality | metrics + query drill-down | ✅ | `rag-quality/page.tsx` + `agents/inspector/page.tsx` + `ai?tab=rag` |
+| A5 KB management | tree + viewer + chunk table | ✅ | `knowledge-base/page.tsx` (hub) + `documents/`, `vectors/` |
+| A5b KB upload flow | FSM 5 stati + SSE | ✅ | `knowledge-base/upload/page.tsx` |
+| A6 Catalog ingestion | runs + run-now | ✅ | `catalog-ingestion/page.tsx` |
+| A7 Config/Flags | rows + dirty bar + apply | ✅ | `config/page.tsx?tab=flags` (dirty-bar **da verificare**) |
+| A8 Monitor | metrics + LiveEventLog SSE | ✅ | `monitor/page.tsx` (12 tab; LiveEventLog ≈ `LogsTab`) |
+| A9 Notifications | template list + editor + test-send | 🟡 | solo `notifications/compose/page.tsx`; template in `content/email-templates` (scollegato) |
+| B1 Editor | block editor + version history | 🟡 | `(authenticated)/editor/page.tsx` — **fuori da /admin**, `?gameId=` non `[type]/[id]` |
+| B2 Pipeline builder | canvas + nodes | 🟡 | `(authenticated)/pipeline-builder/page.tsx` — fuori da /admin, no `[id]` |
+| B3 n8n | workflows + webhook log + keys | 🟡 | `(authenticated)/n8n/` + `admin/config/n8n/`; copre keys/config, **no** workflow/webhook log |
+| B4 Upload avanzato | bulk + queue + history | 🟡 | `(authenticated)/upload/page.tsx` — fuori da /admin; overlap con A5b |
+| B5 Play records | personal/cross-user | 🟡 | `(authenticated)/play-records/new` + `[id]/edit` — **manca index** |
+| B6 Versions | timeline + diff + publish | 🟡 | `(authenticated)/versions/page.tsx` — fuori da /admin, `?gameId=` non `[artifact]` |
+| B7 Private games | publish checklist | 🟡 | `(authenticated)/private-games/[id]` — manca index + checklist |
+| B8 Dev tools | scenario/auth-switcher/store-inspector | ❌ | solo `(public)/dev/meeple-card` (showcase) — concetto SP5 assente |
+
+**Copertura FE**: ✅ 7 full · 🟡 10 parziali · ❌ 1 mancante.
+
+### Pattern di routing (3 coesistono, con duplicazione di IA)
+
+1. **Hub `?tab=`** (server component): `ai` (9 tab), `monitor` (12 tab), `config` (5 tab), `content` (2 tab), `analytics`.
+2. **Tabs in-page** (shadcn, stato locale): `catalog-ingestion`.
+3. **Route separate vere**: `overview`, `users`, `users/[id]`, `rag-quality`, `knowledge-base/*`, `agents/inspector`.
+
+⚠️ **Duplicazione IA**: AI/RAG/KB raggiungibili da 2-3 path (`/admin/ai?tab=rag` ≈ `/admin/agents/inspector` ≈ `/admin/rag-quality`; `/admin/content?tab=kb` ≈ `/admin/knowledge-base`). Il design SP5 assume route-separate 1:1.
+
+---
+
+## 7. Componenti — riuso vs nuovi
+
+**~33-36 dei 38 componenti SP5 già coperti.** Solo **~2-3 realmente nuovi**.
+
+Riuso diretto/quasi-diretto (✅): AdminShell, AdminTopbar (`TopBar`), BulkActionsBar (`BulkActionBar`), AdminKPICard (`KPICard`/`KPIStatCard`), AdminPanel (`Card`), AdminTabs (`Tabs`/`AdminHubTabBar`), RoleChip (`UserRoleBadge`, 5 ruoli), StatusChip (`Badge`+status-badge), Admin{Input,Select,Toggle,Textarea} (primitives), AdminFormRow (`Form`/`settings-row`), RetrievalChunkList (`RetrievedChunkCard`), LatencyBreakdownBar (`WaterfallChart`), DocumentViewer (`PdfViewerModal`), ProcessingTimeline (`PdfStatusTimeline`), ConfirmModal (`AdminConfirmationDialog`), AuditLogTimeline (`AuditTab`/`UserActivityTimeline`), VersionHistory/Timeline, VersionDiffViewer (`components/diff/`), FlowCanvas/NodePalette/NodeConfigPanel (ReactFlow `@xyflow/react`, **2 impl. esistenti**), TemplateEditor/BlockEditor (Tiptap `RichTextEditor`), FlagRow (`FeatureFlagsTab`).
+
+Adattamento/estensione (🟡): AdminSidebar (drawer→sidebar persistente, **se richiesta**), AdminDataTable (+pagination +virtualization), KPISparkline (wrapper Recharts), EnvPill, StatusDot, QueryDrillDown, ChunkTable, IngestionLog, SyncStatusHero, DirtyStateBar, LiveEventLog (UI), TimeRangePicker (`DateRangePicker`+presets), PreviewFrame, PublishChecklist (`setup-checklist`), ScenarioPicker/StoreInspector, DangerZoneBox.
+
+Da creare ex-novo (❌, ~2-3): **KBTree** (tree-view generico file/cartelle), **MobileFallback** "desktop-only gate" (se richiesto come componente), eventuale **density system** admin-wide.
+
+**Collocazione (rispettare il freeze de-versioning — NO `components/v2/`)**:
+- Primitive trasversali → `apps/web/src/components/ui/<primitive>/` (es. `ui/status-dot/`, `ui/sparkline/`; esiste già `ui/admin/`).
+- Composizioni admin → `apps/web/src/components/admin/<feature>/` (home dei ~220 componenti admin esistenti).
+- ❌ vietato ricreare `components/admin/v2/`, `components/v2/**`, `components/ui/v2/**`.
+
+**Note tecniche**:
+- `AdminConfirmationDialog` Level2 chiede di digitare letteralmente `CONFIRM` (hardcoded) → parametrizzare per il "type the resource name" del handoff.
+- Diversi componenti admin hanno `eslint-disable local/no-hardcoded-color-utility` (debito DS-15). I nuovi SP5 devono usare i token canonici (`bg-card`, `text-foreground`, `bg-entity-*`).
+- `FlowCanvas`: 2 impl. ReactFlow esistenti — generalizzarne una, non crearne una terza.
+
+---
+
+## 8. SSE/realtime, virtualization, design tokens
+
+- **SSE FE maturo** (niente da creare per A8/A5b): pattern di riferimento `apps/web/src/app/admin/(dashboard)/knowledge-base/queue/hooks/use-queue-sse.ts` (EventSource `withCredentials`, named events, backoff esponenziale, stato tipizzato). Indicator riusabile: `…/queue/components/sse-connection-indicator.tsx`. Hook per-job: `use-job-sse.ts` (→ A5b). Chat RAG via SignalR (`@microsoft/signalr`) + `apps/web/src/lib/agent/sse-handler.ts`. **Gap = solo il bus BE globale `events/live`** (vedi §5).
+- **Virtualization**: `react-window ^2.2.7` ✅ (NON `@tanstack/react-virtual`). Precedente: `apps/web/src/components/pdf/PdfTableRow.tsx`. Il `DataTable` generico **non** è virtualizzato → estendere per il requisito SP5 ">200 righe".
+- **Design tokens**: sistema canonicalizzato (semantic `bg-background`/`bg-card`/`text-foreground`/`border-border`, entity `bg-entity-*`), tema `[data-theme="light|dark"]` (**default light**, mockup cream). ESLint `local/no-hardcoded-color-utility` (error). Il handoff chiede **density alta + dark default** per `/admin/*`: configurabile via scope `[data-theme]` + utility, ma **diverge dal default light** del prodotto → decisione di prodotto.
+- **Mobile/density**: shell già responsive ma **nessun** `MobileFallback` "desktop-only" né density system admin-wide (da creare se richiesti).
+
+---
+
+## 9. Rischi e decisioni aperte
+
+| # | Tema | Decisione richiesta |
+|---|---|---|
+| R1 | `premium` ruolo vs `UserTier` | Mappare a tier (consigliato) o aggiungere ruolo? Impatta tutta la matrice RBAC SP5. |
+| R2 | 5 ruoli reali vs 4 del handoff | Estendere matrice RBAC a `editor`/`creator`. |
+| R3 | Doppia entità `AuditLog` (Administration vs SecurityAudit) | Stabilire quale è canonica **prima** di estendere lo schema. |
+| R4 | Impersonate: session 30gg vs token 15min + claim actor | Estendere `Session` (consigliato) o introdurre JWT. |
+| R5 | Step-up shadow→strict | Trasformare il behavior, aggiungere `LastTotpVerifiedAt`, header, endpoint challenge. |
+| R6 | Shell drawer off-canvas vs sidebar persistente SP5 | Re-skin verso sidebar fissa o mantenere drawer? (impatto UX ampio) |
+| R7 | Duplicazione IA (AI/RAG/KB su 2-3 path) | Consolidare prima di re-skin, o il design SP5 moltiplica la confusione. |
+| R8 | Convenzioni API divergenti | `/api/v1` (non `/api/admin`), PUT (non PATCH), page/limit (non cursor), `/play-records` & `/private-games` (non `/me`). Allineare contratto FE ai path reali. |
+| R9 | Tema dark default per admin vs light di prodotto | Decisione di prodotto. |
+| R10 | Sovrastima del handoff (38 "nuovi" componenti) | Ripianificare gli sprint SP5 sul **delta** reale, non sul greenfield. |
+
+---
+
+## 10. Schermata pilota raccomandata
+
+**Pilota: A1 Overview** (`/admin/overview`) — P0, già `✅ full`, basso rischio. Obiettivo del pilota: validare il *workflow di traduzione mock SP5 → componente* e le fondamenta (shell, design-system/token SP5, tree-shaking admin, mobile fallback) **senza** dipendere da nuovi endpoint o RBAC. Allineato a `SCREENS.md` (Sprint 1) e `QUICK_START.md` (step 5).
+
+**Secondo step (stress-test sicurezza): A2 Users** (`/admin/users` + `[id]`) — P0, esercita TUTTI i pattern rischiosi: `AdminDataTable` (sort/multi-select/pagination/virtualization), drill-down, impersonate (con i gap §4), delete con typed-confirm + step-up, audit timeline. È il vero banco di prova prima di scalare agli altri 16.
+
+**Sconsigliato** partire da B1-B8: stanno fuori da `/admin`, hanno gap di routing (path param) e in parte di endpoint; vanno affrontati dopo aver consolidato shell + pattern sicurezza.
+
+---
+
+## Appendice — Convenzioni divergenti (contratto FE)
+
+| Tema | Handoff SP5 | Realtà codebase |
+|---|---|---|
+| Prefisso API | `/api/admin/*` | `/api/v1/admin/*` |
+| Mutazione update | `PATCH` | `PUT` / `POST .../toggle` |
+| Paginazione liste | cursor | page/limit (alcune) |
+| Endpoint personali | `/api/me/play-records`, `/api/me/private-games` | `/play-records`, `/private-games` |
+| Token sessione | JWT short-lived | cookie + session table (hash, 30gg) |
+| Ruoli | `user/premium/admin/superadmin` | `user/editor/creator/admin/superadmin` (+ `UserTier`) |
+| Nav admin | sidebar+topbar fissi | TopBar + drawer off-canvas |
+
+---
+
+*Audit prodotto in sola lettura. Nessuna modifica al codice. Prossimo passo suggerito: condividere §9 (decisioni aperte) con il design owner prima di avviare il pilota A1.*

--- a/admin-mockups/design_handoff_admin/BACKEND_PROMPTS.md
+++ b/admin-mockups/design_handoff_admin/BACKEND_PROMPTS.md
@@ -1,0 +1,694 @@
+# Backend Prompts — Admin Console (SP5)
+
+Prompt template pronti per Claude Code. 18 mockup, uno per prompt. **Adatta i path al codebase**.
+
+## Premessa per ogni prompt
+
+```
+Vincoli generali admin:
+- Tutte le route /admin/* richiedono role admin o superadmin (verifica in middleware)
+- Ogni POST/PATCH/DELETE produce un audit_log entry (middleware auditLogger)
+- Mobile fallback: <880px mostra "console solo desktop"
+- Dark theme default
+- Density alta (admin-base.css)
+- Pagination cursor-based, NO offset
+- Stati: default + loading + empty + error
+- Server-side filter+sort per liste >100 row
+- Virtualization per >200 row visibili
+- data-testid solo dove specificato
+```
+
+---
+
+## 1.1 A1 · Admin Overview
+
+**Mock**: `design/admin/sp5-admin-overview.html` → `/admin/overview`
+
+```
+Implementa /admin/overview basato su design/admin/sp5-admin-overview.html.
+
+Min role: admin. Audit log per ogni mutazione (qui poche: solo quick actions).
+
+Backend GET /api/admin/overview restituisce:
+{
+  kpis: {
+    usersTotal: number,
+    usersDelta24h: number,
+    sessionsActive: number,
+    sessionsDeltaPercent: number,
+    agentsLive: number,
+    kbStorageBytes: number,
+    kbStorageDeltaBytes7d: number
+  },
+  alerts: AdminAlert[],   // up to 4, ordered by severity
+  activityFeed: ActivityEntry[],  // last 12h, up to 20
+  charts: {
+    uptime7d: { value: number, slo: number, sparkline: number[] },
+    requestsPerMin: { value: number, sparkline: number[] },
+    errorRate: { value: number, threshold: number, sparkline: number[] },
+    aiCostToday: { value: number, budget: number, sparkline: number[] }
+  },
+  deployment: { env, lastDeployAt, buildId, commit, by, status }
+}
+
+Cache server-side 30s. SWR/RQ frontend 30s.
+
+Quick actions (alcune richiedono superadmin):
+- Impersonate user (superadmin + 2FA step-up)
+- Reset rate limit (admin)
+- Force cache flush (superadmin + confirm)
+- Pausa ingestion (admin + confirm)
+- Broadcast banner (superadmin + typed-confirm)
+- Emergency shutdown (superadmin + typed-confirm "EMERGENCY")
+
+Componenti da creare:
+- AdminKPICard (entity-tinted + sparkline)
+- AdminAlertBanner
+- AdminActivityFeed
+- ChartPanel (4 varianti: uptime, requests, errors, cost)
+- QuickActionsPanel
+- StatusDot + meeple-pulse animation
+
+Keyboard: R refresh, ⌘K search.
+```
+
+---
+
+## 1.2 A2 · Admin Users
+
+**Mock**: `design/admin/sp5-admin-users.html` → `/admin/users[?selected=u-X]`
+
+```
+Implementa /admin/users basato su design/admin/sp5-admin-users.html.
+
+Min role: admin per lista/sospensione. Superadmin per promote/delete/impersonate.
+
+Backend:
+- GET /api/admin/users?q=&role=&status=&lastSeenWithin=&plan=&cursor=&sort=&dir=
+  → cursor-based pagination, restituisce { items: User[], cursor, total, facets }
+- GET /api/admin/users/{id} → full profile + sessions + 2fa status + audit history
+- PATCH /api/admin/users/{id} { role?, suspended? } (audit + step-up se role→admin/superadmin)
+- POST /api/admin/users/{id}/force-logout (admin + confirm)
+- POST /api/admin/users/{id}/reset-password (admin)
+- POST /api/admin/users/{id}/suspend|unsuspend (admin)
+- DELETE /api/admin/users/{id} (superadmin + step-up + typed-confirm "ELIMINA UTENTE {NAME}")
+- POST /api/admin/users/{id}/impersonate-start → JWT ttl=900s (superadmin + step-up)
+- POST /api/admin/impersonate-end
+- POST /api/admin/users/{id}/export-gdpr → genera ZIP async + job
+
+Frontend:
+- src/features/admin/users/UsersPage.tsx
+- AdminDataTable con virtualization
+- Filter chips (role/status/lastSeen/plan)
+- BulkActionsBar quando >0 selezionati
+- Multi-select con shift-click range
+- Right side drill-down panel sticky con:
+  - Hero (avatar grad + nome + role chip + status)
+  - Tabs: Profilo · Sessioni (n) · Agenti (n) · Audit (n) · Billing
+  - DangerZone (force logout, delete account)
+
+ImpersonateFlow:
+- Step-up modal 2FA TOTP
+- Banner persistente fixed top "TU SEI {USER} · termina »"
+- Tutte le altre pagine accessibili tranne /admin/*
+- Auto-end dopo 15 min con countdown banner
+- audit_log su ogni request durante impersonate
+
+Keyboard: j/k navigate rows · Enter open detail · Escape close drawer.
+```
+
+---
+
+## 1.3 A3 · Content Moderation
+
+**Mock**: `design/admin/sp5-admin-content.html` → `/admin/content`
+
+```
+Implementa /admin/content basato su design/admin/sp5-admin-content.html.
+
+Min role: admin.
+
+Tabs:
+1. Games queue (giochi community submitted, in attesa)
+2. Toolkit condivisi
+3. KB docs (proposed da utenti per gioco condiviso)
+4. Comments flagged (segnalati da N utenti)
+
+Backend:
+- GET /api/admin/moderation/queue?type=&status=in_review&cursor=
+- GET /api/admin/moderation/{id}/preview → full content per review
+- POST /api/admin/moderation/{id}/approve (audit)
+- POST /api/admin/moderation/{id}/reject { reason }  (audit, notifica autore)
+- POST /api/admin/moderation/{id}/request-changes { notes }
+- POST /api/admin/moderation/comments/{id}/delete
+- POST /api/admin/moderation/users/{id}/mute?duration_days=
+- POST /api/admin/moderation/users/{id}/ban (superadmin + typed-confirm)
+
+UI:
+- ModerationQueue (rows con preview button)
+- ContentStatusChip
+- CommentCard con flag-count badge + delete/mute/ban actions
+- Spoiler-block edit modal (per spoiler-tag wrapping)
+
+Notifiche outbound:
+- Approve game → notif a designer "Il tuo gioco è online!"
+- Reject → notif con reason
+- Comment delete → notif silenziosa solo se autore richiede transparency settings
+```
+
+---
+
+## 1.4 A4 · AI / RAG Quality
+
+**Mock**: `design/admin/sp5-admin-ai.html` → `/admin/ai` + `/admin/rag-quality`
+
+```
+Implementa /admin/ai basato su design/admin/sp5-admin-ai.html.
+
+Min role: admin.
+
+Backend:
+- GET /api/admin/ai/metrics?range=1h|24h|7d|30d → 5 KPI
+- GET /api/admin/ai/metrics/timeseries?range=&kind=p50|p95|errorRate
+- GET /api/admin/ai/queries?sort=worst&limit=10
+  → ordered by composite: low_rating + high_latency + low_confidence
+- GET /api/admin/ai/queries/{id}/drill
+  → { query, response, confidence, retrievedChunks[], latencyBreakdown, tokens, cost, debug }
+- POST /api/admin/ai/queries/{id}/rerun { kbVersion?: 'current' | 'beta' }
+- POST /api/admin/ai/queries/{id}/flag-hallucination
+- POST /api/admin/ai/queries/{id}/notify-user
+- GET /api/admin/ai/agents/usage?range=
+
+Frontend:
+- 5 KPI sparklines (Query/day, Avg latency, P95, Cost/day, Hallucination rate)
+- TrendChart (multi-line p50/p95/error% over 7d)
+- WorstQueriesTable
+- QueryDrillDown sidebar:
+  - Header con confidence-badge entity-event/agent/toolkit + meta
+  - RetrievalChunkList con highlight mark e score colorato
+  - Response card + feedback utente
+  - LatencyBreakdownBar (4 segmenti: retrieval, rerank, llm, postprocess)
+  - Debug expandable (tokens, cache, model, embedder, indexer version)
+  - Actions row (rerun current/beta, flag hallucination, copy query, notify author)
+
+Componenti nuovi: QueryDrillDown, RetrievalChunkList, LatencyBreakdownBar, ConfidenceBadge (riuso da sp6/sp7).
+```
+
+---
+
+## 1.5 A5 · Knowledge Base
+
+**Mock**: `design/admin/sp5-admin-kb.html` → `/admin/knowledge-base`
+
+```
+Implementa /admin/knowledge-base basato su design/admin/sp5-admin-kb.html.
+
+Min role: admin per read/upload/reindex. Admin + confirm per delete chunk.
+Superadmin per reindex con strategy=raptor (costoso).
+
+Backend:
+- GET /api/admin/kb/tree → { games: [{ id, title, em, docs: [{ id, title, chunks, status }] }] }
+- GET /api/admin/kb/docs/{id} → { doc, ingestionLog, metadata, usedByAgents }
+- GET /api/admin/kb/docs/{id}/chunks?q=&topK=&minScore=&chapter=&cursor=
+  → ricerca semantica con highlight
+- GET /api/admin/kb/docs/{id}/chunks/{chunkId} → full chunk text + embedding (debug)
+- POST /api/admin/kb/docs/{id}/reindex { strategy: 'standard' | 'raptor' }
+- DELETE /api/admin/kb/docs/{id} (admin + confirm)
+- DELETE /api/admin/kb/chunks/{id} (superadmin + confirm)
+- GET /api/admin/kb/docs/{id}/embeddings.json (debug export)
+
+UI:
+- KBTree (left sidebar 300px, accordion per gioco, sticky)
+- DocumentHero (cover game-color + title + meta + 5 stats KPI)
+- AdminTabs: Preview · Chunks (n) · IngestionLog · UsedBy (n)
+- ChunkTable con search inline, score colored (hi=kb, md=warn, lo=event)
+- IngestionLog pre-formatted con colorate (ok=toolkit, warn=yellow, err=event)
+
+NB: chunk preview deve avere `<mark>` highlight per query match (server o client).
+```
+
+---
+
+## 1.6 A5b · KB Upload Flow
+
+**Mock**: `design/admin/sp5-kb-upload-flow.html` → `/admin/knowledge-base/upload`
+
+```
+Implementa /admin/knowledge-base/upload basato su design/admin/sp5-kb-upload-flow.html.
+
+FSM 5 stati: empty → idempotency-check → uploading → processing → complete|error.
+
+Backend:
+- POST /api/admin/kb/idempotency-check { sha256 } → { match: KbDoc | null, similarity }
+- POST /api/admin/kb/upload (multipart) { file, gameId, language?, ocr?, smolDocling?, chunkSize?, indexerVersion? }
+  → 202 Accepted { jobId }
+- GET /api/jobs/{id} → { stage: 'upload'|'parse'|'layout'|'embed'|'index', progress, eta, log[], error? }
+- SSE /api/jobs/{id}/events → live progress updates
+- POST /api/jobs/{id}/cancel
+- POST /api/jobs/{id}/retry { skipStage?: number }
+
+UI FSM:
+- StateEmpty: dropzone tabindex+keyboard accessible, settings card readonly
+- StateUploading: dropzone con progress + cancel
+- StateProcessing: dropzone shrink + queue card con 5-stage timeline (each con dot pulsing for running)
+- StateComplete: success banner + queue history + first 3 chunks preview
+- StateError: danger banner con error code + log download + retry option
+- GuardWarn (idempotency-warn): banner warning con CTA (Vai a KB / Sovrascrivi / Aggiungi come nuovo)
+
+UploadDropzone:
+- Accessible: keyboard space/enter, drag-over visual feedback
+- Multi-file (queue ognuno come job separato)
+- Cap size 100MB · MIME check
+
+ProcessingTimeline:
+- 5 stage cards in grid 5col
+- Each: name + state + sub-state animated bar for running
+
+Componente nuovo: UploadFSMProvider context per condividere state tra dropzone/settings/queue.
+```
+
+---
+
+## 1.7 A6 · Catalog Ingestion
+
+**Mock**: `design/admin/sp5-admin-catalog.html` → `/admin/catalog-ingestion`
+
+```
+Implementa /admin/catalog-ingestion basato su design/admin/sp5-admin-catalog.html.
+
+Min role: admin.
+
+Backend:
+- GET /api/admin/catalog/status → SyncStatus hero
+- GET /api/admin/catalog/runs?cursor= → history runs
+- GET /api/admin/catalog/runs/{id} → detail con log
+- POST /api/admin/catalog/run-now { provider: 'bgg'|'csv'|'manual' } (admin)
+- GET /api/admin/catalog/queue?status=pending|failed → items
+- POST /api/admin/catalog/queue/{id}/retry
+- POST /api/admin/catalog/queue/retry-bulk (failed items)
+- POST /api/admin/catalog/import-csv (multipart)
+
+UI:
+- SyncStatusHero con last-run + next-scheduled + provider settings inline
+- SyncRunTimeline (table runs con status dot + delta added/updated/failed)
+- PendingQueueList (priority high/stale)
+- FailedItemsList (con error code mono + retry button inline)
+
+Componenti nuovi: SyncStatusHero, SyncRunTimeline.
+
+Rate limit consciousness: mostra "stiamo a 47/60 req/min" se BGG.
+```
+
+---
+
+## 1.8 A7 · Config / Feature Flags
+
+**Mock**: `design/admin/sp5-admin-config.html` → `/admin/config`
+
+```
+Implementa /admin/config basato su design/admin/sp5-admin-config.html.
+
+Min role: admin per read e cambio in dev/stg. Superadmin per cambio in prd + audit + step-up.
+
+Backend:
+- GET /api/admin/flags?env=dev|stg|prd
+  → { flags: [{ key, value, type, description, lastChangedAt, lastChangedBy, scopes: ['dev','stg','prd'] }] }
+- PATCH /api/admin/flags/batch { env, changes: { [key]: value } } → dry-run preview
+- POST /api/admin/flags/apply { env, changes } → commit (audit + step-up if env=prd)
+- GET /api/admin/flags/history/{key}?limit=
+
+UI:
+- Tabs per categoria (General, Features, AI, Integrations, Security)
+- FlagRow grid: name+desc | envs available | toggle | last-changed meta
+- Dirty state tracking client-side
+- DirtyStateBar sticky-bottom con:
+  - count "N modifiche non salvate"
+  - Revert, Preview diff (modal con before/after), Apply
+
+Apply flow:
+1. Validation BE (type-check, deps)
+2. If env=prd → step-up modal 2FA
+3. Audit log + notification a Slack #ops
+4. Optimistic update + rollback su error
+```
+
+---
+
+## 1.9 A8 · Monitor
+
+**Mock**: `design/admin/sp5-admin-monitor.html` → `/admin/monitor`
+
+```
+Implementa /admin/monitor basato su design/admin/sp5-admin-monitor.html.
+
+Min role: admin.
+
+Backend:
+- GET /api/admin/metrics/strip?range= → 6 KPI sparklines
+- GET /api/admin/metrics/requests-by-endpoint?range= → stacked area
+- GET /api/admin/metrics/errors-by-route?range= → bar chart
+- GET /api/admin/metrics/signups-sessions?range=
+- GET /api/admin/metrics/session-duration-histogram?range=
+- SSE /api/admin/events/live?level=&route= → streaming events
+
+UI:
+- TimeRangePicker (1h/24h/7gg/30gg/custom)
+- KpiStrip 6 cards
+- 4 BigChart (con header + sub + svg)
+- LiveEventLog (sticky-bottom panel, 80-col mono, virtualized)
+
+LiveEventLog component:
+- Subscribe SSE on mount, unsubscribe on unmount
+- Auto-reconnect with exponential backoff
+- Filter bar: level (debug|info|warn|err|ok), route (regex)
+- Pause/Resume button (when paused, buffer events, show count)
+- Click row → expand JSON payload modal
+- Virtualize per 200+ rows visible
+
+Componenti nuovi: TimeRangePicker, KPISparkline, LiveEventLog.
+```
+
+---
+
+## 1.10 A9 · Notifications Templates
+
+**Mock**: `design/admin/sp5-admin-notifications.html` → `/admin/notifications`
+
+```
+Implementa /admin/notifications basato su design/admin/sp5-admin-notifications.html.
+
+Min role: admin. Broadcast = superadmin + typed-confirm.
+
+Backend:
+- GET /api/admin/notif/templates → all
+- GET /api/admin/notif/templates/{id} → with versions[]
+- PATCH /api/admin/notif/templates/{id} { subject, body, variables, channels[] }
+- POST /api/admin/notif/templates/{id}/preview { variables } → rendered HTML
+- POST /api/admin/notif/templates/{id}/test-send { to, variables }
+- POST /api/admin/notif/templates/{id}/publish (admin + audit)
+- POST /api/admin/notif/broadcast (superadmin + typed-confirm)
+  Body: { audience: 'all'|'premium'|'admins'|filter, channels: [], subject, body }
+
+UI:
+- Left list templates (filter by channel)
+- Right editor area:
+  - Tabs Edit · Preview · TestSend · History
+  - Markdown editor with Handlebars vars (highlight {{var}})
+  - Variables helper panel (collapsible)
+  - PreviewFrame iframe-mockup 380px width (email/mobile/desktop toggle)
+  - Test-send form (recipient, sample variables)
+  - HistoryTab versions timeline
+
+Components nuovi: TemplateEditor, TemplatePreviewFrame, VariableHelper.
+
+Variables helper: parse template body, extract {{x.y}}, show available with example values from current context.
+```
+
+---
+
+## 2.1 B1 · Editor
+
+**Mock**: `design/admin/sp5-editor.html` → `/editor/[type]/[id]`
+
+```
+Implementa /editor basato su design/admin/sp5-editor.html.
+
+Min role: admin per editare draft. Superadmin per publish.
+
+Backend:
+- GET /api/admin/editor/{type}/{id} → { blocks: Block[], metadata, version, status }
+- POST /api/admin/editor/{type}/{id}/blocks { block } (insert)
+- PATCH /api/admin/editor/{type}/{id}/blocks/{blockId} { block }
+- DELETE /api/admin/editor/{type}/{id}/blocks/{blockId}
+- POST /api/admin/editor/{type}/{id}/reorder { blockIds: [] }
+- POST /api/admin/editor/{type}/{id}/commit { message, version? } → new version
+- POST /api/admin/editor/{type}/{id}/publish (superadmin)
+- POST /api/admin/editor/{type}/{id}/autosave (debounced 30s)
+
+UI:
+- 3-column layout: tree 240px | editor 1fr | metadata+preview 320px
+- TreeNav (giochi → rules/faq/scenarios/glossary)
+- BlockEditor:
+  - Hover row reveals handle (drag, +, delete)
+  - Toolbar sticky (B I U S, H2/H3/code, list/table/quote, undo/redo)
+  - Slash commands "/" for inserting blocks
+  - Keyboard ⌘B bold ⌘K link ⌘/ commands
+- Live PreviewFrame (renders blocks → final HTML/PDF preview)
+- Metadata panel (slug, lang, tags, linked entities, status)
+- VersionHistoryPanel (last 5 + "See all")
+
+Auto-save UX: "⚪ Auto-save in 12s" counter → "✓ Salvato 14:22" toast.
+Commit dialog: "Apply changes" forces version bump + commit message.
+
+Components nuovi: BlockEditor, PreviewFrame, VersionHistoryPanel, SlashCommandMenu.
+```
+
+---
+
+## 2.2 B2 · Pipeline Builder
+
+**Mock**: `design/admin/sp5-pipeline-builder.html` → `/pipeline-builder/[id]`
+
+```
+Implementa /pipeline-builder basato su design/admin/sp5-pipeline-builder.html.
+
+Min role: admin per draft/test. Superadmin per publish in prod.
+
+Backend:
+- GET /api/admin/pipelines → list
+- GET /api/admin/pipelines/{id} → { nodes, edges, metadata, status, lastRunStats }
+- PATCH /api/admin/pipelines/{id} { nodes, edges }
+- POST /api/admin/pipelines/{id}/test-run { query } → { perNodeOutput, totalLatency, totalCost }
+- POST /api/admin/pipelines/{id}/publish (superadmin)
+- GET /api/admin/pipelines/{id}/runs?limit= → recent
+
+UI:
+- 3-col: palette 220px | canvas 1fr | config 300px
+- Palette categorie (Retrieval, Processing, Output, Integrations)
+- Drag nodes da palette → canvas
+- Canvas con grid background + SVG edges (Bezier)
+- Node component:
+  - Header type-colored
+  - Name + props summary
+  - In/out dots (left/right)
+  - Hover → handle + connect
+  - Stats footer (lat/cost/hit-rate) se ran recently
+- ConfigPanel context-aware al node selected
+- TestRun bottom panel con json output + warnings
+- Error nodes (border red) con tooltip "property X missing"
+
+Librerie suggerite: React Flow, dagre per layout auto.
+
+Components nuovi: FlowCanvas (wrapper React Flow), NodePalette, NodeConfigPanel.
+```
+
+---
+
+## 2.3 B3 · n8n Integrations
+
+**Mock**: `design/admin/sp5-n8n.html` → `/n8n`
+
+```
+Implementa /n8n basato su design/admin/sp5-n8n.html.
+
+Min role: admin per read. Superadmin per gestione keys + disconnect.
+
+Backend:
+- GET /api/admin/n8n/connection → status + endpoint
+- POST /api/admin/n8n/test-connection
+- POST /api/admin/n8n/disconnect (superadmin + confirm)
+- GET /api/admin/n8n/workflows → list with stats 24h
+- GET /api/admin/n8n/workflows/{id}/runs?cursor=
+- GET /api/admin/n8n/webhooks/log?cursor=&level=&status=
+- GET /api/admin/n8n/keys → list (only key prefix, never full)
+- POST /api/admin/n8n/keys { name, scope, expiresInDays } (superadmin)
+  → returns full key ONCE in response, never again
+- DELETE /api/admin/n8n/keys/{id} (superadmin + confirm)
+- POST /api/admin/n8n/keys/{id}/rotate
+
+UI:
+- ConnectionHero con endpoint + actions (test/rotate/disconnect)
+- Tabs: Workflows (n) · Webhooks (n) · Logs · API keys (n)
+- Workflows table con rate-bar (last 7 runs visualized)
+- Webhook log compact stream
+- API keys list con expiry warning <30d
+
+Security: quando generi nuova key, mostra UNA volta in modal "Salva questa key, non verrà mostrata di nuovo. [Copia]". Audit log con key prefix.
+```
+
+---
+
+## 2.4 B4 · Upload avanzato
+
+**Mock**: `design/admin/sp5-upload-advanced.html` → `/upload`
+
+```
+Implementa /upload basato su design/admin/sp5-upload-advanced.html.
+
+Backend:
+- POST /api/admin/upload/bulk (multipart, files[])
+- GET /api/admin/upload/queue → active jobs
+- GET /api/admin/upload/history?cursor=
+- SSE /api/jobs/{id}/events
+
+UI:
+- Left: dropzone + queue list + history list
+- Right: detailed processing view of selected job
+  - 4 KPI top (current stage, progress %, ETA, cost stim)
+  - Pipeline timeline 5 step (riuso A5b component)
+  - Metadata grid (lingua, ocr, chunk size, indexer)
+  - Actions grid (download orig, view extracted, retry stage, delete KB)
+
+Riuso pesante di ProcessingTimeline da A5b.
+Differenza vs A5b: qui è multi-file con queue prioritization.
+
+Components nuovi: BulkUploadQueue.
+```
+
+---
+
+## 2.5 B5 · Play Records
+
+**Mock**: `design/admin/sp5-play-records.html` → `/play-records`
+
+```
+Implementa /play-records basato su design/admin/sp5-play-records.html.
+
+NOTA: questo è SCOPE personale (user role), non admin-only.
+
+Backend:
+- GET /api/me/play-records?game=&from=&to=&player=&winner=&duration=&location=&sort=&cursor=
+- POST /api/me/play-records { gameId, playedAt, players[], duration, winner, scores[], notes, photos[] }
+- PATCH /api/me/play-records/{id}
+- DELETE /api/me/play-records/{id}
+- GET /api/me/play-records/stats?range= → wins per game, top opponents, KPI
+
+UI Tabs:
+1. List (sortable table con date · game · players · duration · winner · notes)
+2. Calendar (mensile, click giorno → modal con partite)
+3. Analytics (4 KPI + wins per gioco bar + top opponents card)
+
+Filter chips (multi-select) sticky-top.
+Quick analytics row 4 KPI.
+List paginated cursor + lazy load.
+
+NB: usa locale data formatting (Europe/Rome).
+```
+
+---
+
+## 2.6 B6 · Versions
+
+**Mock**: `design/admin/sp5-versions.html` → `/versions/[artifact]`
+
+```
+Implementa /versions basato su design/admin/sp5-versions.html.
+
+Min role: admin per read/restore. Superadmin per publish.
+
+Backend:
+- GET /api/admin/versions/artifacts → list artifacts (rules, toolkits, prompts, glossaries)
+- GET /api/admin/versions/{artifact} → versions timeline
+- GET /api/admin/versions/{artifact}/diff?from=&to= → unified diff (left+right)
+- POST /api/admin/versions/{artifact}/{vid}/publish (superadmin)
+- POST /api/admin/versions/{artifact}/{vid}/restore (admin)
+- GET /api/admin/versions/{artifact}/{vid}/changelog
+
+UI:
+- Left list artifacts (search + filter type)
+- Right:
+  - VersionTimeline (rows: tag · commit msg · author · status · diff size · checkbox compare)
+  - Compare selector (header: v2.0.0 ↔ v2.1.0 + View diff)
+  - DiffViewer side-by-side (left=v1 red del, right=v2 green add)
+
+Components nuovi: VersionTimeline, VersionDiffViewer, CompareSelector.
+
+Diff lib: usa diff-match-patch o diff2html.
+```
+
+---
+
+## 2.7 B7 · Private Games
+
+**Mock**: `design/admin/sp5-private-games.html` → `/private-games`
+
+```
+Implementa /private-games basato su design/admin/sp5-private-games.html.
+
+SCOPE: user-level (proprio account).
+
+Backend:
+- GET /api/me/private-games → list
+- POST /api/me/private-games { title, cover, players, duration, weight }
+- GET /api/me/private-games/{id} → full detail with all chapters/rules
+- PATCH /api/me/private-games/{id}
+- GET /api/me/private-games/{id}/publish-checklist → { items: [{ id, label, done, notes }] }
+- POST /api/me/private-games/{id}/submit-for-review → moves to admin moderation queue
+
+Schema DB: games table has is_private bool + owner_user_id. NEVER exposed by /api/public/*.
+
+UI:
+- Hero card: highlight gioco "ready for review" with checklist 7/9
+- Grid card layout
+- PrivateGameCard:
+  - Cover gradient + emoji + 🔒 lock badge
+  - Name + meta (players · duration · weight)
+  - Status chip (draft|in playtest|ready|published)
+  - Stats (version · partite test · last update)
+- New card (dashed) per creare nuovo
+
+Components nuovi: PublishChecklist, PrivateGameCard.
+
+PublishChecklist:
+- Items con criteri auto-computed (es. "almeno 5 partite test" → controlla play_records collegate)
+- Submit disabled finché completamento < 100%
+- Show completion ring + percent in side-card
+```
+
+---
+
+## 2.8 B8 · Dev Tools
+
+**Mock**: `design/admin/sp5-dev-tools.html` → `/dev`
+
+```
+Implementa /dev basato su design/admin/sp5-dev-tools.html.
+
+⚠ DEV-ONLY: wrap entire route in NODE_ENV check.
+Tree-shake con entry-point separato dev-entry.tsx.
+
+NO backend changes — tutto client-side (MSW handlers, Zustand stores, RQ cache, localStorage).
+
+Sections:
+1. Scenarios (MSW) — switch handler bundle:
+   - empty | small-library-marco | power-user-aaron | alpha-features-on | degraded-api | offline-mode
+   - Click "Load" → swap MSW worker handlers, page reload
+2. Auth role switcher — pills user/premium/admin/superadmin → set mock JWT in localStorage
+3. Runtime feature flags — localStorage flags (alphaMode, devTools, etc.) + toggles
+4. Memory store inspector — Zustand stores JSON tree
+5. React Query cache inspector — query keys with fresh/stale status + invalidate buttons
+6. Danger reset — localStorage/sessionStorage/IndexedDB/cookies/zustand/rq cache/nuke-all
+
+Components nuovi: ScenarioPicker, AuthRoleSwitcher, FlagRuntimeToggle, StoreInspector, CacheInspector, ResetPanel.
+
+Importa @tanstack/react-query-devtools come optional dep solo in dev.
+Storybook link in foot.
+
+⚠ Verifica con build production che TUTTO il /dev codebase sia tree-shaken (bundle analyzer).
+```
+
+---
+
+## Sequenza consigliata
+
+Vedi `SCREENS.md` per lo Sprint plan a 8 settimane. Pilot suggerito: **A1 Overview** poi **A2 Users**.
+
+Per ogni pagina, segui sempre:
+1. Backend audit prima (esistono già endpoint?)
+2. Schema migration se serve
+3. Componenti riusabili first
+4. Page composition
+5. Permission gates
+6. Audit log middleware verifica
+7. Tests (unit + integration + E2E critici)
+8. PR review da 2 reviewer (admin = alto rischio)

--- a/admin-mockups/design_handoff_admin/QUICK_START.md
+++ b/admin-mockups/design_handoff_admin/QUICK_START.md
@@ -1,0 +1,124 @@
+# Quick Start — Admin Console Setup
+
+> Da fare PRIMA di lanciare qualsiasi prompt di feature admin.
+
+## 1. Audit dello stato corrente
+
+```
+Verifica lo stato corrente dell'admin nel codebase:
+
+1. Esiste una sezione /admin/* già? Se sì, lista le pagine.
+2. Modello RBAC: come sono gestiti i ruoli? Quali ruoli esistono?
+3. Esiste un audit_log o equivalente? Schema della tabella?
+4. Endpoint /api/admin/* esistenti? Lista.
+5. Permission middleware/decorator? Path del file.
+6. Esiste una "danger zone" pattern (Delete user, etc)? Path.
+7. SSE/WebSocket admin (es. live event log)? Implementati?
+
+Scrivi report in design_handoff_admin/ADMIN_AUDIT.md.
+Non modificare niente.
+```
+
+## 2. Setup RBAC
+
+```
+Imposta il modello RBAC per la console admin:
+
+1. Verifica/aggiungi al modello User:
+   role: 'user' | 'premium' | 'admin' | 'superadmin'
+   2faEnabled: boolean
+   2faMethod: 'totp' | 'sms' | null
+   impersonatedBy: userId | null  (transient JWT claim, non in DB)
+
+2. Crea middleware/guard:
+   - requireAuth() → 401 se non loggato
+   - requireRole('admin') → 403 se ruolo insufficiente
+   - requireRole('superadmin') → 403 + audit log
+   - requireStepUp() → forza 2FA challenge se >5 min dall'ultimo check
+
+3. Crea audit_log table:
+   id, actor_id, impersonated_user_id (nullable),
+   action (string slug), target_type, target_id,
+   before_json, after_json, ip, user_agent, created_at
+
+4. Helper: auditLog(action, target, before, after) chiamato in ogni
+   mutazione admin. NO eccezioni.
+
+Mostra schema migration prima di applicare.
+```
+
+## 3. Importa il design system admin
+
+```
+Copia in src/styles/:
+- design/admin/admin-base.css → src/styles/admin-base.css
+- design/admin/admin-nav.js → src/components/admin/admin-nav.tsx
+  (convertilo a React component <AdminNav>)
+
+In src/layouts/AdminLayout.tsx (o equivalente):
+- Importa admin-base.css solo per route /admin/*
+- Default theme: dark
+- Render <AdminSidebar> + <main>{children}</main>
+
+Conferma: bundle dimension admin-only resta isolato dal bundle utente.
+```
+
+## 4. Crea i componenti base
+
+In ordine, crea questi componenti riusabili che saranno usati da TUTTE le pagine admin:
+
+```
+Sprint 1 admin base:
+1. <AdminShell> con sidebar 240px + topbar 56px sticky
+2. <AdminSidebar> con groups + items + active state da useRouter
+3. <AdminTopbar> con title/crumbs/search/actions
+4. <AdminPanel> + <AdminPanel.Head> + <AdminPanel.Body>
+5. <AdminDataTable> con: sort, multi-select, bulk-actions, pagination cursor,
+   sticky header, row hover, selected state, density compact/normal
+6. <AdminKPICard> entity-tinted con sparkline opzionale
+7. <StatusChip> + <RoleChip> + <EnvPill>
+8. <BulkActionsBar> sticky-top quando >0 selezionati
+9. <ConfirmModal> con typed-confirm opzionale per superadmin actions
+10. <AuditLogTimeline> per drill-down user/agent
+
+Crea Storybook story per ognuno. Test base: render + a11y.
+```
+
+## 5. Crea il `/admin/overview` come pilot
+
+Stesso prompt che la skill base + adattamento al codebase. Conferma:
+- Route protetta (admin/superadmin only)
+- Dati da `GET /api/admin/overview` (mockato se BE non c'è)
+- 4 KPI + activity feed + alerts + 4 charts + sidebar quick actions
+- Mobile fallback funzionante
+- Build size admin-only resta tree-shaken dal prod utente
+
+## 6. Audit log middleware
+
+```
+Verifica che TUTTE le route /api/admin/* logghino in audit_log.
+
+Test: simula 3 azioni e verifica entry in DB:
+1. PATCH /api/admin/users/u-marco { role: 'admin' }
+2. POST /api/admin/notifications/templates/tpl-x/test-send
+3. DELETE /api/admin/kb/docs/d-old
+
+Se manca, aggiungi a livello di middleware (NON nei singoli handler — è
+un trap per dimenticarsi). Pattern: wrap il router /admin/* in un
+auditLoggingMiddleware che intercetta tutti i POST/PATCH/DELETE.
+```
+
+## Checklist setup completato
+
+- [ ] design_handoff_admin/ADMIN_AUDIT.md generato
+- [ ] RBAC esteso con admin/superadmin
+- [ ] audit_log table creata + middleware applicato
+- [ ] admin-base.css + admin-nav importati
+- [ ] 10 componenti base in `src/components/admin/v2/`
+- [ ] Storybook stories per ognuno
+- [ ] /admin/overview pilot funzionante
+- [ ] Mobile fallback per /admin/*
+- [ ] Build size verificata: admin tree-shaken da utente bundle
+- [ ] 3 azioni di test audit-logged correttamente
+
+Solo dopo questa checklist, parti con gli altri 17 mockup.

--- a/admin-mockups/design_handoff_admin/RBAC.md
+++ b/admin-mockups/design_handoff_admin/RBAC.md
@@ -1,0 +1,141 @@
+# RBAC — Role-Based Access Control per Admin Console
+
+## 4 ruoli
+
+| Ruolo | Permessi | Note |
+|---|---|---|
+| `user` | Solo proprio profilo + content pubblico | Default |
+| `premium` | come user + feature premium | Subscription |
+| `admin` | Tutto user + /admin/* (read+write content moderation, KB, monitor read) | Staff |
+| `superadmin` | Tutto admin + impersonate + danger zone (delete user, force logout, broadcast, emergency shutdown) | Aaron + cofounder |
+
+## Matrice permessi per route
+
+| Route | guest | user | premium | admin | superadmin |
+|---|---|---|---|---|---|
+| `/`, `/faq`, `/how-it-works` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `/login`, `/signup`, `/join` | ✓ | — | — | — | — |
+| `/dashboard`, `/library`, `/games/*` | — | ✓ | ✓ | ✓ | ✓ |
+| `/game-nights/*`, `/sessions/*` | — | ✓ | ✓ | ✓ | ✓ |
+| `/librogame/*` | — | partial | ✓ | ✓ | ✓ |
+| `/settings/*` (proprio) | — | ✓ | ✓ | ✓ | ✓ |
+| `/admin/overview` | — | — | — | ✓ read | ✓ |
+| `/admin/users` (lista, drill) | — | — | — | ✓ read | ✓ |
+| `/admin/users` · cambia ruolo `user→premium` | — | — | — | ✓ | ✓ |
+| `/admin/users` · cambia ruolo `→admin` | — | — | — | — | ✓ |
+| `/admin/users` · cambia ruolo `→superadmin` | — | — | — | — | ✓ + 2FA step-up |
+| `/admin/users` · impersonate | — | — | — | — | ✓ + 2FA + audit ogni req |
+| `/admin/users` · suspend | — | — | — | ✓ | ✓ |
+| `/admin/users` · delete account | — | — | — | — | ✓ + typed-confirm |
+| `/admin/users` · force logout | — | — | — | ✓ | ✓ |
+| `/admin/content` (mod queue) | — | — | — | ✓ | ✓ |
+| `/admin/ai` | — | — | — | ✓ read | ✓ |
+| `/admin/kb`, `/admin/kb/upload` | — | — | — | ✓ | ✓ |
+| `/admin/kb` · delete doc | — | — | — | ✓ + confirm | ✓ |
+| `/admin/catalog` | — | — | — | ✓ | ✓ |
+| `/admin/config` (read flags) | — | — | — | ✓ | ✓ |
+| `/admin/config` · cambia flag in `prd` | — | — | — | — | ✓ + audit |
+| `/admin/monitor` | — | — | — | ✓ | ✓ |
+| `/admin/notifications` (template) | — | — | — | ✓ | ✓ |
+| `/admin/notifications` · broadcast | — | — | — | — | ✓ + typed-confirm |
+| `/editor`, `/upload`, `/versions`, `/play-records` | — | — | — | ✓ | ✓ |
+| `/pipeline-builder` | — | — | — | ✓ | ✓ |
+| `/pipeline-builder` · publish to prod | — | — | — | — | ✓ |
+| `/n8n` | — | — | — | ✓ read | ✓ |
+| `/n8n` · rotate API key | — | — | — | — | ✓ |
+| `/private-games` (proprio) | — | ✓ | ✓ | ✓ | ✓ |
+| `/dev` | — | — | — | — | ✓ + env=dev |
+
+Legenda: ✓ = permesso · — = negato · `read` = solo lettura · `+ X` = richiede anche X
+
+## Step-up authentication (2FA challenge)
+
+Operazioni che richiedono **step-up** anche per superadmin già loggato:
+
+- Promote user to `superadmin`
+- Start impersonate
+- Generate/rotate API key
+- Emergency shutdown
+- Mass delete (>5 entity)
+- Change config flag in `prd`
+- Approve marketplace toolkit pubblicato
+
+**Implementazione**:
+- Frontend: prima di chiamare l'endpoint, controlla se `lastStepUpAt > Date.now() - 5min`. Se no, apri `<StepUpModal>` con TOTP input.
+- Backend: il middleware accetta sia il JWT normale che un header `X-StepUp-Token` valido. Senza, restituisce `403 STEP_UP_REQUIRED`.
+
+## Impersonate (la più pericolosa)
+
+Flow:
+1. SuperAdmin clicca "Impersonate" su user u-marco
+2. `<StepUpModal>` 2FA challenge
+3. Backend: `POST /api/admin/users/u-marco/impersonate-start`
+   - verifica step-up token
+   - genera JWT short-lived (15 min) con claim:
+     ```json
+     { "sub": "u-marco", "actor": "u-aaron", "exp": ..., "ttl": 900 }
+     ```
+   - audit_log: action='impersonate.start', target='u-marco'
+4. Frontend: salva il token in sessionStorage (NON localStorage), mostra banner persistente in TUTTE le pagine:
+   ```
+   👁 IMPERSONATE · Stai navigando come Marco Rossi · termina »
+   ```
+5. Tutte le API call usano il JWT impersonate. Lato backend, ogni request audit-logga `actor=u-aaron, impersonated=u-marco`.
+6. Dopo 15 min o click "termina", `POST /api/admin/impersonate-end` chiude la sessione. audit_log: `action='impersonate.end'`.
+
+**Cosa NON è permesso durante impersonate**:
+- Mutazioni che richiedono 2FA dell'utente target (cambio password, 2FA settings)
+- Reset password proprio
+- Cancellazione account
+- Pagamenti / billing changes
+- Accesso a /admin/*
+
+## Audit log payload
+
+Ogni entry:
+
+```ts
+type AuditLog = {
+  id: string;                          // auditlog-${ulid}
+  actor_id: string;                    // chi ha fatto l'azione
+  impersonated_user_id?: string;       // se sotto impersonate
+  action: string;                      // slug: "user.role.change", "kb.doc.delete"
+  target_type: string;                 // "user" | "game" | "kb-doc" | ...
+  target_id: string;
+  before_json?: object;                // stato precedente (per mutate)
+  after_json?: object;                 // stato risultante
+  ip: string;
+  user_agent: string;
+  step_up_token_id?: string;           // se l'azione ha richiesto step-up
+  created_at: string;                  // ISO timestamp
+};
+```
+
+Action slugs canonici (estendere):
+
+- `user.role.change`, `user.suspend`, `user.unsuspend`, `user.delete`, `user.force_logout`
+- `user.impersonate.start`, `user.impersonate.end`
+- `content.game.approve`, `content.game.reject`, `content.comment.delete`
+- `kb.doc.upload`, `kb.doc.reindex`, `kb.doc.delete`
+- `kb.chunk.delete`
+- `config.flag.change`
+- `notif.template.edit`, `notif.template.publish`, `notif.broadcast.send`
+- `agent.deploy`, `agent.rollback`
+- `apikey.create`, `apikey.rotate`, `apikey.revoke`
+- `system.cache.flush`, `system.rate_limit.reset`, `system.emergency_shutdown`
+
+## UI pattern audit-aware
+
+In ogni drill-down (user, agent, kb-doc) mostra `<AuditLogTimeline>` con gli ultimi N eventi che hanno toccato quella entity:
+
+```tsx
+<AuditLogTimeline
+  targetType="user"
+  targetId={user.id}
+  limit={20}
+  showActor
+  showImpersonate
+/>
+```
+
+Backend: `GET /api/admin/audit-log?target_type=user&target_id=u-marco&limit=20`

--- a/admin-mockups/design_handoff_admin/README.md
+++ b/admin-mockups/design_handoff_admin/README.md
@@ -1,0 +1,119 @@
+# Handoff Claude Code — MeepleAI Admin Console (SP5)
+
+## Cosa contiene questo pacchetto
+
+Una guida operativa per integrare i **18 mockup admin** in `design/admin/` nel tuo codebase MeepleAI esistente, usando Claude Code in VSCode.
+
+I file sono HTML standalone (no React inline) con dati realistici. Replicano look-and-feel finale ma il task è ricreare quei design nel codebase reale come componenti React tipizzati, riusando i componenti già in produzione (`ConnectionBar`, `EntityChip`, `Drawer`, `Tabs`...) e cablando il backend reale + autorizzazioni RBAC.
+
+## File in questo pacchetto
+
+| File | A cosa serve |
+|---|---|
+| `README.md` | Questo file — overview + workflow |
+| `QUICK_START.md` | Setup iniziale per Admin Console (RBAC, layout shell, gates) |
+| `WIRING_GUIDE.md` | Come tradurre un mock admin in componente reale + RBAC + audit log |
+| `BACKEND_PROMPTS.md` | 18 prompt pronti — uno per ogni mockup admin |
+| `SCREENS.md` | Inventario 18 schermate + endpoint + permessi + priorità |
+| `RBAC.md` | Modello permessi: user/admin/superadmin · audit log · impersonate |
+| `admin-base.css` + `admin-nav.js` | Copie pronte per importare |
+
+## Workflow consigliato
+
+### 1. Apri il progetto + lancia Claude Code
+
+```bash
+cd /percorso/al/tuo/progetto-meepleai
+code .
+claude
+```
+
+### 2. Primo prompt (incolla esattamente)
+
+```
+Devo integrare nel codebase un set di 18 mockup admin in `design/admin/`.
+È SEPARATO dal demo utente — questa è la console di amministrazione
+per ruoli admin + superadmin (Aaron).
+
+Leggi in ordine:
+- design_handoff_admin/README.md
+- design_handoff_admin/QUICK_START.md
+- design_handoff_admin/RBAC.md
+- design_handoff_admin/SCREENS.md
+- design_handoff_admin/WIRING_GUIDE.md
+
+Poi dimmi:
+1. Esiste già una sezione admin nel codebase? Se sì, dove e quali pagine.
+2. Quale modello RBAC c'è oggi? È compatibile con `user`/`admin`/`superadmin`?
+3. Esiste già `AdminDataTable`, `KPISparkline`, `LiveEventLog`? Path?
+4. Quale endpoint admin esistono lato BE? Quali mancano?
+5. Quale schermata proponi come pilota?
+
+NON modificare codice ancora. Voglio prima il report scritto in
+design_handoff_admin/CODEBASE_AUDIT.md.
+```
+
+### 3. Procedi schermata per schermata
+
+```
+Implementiamo SP5 A1 Overview.
+Usa il prompt 1.1 da BACKEND_PROMPTS.md.
+Mostrami i diff prima di applicare.
+```
+
+## Regole d'oro per Claude Code (admin-specific)
+
+1. **Tutte le pagine /admin/* richiedono ruolo `admin` o `superadmin`**. Il gate va al livello di route + API + UI. Triple lock.
+
+2. **Tutte le mutazioni admin scrivono un audit_log entry** con: `actor`, `action`, `target`, `before`, `after`, `ip`, `ua`, `timestamp`. È non-negoziabile.
+
+3. **Density alta**: `--s-2`/`--s-3` spacing, `--fs-sm` body, tabelle con righe 32-40px. NON applicare la density del prodotto utente.
+
+4. **Dark mode preferito** in admin (vedi `admin-base.css`). Light mode è secondario.
+
+5. **Mobile fallback** per /admin/*: messaggio "console solo desktop". NON ottimizzare per mobile. Eccezione: `/admin/overview` e `/admin/monitor` possono avere read-only mobile view.
+
+6. **Keyboard shortcuts obbligatori**: `⌘K` search globale, `g+u` go to Users, `g+a` go to AI, `R` refresh. Implementa anche `Escape` per chiudere drawer/modal e `j/k` per navigare righe tabelle.
+
+7. **NO action sensibile senza conferma**. Delete/Ban/Suspend/Force-logout vanno SEMPRE dietro un `<ConfirmModal>` con typed-confirm per superadmin actions (es. typing "DELETE USER MARCO" per cancellare un utente).
+
+8. **Impersonate** è la più pericolosa: blocca con 2FA step-up, banner persistente con "TU SEI MARCO · termina impersonate", audit ogni request, max 30 min poi auto-end.
+
+9. **Token only**: usa solo CSS vars da `admin-base.css`. NO hex hardcoded. Mantieni le 9 entity colors per le badge/chip cross-entity.
+
+10. **Performance**: tabelle admin possono mostrare 10k+ row. Implementa virtualization (react-window/TanStack Virtual), cursor pagination, server-side filter+sort. NO client-side filtering su >500 row.
+
+## Componenti v2 nuovi da estrarre (~38)
+
+Ognuno va creato come componente isolato in `src/components/admin/v2/`:
+
+- **Layout**: `AdminShell`, `AdminSidebar`, `AdminTopbar`, `MobileFallback`
+- **Data display**: `AdminDataTable`, `BulkActionsBar`, `AdminKPICard`, `KPISparkline`, `AdminPanel`, `AdminTabs`
+- **Status**: `StatusChip`, `RoleChip`, `EnvPill`, `StatusDot`
+- **Forms**: `AdminFormRow`, `AdminInput`, `AdminSelect`, `AdminToggle`, `AdminTextarea`
+- **Specialized**:
+  - `QueryDrillDown` + `RetrievalChunkList` + `LatencyBreakdownBar` (A4)
+  - `KBTree` + `DocumentViewer` + `ChunkTable` + `IngestionLog` (A5)
+  - `UploadDropzone` + `ProcessingTimeline` + `KbIdempotencyBanner` (A5b/B4)
+  - `SyncStatusHero` + `SyncRunTimeline` (A6)
+  - `FlagRow` + `DirtyStateBar` (A7)
+  - `LiveEventLog` + `TimeRangePicker` (A8)
+  - `TemplateEditor` + `TemplatePreviewFrame` + `VariableHelper` (A9)
+  - `BlockEditor` + `PreviewFrame` + `VersionHistoryPanel` (B1)
+  - `FlowCanvas` + `NodePalette` + `NodeConfigPanel` (B2)
+  - `VersionTimeline` + `VersionDiffViewer` (B6)
+  - `PublishChecklist` + `PrivateGameCard` (B7)
+  - `ScenarioPicker` + `AuthRoleSwitcher` + `StoreInspector` (B8, dev-only)
+- **Modals**: `ConfirmModal`, `DangerZoneBox`, `AuditLogTimeline`
+
+## Note specifiche admin
+
+**SP5 B8 Dev Tools è DEV-ONLY**: deve essere tree-shaken in prod bundle. Wrap tutto in `if (process.env.NODE_ENV === 'development')` + entry-point separato.
+
+**SP5 B7 Private Games**: i giochi privati DEVONO avere flag `is_private=true` lato DB. Endpoint `/api/public/*` NON deve mai esporli, anche con typo URL. Test esplicito.
+
+**SP5 A2 Users · Impersonate**: il backend deve avere endpoint `POST /api/admin/users/{id}/impersonate-start` che restituisce un JWT short-lived (15 min) con claim `impersonated_by`. Ogni API call con questo token logga BOTH `actor` (admin) AND `impersonated_user_id`.
+
+---
+
+Vedi `WIRING_GUIDE.md`, `BACKEND_PROMPTS.md`, `SCREENS.md` per il dettaglio operativo.

--- a/admin-mockups/design_handoff_admin/SCREENS.md
+++ b/admin-mockups/design_handoff_admin/SCREENS.md
@@ -1,0 +1,218 @@
+# SCREENS — Inventario completo Admin Console
+
+18 schermate. Per ognuna: mock file, route attesa, ruolo minimo, endpoint backend, priorità.
+
+**Priorità**:
+P0 = critical / quotidiano
+P1 = importante
+P2 = nice to have
+P3 = solo per dev / superadmin esoterico
+
+---
+
+## 🛡 Admin Console (10 schermate)
+
+| # | Mock | Route | Min role | Endpoint principale | P |
+|---|---|---|---|---|---|
+| A1 | `sp5-admin-overview` | `/admin/overview` | admin | `GET /api/admin/overview` | P0 |
+| A2 | `sp5-admin-users` | `/admin/users` + `/admin/users/[id]` | admin | `GET /api/admin/users` · `GET /api/admin/users/{id}` | P0 |
+| A3 | `sp5-admin-content` | `/admin/content` | admin | `GET /api/admin/moderation/queue` · `POST .../{id}/approve|reject` | P1 |
+| A4 | `sp5-admin-ai` | `/admin/ai` + `/admin/rag-quality` | admin | `GET /api/admin/ai/metrics` · `GET .../queries/{id}/drill` | P0 |
+| A5 | `sp5-admin-kb` | `/admin/knowledge-base` | admin | `GET /api/admin/kb/tree` · `GET .../docs/{id}` | P0 |
+| A5b | `sp5-kb-upload-flow` | `/admin/knowledge-base/upload` | admin | `POST /api/admin/kb/upload` (SSE progress) | P0 |
+| A6 | `sp5-admin-catalog` | `/admin/catalog-ingestion` | admin | `GET /api/admin/catalog/runs` · `POST .../run-now` | P1 |
+| A7 | `sp5-admin-config` | `/admin/config` | admin (read) / superadmin (write prd) | `GET /api/admin/flags` · `PATCH .../{key}` | P1 |
+| A8 | `sp5-admin-monitor` | `/admin/monitor` | admin | `GET /api/admin/metrics?range=` · `SSE .../events/live` | P1 |
+| A9 | `sp5-admin-notifications` | `/admin/notifications` + `/admin/notifications/templates/[id]` | admin | `GET /api/admin/notif/templates` · `POST .../test-send` | P2 |
+
+---
+
+## 🛠 Power-User Tools (8 schermate)
+
+| # | Mock | Route | Min role | Endpoint principale | P |
+|---|---|---|---|---|---|
+| B1 | `sp5-editor` | `/editor/[type]/[id]` | admin | `GET /api/admin/editor/{type}/{id}` · `PATCH/POST commit` | P1 |
+| B2 | `sp5-pipeline-builder` | `/pipeline-builder/[id]` | admin · publish=superadmin | `GET /api/admin/pipelines/{id}` · `POST .../test-run` · `POST .../publish` | P2 |
+| B3 | `sp5-n8n` | `/n8n` | admin (read) · keys=superadmin | `GET /api/admin/n8n/workflows` · `POST .../keys` (rotate) | P2 |
+| B4 | `sp5-upload-advanced` | `/upload` | admin | `POST /api/admin/upload/bulk` (multipart + SSE) | P1 |
+| B5 | `sp5-play-records` | `/play-records` | user (proprio) / admin (cross-user) | `GET /api/play-records?user=` | P2 |
+| B6 | `sp5-versions` | `/versions/[artifact]` | admin · publish=superadmin | `GET /api/admin/versions/{artifact}` · `POST .../publish` | P1 |
+| B7 | `sp5-private-games` | `/private-games` | user (proprio) | `GET /api/me/private-games` · `POST publish-review` | P2 |
+| B8 | `sp5-dev-tools` | `/dev` | superadmin + env=dev | (mock) | P3 dev-only |
+
+---
+
+## 🧩 Surplus — Platform & Operations + AI Tooling (13 schermate)
+
+Mockup per le funzioni admin reali prive di mockup SP5 (vedi `SURPLUS_DESIGN_PROMPTS.md` + `ADMIN_AUDIT.md`). Generati su claude.ai, verificati, integrati in `admin-nav.js` (gruppi "Platform & Operations" e "AI Tooling & Data Quality").
+
+### 🛡 Platform & Operations (C)
+
+| # | Mock | Route | Min role | Endpoint principale | P |
+|---|---|---|---|---|---|
+| C1 | `sp5-admin-infra` | `/admin/monitor/containers` | admin | `GET /api/v1/admin/docker` · `/admin/operations/batch-jobs` (SSE) | P1 |
+| C2 | `sp5-admin-database-sync` | `/admin/database-sync` · `/admin/staging-access` | superadmin | `/api/v1/admin/database-sync` · `/admin/staging-allowlist` | P1 |
+| C3 | `sp5-admin-providers` | `/admin/providers` | admin (rotate=superadmin) | `/api/v1/admin/providers` · `/admin/circuit-breakers` | P0 |
+| C4 | `sp5-admin-emergency` | `/admin/llm/emergency` | superadmin + step-up | `POST /api/v1/admin/llm/emergency/*` | P1 |
+| C5 | `sp5-admin-budget` | `/admin/business` | admin | `/api/v1/admin/business` · `/admin/budget` · `/admin/cost-calculator` | P1 |
+| C6 | `sp5-admin-secrets` | `/admin/secrets` | superadmin + step-up | `/api/v1/admin/secrets` | P1 |
+| C7 | `sp5-admin-alerts` | `/admin/monitor` (tab alerts) | admin | `/api/v1/admin/alert-rules` | P1 |
+
+### 🛠 AI Tooling & Data Quality (D)
+
+| # | Mock | Route | Min role | Endpoint principale | P |
+|---|---|---|---|---|---|
+| D1 | `sp5-admin-mechanic-extractor` | `/admin/knowledge-base/mechanic-extractor` | admin | `/api/v1/admin/mechanic-analyses` · `.../mechanic-extractor/run` | P1 |
+| D2 | `sp5-admin-sandbox` | `/admin/agents/sandbox` · `/admin/agents/debug-chat` | admin | `POST /api/v1/admin/agents/debug-chat/stream` (SSE) | P2 |
+| D3 | `sp5-admin-ab-testing` | `/admin/agents/ab-testing` | admin | `/api/v1/admin/ab-tests` | P2 |
+| D4 | `sp5-admin-prompts` | `/admin/agents/...prompts` | admin | `/api/v1/admin/prompts` | P2 |
+| D5 | `sp5-admin-rag-backup` | `/admin/...rag-backup` · seeding | admin (seed=superadmin) | `/api/v1/admin/rag-backup` · `/admin/seeding` (SSE) | P2 |
+| D6 | `sp5-admin-integrations` | `/admin/slack` · `/admin/content/email-templates` | admin | `/api/v1/admin/slack` · `/admin/email-templates` | P2 |
+
+---
+
+## Endpoint admin completi (per QUICK_START audit)
+
+### Overview & monitor
+- `GET /api/admin/overview` → aggregate
+- `GET /api/admin/metrics?range=1h|24h|7d|30d&kind=`
+- `SSE /api/admin/events/live` → live event stream
+- `GET /api/admin/health` → SLO/uptime
+
+### Users
+- `GET /api/admin/users?q=&role=&status=&cursor=`
+- `GET /api/admin/users/{id}`
+- `PATCH /api/admin/users/{id}` (role/status)
+- `POST /api/admin/users/{id}/suspend` · `POST .../unsuspend`
+- `POST /api/admin/users/{id}/force-logout`
+- `POST /api/admin/users/{id}/reset-password`
+- `POST /api/admin/users/{id}/impersonate-start` → JWT short-lived
+- `POST /api/admin/impersonate-end`
+- `DELETE /api/admin/users/{id}` (superadmin + typed-confirm)
+- `GET /api/admin/users/{id}/sessions`
+- `GET /api/admin/users/{id}/audit-log`
+
+### Content moderation
+- `GET /api/admin/moderation/queue?type=game|toolkit|kb|comment`
+- `POST /api/admin/moderation/{id}/approve`
+- `POST /api/admin/moderation/{id}/reject` (with reason)
+- `POST /api/admin/moderation/comments/{id}/delete`
+- `POST /api/admin/moderation/users/{id}/mute?duration=`
+
+### AI / RAG
+- `GET /api/admin/ai/metrics?range=`
+- `GET /api/admin/ai/queries?sort=worst&limit=`
+- `GET /api/admin/ai/queries/{id}/drill` → retrieval + response + latency
+- `POST /api/admin/ai/queries/{id}/rerun` (with optional KB version)
+- `POST /api/admin/ai/queries/{id}/flag-hallucination`
+- `GET /api/admin/ai/agents/usage?range=`
+
+### KB
+- `GET /api/admin/kb/tree` → tree per gioco con count
+- `GET /api/admin/kb/docs/{id}`
+- `GET /api/admin/kb/docs/{id}/chunks?q=&topK=`
+- `POST /api/admin/kb/upload` (multipart, async → SSE job)
+- `POST /api/admin/kb/docs/{id}/reindex`
+- `DELETE /api/admin/kb/docs/{id}`
+- `GET /api/admin/kb/idempotency-check?hash=` → potential duplicate
+- `GET /api/jobs/{id}` (status async)
+- `SSE /api/jobs/{id}/events`
+
+### Catalog
+- `GET /api/admin/catalog/runs?cursor=`
+- `POST /api/admin/catalog/run-now`
+- `POST /api/admin/catalog/queue/{id}/retry`
+- `GET /api/admin/catalog/queue?status=`
+
+### Config / Flags
+- `GET /api/admin/flags?env=`
+- `PATCH /api/admin/flags/{key}` { env, value } → dirty
+- `POST /api/admin/flags/apply` → commit batched changes (audit)
+
+### Notifications
+- `GET /api/admin/notif/templates`
+- `GET /api/admin/notif/templates/{id}` (with versions)
+- `PATCH /api/admin/notif/templates/{id}`
+- `POST /api/admin/notif/templates/{id}/test-send?to=`
+- `POST /api/admin/notif/broadcast` (superadmin) { audience, body, channels }
+
+### Editor / Versions
+- `GET /api/admin/editor/{type}/{id}` → blocks
+- `POST /api/admin/editor/{type}/{id}/commit` → new version
+- `GET /api/admin/versions/{artifact}?limit=`
+- `GET /api/admin/versions/{artifact}/diff?from=&to=`
+- `POST /api/admin/versions/{artifact}/{vid}/publish`
+- `POST /api/admin/versions/{artifact}/{vid}/restore`
+
+### Pipeline & n8n
+- `GET /api/admin/pipelines`
+- `GET /api/admin/pipelines/{id}`
+- `POST /api/admin/pipelines/{id}/test-run`
+- `POST /api/admin/pipelines/{id}/publish` (superadmin)
+- `GET /api/admin/n8n/workflows`
+- `GET /api/admin/n8n/webhooks/log?cursor=`
+- `GET /api/admin/n8n/keys` · `POST .../keys` · `DELETE .../keys/{id}`
+
+### Upload avanzato
+- `POST /api/admin/upload/bulk` (multipart)
+- `GET /api/admin/upload/queue`
+- `GET /api/admin/upload/history?cursor=`
+
+### Play records (personal)
+- `GET /api/me/play-records?game=&from=&to=&cursor=`
+- `POST /api/me/play-records` { gameId, players, duration, winner, notes }
+- `PATCH /api/me/play-records/{id}` · `DELETE`
+- `GET /api/me/play-records/stats?range=`
+
+### Private games (personal)
+- `GET /api/me/private-games`
+- `POST /api/me/private-games`
+- `GET /api/me/private-games/{id}`
+- `PATCH /api/me/private-games/{id}` (any field)
+- `GET /api/me/private-games/{id}/publish-checklist`
+- `POST /api/me/private-games/{id}/submit-for-review`
+
+---
+
+## Sprint plan consigliato
+
+### Sprint 1 — Foundation (settimana 1)
+- RBAC + audit_log middleware
+- AdminShell, AdminSidebar, AdminTopbar
+- AdminDataTable + BulkActionsBar + AdminKPICard
+- A1 Overview (pilot)
+
+### Sprint 2 — Users + Content (settimana 2)
+- A2 Users (lista + drill + impersonate flow)
+- Step-up 2FA modal
+- ConfirmModal con typed-confirm
+- A3 Content moderation
+
+### Sprint 3 — KB management (settimana 3)
+- A5 KB tree + doc viewer
+- A5b Upload flow (FSM 5 stati)
+- B4 Upload avanzato (queue + history)
+
+### Sprint 4 — AI quality (settimana 4)
+- A4 AI/RAG metrics + drill-down
+- B6 Versions (timeline + diff)
+
+### Sprint 5 — Operations (settimana 5)
+- A6 Catalog ingestion
+- A7 Config / Flags
+- A8 Monitor + LiveEventLog SSE
+
+### Sprint 6 — Content & Tools (settimana 6)
+- A9 Notifications + TemplateEditor
+- B1 Editor (block-based)
+
+### Sprint 7 — Advanced (settimana 7)
+- B2 Pipeline builder (canvas)
+- B3 n8n integrations
+- B7 Private games
+- B5 Play records
+
+### Sprint 8 — Polish & Dev (settimana 8)
+- B8 Dev tools (env=dev only)
+- Tests E2E flow critici (impersonate, KB upload, broadcast)
+- Performance: virtualization tabelle, lazy loading drill-down

--- a/admin-mockups/design_handoff_admin/SURPLUS_DESIGN_PROMPTS.md
+++ b/admin-mockups/design_handoff_admin/SURPLUS_DESIGN_PROMPTS.md
@@ -1,0 +1,311 @@
+# SURPLUS_DESIGN_PROMPTS.md — Guida per disegnare i mockup "surplus" con Claude (web)
+
+> **Scopo**: l'audit (`ADMIN_AUDIT.md`) ha rilevato che la console admin reale ha **decine di funzioni senza un mockup SP5**. Per consolidare l'IA (driver scelto: *"Consolidare IA + re-skin"*) serve prima **disegnare quei mockup mancanti**, coerenti con il design system SP5. Questa guida è un **prompt-pack** da usare su **claude.ai** (web) per generarli, uno alla volta, nello stesso formato dei 18 mockup esistenti in `admin/`.
+>
+> **Relazione con gli altri file del pacchetto**:
+> - `ADMIN_AUDIT.md` → da dove viene l'inventario del surplus (§4).
+> - `BACKEND_PROMPTS.md` → formato dei prompt (questa guida ne è la versione "design", non "implementazione").
+> - `admin/tokens.css` · `admin/components.css` · `admin/admin-base.css` · `admin/admin-nav.js` → il design system da riusare.
+> - `WIRING_GUIDE.md` → lo scheletro HTML dei mockup admin.
+>
+> **Output atteso**: nuovi file `admin/sp5-<id>.html` standalone, indistinguibili per stile dai 18 esistenti, pronti per il passo successivo (traduzione in React durante il consolidamento).
+
+---
+
+## 1. Workflow su claude.ai (per ogni schermata)
+
+1. Apri **claude.ai** → nuova conversazione. Tieni attivi gli **Artifacts** (il mockup apparirà come anteprima live).
+2. **Primo messaggio della conversazione**: incolla il **Design Brief** (§3) **+** il contenuto reale dei 3 CSS (`admin/tokens.css`, `admin/components.css`, `admin/admin-base.css`). Servono a Claude per riprodurre il look senza accedere al repo.
+3. **Messaggi successivi**: incolla **un prompt-schermata alla volta** (§6/§7). Claude restituisce un singolo file HTML come artifact.
+4. **Verifica visiva** nell'anteprima (dark default, density alta, sidebar, tabelle). Itera con follow-up ("rendi la tabella virtualizzabile a vista", "aggiungi stato empty", ecc.).
+5. **Salvataggio nel repo**: scarica l'artifact come `admin/sp5-<id>.html`. **Sostituisci** il blocco `<style>` inline con i `<link>` ai 4 asset, esattamente come negli altri mockup (vedi §3 scheletro). Aggiungi la voce in `admin/admin-nav.js`.
+6. **Aggiorna** `SCREENS.md` (riga nuova) e marca lo stato qui in §4.
+
+> **Perché inline + poi link**: su claude.ai gli asset esterni non esistono, quindi per *vedere* il mockup Claude deve inlinearne il CSS; nel repo invece i 4 file esistono già, quindi il file finale deve linkarli (handoff omogeneo, niente CSS duplicato).
+
+---
+
+## 2. Convenzioni (valide per tutti i mockup surplus)
+
+- **Vanilla HTML** standalone. **NO** React/Vue/framework, **NO** build. Solo HTML + i 4 asset condivisi.
+- **Dark default** (`<html data-theme="dark">`), light come secondaria (`admin-nav.js` gestisce il toggle).
+- **Density alta**, **desktop-first 1440px**, **mobile fallback** `<880px` (blocco `.admin-mobile-fallback` già nello scheletro).
+- **Solo token/classi del design system** — **NO hex hardcoded**. Usa `var(--*)`, le classi `admin-*` e le utility entità `.e-*`.
+- **Dati realistici** (nomi, timestamp, conteggi plausibili), mai "Lorem ipsum" o "TODO".
+- **Stati**: includi sempre default; quando pertinente mostra anche loading/empty/error come varianti commentate o sezioni.
+- **9 entity color** per badge/chip cross-entity (vedi cheat-sheet §3).
+- **Accessibilità**: `aria-label` su nav e azioni, focus visibile, target ≥28px.
+
+---
+
+## 3. DESIGN BRIEF — da incollare UNA volta a inizio conversazione
+
+> Copia da qui fino a fine sezione, e in coda allega il contenuto di `admin/tokens.css`, `admin/components.css`, `admin/admin-base.css`.
+
+```
+Sei un designer frontend. Devi produrre MOCKUP HTML statici e standalone per la
+"Admin Console" di MeepleAI (un assistente AI per giochi da tavolo), nello stile
+del design system "SP5" che ti incollo sotto (3 file CSS: tokens.css, components.css,
+admin-base.css).
+
+REGOLE FERME:
+- Vanilla HTML, un solo file per schermata. NIENTE React/JS framework/build.
+- Riproduci ESATTAMENTE il look del design system: dark theme default, density alta,
+  desktop-first 1440px. Usa SOLO le CSS variables e le classi che ti fornisco
+  (admin-shell, admin-nav, admin-top, admin-table, admin-kpi, admin-panel, status-chip,
+  role-chip, btn-admin, admin-tabs, alert-banner, admin-form-row, bulk-bar, ecc.).
+- VIETATO colore hex hardcoded: usa var(--*) e le utility entità .e-game/.e-kb/...
+- Dati realistici e plausibili (nomi, date, numeri). Niente Lorem ipsum.
+- Per l'anteprima qui su claude.ai: inlinea i 3 CSS in un blocco <style> nell'<head>.
+- Includi sempre il blocco mobile-fallback e la struttura shell qui sotto.
+
+SCHELETRO HTML OBBLIGATORIO (riempi solo .admin-body):
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{TITOLO} · MeepleAI Admin</title>
+  <!-- nel repo: <link rel="stylesheet" href="tokens.css"> + components.css + admin-base.css -->
+  <style>/* su claude.ai: incolla qui i 3 CSS */</style>
+</head>
+<body class="admin-page">
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+  <div class="admin-shell"> <!-- o admin-shell-3col se serve un pannello laterale dx -->
+    <div data-admin-nav-mount></div>
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>{TITOLO}</h1>
+          <div class="crumbs">Admin › {SEZIONE} › aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+      <div class="admin-body">
+        <!-- CONTENUTO SPECIFICO DELLA SCHERMATA QUI -->
+      </div>
+    </main>
+  </div>
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('{NAV_ID}');</script>
+</body>
+</html>
+
+CHEAT-SHEET design system (classi/variabili più usate):
+- Layout: .admin-shell (240px+1fr) · .admin-shell-3col (240px+1fr+360px) · .admin-body
+- Topbar: .admin-top h1 + .crumbs + .admin-top-actions · .admin-search (con <kbd>)
+- KPI: .admin-kpi (+ .e-game/.e-kb/… per il bordo sx colorato) con
+       .admin-kpi-label / .admin-kpi-value / .admin-kpi-trend(.up/.down/.flat) /
+       .admin-kpi-spark (svg 70x28) / .admin-kpi-icon
+- Pannelli: .admin-panel > .admin-panel-head (h3 + .meta) + .admin-panel-body
+- Tabelle: .admin-table (th sticky, .sort-asc/.sort-desc, tr.selected, td .checkbox/.menu)
+- Bulk: .bulk-bar (.count + .actions) — mostrala sopra la tabella quando ci sono selezioni
+- Tabs: .admin-tabs > .admin-tab(.active) con .count badge
+- Chip stato: .status-chip .healthy/.warning/.danger/.muted/.info/.running (dot integrato)
+- Chip ruolo: .role-chip .superadmin/.admin/.premium/.user
+- Bottoni: .btn-admin (.primary/.danger/.success/.ghost/.icon/.sm) — kbd inline supportato
+- Form: .admin-form-row (label 200px + campo) · .admin-input/.admin-select/.admin-textarea
+        (.mono per monospazio) · .admin-toggle(.on)
+- Alert: .alert-banner .warning/.danger/.info/.success (em + .title + .actions)
+- Feed: .activity-feed > .activity-item (.em cerchio + .body + .ts mono)
+- Sparkline: <svg><path class="spark"/><path class="spark-fill"/></svg>
+- Entità (9): .e-game .e-player .e-session .e-agent .e-kb .e-chat .e-event .e-toolkit .e-tool
+  → usa .e-bg / .e-tint / .e-fg / .e-ring per badge e accenti cross-entity
+- Mono per dati tecnici (id, timestamp, byte, versioni): font var(--f-mono)
+
+Dato che la nav (admin-nav.js) elenca le voci ufficiali, quando una schermata surplus
+appartiene a un gruppo nuovo ("Platform & Operations" o "AI Tooling & Data Quality"),
+indicalo nel mockup con la voce attiva corrispondente (NAV_ID indicato in ogni prompt).
+Se NAV_ID non esiste ancora in admin-nav.js, useremo un placeholder e lo aggiungeremo dopo.
+
+Conferma di aver capito e attendi il primo prompt-schermata.
+```
+
+---
+
+## 4. Inventario schermate surplus (da disegnare)
+
+Derivato da `ADMIN_AUDIT.md` (aree admin reali senza mockup SP5). Nomenclatura continua dopo A (Admin Console) e B (Power Tools): **gruppo C = Platform & Operations**, **gruppo D = AI Tooling & Data Quality**. Gli endpoint reali (prefisso `/api/v1`) servono a rendere i mockup realistici e già "wirable".
+
+### Gruppo C — Platform & Operations
+
+| ID | Schermata | Route reale | Ruolo min | Endpoint reali (riferimento) | Stato mockup |
+|----|-----------|-------------|-----------|------------------------------|--------------|
+| C1 | Infrastructure & Containers | `/admin/monitor/containers` | admin | `AdminDockerEndpoints`, `AdminInfrastructureEndpoints`, `AdminOperationsEndpoints`, `BatchJobLogsEndpoints` (SSE) | ✅ `sp5-admin-infra.html` |
+| C2 | Database Sync & Staging Access | `/admin/database-sync`, `/admin/staging-access` | superadmin | `DatabaseSyncEndpoints`, `Admin/AdminStagingAllowlistEndpoints` | ✅ `sp5-admin-database-sync.html` |
+| C3 | LLM Providers & Circuit Breakers | `/admin/providers` | admin (rotate=superadmin) | `AdminProviderEndpoints`, `AdminOpenRouterEndpoints`, `AdminCircuitBreakerEndpoints`, `AdminLlmConfigEndpoints` | ✅ `sp5-admin-providers.html` |
+| C4 | LLM Emergency Controls | `/admin/llm/emergency` | superadmin + step-up | `AdminEmergencyControlsEndpoints`, `AdminServiceCallEndpoints` | ✅ `sp5-admin-emergency.html` |
+| C5 | Budget & Cost | `/admin/business` | admin | `BudgetEndpoints`, `CostCalculatorEndpoints`, `AdminBusinessStatsEndpoints` | ✅ `sp5-admin-budget.html` |
+| C6 | Secrets Vault | `/admin/secrets` | superadmin + step-up | `AdminSecretsEndpoints` | ✅ `sp5-admin-secrets.html` |
+| C7 | Alerting Config | `/admin/monitor` (tab alerts) | admin | `AlertConfig*Endpoints`, AlertRules (`Administration/.../AlertRules`) | ✅ `sp5-admin-alerts.html` |
+
+### Gruppo D — AI Tooling & Data Quality
+
+| ID | Schermata | Route reale | Ruolo min | Endpoint reali (riferimento) | Stato mockup |
+|----|-----------|-------------|-----------|------------------------------|--------------|
+| D1 | Mechanic Extractor | `/admin/knowledge-base/mechanic-extractor` | admin | `AdminMechanicExtractorEndpoints`, `AdminMechanicAnalysesEndpoints`, `AdminMechanicExtractorValidationEndpoints` | ✅ `sp5-admin-mechanic-extractor.html` |
+| D2 | Agent Sandbox & Debug | `/admin/agents/sandbox`, `/admin/agents/debug-chat` | admin | `AdminSandboxEndpoints`, `AdminDebugChatEndpoints` (SSE), `AdminAgentTestEndpoints` | ✅ `sp5-admin-sandbox.html` |
+| D3 | A/B Testing agenti | `/admin/agents/ab-testing` | admin | `AdminAbTestEndpoints` | ✅ `sp5-admin-ab-testing.html` (nota: 3 hex-contrasto su badge, DS-equivalenti a `.e-bg`) |
+| D4 | Prompt Management | `/admin/agents/...prompts` | admin | `PromptManagementEndpoints` | ✅ `sp5-admin-prompts.html` |
+| D5 | RAG Backup & Seeding | `/admin/...rag-backup`, seeding | superadmin (seed) | `AdminRagBackupEndpoints`, `RagEnhancementAdminEndpoints`, `AdminSeedingEndpoints` | ✅ `sp5-admin-rag-backup.html` |
+| D6 | Integrations: Slack & Email Templates | `/admin/slack`, `/admin/content/email-templates` | admin | `AdminSlackEndpoints`, `AdminEmailTemplateEndpoints` | ✅ `sp5-admin-integrations.html` |
+
+> **Estendibile**: con lo stesso pattern si possono aggiungere `entity-link` (`EntityLinkAdminEndpoints`), `user-tier management` (`Admin/AdminUserTier*Endpoints`, `AdminTierEndpoints`), `categories` (`AdminCategoriesEndpoints`), `ai-model registry` (`AiModelAdminEndpoints`). Aggiungili come C8/D7… quando servono.
+
+---
+
+## 5. Prompt template generico (riusabile per qualsiasi schermata surplus)
+
+> Riempi i `{segnaposto}` con i dati della scheda (§6/§7) e incollalo come messaggio singolo.
+
+```
+Crea il mockup HTML standalone della schermata "{TITOLO}" (id: {ID}, NAV_ID: {NAV_ID}).
+
+Contesto: {1-2 frasi su cosa fa la schermata e per chi}.
+Ruolo minimo: {ruolo}. Azioni sensibili (mostra il pattern UI, non implementare):
+{lista azioni che richiedono confirm/typed-confirm/step-up, se presenti}.
+
+Layout: usa {admin-shell | admin-shell-3col}. La .admin-body contiene, in quest'ordine:
+{elenco numerato delle sezioni UI: KPI strip, tabella, pannelli, form, log, timeline…}
+
+Dettagli per sezione:
+{per ciascuna sezione: quali componenti del cheat-sheet usare, quali colonne/campi,
+quali dati realistici, quali entity-color, stati empty/error se rilevanti}.
+
+Dati realistici da mostrare: {esempi concreti coerenti con MeepleAI}.
+Realtime: {se serve, indica un pannello "live" stile LiveEventLog con dot .running}.
+Keyboard hint: ⌘K ricerca, R refresh{, altri se pertinenti}.
+
+Riferimento endpoint (solo per realismo dei dati mostrati, NON per codice):
+{endpoint reali dalla scheda}.
+
+Rispetta lo SCHELETRO e il CHEAT-SHEET del brief. Inlinea i 3 CSS per l'anteprima.
+```
+
+---
+
+## 6. Prompt completi di esempio (2)
+
+### C1 · Infrastructure & Containers
+
+```
+Crea il mockup HTML standalone della schermata "Infrastructure & Containers"
+(id: C1, NAV_ID: 'infra').
+
+Contesto: pannello operativo per admin/superadmin che monitora i container Docker,
+i servizi backend (API, embedding, reranker, postgres, redis, n8n) e i batch job.
+Ruolo minimo: admin (restart servizio = superadmin + confirm).
+Azioni sensibili: "Restart" su un servizio → btn-admin.danger + ConfirmModal;
+"Restart all" → typed-confirm. Mostra solo il pattern UI (bottone + nota "richiede conferma").
+
+Layout: admin-shell. La .admin-body contiene in quest'ordine:
+1. KPI strip (4x .admin-kpi): Container attivi (e-toolkit), CPU media %, RAM usata/totale,
+   Batch job in coda (e-agent). Ognuna con trend e sparkline.
+2. .admin-panel "Servizi" con .admin-table: colonne Servizio | Stato (status-chip
+   healthy/warning/danger/running) | Uptime (mono) | CPU% | RAM | Immagine (mono) | azioni
+   (.menu con Restart/Logs). Righe: meepleai-api (healthy), embedding-service (healthy),
+   reranker-service (warning), postgres (healthy), redis (healthy), n8n (healthy),
+   smoldocling (muted/stopped).
+3. .admin-panel "Batch jobs (live)" con un mini LiveEventLog: lista mono di righe
+   timestamp + livello (ok/info/warn) + messaggio, con un dot .status-chip.running in testa
+   "● streaming". Mostra ~8 righe realistiche (es. "reindex game=catan stage=embed 64%").
+4. .admin-panel "Risorse" con due barre orizzontali (disco, memoria) usando .e-tint.
+
+Dati realistici: uptime tipo "12d 4h", immagini "ghcr.io/meepleai/api:1.8.2".
+Realtime: il pannello Batch jobs ha aspetto "live" (dot pulsante).
+Keyboard hint: ⌘K, R.
+
+Riferimento endpoint: GET /api/v1/admin/docker, /admin/infrastructure,
+/admin/operations/batch-jobs (+ SSE), POST /admin/operations/restart-service.
+
+Rispetta SCHELETRO + CHEAT-SHEET. Inlinea i 3 CSS per l'anteprima.
+```
+
+### D1 · Mechanic Extractor
+
+```
+Crea il mockup HTML standalone della schermata "Mechanic Extractor"
+(id: D1, NAV_ID: 'mechanic-extractor').
+
+Contesto: tool admin che analizza i PDF dei regolamenti per estrarre le meccaniche di
+gioco con un pipeline LLM asincrono e a costo controllato (cost cap + override). Mostra
+la lista delle analisi, lo stato di avanzamento, e un drill-down per analisi.
+Ruolo minimo: admin.
+Azioni sensibili: "Avvia analisi" con cost cap; "Override cap" → conferma.
+
+Layout: admin-shell-3col (lista a sx dentro la body NON serve: usa il 3° col come drill).
+In realtà usa admin-shell e metti il drill come .admin-panel a destra in una grid 1fr/360px.
+La .admin-body contiene:
+1. Barra azioni: select gioco (admin-select) + select PDF + input "Cost cap ($)"
+   (admin-input mono) + admin-toggle "Override cap" + btn-admin.primary "Avvia analisi".
+2. KPI strip (3x): Analisi totali, Costo medio/analisi ($, e-event), Meccaniche estratte (e-kb).
+3. grid 1fr 360px:
+   - sx: .admin-panel "Analisi" con .admin-table: colonne Gioco | PDF (mono) | Stato
+     (status-chip queued/running/completed/failed) | Sezioni (n) | Costo ($) | Avviata (mono)
+     | azioni. Una riga .selected (running, con .status-chip.running).
+   - dx: .admin-panel "Dettaglio analisi" (drill): hero col titolo gioco + status-chip;
+     .admin-tabs Sezioni · Meccaniche · Log · Validazione; sotto, una lista di "section runs"
+     con barra avanzamento (.e-tint) e una tabella meccaniche estratte con confidence
+     (status-chip healthy/warning per high/low confidence).
+4. Stato empty (commentato) per "nessuna analisi".
+
+Dati realistici: giochi "Catan", "Wingspan"; PDF "wingspan-rules-en.pdf"; meccaniche
+"Engine Building", "Set Collection" con confidence 0.92/0.61; costi tipo "$0.43".
+Keyboard hint: ⌘K, R.
+
+Riferimento endpoint: GET /api/v1/admin/mechanic-analyses, POST .../mechanic-extractor/run,
+GET .../mechanic-extractor/validation.
+
+Rispetta SCHELETRO + CHEAT-SHEET. Inlinea i 3 CSS per l'anteprima.
+```
+
+---
+
+## 7. Schede compatte per le restanti schermate
+
+> Incastra ciascuna nel template §5. Tono e densità come gli esempi §6.
+
+- **C2 · Database Sync & Staging Access** (`NAV_ID: 'database-sync'`, superadmin): hero stato sync (ultimo/prossimo run, tunnel up/down con status-chip), timeline run (admin-table: run · direzione · righe · stato · durata mono), pannello "Staging allowlist" (tabella email/ip + btn-admin.danger rimuovi + form aggiungi). Azione sensibile: avviare sync prod→staging (confirm).
+- **C3 · LLM Providers & Circuit Breakers** (`NAV_ID: 'providers'`, admin): KPI (provider attivi, richieste 24h, error-rate, costo 24h), tabella provider (OpenRouter/DeepSeek/… stato status-chip, modello default, latenza p95 mono, circuit-breaker open/closed), pannello "Routing chain" (ordine fallback con frecce →), azione "Rotate API key" (superadmin, mostra una volta in modal).
+- **C4 · LLM Emergency Controls** (`NAV_ID: 'emergency'`, superadmin+step-up): alert-banner.danger in testa "Zona critica". Grid di "kill-switch" (admin-toggle) per: pausa ingestion, blocco nuove chat, force cache flush, rate-limit reset, emergency shutdown. Ogni switch pericoloso → typed-confirm (es. digita "EMERGENCY"). Mostra il pattern, non il backend.
+- **C5 · Budget & Cost** (`NAV_ID: 'budget'`, admin): KPI (spesa oggi/mese, budget residuo, proiezione fine mese), grafico costi per provider (barre/area con sparkline), tabella "cost breakdown" per feature (chat, embedding, reranking, mechanic-extractor), simulatore costo (admin-form-row con input → risultato).
+- **C6 · Secrets Vault** (`NAV_ID: 'secrets'`, superadmin+step-up): alert-banner.warning "Modifiche audit-logged". Tabella secret (nome mono, scope, ultima rotazione, stato) — i valori sono SEMPRE mascherati (`••••••`); azioni Reveal (step-up)/Rotate/Delete (typed-confirm). Mai mostrare valori in chiaro nel mockup.
+- **C7 · Alerting Config** (`NAV_ID: 'alerts'`, admin): lista regole alert (admin-table: nome · metrica · soglia · finestra · severità status-chip · stato toggle), form "Nuova regola" (admin-form-row: metrica select, operatore, soglia, durata, canale Slack/email), pannello "Alert recenti" (activity-feed con severità colorata).
+- **D2 · Agent Sandbox & Debug** (`NAV_ID: 'sandbox'`, admin): admin-shell-3col. Sx config (select agente/gioco, parametri), centro chat di test (bolle + retrieval inline), dx pannello debug (pipeline trace tree con step + latenza, waterfall a segmenti). Pannello "live" con dot .running durante lo stream.
+- **D3 · A/B Testing agenti** (`NAV_ID: 'ab-testing'`, admin): KPI (test attivi, vincitore corrente, lift %), tabella esperimenti (nome · variante A/B · metrica · campione · significatività status-chip), grafico confronto due linee, azioni start/stop/promote-winner (confirm).
+- **D4 · Prompt Management** (`NAV_ID: 'prompts'`, admin): admin-shell-3col. Sx lista template prompt (filtro per agente), centro editor (textarea mono con evidenza `{{variabili}}`), dx versioni (timeline) + preview. Tabs Edit · Preview · Versioni. Azione "Activate version" (confirm).
+- **D5 · RAG Backup & Seeding** (`NAV_ID: 'rag-backup'`, superadmin per seed): KPI (ultimo backup, dimensione indice, giochi indicizzati), tabella backup (data · dimensione · stato · azioni restore), pannello "Seeding" con progress (barra + coda) e bottone "Reindex all" (typed-confirm, costoso). Pannello "live" SSE per il progress.
+- **D6 · Integrations: Slack & Email Templates** (`NAV_ID: 'integrations'`, admin): admin-tabs "Slack" · "Email templates". Tab Slack: stato connessione (status-chip), canali configurati (#ops, #alerts), test-message. Tab Email: lista template (admin-table) + editor (textarea mono Handlebars) + PreviewFrame (riquadro 380px) + test-send form.
+
+---
+
+## 8. Checklist per ogni mockup generato
+
+Prima di considerare "fatto" un `sp5-<id>.html`:
+
+- [ ] Importa i 4 asset (`tokens.css`, `components.css`, `admin-base.css`, `admin-nav.js`) via `<link>`/`<script>` (NON `<style>` inline nel file di repo)
+- [ ] `data-theme="dark"` di default; toggle funzionante via `admin-nav.js`
+- [ ] Blocco `.admin-mobile-fallback` presente; shell nascosta `<880px`
+- [ ] Density alta, `font-size: var(--fs-sm)` ereditato da `.admin-page`
+- [ ] **Zero hex hardcoded** — solo `var(--*)` / classi `admin-*` / utility `.e-*`
+- [ ] Dati realistici (no Lorem ipsum, no "TODO")
+- [ ] Azioni sensibili mostrano il pattern (ConfirmModal / typed-confirm / step-up badge)
+- [ ] Stati: almeno default; empty/error dove rilevante
+- [ ] `renderAdminNav('<NAV_ID>')` con id corretto
+- [ ] Voce aggiunta in `admin/admin-nav.js` (nuovo gruppo "Platform & Operations" / "AI Tooling & Data Quality") se il NAV_ID è nuovo
+- [ ] Riga aggiunta in `SCREENS.md` e stato aggiornato in §4 di questo file
+
+---
+
+## 9. Dopo i mockup → consolidamento
+
+Una volta disegnato il surplus, si chiude il cerchio del driver *"Consolidare IA + re-skin"*: si ridefinisce la sidebar (gruppi A/B/C/D), si riconcilia la duplicazione IA (AI/RAG/KB su più path → un canonico + redirect) e si pianifica il re-skin verso la shell ibrida sidebar+drawer. Quel passaggio è **implementazione** e va trattato con il flusso design → plan (non in questa guida, che resta sul piano del *design dei mockup*).

--- a/admin-mockups/design_handoff_admin/WIRING_GUIDE.md
+++ b/admin-mockups/design_handoff_admin/WIRING_GUIDE.md
@@ -1,0 +1,311 @@
+# Wiring Guide — Admin mockup → componente reale
+
+## Differenze vs handoff utente
+
+Le pagine admin **hanno regole più strette**:
+
+| Aspetto | Demo utente | Admin Console |
+|---|---|---|
+| Density | Comfortable | High (-1 step) |
+| Mobile | Fullscreen | Solo desktop (fallback msg) |
+| Dark mode | Auto | Default dark |
+| Permission | viewer dell'entity | RBAC server-checked + UI gate |
+| Mutazioni | Form + toast | + audit_log + typed-confirm per sensibili |
+| Performance | <500 entities | virtualize per 10k+ rows |
+| Realtime | Opzionale | SSE/WS spesso obbligatori (live event log, KB upload) |
+
+## Anatomia di un mock admin
+
+```
+sp5-admin-X.html
+```
+
+Ogni file è **vanilla HTML** (no React) che importa:
+- `tokens.css` (design system base)
+- `components.css` (design system base)
+- `admin-base.css` (admin overrides: density, dark default, admin components)
+- `admin-nav.js` (sidebar nav data + renderer)
+
+Pattern HTML ricorrente:
+
+```html
+<body class="admin-page">
+  <div class="admin-mobile-fallback">...</div>
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+    <main>
+      <header class="admin-top">...</header>
+      <div class="admin-body">
+        <!-- contenuto specifico pagina -->
+      </div>
+    </main>
+  </div>
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('overview');</script>
+</body>
+```
+
+Da portare in React:
+
+```tsx
+<AdminLayout activeNavId="overview">
+  <AdminTopbar
+    title="Overview sistema"
+    crumbs={['Admin', 'Overview', 'ultimo refresh 14:23:08']}
+    actions={<>
+      <ShortcutHint keys={['g', 'o']}>torna qui</ShortcutHint>
+      <Button onClick={refresh}>⟳ Refresh <Kbd>R</Kbd></Button>
+      <IconButton onClick={toggleTheme}>🌗</IconButton>
+    </>}
+  />
+  <AdminBody>
+    {/* page-specific content */}
+  </AdminBody>
+</AdminLayout>
+```
+
+`<AdminLayout>` decide internamente:
+- Se viewport <880px → renderizza solo `<MobileFallback>`
+- Altrimenti → shell completo con sidebar + topbar + children
+
+## Estrazione componenti dai mock
+
+Per ogni mock, identifica:
+
+1. **Dati statici** (KPI values, table rows, log lines) → vanno API-ificati
+2. **Stati interattivi** (selected row, tab active, form input) → `useState` o URL state
+3. **Componenti riusabili** → estrai in `src/components/admin/v2/`
+4. **Permessi** → wrap con `<RequireRole role="admin|superadmin">`
+5. **Mutazioni** → audit_log middleware + ConfirmModal se sensibili
+6. **Realtime** → SSE/WebSocket hook
+
+## Pattern: tabella admin
+
+I mock admin usano una tabella ricorrente. Esempio (sp5-admin-users):
+
+```html
+<table class="admin-table">
+  <thead><tr>...</tr></thead>
+  <tbody>
+    <tr class="selected"><td>...</td></tr>
+  </tbody>
+</table>
+```
+
+Da React:
+
+```tsx
+<AdminDataTable
+  data={users}
+  columns={[
+    { id: 'user', header: 'Utente', sortable: true, render: u => <UserCell user={u}/> },
+    { id: 'role', header: 'Ruolo', render: u => <RoleChip role={u.role}/> },
+    { id: 'joined', header: 'Joined', sortable: true, render: u => <DateMono date={u.joined}/> },
+    { id: 'lastActive', header: 'Last active', sortable: true, render: u => <RelativeTime date={u.lastActive}/> },
+    { id: 'status', header: 'Status', render: u => <StatusChip kind={u.status}/> },
+  ]}
+  enableMultiSelect
+  bulkActions={[
+    { id: 'changeRole', label: '✏️ Cambia ruolo', onClick: openChangeRoleModal },
+    { id: 'suspend', label: '⏸ Sospendi', onClick: openSuspendModal, requireRole: 'admin' },
+    { id: 'delete', label: '🗑 Elimina', danger: true, onClick: openDeleteModal, requireRole: 'superadmin', requireStepUp: true },
+  ]}
+  onRowClick={user => openDrillDown(user)}
+  onSort={(col, dir) => setSorting({ col, dir })}
+  virtualizeIf={rows => rows.length > 200}
+/>
+```
+
+## Pattern: drill-down sidebar (A2, A4, A5)
+
+Sidebar destra che si apre quando una riga è selezionata. Pattern URL: `/admin/users?selected=u-marco`
+
+```tsx
+function AdminUsersPage() {
+  const [selectedId, setSelectedId] = useSearchParam('selected');
+  const { data: users } = useUsers(filters);
+  const { data: drillData } = useUserDrillDown(selectedId);
+
+  return (
+    <div className="users-grid">
+      <AdminDataTable {...} onRowClick={u => setSelectedId(u.id)} />
+      {selectedId && (
+        <UserDetailDrawer
+          user={drillData}
+          onClose={() => setSelectedId(null)}
+          showAuditLog
+          showDangerZone={currentUser.role === 'superadmin'}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+## Pattern: bulk actions con typed-confirm
+
+```tsx
+async function handleBulkDelete(ids: string[]) {
+  if (ids.length === 0) return;
+
+  const confirmed = await openConfirmModal({
+    title: `Elimina ${ids.length} utenti?`,
+    danger: true,
+    body: (
+      <>
+        <p>Questa operazione è <strong>permanente</strong>. {ids.length} account, le loro sessioni, agenti personali e KB privati saranno cancellati irreversibilmente.</p>
+        <p>Audit log: questa azione sarà registrata con il tuo ID e l'IP corrente.</p>
+      </>
+    ),
+    typedConfirm: 'ELIMINA UTENTI',  // utente deve digitare esattamente questo
+    confirmLabel: 'Elimina definitivamente',
+    requireStepUp: true,             // 2FA challenge
+  });
+  if (!confirmed) return;
+
+  await api.bulkDelete(ids);
+  // audit log scritto lato BE dal middleware
+  toast.success(`${ids.length} utenti eliminati`);
+}
+```
+
+## Pattern: SSE per realtime (A8, A5b)
+
+```tsx
+function LiveEventLog() {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  useSSE('/api/admin/events/live', {
+    onEvent: (e) => setEvents(prev => [parseEvent(e), ...prev].slice(0, 200)),
+    onError: () => toast.error('Stream disconnesso, riconnetto…'),
+    reconnect: { interval: 2000, maxAttempts: Infinity },
+  });
+
+  return (
+    <EventLog>
+      {events.map(e => <EventRow key={e.id} event={e}/>)}
+    </EventLog>
+  );
+}
+```
+
+## Pattern: KB upload con FSM
+
+```tsx
+type UploadFSM =
+  | { state: 'idle' }
+  | { state: 'idempotency-check', hash: string }
+  | { state: 'idempotency-warn', match: KbDoc }
+  | { state: 'uploading', progress: number }
+  | { state: 'processing', jobId: string, currentStage: number }
+  | { state: 'complete', doc: KbDoc }
+  | { state: 'error', code: string, retryable: boolean };
+
+function useKbUpload() {
+  const [fsm, setFsm] = useState<UploadFSM>({ state: 'idle' });
+
+  async function upload(file: File, settings: UploadSettings) {
+    setFsm({ state: 'idempotency-check', hash: await sha256(file) });
+    const dup = await api.kbIdempotencyCheck(hash);
+    if (dup) {
+      setFsm({ state: 'idempotency-warn', match: dup });
+      return; // wait for user decision
+    }
+    setFsm({ state: 'uploading', progress: 0 });
+    const { jobId } = await api.kbUpload(file, settings, p => {
+      setFsm({ state: 'uploading', progress: p });
+    });
+    setFsm({ state: 'processing', jobId, currentStage: 0 });
+    // subscribe SSE for stage progress…
+  }
+
+  return { fsm, upload, ... };
+}
+```
+
+## Pattern: feature flags con dirty bar (A7)
+
+```tsx
+function ConfigPage() {
+  const { data: serverFlags } = useFlags();
+  const [dirty, setDirty] = useState<Record<string, FlagValue>>({});
+
+  const hasDirty = Object.keys(dirty).length > 0;
+
+  return (
+    <>
+      {flags.map(f => (
+        <FlagRow
+          flag={f}
+          value={dirty[f.key] ?? serverFlags[f.key]}
+          isDirty={dirty[f.key] !== undefined}
+          onChange={v => setDirty(d => ({ ...d, [f.key]: v }))}
+        />
+      ))}
+
+      {hasDirty && (
+        <DirtyStateBar
+          count={Object.keys(dirty).length}
+          onRevert={() => setDirty({})}
+          onPreview={() => openDiffModal(dirty)}
+          onApply={async () => {
+            await api.applyFlags(dirty); // audit-logged
+            setDirty({});
+            toast.success('Modifiche applicate in prod');
+          }}
+          applyRequiresStepUp={env === 'prd'}
+        />
+      )}
+    </>
+  );
+}
+```
+
+## Performance: virtualization
+
+`<AdminDataTable>` deve usare virtualization quando rows > 200:
+
+```tsx
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+function VirtualizedTableBody({ rows }: { rows: Row[] }) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const v = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 40,
+    overscan: 10,
+  });
+
+  return (
+    <div ref={parentRef} style={{ overflow: 'auto', height: 'calc(100vh - 240px)' }}>
+      <div style={{ height: v.getTotalSize(), position: 'relative' }}>
+        {v.getVirtualItems().map(vi => (
+          <Row key={vi.key} style={{ position: 'absolute', top: 0, transform: `translateY(${vi.start}px)` }}>
+            {/* row content */}
+          </Row>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## Definition of Done per ogni pagina admin
+
+- [ ] Render 1:1 con il mock (desktop 1440px)
+- [ ] Mobile fallback funzionante (<880px)
+- [ ] RBAC: route protetta + ogni button gates su role check
+- [ ] Audit log: ogni mutazione produce entry verificabile in DB
+- [ ] Confirm modal per azioni distruttive
+- [ ] Typed-confirm per superadmin actions
+- [ ] Step-up 2FA per impersonate/promote/broadcast
+- [ ] Stati: default + loading skeleton + empty + error
+- [ ] Pagination cursor-based (NO offset)
+- [ ] Server-side filter+sort per liste >100 row
+- [ ] Virtualization per >200 row visibili
+- [ ] Keyboard shortcuts implementati (almeno ⌘K, j/k, Escape)
+- [ ] Tests: unit per componenti, integration per flow critici, E2E per impersonate/delete/broadcast
+- [ ] Performance: P95 render <200ms da cache, <800ms da fresh fetch
+- [ ] data-comment-anchor preservati se nei mock ci sono
+- [ ] PR review da almeno 2 reviewer (admin pages = alto rischio)

--- a/admin-mockups/design_handoff_admin/admin-base.css
+++ b/admin-mockups/design_handoff_admin/admin-base.css
@@ -1,0 +1,455 @@
+/* ═══════════════════════════════════════════════════════════════════
+   MeepleAI Admin Console — SP5 base stylesheet
+   Density high · Dark-mode preferred · Desktop-first 1440px
+   Importa DOPO tokens.css + components.css
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* Density override: tutto il chrome admin usa spacing -1 step rispetto al base */
+.admin-page {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  font-family: var(--f-body);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+/* ── Layout principali ─────────────────────────────────────────── */
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+.admin-shell-3col { display: grid; grid-template-columns: 240px 1fr 360px; min-height: 100vh; }
+
+/* ── Sidebar admin nav ─────────────────────────────────────────── */
+.admin-nav {
+  background: var(--bg-card);
+  border-right: 1px solid var(--border);
+  padding: 16px 0;
+  display: flex; flex-direction: column; gap: 2px;
+  position: sticky; top: 0; height: 100vh; overflow-y: auto;
+}
+.admin-nav-brand {
+  padding: 4px 16px 16px;
+  display: flex; align-items: center; gap: 8px;
+  border-bottom: 1px solid var(--border-light);
+  margin-bottom: 12px;
+}
+.admin-nav-brand-mark {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)));
+  color: #fff; display: grid; place-items: center;
+  font-family: var(--f-display); font-weight: 900; font-size: 14px;
+}
+.admin-nav-brand-name {
+  font-family: var(--f-display); font-weight: 800; font-size: 14px;
+}
+.admin-nav-brand-tag {
+  font-family: var(--f-mono); font-size: 9px; font-weight: 700;
+  color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em;
+  padding: 2px 6px; border-radius: 4px;
+  background: hsl(var(--c-event) / .12);
+  margin-left: auto;
+}
+.admin-nav-group {
+  padding: 10px 16px 4px;
+  font-family: var(--f-mono); font-size: 9.5px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em;
+}
+.admin-nav-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 16px;
+  color: var(--text-sec);
+  font-family: var(--f-display); font-size: 13px; font-weight: 600;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  text-decoration: none;
+}
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active {
+  background: hsl(var(--c-event) / .08);
+  color: hsl(var(--c-event));
+  border-left-color: hsl(var(--c-event));
+}
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count {
+  margin-left: auto;
+  font-family: var(--f-mono); font-size: 10px;
+  color: var(--text-muted); font-weight: 700;
+}
+.admin-nav-foot {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-light);
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.admin-nav-foot .badge {
+  padding: 2px 6px; border-radius: 4px;
+  background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit));
+  font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em;
+}
+
+/* ── Topbar admin ──────────────────────────────────────────────── */
+.admin-top {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-light);
+  padding: 12px 24px;
+  display: flex; align-items: center; gap: 16px;
+  position: sticky; top: 0; z-index: 50;
+  backdrop-filter: blur(12px);
+}
+.admin-top h1 {
+  font-family: var(--f-display); font-size: 20px; font-weight: 800;
+  margin: 0; line-height: 1.2;
+}
+.admin-top .crumbs {
+  font-family: var(--f-mono); font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+/* ── Search input admin ────────────────────────────────────────── */
+.admin-search {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 12px; background: var(--bg-card);
+  border: 1px solid var(--border); border-radius: 8px;
+  width: 280px;
+  font-size: 12px;
+}
+.admin-search input {
+  flex: 1; border: 0; background: transparent;
+  color: var(--text); font-family: var(--f-body); font-size: 12.5px;
+  outline: 0;
+}
+.admin-search kbd {
+  padding: 1px 5px; border-radius: 4px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+  font-family: var(--f-mono); font-size: 9px;
+  color: var(--text-muted);
+}
+
+/* ── Buttons admin ─────────────────────────────────────────────── */
+.btn-admin {
+  padding: 6px 12px; border-radius: 6px;
+  font-family: var(--f-display); font-size: 12.5px; font-weight: 700;
+  cursor: pointer; border: 1px solid var(--border);
+  background: var(--bg-card); color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+  white-space: nowrap;
+}
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary {
+  background: hsl(var(--c-event));
+  border-color: hsl(var(--c-event));
+  color: #fff;
+  box-shadow: 0 2px 6px hsl(var(--c-event) / .3);
+}
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger {
+  background: var(--bg-card); border-color: hsl(var(--c-event) / .5);
+  color: hsl(var(--c-event));
+}
+.btn-admin.success {
+  background: hsl(var(--c-toolkit));
+  border-color: hsl(var(--c-toolkit));
+  color: #fff;
+}
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin.icon { padding: 6px; width: 28px; height: 28px; justify-content: center; }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin kbd {
+  padding: 1px 4px; border-radius: 3px;
+  background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2);
+  font-family: var(--f-mono); font-size: 9px; margin-left: 4px;
+}
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+/* ── KPI cards admin ───────────────────────────────────────────── */
+.admin-kpi {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 4px;
+  min-height: 88px;
+  position: relative;
+}
+.admin-kpi-label {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+}
+.admin-kpi-value {
+  font-family: var(--f-display); font-size: 28px; font-weight: 800;
+  color: var(--text); line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.admin-kpi-trend {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 600;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.admin-kpi-trend.up   { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark {
+  position: absolute; right: 12px; top: 12px;
+  width: 70px; height: 28px; opacity: .85;
+}
+.admin-kpi-icon {
+  position: absolute; right: 14px; bottom: 12px;
+  font-size: 22px; opacity: .35;
+}
+
+/* Entity tinted variants */
+.admin-kpi.e-game    { border-left: 3px solid hsl(var(--c-game)); }
+.admin-kpi.e-player  { border-left: 3px solid hsl(var(--c-player)); }
+.admin-kpi.e-session { border-left: 3px solid hsl(var(--c-session)); }
+.admin-kpi.e-agent   { border-left: 3px solid hsl(var(--c-agent)); }
+.admin-kpi.e-kb      { border-left: 3px solid hsl(var(--c-kb)); }
+.admin-kpi.e-chat    { border-left: 3px solid hsl(var(--c-chat)); }
+.admin-kpi.e-event   { border-left: 3px solid hsl(var(--c-event)); }
+.admin-kpi.e-toolkit { border-left: 3px solid hsl(var(--c-toolkit)); }
+
+/* ── Cards / panels admin ──────────────────────────────────────── */
+.admin-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.admin-panel-head {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex; align-items: center; gap: 10px;
+  background: var(--bg);
+}
+.admin-panel-head h3 {
+  margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800;
+}
+.admin-panel-head .meta {
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  margin-left: auto;
+}
+.admin-panel-body { padding: 14px; }
+
+/* ── Data table admin ──────────────────────────────────────────── */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+.admin-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg);
+  position: sticky; top: 0;
+  white-space: nowrap;
+}
+.admin-table th.sort-asc::after  { content: ' ↑'; color: hsl(var(--c-event)); }
+.admin-table th.sort-desc::after { content: ' ↓'; color: hsl(var(--c-event)); }
+.admin-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: middle;
+}
+.admin-table tr:hover td { background: var(--bg-muted); }
+.admin-table tr.selected td { background: hsl(var(--c-event) / .06); }
+.admin-table .checkbox { width: 32px; }
+.admin-table .menu { width: 32px; text-align: right; }
+.admin-table .menu button { background: transparent; border: 0; cursor: pointer; color: var(--text-sec); padding: 4px; border-radius: 4px; }
+.admin-table .menu button:hover { background: var(--bg-muted); color: var(--text); }
+
+/* ── Status chips ──────────────────────────────────────────────── */
+.status-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: 999px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+  white-space: nowrap;
+}
+.status-chip::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger  { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted   { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info    { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.running::before { animation: admin-pulse 1.4s ease-in-out infinite; }
+@keyframes admin-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%      { transform: scale(1.5); opacity: .5; }
+}
+
+/* ── Role chips (player entity) ────────────────────────────────── */
+.role-chip {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; border-radius: 999px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.role-chip.superadmin { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.role-chip.admin      { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); }
+.role-chip.premium    { background: hsl(var(--c-agent) / .14); color: hsl(38 90% 38%); }
+.role-chip.user       { background: hsl(var(--c-player) / .1); color: hsl(var(--c-player)); }
+
+/* ── Activity feed ─────────────────────────────────────────────── */
+.activity-feed { display: flex; flex-direction: column; gap: 1px; }
+.activity-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex; align-items: flex-start; gap: 10px;
+  font-size: 12.5px;
+}
+.activity-item:last-child { border-bottom: 0; }
+.activity-item:hover { background: var(--bg-muted); }
+.activity-item .em {
+  width: 28px; height: 28px; border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 14px; flex-shrink: 0;
+}
+.activity-item .body { flex: 1; min-width: 0; }
+.activity-item .body strong { font-weight: 700; color: var(--text); }
+.activity-item .ts {
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Sparkline mini ────────────────────────────────────────────── */
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+/* ── Forms compatti admin ──────────────────────────────────────── */
+.admin-form-row {
+  display: grid; grid-template-columns: 200px 1fr;
+  gap: 16px; align-items: flex-start;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.admin-form-row:last-child { border-bottom: 0; }
+.admin-form-label {
+  font-family: var(--f-display); font-size: 12.5px; font-weight: 700;
+}
+.admin-form-label .desc {
+  display: block; margin-top: 3px;
+  font-family: var(--f-body); font-size: 11px; font-weight: 400;
+  color: var(--text-muted); line-height: 1.4;
+}
+.admin-input, .admin-select, .admin-textarea {
+  width: 100%; max-width: 360px;
+  padding: 6px 10px;
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--f-body); font-size: 12.5px;
+}
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-toggle {
+  position: relative;
+  width: 36px; height: 20px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.admin-toggle::after {
+  content: ''; position: absolute; top: 2px; left: 2px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--text-sec); transition: all .2s var(--ease-out);
+}
+.admin-toggle.on { background: hsl(var(--c-toolkit) / .25); border-color: hsl(var(--c-toolkit)); }
+.admin-toggle.on::after { left: 18px; background: hsl(var(--c-toolkit)); }
+
+/* ── Bulk actions bar ──────────────────────────────────────────── */
+.bulk-bar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 14px;
+  background: hsl(var(--c-event) / .08);
+  border: 1px solid hsl(var(--c-event) / .25);
+  border-radius: 8px;
+  font-size: 12.5px;
+  margin-bottom: 12px;
+}
+.bulk-bar .count {
+  font-family: var(--f-display); font-weight: 800;
+  color: hsl(var(--c-event));
+}
+.bulk-bar .actions { display: flex; gap: 6px; margin-left: auto; }
+
+/* ── Tabs admin (underline) ────────────────────────────────────── */
+.admin-tabs {
+  display: flex; gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+.admin-tab {
+  padding: 8px 14px;
+  background: transparent; border: 0;
+  font-family: var(--f-display); font-size: 13px; font-weight: 700;
+  color: var(--text-sec); cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.admin-tab .count {
+  padding: 1px 6px; border-radius: 999px;
+  background: var(--bg-muted); color: var(--text-muted);
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+}
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active {
+  color: hsl(var(--c-event));
+  border-bottom-color: hsl(var(--c-event));
+}
+.admin-tab.active .count {
+  background: hsl(var(--c-event) / .14); color: hsl(var(--c-event));
+}
+
+/* ── Alert banner ──────────────────────────────────────────────── */
+.alert-banner {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  font-size: 12.5px;
+}
+.alert-banner.warning { background: hsl(38 90% 56% / .1); border: 1px solid hsl(38 90% 56% / .35); color: var(--text); }
+.alert-banner.danger  { background: hsl(var(--c-event) / .08); border: 1px solid hsl(var(--c-event) / .35); color: var(--text); }
+.alert-banner.info    { background: hsl(var(--c-chat) / .08); border: 1px solid hsl(var(--c-chat) / .3); color: var(--text); }
+.alert-banner.success { background: hsl(var(--c-toolkit) / .08); border: 1px solid hsl(var(--c-toolkit) / .3); color: var(--text); }
+.alert-banner .em { font-size: 18px; flex-shrink: 0; }
+.alert-banner .title { font-family: var(--f-display); font-weight: 800; margin-bottom: 2px; font-size: 13px; }
+.alert-banner .actions { margin-left: auto; display: flex; gap: 6px; }
+
+/* ── Mobile fallback ───────────────────────────────────────────── */
+@media (max-width: 880px) {
+  .admin-mobile-fallback {
+    display: flex !important;
+    flex-direction: column; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 32px;
+    text-align: center; gap: 16px;
+  }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell, .admin-shell-3col { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+/* ── Section header in body ────────────────────────────────────── */
+.admin-body { padding: 20px 24px; }
+.admin-body-grid { display: grid; gap: 16px; }
+
+/* ── Inline labels ─────────────────────────────────────────────── */
+.kbd-hint {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+}
+.kbd-hint kbd {
+  padding: 1px 5px; border-radius: 4px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+}

--- a/admin-mockups/design_handoff_admin/admin-nav.js
+++ b/admin-mockups/design_handoff_admin/admin-nav.js
@@ -1,0 +1,76 @@
+/* admin-nav.js — Shared admin sidebar nav.
+   Call after DOMContentLoaded with: renderAdminNav('active-id').
+   IDs reflect file basename (sp5-admin-overview → 'overview', sp5-editor → 'editor'). */
+
+const ADMIN_NAV = [
+  { group: 'Admin Console', items: [
+    { id: 'overview',      em: '📊', label: 'Overview',         href: 'sp5-admin-overview.html',     count: '' },
+    { id: 'users',         em: '👥', label: 'Utenti',           href: 'sp5-admin-users.html',        count: '1.2k' },
+    { id: 'content',       em: '📦', label: 'Content',          href: 'sp5-admin-content.html',      count: '14' },
+    { id: 'ai',            em: '🤖', label: 'AI / RAG',         href: 'sp5-admin-ai.html',           count: '' },
+    { id: 'kb',            em: '📚', label: 'Knowledge Base',   href: 'sp5-admin-kb.html',           count: '247' },
+    { id: 'kb-upload',     em: '⤴️',  label: 'KB Upload',        href: 'sp5-kb-upload-flow.html',     count: '' },
+    { id: 'catalog',       em: '🔄', label: 'Catalog ingest',   href: 'sp5-admin-catalog.html',      count: '' },
+    { id: 'config',        em: '⚙️',  label: 'Config / Flags',   href: 'sp5-admin-config.html',       count: '' },
+    { id: 'monitor',       em: '📈', label: 'Monitor',          href: 'sp5-admin-monitor.html',      count: '' },
+    { id: 'notifications', em: '📨', label: 'Notifications',    href: 'sp5-admin-notifications.html', count: '' },
+  ]},
+  { group: 'Power-User Tools', items: [
+    { id: 'editor',         em: '✏️',  label: 'Editor',            href: 'sp5-editor.html',           count: '' },
+    { id: 'pipeline',       em: '🔗', label: 'Pipeline Builder',  href: 'sp5-pipeline-builder.html', count: '' },
+    { id: 'n8n',            em: '⚡', label: 'n8n Integrations', href: 'sp5-n8n.html',              count: '' },
+    { id: 'upload',         em: '📤', label: 'Upload avanzato',  href: 'sp5-upload-advanced.html',  count: '3' },
+    { id: 'play-records',   em: '🎲', label: 'Play Records',     href: 'sp5-play-records.html',     count: '' },
+    { id: 'versions',       em: '🔢', label: 'Versions',         href: 'sp5-versions.html',         count: '' },
+    { id: 'private-games',  em: '🔒', label: 'Private Games',    href: 'sp5-private-games.html',    count: '' },
+    { id: 'dev-tools',      em: '🛠️',  label: 'Dev Tools',        href: 'sp5-dev-tools.html',        count: '' },
+  ]},
+];
+
+function renderAdminNav(activeId) {
+  const html = `
+    <aside class="admin-nav" aria-label="Admin navigation">
+      <div class="admin-nav-brand">
+        <div class="admin-nav-brand-mark">M</div>
+        <span class="admin-nav-brand-name">MeepleAI</span>
+        <span class="admin-nav-brand-tag">Admin</span>
+      </div>
+
+      ${ADMIN_NAV.map(g => `
+        <div class="admin-nav-group">${g.group}</div>
+        ${g.items.map(i => `
+          <a class="admin-nav-item ${i.id === activeId ? 'active' : ''}" href="${i.href}">
+            <span class="em" aria-hidden="true">${i.em}</span>
+            <span>${i.label}</span>
+            ${i.count ? `<span class="count">${i.count}</span>` : ''}
+          </a>
+        `).join('')}
+      `).join('')}
+
+      <div class="admin-nav-foot">
+        <span class="badge">SuperAdmin</span>
+        <span>Aaron</span>
+      </div>
+    </aside>
+  `;
+  const container = document.querySelector('[data-admin-nav-mount]');
+  if (container) container.innerHTML = html;
+}
+
+/* Theme auto from system + manual toggle persisted */
+(function initAdminTheme() {
+  const saved = localStorage.getItem('mai-admin-theme');
+  if (saved) {
+    document.documentElement.setAttribute('data-theme', saved);
+  } else {
+    // Admin prefers DARK as per brief
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+})();
+
+function toggleAdminTheme() {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('mai-admin-theme', next);
+}

--- a/admin-mockups/design_handoff_admin/admin/admin-base.css
+++ b/admin-mockups/design_handoff_admin/admin/admin-base.css
@@ -1,0 +1,455 @@
+/* ═══════════════════════════════════════════════════════════════════
+   MeepleAI Admin Console — SP5 base stylesheet
+   Density high · Dark-mode preferred · Desktop-first 1440px
+   Importa DOPO tokens.css + components.css
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* Density override: tutto il chrome admin usa spacing -1 step rispetto al base */
+.admin-page {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  font-family: var(--f-body);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+/* ── Layout principali ─────────────────────────────────────────── */
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+.admin-shell-3col { display: grid; grid-template-columns: 240px 1fr 360px; min-height: 100vh; }
+
+/* ── Sidebar admin nav ─────────────────────────────────────────── */
+.admin-nav {
+  background: var(--bg-card);
+  border-right: 1px solid var(--border);
+  padding: 16px 0;
+  display: flex; flex-direction: column; gap: 2px;
+  position: sticky; top: 0; height: 100vh; overflow-y: auto;
+}
+.admin-nav-brand {
+  padding: 4px 16px 16px;
+  display: flex; align-items: center; gap: 8px;
+  border-bottom: 1px solid var(--border-light);
+  margin-bottom: 12px;
+}
+.admin-nav-brand-mark {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)));
+  color: #fff; display: grid; place-items: center;
+  font-family: var(--f-display); font-weight: 900; font-size: 14px;
+}
+.admin-nav-brand-name {
+  font-family: var(--f-display); font-weight: 800; font-size: 14px;
+}
+.admin-nav-brand-tag {
+  font-family: var(--f-mono); font-size: 9px; font-weight: 700;
+  color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em;
+  padding: 2px 6px; border-radius: 4px;
+  background: hsl(var(--c-event) / .12);
+  margin-left: auto;
+}
+.admin-nav-group {
+  padding: 10px 16px 4px;
+  font-family: var(--f-mono); font-size: 9.5px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em;
+}
+.admin-nav-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 16px;
+  color: var(--text-sec);
+  font-family: var(--f-display); font-size: 13px; font-weight: 600;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  text-decoration: none;
+}
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active {
+  background: hsl(var(--c-event) / .08);
+  color: hsl(var(--c-event));
+  border-left-color: hsl(var(--c-event));
+}
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count {
+  margin-left: auto;
+  font-family: var(--f-mono); font-size: 10px;
+  color: var(--text-muted); font-weight: 700;
+}
+.admin-nav-foot {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-light);
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.admin-nav-foot .badge {
+  padding: 2px 6px; border-radius: 4px;
+  background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit));
+  font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em;
+}
+
+/* ── Topbar admin ──────────────────────────────────────────────── */
+.admin-top {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-light);
+  padding: 12px 24px;
+  display: flex; align-items: center; gap: 16px;
+  position: sticky; top: 0; z-index: 50;
+  backdrop-filter: blur(12px);
+}
+.admin-top h1 {
+  font-family: var(--f-display); font-size: 20px; font-weight: 800;
+  margin: 0; line-height: 1.2;
+}
+.admin-top .crumbs {
+  font-family: var(--f-mono); font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+/* ── Search input admin ────────────────────────────────────────── */
+.admin-search {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 12px; background: var(--bg-card);
+  border: 1px solid var(--border); border-radius: 8px;
+  width: 280px;
+  font-size: 12px;
+}
+.admin-search input {
+  flex: 1; border: 0; background: transparent;
+  color: var(--text); font-family: var(--f-body); font-size: 12.5px;
+  outline: 0;
+}
+.admin-search kbd {
+  padding: 1px 5px; border-radius: 4px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+  font-family: var(--f-mono); font-size: 9px;
+  color: var(--text-muted);
+}
+
+/* ── Buttons admin ─────────────────────────────────────────────── */
+.btn-admin {
+  padding: 6px 12px; border-radius: 6px;
+  font-family: var(--f-display); font-size: 12.5px; font-weight: 700;
+  cursor: pointer; border: 1px solid var(--border);
+  background: var(--bg-card); color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+  white-space: nowrap;
+}
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary {
+  background: hsl(var(--c-event));
+  border-color: hsl(var(--c-event));
+  color: #fff;
+  box-shadow: 0 2px 6px hsl(var(--c-event) / .3);
+}
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger {
+  background: var(--bg-card); border-color: hsl(var(--c-event) / .5);
+  color: hsl(var(--c-event));
+}
+.btn-admin.success {
+  background: hsl(var(--c-toolkit));
+  border-color: hsl(var(--c-toolkit));
+  color: #fff;
+}
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin.icon { padding: 6px; width: 28px; height: 28px; justify-content: center; }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin kbd {
+  padding: 1px 4px; border-radius: 3px;
+  background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2);
+  font-family: var(--f-mono); font-size: 9px; margin-left: 4px;
+}
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+/* ── KPI cards admin ───────────────────────────────────────────── */
+.admin-kpi {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 4px;
+  min-height: 88px;
+  position: relative;
+}
+.admin-kpi-label {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+}
+.admin-kpi-value {
+  font-family: var(--f-display); font-size: 28px; font-weight: 800;
+  color: var(--text); line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.admin-kpi-trend {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 600;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.admin-kpi-trend.up   { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark {
+  position: absolute; right: 12px; top: 12px;
+  width: 70px; height: 28px; opacity: .85;
+}
+.admin-kpi-icon {
+  position: absolute; right: 14px; bottom: 12px;
+  font-size: 22px; opacity: .35;
+}
+
+/* Entity tinted variants */
+.admin-kpi.e-game    { border-left: 3px solid hsl(var(--c-game)); }
+.admin-kpi.e-player  { border-left: 3px solid hsl(var(--c-player)); }
+.admin-kpi.e-session { border-left: 3px solid hsl(var(--c-session)); }
+.admin-kpi.e-agent   { border-left: 3px solid hsl(var(--c-agent)); }
+.admin-kpi.e-kb      { border-left: 3px solid hsl(var(--c-kb)); }
+.admin-kpi.e-chat    { border-left: 3px solid hsl(var(--c-chat)); }
+.admin-kpi.e-event   { border-left: 3px solid hsl(var(--c-event)); }
+.admin-kpi.e-toolkit { border-left: 3px solid hsl(var(--c-toolkit)); }
+
+/* ── Cards / panels admin ──────────────────────────────────────── */
+.admin-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.admin-panel-head {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex; align-items: center; gap: 10px;
+  background: var(--bg);
+}
+.admin-panel-head h3 {
+  margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800;
+}
+.admin-panel-head .meta {
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  margin-left: auto;
+}
+.admin-panel-body { padding: 14px; }
+
+/* ── Data table admin ──────────────────────────────────────────── */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+.admin-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg);
+  position: sticky; top: 0;
+  white-space: nowrap;
+}
+.admin-table th.sort-asc::after  { content: ' ↑'; color: hsl(var(--c-event)); }
+.admin-table th.sort-desc::after { content: ' ↓'; color: hsl(var(--c-event)); }
+.admin-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: middle;
+}
+.admin-table tr:hover td { background: var(--bg-muted); }
+.admin-table tr.selected td { background: hsl(var(--c-event) / .06); }
+.admin-table .checkbox { width: 32px; }
+.admin-table .menu { width: 32px; text-align: right; }
+.admin-table .menu button { background: transparent; border: 0; cursor: pointer; color: var(--text-sec); padding: 4px; border-radius: 4px; }
+.admin-table .menu button:hover { background: var(--bg-muted); color: var(--text); }
+
+/* ── Status chips ──────────────────────────────────────────────── */
+.status-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: 999px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+  white-space: nowrap;
+}
+.status-chip::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger  { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted   { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info    { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.running::before { animation: admin-pulse 1.4s ease-in-out infinite; }
+@keyframes admin-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%      { transform: scale(1.5); opacity: .5; }
+}
+
+/* ── Role chips (player entity) ────────────────────────────────── */
+.role-chip {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; border-radius: 999px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.role-chip.superadmin { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.role-chip.admin      { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); }
+.role-chip.premium    { background: hsl(var(--c-agent) / .14); color: hsl(38 90% 38%); }
+.role-chip.user       { background: hsl(var(--c-player) / .1); color: hsl(var(--c-player)); }
+
+/* ── Activity feed ─────────────────────────────────────────────── */
+.activity-feed { display: flex; flex-direction: column; gap: 1px; }
+.activity-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex; align-items: flex-start; gap: 10px;
+  font-size: 12.5px;
+}
+.activity-item:last-child { border-bottom: 0; }
+.activity-item:hover { background: var(--bg-muted); }
+.activity-item .em {
+  width: 28px; height: 28px; border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 14px; flex-shrink: 0;
+}
+.activity-item .body { flex: 1; min-width: 0; }
+.activity-item .body strong { font-weight: 700; color: var(--text); }
+.activity-item .ts {
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Sparkline mini ────────────────────────────────────────────── */
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+/* ── Forms compatti admin ──────────────────────────────────────── */
+.admin-form-row {
+  display: grid; grid-template-columns: 200px 1fr;
+  gap: 16px; align-items: flex-start;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.admin-form-row:last-child { border-bottom: 0; }
+.admin-form-label {
+  font-family: var(--f-display); font-size: 12.5px; font-weight: 700;
+}
+.admin-form-label .desc {
+  display: block; margin-top: 3px;
+  font-family: var(--f-body); font-size: 11px; font-weight: 400;
+  color: var(--text-muted); line-height: 1.4;
+}
+.admin-input, .admin-select, .admin-textarea {
+  width: 100%; max-width: 360px;
+  padding: 6px 10px;
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  font-family: var(--f-body); font-size: 12.5px;
+}
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-toggle {
+  position: relative;
+  width: 36px; height: 20px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.admin-toggle::after {
+  content: ''; position: absolute; top: 2px; left: 2px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--text-sec); transition: all .2s var(--ease-out);
+}
+.admin-toggle.on { background: hsl(var(--c-toolkit) / .25); border-color: hsl(var(--c-toolkit)); }
+.admin-toggle.on::after { left: 18px; background: hsl(var(--c-toolkit)); }
+
+/* ── Bulk actions bar ──────────────────────────────────────────── */
+.bulk-bar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 14px;
+  background: hsl(var(--c-event) / .08);
+  border: 1px solid hsl(var(--c-event) / .25);
+  border-radius: 8px;
+  font-size: 12.5px;
+  margin-bottom: 12px;
+}
+.bulk-bar .count {
+  font-family: var(--f-display); font-weight: 800;
+  color: hsl(var(--c-event));
+}
+.bulk-bar .actions { display: flex; gap: 6px; margin-left: auto; }
+
+/* ── Tabs admin (underline) ────────────────────────────────────── */
+.admin-tabs {
+  display: flex; gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+.admin-tab {
+  padding: 8px 14px;
+  background: transparent; border: 0;
+  font-family: var(--f-display); font-size: 13px; font-weight: 700;
+  color: var(--text-sec); cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.admin-tab .count {
+  padding: 1px 6px; border-radius: 999px;
+  background: var(--bg-muted); color: var(--text-muted);
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+}
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active {
+  color: hsl(var(--c-event));
+  border-bottom-color: hsl(var(--c-event));
+}
+.admin-tab.active .count {
+  background: hsl(var(--c-event) / .14); color: hsl(var(--c-event));
+}
+
+/* ── Alert banner ──────────────────────────────────────────────── */
+.alert-banner {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  font-size: 12.5px;
+}
+.alert-banner.warning { background: hsl(38 90% 56% / .1); border: 1px solid hsl(38 90% 56% / .35); color: var(--text); }
+.alert-banner.danger  { background: hsl(var(--c-event) / .08); border: 1px solid hsl(var(--c-event) / .35); color: var(--text); }
+.alert-banner.info    { background: hsl(var(--c-chat) / .08); border: 1px solid hsl(var(--c-chat) / .3); color: var(--text); }
+.alert-banner.success { background: hsl(var(--c-toolkit) / .08); border: 1px solid hsl(var(--c-toolkit) / .3); color: var(--text); }
+.alert-banner .em { font-size: 18px; flex-shrink: 0; }
+.alert-banner .title { font-family: var(--f-display); font-weight: 800; margin-bottom: 2px; font-size: 13px; }
+.alert-banner .actions { margin-left: auto; display: flex; gap: 6px; }
+
+/* ── Mobile fallback ───────────────────────────────────────────── */
+@media (max-width: 880px) {
+  .admin-mobile-fallback {
+    display: flex !important;
+    flex-direction: column; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 32px;
+    text-align: center; gap: 16px;
+  }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell, .admin-shell-3col { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+/* ── Section header in body ────────────────────────────────────── */
+.admin-body { padding: 20px 24px; }
+.admin-body-grid { display: grid; gap: 16px; }
+
+/* ── Inline labels ─────────────────────────────────────────────── */
+.kbd-hint {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+}
+.kbd-hint kbd {
+  padding: 1px 5px; border-radius: 4px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+}

--- a/admin-mockups/design_handoff_admin/admin/admin-nav.js
+++ b/admin-mockups/design_handoff_admin/admin/admin-nav.js
@@ -1,0 +1,93 @@
+/* admin-nav.js — Shared admin sidebar nav.
+   Call after DOMContentLoaded with: renderAdminNav('active-id').
+   IDs reflect file basename (sp5-admin-overview → 'overview', sp5-editor → 'editor'). */
+
+const ADMIN_NAV = [
+  { group: 'Admin Console', items: [
+    { id: 'overview',      em: '📊', label: 'Overview',         href: 'sp5-admin-overview.html',     count: '' },
+    { id: 'users',         em: '👥', label: 'Utenti',           href: 'sp5-admin-users.html',        count: '1.2k' },
+    { id: 'content',       em: '📦', label: 'Content',          href: 'sp5-admin-content.html',      count: '14' },
+    { id: 'ai',            em: '🤖', label: 'AI / RAG',         href: 'sp5-admin-ai.html',           count: '' },
+    { id: 'kb',            em: '📚', label: 'Knowledge Base',   href: 'sp5-admin-kb.html',           count: '247' },
+    { id: 'kb-upload',     em: '⤴️',  label: 'KB Upload',        href: 'sp5-kb-upload-flow.html',     count: '' },
+    { id: 'catalog',       em: '🔄', label: 'Catalog ingest',   href: 'sp5-admin-catalog.html',      count: '' },
+    { id: 'config',        em: '⚙️',  label: 'Config / Flags',   href: 'sp5-admin-config.html',       count: '' },
+    { id: 'monitor',       em: '📈', label: 'Monitor',          href: 'sp5-admin-monitor.html',      count: '' },
+    { id: 'notifications', em: '📨', label: 'Notifications',    href: 'sp5-admin-notifications.html', count: '' },
+  ]},
+  { group: 'Power-User Tools', items: [
+    { id: 'editor',         em: '✏️',  label: 'Editor',            href: 'sp5-editor.html',           count: '' },
+    { id: 'pipeline',       em: '🔗', label: 'Pipeline Builder',  href: 'sp5-pipeline-builder.html', count: '' },
+    { id: 'n8n',            em: '⚡', label: 'n8n Integrations', href: 'sp5-n8n.html',              count: '' },
+    { id: 'upload',         em: '📤', label: 'Upload avanzato',  href: 'sp5-upload-advanced.html',  count: '3' },
+    { id: 'play-records',   em: '🎲', label: 'Play Records',     href: 'sp5-play-records.html',     count: '' },
+    { id: 'versions',       em: '🔢', label: 'Versions',         href: 'sp5-versions.html',         count: '' },
+    { id: 'private-games',  em: '🔒', label: 'Private Games',    href: 'sp5-private-games.html',    count: '' },
+    { id: 'dev-tools',      em: '🛠️',  label: 'Dev Tools',        href: 'sp5-dev-tools.html',        count: '' },
+  ]},
+  { group: 'Platform & Operations', items: [
+    { id: 'infra',          em: '🖥️',  label: 'Infrastructure',    href: 'sp5-admin-infra.html',      count: '' },
+    { id: 'database-sync',  em: '🗄️',  label: 'Database Sync',     href: 'sp5-admin-database-sync.html', count: '' },
+    { id: 'providers',      em: '🧠',  label: 'LLM Providers',     href: 'sp5-admin-providers.html',  count: '' },
+    { id: 'emergency',      em: '⛔', label: 'Emergency',         href: 'sp5-admin-emergency.html',  count: '' },
+    { id: 'budget',         em: '💰', label: 'Budget & Cost',     href: 'sp5-admin-budget.html',     count: '' },
+    { id: 'secrets',        em: '🔐', label: 'Secrets Vault',     href: 'sp5-admin-secrets.html',    count: '' },
+    { id: 'alerts',         em: '🔔', label: 'Alerting',          href: 'sp5-admin-alerts.html',     count: '' },
+  ]},
+  { group: 'AI Tooling & Data Quality', items: [
+    { id: 'mechanic-extractor', em: '⚙️', label: 'Mechanic Extractor', href: 'sp5-admin-mechanic-extractor.html', count: '' },
+    { id: 'sandbox',        em: '🧪', label: 'Agent Sandbox',     href: 'sp5-admin-sandbox.html',    count: '' },
+    { id: 'ab-testing',     em: '🆎', label: 'A/B Testing',       href: 'sp5-admin-ab-testing.html', count: '' },
+    { id: 'prompts',        em: '📝', label: 'Prompt Management',  href: 'sp5-admin-prompts.html',    count: '' },
+    { id: 'rag-backup',     em: '💾', label: 'RAG Backup',        href: 'sp5-admin-rag-backup.html', count: '' },
+    { id: 'integrations',   em: '🔌', label: 'Integrations',      href: 'sp5-admin-integrations.html', count: '' },
+  ]},
+];
+
+function renderAdminNav(activeId) {
+  const html = `
+    <aside class="admin-nav" aria-label="Admin navigation">
+      <div class="admin-nav-brand">
+        <div class="admin-nav-brand-mark">M</div>
+        <span class="admin-nav-brand-name">MeepleAI</span>
+        <span class="admin-nav-brand-tag">Admin</span>
+      </div>
+
+      ${ADMIN_NAV.map(g => `
+        <div class="admin-nav-group">${g.group}</div>
+        ${g.items.map(i => `
+          <a class="admin-nav-item ${i.id === activeId ? 'active' : ''}" href="${i.href}">
+            <span class="em" aria-hidden="true">${i.em}</span>
+            <span>${i.label}</span>
+            ${i.count ? `<span class="count">${i.count}</span>` : ''}
+          </a>
+        `).join('')}
+      `).join('')}
+
+      <div class="admin-nav-foot">
+        <span class="badge">SuperAdmin</span>
+        <span>Aaron</span>
+      </div>
+    </aside>
+  `;
+  const container = document.querySelector('[data-admin-nav-mount]');
+  if (container) container.innerHTML = html;
+}
+
+/* Theme auto from system + manual toggle persisted */
+(function initAdminTheme() {
+  const saved = localStorage.getItem('mai-admin-theme');
+  if (saved) {
+    document.documentElement.setAttribute('data-theme', saved);
+  } else {
+    // Admin prefers DARK as per brief
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+})();
+
+function toggleAdminTheme() {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('mai-admin-theme', next);
+}

--- a/admin-mockups/design_handoff_admin/admin/components.css
+++ b/admin-mockups/design_handoff_admin/admin/components.css
@@ -1,0 +1,132 @@
+/* MeepleAI Design System v1 — Shared components & layout
+   Uses tokens.css variables. Import after tokens.css. */
+
+/* ─── Theme toggle ─── */
+.theme-toggle {
+  position: fixed; top: 20px; right: 20px; z-index: var(--z-toast);
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px; border-radius: var(--r-pill);
+  background: var(--glass-bg); backdrop-filter: blur(12px);
+  border: 1px solid var(--border); color: var(--text);
+  font-size: var(--fs-sm); font-weight: var(--fw-semi);
+  box-shadow: var(--shadow-md); cursor: pointer;
+  transition: transform var(--dur-sm) var(--ease-out);
+}
+.theme-toggle:hover { transform: translateY(-1px); }
+
+/* ─── Entity badges & chips ─── */
+.e-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px; border-radius: var(--r-sm);
+  background: hsl(var(--e) / 0.12); color: hsl(var(--e));
+  font-size: var(--fs-xs); font-weight: var(--fw-bold);
+  font-family: var(--f-display); text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.e-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: hsl(var(--e)); flex-shrink: 0;
+  display: inline-block;
+}
+
+/* ─── Cards ─── */
+.card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--r-xl); box-shadow: var(--shadow-sm);
+  transition: transform var(--dur-sm) var(--ease-out),
+              box-shadow var(--dur-sm) var(--ease-out),
+              border-color var(--dur-sm) var(--ease-out);
+}
+.card.interactive { cursor: pointer; }
+.card.interactive:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: hsl(var(--e, var(--c-game)) / 0.4);
+}
+
+/* ─── Buttons ─── */
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px; border-radius: var(--r-md);
+  font-size: var(--fs-sm); font-weight: var(--fw-bold);
+  font-family: var(--f-display); border: 1px solid transparent;
+  transition: all var(--dur-sm) var(--ease-out);
+  background: var(--bg-muted); color: var(--text);
+}
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-xs); }
+.btn.primary { background: hsl(var(--e, var(--c-game))); color: #fff; }
+.btn.ghost { background: transparent; border-color: var(--border); color: var(--text-sec); }
+.btn.sm { padding: 5px 10px; font-size: var(--fs-xs); }
+
+/* ─── Phone frame ─── */
+.phone {
+  width: 380px; height: 780px;
+  border-radius: 48px; border: 10px solid #1a1a1a;
+  background: var(--bg);
+  overflow: hidden; position: relative;
+  box-shadow: 0 40px 80px rgba(0,0,0,.25), 0 0 0 2px #000;
+  display: flex; flex-direction: column;
+}
+[data-theme="dark"] .phone { border-color: #0a0a0a; box-shadow: 0 40px 80px rgba(0,0,0,.6); }
+
+.phone-sbar {
+  height: 32px; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 6px 22px 0; font-size: 12px; font-weight: var(--fw-bold);
+}
+.phone-sbar .ind { display: flex; gap: 4px; font-size: 11px; }
+
+/* ─── Section grid ─── */
+.stage {
+  min-height: 100vh; padding: var(--s-8) var(--s-6) var(--s-10);
+  background: var(--bg); color: var(--text);
+}
+.stage-wrap { max-width: 1400px; margin: 0 auto; }
+.stage h1 { font-size: var(--fs-3xl); margin-bottom: var(--s-2); }
+.stage > .stage-wrap > .lead {
+  color: var(--text-sec); font-size: var(--fs-md);
+  max-width: 720px; margin-bottom: var(--s-7);
+}
+.section-label {
+  font-family: var(--f-mono); font-size: var(--fs-xs);
+  color: var(--text-muted); text-transform: uppercase;
+  letter-spacing: 0.08em; margin: var(--s-8) 0 var(--s-3);
+  padding-bottom: var(--s-2); border-bottom: 1px solid var(--border);
+}
+
+/* ─── Hub nav ─── */
+.hub-nav {
+  position: sticky; top: 0; z-index: var(--z-sticky);
+  background: var(--glass-bg); backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+  padding: var(--s-3) var(--s-6);
+  display: flex; align-items: center; gap: var(--s-4);
+}
+.hub-nav .brand {
+  display: flex; align-items: center; gap: var(--s-2);
+  font-family: var(--f-display); font-weight: var(--fw-bold);
+  font-size: var(--fs-md);
+}
+.hub-nav .brand-mark {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)));
+  color: #fff; display: flex; align-items: center; justify-content: center;
+  font-weight: var(--fw-ext); font-size: 14px;
+}
+.hub-nav .spacer { flex: 1; }
+.hub-nav a {
+  padding: 6px 12px; border-radius: var(--r-md);
+  color: var(--text-sec); font-size: var(--fs-sm);
+  font-weight: var(--fw-semi); transition: all var(--dur-sm);
+  white-space: nowrap;
+}
+.hub-nav a:hover { background: var(--bg-hover); color: var(--text); }
+.hub-nav a.active { background: hsl(var(--c-game) / 0.12); color: hsl(var(--c-game)); }
+
+/* ─── Placeholder cover ─── */
+.cover-ph {
+  width: 100%; height: 100%; display: flex;
+  align-items: center; justify-content: center;
+  font-size: 2.5rem; color: rgba(255,255,255,.9);
+  text-shadow: 0 2px 8px rgba(0,0,0,.25);
+}

--- a/admin-mockups/design_handoff_admin/admin/index.html
+++ b/admin-mockups/design_handoff_admin/admin/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 Admin Console — Index</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  body { padding: 32px 48px; max-width: 1100px; margin: 0 auto; }
+  h1 { font-family: var(--f-display); font-size: 32px; font-weight: 800; margin: 0 0 6px; }
+  .lede { font-size: 14px; color: var(--text-sec); margin: 0 0 28px; max-width: 700px; line-height: 1.55; }
+  .grp-title { font-family: var(--f-mono); font-size: 11px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; margin: 28px 0 12px; }
+  .pages { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+  .page-card { display: block; padding: 14px 16px; background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; color: var(--text); text-decoration: none; }
+  .page-card:hover { border-color: hsl(var(--c-event) / .4); transform: translateY(-1px); }
+  .page-card .tag { font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .06em; }
+  .page-card h3 { margin: 4px 0 6px; font-family: var(--f-display); font-size: 16px; font-weight: 800; display: flex; align-items: center; gap: 6px; }
+  .page-card .desc { font-size: 12px; color: var(--text-sec); line-height: 1.5; }
+  .page-card .route { display: inline-block; margin-top: 8px; font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); padding: 2px 6px; background: var(--bg-muted); border-radius: 4px; }
+</style>
+</head>
+<body class="admin-page">
+
+<h1>🎲 MeepleAI · SP5 Admin Console</h1>
+<p class="lede">15 mockup admin + power-user tools. Desktop-first 1440px, density alta, dark-mode preferito. Aaron superadmin. <strong>Indipendenti dal demo principale</strong>: ognuno è una pagina standalone.</p>
+
+<div class="grp-title">🛡 Admin Console (10 schermate)</div>
+<div class="pages">
+  <a href="sp5-admin-overview.html" class="page-card"><span class="tag">A1</span><h3>📊 Overview</h3><div class="desc">Dashboard health: 4 KPI, activity feed, alerts, 4 charts, quick actions</div><span class="route">/admin/overview</span></a>
+  <a href="sp5-admin-users.html" class="page-card"><span class="tag">A2</span><h3>👥 Utenti</h3><div class="desc">Tabella utenti + bulk actions + drill-down profile + audit log + danger zone</div><span class="route">/admin/users</span></a>
+  <a href="sp5-admin-content.html" class="page-card"><span class="tag">A3</span><h3>📦 Content moderation</h3><div class="desc">Queue moderazione giochi · commenti flagged · approve/reject workflow</div><span class="route">/admin/content</span></a>
+  <a href="sp5-admin-ai.html" class="page-card"><span class="tag">A4</span><h3>🤖 AI / RAG Quality</h3><div class="desc">5 KPI · trend chart · worst queries · query drill-down · latency breakdown</div><span class="route">/admin/ai</span></a>
+  <a href="sp5-admin-kb.html" class="page-card"><span class="tag">A5</span><h3>📚 Knowledge Base</h3><div class="desc">Tree giochi+docs · document viewer · chunk table · ingestion log</div><span class="route">/admin/knowledge-base</span></a>
+  <a href="sp5-kb-upload-flow.html" class="page-card"><span class="tag">A5b</span><h3>⤴️ KB Upload Flow</h3><div class="desc">FSM 5 stati: empty · uploading · processing · complete · error + idempotency guard</div><span class="route">/admin/knowledge-base/upload</span></a>
+  <a href="sp5-admin-catalog.html" class="page-card"><span class="tag">A6</span><h3>🔄 Catalog ingestion</h3><div class="desc">BGG sync hero · history runs · queue pending · failed items retry</div><span class="route">/admin/catalog-ingestion</span></a>
+  <a href="sp5-admin-config.html" class="page-card"><span class="tag">A7</span><h3>⚙️ Config / Flags</h3><div class="desc">Feature flags + envs + dirty-state bar Apply/Revert</div><span class="route">/admin/config</span></a>
+  <a href="sp5-admin-monitor.html" class="page-card"><span class="tag">A8</span><h3>📈 Monitor</h3><div class="desc">6 KPI sparklines · 4 big charts · live event log SSE</div><span class="route">/admin/monitor</span></a>
+  <a href="sp5-admin-notifications.html" class="page-card"><span class="tag">A9</span><h3>📨 Notifications</h3><div class="desc">Template list · editor markdown · live preview email · variables helper</div><span class="route">/admin/notifications</span></a>
+</div>
+
+<div class="grp-title">🛠 Power-User Tools (8 schermate)</div>
+<div class="pages">
+  <a href="sp5-editor.html" class="page-card"><span class="tag">B1</span><h3>✏️ Editor</h3><div class="desc">3-col tree · block editor · preview live · metadata · version history</div><span class="route">/editor</span></a>
+  <a href="sp5-pipeline-builder.html" class="page-card"><span class="tag">B2</span><h3>🔗 Pipeline Builder</h3><div class="desc">Canvas node-based · palette · node config · test output JSON</div><span class="route">/pipeline-builder</span></a>
+  <a href="sp5-n8n.html" class="page-card"><span class="tag">B3</span><h3>⚡ n8n Integrations</h3><div class="desc">Connection hero · workflows table · webhook log · API keys</div><span class="route">/n8n</span></a>
+  <a href="sp5-upload-advanced.html" class="page-card"><span class="tag">B4</span><h3>📤 Upload avanzato</h3><div class="desc">Dropzone · queue · history · processing timeline 5 stages</div><span class="route">/upload</span></a>
+  <a href="sp5-play-records.html" class="page-card"><span class="tag">B5</span><h3>🎲 Play Records</h3><div class="desc">Storico partite personale · stats wins/gioco · top opponents</div><span class="route">/play-records</span></a>
+  <a href="sp5-versions.html" class="page-card"><span class="tag">B6</span><h3>🔢 Versions</h3><div class="desc">Timeline versioni artefatti · diff viewer · compare selector</div><span class="route">/versions</span></a>
+  <a href="sp5-private-games.html" class="page-card"><span class="tag">B7</span><h3>🔒 Private Games</h3><div class="desc">Grid card private · publish checklist · review workflow</div><span class="route">/private-games</span></a>
+  <a href="sp5-dev-tools.html" class="page-card"><span class="tag">B8</span><h3>🛠️ Dev Tools</h3><div class="desc">MSW scenarios · auth role switcher · runtime flags · cache/store inspector · reset</div><span class="route">/dev (dev-only)</span></a>
+</div>
+
+<div class="grp-title">↩ Torna al demo principale</div>
+<div class="pages">
+  <a href="../demo.html" class="page-card"><span class="tag">DEMO</span><h3>🎯 Demo principale (utente authenticated)</h3><div class="desc">71 step tour del prodotto end-user · Marco/Aaron/Davide flow</div></a>
+</div>
+
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-ab-testing.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-ab-testing.html
@@ -1,0 +1,678 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>A/B Testing Agenti · MeepleAI Admin</title>
+<!-- D3 · AI Tooling & Data Quality → 'ab-testing' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 ABTestTable · VariantChip · LiftCell · SignificanceChip · ComparisonChart · DetailDrawer
+     · PromoteWinnerCTA reuse
+     Endpoints: GET/POST /api/v1/admin/ab-tests
+                POST /api/v1/admin/ab-tests/{id}/{promote|stop}
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.danger:hover{background:hsl(var(--c-event)/.08)}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff;box-shadow:0 2px 6px hsl(var(--c-toolkit)/.3)}
+.btn-admin.success:hover{filter:brightness(1.08)}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit))}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table tr.selected td{background:hsl(var(--c-event)/.07)}
+.admin-table tr.selected td:first-child{box-shadow:inset 3px 0 0 hsl(var(--c-event))}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+
+/* Variant chips A/B */
+.variant-pair{display:inline-flex;align-items:center;gap:6px}
+.var-chip{display:inline-flex;align-items:center;gap:5px;padding:3px 8px;border-radius:6px;font-family:var(--f-display);font-weight:800;font-size:11.5px;border:1px solid hsl(var(--e)/.3);background:hsl(var(--e)/.1);color:hsl(var(--e));white-space:nowrap}
+.var-chip .tag{font-family:var(--f-mono);font-weight:800;font-size:9px;letter-spacing:.04em;background:hsl(var(--e));color:#14100a;padding:1px 5px;border-radius:3px;text-transform:uppercase}
+.vs{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);font-weight:700;text-transform:uppercase;padding:0 2px}
+
+/* Experiment name cell */
+.exp-cell{display:flex;align-items:center;gap:10px}
+.exp-mark{width:28px;height:28px;border-radius:7px;background:hsl(var(--e)/.12);color:hsl(var(--e));display:grid;place-items:center;font-size:14px;flex-shrink:0;border:1px solid hsl(var(--e)/.25)}
+.exp-info{display:flex;flex-direction:column;line-height:1.2;min-width:0}
+.exp-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.exp-id{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;margin-top:1px;letter-spacing:.02em}
+
+.metric-chip{font-family:var(--f-mono);font-size:11px;color:var(--text);background:var(--bg-sunken,var(--bg));padding:2px 7px;border-radius:5px;border:1px solid var(--border-light);font-weight:600;display:inline-block}
+.metric-chip .ns{color:var(--text-muted)}
+
+.sample-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text);font-weight:600;font-variant-numeric:tabular-nums}
+.sample-cell .sep{color:var(--text-muted);margin:0 3px}
+.sample-cell .total{color:var(--text-muted);font-size:9.5px;display:block;margin-top:1px;font-weight:500}
+
+.lift-cell{display:inline-flex;align-items:baseline;gap:4px;font-family:var(--f-mono);font-weight:800;font-size:13px;font-variant-numeric:tabular-nums}
+.lift-cell.up{color:hsl(var(--c-toolkit))}
+.lift-cell.down{color:hsl(var(--c-event))}
+.lift-cell.flat{color:var(--text-muted)}
+.lift-cell .arr{font-size:11px}
+
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 7px;font-size:10.5px}
+
+/* ── Layout split row ───────────────────────────────────────────── */
+.split-grid{display:grid;grid-template-columns:1fr 380px;gap:14px;align-items:stretch}
+
+/* ── Comparison chart panel ─────────────────────────────────────── */
+.chart-body{padding:16px 18px 14px;display:flex;flex-direction:column;gap:10px}
+.chart-context{display:flex;align-items:center;gap:8px;font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted)}
+.chart-context .k{text-transform:uppercase;letter-spacing:.06em;font-weight:700;font-size:9.5px}
+.chart-context .v{color:var(--text);font-weight:700}
+.chart-context .pill{padding:2px 7px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border-light);font-weight:700}
+
+.chart-frame{position:relative;width:100%;height:260px;background:linear-gradient(180deg, var(--bg-sunken,var(--bg)) 0%, var(--bg) 100%);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.chart-frame svg{display:block;width:100%;height:100%}
+.chart-frame .y-axis{position:absolute;left:0;top:0;bottom:18px;width:44px;display:flex;flex-direction:column;justify-content:space-between;align-items:flex-end;padding:6px 6px 0 0;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);pointer-events:none}
+.chart-frame .x-axis{position:absolute;left:44px;right:8px;bottom:0;height:18px;display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);padding-top:2px;pointer-events:none}
+.chart-frame .grid-line{stroke:hsl(var(--border-strong));stroke-width:.5;opacity:.4;stroke-dasharray:2 4}
+.chart-frame .start-line{stroke:hsl(var(--c-event));stroke-width:1;stroke-dasharray:4 3;opacity:.6}
+.chart-frame .start-lbl{font-family:var(--f-mono);font-size:9.5px;fill:hsl(var(--c-event));font-weight:700}
+.chart-frame .significance-marker{font-family:var(--f-mono);font-size:9px;fill:hsl(var(--c-toolkit));font-weight:700}
+
+.chart-legend{display:flex;align-items:center;gap:16px;flex-wrap:wrap;font-family:var(--f-mono);font-size:11px}
+.chart-legend .item{display:inline-flex;align-items:center;gap:6px;color:var(--text-sec)}
+.chart-legend .item .sw{width:14px;height:3px;border-radius:2px;background:hsl(var(--e));position:relative}
+.chart-legend .item .sw::after{content:'';position:absolute;top:-3px;bottom:-3px;left:0;right:0;border-radius:99px;background:hsl(var(--e)/.18)}
+.chart-legend .item .nm{font-family:var(--f-display);color:var(--text);font-weight:800;font-size:12px}
+.chart-legend .item .val{color:var(--text);font-weight:700;margin-left:2px}
+.chart-legend .item .sub{color:var(--text-muted)}
+.chart-legend .sep{width:1px;height:14px;background:var(--border-light)}
+.chart-legend .ci-note{display:inline-flex;align-items:center;gap:6px;color:var(--text-muted);font-size:10px;margin-left:auto}
+.chart-legend .ci-note .band{width:14px;height:8px;border-radius:3px;background:repeating-linear-gradient(45deg,hsl(var(--c-chat)/.16),hsl(var(--c-chat)/.16) 3px,transparent 3px,transparent 6px);border:1px solid hsl(var(--c-chat)/.3)}
+
+/* ── Detail drawer ──────────────────────────────────────────────── */
+.detail-panel{display:flex;flex-direction:column;overflow:hidden}
+.detail-hero{padding:14px 16px;border-bottom:1px solid var(--border-light);display:flex;flex-direction:column;gap:8px;background:linear-gradient(180deg, hsl(var(--c-event)/.06), transparent 80%)}
+.detail-hero .title{display:flex;align-items:center;gap:10px}
+.detail-hero h2{font-family:var(--f-display);font-size:16px;font-weight:800;line-height:1.2}
+.detail-hero .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.detail-hero .chips{display:flex;gap:5px;flex-wrap:wrap}
+
+.variant-versus{padding:14px;display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:stretch;border-bottom:1px solid var(--border-light)}
+.v-card{background:var(--bg);border:1px solid hsl(var(--e)/.3);border-left:3px solid hsl(var(--e));border-radius:8px;padding:10px 12px;display:flex;flex-direction:column;gap:5px;min-height:148px;position:relative}
+.v-card.winner{background:hsl(var(--c-toolkit)/.06);border-color:hsl(var(--c-toolkit)/.45);border-left-color:hsl(var(--c-toolkit))}
+.v-card .v-tag{font-family:var(--f-mono);font-size:9px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;padding:1px 6px;border-radius:4px;color:#14100a;background:hsl(var(--e));align-self:flex-start}
+.v-card.winner .v-tag{background:hsl(var(--c-toolkit));color:#0f0c08}
+.v-card .v-name{font-family:var(--f-display);font-weight:800;font-size:12.5px;color:var(--text);line-height:1.25}
+.v-card .v-sub{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700}
+.v-card .v-metric{font-family:var(--f-display);font-weight:800;font-size:26px;color:var(--text);line-height:1;margin-top:6px;font-variant-numeric:tabular-nums}
+.v-card.winner .v-metric{color:hsl(var(--c-toolkit))}
+.v-card .v-metric .unit{font-size:13px;color:var(--text-muted);font-weight:700;margin-left:2px}
+.v-card .v-sample{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700;display:flex;justify-content:space-between;margin-top:auto;padding-top:6px;border-top:1px dashed var(--border-light)}
+.v-card .v-sample .v{color:var(--text);font-weight:700}
+.v-card .crown{position:absolute;top:8px;right:10px;font-size:14px}
+
+.versus-pill{align-self:center;font-family:var(--f-mono);font-size:10px;font-weight:800;color:var(--text-muted);background:var(--bg-card);border:1px solid var(--border);border-radius:99px;padding:3px 8px;text-transform:uppercase;letter-spacing:.04em}
+
+.stats-grid{padding:14px;display:grid;grid-template-columns:1fr 1fr;gap:10px;border-bottom:1px solid var(--border-light)}
+.stat-cell{background:var(--bg);border:1px solid var(--border-light);border-radius:7px;padding:8px 10px}
+.stat-cell .lbl{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.stat-cell .v{font-family:var(--f-mono);font-size:14px;font-weight:800;color:var(--text);font-variant-numeric:tabular-nums;margin-top:2px}
+.stat-cell .v.good{color:hsl(var(--c-toolkit))}
+.stat-cell .v.bad{color:hsl(var(--c-event))}
+.stat-cell .sub{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);margin-top:1px;font-weight:600}
+
+.reco{padding:14px;display:flex;flex-direction:column;gap:10px;background:hsl(var(--c-toolkit)/.04);border-bottom:1px solid var(--border-light)}
+.reco .reco-head{display:flex;align-items:center;gap:8px}
+.reco .reco-head .em{font-size:18px}
+.reco .reco-head .title{font-family:var(--f-display);font-weight:800;font-size:13px;color:hsl(var(--c-toolkit))}
+.reco .reco-text{font-size:12px;color:var(--text);line-height:1.5}
+.reco .reco-text strong{font-weight:800}
+.reco .reco-text .v-mono{font-family:var(--f-mono);background:var(--bg-muted);padding:1px 5px;border-radius:4px;font-size:11px}
+
+.detail-actions{padding:12px 14px;display:flex;flex-direction:column;gap:6px;background:var(--bg)}
+.detail-actions .btn-admin{width:100%;justify-content:center;font-size:13px;padding:8px 12px}
+.detail-actions .helper{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);display:flex;align-items:center;gap:4px;padding:2px 4px}
+.detail-actions .helper .lock{color:hsl(var(--c-event))}
+.detail-actions .row{display:flex;gap:6px}
+.detail-actions .row .btn-admin{flex:1}
+
+/* Pre-formatted secondary value cell for table */
+.no-arr{color:var(--text-muted)}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>A/B Testing Agenti</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › A/B Testing · 4 esperimenti · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca esperimento, variante…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">📊 Significance calc</button>
+          <button class="btn-admin primary">＋ Nuovo esperimento</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Test attivi</div>
+            <div class="admin-kpi-value">4<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 1 pronto promote</span></div>
+            <div class="admin-kpi-trend flat">▬ 3 running · 1 inconclusive</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,18 L8,18 L16,16 L24,14 L32,14 L40,12 L48,10 L56,10 L64,8 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,18 L8,18 L16,16 L24,14 L32,14 L40,12 L48,10 L56,10 L64,8 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-agent">
+            <div class="admin-kpi-label">Esperimenti totali</div>
+            <div class="admin-kpi-value">38<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 30g</span></div>
+            <div class="admin-kpi-trend up">▲ 22 promote · 8 stop · 8 attivi</div>
+            <svg class="admin-kpi-spark e-agent" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,18 L24,15 L32,12 L40,11 L48,9 L56,7 L64,5 L70,4 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,18 L24,15 L32,12 L40,11 L48,9 L56,7 L64,5 L70,4"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-toolkit">
+            <div class="admin-kpi-label">Lift medio (promoted)</div>
+            <div class="admin-kpi-value">+6.4<span style="font-size:14px;color:var(--text-muted);font-weight:600">%</span></div>
+            <div class="admin-kpi-trend up">▲ vs 30g precedenti · 22 promoted</div>
+            <svg class="admin-kpi-spark e-toolkit" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,20 L8,18 L16,17 L24,14 L32,12 L40,10 L48,9 L56,7 L64,6 L70,5 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,20 L8,18 L16,17 L24,14 L32,12 L40,10 L48,9 L56,7 L64,6 L70,5"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">Campione totale</div>
+            <div class="admin-kpi-value">14.2<span style="font-size:14px;color:var(--text-muted);font-weight:600">k esposizioni</span></div>
+            <div class="admin-kpi-trend up">▲ +2.4k 7g · split 50/50</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,21 L16,19 L24,17 L32,15 L40,13 L48,11 L56,9 L64,7 L70,6 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,21 L16,19 L24,17 L32,15 L40,13 L48,11 L56,9 L64,7 L70,6"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 2) Esperimenti table ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Esperimenti A/B</h3>
+            <span class="status-chip running">3 running</span>
+            <span class="status-chip healthy">1 significant</span>
+            <span class="status-chip warning">1 inconclusive</span>
+            <div class="head-cluster">
+              <span class="meta">significance test · Welch t-test · α=0.05 · power 0.80</span>
+              <button class="btn-admin sm ghost">⤓ Export</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:22%">Esperimento</th>
+                <th style="width:24%">Varianti</th>
+                <th style="width:13%">Metrica</th>
+                <th style="width:11%">Campione</th>
+                <th style="width:8%;text-align:right">Lift</th>
+                <th style="width:12%">Significatività</th>
+                <th style="width:9%">Stato</th>
+                <th style="width:160px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="selected">
+                <td>
+                  <div class="exp-cell e-event">
+                    <div class="exp-mark">✎</div>
+                    <div class="exp-info"><span class="exp-name">Prompt v2.4 vs v2.5</span><span class="exp-id">abt_prompt_84a1 · Wingspan</span></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="variant-pair">
+                    <span class="var-chip e-chat"><span class="tag">A</span>prompt v2.4</span>
+                    <span class="vs">vs</span>
+                    <span class="var-chip e-agent"><span class="tag">B</span>prompt v2.5</span>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">rag.</span>answer_rating</span></td>
+                <td class="sample-cell">1 240<span class="sep">/</span>1 198<span class="total">tot 2 438 · 50/50</span></td>
+                <td><span class="lift-cell up"><span class="arr">▲</span>+8.2%</span></td>
+                <td><span class="status-chip healthy">significant · p=0.03</span></td>
+                <td><span class="status-chip running">running · 6g</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">↗ Dettagli</button>
+                    <button class="btn-admin sm success" title="ConfirmModal">👑 Promote</button>
+                    <button class="btn-admin sm danger" title="ConfirmModal">⏹ Stop</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div class="exp-cell e-agent">
+                    <div class="exp-mark">⚡</div>
+                    <div class="exp-info"><span class="exp-name">deepseek vs gpt-4o-mini</span><span class="exp-id">abt_model_84a2 · cross-game</span></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="variant-pair">
+                    <span class="var-chip e-chat"><span class="tag">A</span>deepseek-chat</span>
+                    <span class="vs">vs</span>
+                    <span class="var-chip e-agent"><span class="tag">B</span>gpt-4o-mini</span>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">cost.</span>per_session_usd</span></td>
+                <td class="sample-cell">4 120<span class="sep">/</span>4 088<span class="total">tot 8 208 · 50/50</span></td>
+                <td><span class="lift-cell down"><span class="arr">▼</span>−12.0%</span></td>
+                <td><span class="status-chip healthy">significant · p=0.001</span></td>
+                <td><span class="status-chip running">running · 14g</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">↗ Dettagli</button>
+                    <button class="btn-admin sm success">👑 Promote</button>
+                    <button class="btn-admin sm danger">⏹ Stop</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div class="exp-cell e-tool">
+                    <div class="exp-mark">🎯</div>
+                    <div class="exp-info"><span class="exp-name">Rerank on/off</span><span class="exp-id">abt_rerank_84a3 · Catan + Wingspan</span></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="variant-pair">
+                    <span class="var-chip e-chat"><span class="tag">A</span>rerank ON · top-5</span>
+                    <span class="vs">vs</span>
+                    <span class="var-chip e-agent"><span class="tag">B</span>rerank OFF · top-8</span>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">rag.</span>recall_at_5</span></td>
+                <td class="sample-cell">612<span class="sep">/</span>608<span class="total">tot 1 220 · 50/50</span></td>
+                <td><span class="lift-cell up"><span class="arr">▲</span>+3.0%</span></td>
+                <td><span class="status-chip warning">inconclusive · p=0.21</span></td>
+                <td><span class="status-chip warning">running · 9g</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">↗ Dettagli</button>
+                    <button class="btn-admin sm ghost" style="opacity:.5;cursor:not-allowed" title="serve più campione">👑 Promote</button>
+                    <button class="btn-admin sm danger">⏹ Stop</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div class="exp-cell e-kb">
+                    <div class="exp-mark">📦</div>
+                    <div class="exp-info"><span class="exp-name">Chunk 512 vs 1024</span><span class="exp-id">abt_chunk_84a4 · KB embedding</span></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="variant-pair">
+                    <span class="var-chip e-chat"><span class="tag">A</span>chunk 512 tok</span>
+                    <span class="vs">vs</span>
+                    <span class="var-chip e-agent"><span class="tag">B</span>chunk 1024 tok</span>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">rag.</span>faithfulness</span></td>
+                <td class="sample-cell">142<span class="sep">/</span>138<span class="total">tot 280 · 50/50</span></td>
+                <td><span class="lift-cell flat no-arr">—</span></td>
+                <td><span class="status-chip info">running · in raccolta</span></td>
+                <td><span class="status-chip running">running · 2g</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">↗ Dettagli</button>
+                    <button class="btn-admin sm ghost" style="opacity:.5;cursor:not-allowed">👑 Promote</button>
+                    <button class="btn-admin sm danger">⏹ Stop</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr style="opacity:.7">
+                <td>
+                  <div class="exp-cell e-toolkit">
+                    <div class="exp-mark">📐</div>
+                    <div class="exp-info"><span class="exp-name">Temperatura 0.1 vs 0.4</span><span class="exp-id">abt_temp_84a0 · completed</span></div>
+                  </div>
+                </td>
+                <td>
+                  <div class="variant-pair">
+                    <span class="var-chip e-chat"><span class="tag">A</span>temp 0.10</span>
+                    <span class="vs">vs</span>
+                    <span class="var-chip e-agent"><span class="tag">B</span>temp 0.40</span>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">rag.</span>answer_rating</span></td>
+                <td class="sample-cell">2 040<span class="sep">/</span>2 002<span class="total">tot 4 042 · final</span></td>
+                <td><span class="lift-cell down"><span class="arr">▼</span>−2.1%</span></td>
+                <td><span class="status-chip healthy">significant · p=0.01</span></td>
+                <td><span class="status-chip muted">completed · A win</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">↗ Dettagli</button>
+                    <button class="btn-admin sm ghost" title="già promoted">✓ promoted</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Split: chart sx + detail dx ────────── -->
+        <div class="split-grid">
+
+          <!-- ░ Comparison chart -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Confronto · andamento metrica</h3>
+              <span class="status-chip info">answer_rating · 7g</span>
+              <div class="head-cluster">
+                <span class="meta">esperimento abt_prompt_84a1 · Welch t-test · n 2 438</span>
+                <button class="btn-admin sm ghost">⤓ ndjson</button>
+              </div>
+            </div>
+
+            <div class="chart-body">
+
+              <div class="chart-context">
+                <span class="pill"><span class="k">Metrica</span> <span class="v">rag.answer_rating</span></span>
+                <span class="pill"><span class="k">Asse</span> <span class="v">media giornaliera · scala 1–5</span></span>
+                <span class="pill"><span class="k">Banda</span> <span class="v">95% CI</span></span>
+              </div>
+
+              <div class="chart-frame">
+                <!-- Y axis labels -->
+                <div class="y-axis"><span>5.0</span><span>4.5</span><span>4.0</span><span>3.5</span><span>3.0</span></div>
+                <!-- X axis labels -->
+                <div class="x-axis"><span>giorno 1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>oggi</span></div>
+
+                <!-- viewBox 700x240, padding L44 R8 T6 B18 -> inner: x[44..692], y[6..222] = 216px tall
+                     Metric range 3.0..5.0 (2 units), so 1 unit = 108px; rating 4.5 -> y = 222 - (4.5-3.0)*108 = 222 - 162 = 60
+                     A (v2.4) values per day: 4.18, 4.22, 4.20, 4.19, 4.22, 4.21, 4.20 → y around 100
+                     B (v2.5) values per day: 4.20, 4.32, 4.40, 4.45, 4.48, 4.50, 4.52 → y descending
+                -->
+                <svg viewBox="0 0 700 240" preserveAspectRatio="none">
+                  <!-- gridlines -->
+                  <line class="grid-line" x1="44" y1="60" x2="692" y2="60"/>
+                  <line class="grid-line" x1="44" y1="114" x2="692" y2="114"/>
+                  <line class="grid-line" x1="44" y1="168" x2="692" y2="168"/>
+                  <line class="grid-line" x1="44" y1="222" x2="692" y2="222"/>
+
+                  <!-- start line (where experiment started) -->
+                  <line class="start-line" x1="44" y1="6" x2="44" y2="222"/>
+                  <text class="start-lbl" x="50" y="16">start · v2.5 deploy</text>
+
+                  <!-- B confidence band (95% CI shaded around B line) -->
+                  <!-- B y points: 92, 80, 71, 65, 62, 60, 58; CI ±0.06 → ±6.5px -->
+                  <path d="M44,98 L152,86 L260,77 L368,71 L476,68 L584,66 L692,64 L692,52 L584,54 L476,56 L368,59 L260,65 L152,74 L44,86 Z"
+                        fill="hsl(var(--c-agent) / .18)"/>
+
+                  <!-- A confidence band -->
+                  <!-- A y points: 100, 96, 98, 99, 96, 97, 98; CI ±0.04 → ±4px -->
+                  <path d="M44,104 L152,100 L260,102 L368,103 L476,100 L584,101 L692,102 L692,94 L584,93 L476,92 L368,95 L260,94 L152,92 L44,96 Z"
+                        fill="hsl(var(--c-chat) / .15)"/>
+
+                  <!-- A line (v2.4) -->
+                  <path class="spark e-chat e-fg" stroke-width="2"
+                        d="M44,100 L152,96 L260,98 L368,99 L476,96 L584,97 L692,98"/>
+                  <!-- A points -->
+                  <g fill="hsl(var(--c-chat))">
+                    <circle cx="44" cy="100" r="3"/><circle cx="152" cy="96" r="3"/><circle cx="260" cy="98" r="3"/>
+                    <circle cx="368" cy="99" r="3"/><circle cx="476" cy="96" r="3"/><circle cx="584" cy="97" r="3"/>
+                    <circle cx="692" cy="98" r="4" stroke="var(--bg)" stroke-width="2"/>
+                  </g>
+
+                  <!-- B line (v2.5) -->
+                  <path class="spark e-agent e-fg" stroke-width="2"
+                        d="M44,92 L152,80 L260,71 L368,65 L476,62 L584,60 L692,58"/>
+                  <!-- B points -->
+                  <g fill="hsl(var(--c-agent))">
+                    <circle cx="44" cy="92" r="3"/><circle cx="152" cy="80" r="3"/><circle cx="260" cy="71" r="3"/>
+                    <circle cx="368" cy="65" r="3"/><circle cx="476" cy="62" r="3"/><circle cx="584" cy="60" r="3"/>
+                    <circle cx="692" cy="58" r="4" stroke="var(--bg)" stroke-width="2"/>
+                  </g>
+
+                  <!-- Significance crossing annotation: ~giorno 4 (x=368), midway -->
+                  <line x1="368" y1="6" x2="368" y2="222" stroke="hsl(var(--c-toolkit) / .35)" stroke-width="1" stroke-dasharray="3 3"/>
+                  <text class="significance-marker" x="372" y="22">▲ significance reached · giorno 4 · p=0.04</text>
+
+                  <!-- End labels -->
+                  <text x="688" y="56" text-anchor="end" font-family="var(--f-mono)" font-size="11" font-weight="700" fill="hsl(var(--c-agent))">4.50 · B</text>
+                  <text x="688" y="96" text-anchor="end" font-family="var(--f-mono)" font-size="11" font-weight="700" fill="hsl(var(--c-chat))">4.18 · A</text>
+                </svg>
+              </div>
+
+              <div class="chart-legend">
+                <span class="item e-chat"><span class="sw"></span><span class="nm">A · prompt v2.4</span> <span class="val">4.18</span> <span class="sub">· baseline</span></span>
+                <span class="sep"></span>
+                <span class="item e-agent"><span class="sw"></span><span class="nm">B · prompt v2.5</span> <span class="val">4.50</span> <span class="sub">· +8.2%</span></span>
+                <span class="ci-note"><span class="band"></span>banda = 95% CI · Welch t-test · α=0.05</span>
+              </div>
+            </div>
+          </section>
+
+          <!-- ░ Detail drawer -->
+          <aside class="admin-panel detail-panel">
+            <div class="detail-hero">
+              <div class="title">
+                <h2 style="flex:1">Prompt v2.4 vs v2.5</h2>
+                <span class="status-chip running">running · 6g</span>
+              </div>
+              <div class="sub">abt_prompt_84a1 · Wingspan Rules Bot · metric: <strong style="color:var(--text)">rag.answer_rating</strong></div>
+              <div class="chips">
+                <span class="status-chip healthy">significant · p=0.03</span>
+                <span class="status-chip info">n=2 438</span>
+                <span class="status-chip muted">split 50/50</span>
+              </div>
+            </div>
+
+            <div class="variant-versus">
+              <div class="v-card e-chat">
+                <span class="v-tag">A</span>
+                <span class="v-name">prompt v2.4</span>
+                <span class="v-sub">baseline · prod</span>
+                <span class="v-metric">4.2<span class="unit">/5</span></span>
+                <div class="v-sample"><span>campione</span><span class="v">1 240</span></div>
+              </div>
+              <span class="versus-pill">vs</span>
+              <div class="v-card e-agent winner">
+                <span class="crown">👑</span>
+                <span class="v-tag">B</span>
+                <span class="v-name">prompt v2.5</span>
+                <span class="v-sub">draft · sandbox</span>
+                <span class="v-metric">4.5<span class="unit">/5</span></span>
+                <div class="v-sample"><span>campione</span><span class="v">1 198</span></div>
+              </div>
+            </div>
+
+            <div class="stats-grid">
+              <div class="stat-cell">
+                <div class="lbl">Lift</div>
+                <div class="v good">+8.2%</div>
+                <div class="sub">B − A · effetto</div>
+              </div>
+              <div class="stat-cell">
+                <div class="lbl">p-value</div>
+                <div class="v good">0.03</div>
+                <div class="sub">soglia 0.05 · Welch t</div>
+              </div>
+              <div class="stat-cell">
+                <div class="lbl">95% CI</div>
+                <div class="v">[+0.18; +0.46]</div>
+                <div class="sub">non include 0</div>
+              </div>
+              <div class="stat-cell">
+                <div class="lbl">Power</div>
+                <div class="v">0.84</div>
+                <div class="sub">target 0.80 · raggiunto</div>
+              </div>
+              <div class="stat-cell">
+                <div class="lbl">Durata</div>
+                <div class="v">6g 02h</div>
+                <div class="sub">min 5g · ok</div>
+              </div>
+              <div class="stat-cell">
+                <div class="lbl">Δ costo</div>
+                <div class="v bad">+$0.001</div>
+                <div class="sub">per sessione · trascurabile</div>
+              </div>
+            </div>
+
+            <div class="reco">
+              <div class="reco-head"><span class="em">🏆</span><span class="title">Variante B vince</span></div>
+              <div class="reco-text">
+                Lift di <strong>+8.2%</strong> sulla metrica <span class="v-mono">answer_rating</span> con <strong>p=0.03</strong> e CI <span class="v-mono">[+0.18; +0.46]</span>. Power <strong>0.84</strong>, oltre il target <strong>0.80</strong>. Durata <strong>6g</strong> ≥ minimo richiesto. Promote <strong>v2.5</strong> in produzione: il rollout aggiornerà <span class="v-mono">prompt_id</span> negli agenti che usano il template Wingspan Rules Bot.
+              </div>
+            </div>
+
+            <div class="detail-actions">
+              <button class="btn-admin success">👑 Promote winner · variante B</button>
+              <span class="helper"><span class="lock">🔒</span> ConfirmModal · sostituisce prompt_id in 1 agente · revert da history</span>
+              <div class="row">
+                <button class="btn-admin danger">⏹ Stop esperimento</button>
+                <button class="btn-admin ghost">⏸ Pausa</button>
+              </div>
+            </div>
+          </aside>
+
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('ab-testing');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-ai.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-ai.html
@@ -1,0 +1,501 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A4 · Admin AI / RAG Quality · /admin/ai</title>
+<!--
+  @route /admin/ai + /admin/rag-quality
+  @pattern Split-view: metriche aggregate left 58% · query drill-down right 42%
+  @v2 components: QueryDrillDown · RetrievalChunkList · LatencyBreakdownBar · AdminMetricsPanel
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .ai-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 16px; align-items: start; }
+  .ai-left { display: flex; flex-direction: column; gap: 16px; }
+  .kpi-row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; }
+  .admin-kpi.compact { min-height: 70px; padding: 10px 12px; }
+  .admin-kpi.compact .admin-kpi-value { font-size: 22px; }
+  .admin-kpi.compact .admin-kpi-icon { font-size: 18px; right: 10px; bottom: 8px; }
+
+  .trend-chart {
+    height: 200px; padding: 12px 14px;
+    display: flex; flex-direction: column;
+  }
+  .trend-chart-svg { flex: 1; width: 100%; }
+  .trend-chart-svg .grid line { stroke: var(--border-light); stroke-dasharray: 2 4; }
+  .trend-chart-svg .axis text { font-family: var(--f-mono); font-size: 9px; fill: var(--text-muted); }
+  .trend-chart-svg .ln { fill: none; stroke-width: 2; }
+  .trend-chart-svg .ln-p50 { stroke: hsl(var(--c-chat)); }
+  .trend-chart-svg .ln-p95 { stroke: hsl(var(--c-agent)); }
+  .trend-chart-svg .ln-err { stroke: hsl(var(--c-event)); }
+
+  .legend { display: flex; gap: 12px; font-family: var(--f-mono); font-size: 10px; align-items: center; }
+  .legend-item { display: inline-flex; align-items: center; gap: 5px; }
+  .legend-dot { width: 8px; height: 8px; border-radius: 2px; }
+
+  /* Query drill-down right */
+  .drill {
+    background: var(--bg-card);
+    border: 1px solid hsl(var(--c-agent) / .4);
+    border-radius: 10px;
+    overflow: hidden;
+    position: sticky; top: 76px;
+    max-height: calc(100vh - 100px);
+    display: flex; flex-direction: column;
+  }
+  .drill-head {
+    padding: 12px 14px;
+    background: linear-gradient(180deg, hsl(var(--c-agent) / .12), transparent);
+    border-bottom: 1px solid var(--border-light);
+  }
+  .drill-head .qtag {
+    font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+    color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .06em;
+    margin-bottom: 4px;
+  }
+  .drill-head .qtext {
+    font-family: var(--f-display); font-size: 14px; font-weight: 700; line-height: 1.4;
+  }
+  .drill-head .qmeta {
+    font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+    margin-top: 6px;
+    display: flex; flex-wrap: wrap; gap: 4px 12px;
+  }
+  .drill-body { padding: 14px; overflow-y: auto; flex: 1; }
+  .drill-section { margin-bottom: 16px; }
+  .drill-section h4 {
+    margin: 0 0 6px;
+    font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+    color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+    display: flex; align-items: center; gap: 8px;
+  }
+
+  /* Chunk list */
+  .chunk-row {
+    padding: 10px 12px;
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    margin-bottom: 6px;
+    font-size: 12px;
+    position: relative;
+  }
+  .chunk-row.matched {
+    border-color: hsl(var(--c-kb) / .5);
+    background: hsl(var(--c-kb) / .06);
+  }
+  .chunk-row .crow-top {
+    display: flex; align-items: center; gap: 6px;
+    margin-bottom: 4px;
+  }
+  .chunk-row .src {
+    font-family: var(--f-mono); font-size: 10px;
+    color: hsl(var(--c-kb)); font-weight: 700;
+  }
+  .chunk-row .score {
+    margin-left: auto;
+    font-family: var(--f-mono); font-size: 10px;
+    padding: 1px 6px; border-radius: 4px;
+    background: hsl(var(--c-kb) / .14);
+    color: hsl(var(--c-kb)); font-weight: 700;
+  }
+  .chunk-row .text {
+    color: var(--text-sec); line-height: 1.5;
+  }
+  .chunk-row .text mark {
+    background: hsl(var(--c-agent) / .35);
+    color: var(--text); padding: 0 2px; border-radius: 2px;
+  }
+  .chunk-row .text code {
+    font-family: var(--f-mono); font-size: 11px;
+    background: var(--bg-muted); padding: 0 4px; border-radius: 3px;
+  }
+
+  /* Latency breakdown bar */
+  .latency-bar {
+    height: 28px; display: flex;
+    border-radius: 6px; overflow: hidden;
+    background: var(--bg-muted);
+    border: 1px solid var(--border-light);
+  }
+  .latency-bar .seg {
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+    color: #fff; white-space: nowrap; padding: 0 4px;
+  }
+  .latency-bar .seg.retrieval { background: hsl(var(--c-kb)); }
+  .latency-bar .seg.rerank    { background: hsl(var(--c-toolkit)); }
+  .latency-bar .seg.llm       { background: hsl(var(--c-agent)); }
+  .latency-bar .seg.post      { background: hsl(var(--c-chat)); }
+  .latency-table {
+    width: 100%; font-size: 11.5px; margin-top: 8px;
+  }
+  .latency-table td { padding: 3px 0; }
+  .latency-table td:first-child {
+    display: flex; align-items: center; gap: 6px;
+  }
+  .latency-table td:last-child {
+    text-align: right;
+    font-family: var(--f-mono); font-weight: 700;
+  }
+  .latency-table .swatch { width: 10px; height: 10px; border-radius: 2px; }
+
+  /* Worst queries table */
+  .worst-row {
+    display: grid;
+    grid-template-columns: 1fr 70px 70px 70px;
+    gap: 12px; padding: 8px 12px;
+    border-bottom: 1px solid var(--border-light);
+    align-items: center;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .worst-row:last-child { border-bottom: 0; }
+  .worst-row.selected { background: hsl(var(--c-event) / .08); }
+  .worst-row:hover { background: var(--bg-muted); }
+  .worst-row .q {
+    font-family: var(--f-body);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .worst-row .stat {
+    font-family: var(--f-mono); font-size: 11px; text-align: right;
+    color: var(--text-sec); font-weight: 700;
+  }
+  .worst-row .stat.bad { color: hsl(var(--c-event)); }
+  .worst-row .stat.warn { color: hsl(38 90% 50%); }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <span class="em">🖥️</span><h2>Console solo desktop</h2><p>Il drill-down RAG richiede schermo wide.</p>
+</div>
+
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <header class="admin-top">
+      <div>
+        <h1>AI / RAG Quality</h1>
+        <div class="crumbs">Admin · AI · ultime 24h · live polling 5s</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="filter-chip active">Tutti agent <span class="x">▾</span></div>
+        <div class="filter-chip">24h <span class="x">▾</span></div>
+        <button class="btn-admin">⤓ Export</button>
+        <button class="btn-admin primary">+ Nuovo eval</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="ai-grid">
+
+        <!-- Left: aggregate metrics ─────────────────────────── -->
+        <div class="ai-left">
+
+          <!-- KPI row 5 -->
+          <div class="kpi-row">
+            <div class="admin-kpi compact e-chat">
+              <div class="admin-kpi-label">Query / day</div>
+              <div class="admin-kpi-value">14.2<span style="font-size:13px;color:var(--text-muted)">k</span></div>
+              <div class="admin-kpi-trend up">↗ +6%</div>
+              <span class="admin-kpi-icon">💬</span>
+            </div>
+            <div class="admin-kpi compact e-session">
+              <div class="admin-kpi-label">Avg latency</div>
+              <div class="admin-kpi-value">1.32<span style="font-size:13px;color:var(--text-muted)">s</span></div>
+              <div class="admin-kpi-trend down">↗ +180ms</div>
+              <span class="admin-kpi-icon">⏱️</span>
+            </div>
+            <div class="admin-kpi compact e-event">
+              <div class="admin-kpi-label">P95 latency</div>
+              <div class="admin-kpi-value">3.84<span style="font-size:13px;color:var(--text-muted)">s</span></div>
+              <div class="admin-kpi-trend down">↗ sopra SLO 3.0s</div>
+              <span class="admin-kpi-icon">⚠️</span>
+            </div>
+            <div class="admin-kpi compact e-agent">
+              <div class="admin-kpi-label">Cost / day</div>
+              <div class="admin-kpi-value">$348</div>
+              <div class="admin-kpi-trend down">↗ +14%</div>
+              <span class="admin-kpi-icon">💸</span>
+            </div>
+            <div class="admin-kpi compact e-kb">
+              <div class="admin-kpi-label">Hallucination rate</div>
+              <div class="admin-kpi-value">2.4<span style="font-size:13px;color:var(--text-muted)">%</span></div>
+              <div class="admin-kpi-trend up">↘ -0.6%</div>
+              <span class="admin-kpi-icon">🪄</span>
+            </div>
+          </div>
+
+          <!-- Trend chart 7gg -->
+          <section class="admin-panel trend-chart">
+            <div class="admin-panel-head" style="margin: -12px -14px 8px; padding: 8px 14px;">
+              <h3>Latency P50 / P95 / Error rate · ultimi 7gg</h3>
+              <div class="legend">
+                <span class="legend-item"><span class="legend-dot" style="background: hsl(var(--c-chat))"></span>P50</span>
+                <span class="legend-item"><span class="legend-dot" style="background: hsl(var(--c-agent))"></span>P95</span>
+                <span class="legend-item"><span class="legend-dot" style="background: hsl(var(--c-event))"></span>Error % (×10)</span>
+              </div>
+            </div>
+            <svg class="trend-chart-svg" viewBox="0 0 700 160" preserveAspectRatio="none">
+              <g class="grid">
+                <line x1="0" y1="40" x2="700" y2="40"/>
+                <line x1="0" y1="80" x2="700" y2="80"/>
+                <line x1="0" y1="120" x2="700" y2="120"/>
+              </g>
+              <polyline class="ln ln-p50" points="0,110 100,108 200,112 300,105 400,108 500,102 600,104 700,100"/>
+              <polyline class="ln ln-p95" points="0,55 100,60 200,52 300,48 400,38 500,42 600,30 700,28"/>
+              <polyline class="ln ln-err" points="0,140 100,135 200,138 300,142 400,128 500,130 600,132 700,135"/>
+              <g class="axis">
+                <text x="0" y="158">17 mag</text>
+                <text x="100" y="158">18</text>
+                <text x="200" y="158">19</text>
+                <text x="300" y="158">20</text>
+                <text x="400" y="158">21</text>
+                <text x="500" y="158">22</text>
+                <text x="600" y="158">23</text>
+                <text x="680" y="158">oggi</text>
+                <text x="0" y="42">3s</text>
+                <text x="0" y="82">2s</text>
+                <text x="0" y="122">1s</text>
+              </g>
+            </svg>
+          </section>
+
+          <!-- Worst queries -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Top 10 worst queries</h3>
+              <span class="meta">low rating · high latency · low confidence</span>
+            </div>
+            <div style="padding: 0 0 4px">
+              <div class="worst-row" style="background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 6px 12px; font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;">
+                <div>Query</div>
+                <div class="stat" style="color: var(--text-muted)">Latency</div>
+                <div class="stat" style="color: var(--text-muted)">Conf</div>
+                <div class="stat" style="color: var(--text-muted)">Rating</div>
+              </div>
+              <div class="worst-row selected">
+                <div class="q">Se due uccelli predatori finiscono entrambi le carte cibo nello stesso turno, chi viene attivato per primo?</div>
+                <div class="stat bad">4.82s</div>
+                <div class="stat warn">0.42</div>
+                <div class="stat bad">👎</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Posso giocare due workers nella stessa azione nel turno 4 di Brass Birmingham?</div>
+                <div class="stat warn">3.21s</div>
+                <div class="stat warn">0.54</div>
+                <div class="stat bad">👎</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Come si calcola il VP della cattedrale a Lancaster in espansione "Nobles"?</div>
+                <div class="stat bad">5.18s</div>
+                <div class="stat bad">0.38</div>
+                <div class="stat bad">👎</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Lancio dadi simultaneo in Tainted Grail capitolo 7 — cosa succede al pareggio?</div>
+                <div class="stat warn">2.84s</div>
+                <div class="stat warn">0.51</div>
+                <div class="stat warn">👎🤷</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">ISS Vanguard scelta turno comandante con malus equipaggio sotto 3</div>
+                <div class="stat warn">2.94s</div>
+                <div class="stat warn">0.49</div>
+                <div class="stat bad">👎</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Wingspan power "guadagna 2 cibo se tutti gli avversari hanno meno di 3 uccelli"</div>
+                <div class="stat warn">2.18s</div>
+                <div class="stat warn">0.58</div>
+                <div class="stat warn">👎🤷</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Ark Nova: zone climatiche delle carte habitat che si sovrappongono</div>
+                <div class="stat bad">4.02s</div>
+                <div class="stat warn">0.46</div>
+                <div class="stat bad">👎</div>
+              </div>
+              <div class="worst-row">
+                <div class="q">Spirit Island: difensori coordinati spirito Vital Strength of the Earth</div>
+                <div class="stat warn">2.62s</div>
+                <div class="stat warn">0.55</div>
+                <div class="stat warn">👎🤷</div>
+              </div>
+            </div>
+          </section>
+
+          <!-- Top agents by usage -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Top 5 agenti per uso · 24h</h3>
+              <span class="meta">14.247 query totali</span>
+            </div>
+            <div style="padding: 12px 14px">
+              <div style="display: flex; flex-direction: column; gap: 10px">
+                <div style="display:grid; grid-template-columns: 1fr 60px 80px; align-items:center; gap: 8px; font-size: 12px">
+                  <div style="display:flex; align-items: center; gap: 8px">
+                    <span style="font-size:14px">🤖</span>
+                    <span><strong>Wingspan Rules Expert v3</strong> · agent <code style="font-family: var(--f-mono); font-size: 10px">a-wingspan-rules</code></span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700">3.847</div>
+                  <div style="background: var(--bg-muted); border-radius: 4px; height: 8px; overflow: hidden"><div style="background: hsl(var(--c-agent)); height: 100%; width: 100%"></div></div>
+                </div>
+                <div style="display:grid; grid-template-columns: 1fr 60px 80px; align-items:center; gap: 8px; font-size: 12px">
+                  <div style="display:flex; align-items: center; gap: 8px">
+                    <span style="font-size:14px">🤖</span>
+                    <span><strong>Brass Birmingham Rules</strong> · <code style="font-family: var(--f-mono); font-size: 10px">a-brass-rules</code></span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700">2.214</div>
+                  <div style="background: var(--bg-muted); border-radius: 4px; height: 8px; overflow: hidden"><div style="background: hsl(var(--c-agent)); height: 100%; width: 58%"></div></div>
+                </div>
+                <div style="display:grid; grid-template-columns: 1fr 60px 80px; align-items:center; gap: 8px; font-size: 12px">
+                  <div style="display:flex; align-items: center; gap: 8px">
+                    <span style="font-size:14px">🤖</span>
+                    <span><strong>Tainted Grail Companion</strong> · <code style="font-family: var(--f-mono); font-size: 10px">a-tainted-grail</code></span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700">1.802</div>
+                  <div style="background: var(--bg-muted); border-radius: 4px; height: 8px; overflow: hidden"><div style="background: hsl(var(--c-agent)); height: 100%; width: 47%"></div></div>
+                </div>
+                <div style="display:grid; grid-template-columns: 1fr 60px 80px; align-items:center; gap: 8px; font-size: 12px">
+                  <div style="display:flex; align-items: center; gap: 8px">
+                    <span style="font-size:14px">🤖</span>
+                    <span><strong>Spirit Island Strategist</strong> · <code style="font-family: var(--f-mono); font-size: 10px">a-spirit-island</code></span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700">1.387</div>
+                  <div style="background: var(--bg-muted); border-radius: 4px; height: 8px; overflow: hidden"><div style="background: hsl(var(--c-agent)); height: 100%; width: 36%"></div></div>
+                </div>
+                <div style="display:grid; grid-template-columns: 1fr 60px 80px; align-items:center; gap: 8px; font-size: 12px">
+                  <div style="display:flex; align-items: center; gap: 8px">
+                    <span style="font-size:14px">🤖</span>
+                    <span><strong>ISS Vanguard Operations</strong> · <code style="font-family: var(--f-mono); font-size: 10px">a-iss-vanguard</code></span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700">982</div>
+                  <div style="background: var(--bg-muted); border-radius: 4px; height: 8px; overflow: hidden"><div style="background: hsl(var(--c-agent)); height: 100%; width: 26%"></div></div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <!-- Right: Query drill-down ────────────────────────── -->
+        <aside class="drill">
+          <div class="drill-head">
+            <div class="qtag">⚠️ Low confidence · 0.42</div>
+            <div class="qtext">"Se due uccelli predatori finiscono entrambi le carte cibo nello stesso turno, chi viene attivato per primo?"</div>
+            <div class="qmeta">
+              <span>👤 Marco Rossi</span>
+              <span>🤖 Wingspan Rules Expert v3</span>
+              <span>🕒 2026-05-24 14:08:42</span>
+              <span>🆔 <code>q-7f8a2c</code></span>
+            </div>
+          </div>
+
+          <div class="drill-body">
+
+            <!-- Retrieval -->
+            <div class="drill-section">
+              <h4>📚 Retrieval · 4 chunks dal top-10</h4>
+              <div class="chunk-row matched">
+                <div class="crow-top">
+                  <span class="src">📄 Wingspan-Asia-EN.pdf · p.22</span>
+                  <span class="score">0.84 ✓</span>
+                </div>
+                <div class="text">"<mark>Quando più uccelli predatori sono attivati nello stesso turno</mark>, l'attivazione segue l'ordine di piazzamento da sinistra a destra…"</div>
+              </div>
+              <div class="chunk-row matched">
+                <div class="crow-top">
+                  <span class="src">📄 Wingspan-Asia-EN.pdf · p.22</span>
+                  <span class="score">0.72</span>
+                </div>
+                <div class="text">"…un cibo non disponibile sulla mappa cibo viene preso dal banco. Se ci sono <mark>più predatori in competizione</mark>, il giocatore decide…"</div>
+              </div>
+              <div class="chunk-row">
+                <div class="crow-top">
+                  <span class="src">📄 Wingspan-Oceania-EN.pdf · p.14</span>
+                  <span class="score">0.58</span>
+                </div>
+                <div class="text">"Power di tipo <code>predator</code> si attiva su trigger when activated. In espansione Oceania, l'ordine è importante per i power con interferenza…"</div>
+              </div>
+              <div class="chunk-row">
+                <div class="crow-top">
+                  <span class="src">📄 wingspan-faq-bgg-thread.txt · p.1</span>
+                  <span class="score">0.41 ⚠</span>
+                </div>
+                <div class="text">"Domanda community: 'Cosa succede se due predatori falliscono insieme?' — risposta non ufficiale di Elizabeth Hargrave su BGG…"</div>
+              </div>
+            </div>
+
+            <!-- Response -->
+            <div class="drill-section">
+              <h4>💬 Response · confidence 0.42</h4>
+              <div style="padding: 10px 12px; background: var(--bg-muted); border-left: 3px solid hsl(var(--c-agent)); border-radius: 6px; font-size: 12px; line-height: 1.5">
+                "<strong>Non sono sicuro</strong> — questa specifica casistica non è trattata esplicitamente nel manuale. Il testo a p.22 spiega l'ordine di attivazione standard ma non il caso di esaurimento cibo <em>simultaneo</em>. Confidence bassa (0.42)."
+              </div>
+              <div style="margin-top: 6px; display: flex; gap: 6px; align-items: center; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">
+                <span>Feedback utente:</span>
+                <span class="status-chip danger">👎 Non utile</span>
+                <span>"Non ha risposto"</span>
+              </div>
+            </div>
+
+            <!-- Latency breakdown -->
+            <div class="drill-section">
+              <h4>⏱ Latency breakdown · 4.82s totali</h4>
+              <div class="latency-bar">
+                <div class="seg retrieval" style="width: 28%">1.35s</div>
+                <div class="seg rerank" style="width: 8%">0.4</div>
+                <div class="seg llm" style="width: 56%">2.7s</div>
+                <div class="seg post" style="width: 8%">0.4</div>
+              </div>
+              <table class="latency-table">
+                <tr><td><span class="swatch" style="background: hsl(var(--c-kb))"></span> Retrieval (Pinecone)</td><td>1.35s</td></tr>
+                <tr><td><span class="swatch" style="background: hsl(var(--c-toolkit))"></span> Rerank (Cohere)</td><td>0.40s</td></tr>
+                <tr><td><span class="swatch" style="background: hsl(var(--c-agent))"></span> LLM (GPT-4o-mini)</td><td>2.70s</td></tr>
+                <tr><td><span class="swatch" style="background: hsl(var(--c-chat))"></span> Postprocess + stream</td><td>0.37s</td></tr>
+              </table>
+            </div>
+
+            <!-- Debug -->
+            <div class="drill-section">
+              <h4>🔬 Debug</h4>
+              <dl class="kv-grid" style="display: grid; grid-template-columns: 100px 1fr; gap: 4px 10px; font-size: 11.5px; font-family: var(--f-mono)">
+                <dt style="color: var(--text-muted)">Tokens IN</dt><dd>2.847 (sys 412 · ret 2.218 · q 217)</dd>
+                <dt style="color: var(--text-muted)">Tokens OUT</dt><dd>184</dd>
+                <dt style="color: var(--text-muted)">Cost</dt><dd>$0.0042</dd>
+                <dt style="color: var(--text-muted)">Cache hit</dt><dd>no (cold)</dd>
+                <dt style="color: var(--text-muted)">Reranker</dt><dd>cohere-rerank-3.5</dd>
+                <dt style="color: var(--text-muted)">Embedding</dt><dd>text-embedding-3-large</dd>
+                <dt style="color: var(--text-muted)">Index version</dt><dd>v2024.11.18</dd>
+              </dl>
+            </div>
+
+            <!-- Actions -->
+            <div class="drill-section" style="display: flex; gap: 6px; flex-wrap: wrap">
+              <button class="btn-admin sm primary">▶ Re-run con KB attuale</button>
+              <button class="btn-admin sm">▶ Re-run con KB beta</button>
+              <button class="btn-admin sm">🚩 Flag hallucination</button>
+              <button class="btn-admin sm">📋 Copia query</button>
+              <button class="btn-admin sm">📨 Notifica autore</button>
+            </div>
+
+          </div>
+        </aside>
+
+      </div>
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script>
+<script>renderAdminNav('ai');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-alerts.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-alerts.html
@@ -1,0 +1,680 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Alerting Config · MeepleAI Admin</title>
+<!-- C7 · Platform & Operations → 'alerts' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 AlertRulesTable · MetricSelector · ChannelChip · AlertActivityFeed · TestAlert reuse
+     Endpoints: GET/POST/PUT/DELETE /api/v1/admin/alert-rules
+                GET /api/v1/admin/alert-config
+                POST /api/v1/alerts/prometheus (webhook)
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.admin-form-row{display:grid;grid-template-columns:200px 1fr;gap:16px;align-items:flex-start;padding:12px 0;border-bottom:1px solid var(--border-light)}
+.admin-form-row:last-child{border-bottom:0}
+.admin-form-label{font-family:var(--f-display);font-size:12.5px;font-weight:700}
+.admin-form-label .desc{display:block;margin-top:3px;font-family:var(--f-body);font-size:11px;font-weight:400;color:var(--text-muted);line-height:1.4}
+.admin-input,.admin-select,.admin-textarea{width:100%;max-width:360px;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.admin-toggle{position:relative;width:36px;height:20px;background:var(--bg-muted);border:1px solid var(--border);border-radius:999px;cursor:pointer;flex-shrink:0;display:inline-block}
+.admin-toggle::after{content:'';position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;background:var(--text-sec);transition:all .2s var(--ease-out)}
+.admin-toggle.on{background:hsl(var(--c-toolkit)/.25);border-color:hsl(var(--c-toolkit))}
+.admin-toggle.on::after{left:18px;background:hsl(var(--c-toolkit))}
+.activity-feed{display:flex;flex-direction:column;gap:1px}
+.activity-item{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:flex-start;gap:10px;font-size:12.5px}
+.activity-item:last-child{border-bottom:0}
+.activity-item:hover{background:var(--bg-muted)}
+.activity-item .em{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;font-size:14px;flex-shrink:0}
+.activity-item .body{flex:1;min-width:0}
+.activity-item .body strong{font-weight:700;color:var(--text)}
+.activity-item .ts{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);flex-shrink:0}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+
+/* ── Rule name cell ─────────────────────────────────────────────── */
+.rule-cell{display:flex;align-items:center;gap:10px}
+.rule-mark{width:28px;height:28px;border-radius:7px;background:hsl(var(--e)/.12);color:hsl(var(--e));display:grid;place-items:center;font-size:14px;flex-shrink:0;border:1px solid hsl(var(--e)/.25)}
+.rule-info{display:flex;flex-direction:column;line-height:1.2;min-width:0}
+.rule-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.rule-id{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;margin-top:2px;letter-spacing:.02em}
+
+/* Metric / condition cells */
+.metric-chip{font-family:var(--f-mono);font-size:11px;color:var(--text);background:var(--bg-sunken,var(--bg));padding:2px 7px;border-radius:5px;border:1px solid var(--border-light);font-weight:600;display:inline-block}
+.metric-chip .ns{color:var(--text-muted)}
+.cond-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text);font-weight:700}
+.cond-cell .op{padding:1px 5px;border-radius:4px;background:hsl(var(--c-event)/.1);color:hsl(var(--c-event));margin:0 3px;font-weight:700}
+.win-cell{font-family:var(--f-mono);font-size:11.5px;font-weight:600;color:var(--text-sec)}
+
+/* Channel chip */
+.chan-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;font-family:var(--f-mono);font-size:10.5px;font-weight:700;letter-spacing:.02em;border:1px solid hsl(var(--e)/.25);background:hsl(var(--e)/.08);color:hsl(var(--e))}
+.chan-chip .em-ico{font-size:11px}
+.chan-stack{display:flex;flex-wrap:wrap;gap:4px}
+
+/* Row actions */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+.lock-mini{color:hsl(var(--c-event));font-size:10px}
+
+/* Nuova regola form grid */
+.new-rule-grid{display:grid;grid-template-columns:1fr 1fr;gap:0 24px;padding:8px 20px 0}
+.new-rule-grid .admin-form-row{grid-template-columns:150px 1fr;padding:10px 0}
+.new-rule-grid .admin-input,.new-rule-grid .admin-select{max-width:none;width:100%}
+.cond-row{display:grid;grid-template-columns:1fr 80px 1fr;gap:8px;align-items:center}
+.cond-row .op-sel{font-family:var(--f-mono);font-weight:700;text-align:center}
+.preview-pill{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;background:hsl(var(--c-event)/.06);border:1px dashed hsl(var(--c-event)/.35);border-radius:6px;font-family:var(--f-mono);font-size:11px;color:var(--text);margin-top:6px}
+.preview-pill .k{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:9px;font-weight:700}
+.preview-pill .v{color:hsl(var(--c-event));font-weight:700}
+.new-rule-foot{display:flex;align-items:center;gap:12px;padding:12px 20px;border-top:1px solid var(--border-light);background:var(--bg)}
+.new-rule-foot .grow{flex:1}
+.new-rule-foot .helper{font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+
+/* Activity feed customizations */
+.activity-feed .activity-item .em.danger{background:hsl(var(--c-event)/.14);color:hsl(var(--c-event))}
+.activity-feed .activity-item .em.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.activity-feed .activity-item .em.info{background:hsl(var(--c-chat)/.14);color:hsl(var(--c-chat))}
+.activity-feed .activity-item .body .msg{margin-top:1px;color:var(--text-sec);font-size:11.5px}
+.activity-feed .activity-item .body .msg .val{font-family:var(--f-mono);color:var(--text);font-weight:700;padding:1px 5px;background:var(--bg-muted);border-radius:4px}
+.activity-feed .activity-item .body .head-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.activity-feed .activity-item .body .rule{font-family:var(--f-display);font-weight:800;color:var(--text);font-size:13px}
+.activity-feed .activity-item .right{display:flex;flex-direction:column;align-items:flex-end;gap:4px;flex-shrink:0}
+.dur-pill{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);background:var(--bg-muted);border-radius:99px;padding:1px 7px;font-weight:700}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Alerting Config</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Alerts · 6 regole · prom-pushgateway · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca regola, metrica…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">⚙ Canali</button>
+          <button class="btn-admin primary">＋ Nuova regola</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Regole attive</div>
+            <div class="admin-kpi-value">6<span style="font-size:14px;color:var(--text-muted);font-weight:600">/7</span></div>
+            <div class="admin-kpi-trend flat">▬ 4 warning · 2 danger · 1 disattivata</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,20 L8,20 L16,18 L24,18 L32,14 L40,14 L48,12 L56,12 L64,10 L70,10 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,20 L8,20 L16,18 L24,18 L32,14 L40,14 L48,12 L56,12 L64,10 L70,10"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-event">
+            <div class="admin-kpi-label">Alert oggi</div>
+            <div class="admin-kpi-value">3<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 2 risolti</span></div>
+            <div class="admin-kpi-trend up">▲ vs media 7g (1.4) · 1 attivo</div>
+            <svg class="admin-kpi-spark e-event" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,22 L24,18 L32,20 L40,16 L48,18 L56,12 L64,14 L70,10 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,22 L24,18 L32,20 L40,16 L48,18 L56,12 L64,14 L70,10"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">Canali configurati</div>
+            <div class="admin-kpi-value">4</div>
+            <div class="admin-kpi-trend flat">▬ 2 slack · 2 email · 0 pagerduty</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,16 L14,16 L14,12 L28,12 L28,18 L42,18 L42,10 L56,10 L56,14 L70,14 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,16 L14,16 L14,12 L28,12 L28,18 L42,18 L42,10 L56,10 L56,14 L70,14"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 2) Regole di alerting ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Regole di alerting</h3>
+            <span class="status-chip danger">2 danger</span>
+            <span class="status-chip warning">4 warning</span>
+            <span class="status-chip muted">1 disattiva</span>
+            <div class="head-cluster">
+              <span class="meta">prom-pushgateway · scrape 30s · webhook POST /alerts/prometheus</span>
+              <button class="btn-admin sm ghost">⤓ Export YAML</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:24%">Regola</th>
+                <th style="width:16%">Metrica</th>
+                <th style="width:14%">Condizione</th>
+                <th style="width:8%">Finestra</th>
+                <th style="width:9%">Severità</th>
+                <th style="width:14%">Canale</th>
+                <th style="width:6%">Attiva</th>
+                <th style="width:170px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="e-event">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">⚠</div>
+                    <div class="rule-info"><span class="rule-name">Error rate alto</span><span class="rule-id">rule_alrt_84a1 · v3</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">rag.</span>error_rate</span></td>
+                <td class="cond-cell"><span class="op">&gt;</span> 1.0%</td>
+                <td class="win-cell">5m</td>
+                <td><span class="status-chip danger">danger</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost" title="Elimina (ConfirmModal)">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">⏱</div>
+                    <div class="rule-info"><span class="rule-name">Latenza p95 alta</span><span class="rule-id">rule_alrt_84a2 · v2</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">llm.</span>latency_p95</span></td>
+                <td class="cond-cell"><span class="op">&gt;</span> 2000 ms</td>
+                <td class="win-cell">10m</td>
+                <td><span class="status-chip warning">warning</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">💰</div>
+                    <div class="rule-info"><span class="rule-name">Costo giornaliero</span><span class="rule-id">rule_alrt_84a3 · v1</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">cost.</span>daily_usd</span></td>
+                <td class="cond-cell"><span class="op">&gt;</span> $40.00</td>
+                <td class="win-cell">1d</td>
+                <td><span class="status-chip warning">warning</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-agent"><span class="em-ico">📧</span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="214e5152614c4444514d4440480f405151">[email&#160;protected]</a></span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">📦</div>
+                    <div class="rule-info"><span class="rule-name">Coda job profonda</span><span class="rule-id">rule_alrt_84a4 · v2</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">queue.</span>depth</span></td>
+                <td class="cond-cell"><span class="op">&gt;</span> 50 job</td>
+                <td class="win-cell">15m</td>
+                <td><span class="status-chip warning">warning</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #alerts</span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-session">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">🔌</div>
+                    <div class="rule-info"><span class="rule-name">Tunnel staging down</span><span class="rule-id">rule_alrt_84a5 · v1</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">infra.</span>tunnel.staging</span></td>
+                <td class="cond-cell"><span class="op">==</span> "down"</td>
+                <td class="win-cell">1m</td>
+                <td><span class="status-chip danger">danger</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span><span class="chan-chip e-agent"><span class="em-ico">📧</span>ops@</span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-kb">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">💾</div>
+                    <div class="rule-info"><span class="rule-name">Disco basso</span><span class="rule-id">rule_alrt_84a6 · v3</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">infra.</span>disk_free_pct</span></td>
+                <td class="cond-cell"><span class="op">&lt;</span> 10%</td>
+                <td class="win-cell">5m</td>
+                <td><span class="status-chip danger">danger</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-agent"><span class="em-ico">📧</span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="8de2fdfecde0e8e8fde1e8ece4a3ecfdfd">[email&#160;protected]</a></span></div></td>
+                <td><span class="admin-toggle on" role="switch" aria-checked="true"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-toolkit" style="opacity:.62">
+                <td>
+                  <div class="rule-cell">
+                    <div class="rule-mark">🪝</div>
+                    <div class="rule-info"><span class="rule-name">n8n flow failure</span><span class="rule-id">rule_alrt_84a7 · v1 · paused</span></div>
+                  </div>
+                </td>
+                <td><span class="metric-chip"><span class="ns">n8n.</span>flow_fail_rate</span></td>
+                <td class="cond-cell"><span class="op">&gt;</span> 5%</td>
+                <td class="win-cell">30m</td>
+                <td><span class="status-chip info">info</span></td>
+                <td><div class="chan-stack"><span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #alerts</span></div></td>
+                <td><span class="admin-toggle" role="switch" aria-checked="false"></span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                    <button class="btn-admin sm ghost">🔔 Test</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Nuova regola ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Nuova regola</h3>
+            <span class="status-chip info">draft · 0 unsaved</span>
+            <div class="head-cluster">
+              <span class="meta">expression engine v1.4 · validated client-side</span>
+              <button class="btn-admin sm ghost">📋 Da template…</button>
+            </div>
+          </div>
+
+          <div class="new-rule-grid">
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Nome<span class="desc">Identificatore umano</span></span>
+              <input class="admin-input" placeholder="Es. Embedding queue saturata" />
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Metrica<span class="desc">Sorgente Prometheus / push</span></span>
+              <select class="admin-select">
+                <option>rag.error_rate</option>
+                <option>llm.latency_p95</option>
+                <option>llm.latency_p99</option>
+                <option>cost.daily_usd</option>
+                <option>cost.monthly_usd</option>
+                <option>queue.depth</option>
+                <option>queue.failed_count</option>
+                <option>infra.tunnel.staging</option>
+                <option>infra.disk_free_pct</option>
+                <option>infra.cpu_avg_pct</option>
+                <option>infra.ram_used_pct</option>
+              </select>
+            </div>
+
+            <div class="admin-form-row" style="grid-column:span 2">
+              <span class="admin-form-label">Condizione<span class="desc">Operatore + soglia</span></span>
+              <div>
+                <div class="cond-row">
+                  <select class="admin-select"><option>rag.error_rate</option></select>
+                  <select class="admin-select op-sel"><option>&gt;</option><option>&lt;</option><option>&gt;=</option><option>&lt;=</option><option>==</option><option>!=</option></select>
+                  <input class="admin-input mono" value="1.0" placeholder="soglia" />
+                </div>
+                <div class="preview-pill"><span class="k">Preview</span><span class="v">rag.error_rate &gt; 1.0%</span></div>
+              </div>
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Finestra<span class="desc">Durata sostenuta della condizione</span></span>
+              <select class="admin-select">
+                <option>1m</option>
+                <option>5m</option>
+                <option>10m</option>
+                <option>15m</option>
+                <option>30m</option>
+                <option>1h</option>
+                <option>1d</option>
+              </select>
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Severità<span class="desc">Determina colore e canale di default</span></span>
+              <select class="admin-select">
+                <option>info — solo log</option>
+                <option>warning — canale ops</option>
+                <option>danger — canale ops + email</option>
+              </select>
+            </div>
+
+            <div class="admin-form-row" style="grid-column:span 2;border-bottom:0">
+              <span class="admin-form-label">Canali<span class="desc">Dove inviare la notifica</span></span>
+              <select class="admin-select" multiple size="3" style="height:auto">
+                <option selected>slack · #ops</option>
+                <option>slack · #alerts</option>
+                <option>email · <template class="__cf_email__" data-cfemail="1e716e6d5e737b7b6e727b7f77307f6e6e">[email&#160;protected]</template></option>
+                <option>email · <template class="__cf_email__" data-cfemail="3c5d5d4e53527c5159594c50595d55125d4c4c">[email&#160;protected]</template></option>
+                <option>webhook · n8n/incident-flow</option>
+              </select>
+            </div>
+
+          </div>
+
+          <div class="new-rule-foot">
+            <span class="helper">⏱ Validazione live · debouncer 30s prima del primo invio · cooldown ripetuto 10m</span>
+            <span class="grow"></span>
+            <button class="btn-admin">🔔 Test invio</button>
+            <button class="btn-admin">Annulla</button>
+            <button class="btn-admin primary">＋ Crea regola <kbd>↵</kbd></button>
+          </div>
+        </section>
+
+        <!-- ────────── 4) Alert recenti (activity feed) ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Alert recenti</h3>
+            <span class="status-chip running">● 1 attivo</span>
+            <div class="head-cluster">
+              <span class="meta">ultimi 7 giorni · MTTR medio 4m 12s · ack rate 92%</span>
+              <button class="btn-admin sm ghost">⤓ Export</button>
+              <button class="btn-admin sm ghost">📜 Audit log</button>
+            </div>
+          </div>
+
+          <div class="activity-feed">
+
+            <div class="activity-item">
+              <span class="em danger">⚠</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Latenza p95 alta</span>
+                  <span class="metric-chip"><span class="ns">llm.</span>latency_p95</span>
+                  <span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span>
+                </div>
+                <div class="msg">Soglia <span class="val">&gt; 2000ms</span> superata · valore corrente <span class="val">2148 ms</span> · provider <strong>OpenAI</strong> · azione raccomandata: verifica circuit breaker.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip running">attivo</span>
+                <span class="ts">14:22:45 · 23s fa</span>
+              </div>
+            </div>
+
+            <div class="activity-item">
+              <span class="em warning">📦</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Coda job profonda</span>
+                  <span class="metric-chip"><span class="ns">queue.</span>depth</span>
+                  <span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #alerts</span>
+                </div>
+                <div class="msg">Coda salita a <span class="val">62</span> &gt; soglia <span class="val">50</span> per 16m · risolto automaticamente quando ingestion ha drenato.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip healthy">risolto</span>
+                <span class="dur-pill">durata 18m 02s</span>
+                <span class="ts">oggi 11:08:14</span>
+              </div>
+            </div>
+
+            <div class="activity-item">
+              <span class="em danger">⚠</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Error rate alto</span>
+                  <span class="metric-chip"><span class="ns">rag.</span>error_rate</span>
+                  <span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span>
+                </div>
+                <div class="msg">Error rate <span class="val">1.42%</span> &gt; soglia <span class="val">1.0%</span> · root cause: timeout reranker-service.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip healthy">risolto</span>
+                <span class="dur-pill">durata 3m 18s</span>
+                <span class="ts">oggi 09:42:01</span>
+              </div>
+            </div>
+
+            <div class="activity-item">
+              <span class="em warning">💰</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Costo giornaliero</span>
+                  <span class="metric-chip"><span class="ns">cost.</span>daily_usd</span>
+                  <span class="chan-chip e-agent"><span class="em-ico">📧</span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="95fae5e6d5f8f0f0e5f9f0f4fcbbf4e5e5">[email&#160;protected]</a></span>
+                </div>
+                <div class="msg">Spesa giornaliera <span class="val">$42.08</span> &gt; soglia <span class="val">$40.00</span> · picco 12 mag dovuto a reindex Wingspan.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip muted">silenziato 24h</span>
+                <span class="ts">12 mag · 23:55:02</span>
+              </div>
+            </div>
+
+            <div class="activity-item">
+              <span class="em danger">🔌</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Tunnel staging down</span>
+                  <span class="metric-chip"><span class="ns">infra.</span>tunnel.staging</span>
+                  <span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span>
+                  <span class="chan-chip e-agent"><span class="em-ico">📧</span>ops@</span>
+                </div>
+                <div class="msg">Tunnel ssh <span class="val">== "down"</span> · sync prod→staging non eseguito · ripristino manuale da bastion-prod.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip healthy">risolto</span>
+                <span class="dur-pill">durata 8m 41s</span>
+                <span class="ts">21 mag · 03:14:08</span>
+              </div>
+            </div>
+
+            <div class="activity-item">
+              <span class="em info">⏱</span>
+              <div class="body">
+                <div class="head-row">
+                  <span class="rule">Latenza p95 alta</span>
+                  <span class="metric-chip"><span class="ns">llm.</span>latency_p95</span>
+                  <span class="chan-chip e-chat"><span class="em-ico">💬</span>slack · #ops</span>
+                </div>
+                <div class="msg">Soglia superata per <span class="val">11m</span> · flap su OpenRouter, fallback su DeepSeek.</div>
+              </div>
+              <div class="right">
+                <span class="status-chip healthy">risolto</span>
+                <span class="dur-pill">durata 12m 02s</span>
+                <span class="ts">20 mag · 17:28:55</span>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('alerts');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-budget.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-budget.html
@@ -1,0 +1,619 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Budget &amp; Cost · MeepleAI Admin</title>
+<!-- C5 · Platform & Operations → 'budget' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 CostStackedArea · FeatureCostTable · CostSimulator · BudgetGauge reuse
+     Endpoints: GET /api/v1/admin/business, /admin/budget, /admin/cost-calculator
+                POST /api/v1/admin/budget/limit
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}
+.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit))}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:8px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.admin-form-row{display:grid;grid-template-columns:200px 1fr;gap:16px;align-items:flex-start;padding:12px 0;border-bottom:1px solid var(--border-light)}
+.admin-form-row:last-child{border-bottom:0}
+.admin-form-label{font-family:var(--f-display);font-size:12.5px;font-weight:700}
+.admin-form-label .desc{display:block;margin-top:3px;font-family:var(--f-body);font-size:11px;font-weight:400;color:var(--text-muted);line-height:1.4}
+.admin-input,.admin-select,.admin-textarea{width:100%;max-width:360px;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.alert-banner{display:flex;align-items:flex-start;gap:12px;padding:12px 14px;border-radius:8px;font-size:12.5px}
+.alert-banner.warning{background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.35);color:var(--text)}
+.alert-banner.danger{background:hsl(var(--c-event)/.08);border:1px solid hsl(var(--c-event)/.35);color:var(--text)}
+.alert-banner.success{background:hsl(var(--c-toolkit)/.08);border:1px solid hsl(var(--c-toolkit)/.3);color:var(--text)}
+.alert-banner .em{font-size:18px;flex-shrink:0}
+.alert-banner .title{font-family:var(--f-display);font-weight:800;margin-bottom:2px;font-size:13px}
+.alert-banner .actions{margin-left:auto;display:flex;gap:6px;align-items:center}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.kpi-bar{position:absolute;left:14px;right:14px;bottom:10px;height:4px;border-radius:99px;background:hsl(var(--e)/.12);overflow:hidden}
+.kpi-bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px}
+
+/* ── Cost chart (stacked area, 30 days) ─────────────────────────── */
+.chart-wrap{padding:16px 20px 12px;display:flex;flex-direction:column;gap:8px}
+.chart-frame{position:relative;width:100%;height:260px;background:linear-gradient(180deg, var(--bg-sunken,var(--bg)) 0%, var(--bg) 100%);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.chart-frame svg{display:block;width:100%;height:100%}
+.chart-frame .y-axis{position:absolute;left:0;top:0;bottom:18px;width:46px;display:flex;flex-direction:column;justify-content:space-between;align-items:flex-end;padding:6px 6px 0 0;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);pointer-events:none}
+.chart-frame .x-axis{position:absolute;left:46px;right:8px;bottom:0;height:18px;display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);padding-top:2px;pointer-events:none}
+.chart-frame .grid{stroke:hsl(var(--border-strong));stroke-width:.5;opacity:.4;stroke-dasharray:2 4}
+.chart-frame .ann{font-family:var(--f-mono);font-size:9px;fill:var(--text-muted)}
+.chart-frame .budget-line{stroke:hsl(38 90% 50%);stroke-width:1;stroke-dasharray:4 3;fill:none;opacity:.8}
+.chart-frame .budget-lbl{font-family:var(--f-mono);font-size:9.5px;fill:hsl(38 90% 50%);font-weight:700}
+
+.chart-legend{display:flex;align-items:center;gap:14px;flex-wrap:wrap;padding-top:4px;font-family:var(--f-mono);font-size:11px}
+.chart-legend .item{display:inline-flex;align-items:center;gap:6px;color:var(--text-sec)}
+.chart-legend .item .sw{width:12px;height:12px;border-radius:3px;background:hsl(var(--e))}
+.chart-legend .item .val{color:var(--text);font-weight:700;margin-left:2px}
+.chart-legend .item .pct{color:var(--text-muted);font-weight:500}
+
+/* ── Feature cost table ─────────────────────────────────────────── */
+.feat-cell{display:flex;align-items:center;gap:10px}
+.feat-cell .feat-mark{width:28px;height:28px;border-radius:7px;background:hsl(var(--e)/.12);color:hsl(var(--e));display:grid;place-items:center;font-size:14px;flex-shrink:0;border:1px solid hsl(var(--e)/.25)}
+.feat-cell .feat-info{display:flex;flex-direction:column;min-width:0;line-height:1.2}
+.feat-cell .feat-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.feat-cell .feat-sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.pct-bar{display:flex;align-items:center;gap:8px;justify-content:flex-start}
+.pct-bar .bar{flex:1;height:6px;border-radius:99px;background:hsl(var(--e)/.12);overflow:hidden;position:relative;max-width:160px}
+.pct-bar .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px}
+.pct-bar .v{font-family:var(--f-mono);font-size:11px;color:var(--text);font-weight:700;min-width:44px;text-align:right;font-variant-numeric:tabular-nums}
+.mini-spark{width:60px;height:20px;display:inline-block;vertical-align:middle}
+.trend-cell{display:inline-flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:11px;font-weight:600}
+.trend-cell.up{color:hsl(var(--c-toolkit))}
+.trend-cell.down{color:hsl(var(--c-event))}
+.trend-cell.flat{color:var(--text-muted)}
+
+/* ── Simulator ──────────────────────────────────────────────────── */
+.sim-grid{display:grid;grid-template-columns:1.1fr 1fr;gap:0;align-items:stretch}
+.sim-form{padding:6px 20px 16px}
+.sim-form .admin-form-row{grid-template-columns:170px 1fr;padding:10px 0}
+.sim-form .admin-input,.sim-form .admin-select{max-width:none;width:100%}
+.sim-form .admin-input.mono.compact{max-width:160px}
+.sim-form .row-inline{display:flex;align-items:center;gap:8px;font-family:var(--f-mono);font-size:11px;color:var(--text-muted)}
+.sim-form .row-inline .v{color:var(--text);font-weight:700}
+.sim-form .pricing-readout{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);margin-top:6px;padding:6px 10px;background:var(--bg);border:1px solid var(--border-light);border-radius:6px;display:flex;justify-content:space-between;align-items:center}
+.sim-form .pricing-readout .k{color:var(--text-muted)}
+.sim-form .pricing-readout .v{color:var(--text);font-weight:700}
+
+.sim-readout{padding:20px;background:linear-gradient(180deg, hsl(var(--c-agent)/.06) 0%, var(--bg) 100%);border-left:1px solid var(--border-light);display:flex;flex-direction:column;gap:16px;justify-content:center}
+.sim-readout .label{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+.sim-readout .big{font-family:var(--f-display);font-weight:800;font-size:44px;line-height:1;color:hsl(var(--c-agent));font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.sim-readout .big .cur{font-size:24px;color:var(--text-muted);margin-right:2px;font-weight:700}
+.sim-readout .big .unit{font-size:14px;color:var(--text-muted);margin-left:4px;font-weight:600}
+.sim-readout .alt-stack{display:flex;flex-direction:column;gap:6px;padding-top:10px;border-top:1px dashed var(--border-light)}
+.sim-readout .alt{display:flex;justify-content:space-between;align-items:baseline;font-family:var(--f-mono);font-size:12px}
+.sim-readout .alt .k{color:var(--text-muted);text-transform:uppercase;letter-spacing:.04em;font-size:10px;font-weight:700}
+.sim-readout .alt .v{color:var(--text);font-weight:700;font-size:14px;font-variant-numeric:tabular-nums}
+.sim-readout .alt .v.diff-down{color:hsl(var(--c-toolkit))}
+.sim-readout .alt .v.diff-up{color:hsl(var(--c-event))}
+.sim-readout .impact{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);display:flex;align-items:center;gap:6px;margin-top:4px}
+.sim-readout .impact .dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--c-toolkit))}
+
+/* ── Budget banner gauge inline ─────────────────────────────────── */
+.budget-banner-gauge{flex:1;max-width:280px;display:flex;flex-direction:column;gap:4px}
+.budget-banner-gauge .bar{position:relative;height:10px;border-radius:99px;background:hsl(38 90% 56%/.15);overflow:hidden}
+.budget-banner-gauge .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(38 90% 50%);border-radius:99px}
+.budget-banner-gauge .ll{display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:10px;color:var(--text)}
+.budget-banner-gauge .ll .k{color:var(--text-muted)}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Budget &amp; Cost</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Budget · maggio 2026 · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca feature, provider…"/><kbd>⌘K</kbd></div>
+          <select class="admin-select" style="width:130px;font-size:12px;padding:5px 8px">
+            <option>30 giorni</option>
+            <option>7 giorni</option>
+            <option>90 giorni</option>
+            <option>Anno</option>
+          </select>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">⤓ Export CSV</button>
+          <button class="btn-admin primary">＋ Imposta budget</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-agent">
+            <div class="admin-kpi-label">Spesa oggi</div>
+            <div class="admin-kpi-value"><span style="font-size:18px;color:var(--text-muted);font-weight:700">$</span>12.40</div>
+            <div class="admin-kpi-trend up">▲ 8.6% vs ieri ($11.42)</div>
+            <svg class="admin-kpi-spark e-agent" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,20 L8,18 L16,16 L24,17 L32,14 L40,13 L48,11 L56,12 L64,9 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,20 L8,18 L16,16 L24,17 L32,14 L40,13 L48,11 L56,12 L64,9 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-event" style="--e:var(--c-event)">
+            <div class="admin-kpi-label">Spesa mese</div>
+            <div class="admin-kpi-value"><span style="font-size:18px;color:var(--text-muted);font-weight:700">$</span>284<span style="font-size:14px;color:var(--text-muted);font-weight:600"> / 1.200</span></div>
+            <div class="admin-kpi-trend flat">▬ 23.6% del budget · giorno 22/31</div>
+            <div class="kpi-bar"><i style="width:23.6%"></i></div>
+          </div>
+
+          <div class="admin-kpi e-toolkit">
+            <div class="admin-kpi-label">Budget residuo</div>
+            <div class="admin-kpi-value"><span style="font-size:18px;color:var(--text-muted);font-weight:700">$</span>916<span style="font-size:14px;color:var(--text-muted);font-weight:600">.00</span></div>
+            <div class="admin-kpi-trend up">▲ 9 giorni residui · $101.7/d capacità</div>
+            <svg class="admin-kpi-spark e-toolkit" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,4 L8,6 L16,8 L24,10 L32,12 L40,14 L48,16 L56,18 L64,19 L70,20 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,4 L8,6 L16,8 L24,10 L32,12 L40,14 L48,16 L56,18 L64,19 L70,20"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">Proiezione fine mese</div>
+            <div class="admin-kpi-value"><span style="font-size:18px;color:var(--text-muted);font-weight:700">$</span>890<span style="font-size:14px;color:var(--text-muted);font-weight:600">.00</span></div>
+            <div class="admin-kpi-trend up">▼ -$310 sotto budget · 74.2%</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,21 L16,19 L24,18 L32,16 L40,14 L48,12 L56,11 L64,9 L70,7 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,21 L16,19 L24,18 L32,16 L40,14 L48,12 L56,11 L64,9 L70,7"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 2) Costi per provider · 30 giorni ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Costi per provider · 30 giorni</h3>
+            <span class="status-chip info">stacked area · $/giorno</span>
+            <div class="head-cluster">
+              <span class="meta">tot $284.34 · media $9.18/d · picco $14.20 (12 mag)</span>
+              <button class="btn-admin sm ghost">⤓ ndjson</button>
+            </div>
+          </div>
+
+          <div class="chart-wrap">
+            <div class="chart-frame">
+              <!-- Y axis labels -->
+              <div class="y-axis">
+                <span>$16</span><span>$12</span><span>$8</span><span>$4</span><span>$0</span>
+              </div>
+              <!-- X axis labels -->
+              <div class="x-axis">
+                <span>22 apr</span><span>27 apr</span><span>02 mag</span><span>07 mag</span><span>12 mag</span><span>17 mag</span><span>22 mag</span>
+              </div>
+
+              <!-- Chart SVG: padding left 46, right 8, top 6, bottom 18 -->
+              <svg viewBox="0 0 700 240" preserveAspectRatio="none" aria-hidden="true">
+                <!-- y values: chart inner height 216 (240-6-18) -->
+                <!-- gridlines -->
+                <g>
+                  <line class="grid" x1="46" y1="60"  x2="692" y2="60"/>
+                  <line class="grid" x1="46" y1="114" x2="692" y2="114"/>
+                  <line class="grid" x1="46" y1="168" x2="692" y2="168"/>
+                  <line class="grid" x1="46" y1="222" x2="692" y2="222"/>
+                </g>
+
+                <!-- Stacked layers, bottom→top:
+                     DeepSeek (e-tool)  base
+                     OpenRouter (e-chat)
+                     OpenAI (e-toolkit)
+                     Anthropic (e-agent) top
+                     y=222 is $0, y=6 is $16; scale: 1$ = 13.5px -->
+
+                <!-- Anthropic layer (top, smallest) ~$0.40-$0.80 -->
+                <g class="e-agent" style="color:hsl(var(--c-agent))">
+                  <path d="M46,128 L77,125 L108,123 L138,127 L169,121 L200,118 L231,115 L261,123 L292,118 L323,112 L354,108 L384,110 L415,104 L446,99 L477,95 L507,98 L538,92 L569,90 L600,82 L630,80 L661,75 L692,70 L692,134 L661,80 L630,85 L600,88 L569,95 L538,98 L507,103 L477,100 L446,106 L415,109 L384,114 L354,113 L323,118 L292,122 L261,127 L231,120 L200,123 L169,125 L138,131 L108,128 L77,130 L46,134 Z" fill="hsl(var(--c-agent) / .55)"/>
+                </g>
+
+                <!-- OpenAI (gpt-4o-mini) layer ~$1-$2 -->
+                <g class="e-toolkit" style="color:hsl(var(--c-toolkit))">
+                  <path d="M46,148 L77,145 L108,142 L138,148 L169,140 L200,138 L231,135 L261,144 L292,138 L323,130 L354,128 L384,131 L415,124 L446,118 L477,114 L507,118 L538,110 L569,108 L600,99 L630,98 L661,92 L692,86 L692,134 L661,80 L630,85 L600,88 L569,95 L538,98 L507,103 L477,100 L446,106 L415,109 L384,114 L354,113 L323,118 L292,122 L261,127 L231,120 L200,123 L169,125 L138,131 L108,128 L77,130 L46,134 Z" fill="hsl(var(--c-toolkit) / .55)"/>
+                </g>
+
+                <!-- OpenRouter layer ~$3-$4 -->
+                <g class="e-chat" style="color:hsl(var(--c-chat))">
+                  <path d="M46,182 L77,178 L108,175 L138,180 L169,170 L200,168 L231,165 L261,174 L292,168 L323,160 L354,158 L384,162 L415,154 L446,148 L477,144 L507,148 L538,140 L569,138 L600,128 L630,128 L661,121 L692,114 L692,148 L661,92 L630,98 L600,99 L569,108 L538,110 L507,118 L477,114 L446,118 L415,124 L384,131 L354,128 L323,130 L292,138 L261,144 L231,135 L200,138 L169,140 L138,148 L108,142 L77,145 L46,148 Z" fill="hsl(var(--c-chat) / .6)"/>
+                </g>
+
+                <!-- DeepSeek (base, largest) ~$5-$7 -->
+                <g class="e-tool" style="color:hsl(var(--c-tool))">
+                  <path d="M46,222 L77,216 L108,210 L138,216 L169,205 L200,202 L231,198 L261,210 L292,202 L323,193 L354,190 L384,196 L415,186 L446,178 L477,172 L507,178 L538,168 L569,165 L600,154 L630,152 L661,144 L692,136 L692,182 L661,121 L630,128 L600,128 L569,138 L538,140 L507,148 L477,144 L446,148 L415,154 L384,162 L354,158 L323,160 L292,168 L261,174 L231,165 L200,168 L169,170 L138,180 L108,175 L77,178 L46,182 Z" fill="hsl(var(--c-tool) / .65)"/>
+                </g>
+
+                <!-- Top contour line -->
+                <path class="spark" stroke="hsl(var(--text-sec))" stroke-opacity=".25" fill="none"
+                      d="M46,128 L77,125 L108,123 L138,127 L169,121 L200,118 L231,115 L261,123 L292,118 L323,112 L354,108 L384,110 L415,104 L446,99 L477,95 L507,98 L538,92 L569,90 L600,82 L630,80 L661,75 L692,70"/>
+
+                <!-- Budget daily line ($1200/30 = $40/d), but realistic cap ~$15/d for chart scope -> $15 = y 19.5; drawing budget ceiling at $15 -->
+                <line class="budget-line" x1="46" y1="19" x2="692" y2="19"/>
+                <text class="budget-lbl" x="688" y="14" text-anchor="end">budget cap · $40/d (off-scale)</text>
+
+                <!-- Annotation point: peak 12 mag -->
+                <circle cx="446" cy="99" r="3" fill="hsl(var(--c-event))"/>
+                <text class="ann" x="452" y="94">12 mag · $14.20 picco</text>
+              </svg>
+            </div>
+
+            <div class="chart-legend">
+              <span class="item e-tool"><span class="sw"></span>DeepSeek <span class="val">$162.18</span> <span class="pct">· 57.0%</span></span>
+              <span class="item e-chat"><span class="sw"></span>OpenRouter <span class="val">$78.94</span> <span class="pct">· 27.8%</span></span>
+              <span class="item e-toolkit"><span class="sw"></span>OpenAI <span class="val">$31.06</span> <span class="pct">· 10.9%</span></span>
+              <span class="item e-agent"><span class="sw"></span>Anthropic <span class="val">$12.16</span> <span class="pct">· 4.3%</span></span>
+              <span class="item" style="color:hsl(38 90% 50%);margin-left:auto"><span class="sw" style="background:transparent;border-top:2px dashed hsl(38 90% 50%);border-radius:0;height:0;width:14px"></span>budget cap $40/d</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ────────── 3) Costo per feature ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Costo per feature · 30 giorni</h3>
+            <span class="status-chip info">6 feature attive</span>
+            <div class="head-cluster">
+              <span class="meta">tot $284.34 · 6 feature · 48.3k richieste</span>
+              <button class="btn-admin sm ghost">⤓ Export</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:28%">Feature</th>
+                <th style="width:11%;text-align:right">Richieste</th>
+                <th style="width:11%;text-align:right">Token</th>
+                <th style="width:11%;text-align:right">Costo</th>
+                <th style="width:20%">% del totale</th>
+                <th style="width:130px;text-align:right">Trend 7g</th>
+                <th style="width:90px"></th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="e-chat">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">💬</div>
+                    <div class="feat-info"><span class="feat-name">Chat / RAG</span><span class="feat-sub">deepseek-chat · openrouter</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">28 144</td>
+                <td class="mono" style="text-align:right">1.24 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$148.92</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:52.4%"></i></div><span class="v">52.4%</span></div></td>
+                <td><span class="trend-cell up">▲ 12.4% <svg class="mini-spark e-chat" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,15 L10,14 L20,13 L30,11 L40,9 L50,7 L60,5"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+              <tr class="e-kb">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">🧩</div>
+                    <div class="feat-info"><span class="feat-name">Embedding</span><span class="feat-sub">bge-m3 (locale) + openai backup</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">142 880</td>
+                <td class="mono" style="text-align:right">2.86 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$62.18</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:21.9%"></i></div><span class="v">21.9%</span></div></td>
+                <td><span class="trend-cell flat">▬ +0.8% <svg class="mini-spark e-kb" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,11 L10,12 L20,10 L30,11 L40,10 L50,11 L60,10"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+              <tr class="e-tool">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">🎯</div>
+                    <div class="feat-info"><span class="feat-name">Reranking</span><span class="feat-sub">bge-reranker · top-50→8</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">26 408</td>
+                <td class="mono" style="text-align:right">0.32 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$28.40</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:10.0%"></i></div><span class="v">10.0%</span></div></td>
+                <td><span class="trend-cell up">▲ 4.1% <svg class="mini-spark e-tool" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,14 L10,13 L20,12 L30,12 L40,10 L50,9 L60,8"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">🧠</div>
+                    <div class="feat-info"><span class="feat-name">Mechanic Extractor</span><span class="feat-sub">claude-3.5-sonnet · per-game</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">812</td>
+                <td class="mono" style="text-align:right">0.41 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$22.84</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:8.0%"></i></div><span class="v">8.0%</span></div></td>
+                <td><span class="trend-cell up">▲ 28.2% <svg class="mini-spark e-agent" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,17 L10,15 L20,13 L30,12 L40,9 L50,7 L60,4"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+              <tr class="e-toolkit">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">👁️</div>
+                    <div class="feat-info"><span class="feat-name">Vision / OCR</span><span class="feat-sub">smoldocling + gpt-4o-mini fallback</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">3 244</td>
+                <td class="mono" style="text-align:right">0.18 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$15.06</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:5.3%"></i></div><span class="v">5.3%</span></div></td>
+                <td><span class="trend-cell down">▼ -6.7% <svg class="mini-spark e-toolkit" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,8 L10,9 L20,11 L30,10 L40,12 L50,13 L60,14"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+              <tr class="e-game">
+                <td>
+                  <div class="feat-cell">
+                    <div class="feat-mark">📚</div>
+                    <div class="feat-info"><span class="feat-name">Catalog enrichment</span><span class="feat-sub">BGG ingest · cron 02:00</span></div>
+                  </div>
+                </td>
+                <td class="mono" style="text-align:right">488</td>
+                <td class="mono" style="text-align:right">0.09 M</td>
+                <td class="mono" style="text-align:right;font-weight:700;color:var(--text)">$6.94</td>
+                <td><div class="pct-bar"><div class="bar"><i style="width:2.4%"></i></div><span class="v">2.4%</span></div></td>
+                <td><span class="trend-cell flat">▬ +1.2% <svg class="mini-spark e-game" viewBox="0 0 60 20"><path class="spark e-fg" d="M0,12 L10,11 L20,12 L30,11 L40,11 L50,10 L60,10"/></svg></span></td>
+                <td style="text-align:right"><button class="btn-admin sm ghost">↗ Dettaglio</button></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 4) Simulatore costo ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Simulatore costo</h3>
+            <span class="status-chip info">live recompute</span>
+            <div class="head-cluster">
+              <span class="meta">pricing snapshot · 22 mag 2026 · USD per 1M token</span>
+              <button class="btn-admin sm ghost">⤓ Esporta scenario</button>
+            </div>
+          </div>
+
+          <div class="sim-grid">
+            <div class="sim-form">
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Modello<span class="desc">Provider e tariffa input/output</span></span>
+                <div>
+                  <select class="admin-select">
+                    <option>deepseek-chat — $0.27 in · $1.10 out / 1M</option>
+                    <option>openai/gpt-4o-mini — $0.15 in · $0.60 out / 1M</option>
+                    <option>anthropic/claude-3.5-sonnet — $3.00 in · $15.00 out / 1M</option>
+                    <option>openrouter/auto — best-cost routing</option>
+                    <option>bge-m3 (embedding) — $0.05 / 1M token</option>
+                  </select>
+                  <div class="pricing-readout">
+                    <span><span class="k">Tariffa input</span> <span class="v">$0.27</span></span>
+                    <span><span class="k">Tariffa output</span> <span class="v">$1.10</span></span>
+                    <span><span class="k">Context max</span> <span class="v">64k</span></span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Richieste / giorno<span class="desc">Volume previsto per la feature</span></span>
+                <div class="row-inline">
+                  <input class="admin-input mono compact" value="1 200" />
+                  <span>req/d</span>
+                  <span style="color:var(--text-muted)">· stima a regime · </span>
+                  <span class="v">36 000 req/mese</span>
+                </div>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Token input medi<span class="desc">Prompt + RAG context per richiesta</span></span>
+                <div class="row-inline">
+                  <input class="admin-input mono compact" value="2 400" />
+                  <span>tok in</span>
+                  <span style="color:var(--text-muted)">· 2.88M tok/d</span>
+                </div>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Token output medi<span class="desc">Risposta generata stimata</span></span>
+                <div class="row-inline">
+                  <input class="admin-input mono compact" value="480" />
+                  <span>tok out</span>
+                  <span style="color:var(--text-muted)">· 576k tok/d</span>
+                </div>
+              </div>
+
+              <div class="admin-form-row" style="border-bottom:0">
+                <span class="admin-form-label">Cache-hit RAG<span class="desc">% richieste servite da cache</span></span>
+                <div class="row-inline">
+                  <input class="admin-input mono compact" value="35" />
+                  <span>%</span>
+                  <span style="color:var(--text-muted)">· risparmio</span>
+                  <span class="v" style="color:hsl(var(--c-toolkit))">−$13.04 / mese</span>
+                </div>
+              </div>
+
+            </div>
+
+            <div class="sim-readout">
+              <div>
+                <div class="label">Costo stimato · giornaliero</div>
+                <div class="big"><span class="cur">$</span>1.41<span class="unit">/ d</span></div>
+              </div>
+
+              <div class="alt-stack">
+                <div class="alt"><span class="k">Mensile (30g)</span><span class="v">$42.30</span></div>
+                <div class="alt"><span class="k">Annuale</span><span class="v">$514.65</span></div>
+                <div class="alt"><span class="k">Δ vs feature attuale (Chat/RAG)</span><span class="v diff-down">−71.6%</span></div>
+                <div class="alt"><span class="k">Δ vs gpt-4o-mini</span><span class="v diff-up">+32.4%</span></div>
+              </div>
+
+              <div class="impact"><span class="dot"></span>Impatto su budget mensile · <strong style="color:var(--text);margin:0 4px">3.5%</strong> di $1.200</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- ────────── 5) Alert proiezione vs budget ────────── -->
+        <div class="alert-banner warning">
+          <span class="em">📉</span>
+          <div style="flex:1">
+            <div class="title">Proiezione fine mese sotto budget</div>
+            <div style="line-height:1.55">Proiezione attuale <strong>$890</strong> contro budget di <strong>$1.200</strong> (74.2%, margine $310). Trend stabile · nessuna azione richiesta. Ti avviseremo se la proiezione supera il <strong>90%</strong> del budget.</div>
+          </div>
+          <div class="budget-banner-gauge">
+            <div class="bar"><i style="width:74.2%"></i></div>
+            <div class="ll"><span class="k">$0</span><span>$890 / $1.200 · 74.2%</span><span class="k">$1.200</span></div>
+          </div>
+          <div class="actions">
+            <button class="btn-admin sm ghost">🔔 Regola soglia</button>
+            <button class="btn-admin sm">＋ Edita budget</button>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('budget');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-catalog.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-catalog.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A6 · Admin Catalog Ingestion · /admin/catalog-ingestion</title>
+<!-- @v2 SyncStatusHero · SyncRunTimeline · LogStream -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .catalog-hero { background: linear-gradient(135deg, hsl(var(--c-toolkit) / .14), hsl(var(--c-game) / .08)); border: 1px solid hsl(var(--c-toolkit) / .25); border-radius: 12px; padding: 20px 24px; display: grid; grid-template-columns: 1fr 320px; gap: 24px; align-items: center; }
+  .catalog-hero h2 { margin: 0 0 6px; font-family: var(--f-display); font-size: 22px; font-weight: 800; display: flex; align-items: center; gap: 10px; }
+  .catalog-hero .stats { display: flex; gap: 20px; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 6px; flex-wrap: wrap; }
+  .catalog-hero .stat-val { color: var(--text); font-weight: 700; }
+  .catalog-controls { background: var(--bg-card); border-radius: 8px; padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+  .catalog-controls .sf-row { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+  .catalog-controls label { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase; min-width: 90px; }
+
+  .run-card { padding: 12px 14px; border-bottom: 1px solid var(--border-light); display: grid; grid-template-columns: 32px 1fr 90px 60px 60px 60px 24px; gap: 12px; align-items: center; font-size: 12px; }
+  .run-card:last-child { border-bottom: 0; }
+  .run-card .status-dot { width: 10px; height: 10px; border-radius: 50%; }
+  .run-card.success .status-dot { background: hsl(var(--c-toolkit)); }
+  .run-card.failed .status-dot { background: hsl(var(--c-event)); }
+  .run-card.running .status-dot { background: hsl(var(--c-kb)); animation: admin-pulse 2s infinite; }
+  .run-card .title { font-family: var(--f-display); font-weight: 700; }
+  .run-card .ts { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .run-card .num { font-family: var(--f-mono); text-align: right; font-weight: 700; }
+  .run-card .num.added { color: hsl(var(--c-toolkit)); }
+  .run-card .num.updated { color: hsl(var(--c-chat)); }
+  .run-card .num.failed { color: hsl(var(--c-event)); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Catalog ingestion</h1><div class="crumbs">Admin · Catalog · BoardGameGeek sync · last run 14 min fa</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">⤓ Export history</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="display: flex; flex-direction: column; gap: 16px;">
+
+      <div class="catalog-hero">
+        <div>
+          <h2>🔄 BGG Catalog Sync <span class="status-chip healthy" style="font-size: 11px">Idle</span></h2>
+          <div style="font-size: 13px; color: var(--text-sec); line-height: 1.5">Sincronizzazione automatica da BoardGameGeek API. Cron schedule ogni 6h.</div>
+          <div class="stats">
+            <span>Ultima sync: <span class="stat-val">14 min fa · 2026-05-24 14:08</span></span>
+            <span>Giochi importati totali: <span class="stat-val">4.812</span></span>
+            <span>Next scheduled: <span class="stat-val">17:08</span></span>
+            <span>Provider: <span class="stat-val">BGG API v2</span></span>
+          </div>
+        </div>
+        <div class="catalog-controls">
+          <div class="sf-row"><label>Provider</label><select class="admin-select"><option>BGG API v2</option><option>CSV import</option><option>Manual</option></select></div>
+          <div class="sf-row"><label>Batch size</label><input class="admin-input mono" value="100" style="max-width: 80px"></div>
+          <div class="sf-row"><label>Rate limit</label><input class="admin-input mono" value="60/min" style="max-width: 80px"></div>
+          <div class="sf-row"><label>Auto-retry</label><div class="admin-toggle on"></div></div>
+          <button class="btn-admin primary" style="margin-top: 6px">▶ Run sync now</button>
+        </div>
+      </div>
+
+      <div class="admin-panel">
+        <div class="admin-panel-head">
+          <h3>Sync history · ultime 12 run</h3>
+          <span class="meta" style="margin-left: auto">success rate 91.7%</span>
+        </div>
+        <div style="padding: 0">
+          <div class="run-card" style="background: var(--bg); font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700">
+            <div></div><div>Run</div><div style="text-align: right">Durata</div><div style="text-align: right">+add</div><div style="text-align: right">~upd</div><div style="text-align: right">✕fail</div><div></div>
+          </div>
+          <div class="run-card success">
+            <div class="status-dot"></div>
+            <div><div class="title">BGG full sync</div><div class="ts">2026-05-24 14:08 · cron · by system</div></div>
+            <div class="num">4m 18s</div>
+            <div class="num added">+12</div>
+            <div class="num updated">~847</div>
+            <div class="num failed">0</div>
+            <div>›</div>
+          </div>
+          <div class="run-card success">
+            <div class="status-dot"></div>
+            <div><div class="title">BGG full sync</div><div class="ts">2026-05-24 08:08 · cron</div></div>
+            <div class="num">3m 52s</div>
+            <div class="num added">+8</div>
+            <div class="num updated">~743</div>
+            <div class="num failed">0</div>
+            <div>›</div>
+          </div>
+          <div class="run-card failed" style="background: hsl(var(--c-event) / .04)">
+            <div class="status-dot"></div>
+            <div><div class="title">BGG full sync</div><div class="ts">2026-05-24 02:08 · cron · timeout BGG API</div></div>
+            <div class="num">6m 02s</div>
+            <div class="num added">+3</div>
+            <div class="num updated">~218</div>
+            <div class="num failed">14</div>
+            <div>›</div>
+          </div>
+          <div class="run-card success">
+            <div class="status-dot"></div>
+            <div><div class="title">Manual import · "Wingspan Antarctic"</div><div class="ts">2026-05-23 16:42 · by Aaron</div></div>
+            <div class="num">2.4s</div>
+            <div class="num added">+1</div>
+            <div class="num updated">~0</div>
+            <div class="num failed">0</div>
+            <div>›</div>
+          </div>
+          <div class="run-card success">
+            <div class="status-dot"></div>
+            <div><div class="title">BGG full sync</div><div class="ts">2026-05-23 14:08 · cron</div></div>
+            <div class="num">4m 02s</div>
+            <div class="num added">+14</div>
+            <div class="num updated">~912</div>
+            <div class="num failed">0</div>
+            <div>›</div>
+          </div>
+          <div class="run-card success">
+            <div class="status-dot"></div>
+            <div><div class="title">CSV bulk · designers-curation-v3.csv</div><div class="ts">2026-05-22 19:14 · by Marco · 142 rows</div></div>
+            <div class="num">8.4s</div>
+            <div class="num added">+142</div>
+            <div class="num updated">~0</div>
+            <div class="num failed">0</div>
+            <div>›</div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px">
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>⏳ Queue pending re-sync</h3><span class="meta" style="margin-left: auto">23 items</span></div>
+          <div style="padding: 12px 14px">
+            <div style="display: flex; flex-direction: column; gap: 8px; font-size: 12px">
+              <div style="display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px; background: var(--bg-muted)"><span>🎲</span><span style="flex:1">Tainted Grail FoA v2.1 errata</span><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">priority high</span></div>
+              <div style="display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px"><span>🎲</span><span style="flex:1">Spirit Island base game pricing</span><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">stale 30gg</span></div>
+              <div style="display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px"><span>🎲</span><span style="flex:1">Brass Birmingham reprint 2026</span><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">stale 30gg</span></div>
+              <div style="display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px"><span>🎲</span><span style="flex:1">Ark Nova marine errata</span><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">stale 24gg</span></div>
+              <div style="text-align: center; padding: 6px; color: var(--text-muted); font-family: var(--f-mono); font-size: 11px">+ 19 altri in queue</div>
+            </div>
+            <div style="margin-top: 12px; display: flex; gap: 6px"><button class="btn-admin sm">▶ Run pending now</button><button class="btn-admin sm">⏰ Schedule</button></div>
+          </div>
+        </div>
+
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>✕ Failed items (last 30gg)</h3><span class="meta" style="margin-left: auto">14 errori</span></div>
+          <div style="padding: 12px 14px">
+            <div style="display: flex; flex-direction: column; gap: 8px; font-size: 12px">
+              <div style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 6px; border-left: 3px solid hsl(var(--c-event)); background: hsl(var(--c-event) / .04)">
+                <span>🎲</span><div style="flex:1"><div style="font-weight: 700">Twilight Imperium 4E</div><div style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-event))">BGG_API_RATE_LIMIT_429 · 4 retry esauriti</div></div>
+                <button class="btn-admin sm">↻</button>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 6px; border-left: 3px solid hsl(var(--c-event)); background: hsl(var(--c-event) / .04)">
+                <span>🎲</span><div style="flex:1"><div style="font-weight: 700">Gloomhaven JOTL</div><div style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-event))">SCHEMA_MISMATCH · expected designers[]</div></div>
+                <button class="btn-admin sm">↻</button>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 6px; border-left: 3px solid hsl(var(--c-event)); background: hsl(var(--c-event) / .04)">
+                <span>🎲</span><div style="flex:1"><div style="font-weight: 700">+ 12 altri errori</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">vedi log completo</div></div>
+              </div>
+            </div>
+            <div style="margin-top: 12px; display: flex; gap: 6px"><button class="btn-admin sm">↻ Retry bulk</button><button class="btn-admin sm">⤓ Export errors</button></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('catalog');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-config.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-config.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A7 · Admin Config / Flags · /admin/config</title>
+<!-- @v2 ConfigSection · FlagRow · DirtyStateBar -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .flag-row { display: grid; grid-template-columns: 1fr 160px 120px 110px; gap: 12px; align-items: center; padding: 12px 14px; border-bottom: 1px solid var(--border-light); font-size: 12.5px; }
+  .flag-row:last-child { border-bottom: 0; }
+  .flag-row .flag-name { font-family: var(--f-mono); font-size: 12px; font-weight: 700; }
+  .flag-row .flag-desc { font-family: var(--f-body); font-size: 11.5px; color: var(--text-muted); margin-top: 2px; line-height: 1.4; }
+  .flag-row.dirty { background: hsl(38 90% 56% / .06); border-left: 3px solid hsl(38 90% 50%); padding-left: 11px; }
+  .env-pill { display: inline-flex; padding: 1px 6px; border-radius: 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+  .env-pill.dev { background: var(--bg-muted); color: var(--text-muted); }
+  .env-pill.stg { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+  .env-pill.prd { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+  .dirty-bar {
+    position: sticky; bottom: 0;
+    background: hsl(38 90% 56% / .14);
+    border-top: 2px solid hsl(38 90% 50%);
+    padding: 12px 24px;
+    display: flex; align-items: center; gap: 12px;
+    z-index: 40;
+    backdrop-filter: blur(12px);
+  }
+  .dirty-bar .count { font-family: var(--f-display); font-weight: 800; color: hsl(38 90% 40%); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Config / Feature flags</h1><div class="crumbs">Admin · Config · 47 flags · 3 unsaved changes</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <span class="filter-chip active">env: prd <span class="x">▾</span></span>
+        <button class="btn-admin">📜 Audit log</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="padding-bottom: 80px">
+
+      <div class="admin-tabs">
+        <button class="admin-tab active">⚙️ General</button>
+        <button class="admin-tab">🚩 Features <span class="count">14</span></button>
+        <button class="admin-tab">🤖 AI <span class="count">8</span></button>
+        <button class="admin-tab">🔗 Integrations <span class="count">12</span></button>
+        <button class="admin-tab">🔒 Security <span class="count">9</span></button>
+      </div>
+
+      <div class="admin-panel">
+        <div class="admin-panel-head"><h3>Features runtime</h3><span class="meta" style="margin-left: auto">last changed by Aaron 2h fa</span></div>
+        <div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.PdfUpload</div>
+              <div class="flag-desc">Abilita upload PDF utente nella library personale (post-acquisizione gioco)</div>
+            </div>
+            <div class="env-pill prd">prd</div>
+            <div class="admin-toggle on" role="switch" aria-checked="true"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">updated<br/>2026-05-12 · Aaron</div>
+          </div>
+
+          <div class="flag-row dirty">
+            <div>
+              <div class="flag-name">Features.AlphaMode</div>
+              <div class="flag-desc">Sblocca UI alpha (nuovo agent builder, librogame v2, RAG hybrid v3) per gli utenti beta</div>
+            </div>
+            <div style="display: flex; gap: 4px">
+              <span class="env-pill dev">dev</span><span class="env-pill stg">stg</span><span class="env-pill prd">prd</span>
+            </div>
+            <div class="admin-toggle on" role="switch" aria-checked="true"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: hsl(38 90% 50%); text-align: right; font-weight: 700">UNSAVED<br/>was OFF</div>
+          </div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.HouseRuleDrawer</div>
+              <div class="flag-desc">Drawer per definire house-rule quando l'agente risponde con low-confidence (&lt;0.5)</div>
+            </div>
+            <div class="env-pill prd">prd</div>
+            <div class="admin-toggle on" role="switch" aria-checked="true"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">updated<br/>2026-04-28</div>
+          </div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.SsestreamingV2</div>
+              <div class="flag-desc">Server-Sent Events v2 con auto-reconnect e back-pressure handling per chat agent</div>
+            </div>
+            <div style="display: flex; gap: 4px">
+              <span class="env-pill stg">stg</span>
+            </div>
+            <div class="admin-toggle on"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">stg-only<br/>canary 20%</div>
+          </div>
+
+          <div class="flag-row dirty">
+            <div>
+              <div class="flag-name">Features.GameNightLiveV2</div>
+              <div class="flag-desc">UI multi-tavolo per Game Night con quick-jump tra session attive contemporanee</div>
+            </div>
+            <div class="env-pill prd">prd</div>
+            <div class="admin-toggle on"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: hsl(38 90% 50%); text-align: right; font-weight: 700">UNSAVED<br/>was OFF</div>
+          </div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.LibrogameBeta</div>
+              <div class="flag-desc">Modalità gamebook AI (foto manuale → OCR → Q&amp;A) — limited release</div>
+            </div>
+            <div class="env-pill stg">stg</div>
+            <div class="admin-toggle on"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">cohort:<br/>beta-12</div>
+          </div>
+
+          <div class="flag-row dirty">
+            <div>
+              <div class="flag-name">Features.NewOnboardingV3</div>
+              <div class="flag-desc">Onboarding rifatto con persona-picker + tour interattivo (vs. checklist statica)</div>
+            </div>
+            <div class="env-pill prd">prd</div>
+            <div class="admin-toggle"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: hsl(38 90% 50%); text-align: right; font-weight: 700">UNSAVED<br/>was ON</div>
+          </div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.SharedToolkitMarketplace</div>
+              <div class="flag-desc">Marketplace toolkit community con install + rating + reporting (placeholder per Q3)</div>
+            </div>
+            <div class="env-pill dev">dev</div>
+            <div class="admin-toggle"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">dev-only<br/>WIP</div>
+          </div>
+
+          <div class="flag-row">
+            <div>
+              <div class="flag-name">Features.AdminImpersonate</div>
+              <div class="flag-desc">Superadmin può aprire sessione utente in lettura (audit log full trace)</div>
+            </div>
+            <div class="env-pill prd">prd</div>
+            <div class="admin-toggle on"></div>
+            <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-align: right">updated<br/>2025-11-08</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Dirty state bar -->
+    <div class="dirty-bar">
+      <span class="em">⚠️</span>
+      <span><span class="count">3 modifiche non salvate</span> · richiesto deploy in prod</span>
+      <div style="margin-left: auto; display: flex; gap: 8px">
+        <button class="btn-admin">↩ Revert</button>
+        <button class="btn-admin">👁 Preview diff</button>
+        <button class="btn-admin primary">✓ Apply changes</button>
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('config');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-content.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-content.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A3 · Admin Content · /admin/content</title>
+<!-- @v2 ModerationQueue · ContentStatusChip · AdminDataTable (reuse) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .content-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+  .game-cover { width: 36px; height: 36px; border-radius: 6px; display: grid; place-items: center; font-size: 18px; }
+  .mod-row { display: grid; grid-template-columns: 36px 1fr 100px 90px 70px 120px; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border-light); align-items: center; }
+  .mod-row:hover { background: var(--bg-muted); }
+  .flagged { font-size: 12px; }
+  .flag-reason { font-family: var(--f-mono); font-size: 10px; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+  .comment-card { background: var(--bg); border: 1px solid var(--border-light); border-left: 3px solid hsl(var(--c-event)); border-radius: 6px; padding: 12px; margin-bottom: 8px; font-size: 12.5px; }
+  .comment-card .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-bottom: 4px; }
+  .comment-card .body { line-height: 1.5; color: var(--text); }
+  .comment-card .actions { display: flex; gap: 6px; margin-top: 8px; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2><p>Moderazione contenuti richiede desktop.</p></div>
+
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <header class="admin-top">
+      <div><h1>Content moderation</h1><div class="crumbs">Admin · Content · 14 in queue · 3 flag aperti</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Cerca content…"><kbd>⌘K</kbd></div>
+        <button class="btn-admin">⤓ Export queue</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+
+      <div class="admin-tabs">
+        <button class="admin-tab active">🎲 Games <span class="count">8</span></button>
+        <button class="admin-tab">🧰 Toolkit condivisi <span class="count">4</span></button>
+        <button class="admin-tab">📚 KB docs <span class="count">2</span></button>
+        <button class="admin-tab">💬 Comments flagged <span class="count">3</span></button>
+      </div>
+
+      <!-- Filters -->
+      <div style="display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap">
+        <span class="filter-chip active">Status: in review <span class="x">▾</span></span>
+        <span class="filter-chip">Year: tutti <span class="x">▾</span></span>
+        <span class="filter-chip">Designer: tutti <span class="x">▾</span></span>
+        <span class="filter-chip">Rating BGG ≥ 7.0 <span class="x">▾</span></span>
+        <span class="filter-chip">+ Filtro</span>
+      </div>
+
+      <!-- Games moderation queue -->
+      <div class="content-card">
+        <div class="admin-panel-head">
+          <h3>Queue moderazione · 8 giochi in attesa</h3>
+          <div style="margin-left: auto; display: flex; gap: 6px">
+            <button class="btn-admin sm">✓ Approve all</button>
+            <button class="btn-admin sm danger">✕ Reject all</button>
+          </div>
+        </div>
+
+        <div class="mod-row" style="background: var(--bg); font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700">
+          <div></div><div>Gioco</div><div>Submitted</div><div>Designer</div><div>Rating</div><div>Status</div>
+        </div>
+
+        <div class="mod-row">
+          <div class="game-cover" style="background: linear-gradient(135deg, hsl(28, 84%, 55%), hsl(28, 84%, 35%))">🦅</div>
+          <div>
+            <div style="font-family: var(--f-display); font-weight: 700; font-size: 13px">Wingspan: Antarctic Birds</div>
+            <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)"><code>g-wingspan-antarctic</code> · expansion · 2026 · 30-50min</div>
+            <div style="margin-top: 4px; display: flex; gap: 6px; align-items: center">
+              <span class="role-chip user">submitted by Elena Parisi</span>
+              <span class="flag-reason">⚠ 1 chunk parsing failed</span>
+            </div>
+          </div>
+          <div style="font-family: var(--f-mono); font-size: 11px">2026-05-22<br/><span style="color: var(--text-muted)">2gg fa</span></div>
+          <div style="font-family: var(--f-display); font-size: 12px">Elizabeth<br/>Hargrave</div>
+          <div style="font-family: var(--f-mono); font-size: 13px; font-weight: 700; color: hsl(var(--c-toolkit))">8.2 ★</div>
+          <div style="display: flex; gap: 4px">
+            <button class="btn-admin sm" title="Preview">👁</button>
+            <button class="btn-admin sm success" title="Approve">✓</button>
+            <button class="btn-admin sm danger" title="Reject">✕</button>
+            <button class="btn-admin sm" title="Request changes">✎</button>
+          </div>
+        </div>
+
+        <div class="mod-row">
+          <div class="game-cover" style="background: linear-gradient(135deg, hsl(348, 78%, 52%), hsl(348, 78%, 32%))">🏰</div>
+          <div>
+            <div style="font-family: var(--f-display); font-weight: 700; font-size: 13px">Brass: Lancashire Reborn</div>
+            <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)"><code>g-brass-lancashire-r</code> · standalone · 2026 · 60-120min</div>
+          </div>
+          <div style="font-family: var(--f-mono); font-size: 11px">2026-05-20<br/><span style="color: var(--text-muted)">4gg fa</span></div>
+          <div style="font-family: var(--f-display); font-size: 12px">Martin<br/>Wallace</div>
+          <div style="font-family: var(--f-mono); font-size: 13px; font-weight: 700; color: hsl(var(--c-toolkit))">8.7 ★</div>
+          <div style="display: flex; gap: 4px">
+            <button class="btn-admin sm">👁</button>
+            <button class="btn-admin sm success">✓</button>
+            <button class="btn-admin sm danger">✕</button>
+            <button class="btn-admin sm">✎</button>
+          </div>
+        </div>
+
+        <div class="mod-row">
+          <div class="game-cover" style="background: linear-gradient(135deg, hsl(235, 64%, 56%), hsl(262, 83%, 58%))">🌌</div>
+          <div>
+            <div style="font-family: var(--f-display); font-weight: 700; font-size: 13px">Spirit Island: Branch &amp; Claw</div>
+            <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)"><code>g-spirit-branch-claw</code> · expansion · 2026 · 90-120min</div>
+            <div style="margin-top: 4px"><span class="flag-reason">⚠ duplicate? matches g-spirit-bc-old al 87%</span></div>
+          </div>
+          <div style="font-family: var(--f-mono); font-size: 11px">2026-05-18<br/><span style="color: var(--text-muted)">6gg fa</span></div>
+          <div style="font-family: var(--f-display); font-size: 12px">R. Eric<br/>Reuss</div>
+          <div style="font-family: var(--f-mono); font-size: 13px; font-weight: 700; color: hsl(var(--c-toolkit))">8.6 ★</div>
+          <div style="display: flex; gap: 4px">
+            <button class="btn-admin sm">👁</button>
+            <button class="btn-admin sm success">✓</button>
+            <button class="btn-admin sm danger">✕</button>
+            <button class="btn-admin sm">✎</button>
+          </div>
+        </div>
+
+        <div class="mod-row">
+          <div class="game-cover" style="background: linear-gradient(135deg, hsl(168, 60%, 38%), hsl(142, 54%, 42%))">🦖</div>
+          <div>
+            <div style="font-family: var(--f-display); font-weight: 700; font-size: 13px">Ark Nova: Marine Worlds</div>
+            <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)"><code>g-ark-nova-marine</code> · expansion · 2026 · 90-150min</div>
+          </div>
+          <div style="font-family: var(--f-mono); font-size: 11px">2026-05-15<br/><span style="color: var(--text-muted)">9gg fa</span></div>
+          <div style="font-family: var(--f-display); font-size: 12px">Mathias<br/>Wigge</div>
+          <div style="font-family: var(--f-mono); font-size: 13px; font-weight: 700; color: hsl(var(--c-toolkit))">8.4 ★</div>
+          <div style="display: flex; gap: 4px">
+            <button class="btn-admin sm">👁</button>
+            <button class="btn-admin sm success">✓</button>
+            <button class="btn-admin sm danger">✕</button>
+            <button class="btn-admin sm">✎</button>
+          </div>
+        </div>
+
+        <div class="mod-row">
+          <div class="game-cover" style="background: var(--bg-muted); color: var(--text-muted)">+4</div>
+          <div style="color: var(--text-muted); font-family: var(--f-display); font-size: 12px">Altri 4 giochi in coda — scroll per vedere</div>
+          <div></div><div></div><div></div><div></div>
+        </div>
+      </div>
+
+      <!-- Comments flagged section (compact) -->
+      <div class="content-card" style="margin-top: 14px">
+        <div class="admin-panel-head">
+          <h3>💬 Commenti segnalati · 3 in queue</h3>
+          <span class="meta" style="margin-left: auto">ultime 48h</span>
+        </div>
+        <div style="padding: 14px">
+          <div class="comment-card">
+            <div class="meta">
+              <strong style="color: var(--text-sec); font-family: var(--f-display)">"Anonimo73"</strong> su <strong style="color: hsl(var(--c-game))">Spirit Island Branch &amp; Claw</strong> · 2026-05-23 19:18 · 🚩 segnalato 4 volte (spam + offensivo)
+            </div>
+            <div class="body">"questo gioco è una sòla! perché lo recensite [REDACTED] è solo riciclato come tutti i giochi made by Stonemaier, andate tutti a [REDACTED]…"</div>
+            <div class="actions">
+              <button class="btn-admin sm success">✓ Approva</button>
+              <button class="btn-admin sm danger">🗑 Rimuovi</button>
+              <button class="btn-admin sm">🔇 Mute autore 7gg</button>
+              <button class="btn-admin sm danger">🚫 Ban autore</button>
+              <button class="btn-admin sm ghost">📋 Copia per report</button>
+            </div>
+          </div>
+
+          <div class="comment-card">
+            <div class="meta">
+              <strong style="color: var(--text-sec); font-family: var(--f-display)">"MarcoSpolverini"</strong> su <strong style="color: hsl(var(--c-game))">Brass Birmingham</strong> · 2026-05-23 11:42 · 🚩 segnalato 2 volte (off-topic + auto-promo)
+            </div>
+            <div class="body">"Per chi vuole imparare Brass, ho fatto un corso completo su Twitch ogni martedì sera, link in bio @MarcoSpolverini, costo 19€/mese ma sconto del 30% se usate il codice…"</div>
+            <div class="actions">
+              <button class="btn-admin sm success">✓ Approva</button>
+              <button class="btn-admin sm danger">🗑 Rimuovi</button>
+              <button class="btn-admin sm">🔇 Mute autore 7gg</button>
+              <button class="btn-admin sm danger">🚫 Ban autore</button>
+            </div>
+          </div>
+
+          <div class="comment-card" style="border-left-color: hsl(38 90% 50%)">
+            <div class="meta">
+              <strong style="color: var(--text-sec); font-family: var(--f-display)">"FedericoVR"</strong> su <strong style="color: hsl(var(--c-game))">Tainted Grail FoA</strong> · 2026-05-22 22:34 · 🚩 segnalato 1 volta (spoiler)
+            </div>
+            <div class="body">"ATTENZIONE SPOILER finale del Capitolo 12: il personaggio di [SPOILER] viene tradito da [SPOILER] alla scena dell'altare e poi…"</div>
+            <div class="actions">
+              <button class="btn-admin sm success">✓ Approva con spoiler-tag</button>
+              <button class="btn-admin sm danger">🗑 Rimuovi</button>
+              <button class="btn-admin sm">✎ Edit spoiler block</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script><script>renderAdminNav('content');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-database-sync.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-database-sync.html
@@ -1,0 +1,532 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Database Sync &amp; Staging Access · MeepleAI Admin</title>
+<!-- C2 · Platform & Operations → 'database-sync' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 SyncStatusHero · ConfirmModal · TypedConfirm · AllowlistTable reuse
+     Endpoints: GET/POST /api/v1/admin/database-sync
+                GET/POST/DELETE /api/v1/admin/staging-allowlist
+     Role: superadmin only -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+
+/* ── components.css (subset) ────────────────────────────────────── */
+.e-chip{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:var(--r-sm);background:hsl(var(--e)/.12);color:hsl(var(--e));font-size:var(--fs-xs);font-weight:var(--fw-bold);font-family:var(--f-display);text-transform:uppercase;letter-spacing:.04em}
+.e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-shell-3col{display:grid;grid-template-columns:240px 1fr 360px;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table th.sort-asc::after{content:' ↑';color:hsl(var(--c-event))}
+.admin-table th.sort-desc::after{content:' ↓';color:hsl(var(--c-event))}
+.admin-table td{padding:8px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table tr.selected td{background:hsl(var(--c-event)/.06)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.admin-form-row{display:grid;grid-template-columns:200px 1fr;gap:16px;align-items:flex-start;padding:12px 0;border-bottom:1px solid var(--border-light)}
+.admin-form-row:last-child{border-bottom:0}
+.admin-form-label{font-family:var(--f-display);font-size:12.5px;font-weight:700}
+.admin-form-label .desc{display:block;margin-top:3px;font-family:var(--f-body);font-size:11px;font-weight:400;color:var(--text-muted);line-height:1.4}
+.admin-input,.admin-select,.admin-textarea{width:100%;max-width:360px;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.alert-banner{display:flex;align-items:flex-start;gap:12px;padding:12px 14px;border-radius:8px;font-size:12.5px}
+.alert-banner.warning{background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.35);color:var(--text)}
+.alert-banner.danger{background:hsl(var(--c-event)/.08);border:1px solid hsl(var(--c-event)/.35);color:var(--text)}
+.alert-banner.info{background:hsl(var(--c-chat)/.08);border:1px solid hsl(var(--c-chat)/.3);color:var(--text)}
+.alert-banner.success{background:hsl(var(--c-toolkit)/.08);border:1px solid hsl(var(--c-toolkit)/.3);color:var(--text)}
+.alert-banner .em{font-size:18px;flex-shrink:0}
+.alert-banner .title{font-family:var(--f-display);font-weight:800;margin-bottom:2px;font-size:13px}
+.alert-banner .actions{margin-left:auto;display:flex;gap:6px}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell,.admin-shell-3col{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}.admin-body-grid{display:grid;gap:16px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.head-cluster{display:inline-flex;align-items:center;gap:8px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* ── SyncStatusHero ─────────────────────────────────────────────── */
+.sync-hero{padding:18px 20px;display:grid;grid-template-columns:1.05fr 1fr;gap:24px;align-items:stretch;border-left:3px solid hsl(var(--c-session))}
+.sync-hero-left{display:flex;flex-direction:column;gap:14px}
+.sync-hero-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.sync-hero-head h2{font-family:var(--f-display);font-size:18px;font-weight:800;letter-spacing:-.01em}
+.sync-hero-head .tunnel-name{font-family:var(--f-mono);font-size:12px;color:hsl(var(--c-session));background:hsl(var(--c-session)/.1);padding:2px 8px;border-radius:6px;font-weight:700}
+.sync-hero-sub{color:var(--text-sec);font-size:12.5px;line-height:1.5;max-width:520px}
+
+.envline{display:flex;align-items:center;gap:12px;padding:14px 16px;background:var(--bg);border:1px solid var(--border-light);border-radius:10px}
+.env-box{display:flex;flex-direction:column;gap:4px;flex:1;min-width:0}
+.env-box .lbl{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+.env-box .name{font-family:var(--f-display);font-weight:800;font-size:15px;color:var(--text);display:inline-flex;align-items:center;gap:8px}
+.env-box .name .e-dot{box-shadow:0 0 0 3px hsl(var(--e)/.18)}
+.env-box .host{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted)}
+.env-arrow{flex-shrink:0;display:flex;flex-direction:column;align-items:center;gap:4px;color:hsl(var(--c-session))}
+.env-arrow .glyph{font-family:var(--f-mono);font-size:22px;font-weight:700;line-height:1;letter-spacing:-.04em}
+.env-arrow .label{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+
+.sync-hero-actions{display:flex;flex-direction:column;align-items:flex-end;gap:10px}
+.sync-actions-row{display:flex;gap:8px;align-items:center;flex-wrap:wrap;justify-content:flex-end}
+.typed-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.typed-note .lock{color:hsl(var(--c-event))}
+
+.sync-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.sync-stat{background:var(--bg);border:1px solid var(--border-light);border-radius:8px;padding:10px 12px;display:flex;flex-direction:column;gap:4px;min-height:74px}
+.sync-stat .lbl{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700}
+.sync-stat .val{font-family:var(--f-display);font-size:18px;font-weight:800;color:var(--text);font-variant-numeric:tabular-nums;line-height:1.15}
+.sync-stat .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.sync-stat.session{border-left:2px solid hsl(var(--c-session))}
+
+/* tunnel readout line */
+.tunnel-readout{display:flex;gap:14px;flex-wrap:wrap;align-items:center;padding-top:2px;color:var(--text-sec);font-family:var(--f-mono);font-size:11px}
+.tunnel-readout .seg{display:inline-flex;align-items:center;gap:6px}
+.tunnel-readout .k{color:var(--text-muted)}
+.tunnel-readout .v{color:var(--text);font-weight:600}
+
+/* ── Direzione cell ─────────────────────────────────────────────── */
+.dir-cell{display:inline-flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:11px;font-weight:700}
+.dir-cell .env{padding:1px 7px;border-radius:4px;background:hsl(var(--c-session)/.1);color:hsl(var(--c-session));letter-spacing:.02em}
+.dir-cell .env.prod{background:hsl(var(--c-event)/.1);color:hsl(var(--c-event))}
+.dir-cell .arrow{color:var(--text-muted)}
+
+/* ── Allowlist form inline ──────────────────────────────────────── */
+.allow-form{display:flex;align-items:center;gap:8px;padding:10px 14px;background:var(--bg);border-bottom:1px solid var(--border-light)}
+.allow-form .admin-input{max-width:none;flex:1;font-family:var(--f-mono);font-size:12px}
+.allow-form .admin-select{max-width:none;width:140px;flex-shrink:0}
+.allow-form label{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;margin-right:2px}
+
+.id-cell{font-family:var(--f-mono);font-size:12px;color:var(--text);font-weight:600}
+.id-cell .at{color:var(--text-muted)}
+
+/* Row actions */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Database Sync &amp; Staging Access</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Database Sync · aggiornato 14:23:08 · <span style="color:hsl(var(--c-event));font-weight:700">superadmin</span></div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca run, email, IP…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) SyncStatusHero ────────── -->
+        <section class="admin-panel">
+          <div class="sync-hero">
+
+            <!-- LEFT: tunnel name + env line + readout -->
+            <div class="sync-hero-left">
+              <div class="sync-hero-head">
+                <h2>Sync tunnel</h2>
+                <span class="tunnel-name">meepleai-staging</span>
+                <span class="status-chip healthy">tunnel up</span>
+              </div>
+
+              <div class="envline">
+                <div class="env-box e-event">
+                  <span class="lbl">Source</span>
+                  <span class="name"><span class="e-dot"></span>production</span>
+                  <span class="host">db-prod-01.fra · postgres:16.3</span>
+                </div>
+                <div class="env-arrow">
+                  <span class="glyph">→</span>
+                  <span class="label">last direction</span>
+                </div>
+                <div class="env-box e-session">
+                  <span class="lbl">Target</span>
+                  <span class="name"><span class="e-dot"></span>staging</span>
+                  <span class="host">db-stg-01.fra · postgres:16.3</span>
+                </div>
+              </div>
+
+              <div class="tunnel-readout">
+                <span class="seg"><span class="k">ssh</span><span class="v">bastion-prod.meepleai.io:2222</span></span>
+                <span class="seg"><span class="k">key</span><span class="v">ed25519/SHA256:7Hf2…BqRk</span></span>
+                <span class="seg"><span class="k">latency</span><span class="v">38 ms</span></span>
+                <span class="seg"><span class="k">since</span><span class="v">2026-05-20 09:14</span></span>
+              </div>
+            </div>
+
+            <!-- RIGHT: actions + stat grid -->
+            <div class="sync-hero-actions">
+              <div class="sync-actions-row">
+                <button class="btn-admin">🔌 Test tunnel</button>
+                <button class="btn-admin primary">▶ Avvia sync ora</button>
+                <button class="btn-admin danger" title="Richiede typed-confirm: sovrascrive dati staging">⤓ Sync prod → staging</button>
+              </div>
+              <span class="typed-note"><span class="lock">🔒</span> typed-confirm · sovrascrive dati staging</span>
+
+              <div class="sync-stats" style="width:100%;margin-top:6px">
+                <div class="sync-stat session">
+                  <span class="lbl">Ultimo sync</span>
+                  <span class="val">03:14</span>
+                  <span class="sub">oggi · 12 482 righe</span>
+                </div>
+                <div class="sync-stat session">
+                  <span class="lbl">Durata</span>
+                  <span class="val">4m 12s</span>
+                  <span class="sub">3.2 GB · 0 conflitti</span>
+                </div>
+                <div class="sync-stat session">
+                  <span class="lbl">Prossimo run</span>
+                  <span class="val">03:14</span>
+                  <span class="sub">domani · cron 14 3 * * *</span>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+        <!-- ────────── 2) Storico sync ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Storico sync</h3>
+            <span class="status-chip running">1 running</span>
+            <div class="head-cluster">
+              <span class="meta">ultimi 30 run · success 96.7%</span>
+              <button class="btn-admin sm ghost">⤓ Export CSV</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:140px">Run</th>
+                <th style="width:180px">Direzione</th>
+                <th style="width:110px;text-align:right">Righe</th>
+                <th style="width:130px">Stato</th>
+                <th style="width:110px;text-align:right">Durata</th>
+                <th>Avviato da</th>
+                <th style="width:150px">Quando</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8f2c1</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right;color:var(--text-muted)">8 642 / 12.4k</td>
+                <td><span class="status-chip running">running · 64%</span></td>
+                <td class="mono" style="text-align:right">2m 38s</td>
+                <td>aaron@meepleai.app <span class="role-chip" style="font-family:var(--f-mono);font-size:9px;background:hsl(var(--c-event)/.12);color:hsl(var(--c-event));padding:1px 6px;border-radius:99px;margin-left:4px;font-weight:700">SUPERADMIN</span></td>
+                <td class="mono">14:20:30</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8f1ed</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right">12 482</td>
+                <td><span class="status-chip healthy">success</span></td>
+                <td class="mono" style="text-align:right">4m 12s</td>
+                <td>cron · scheduled</td>
+                <td class="mono">oggi 03:14:02</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8f0b4</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right">12 388</td>
+                <td><span class="status-chip healthy">success</span></td>
+                <td class="mono" style="text-align:right">4m 06s</td>
+                <td>cron · scheduled</td>
+                <td class="mono">ieri 03:14:01</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8ee92</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right">12 287</td>
+                <td><span class="status-chip warning">partial · 8 skipped</span></td>
+                <td class="mono" style="text-align:right">4m 41s</td>
+                <td>cron · scheduled</td>
+                <td class="mono">22 mag 03:14</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8ed05</span></td>
+                <td><span class="dir-cell"><span class="env">staging</span><span class="arrow">→</span><span class="env prod">prod</span></span></td>
+                <td class="mono" style="text-align:right">312</td>
+                <td><span class="status-chip healthy">success</span></td>
+                <td class="mono" style="text-align:right">0m 38s</td>
+                <td>aaron@meepleai.app</td>
+                <td class="mono">21 mag 17:42</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8ec71</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right">0</td>
+                <td><span class="status-chip danger">failed · ssh refused</span></td>
+                <td class="mono" style="text-align:right">0m 04s</td>
+                <td>cron · scheduled</td>
+                <td class="mono">21 mag 03:14</td>
+              </tr>
+
+              <tr>
+                <td><span class="mono" style="color:hsl(var(--c-session));font-weight:700">run_a8eb19</span></td>
+                <td><span class="dir-cell"><span class="env prod">prod</span><span class="arrow">→</span><span class="env">staging</span></span></td>
+                <td class="mono" style="text-align:right">12 104</td>
+                <td><span class="status-chip healthy">success</span></td>
+                <td class="mono" style="text-align:right">3m 58s</td>
+                <td>cron · scheduled</td>
+                <td class="mono">20 mag 03:14</td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Staging allowlist ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Staging allowlist</h3>
+            <span class="status-chip info">8 entries · 5 email · 3 IP</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Rimuovi → richiede conferma</span>
+              <span class="sep"></span>
+              <span class="meta">stg.meepleai.app · ACL rev 14</span>
+            </div>
+          </div>
+
+          <div class="allow-form">
+            <label>Aggiungi</label>
+            <input class="admin-input mono" placeholder="qa-new@meepleai.app  ·  82.49.117.42  ·  192.168.10.0/24" />
+            <select class="admin-select">
+              <option>Email</option>
+              <option>IP singolo</option>
+              <option>CIDR /24</option>
+              <option>CIDR /16</option>
+            </select>
+            <select class="admin-select" style="width:160px">
+              <option>Scadenza · mai</option>
+              <option>7 giorni</option>
+              <option>30 giorni</option>
+              <option>Custom…</option>
+            </select>
+            <button class="btn-admin primary">＋ Aggiungi</button>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:34%">Identità</th>
+                <th style="width:14%">Tipo</th>
+                <th>Aggiunto da</th>
+                <th style="width:160px">Data</th>
+                <th style="width:140px">Scadenza</th>
+                <th style="width:120px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr>
+                <td><span class="id-cell">qa@meepleai.app</span></td>
+                <td><span class="status-chip info">email</span></td>
+                <td>aaron@meepleai.app</td>
+                <td class="mono">2025-11-04 09:12</td>
+                <td class="mono" style="color:var(--text-muted)">—</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+              <tr>
+                <td><span class="id-cell">aaron@meepleai.app</span></td>
+                <td><span class="status-chip info">email</span></td>
+                <td>system · bootstrap</td>
+                <td class="mono">2025-08-01 00:00</td>
+                <td class="mono" style="color:var(--text-muted)">—</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+              <tr>
+                <td><span class="id-cell">marco.rossi@meepleai.app</span></td>
+                <td><span class="status-chip info">email</span></td>
+                <td>aaron@meepleai.app</td>
+                <td class="mono">2026-02-18 14:30</td>
+                <td class="mono" style="color:hsl(38 90% 50%)">7 giorni · 4g rim.</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+              <tr>
+                <td><span class="id-cell">82.49.117.42</span></td>
+                <td><span class="status-chip info">ip</span></td>
+                <td>aaron@meepleai.app</td>
+                <td class="mono">2026-04-22 11:08</td>
+                <td class="mono" style="color:var(--text-muted)">—</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+              <tr>
+                <td><span class="id-cell">82.49.117.0<span class="at">/24</span></span></td>
+                <td><span class="status-chip info">cidr</span></td>
+                <td>aaron@meepleai.app</td>
+                <td class="mono">2026-04-22 11:09</td>
+                <td class="mono" style="color:var(--text-muted)">—</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+              <tr>
+                <td><span class="id-cell">contractor.qa@partner.io</span></td>
+                <td><span class="status-chip info">email</span></td>
+                <td>marco.rossi@meepleai.app</td>
+                <td class="mono">2026-05-19 16:44</td>
+                <td class="mono" style="color:hsl(38 90% 50%)">30 giorni · 26g rim.</td>
+                <td><div class="row-actions"><button class="btn-admin sm danger">🗑 Rimuovi</button></div></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 4) Audit-log alert ────────── -->
+        <div class="alert-banner warning">
+          <span class="em">⚠️</span>
+          <div>
+            <div class="title">Audit-log attivo</div>
+            <div>Tutti i sync e le modifiche all'allowlist (aggiunte, rimozioni, scadenze) sono <strong>audit-logged</strong> con email, IP di origine e timestamp UTC. Le voci non sono modificabili e vengono conservate per 365 giorni in <code style="font-family:var(--f-mono);background:var(--bg-muted);padding:1px 5px;border-radius:4px">audit.events</code>.</div>
+          </div>
+          <div class="actions">
+            <button class="btn-admin sm ghost">📜 Apri audit log</button>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('database-sync');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-emergency.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-emergency.html
@@ -1,0 +1,547 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>LLM Emergency Controls · MeepleAI Admin</title>
+<!-- C4 · Platform & Operations → 'emergency' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 KillSwitchGrid · OneShotActionRow · DangerZone · TypedConfirm · StepUp2FA · AuditLog reuse
+     Endpoints: POST /api/v1/admin/llm/emergency/*, /admin/service-call
+                POST /api/v1/admin/system/{cache-flush|rate-limit-reset|shutdown}
+     Role: superadmin + step-up 2FA -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.danger:hover{background:hsl(var(--c-event)/.08)}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.admin-toggle{position:relative;width:36px;height:20px;background:var(--bg-muted);border:1px solid var(--border);border-radius:999px;cursor:pointer;flex-shrink:0;display:inline-block}
+.admin-toggle::after{content:'';position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;background:var(--text-sec);transition:all .2s var(--ease-out)}
+.admin-toggle.on{background:hsl(var(--c-toolkit)/.25);border-color:hsl(var(--c-toolkit))}
+.admin-toggle.on::after{left:18px;background:hsl(var(--c-toolkit))}
+.admin-toggle.danger.on{background:hsl(var(--c-event)/.25);border-color:hsl(var(--c-event))}
+.admin-toggle.danger.on::after{left:18px;background:hsl(var(--c-event))}
+.alert-banner{display:flex;align-items:flex-start;gap:14px;padding:16px 18px;border-radius:10px;font-size:12.5px}
+.alert-banner.warning{background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.35);color:var(--text)}
+.alert-banner.danger{background:hsl(var(--c-event)/.08);border:1px solid hsl(var(--c-event)/.4);color:var(--text)}
+.alert-banner.info{background:hsl(var(--c-chat)/.08);border:1px solid hsl(var(--c-chat)/.3);color:var(--text)}
+.alert-banner.success{background:hsl(var(--c-toolkit)/.08);border:1px solid hsl(var(--c-toolkit)/.3);color:var(--text)}
+.alert-banner .em{font-size:22px;flex-shrink:0;line-height:1}
+.alert-banner .title{font-family:var(--f-display);font-weight:800;margin-bottom:4px;font-size:14px}
+.alert-banner .actions{margin-left:auto;display:flex;gap:6px;align-items:center}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* Topbar role pill */
+.role-pill{display:inline-flex;align-items:center;gap:5px;padding:3px 8px;border-radius:6px;background:hsl(var(--c-event)/.12);color:hsl(var(--c-event));font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em}
+.role-pill::before{content:'🔒';font-size:10px;filter:grayscale(0.2)}
+.role-pill .gap{opacity:.5}
+
+/* Kill-switch grid */
+.ks-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;padding:14px}
+.ks-card{background:var(--bg);border:1px solid var(--border-light);border-radius:10px;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:160px;position:relative}
+.ks-card.armed{border-color:hsl(var(--c-event)/.4);background:hsl(var(--c-event)/.05)}
+.ks-card .ks-head{display:flex;align-items:flex-start;gap:10px}
+.ks-card .ks-icon{width:36px;height:36px;border-radius:8px;display:grid;place-items:center;font-size:18px;background:hsl(var(--c-event)/.1);color:hsl(var(--c-event));flex-shrink:0;border:1px solid hsl(var(--c-event)/.25)}
+.ks-card .ks-title-block{flex:1;min-width:0}
+.ks-card .ks-title{font-family:var(--f-display);font-weight:800;font-size:14px;color:var(--text);line-height:1.25}
+.ks-card .ks-desc{margin-top:4px;font-size:11.5px;color:var(--text-sec);line-height:1.45}
+.ks-card .ks-foot{display:flex;align-items:center;gap:10px;margin-top:auto;padding-top:8px;border-top:1px dashed var(--border-light)}
+.ks-card .ks-foot .admin-toggle{margin-left:auto}
+.ks-card .ks-meta{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700}
+
+/* One-shot actions row */
+.one-shot-row{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;padding:14px}
+.os-card{background:var(--bg);border:1px solid var(--border-light);border-radius:10px;padding:14px;display:flex;flex-direction:column;gap:8px;min-height:140px}
+.os-card .os-head{display:flex;align-items:center;gap:8px}
+.os-card .os-icon{width:30px;height:30px;border-radius:7px;display:grid;place-items:center;font-size:15px;background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border:1px solid hsl(var(--c-event)/.2)}
+.os-card .os-title{font-family:var(--f-display);font-weight:800;font-size:13.5px;color:var(--text)}
+.os-card .os-desc{font-size:11.5px;color:var(--text-sec);line-height:1.4;flex:1}
+.os-card .os-foot{display:flex;align-items:center;gap:8px;justify-content:space-between}
+.os-card .os-last{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+
+/* DangerZone */
+.danger-zone{padding:18px 20px;display:grid;grid-template-columns:1fr auto;gap:24px;align-items:center;background:linear-gradient(180deg, hsl(var(--c-event)/.04), hsl(var(--c-event)/.08));border-top:1px solid hsl(var(--c-event)/.25)}
+.dz-left{display:flex;flex-direction:column;gap:8px;max-width:740px}
+.dz-title{font-family:var(--f-display);font-weight:800;font-size:18px;color:hsl(var(--c-event));display:flex;align-items:center;gap:10px;letter-spacing:-.01em}
+.dz-title .em{font-size:22px}
+.dz-desc{font-size:13px;color:var(--text);line-height:1.55}
+.dz-consequences{margin:0;padding:0;list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:4px 16px;font-family:var(--f-mono);font-size:11px;color:var(--text-sec)}
+.dz-consequences li{display:flex;align-items:flex-start;gap:6px;padding:2px 0}
+.dz-consequences li::before{content:'×';color:hsl(var(--c-event));font-weight:700;font-size:13px;line-height:1.2;flex-shrink:0}
+.dz-right{display:flex;flex-direction:column;align-items:flex-end;gap:8px}
+.btn-shutdown{padding:14px 24px;border-radius:8px;background:hsl(var(--c-event));border:1px solid hsl(var(--c-event));color:#fff;font-family:var(--f-display);font-weight:800;font-size:14px;cursor:pointer;display:inline-flex;align-items:center;gap:10px;box-shadow:0 4px 16px hsl(var(--c-event)/.35), inset 0 0 0 1px hsl(var(--c-event)/.6)}
+.btn-shutdown:hover{filter:brightness(1.08)}
+.btn-shutdown .glyph{font-size:18px;line-height:1}
+.btn-shutdown kbd{font-family:var(--f-mono);font-size:10px;background:rgba(0,0,0,.25);border:1px solid rgba(0,0,0,.3);padding:2px 5px;border-radius:4px;margin-left:4px;font-weight:700}
+.typed-hint{font-family:var(--f-mono);font-size:10px;color:hsl(var(--c-event));display:inline-flex;align-items:center;gap:6px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.typed-hint .pill{padding:1px 6px;border-radius:4px;background:hsl(var(--c-event)/.15);border:1px dashed hsl(var(--c-event)/.5)}
+
+/* Stato corrente readout */
+.readout-grid{display:grid;grid-template-columns:1.4fr 1fr;gap:16px;padding:14px}
+.readout-col{display:flex;flex-direction:column;gap:6px}
+.readout-col h4{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px}
+.ro-row{display:grid;grid-template-columns:1fr auto;gap:10px;padding:6px 12px;background:var(--bg);border:1px solid var(--border-light);border-radius:7px;font-family:var(--f-mono);font-size:11.5px;align-items:center}
+.ro-row .name{color:var(--text);font-weight:600}
+.audit-list{display:flex;flex-direction:column;gap:4px}
+.audit-row{padding:8px 12px;background:var(--bg);border:1px solid var(--border-light);border-radius:7px;display:grid;grid-template-columns:auto 1fr auto;gap:10px;font-family:var(--f-mono);font-size:11px;align-items:center}
+.audit-row .ts{color:var(--text-muted)}
+.audit-row .act{color:var(--text);font-weight:700}
+.audit-row .who{color:hsl(var(--c-event));font-weight:600}
+.audit-row.healthy{border-left:2px solid hsl(var(--c-toolkit))}
+.audit-row.danger{border-left:2px solid hsl(var(--c-event))}
+.audit-row.warning{border-left:2px solid hsl(38 90% 50%)}
+
+.health-summary{display:flex;align-items:center;gap:10px;padding:12px 14px;background:hsl(var(--c-toolkit)/.06);border:1px solid hsl(var(--c-toolkit)/.25);border-radius:8px;margin-bottom:8px}
+.health-summary .em{font-size:18px}
+.health-summary .lbl{font-family:var(--f-display);font-weight:800;font-size:13px;color:hsl(var(--c-toolkit))}
+.health-summary .sub{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);margin-left:auto}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>LLM Emergency Controls</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Emergency · aggiornato 14:23:08 · <span style="color:hsl(var(--c-event));font-weight:700">DANGER ZONE</span></div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <span class="role-pill">superadmin<span class="gap"> · </span>step-up 2FA</span>
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca azione, switch…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) Alert critico ────────── -->
+        <div class="alert-banner danger">
+          <span class="em">⚠️</span>
+          <div style="flex:1">
+            <div class="title">Zona critica — Controlli di emergenza</div>
+            <div style="line-height:1.55">
+              Questa pagina contiene <strong>kill-switch</strong> e <strong>azioni distruttive</strong> che impattano la piattaforma in produzione (utenti, AI, ingestion). Ogni azione richiede ruolo <strong>superadmin</strong> + <strong>step-up 2FA</strong> e viene tracciata in <code style="font-family:var(--f-mono);background:var(--bg-muted);padding:1px 5px;border-radius:4px">audit.emergency_events</code> con email, IP, timestamp UTC e diff.
+            </div>
+          </div>
+          <div class="actions">
+            <span class="sensitive-note"><span class="lock">🔒</span> audit-logged</span>
+            <button class="btn-admin sm ghost">📜 Apri audit log</button>
+          </div>
+        </div>
+
+        <!-- ────────── 2) Kill-switch globali ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Kill-switch globali</h3>
+            <span class="status-chip healthy">5 off</span>
+            <span class="status-chip muted">0 armed</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> ConfirmModal + step-up · alcuni richiedono typed-confirm</span>
+              <span class="sep"></span>
+              <span class="meta">cluster: production · feature-flags rev 84</span>
+            </div>
+          </div>
+
+          <div class="ks-grid">
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">📥</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Pausa ingestion KB</div>
+                  <div class="ks-desc">Sospende nuovi PDF / fetch BGG / refresh embeddings. Le query restano servite dalla KB attuale.</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip healthy">running</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> ConfirmModal</span>
+                <span class="admin-toggle" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">💬</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Blocca nuove chat / sessioni</div>
+                  <div class="ks-desc">Le sessioni in corso continuano. Nuove richieste POST <span class="mono" style="color:hsl(var(--c-chat))">/sessions</span> → 503 con banner "AI in manutenzione".</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip healthy">open</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> ConfirmModal</span>
+                <span class="admin-toggle" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">🛠️</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Sola-lettura · maintenance</div>
+                  <div class="ks-desc">Disabilita tutte le scritture (POST/PATCH/DELETE) eccetto admin. Mostra banner di manutenzione globale ai client.</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip muted">off</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> typed-confirm</span>
+                <span class="admin-toggle danger" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">👥</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Disabilita registrazioni</div>
+                  <div class="ks-desc">Blocca signup di nuovi account. Login esistente non impattato. Utile in caso di abuso/bot.</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip healthy">enabled</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> ConfirmModal</span>
+                <span class="admin-toggle" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">📄</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Disabilita upload PDF</div>
+                  <div class="ks-desc">Blocca POST <span class="mono" style="color:hsl(var(--c-kb))">/kb/upload</span> da UI e API. La coda smoldocling resta attiva sui job già accodati.</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip healthy">enabled</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> ConfirmModal</span>
+                <span class="admin-toggle" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+            <div class="ks-card">
+              <div class="ks-head">
+                <div class="ks-icon">🧠</div>
+                <div class="ks-title-block">
+                  <div class="ks-title">Stop completo LLM</div>
+                  <div class="ks-desc">Disabilita tutti i provider (DeepSeek, OpenRouter, OpenAI, Anthropic). I client ricevono fallback statico "Spiegazione non disponibile".</div>
+                </div>
+              </div>
+              <div class="ks-foot">
+                <span class="status-chip healthy">routed</span>
+                <span class="sensitive-note"><span class="lock">🔒</span> typed-confirm</span>
+                <span class="admin-toggle danger" role="switch" aria-checked="false"></span>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+        <!-- ────────── 3) Azioni one-shot ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Azioni one-shot</h3>
+            <span class="status-chip info">non reversibili</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Ogni azione → ConfirmModal + step-up 2FA</span>
+              <span class="sep"></span>
+              <span class="meta">ultimo eseguito: cache-flush · ieri 22:10</span>
+            </div>
+          </div>
+
+          <div class="one-shot-row">
+
+            <div class="os-card">
+              <div class="os-head">
+                <div class="os-icon">⚡</div>
+                <div class="os-title">Force cache flush</div>
+              </div>
+              <div class="os-desc">Svuota tutte le chiavi <span class="mono" style="color:hsl(var(--c-event))">redis:answers:*</span> e <span class="mono" style="color:hsl(var(--c-event))">redis:kb:*</span>. P95 salirà nei primi 60s.</div>
+              <div class="os-foot">
+                <span class="os-last">last · ieri 22:10</span>
+                <button class="btn-admin danger">▶ Esegui</button>
+              </div>
+            </div>
+
+            <div class="os-card">
+              <div class="os-head">
+                <div class="os-icon">🚦</div>
+                <div class="os-title">Reset rate-limit globale</div>
+              </div>
+              <div class="os-desc">Azzera i bucket di rate-limit per <strong>tutti</strong> gli utenti e IP. Usare solo se un cap erroneo blocca utenti legittimi.</div>
+              <div class="os-foot">
+                <span class="os-last">last · 14 mag 09:42</span>
+                <button class="btn-admin danger">▶ Esegui</button>
+              </div>
+            </div>
+
+            <div class="os-card">
+              <div class="os-head">
+                <div class="os-icon">🔁</div>
+                <div class="os-title">Riavvia routing LLM</div>
+              </div>
+              <div class="os-desc">Ricarica config provider, reset di tutti i circuit breaker, riavvio del router. ~3-5s di degrado.</div>
+              <div class="os-foot">
+                <span class="os-last">last · 02 mag 16:18</span>
+                <button class="btn-admin danger">▶ Esegui</button>
+              </div>
+            </div>
+
+            <div class="os-card">
+              <div class="os-head">
+                <div class="os-icon">🗑️</div>
+                <div class="os-title">Svuota coda job</div>
+              </div>
+              <div class="os-desc">Cancella batch in coda (reindex, pdf-ingest, embed). I job in running terminano. Conteggio: <span class="mono" style="color:hsl(var(--c-agent))">4 queued · 2 running</span>.</div>
+              <div class="os-foot">
+                <span class="os-last">mai eseguito</span>
+                <button class="btn-admin danger">▶ Esegui</button>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+        <!-- ────────── 4) Emergency shutdown · DangerZone ────────── -->
+        <section class="admin-panel" style="border-color:hsl(var(--c-event)/.45);box-shadow:0 0 0 1px hsl(var(--c-event)/.15)">
+          <div class="admin-panel-head" style="background:hsl(var(--c-event)/.06);border-bottom-color:hsl(var(--c-event)/.25)">
+            <h3 style="color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.04em">⛔ Emergency shutdown</h3>
+            <span class="status-chip danger">last-resort</span>
+            <div class="head-cluster">
+              <span class="meta" style="color:hsl(var(--c-event))">richiede typed-confirm "EMERGENCY" + step-up 2FA</span>
+            </div>
+          </div>
+
+          <div class="danger-zone">
+            <div class="dz-left">
+              <div class="dz-title"><span class="em">⛔</span> Spegni l'intera piattaforma MeepleAI</div>
+              <div class="dz-desc">
+                Azione di ultima istanza. Arresta tutti i container applicativi e blocca il traffico al load balancer. La pagina pubblica mostra <span class="mono" style="color:hsl(var(--c-event))">503 · Service Unavailable</span>. Solo postgres, redis e questa console restano raggiungibili. Il ripristino è manuale (SSH bastion + <span class="mono">docker compose up</span>).
+              </div>
+              <ul class="dz-consequences">
+                <li>API <span class="mono" style="margin-left:4px">/api/v1/*</span> → 503</li>
+                <li>Sessioni AI in corso → interrotte</li>
+                <li>Upload e ingestion → cancellati</li>
+                <li>Webhook n8n → in errore</li>
+                <li>Stripe / billing → in errore</li>
+                <li>Email transazionali → sospese</li>
+              </ul>
+            </div>
+            <div class="dz-right">
+              <button class="btn-shutdown" type="button">
+                <span class="glyph">⛔</span>
+                Emergency shutdown
+                <kbd>ENTER</kbd>
+              </button>
+              <span class="typed-hint">🔒 digita <span class="pill">EMERGENCY</span> + 2FA</span>
+              <span style="font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)">runbook · RUN-OPS-014 · MTTR ~ 9 min</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ────────── 5) Stato corrente ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Stato corrente</h3>
+            <div class="head-cluster">
+              <span class="meta">snapshot 14:23:08 UTC · refresh ogni 10s</span>
+            </div>
+          </div>
+
+          <div class="readout-grid">
+
+            <div class="readout-col">
+              <div class="health-summary">
+                <span class="em">✅</span>
+                <span class="lbl">Tutti i sistemi operativi</span>
+                <span class="sub">0 switch attivi · 0 azioni in volo · uptime 12d 4h</span>
+              </div>
+
+              <h4>Kill-switch · stato live</h4>
+
+              <div class="ro-row"><span class="name">📥 Pausa ingestion KB</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">💬 Blocca nuove chat / sessioni</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">🛠️ Sola-lettura · maintenance</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">👥 Disabilita registrazioni</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">📄 Disabilita upload PDF</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">🧠 Stop completo LLM</span><span class="status-chip healthy">off</span></div>
+              <div class="ro-row"><span class="name">⛔ Emergency shutdown</span><span class="status-chip muted">armed · idle</span></div>
+            </div>
+
+            <div class="readout-col">
+              <h4>Ultime azioni di emergenza</h4>
+
+              <div class="audit-list">
+
+                <div class="audit-row healthy">
+                  <span class="ts">ieri 22:10:04</span>
+                  <span><span class="act">cache flush · redis</span></span>
+                  <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="563737243938163b3333263a33373f78372626">[email&#160;protected]</a></span>
+                </div>
+
+                <div class="audit-row healthy">
+                  <span class="ts">14 mag 09:42:17</span>
+                  <span><span class="act">rate-limit reset · global</span></span>
+                  <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="325353405d5c725f5757425e57535b1c534242">[email&#160;protected]</a></span>
+                </div>
+
+                <div class="audit-row warning">
+                  <span class="ts">02 mag 16:18:02</span>
+                  <span><span class="act">routing LLM restart</span></span>
+                  <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="2a474b5849450458455959436a474f4f5a464f4b43044b5a5a">[email&#160;protected]</a></span>
+                </div>
+
+                <div class="audit-row danger">
+                  <span class="ts">14 apr 03:51:18</span>
+                  <span><span class="act">stop LLM · 23 min</span></span>
+                  <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="e48585968b8aa4898181948881858dca859494">[email&#160;protected]</a></span>
+                </div>
+
+                <div class="audit-row healthy">
+                  <span class="ts">28 mar 18:04:55</span>
+                  <span><span class="act">maintenance mode on / off · 12 min</span></span>
+                  <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="80e1e1f2efeec0ede5e5f0ece5e1e9aee1f0f0">[email&#160;protected]</a></span>
+                </div>
+              </div>
+
+              <button class="btn-admin sm ghost" style="margin-top:8px;align-self:flex-start">📜 Apri audit log completo →</button>
+            </div>
+
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('emergency');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-infra.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-infra.html
@@ -1,0 +1,568 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Infrastructure &amp; Containers · MeepleAI Admin</title>
+<!-- C1 · Platform & Operations → 'infra' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations". Per ora la sidebar non ha voce attiva). -->
+<!-- @v1 KPISparkline · LiveEventLog · ConfirmModal (typed-confirm su Restart all) reuse
+     Endpoints: GET /api/v1/admin/docker, /admin/infrastructure,
+                /admin/operations/batch-jobs (+ SSE),
+                POST /admin/operations/restart-service  (role: superadmin) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+
+/* ── components.css (subset rilevante) ─────────────────────────── */
+.e-chip{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:var(--r-sm);background:hsl(var(--e)/.12);color:hsl(var(--e));font-size:var(--fs-xs);font-weight:var(--fw-bold);font-family:var(--f-display);text-transform:uppercase;letter-spacing:.04em}
+.e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-shell-3col{display:grid;grid-template-columns:240px 1fr 360px;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi-icon{position:absolute;right:14px;bottom:12px;font-size:22px;opacity:.35}
+.admin-kpi.e-game{border-left:3px solid hsl(var(--c-game))}.admin-kpi.e-player{border-left:3px solid hsl(var(--c-player))}
+.admin-kpi.e-session{border-left:3px solid hsl(var(--c-session))}.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent))}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb))}.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table th.sort-asc::after{content:' ↑';color:hsl(var(--c-event))}
+.admin-table th.sort-desc::after{content:' ↓';color:hsl(var(--c-event))}
+.admin-table td{padding:8px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table tr.selected td{background:hsl(var(--c-event)/.06)}
+.admin-table .checkbox{width:32px}.admin-table .menu{width:32px;text-align:right}
+.admin-table .menu button{background:transparent;border:0;cursor:pointer;color:var(--text-sec);padding:4px;border-radius:4px}
+.admin-table .menu button:hover{background:var(--bg-muted);color:var(--text)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.role-chip{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.role-chip.superadmin{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.role-chip.admin{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event))}
+.role-chip.premium{background:hsl(var(--c-agent)/.14);color:hsl(38 90% 38%)}
+.role-chip.user{background:hsl(var(--c-player)/.1);color:hsl(var(--c-player))}
+.activity-feed{display:flex;flex-direction:column;gap:1px}
+.activity-item{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:flex-start;gap:10px;font-size:12.5px}
+.activity-item:last-child{border-bottom:0}.activity-item:hover{background:var(--bg-muted)}
+.activity-item .em{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;font-size:14px;flex-shrink:0}
+.activity-item .body{flex:1;min-width:0}.activity-item .body strong{font-weight:700;color:var(--text)}
+.activity-item .ts{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);flex-shrink:0}
+.alert-banner{display:flex;align-items:flex-start;gap:12px;padding:12px 14px;border-radius:8px;font-size:12.5px}
+.alert-banner.warning{background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.35);color:var(--text)}
+.alert-banner.danger{background:hsl(var(--c-event)/.08);border:1px solid hsl(var(--c-event)/.35);color:var(--text)}
+.alert-banner.info{background:hsl(var(--c-chat)/.08);border:1px solid hsl(var(--c-chat)/.3);color:var(--text)}
+.alert-banner.success{background:hsl(var(--c-toolkit)/.08);border:1px solid hsl(var(--c-toolkit)/.3);color:var(--text)}
+.alert-banner .em{font-size:18px;flex-shrink:0}
+.alert-banner .title{font-family:var(--f-display);font-weight:800;margin-bottom:2px;font-size:13px}
+.alert-banner .actions{margin-left:auto;display:flex;gap:6px}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell,.admin-shell-3col{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}.admin-body-grid{display:grid;gap:16px}
+.kbd-hint{display:inline-flex;align-items:center;gap:4px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.kbd-hint kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border)}
+
+/* ── Page-specific styles ───────────────────────────────────────── */
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+
+.svc-img{font-family:var(--f-mono);font-size:11px;color:var(--text-sec);background:var(--bg-sunken,var(--bg));padding:2px 6px;border-radius:4px;border:1px solid var(--border-light);display:inline-block;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle}
+.svc-name{display:flex;align-items:center;gap:8px}
+.svc-name .dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0}
+.svc-name strong{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.svc-name .port{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:2px}
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.num{font-family:var(--f-mono);font-variant-numeric:tabular-nums;text-align:right}
+.usage-cell{display:flex;align-items:center;gap:8px;justify-content:flex-end}
+.usage-cell .bar{width:54px;height:5px;border-radius:99px;background:var(--bg-muted);overflow:hidden;position:relative}
+.usage-cell .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px;display:block}
+.usage-cell .bar.warn i{background:hsl(38 90% 50%)}
+.usage-cell .bar.crit i{background:hsl(var(--c-event))}
+.usage-cell .val{font-family:var(--f-mono);font-size:11px;color:var(--text);min-width:48px;text-align:right;font-weight:600}
+
+/* Service action group inline */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+
+/* Live event log */
+.event-log{background:var(--bg-sunken,var(--bg));border-top:1px solid var(--border-light);max-height:300px;overflow-y:auto;font-family:var(--f-mono);font-size:11px}
+.event-log .row{display:grid;grid-template-columns:96px 60px 1fr;gap:12px;padding:5px 14px;border-bottom:1px solid var(--border-light);line-height:1.45;align-items:center}
+.event-log .row:hover{background:var(--bg-muted)}
+.event-log .row:last-child{border-bottom:0}
+.event-log .ts{color:var(--text-muted)}
+.event-log .lvl{font-weight:700;text-transform:uppercase;letter-spacing:.04em;font-size:10px}
+.event-log .lvl.info{color:hsl(var(--c-chat))}
+.event-log .lvl.warn{color:hsl(38 90% 50%)}
+.event-log .lvl.err{color:hsl(var(--c-event))}
+.event-log .lvl.ok{color:hsl(var(--c-toolkit))}
+.event-log .msg{color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.event-log .msg .k{color:var(--text-muted)}
+.event-log .msg .v-game{color:hsl(var(--c-game));font-weight:700}
+.event-log .msg .v-kb{color:hsl(var(--c-kb));font-weight:700}
+.event-log .msg .v-agent{color:hsl(var(--c-agent));font-weight:700}
+.event-log .msg .v-tool{color:hsl(var(--c-tool));font-weight:700}
+.event-log .msg .v-session{color:hsl(var(--c-session));font-weight:700}
+.event-log .msg .pct{color:hsl(var(--c-toolkit));font-weight:700}
+
+/* Resources bars */
+.res-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}
+.res-block{display:flex;flex-direction:column;gap:8px}
+.res-head{display:flex;align-items:baseline;justify-content:space-between;gap:8px}
+.res-title{display:flex;align-items:center;gap:8px;font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.res-title .em-ico{font-size:14px;opacity:.85}
+.res-num{font-family:var(--f-mono);font-size:13px;color:var(--text);font-weight:700;font-variant-numeric:tabular-nums}
+.res-num .sub{color:var(--text-muted);font-weight:500;font-size:11px;margin-left:4px}
+.res-bar{position:relative;height:14px;border-radius:99px;background:hsl(var(--e)/.12);overflow:hidden}
+.res-bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px}
+.res-bar i.warn{background:hsl(38 90% 50%)}
+.res-foot{display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.res-foot .seg{display:inline-flex;align-items:center;gap:4px}
+.res-foot .seg::before{content:'';width:8px;height:8px;border-radius:2px;background:hsl(var(--e))}
+.res-foot .seg.warn::before{background:hsl(38 90% 50%)}
+.res-foot .seg.muted::before{background:var(--text-muted);opacity:.4}
+
+/* Live header dot */
+.live-pill{display:inline-flex;align-items:center;gap:6px;padding:2px 10px;border-radius:999px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em}
+.live-pill::before{content:'';width:6px;height:6px;border-radius:50%;background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* Compact panel head right-side cluster */
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Infrastructure &amp; Containers</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Infrastructure · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca servizio, container, job…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin danger" title="Richiede typed-confirm + ruolo superadmin">⟳ Restart all</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+
+          <div class="admin-kpi e-toolkit">
+            <div class="admin-kpi-label">Container attivi</div>
+            <div class="admin-kpi-value">7<span style="font-size:14px;color:var(--text-muted);font-weight:600">/8</span></div>
+            <div class="admin-kpi-trend flat">▬ 1 stopped · 0 crashed</div>
+            <svg class="admin-kpi-spark e-toolkit" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,18 L8,18 L16,18 L24,18 L32,18 L40,8 L48,8 L56,8 L64,8 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,18 L8,18 L16,18 L24,18 L32,18 L40,8 L48,8 L56,8 L64,8 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">CPU media</div>
+            <div class="admin-kpi-value">34<span style="font-size:14px;color:var(--text-muted);font-weight:600">%</span></div>
+            <div class="admin-kpi-trend up">▲ 6.2% vs 1h fa</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,21 L24,18 L32,15 L40,17 L48,12 L56,14 L64,10 L70,9 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,21 L24,18 L32,15 L40,17 L48,12 L56,14 L64,10 L70,9"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-kb">
+            <div class="admin-kpi-label">RAM usata</div>
+            <div class="admin-kpi-value">18.4<span style="font-size:14px;color:var(--text-muted);font-weight:600">/32 GB</span></div>
+            <div class="admin-kpi-trend up">▲ 57.5% allocata</div>
+            <svg class="admin-kpi-spark e-kb" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,16 L8,15 L16,14 L24,15 L32,13 L40,12 L48,11 L56,10 L64,11 L70,10 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,16 L8,15 L16,14 L24,15 L32,13 L40,12 L48,11 L56,10 L64,11 L70,10"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-agent">
+            <div class="admin-kpi-label">Batch job in coda</div>
+            <div class="admin-kpi-value">4<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 2 run</span></div>
+            <div class="admin-kpi-trend down">▼ -3 ultimi 5m</div>
+            <svg class="admin-kpi-spark e-agent" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,4 L8,6 L16,10 L24,12 L32,15 L40,14 L48,17 L56,19 L64,20 L70,22 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,4 L8,6 L16,10 L24,12 L32,15 L40,14 L48,17 L56,19 L64,20 L70,22"/>
+            </svg>
+          </div>
+
+        </section>
+
+        <!-- ────────── 2) Servizi (Docker containers) ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Servizi</h3>
+            <span class="status-chip healthy">6 healthy</span>
+            <span class="status-chip warning">1 warn</span>
+            <span class="status-chip muted">1 stopped</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Restart servizio → richiede conferma (superadmin)</span>
+              <span class="sep"></span>
+              <span class="meta">docker · node-01.fra · 8 svc</span>
+              <button class="btn-admin sm ghost" title="Compose YAML">⛁ Compose</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:24%">Servizio</th>
+                <th style="width:13%">Stato</th>
+                <th class="sort-desc" style="width:11%">Uptime</th>
+                <th style="width:11%; text-align:right">CPU</th>
+                <th style="width:13%; text-align:right">RAM</th>
+                <th>Immagine</th>
+                <th style="width:140px; text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="e-chat">
+                <td><div class="svc-name"><span class="dot"></span><strong>meepleai-api</strong><span class="port">:8080</span></div></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td class="mono">12d 4h 17m</td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:28%"></i></div><span class="val">28%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:42%"></i></div><span class="val">3.4 GB</span></div></td>
+                <td><span class="svc-img">ghcr.io/meepleai/api:1.8.2</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost" title="Logs">📜 Logs</button>
+                    <button class="btn-admin sm danger" title="Richiede conferma">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-kb">
+                <td><div class="svc-name"><span class="dot"></span><strong>embedding-service</strong><span class="port">:9100</span></div></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td class="mono">12d 4h 12m</td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:52%"></i></div><span class="val">52%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:68%"></i></div><span class="val">5.1 GB</span></div></td>
+                <td><span class="svc-img">ghcr.io/meepleai/embed-bge-m3:0.4.1</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm danger">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-tool">
+                <td><div class="svc-name"><span class="dot"></span><strong>reranker-service</strong><span class="port">:9110</span></div></td>
+                <td><span class="status-chip warning">high latency</span></td>
+                <td class="mono">2d 18h 03m</td>
+                <td class="num"><div class="usage-cell"><div class="bar warn"><i style="width:76%"></i></div><span class="val">76%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar warn"><i style="width:81%"></i></div><span class="val">6.5 GB</span></div></td>
+                <td><span class="svc-img">ghcr.io/meepleai/reranker-bge:0.2.0</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm danger">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-kb">
+                <td><div class="svc-name"><span class="dot"></span><strong>postgres</strong><span class="port">:5432</span></div></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td class="mono">42d 11h 56m</td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:14%"></i></div><span class="val">14%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:38%"></i></div><span class="val">2.4 GB</span></div></td>
+                <td><span class="svc-img">postgres:16.3-alpine</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm danger">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-event">
+                <td><div class="svc-name"><span class="dot"></span><strong>redis</strong><span class="port">:6379</span></div></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td class="mono">42d 11h 56m</td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:6%"></i></div><span class="val">6%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:12%"></i></div><span class="val">412 MB</span></div></td>
+                <td><span class="svc-img">redis:7.2-alpine</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm danger">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-toolkit">
+                <td><div class="svc-name"><span class="dot"></span><strong>n8n</strong><span class="port">:5678</span></div></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td class="mono">7d 09h 22m</td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:11%"></i></div><span class="val">11%</span></div></td>
+                <td class="num"><div class="usage-cell"><div class="bar"><i style="width:18%"></i></div><span class="val">620 MB</span></div></td>
+                <td><span class="svc-img">n8nio/n8n:1.62.4</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm danger">⟳ Restart</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td><div class="svc-name"><span class="dot"></span><strong>smoldocling</strong><span class="port">:9200</span></div></td>
+                <td><span class="status-chip muted">stopped</span></td>
+                <td class="mono" style="color:var(--text-muted)">—</td>
+                <td class="num" style="color:var(--text-muted)">—</td>
+                <td class="num" style="color:var(--text-muted)">—</td>
+                <td><span class="svc-img">ghcr.io/ds4sd/smoldocling:0.9.3</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm success">▶ Start</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Batch jobs (live event log) ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Batch jobs <span style="font-family:var(--f-mono);font-weight:500;color:var(--text-muted);font-size:11px;margin-left:6px">/admin/operations/batch-jobs</span></h3>
+            <span class="live-pill">● streaming · SSE</span>
+            <div class="head-cluster">
+              <span class="meta">2 running · 4 queued · 1.4k completed (24h)</span>
+              <button class="btn-admin sm ghost">⏸ Pause stream</button>
+              <button class="btn-admin sm ghost">⤓ Export ndjson</button>
+            </div>
+          </div>
+
+          <div class="event-log" role="log" aria-live="polite">
+            <div class="row">
+              <span class="ts">14:23:08.412</span>
+              <span class="lvl info">INFO</span>
+              <span class="msg">reindex <span class="k">game=</span><span class="v-game">catan</span> <span class="k">stage=</span><span class="v-kb">embed</span> <span class="k">progress=</span><span class="pct">64%</span> <span class="k">batch=</span>128/200 <span class="k">job=</span>job_8f3a21</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:23:07.918</span>
+              <span class="lvl ok">OK</span>
+              <span class="msg">pdf-ingest <span class="k">file=</span>wingspan-rulebook-v3.pdf <span class="k">pages=</span>96 <span class="k">duration=</span>4.812s <span class="k">job=</span>job_8f3a14</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:23:06.204</span>
+              <span class="lvl info">INFO</span>
+              <span class="msg">embedding <span class="k">model=</span><span class="v-agent">bge-m3</span> <span class="k">chunks=</span>1 024 <span class="k">throughput=</span>318/s <span class="k">job=</span>job_8f3a21</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:23:04.871</span>
+              <span class="lvl warn">WARN</span>
+              <span class="msg">reranker <span class="k">latency=</span>1842ms <span class="k">threshold=</span>800ms <span class="k">session=</span><span class="v-session">sess_a14c</span> <span class="k">action=</span>retry-1/3</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:23:02.503</span>
+              <span class="lvl ok">OK</span>
+              <span class="msg">cron-evict <span class="k">expired=</span>312 <span class="k">cache=</span>redis:answers <span class="k">freed=</span>48.2 MB</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:23:01.166</span>
+              <span class="lvl info">INFO</span>
+              <span class="msg">reindex <span class="k">game=</span><span class="v-game">wingspan</span> <span class="k">stage=</span><span class="v-kb">chunk</span> <span class="k">progress=</span><span class="pct">21%</span> <span class="k">job=</span>job_8f3a22</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:22:58.704</span>
+              <span class="lvl ok">OK</span>
+              <span class="msg">tool-sync <span class="k">toolkit=</span><span class="v-tool">bgg-import</span> <span class="k">added=</span>14 <span class="k">updated=</span>3 <span class="k">duration=</span>9.4s</span>
+            </div>
+            <div class="row">
+              <span class="ts">14:22:55.118</span>
+              <span class="lvl info">INFO</span>
+              <span class="msg">n8n-webhook <span class="k">flow=</span>publish-game <span class="k">game=</span><span class="v-game">terraforming-mars</span> <span class="k">status=</span>queued</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ────────── 4) Risorse (disco + memoria) ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Risorse</h3>
+            <div class="head-cluster">
+              <span class="meta">node-01.fra · ext4 · zfs snapshot ogni 6h</span>
+            </div>
+          </div>
+          <div class="admin-panel-body">
+            <div class="res-grid">
+
+              <div class="res-block e-kb">
+                <div class="res-head">
+                  <span class="res-title"><span class="em-ico">💾</span>Disco · /var/lib/docker</span>
+                  <span class="res-num">186.4 <span class="sub">/ 500 GB · 37.3%</span></span>
+                </div>
+                <div class="res-bar">
+                  <i style="width:62%"></i>
+                  <i class="warn" style="left:62%;width:5%"></i>
+                </div>
+                <div class="res-foot">
+                  <span class="seg">images · 72.1 GB</span>
+                  <span class="seg">volumes · 88.6 GB</span>
+                  <span class="seg warn">logs · 25.7 GB</span>
+                  <span class="seg muted">libero · 313.6 GB</span>
+                </div>
+              </div>
+
+              <div class="res-block e-chat">
+                <div class="res-head">
+                  <span class="res-title"><span class="em-ico">🧠</span>Memoria · host</span>
+                  <span class="res-num">18.4 <span class="sub">/ 32 GB · 57.5%</span></span>
+                </div>
+                <div class="res-bar">
+                  <i style="width:57.5%"></i>
+                </div>
+                <div class="res-foot">
+                  <span class="seg">containers · 14.8 GB</span>
+                  <span class="seg">page cache · 2.9 GB</span>
+                  <span class="seg">kernel · 0.7 GB</span>
+                  <span class="seg muted">libero · 13.6 GB</span>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('infra');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-integrations.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-integrations.html
@@ -1,0 +1,759 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Integrations: Slack &amp; Email · MeepleAI Admin</title>
+<!-- D6 · AI Tooling & Data Quality → 'integrations' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 SlackConnection · ChannelRouter · MessageFeed · EmailTemplateEditor · EmailPreviewFrame ·
+     TestSendForm reuse
+     Endpoints: GET/POST /api/v1/admin/slack, POST /api/v1/admin/slack/test
+                GET/PUT /api/v1/admin/email-templates
+                POST /api/v1/admin/email-templates/{id}/{preview|test-send}
+     Role: admin (Disconnect Slack = superadmin) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.danger:hover{background:hsl(var(--c-event)/.08)}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table tr.selected td{background:hsl(var(--c-event)/.07)}
+.admin-table tr.selected td:first-child{box-shadow:inset 3px 0 0 hsl(var(--c-event))}
+.admin-input,.admin-select,.admin-textarea{width:100%;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono,.admin-textarea.mono{font-family:var(--f-mono)}
+.admin-tabs{display:flex;gap:0;border-bottom:1px solid var(--border-light);padding:0 14px;background:var(--bg);border-radius:10px 10px 0 0}
+.admin-tab{padding:9px 14px;font-family:var(--f-display);font-size:12.5px;font-weight:700;color:var(--text-sec);cursor:pointer;border-bottom:2px solid transparent;display:inline-flex;align-items:center;gap:6px;background:transparent;border-top:0;border-left:0;border-right:0}
+.admin-tab:hover{color:var(--text)}
+.admin-tab.active{color:hsl(var(--c-event));border-bottom-color:hsl(var(--c-event))}
+.admin-tab .count{font-family:var(--f-mono);font-size:9px;background:var(--bg-muted);padding:1px 5px;border-radius:99px;color:var(--text-sec);font-weight:700}
+.admin-tab.active .count{background:hsl(var(--c-event)/.14);color:hsl(var(--c-event))}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.activity-feed{display:flex;flex-direction:column;gap:1px}
+.activity-item{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:flex-start;gap:10px;font-size:12.5px}
+.activity-item:last-child{border-bottom:0}
+.activity-item:hover{background:var(--bg-muted)}
+.activity-item .em{width:28px;height:28px;border-radius:50%;display:grid;place-items:center;font-size:14px;flex-shrink:0}
+.activity-item .em.danger{background:hsl(var(--c-event)/.14);color:hsl(var(--c-event))}
+.activity-item .em.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.activity-item .em.info{background:hsl(var(--c-chat)/.14);color:hsl(var(--c-chat))}
+.activity-item .em.success{background:hsl(var(--c-toolkit)/.14);color:hsl(var(--c-toolkit))}
+.activity-item .body{flex:1;min-width:0}
+.activity-item .ts{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);flex-shrink:0}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:18px 22px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* Tab wrap */
+.tab-wrap{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;display:flex;flex-direction:column}
+
+/* ── Tab Slack ──────────────────────────────────────────────────── */
+.slack-grid{display:flex;flex-direction:column;gap:14px;padding:14px}
+
+/* Connection panel */
+.conn-body{padding:16px 20px;display:grid;grid-template-columns:1.05fr 1fr auto;gap:18px;align-items:center}
+.conn-left{display:flex;align-items:center;gap:14px}
+.conn-mark{width:48px;height:48px;border-radius:10px;background:hsl(var(--c-event)/.12);color:hsl(var(--c-event));display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:22px;border:1px solid hsl(var(--c-event)/.25);flex-shrink:0}
+.conn-info .name{font-family:var(--f-display);font-weight:800;font-size:16px;color:var(--text);display:flex;align-items:center;gap:8px}
+.conn-info .desc{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);margin-top:2px;font-weight:600}
+.conn-meta{display:grid;grid-template-columns:1fr 1fr;gap:4px 10px;font-family:var(--f-mono);font-size:10.5px}
+.conn-meta .k{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:9px;font-weight:700}
+.conn-meta .v{color:var(--text);font-weight:700;font-variant-numeric:tabular-nums}
+.conn-actions{display:flex;gap:8px;flex-shrink:0}
+
+.webhook-row{display:flex;align-items:center;gap:8px;padding:8px 14px;background:var(--bg);border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:11px}
+.webhook-row .lbl{color:var(--text-muted);font-weight:700;text-transform:uppercase;letter-spacing:.06em;font-size:9.5px}
+.webhook-row .masked{flex:1;background:var(--bg-sunken,var(--bg));border:1px solid var(--border-light);padding:4px 10px;border-radius:6px;color:var(--text-sec);font-weight:600;letter-spacing:.04em}
+.webhook-row .masked .url{color:var(--text-muted);font-weight:500}
+.webhook-row .masked .dots{color:var(--text);font-weight:700}
+.webhook-row .right{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.webhook-row .right .lock{color:hsl(var(--c-event))}
+
+/* Event chips */
+.evt-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:6px;font-family:var(--f-mono);font-size:10px;font-weight:700;letter-spacing:.02em;border:1px solid hsl(var(--e)/.25);background:hsl(var(--e)/.1);color:hsl(var(--e))}
+.evt-chip::before{content:'';width:5px;height:5px;border-radius:50%;background:hsl(var(--e))}
+.evt-stack{display:flex;gap:4px;flex-wrap:wrap}
+
+/* Channel name cell */
+.chan-cell{font-family:var(--f-mono);font-size:12.5px;color:var(--text);font-weight:700}
+.chan-cell .hash{color:hsl(var(--c-chat));font-weight:800}
+
+/* Add channel inline form */
+.add-channel-form{display:flex;align-items:center;gap:8px;padding:10px 14px;background:var(--bg);border-bottom:1px solid var(--border-light)}
+.add-channel-form .admin-input{max-width:240px;font-family:var(--f-mono);font-size:11.5px}
+.add-channel-form .admin-select{max-width:none;font-size:11.5px;flex:1}
+.add-channel-form label{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;margin-right:2px}
+
+/* Row actions */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+
+/* Slack-style message body */
+.activity-item .body .msg-head{display:flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.activity-item .body .msg-head .ch{color:hsl(var(--c-chat));font-weight:800;font-size:11px}
+.activity-item .body .msg-body{margin-top:3px;color:var(--text);font-size:12.5px;line-height:1.5}
+.activity-item .body .msg-body strong{font-weight:800}
+.activity-item .body .msg-body .v-mono{font-family:var(--f-mono);background:var(--bg-muted);padding:1px 5px;border-radius:4px;font-size:11px}
+.activity-item .body .msg-foot{margin-top:3px;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;display:flex;gap:10px}
+
+/* ── Tab divider (since we show both views) ─────────────────────── */
+.tab-divider{margin:34px 0 14px;display:flex;align-items:center;gap:10px;color:var(--text-muted);font-family:var(--f-mono);font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+.tab-divider::before,.tab-divider::after{content:'';flex:1;height:1px;background:var(--border-light)}
+.tab-divider .pill{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border:1px dashed var(--border-strong);border-radius:99px;color:var(--text-sec)}
+.tab-divider .pill .v{color:hsl(var(--c-event));font-weight:800}
+
+/* ── Tab Email · 3-col grid ─────────────────────────────────────── */
+.email-grid{display:grid;grid-template-columns:280px minmax(0,1fr) 360px;gap:14px;padding:14px}
+
+/* Template name cell */
+.tpl-name-cell{font-family:var(--f-display);font-weight:800;font-size:12.5px;color:var(--text);display:flex;align-items:center;gap:8px}
+.tpl-name-cell .ico{width:24px;height:24px;border-radius:6px;background:hsl(var(--e)/.12);color:hsl(var(--e));display:grid;place-items:center;font-size:12px;border:1px solid hsl(var(--e)/.25);flex-shrink:0}
+.subj-cell{font-family:var(--f-mono);font-size:10.5px;color:var(--text-sec);font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px}
+.subj-cell .var{color:hsl(var(--c-kb));font-weight:700}
+
+/* Editor */
+.email-editor-head{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border-light);background:var(--bg)}
+.email-editor-head .nm{font-family:var(--f-display);font-weight:800;font-size:14px;color:var(--text)}
+.email-editor-head .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.email-editor-toolbar{display:flex;align-items:center;gap:6px;padding:7px 14px;border-bottom:1px solid var(--border-light);background:var(--bg);font-family:var(--f-mono);font-size:11px;color:var(--text-muted);flex-wrap:wrap}
+.email-editor-toolbar .var-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:99px;font-family:var(--f-mono);font-size:10px;font-weight:700;background:hsl(var(--c-kb)/.12);color:hsl(var(--c-kb));border:1px solid hsl(var(--c-kb)/.25);cursor:pointer}
+.email-editor-toolbar .var-pill:hover{background:hsl(var(--c-kb)/.18)}
+.email-editor-toolbar .sep{width:1px;height:16px;background:var(--border-light);margin:0 4px}
+.email-editor-toolbar .spacer{flex:1}
+.email-editor-toolbar .stats{display:inline-flex;gap:10px;color:var(--text-muted)}
+.email-editor-toolbar .stats .v{color:var(--text);font-weight:700}
+
+.email-subject-row{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border-light);background:var(--bg-card)}
+.email-subject-row .lbl{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;text-transform:uppercase;letter-spacing:.06em;min-width:60px}
+.email-subject-row .admin-input{padding:5px 9px;font-family:var(--f-mono);font-size:12px}
+.email-body-wrap{background:var(--bg-sunken,var(--bg));max-height:430px;overflow:auto}
+.hb-source{margin:0;padding:14px 18px;font-family:var(--f-mono);font-size:12.5px;line-height:1.7;color:var(--text);white-space:pre-wrap;tab-size:2;min-height:100%}
+.hb-source .ln{display:inline-block;width:22px;color:var(--text-muted);user-select:none;font-size:10px;text-align:right;padding-right:8px;font-weight:600;opacity:.7}
+.hb-source .var{display:inline-flex;align-items:center;padding:0 4px;border-radius:4px;background:hsl(var(--c-kb)/.14);color:hsl(var(--c-kb));border:1px solid hsl(var(--c-kb)/.25);font-weight:700;font-size:11.5px;cursor:pointer}
+.hb-source .helper{color:hsl(var(--c-toolkit));font-weight:700}
+.hb-source .comment{color:var(--text-muted);font-style:italic;opacity:.85}
+.hb-source .html-tag{color:hsl(var(--c-event))}
+
+.email-editor-foot{display:flex;align-items:center;gap:8px;padding:9px 14px;border-top:1px solid var(--border-light);background:var(--bg)}
+.email-editor-foot .autosave{display:inline-flex;align-items:center;gap:5px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.email-editor-foot .autosave .dot{width:6px;height:6px;border-radius:50%;background:hsl(var(--c-agent));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.email-editor-foot .spacer{flex:1}
+
+/* ── Preview frame (renders the email like a real inbox) ────────── */
+.preview-head{display:flex;align-items:center;gap:8px;padding:9px 14px;border-bottom:1px solid var(--border-light);background:var(--bg)}
+.preview-head .nm{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text);flex:1}
+.preview-frame{margin:14px;padding:0;background:var(--bg-card);border:1px solid var(--border-strong);border-radius:8px;overflow:hidden;box-shadow:0 4px 16px rgba(0,0,0,.25)}
+.inbox-header{padding:10px 14px;background:var(--bg-muted);border-bottom:1px solid var(--border-light);display:flex;flex-direction:column;gap:4px;font-family:var(--f-mono);font-size:10.5px}
+.inbox-header .row{display:flex;align-items:center;gap:6px}
+.inbox-header .lbl{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:9px;font-weight:700;min-width:34px}
+.inbox-header .v{color:var(--text);font-weight:600}
+.inbox-header .v strong{color:hsl(var(--c-kb));font-weight:800}
+.inbox-header .subject{font-family:var(--f-display);font-size:13.5px;font-weight:800;color:var(--text);margin-top:4px;line-height:1.3}
+.inbox-header .subject .injected{color:hsl(var(--c-kb))}
+
+.inbox-body{padding:18px 18px 16px;font-family:'Nunito',system-ui,sans-serif;font-size:12.5px;line-height:1.6;color:var(--text-sec);background:var(--bg-card)}
+.inbox-body h1{font-family:'Quicksand',sans-serif;font-size:18px;font-weight:800;color:var(--text);margin-bottom:10px;letter-spacing:-.01em}
+.inbox-body p{margin:0 0 10px 0}
+.inbox-body strong{color:var(--text);font-weight:700}
+.inbox-body .game-tile{display:flex;align-items:center;gap:10px;padding:10px;background:var(--bg);border:1px solid var(--border-light);border-radius:8px;margin:10px 0}
+.inbox-body .game-tile .cover{width:44px;height:54px;border-radius:5px;background:hsl(var(--c-game)/.16);border:1px solid hsl(var(--c-game)/.3);color:hsl(var(--c-game));display:grid;place-items:center;font-family:'Quicksand',sans-serif;font-weight:800;font-size:18px;flex-shrink:0}
+.inbox-body .game-tile .gi{display:flex;flex-direction:column;line-height:1.25}
+.inbox-body .game-tile .gn{font-family:'Quicksand',sans-serif;font-weight:800;color:var(--text);font-size:13.5px}
+.inbox-body .game-tile .gs{font-size:10.5px;color:var(--text-muted)}
+.inbox-body .cta{display:inline-block;background:hsl(var(--c-event));color:#fff;font-family:'Quicksand',sans-serif;font-weight:800;font-size:12.5px;padding:8px 14px;border-radius:6px;margin:4px 0 6px;text-decoration:none}
+.inbox-body .footer{margin-top:14px;padding-top:10px;border-top:1px solid var(--border-light);font-size:10px;color:var(--text-muted);line-height:1.4}
+
+.test-send{padding:12px 14px;display:flex;flex-direction:column;gap:6px;border-top:1px solid var(--border-light);background:var(--bg)}
+.test-send .label{font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.test-send .row{display:flex;gap:6px}
+.test-send .row .admin-input{flex:1;font-family:var(--f-mono);font-size:11.5px}
+.test-send .helper{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+
+/* Email tab grid: ensure left panel scrolls */
+.email-grid > .admin-panel{align-self:stretch;display:flex;flex-direction:column;overflow:hidden}
+.email-grid .tpl-list-wrap{flex:1;overflow:auto}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Integrations · Slack &amp; Email</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › Integrations · 2 integrazioni · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca canale, template…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body">
+
+        <!-- ═══════════════════ TAB SLACK (attiva) ═══════════════════ -->
+        <div class="tab-wrap">
+
+          <div class="admin-tabs">
+            <button class="admin-tab active">📣 Slack <span class="count">8 msg/24h</span></button>
+            <button class="admin-tab">✉ Email templates <span class="count">5</span></button>
+          </div>
+
+          <div class="slack-grid">
+
+            <!-- ── Connessione ── -->
+            <section class="admin-panel" style="border-left:3px solid hsl(var(--c-toolkit))">
+              <div class="admin-panel-head">
+                <h3>Connessione</h3>
+                <span class="status-chip healthy">connesso</span>
+                <div class="head-cluster">
+                  <span class="sensitive-note"><span class="lock">🔒</span> Disconnetti → ConfirmModal · superadmin</span>
+                  <span class="meta" style="margin-left:0">Slack v2 · workspace owner aaron@</span>
+                </div>
+              </div>
+
+              <div class="conn-body">
+                <div class="conn-left">
+                  <div class="conn-mark">⌘</div>
+                  <div class="conn-info">
+                    <span class="name">meepleai <span class="status-chip muted">workspace</span></span>
+                    <span class="desc">workspace · meepleai.slack.com · 14 membri · 9 canali pubblici</span>
+                  </div>
+                </div>
+                <div class="conn-meta">
+                  <span class="k">Connesso</span><span class="v">14 mar 2026 11:04</span>
+                  <span class="k">Bot user</span><span class="v">@meepleai-ops</span>
+                  <span class="k">Eventi inviati</span><span class="v">412 · 7g</span>
+                  <span class="k">Ultimo invio</span><span class="v">2m 04s fa</span>
+                </div>
+                <div class="conn-actions">
+                  <button class="btn-admin">🔔 Test message</button>
+                  <button class="btn-admin danger">⤬ Disconnetti</button>
+                </div>
+              </div>
+
+              <div class="webhook-row">
+                <span class="lbl">webhook</span>
+                <span class="masked"><span class="url">https://hooks.slack.com/services/</span><span class="dots">••••••••••••/••••••••••••/••••••••••••••••••••••••</span></span>
+                <span class="right"><span class="lock">🔒</span>step-up 2FA per reveal</span>
+                <button class="btn-admin sm ghost">👁 Reveal</button>
+                <button class="btn-admin sm ghost">⤿ Rotate</button>
+              </div>
+            </section>
+
+            <!-- ── Canali instradati ── -->
+            <section class="admin-panel">
+              <div class="admin-panel-head">
+                <h3>Canali instradati</h3>
+                <span class="status-chip healthy">3 attivi</span>
+                <div class="head-cluster">
+                  <span class="meta">routing rules · ordered top-down</span>
+                </div>
+              </div>
+
+              <div class="add-channel-form">
+                <label>Aggiungi</label>
+                <input class="admin-input" placeholder="#nuovo-canale" />
+                <select class="admin-select" style="max-width:240px" multiple size="1">
+                  <option>alert</option>
+                  <option>deploy</option>
+                  <option>error</option>
+                  <option>info</option>
+                </select>
+                <button class="btn-admin primary">＋ Aggiungi canale</button>
+              </div>
+
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th style="width:22%">Canale</th>
+                    <th style="width:28%">Eventi</th>
+                    <th style="width:13%">Stato</th>
+                    <th>Note</th>
+                    <th style="width:170px;text-align:right">Azioni</th>
+                  </tr>
+                </thead>
+                <tbody>
+
+                  <tr>
+                    <td class="chan-cell"><span class="hash">#</span>ops</td>
+                    <td>
+                      <div class="evt-stack">
+                        <span class="evt-chip e-event">alert</span>
+                        <span class="evt-chip e-toolkit">deploy</span>
+                        <span class="evt-chip e-event">error</span>
+                      </div>
+                    </td>
+                    <td><span class="status-chip healthy">attivo</span></td>
+                    <td class="mono" style="font-size:10.5px;color:var(--text-muted)">priorità default · @meepleai-ops</td>
+                    <td>
+                      <div class="row-actions">
+                        <button class="btn-admin sm ghost">🔔 Test</button>
+                        <button class="btn-admin sm ghost">✎ Modifica</button>
+                        <button class="btn-admin sm ghost" title="ConfirmModal">🗑</button>
+                      </div>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td class="chan-cell"><span class="hash">#</span>alerts</td>
+                    <td>
+                      <div class="evt-stack">
+                        <span class="evt-chip e-event">alert</span>
+                        <span class="evt-chip e-event">error</span>
+                      </div>
+                    </td>
+                    <td><span class="status-chip healthy">attivo</span></td>
+                    <td class="mono" style="font-size:10.5px;color:var(--text-muted)">solo warning + danger · @here mention</td>
+                    <td>
+                      <div class="row-actions">
+                        <button class="btn-admin sm ghost">🔔 Test</button>
+                        <button class="btn-admin sm ghost">✎ Modifica</button>
+                        <button class="btn-admin sm ghost">🔇 Silenzia</button>
+                      </div>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td class="chan-cell"><span class="hash">#</span>deploys</td>
+                    <td>
+                      <div class="evt-stack">
+                        <span class="evt-chip e-toolkit">deploy</span>
+                        <span class="evt-chip e-chat">info</span>
+                      </div>
+                    </td>
+                    <td><span class="status-chip healthy">attivo</span></td>
+                    <td class="mono" style="font-size:10.5px;color:var(--text-muted)">CI/CD · webhook github + n8n</td>
+                    <td>
+                      <div class="row-actions">
+                        <button class="btn-admin sm ghost">🔔 Test</button>
+                        <button class="btn-admin sm ghost">✎ Modifica</button>
+                        <button class="btn-admin sm ghost">🗑</button>
+                      </div>
+                    </td>
+                  </tr>
+
+                  <tr style="opacity:.6">
+                    <td class="chan-cell"><span class="hash">#</span>random</td>
+                    <td>
+                      <div class="evt-stack">
+                        <span class="evt-chip e-chat">info</span>
+                      </div>
+                    </td>
+                    <td><span class="status-chip muted">silenziato</span></td>
+                    <td class="mono" style="font-size:10.5px;color:var(--text-muted)">memes &amp; promo · silenziato fino al 30 mag</td>
+                    <td>
+                      <div class="row-actions">
+                        <button class="btn-admin sm ghost">🔊 Riattiva</button>
+                        <button class="btn-admin sm ghost">✎ Modifica</button>
+                        <button class="btn-admin sm ghost">🗑</button>
+                      </div>
+                    </td>
+                  </tr>
+
+                </tbody>
+              </table>
+            </section>
+
+            <!-- ── Messaggi recenti ── -->
+            <section class="admin-panel">
+              <div class="admin-panel-head">
+                <h3>Messaggi recenti</h3>
+                <span class="status-chip info">ultimi 8</span>
+                <div class="head-cluster">
+                  <span class="meta">412 invii 7g · 0 fallimenti · delivery rate 100%</span>
+                  <button class="btn-admin sm ghost">📜 Audit log</button>
+                </div>
+              </div>
+
+              <div class="activity-feed">
+
+                <div class="activity-item">
+                  <span class="em danger">⚠</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#ops</span>· bot <strong>@meepleai-ops</strong></div>
+                    <div class="msg-body"><strong>⚠ Error rate alto</strong> · rag.error_rate <span class="v-mono">1.42% &gt; 1.0%</span> su provider <strong>OpenAI</strong> per 4m. <em>azione raccomandata: verifica circuit breaker.</em></div>
+                    <div class="msg-foot"><span>delivery 218ms · ack ✓</span><span>thread · 3 reply</span></div>
+                  </div>
+                  <div class="ts">oggi 14:22:45<br/>23s fa</div>
+                </div>
+
+                <div class="activity-item">
+                  <span class="em success">✓</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#deploys</span>· bot <strong>@meepleai-ops</strong> · CI #842</div>
+                    <div class="msg-body"><strong>✓ Deploy main-dev OK</strong> · commit <span class="v-mono">a8f3c21</span> · 2 service ricostruiti (api, embedding) · downtime <span class="v-mono">0s</span> · canary 5min ok.</div>
+                    <div class="msg-foot"><span>delivery 142ms · ack ✓</span><span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="234242514c4d634e4646534f46424a0d425353">[email&#160;protected]</a></span></div>
+                  </div>
+                  <div class="ts">oggi 11:03:18<br/>3h 20m fa</div>
+                </div>
+
+                <div class="activity-item">
+                  <span class="em warning">📦</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#alerts</span>· bot <strong>@meepleai-ops</strong></div>
+                    <div class="msg-body"><strong>Coda job profonda</strong> · queue.depth <span class="v-mono">62 &gt; 50</span> per 16m · risolto automaticamente.</div>
+                    <div class="msg-foot"><span>delivery 198ms · ack ✓</span><span>autoresolve</span></div>
+                  </div>
+                  <div class="ts">oggi 11:08:14</div>
+                </div>
+
+                <div class="activity-item">
+                  <span class="em danger">🔌</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#ops</span>· bot <strong>@meepleai-ops</strong></div>
+                    <div class="msg-body"><strong>🔌 Tunnel staging down</strong> · sync prod→staging non eseguito · ripristino manuale da bastion-prod.</div>
+                    <div class="msg-foot"><span>delivery 154ms · ack ✓</span><span>thread · 6 reply · risolto 8m 41s</span></div>
+                  </div>
+                  <div class="ts">21 mag 03:14<br/>3g fa</div>
+                </div>
+
+                <div class="activity-item">
+                  <span class="em success">✓</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#deploys</span>· bot <strong>@meepleai-ops</strong> · CI #841</div>
+                    <div class="msg-body"><strong>✓ Deploy prod</strong> · tag <span class="v-mono">v1.8.2</span> · 4 service · canary green · rollout completato.</div>
+                    <div class="msg-foot"><span>delivery 132ms · ack ✓</span><span><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="224343504d4c624f4747524e47434b0c435252">[email&#160;protected]</a></span></div>
+                  </div>
+                  <div class="ts">21 mag 09:42</div>
+                </div>
+
+                <div class="activity-item">
+                  <span class="em info">💰</span>
+                  <div class="body">
+                    <div class="msg-head"><span class="ch">#alerts</span>· bot <strong>@meepleai-ops</strong></div>
+                    <div class="msg-body"><strong>Spesa giornaliera alta</strong> · cost.daily_usd <span class="v-mono">$42.08 &gt; $40</span> · picco dovuto a reindex Wingspan.</div>
+                    <div class="msg-foot"><span>delivery 178ms · ack ✓</span><span>silenziato 24h</span></div>
+                  </div>
+                  <div class="ts">12 mag 23:55</div>
+                </div>
+
+              </div>
+            </section>
+
+          </div>
+        </div>
+
+        <!-- ═══════════════════ TAB EMAIL (seconda vista documentata) ═══════════════════ -->
+        <div class="tab-divider">
+          <span class="pill">↓ Tab successiva · <span class="v">Email templates</span> · vista documentata per handoff</span>
+        </div>
+
+        <div class="tab-wrap">
+
+          <div class="admin-tabs">
+            <button class="admin-tab">📣 Slack <span class="count">8 msg/24h</span></button>
+            <button class="admin-tab active">✉ Email templates <span class="count">5</span></button>
+          </div>
+
+          <div class="email-grid">
+
+            <!-- ░░ LEFT: Templates list ░░ -->
+            <aside class="admin-panel">
+              <div class="admin-panel-head">
+                <h3>Template</h3>
+                <button class="btn-admin sm ghost" style="margin-left:auto">＋ Nuovo</button>
+              </div>
+              <div class="tpl-list-wrap">
+                <table class="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Nome</th>
+                      <th style="width:90px;text-align:right">Modificato</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+
+                    <tr>
+                      <td>
+                        <div class="tpl-name-cell e-player"><div class="ico">👋</div>Benvenuto</div>
+                        <div class="subj-cell" style="margin-top:3px;padding-left:32px">"Benvenuto su MeepleAI, <span class="var">{{user.name}}</span>!"</div>
+                      </td>
+                      <td class="mono" style="font-size:10px;color:var(--text-muted);text-align:right">14g fa</td>
+                    </tr>
+
+                    <tr>
+                      <td>
+                        <div class="tpl-name-cell e-event"><div class="ico">🔑</div>Reset password</div>
+                        <div class="subj-cell" style="margin-top:3px;padding-left:32px">"Reset della tua password"</div>
+                      </td>
+                      <td class="mono" style="font-size:10px;color:var(--text-muted);text-align:right">38g fa</td>
+                    </tr>
+
+                    <tr class="selected">
+                      <td>
+                        <div class="tpl-name-cell e-game"><div class="ico">🎲</div>Gioco pronto</div>
+                        <div class="subj-cell" style="margin-top:3px;padding-left:32px">"Il tuo gioco <span class="var">{{game.title}}</span> è pronto!"</div>
+                      </td>
+                      <td class="mono" style="font-size:10px;color:var(--text-muted);text-align:right">2g fa</td>
+                    </tr>
+
+                    <tr>
+                      <td>
+                        <div class="tpl-name-cell e-session"><div class="ico">🎉</div>Invito game night</div>
+                        <div class="subj-cell" style="margin-top:3px;padding-left:32px">"<span class="var">{{host.name}}</span> ti invita a una serata di gioco"</div>
+                      </td>
+                      <td class="mono" style="font-size:10px;color:var(--text-muted);text-align:right">5g fa</td>
+                    </tr>
+
+                    <tr>
+                      <td>
+                        <div class="tpl-name-cell e-chat"><div class="ico">📊</div>Report settimanale</div>
+                        <div class="subj-cell" style="margin-top:3px;padding-left:32px">"La tua settimana su MeepleAI · <span class="var">{{week.label}}</span>"</div>
+                      </td>
+                      <td class="mono" style="font-size:10px;color:var(--text-muted);text-align:right">7g fa</td>
+                    </tr>
+
+                  </tbody>
+                </table>
+              </div>
+            </aside>
+
+            <!-- ░░ CENTER: Editor ░░ -->
+            <section class="admin-panel">
+              <div class="email-editor-head">
+                <div style="flex:1;min-width:0">
+                  <div class="nm">Gioco pronto</div>
+                  <div class="sub">email_tpl_game_ready · transactional · channel:email · v3</div>
+                </div>
+                <span class="status-chip warning">unsaved</span>
+                <button class="btn-admin sm">📋 Duplica</button>
+              </div>
+
+              <div class="email-subject-row">
+                <span class="lbl">Subject</span>
+                <input class="admin-input mono" value='🎲 Il tuo gioco {{game.title}} è pronto!' />
+              </div>
+
+              <div class="email-editor-toolbar">
+                <button class="btn-admin sm">＋ Inserisci ▾</button>
+                <span class="var-pill">{{user.name}}</span>
+                <span class="var-pill">{{game.title}}</span>
+                <span class="var-pill">{{link}}</span>
+                <span class="sep"></span>
+                <button class="btn-admin sm">⊟ Formatta</button>
+                <button class="btn-admin sm">↪ Plain text</button>
+                <span class="spacer"></span>
+                <span class="stats">
+                  <span>L <span class="v">26</span></span>
+                  <span>var <span class="v">5</span></span>
+                  <span>est. <span class="v">~140w</span></span>
+                </span>
+              </div>
+
+              <div class="email-body-wrap">
+                <pre class="hb-source" contenteditable="false" spellcheck="false"><span class="ln"> 1</span> <span class="html-tag">&lt;h1&gt;</span>Ciao <span class="var">{{user.name}}</span>!<span class="html-tag">&lt;/h1&gt;</span>
+<span class="ln"> 2</span>
+<span class="ln"> 3</span> <span class="html-tag">&lt;p&gt;</span>Buone notizie 🎲 — il regolamento e la knowledge base di
+<span class="ln"> 4</span> <span class="html-tag">&lt;strong&gt;</span><span class="var">{{game.title}}</span><span class="html-tag">&lt;/strong&gt;</span> sono stati elaborati e l'assistente AI
+<span class="ln"> 5</span> è pronto per rispondere alle tue domande.<span class="html-tag">&lt;/p&gt;</span>
+<span class="ln"> 6</span>
+<span class="ln"> 7</span> <span class="comment">{{!-- Game tile card · injected by renderer --}}</span>
+<span class="ln"> 8</span> <span class="html-tag">&lt;div&gt;</span>
+<span class="ln"> 9</span>   <span class="html-tag">&lt;strong&gt;</span><span class="var">{{game.title}}</span><span class="html-tag">&lt;/strong&gt;</span>
+<span class="ln">10</span>   · {{game.player_count}} giocatori · {{game.complexity}}
+<span class="ln">11</span> <span class="html-tag">&lt;/div&gt;</span>
+<span class="ln">12</span>
+<span class="ln">13</span> <span class="html-tag">&lt;a</span> href=<span class="var">"{{link}}"</span><span class="html-tag">&gt;</span>Apri la chat con l'assistente →<span class="html-tag">&lt;/a&gt;</span>
+<span class="ln">14</span>
+<span class="ln">15</span> <span class="helper">{{#if</span> <span class="var">tips.length</span><span class="helper">}}</span>
+<span class="ln">16</span> <span class="html-tag">&lt;h3&gt;</span>3 cose da chiedere subito<span class="html-tag">&lt;/h3&gt;</span>
+<span class="ln">17</span> <span class="html-tag">&lt;ul&gt;</span>
+<span class="ln">18</span>   <span class="helper">{{#each</span> <span class="var">tips</span><span class="helper">}}</span>
+<span class="ln">19</span>     <span class="html-tag">&lt;li&gt;</span><span class="var">{{this}}</span><span class="html-tag">&lt;/li&gt;</span>
+<span class="ln">20</span>   <span class="helper">{{/each}}</span>
+<span class="ln">21</span> <span class="html-tag">&lt;/ul&gt;</span>
+<span class="ln">22</span> <span class="helper">{{/if}}</span>
+<span class="ln">23</span>
+<span class="ln">24</span> <span class="html-tag">&lt;p&gt;</span>Buon gioco!<span class="html-tag">&lt;br&gt;</span>il team di MeepleAI<span class="html-tag">&lt;/p&gt;</span>
+<span class="ln">25</span>
+<span class="ln">26</span> <span class="comment">{{!-- Footer · CAN-SPAM block injected --}}</span></pre>
+              </div>
+
+              <div class="email-editor-foot">
+                <span class="autosave"><span class="dot"></span>Auto-save in 18s</span>
+                <span class="spacer"></span>
+                <button class="btn-admin">⟲ Reset</button>
+                <button class="btn-admin primary">💾 Salva template <kbd>⌘S</kbd></button>
+              </div>
+            </section>
+
+            <!-- ░░ RIGHT: Preview + test ░░ -->
+            <aside class="admin-panel" style="overflow:hidden">
+              <div class="preview-head">
+                <span class="nm">Anteprima</span>
+                <select class="admin-select" style="max-width:120px;font-size:11px;padding:4px 8px">
+                  <option selected>HTML</option>
+                  <option>Plain text</option>
+                  <option>Dark client</option>
+                </select>
+                <button class="btn-admin sm ghost">↻</button>
+              </div>
+
+              <div class="preview-frame">
+                <div class="inbox-header">
+                  <div class="row"><span class="lbl">Da</span><span class="v"><strong>MeepleAI</strong> &lt;<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="523a373e3e3d123f3737223e37333b7c332222">[email&#160;protected]</a>&gt;</span></div>
+                  <div class="row"><span class="lbl">A</span><span class="v"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="bbdadac9d4d5fbd6dedecbd7dedad295dacbcb">[email&#160;protected]</a></span></div>
+                  <div class="subject">🎲 Il tuo gioco <span class="injected">Wingspan</span> è pronto!</div>
+                </div>
+
+                <div class="inbox-body">
+                  <h1>Ciao Aaron!</h1>
+                  <p>Buone notizie 🎲 — il regolamento e la knowledge base di <strong>Wingspan</strong> sono stati elaborati e l'assistente AI è pronto per rispondere alle tue domande.</p>
+
+                  <div class="game-tile">
+                    <div class="cover">W</div>
+                    <div class="gi">
+                      <span class="gn">Wingspan</span>
+                      <span class="gs">1–5 giocatori · complessità media · 40–70 min</span>
+                    </div>
+                  </div>
+
+                  <a href="#" class="cta">Apri la chat con l'assistente →</a>
+
+                  <p style="margin-top:14px"><strong>3 cose da chiedere subito</strong></p>
+                  <p style="margin:0;padding-left:14px">
+                    • Quanti uccelli posso giocare per turno?<br/>
+                    • Come funziona l'azione "Lay Eggs"?<br/>
+                    • Setup base per 2 giocatori?
+                  </p>
+
+                  <p style="margin-top:14px">Buon gioco!<br/>il team di MeepleAI</p>
+
+                  <div class="footer">
+                    MeepleAI · Milano, IT · <a href="#" style="color:hsl(var(--c-chat))">Disiscriviti</a> · <a href="#" style="color:hsl(var(--c-chat))">Gestisci preferenze</a>
+                  </div>
+                </div>
+              </div>
+
+              <div class="test-send">
+                <span class="label">Invia un test</span>
+                <div class="row">
+                  <input class="admin-input mono" value="aaron@meepleai.app" />
+                  <button class="btn-admin primary">▶ Invia test</button>
+                </div>
+                <span class="helper">render server-side · variabili compilate da sample fixture · max 10 invii/h</span>
+              </div>
+            </aside>
+
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('integrations');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A5 · Admin Knowledge Base · /admin/knowledge-base</title>
+<!-- @v2 KBTree · DocumentViewer · IngestionLog · ChunkTable -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .kb-grid { display: grid; grid-template-columns: 300px 1fr; gap: 16px; align-items: start; min-height: calc(100vh - 80px); }
+  .kb-tree {
+    background: var(--bg-card); border: 1px solid var(--border-light);
+    border-radius: 10px; padding: 8px; overflow-y: auto; max-height: calc(100vh - 100px);
+    position: sticky; top: 76px;
+  }
+  .kb-tree-search { padding: 6px 8px; }
+  .kb-tree-game { padding: 6px 8px; border-radius: 6px; font-family: var(--f-display); font-weight: 700; font-size: 13px; cursor: pointer; display: flex; align-items: center; gap: 8px; }
+  .kb-tree-game:hover { background: var(--bg-muted); }
+  .kb-tree-game .em { font-size: 14px; }
+  .kb-tree-game .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 600; padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); }
+  .kb-tree-doc { padding: 5px 8px 5px 30px; font-size: 12px; cursor: pointer; border-radius: 6px; display: flex; align-items: center; gap: 6px; color: var(--text-sec); }
+  .kb-tree-doc:hover { background: var(--bg-muted); color: var(--text); }
+  .kb-tree-doc.selected { background: hsl(var(--c-kb) / .12); color: hsl(var(--c-kb)); }
+  .kb-tree-doc .em { font-size: 11px; }
+  .kb-tree-doc .ind { font-family: var(--f-mono); font-size: 9px; margin-left: auto; }
+  .kb-tree-doc.failed .ind { color: hsl(var(--c-event)); }
+  .kb-tree-doc.pending .ind { color: hsl(38 90% 50%); }
+  .kb-tree-doc.indexed .ind { color: hsl(var(--c-toolkit)); }
+
+  .doc-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+  .doc-hero { padding: 16px 20px; border-bottom: 1px solid var(--border-light); background: linear-gradient(180deg, hsl(var(--c-kb) / .08), transparent); }
+  .doc-hero .head { display: flex; align-items: flex-start; gap: 14px; }
+  .doc-hero h2 { margin: 0; font-family: var(--f-display); font-size: 19px; font-weight: 800; }
+  .doc-hero .meta { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 4px; }
+
+  .doc-stats { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-top: 14px; }
+  .doc-stats .s { background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 8px 10px; }
+  .doc-stats .s-lb { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+  .doc-stats .s-vl { font-family: var(--f-display); font-size: 18px; font-weight: 800; }
+
+  .pdf-preview {
+    background: linear-gradient(180deg, var(--bg-muted), var(--bg-sunken));
+    border: 1px solid var(--border-light); border-radius: 8px;
+    padding: 24px; min-height: 320px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px;
+    color: var(--text-muted);
+  }
+  .pdf-preview .doc-mock {
+    width: 320px; padding: 20px; background: #fff; color: #1a1612;
+    border-radius: 4px; box-shadow: var(--shadow-lg);
+    font-family: 'Georgia', serif; font-size: 9px; line-height: 1.6;
+  }
+  .pdf-preview .doc-mock h3 { font-family: 'Georgia', serif; font-size: 13px; margin: 0 0 8px; color: #000; }
+  .pdf-preview .doc-mock .l { background: #1a1612; opacity: .8; height: 4px; border-radius: 2px; margin-bottom: 3px; }
+  .pdf-preview .doc-mock .l.w70 { width: 70%; } .pdf-preview .doc-mock .l.w50 { width: 50%; } .pdf-preview .doc-mock .l.w90 { width: 90%; }
+  .pdf-preview .doc-mock .l.highlight { background: hsl(var(--c-kb)); opacity: 1; height: 5px; }
+
+  .chunk-table-row { display: grid; grid-template-columns: 60px 1fr 60px 70px 30px; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--border-light); font-size: 11.5px; align-items: center; }
+  .chunk-table-row code { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+  .chunk-table-row .preview { color: var(--text-sec); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chunk-table-row .score { text-align: right; font-family: var(--f-mono); font-weight: 700; }
+  .chunk-table-row .score.hi { color: hsl(var(--c-kb)); }
+  .chunk-table-row .score.md { color: hsl(38 90% 50%); }
+
+  .ingestion-log { font-family: var(--f-mono); font-size: 11px; background: var(--bg-sunken); color: var(--text-sec); padding: 12px 14px; border-radius: 6px; line-height: 1.7; max-height: 200px; overflow-y: auto; }
+  .ingestion-log .t { color: var(--text-muted); }
+  .ingestion-log .ok { color: hsl(var(--c-toolkit)); }
+  .ingestion-log .err { color: hsl(var(--c-event)); }
+  .ingestion-log .warn { color: hsl(38 90% 50%); }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2><p>Knowledge Base management richiede schermo wide.</p></div>
+
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <header class="admin-top">
+      <div><h1>Knowledge Base</h1><div class="crumbs">Admin · KB · 247 docs · 18.487 chunks · 2.4TB</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…" value=""><kbd>⌘K</kbd></div>
+        <a href="sp5-kb-upload-flow.html" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="kb-grid">
+
+        <!-- Left: tree ────────────────────────────────────── -->
+        <div class="kb-tree">
+          <div class="kb-tree-search">
+            <div class="admin-search" style="width: 100%"><span>🔍</span><input placeholder="Filtra tree…"></div>
+          </div>
+          <div style="padding: 4px 8px; font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">8 giochi · 247 docs</div>
+
+          <div class="kb-tree-game"><span>▾</span> <span class="em">🎲</span> Wingspan <span class="count">12</span></div>
+          <div class="kb-tree-doc indexed">📄 Wingspan-Asia-EN.pdf <span class="ind">347ch</span></div>
+          <div class="kb-tree-doc indexed selected">📄 Wingspan-Oceania-EN.pdf <span class="ind">412ch</span></div>
+          <div class="kb-tree-doc indexed">📄 Wingspan-Europa-EN.pdf <span class="ind">298ch</span></div>
+          <div class="kb-tree-doc pending">📄 Wingspan-FAQ.txt <span class="ind">indexing…</span></div>
+          <div class="kb-tree-doc indexed">📄 wingspan-bgg-faq.txt <span class="ind">84ch</span></div>
+          <div class="kb-tree-doc indexed">📄 Errata-2024.pdf <span class="ind">12ch</span></div>
+
+          <div class="kb-tree-game"><span>▾</span> <span class="em">🎲</span> Brass: Birmingham <span class="count">8</span></div>
+          <div class="kb-tree-doc indexed">📄 Brass-Birmingham-Rulebook.pdf <span class="ind">524ch</span></div>
+          <div class="kb-tree-doc failed">📄 brass-faq-thread.txt <span class="ind">⚠ failed</span></div>
+          <div class="kb-tree-doc indexed">📄 Brass-Lancashire-conv.pdf <span class="ind">187ch</span></div>
+
+          <div class="kb-tree-game"><span>▾</span> <span class="em">🎲</span> Tainted Grail <span class="count">14</span></div>
+          <div class="kb-tree-doc indexed">📄 TG-Fall-of-Avalon-IT.pdf <span class="ind">812ch</span></div>
+          <div class="kb-tree-doc indexed">📄 TG-Chapter-Book-Vol1.pdf <span class="ind">2.4kch</span></div>
+          <div class="kb-tree-doc indexed">📄 TG-Chapter-Book-Vol2.pdf <span class="ind">2.8kch</span></div>
+          <div class="kb-tree-doc indexed">📄 TG-Encounters-Cards.pdf <span class="ind">421ch</span></div>
+
+          <div class="kb-tree-game"><span>▸</span> <span class="em">🎲</span> Spirit Island <span class="count">9</span></div>
+          <div class="kb-tree-game"><span>▸</span> <span class="em">🎲</span> Ark Nova <span class="count">11</span></div>
+          <div class="kb-tree-game"><span>▸</span> <span class="em">🎲</span> ISS Vanguard <span class="count">22</span></div>
+          <div class="kb-tree-game"><span>▸</span> <span class="em">🎲</span> Lancaster <span class="count">5</span></div>
+          <div class="kb-tree-game"><span>▸</span> <span class="em">🎲</span> Gloomhaven <span class="count">31</span></div>
+        </div>
+
+        <!-- Right: doc panel ──────────────────────────────── -->
+        <div class="doc-card">
+          <div class="doc-hero">
+            <div class="head">
+              <span style="font-size: 36px">📄</span>
+              <div style="flex: 1">
+                <h2>Wingspan-Oceania-EN.pdf</h2>
+                <div class="meta">EntityChip: <span class="role-chip" style="background: hsl(var(--c-game) / .14); color: hsl(var(--c-game))">🎲 Wingspan</span> · uploaded by Aaron · 2024-12-08 14:22 · indexer v2024.11.18</div>
+              </div>
+              <div style="display: flex; gap: 6px;">
+                <button class="btn-admin sm">⟳ Re-index</button>
+                <button class="btn-admin sm">⤓ Download</button>
+                <button class="btn-admin sm danger">🗑 Delete</button>
+              </div>
+            </div>
+
+            <div class="doc-stats">
+              <div class="s"><div class="s-lb">Pagine</div><div class="s-vl">42</div></div>
+              <div class="s"><div class="s-lb">Chunks</div><div class="s-vl">412</div></div>
+              <div class="s"><div class="s-lb">Avg confidence</div><div class="s-vl" style="color: hsl(var(--c-toolkit))">0.87</div></div>
+              <div class="s"><div class="s-lb">Size</div><div class="s-vl">8.4<span style="font-size:12px;color:var(--text-muted)">MB</span></div></div>
+              <div class="s"><div class="s-lb">Status</div><div class="s-vl"><span class="status-chip healthy" style="font-size: 11px">Indicizzato</span></div></div>
+            </div>
+
+            <div style="margin-top: 14px; display: flex; gap: 4px; align-items: center; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">
+              <span>🌐 EN</span> · <span>📐 OCR no</span> · <span>🧱 chunk 512 tok</span> · <span>🔄 last reindex 8gg fa</span>
+            </div>
+          </div>
+
+          <div style="padding: 0 20px">
+            <div class="admin-tabs" style="margin-bottom: 0">
+              <button class="admin-tab">Preview</button>
+              <button class="admin-tab active">Chunks <span class="count">412</span></button>
+              <button class="admin-tab">Ingestion log</button>
+              <button class="admin-tab">Used by <span class="count">8</span></button>
+            </div>
+          </div>
+
+          <div style="padding: 16px 20px;">
+
+            <!-- Active tab: Chunks ──────────────────────── -->
+            <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 10px">
+              <div class="admin-search" style="width: 320px"><span>🔍</span><input placeholder="Cerca in chunks… (similarity match)" value="predator activation"></div>
+              <span class="filter-chip active">Score ≥ 0.7 <span class="x">▾</span></span>
+              <span class="filter-chip">Capitolo: tutti <span class="x">▾</span></span>
+              <div style="margin-left: auto; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">12 risultati / 412 totali</div>
+            </div>
+
+            <div style="border: 1px solid var(--border-light); border-radius: 8px; overflow: hidden">
+              <div class="chunk-table-row" style="background: var(--bg); font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700">
+                <div>Chunk ID</div><div>Preview</div><div>Pagina</div><div>Score ↓</div><div></div>
+              </div>
+              <div class="chunk-table-row" style="background: hsl(var(--c-kb) / .04)">
+                <code>c-0218</code>
+                <div class="preview">"Quando più uccelli predatori sono attivati nello stesso turno, l'attivazione segue l'ordine di piazzamento da sinistra a destra…"</div>
+                <code>p.22 §3</code>
+                <div class="score hi">0.84</div>
+                <div>›</div>
+              </div>
+              <div class="chunk-table-row">
+                <code>c-0217</code>
+                <div class="preview">"Un cibo non disponibile sulla mappa cibo viene preso dal banco. Se ci sono più predatori in competizione, il giocatore decide…"</div>
+                <code>p.22 §2</code>
+                <div class="score hi">0.72</div>
+                <div>›</div>
+              </div>
+              <div class="chunk-table-row">
+                <code>c-0142</code>
+                <div class="preview">"Power di tipo predator si attiva su trigger 'when activated'. In espansione Oceania, l'ordine è importante per i power…"</div>
+                <code>p.14 §5</code>
+                <div class="score hi">0.58</div>
+                <div>›</div>
+              </div>
+              <div class="chunk-table-row">
+                <code>c-0086</code>
+                <div class="preview">"Carte uccello con keyword predator hanno priorità sull'attivazione fine round se viene innescato il trigger group…"</div>
+                <code>p.9 §2</code>
+                <div class="score md">0.51</div>
+                <div>›</div>
+              </div>
+              <div class="chunk-table-row">
+                <code>c-0312</code>
+                <div class="preview">"Tabella riepilogativa dei power per habitat: foresta (predator activation), prateria (egg lay), zona umida…"</div>
+                <code>p.31 tbl</code>
+                <div class="score md">0.46</div>
+                <div>›</div>
+              </div>
+              <div class="chunk-table-row">
+                <code>c-0398</code>
+                <div class="preview">"FAQ: caso simultaneo di esaurimento cibo durante attivazione predatori (non trattato nella prima stampa, vedi errata)…"</div>
+                <code>p.40 §1</code>
+                <div class="score md">0.42</div>
+                <div>›</div>
+              </div>
+            </div>
+
+            <!-- Ingestion log (collapsed under tabs) -->
+            <h4 style="margin: 18px 0 6px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Ingestion log (snippet)</h4>
+            <pre class="ingestion-log">
+<span class="t">[14:22:01]</span> <span class="ok">▸ Started</span> Wingspan-Oceania-EN.pdf · 8.4MB · 42 pages
+<span class="t">[14:22:03]</span> <span class="ok">✓ Unstructured.io</span> parsed in 2.18s · 1.247 elements
+<span class="t">[14:22:06]</span> <span class="ok">✓ SmolDocling</span> doc-layout in 2.94s · 86 tables · 12 figures
+<span class="t">[14:22:08]</span> <span class="ok">✓ Chunker</span> 412 chunks @ 512 tok · avg 387
+<span class="t">[14:22:12]</span> <span class="warn">⚠ Embedder</span> retry 1 (rate-limit) → ok in 4.21s
+<span class="t">[14:22:14]</span> <span class="ok">✓ Indexer</span> Pinecone wingspan-v3 · 412 vectors
+<span class="t">[14:22:14]</span> <span class="ok">✓ Done</span> total 13.4s · cost $0.087</pre>
+
+            <div style="margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--border-light); display: flex; flex-wrap: wrap; gap: 6px">
+              <button class="btn-admin">⟳ Re-index with v2024.12 indexer</button>
+              <button class="btn-admin">📋 View embeddings</button>
+              <button class="btn-admin">⤓ Export chunks JSON</button>
+              <button class="btn-admin">🔬 Quality eval</button>
+              <button class="btn-admin">🤖 Used by 7 agents</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script><script>renderAdminNav('kb');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-mechanic-extractor.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-mechanic-extractor.html
@@ -1,0 +1,744 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Mechanic Extractor · MeepleAI Admin</title>
+<!-- D1 · AI Tooling & Data Quality → 'mechanic-extractor' (NAV_ID non ancora presente in
+     admin-nav.js; verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 RunAnalysisBar · CostCap · AnalysisTable · DetailDrawer (Sezioni/Meccaniche/Log/Validazione)
+     · ConfidenceChip · SectionProgress reuse
+     Endpoints: GET /api/v1/admin/mechanic-analyses
+                POST /api/v1/admin/mechanic-extractor/run
+                GET /api/v1/admin/mechanic-extractor/validation
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;--dur-md:280ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4,h5{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table tr.selected td{background:hsl(var(--c-event)/.07)}
+.admin-table tr.selected td:first-child{box-shadow:inset 3px 0 0 hsl(var(--c-event))}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.admin-input,.admin-select{padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.admin-toggle{position:relative;width:34px;height:18px;background:var(--bg-muted);border:1px solid var(--border);border-radius:999px;cursor:pointer;display:inline-block;flex-shrink:0}
+.admin-toggle::after{content:'';position:absolute;top:2px;left:2px;width:12px;height:12px;border-radius:50%;background:var(--text-sec);transition:.18s var(--ease-out)}
+.admin-toggle.on{background:hsl(var(--c-event)/.25);border-color:hsl(var(--c-event))}
+.admin-toggle.on::after{left:18px;background:hsl(var(--c-event))}
+.admin-tabs{display:flex;gap:0;border-bottom:1px solid var(--border-light);padding:0 14px;background:var(--bg)}
+.admin-tab{padding:8px 12px;font-family:var(--f-display);font-size:12px;font-weight:700;color:var(--text-sec);cursor:pointer;border-bottom:2px solid transparent;display:inline-flex;align-items:center;gap:6px;background:transparent;border-top:0;border-left:0;border-right:0}
+.admin-tab:hover{color:var(--text)}
+.admin-tab.active{color:hsl(var(--c-event));border-bottom-color:hsl(var(--c-event))}
+.admin-tab .count{font-family:var(--f-mono);font-size:9px;background:var(--bg-muted);padding:1px 5px;border-radius:99px;color:var(--text-sec);font-weight:700}
+.admin-tab.active .count{background:hsl(var(--c-event)/.14);color:hsl(var(--c-event))}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+
+/* ── Run bar ────────────────────────────────────────────────────── */
+.run-bar{background:var(--bg-card);border:1px solid var(--border-light);border-left:3px solid hsl(var(--c-agent));border-radius:10px;padding:14px;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+.run-bar .field{display:flex;flex-direction:column;gap:4px;min-width:0}
+.run-bar .field .lbl{font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.run-bar .field select,.run-bar .field input{font-size:12px;padding:5px 8px}
+.run-bar .field.f-game select{width:170px}
+.run-bar .field.f-pdf select{width:240px;font-family:var(--f-mono);font-size:11.5px}
+.run-bar .field.f-cap input{width:110px;font-family:var(--f-mono);text-align:right}
+.run-bar .field.f-cap .cur{position:relative}
+.run-bar .field.f-cap .cur::before{content:'$';position:absolute;left:10px;top:50%;transform:translateY(-50%);font-family:var(--f-mono);font-size:11.5px;color:var(--text-muted);pointer-events:none}
+.run-bar .field.f-cap input{padding-left:22px;text-align:left}
+.run-bar .override{display:flex;align-items:center;gap:6px;padding:0 6px;border-left:1px dashed var(--border);border-right:1px dashed var(--border);height:44px}
+.run-bar .override .ov-lbl{font-family:var(--f-display);font-weight:700;font-size:12px;color:hsl(var(--c-event));display:inline-flex;align-items:center;gap:5px}
+.run-bar .override .ov-lbl .lock{font-size:11px}
+.run-bar .override .ov-sub{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);display:block;margin-top:1px;text-transform:uppercase;letter-spacing:.05em;font-weight:700}
+.run-bar .spacer{flex:1}
+.run-bar .est{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);text-align:right;display:flex;flex-direction:column;gap:2px}
+.run-bar .est .v{color:var(--text);font-weight:700;font-size:12px}
+
+/* ── Layout drill ───────────────────────────────────────────────── */
+.drill-grid{display:grid;grid-template-columns:1fr 380px;gap:14px;align-items:start}
+
+/* Game cell */
+.game-cell{display:flex;align-items:center;gap:10px}
+.game-cover{width:30px;height:38px;border-radius:5px;background:hsl(var(--e)/.14);border:1px solid hsl(var(--e)/.3);display:grid;place-items:center;font-size:14px;color:hsl(var(--e));flex-shrink:0;font-family:var(--f-display);font-weight:800}
+.game-info{display:flex;flex-direction:column;line-height:1.2;min-width:0}
+.game-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.game-id{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;margin-top:1px;letter-spacing:.02em}
+
+.pdf-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text-sec);background:var(--bg-sunken,var(--bg));padding:2px 7px;border-radius:5px;border:1px solid var(--border-light);display:inline-block;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+.sec-progress-tiny{display:inline-flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:11px;color:var(--text);font-weight:600}
+.sec-progress-tiny .v{color:var(--text-muted);font-size:10px}
+.sec-progress-tiny .bar{display:inline-block;width:60px;height:4px;border-radius:99px;background:hsl(var(--c-event)/.12);overflow:hidden;position:relative;vertical-align:middle}
+.sec-progress-tiny .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--c-event));border-radius:99px;animation:bar-pulse 1.4s ease-in-out infinite}
+@keyframes bar-pulse{0%,100%{opacity:.7}50%{opacity:1}}
+
+.cost-cell{font-family:var(--f-mono);font-size:11.5px;font-weight:700;color:var(--text);text-align:right;font-variant-numeric:tabular-nums}
+.cost-cell.over{color:hsl(var(--c-event))}
+.cost-cell .sub{display:block;color:var(--text-muted);font-weight:500;font-size:9.5px;margin-top:1px}
+
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 7px;font-size:10.5px}
+
+/* ── Drill panel ───────────────────────────────────────────────── */
+.drill-panel{position:sticky;top:80px}
+.drill-hero{padding:14px 16px;display:flex;flex-direction:column;gap:8px;border-left:3px solid hsl(var(--c-game));background:linear-gradient(180deg, hsl(var(--c-game)/.05), transparent 80%)}
+.drill-hero .hh{display:flex;align-items:center;gap:10px}
+.drill-hero .hh .cover{width:40px;height:50px;border-radius:6px;background:hsl(var(--c-game)/.16);border:1px solid hsl(var(--c-game)/.3);display:grid;place-items:center;font-size:18px;color:hsl(var(--c-game));flex-shrink:0;font-family:var(--f-display);font-weight:800}
+.drill-hero h2{font-family:var(--f-display);font-size:17px;font-weight:800;color:var(--text);line-height:1.2}
+.drill-hero .sub{font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted);margin-top:1px;font-weight:600}
+.drill-hero .chips{display:flex;gap:6px;flex-wrap:wrap;padding-top:2px}
+.drill-hero .runinfo{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;font-family:var(--f-mono);font-size:10.5px;border-top:1px dashed var(--border-light);padding-top:8px}
+.drill-hero .runinfo .lbl{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:9px;font-weight:700}
+.drill-hero .runinfo .v{color:var(--text);font-weight:700;margin-top:2px;display:block}
+.drill-hero .runinfo .v.over{color:hsl(var(--c-event))}
+
+.section-runs{padding:6px 14px 14px;display:flex;flex-direction:column;gap:6px}
+.section-runs .sr{display:flex;flex-direction:column;gap:4px;padding:8px 10px;background:var(--bg);border:1px solid var(--border-light);border-radius:7px}
+.section-runs .sr-row{display:flex;align-items:center;gap:8px;font-size:12px}
+.section-runs .sr-row .nm{flex:1;font-family:var(--f-display);font-weight:700;color:var(--text);font-size:12.5px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.section-runs .sr-row .pg{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.section-runs .sr-row .pct{font-family:var(--f-mono);font-size:10.5px;font-weight:700;color:var(--text);min-width:32px;text-align:right}
+.section-runs .sr-row .pct.muted{color:var(--text-muted)}
+.section-runs .sr-bar{height:5px;border-radius:99px;background:hsl(var(--e)/.12);overflow:hidden;position:relative}
+.section-runs .sr-bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px;transition:width .25s var(--ease-out)}
+.section-runs .sr.running .sr-bar i{animation:bar-pulse 1.4s ease-in-out infinite}
+.section-runs .sr-meta{display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+.section-runs .sr-meta .cost{color:var(--text-sec);font-weight:700}
+
+.subhead{display:flex;align-items:center;gap:8px;padding:8px 14px 4px;border-top:1px solid var(--border-light);background:var(--bg)}
+.subhead h4{font-family:var(--f-display);font-weight:800;font-size:11.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted)}
+.subhead .right{margin-left:auto;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+
+.mech-table{width:100%;border-collapse:collapse;font-size:12px}
+.mech-table th{padding:6px 14px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);text-align:left;background:var(--bg)}
+.mech-table td{padding:7px 14px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.mech-table tr:hover td{background:var(--bg-muted)}
+.mech-name{font-family:var(--f-display);font-weight:700;font-size:12.5px;color:var(--text)}
+.mech-pages{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:600}
+.conf-cell{display:inline-flex;align-items:center;gap:6px;justify-content:flex-end;width:100%}
+.conf-cell .v{font-family:var(--f-mono);font-size:11px;font-weight:700;color:var(--text);min-width:34px;text-align:right;font-variant-numeric:tabular-nums}
+
+/* Empty state (commented in DOM, defined for completeness) */
+.empty{padding:36px 24px;display:flex;flex-direction:column;align-items:center;gap:10px;text-align:center;color:var(--text-muted)}
+.empty .em{font-size:36px}
+.empty h3{font-family:var(--f-display);font-size:14px;color:var(--text)}
+.empty p{max-width:300px;font-size:11.5px;line-height:1.5;margin:0}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Mechanic Extractor</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › Mechanic Extractor · 2 in volo · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca gioco, PDF, meccanica…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">📊 Validazione globale</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) Run bar ────────── -->
+        <section class="run-bar">
+          <div class="field f-game">
+            <span class="lbl">Gioco</span>
+            <select class="admin-select">
+              <option>Catan</option>
+              <option selected>Wingspan</option>
+              <option>Terraforming Mars</option>
+              <option>Brass: Birmingham</option>
+              <option>Ark Nova</option>
+            </select>
+          </div>
+
+          <div class="field f-pdf">
+            <span class="lbl">PDF regolamento</span>
+            <select class="admin-select">
+              <option selected>wingspan-rules-en.pdf · 12 pag · 1.8 MB</option>
+              <option>wingspan-rules-it.pdf · 12 pag · 1.7 MB</option>
+              <option>wingspan-european-expansion.pdf · 4 pag · 0.6 MB</option>
+            </select>
+          </div>
+
+          <div class="field f-cap">
+            <span class="lbl">Cost cap</span>
+            <div class="cur"><input class="admin-input mono" value="1.50" /></div>
+          </div>
+
+          <div class="override">
+            <span class="admin-toggle" role="switch" aria-checked="false"></span>
+            <div>
+              <span class="ov-lbl"><span class="lock">🔒</span>Override cap</span>
+              <span class="ov-sub">richiede conferma</span>
+            </div>
+          </div>
+
+          <div class="spacer"></div>
+
+          <div class="est">
+            <span class="v">≈ $0.62 · 4m 30s</span>
+            <span>14 sezioni · claude-3.5-sonnet · v2.4</span>
+          </div>
+
+          <button class="btn-admin primary">▶ Avvia analisi <kbd>↵</kbd></button>
+        </section>
+
+        <!-- ────────── 2) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Analisi totali</div>
+            <div class="admin-kpi-value">48<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · ultimi 30g</span></div>
+            <div class="admin-kpi-trend up">▲ 8 vs mese scorso · 2 in volo</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,18 L24,18 L32,16 L40,14 L48,12 L56,12 L64,10 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,18 L24,18 L32,16 L40,14 L48,12 L56,12 L64,10 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-event">
+            <div class="admin-kpi-label">Costo medio / analisi</div>
+            <div class="admin-kpi-value"><span style="font-size:18px;color:var(--text-muted);font-weight:700">$</span>0.47</div>
+            <div class="admin-kpi-trend down">▼ -$0.08 vs cap medio $1.20</div>
+            <svg class="admin-kpi-spark e-event" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,8 L8,10 L16,12 L24,11 L32,14 L40,15 L48,16 L56,17 L64,18 L70,19 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,8 L8,10 L16,12 L24,11 L32,14 L40,15 L48,16 L56,17 L64,18 L70,19"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-kb">
+            <div class="admin-kpi-label">Meccaniche estratte</div>
+            <div class="admin-kpi-value">418<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 92 high-conf</span></div>
+            <div class="admin-kpi-trend up">▲ 78% conf ≥ 0.80 · 22% review</div>
+            <svg class="admin-kpi-spark e-kb" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,17 L24,15 L32,13 L40,10 L48,9 L56,7 L64,6 L70,4 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,17 L24,15 L32,13 L40,10 L48,9 L56,7 L64,6 L70,4"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 3) Grid: Analisi (sx) + Dettaglio (dx) ────────── -->
+        <div class="drill-grid">
+
+          <!-- ░░ Analisi table ░░ -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Analisi</h3>
+              <span class="status-chip running">2 running</span>
+              <span class="status-chip muted">1 queued</span>
+              <span class="status-chip healthy">44 completate</span>
+              <span class="status-chip danger">1 failed</span>
+              <div class="head-cluster">
+                <span class="meta">model: claude-3.5-sonnet · prompt v2.4</span>
+                <button class="btn-admin sm ghost">⤓ Export</button>
+              </div>
+            </div>
+
+            <table class="admin-table">
+              <thead>
+                <tr>
+                  <th style="width:22%">Gioco</th>
+                  <th style="width:23%">PDF</th>
+                  <th style="width:12%">Stato</th>
+                  <th style="width:13%">Sezioni</th>
+                  <th style="width:10%;text-align:right">Costo</th>
+                  <th style="width:13%">Avviata</th>
+                  <th style="width:80px;text-align:right">Azioni</th>
+                </tr>
+              </thead>
+              <tbody>
+
+                <!-- ░ Selected · running -->
+                <tr class="selected">
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">W</div>
+                      <div class="game-info"><span class="game-name">Wingspan</span><span class="game-id">game_wing01 · v2 ed.</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell" title="wingspan-rules-en.pdf">wingspan-rules-en.pdf</span></td>
+                  <td><span class="status-chip running">running · 64%</span></td>
+                  <td>
+                    <div class="sec-progress-tiny">
+                      <span class="bar"><i style="width:64%"></i></span>
+                      <span class="v">9 / 14</span>
+                    </div>
+                  </td>
+                  <td class="cost-cell">$0.42<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">14:18:42<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">4m 26s fa</span></td>
+                  <td>
+                    <div class="row-actions">
+                      <button class="btn-admin sm ghost" title="Apri dettaglio">↗</button>
+                      <button class="btn-admin sm ghost" title="Pause">⏸</button>
+                    </div>
+                  </td>
+                </tr>
+
+                <!-- ░ Catan · completed -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">C</div>
+                      <div class="game-info"><span class="game-name">Catan</span><span class="game-id">game_ctn01 · base 5th ed.</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">catan-rules-en-v5.pdf</span></td>
+                  <td><span class="status-chip healthy">completed</span></td>
+                  <td><span class="mono" style="font-size:11.5px">11 / 11 · 38 meccaniche</span></td>
+                  <td class="cost-cell">$0.43<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">oggi 09:14:08<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">5h fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button></div></td>
+                </tr>
+
+                <!-- ░ Terraforming Mars · running second -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">T</div>
+                      <div class="game-info"><span class="game-name">Terraforming Mars</span><span class="game-id">game_tfm01 · base</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">tfm-rules-en.pdf</span></td>
+                  <td><span class="status-chip running">running · 28%</span></td>
+                  <td><div class="sec-progress-tiny"><span class="bar"><i style="width:28%"></i></span><span class="v">5 / 18</span></div></td>
+                  <td class="cost-cell">$0.18<span class="sub">cap $2.00</span></td>
+                  <td class="mono" style="font-size:11.5px">14:21:01<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">2m 07s fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button><button class="btn-admin sm ghost">⏸</button></div></td>
+                </tr>
+
+                <!-- ░ Brass · queued -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">B</div>
+                      <div class="game-info"><span class="game-name">Brass: Birmingham</span><span class="game-id">game_brs02</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">brass-birmingham-rules.pdf</span></td>
+                  <td><span class="status-chip muted">queued · pos 1</span></td>
+                  <td class="mono" style="font-size:11.5px;color:var(--text-muted)">— · stima 22 sez.</td>
+                  <td class="cost-cell" style="color:var(--text-muted)">—<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">14:22:55<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">13s fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button><button class="btn-admin sm ghost">✕</button></div></td>
+                </tr>
+
+                <!-- ░ Ark Nova · failed (cost cap) -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">A</div>
+                      <div class="game-info"><span class="game-name">Ark Nova</span><span class="game-id">game_ark01</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">ark-nova-rules-en.pdf</span></td>
+                  <td><span class="status-chip danger">failed · cap reached</span></td>
+                  <td class="mono" style="font-size:11.5px;color:var(--text-muted)">14 / 24 (interrotta)</td>
+                  <td class="cost-cell over">$1.51<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">ieri 22:14:12<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">16h fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button><button class="btn-admin sm">↻ Retry</button></div></td>
+                </tr>
+
+                <!-- ░ Spirit Island · completed older -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">S</div>
+                      <div class="game-info"><span class="game-name">Spirit Island</span><span class="game-id">game_spi01</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">spirit-island-rules.pdf</span></td>
+                  <td><span class="status-chip healthy">completed</span></td>
+                  <td class="mono" style="font-size:11.5px">19 / 19 · 51 meccaniche</td>
+                  <td class="cost-cell">$0.71<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">22 mag 18:42<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">2g fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button></div></td>
+                </tr>
+
+                <!-- ░ Gloomhaven JotL · completed older -->
+                <tr>
+                  <td>
+                    <div class="game-cell e-game">
+                      <div class="game-cover">G</div>
+                      <div class="game-info"><span class="game-name">Gloomhaven: JotL</span><span class="game-id">game_glo04</span></div>
+                    </div>
+                  </td>
+                  <td><span class="pdf-cell">gh-jotl-learn-to-play.pdf</span></td>
+                  <td><span class="status-chip warning">completed · 4 low-conf</span></td>
+                  <td class="mono" style="font-size:11.5px">9 / 9 · 22 meccaniche</td>
+                  <td class="cost-cell">$0.38<span class="sub">cap $1.50</span></td>
+                  <td class="mono" style="font-size:11.5px">21 mag 11:03<span style="display:block;color:var(--text-muted);font-size:9.5px;margin-top:1px">3g fa</span></td>
+                  <td><div class="row-actions"><button class="btn-admin sm ghost">↗</button></div></td>
+                </tr>
+
+              </tbody>
+            </table>
+          </section>
+
+          <!-- ░░ Drill: Dettaglio analisi (Wingspan running) ░░ -->
+          <aside class="admin-panel drill-panel">
+            <div class="drill-hero">
+              <div class="hh">
+                <div class="cover">W</div>
+                <div style="flex:1;min-width:0">
+                  <h2>Wingspan</h2>
+                  <div class="sub">analysis_8f3a21 · v2 ed. · prompt v2.4</div>
+                </div>
+                <span class="status-chip running">running · 64%</span>
+              </div>
+              <div class="chips">
+                <span class="status-chip info">claude-3.5-sonnet</span>
+                <span class="status-chip muted">12 pag · 1.8 MB</span>
+                <span class="status-chip muted">SSE · live</span>
+              </div>
+              <div class="runinfo">
+                <div><span class="lbl">Costo</span><span class="v">$0.42</span></div>
+                <div><span class="lbl">Cap</span><span class="v">$1.50</span></div>
+                <div><span class="lbl">Eta</span><span class="v">1m 38s</span></div>
+              </div>
+            </div>
+
+            <div class="admin-tabs">
+              <button class="admin-tab active">Sezioni <span class="count">14</span></button>
+              <button class="admin-tab">Meccaniche <span class="count">22</span></button>
+              <button class="admin-tab">Log</button>
+              <button class="admin-tab">Validazione <span class="count">3</span></button>
+            </div>
+
+            <div class="section-runs">
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Setup &amp; Components</span><span class="pg">p. 2–3</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>3 meccaniche · 38s</span><span class="cost">$0.04</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Turn Structure</span><span class="pg">p. 4</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>4 meccaniche · 41s</span><span class="cost">$0.05</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Action: Gain Food</span><span class="pg">p. 5</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>2 meccaniche · 29s</span><span class="cost">$0.03</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Action: Lay Eggs</span><span class="pg">p. 5</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>3 meccaniche · 32s</span><span class="cost">$0.04</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Action: Draw Cards</span><span class="pg">p. 6</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>2 meccaniche · 28s</span><span class="cost">$0.03</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Action: Play a Bird</span><span class="pg">p. 6–7</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>5 meccaniche · 52s</span><span class="cost">$0.07</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">Bird Powers</span><span class="pg">p. 8</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>3 meccaniche · 47s</span><span class="cost">$0.06</span></div>
+              </div>
+
+              <div class="sr e-kb">
+                <div class="sr-row"><span class="nm">End of Round Goals</span><span class="pg">p. 9</span><span class="pct">100%</span></div>
+                <div class="sr-bar"><i style="width:100%"></i></div>
+                <div class="sr-meta"><span>1 meccanica · 22s</span><span class="cost">$0.03</span></div>
+              </div>
+
+              <div class="sr e-event running">
+                <div class="sr-row"><span class="nm">Scoring &amp; End Game</span><span class="pg">p. 10</span><span class="pct">58%</span></div>
+                <div class="sr-bar"><i style="width:58%"></i></div>
+                <div class="sr-meta"><span>in corso · estrazione meccaniche…</span><span class="cost">$0.07</span></div>
+              </div>
+
+              <div class="sr e-toolkit">
+                <div class="sr-row"><span class="nm">Solo Mode</span><span class="pg">p. 11</span><span class="pct muted">queued</span></div>
+                <div class="sr-bar"><i style="width:0"></i></div>
+                <div class="sr-meta"><span>in attesa</span><span class="cost">—</span></div>
+              </div>
+
+              <div class="sr e-toolkit">
+                <div class="sr-row"><span class="nm">Appendix · Bird List</span><span class="pg">p. 12</span><span class="pct muted">queued</span></div>
+                <div class="sr-bar"><i style="width:0"></i></div>
+                <div class="sr-meta"><span>in attesa</span><span class="cost">—</span></div>
+              </div>
+
+            </div>
+
+            <div class="subhead">
+              <h4>Meccaniche estratte</h4>
+              <span class="right">22 · sort by confidence ↓</span>
+            </div>
+
+            <table class="mech-table">
+              <thead>
+                <tr>
+                  <th style="width:55%">Meccanica</th>
+                  <th style="width:18%">Sez.</th>
+                  <th style="text-align:right">Conf.</th>
+                </tr>
+              </thead>
+              <tbody>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Engine Building</span>
+                    <span class="mech-pages" style="display:block">classify · p. 6–8</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Play a Bird</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip healthy">high</span>
+                      <span class="v">0.92</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Hand Management</span>
+                    <span class="mech-pages" style="display:block">classify · p. 6</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Draw Cards</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip healthy">high</span>
+                      <span class="v">0.88</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Variable Player Powers</span>
+                    <span class="mech-pages" style="display:block">classify · p. 8</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Bird Powers</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip healthy">high</span>
+                      <span class="v">0.84</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Dice Rolling</span>
+                    <span class="mech-pages" style="display:block">classify · p. 5</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Gain Food</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip healthy">high</span>
+                      <span class="v">0.81</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Push-Your-Luck</span>
+                    <span class="mech-pages" style="display:block">classify · p. 5</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Gain Food</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip healthy">high</span>
+                      <span class="v">0.76</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Set Collection</span>
+                    <span class="mech-pages" style="display:block">classify · p. 9</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">End of Round Goals</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip warning">review</span>
+                      <span class="v">0.61</span>
+                    </div>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <span class="mech-name">Area Control</span>
+                    <span class="mech-pages" style="display:block">classify · p. 2</span>
+                  </td>
+                  <td class="mono" style="font-size:10.5px;color:var(--text-sec)">Setup</td>
+                  <td>
+                    <div class="conf-cell">
+                      <span class="status-chip warning">review</span>
+                      <span class="v">0.42</span>
+                    </div>
+                  </td>
+                </tr>
+
+              </tbody>
+            </table>
+          </aside>
+
+        </div>
+
+        <!-- ─── EMPTY STATE (commentato) ───
+        <section class="admin-panel">
+          <div class="empty">
+            <div class="em">🪶</div>
+            <h3>Nessuna analisi ancora</h3>
+            <p>Avvia la prima estrazione meccaniche scegliendo gioco + PDF in alto. Il primo run su un titolo costa in media $0.40–$0.70.</p>
+            <button class="btn-admin primary" style="margin-top:6px">▶ Avvia analisi</button>
+          </div>
+        </section>
+        ─── /EMPTY STATE ─── -->
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('mechanic-extractor');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-monitor.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-monitor.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A8 · Admin Monitor / Analytics · /admin/monitor</title>
+<!-- @v2 TimeRangePicker · KPISparkline · LiveEventLog · AdminChartPanel reuse -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .kpi-strip { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
+  .admin-kpi.tiny { min-height: 64px; padding: 8px 10px; }
+  .admin-kpi.tiny .admin-kpi-value { font-size: 18px; }
+  .admin-kpi.tiny .admin-kpi-spark { width: 50px; height: 22px; right: 8px; top: 8px; }
+
+  .charts-2x2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .chart-big { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px; height: 240px; display: flex; flex-direction: column; }
+  .chart-big h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+  .chart-big .sub { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .chart-big svg { flex: 1; width: 100%; margin-top: 10px; }
+
+  .event-log {
+    background: var(--bg-card); border: 1px solid var(--border-light);
+    border-radius: 10px; max-height: 280px; overflow-y: auto;
+    font-family: var(--f-mono); font-size: 11px;
+  }
+  .event-log .row {
+    display: grid; grid-template-columns: 80px 80px 80px 1fr;
+    gap: 10px; padding: 5px 14px; border-bottom: 1px solid var(--border-light);
+    line-height: 1.4;
+  }
+  .event-log .row:hover { background: var(--bg-muted); }
+  .event-log .ts { color: var(--text-muted); }
+  .event-log .lvl { font-weight: 700; }
+  .event-log .lvl.info { color: hsl(var(--c-chat)); }
+  .event-log .lvl.warn { color: hsl(38 90% 50%); }
+  .event-log .lvl.err  { color: hsl(var(--c-event)); }
+  .event-log .lvl.ok   { color: hsl(var(--c-toolkit)); }
+  .event-log .route { color: hsl(var(--c-agent)); }
+
+  .time-pills { display: flex; gap: 4px; padding: 3px; background: var(--bg-muted); border-radius: 6px; }
+  .time-pills button { padding: 4px 10px; background: transparent; border: 0; cursor: pointer; font-family: var(--f-mono); font-size: 11px; font-weight: 700; color: var(--text-sec); border-radius: 4px; }
+  .time-pills button.active { background: hsl(var(--c-event)); color: #fff; }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Monitor &amp; Analytics</h1><div class="crumbs">Admin · Live · refresh ogni 5s · 487 metriche</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="time-pills">
+          <button>1h</button>
+          <button class="active">24h</button>
+          <button>7gg</button>
+          <button>30gg</button>
+          <button>Custom</button>
+        </div>
+        <button class="btn-admin">📈 Open Grafana</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="display: flex; flex-direction: column; gap: 14px">
+
+      <div class="kpi-strip">
+        <div class="admin-kpi tiny e-chat"><div class="admin-kpi-label">API P95</div><div class="admin-kpi-value">324<span style="font-size:11px;color:var(--text-muted)">ms</span></div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,12 8,11 16,14 24,10 32,8 40,9 50,7" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+        <div class="admin-kpi tiny e-kb"><div class="admin-kpi-label">DB P95</div><div class="admin-kpi-value">42<span style="font-size:11px;color:var(--text-muted)">ms</span></div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,14 8,13 16,12 24,14 32,11 40,10 50,11" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+        <div class="admin-kpi tiny e-event"><div class="admin-kpi-label">Redis ops/s</div><div class="admin-kpi-value">3.8<span style="font-size:11px;color:var(--text-muted)">k</span></div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,16 8,14 16,12 24,10 32,8 40,6 50,5" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+        <div class="admin-kpi tiny e-agent"><div class="admin-kpi-label">AI tok/min</div><div class="admin-kpi-value">847<span style="font-size:11px;color:var(--text-muted)">k</span></div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,18 8,15 16,14 24,12 32,10 40,9 50,8" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+        <div class="admin-kpi tiny e-toolkit"><div class="admin-kpi-label">PDF queue</div><div class="admin-kpi-value">12</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,15 8,18 16,14 24,12 32,15 40,13 50,11" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+        <div class="admin-kpi tiny e-player"><div class="admin-kpi-label">Err rate</div><div class="admin-kpi-value">0.18<span style="font-size:11px;color:var(--text-muted)">%</span></div>
+          <svg class="admin-kpi-spark" viewBox="0 0 50 22"><polyline points="0,16 8,14 16,16 24,14 32,15 40,16 50,15" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>
+        </div>
+      </div>
+
+      <div class="charts-2x2">
+        <div class="chart-big" style="color: hsl(var(--c-chat))">
+          <h3 style="color: var(--text)">Request rate by endpoint · stacked area · 24h</h3>
+          <div class="sub">Top 5 endpoints · req/min</div>
+          <svg viewBox="0 0 700 160" preserveAspectRatio="none">
+            <polygon points="0,140 50,135 100,128 150,120 200,115 250,118 300,110 350,108 400,105 450,100 500,95 550,90 600,88 650,85 700,82 700,160 0,160" fill="hsl(var(--c-chat) / .3)"/>
+            <polygon points="0,120 50,115 100,108 150,102 200,98 250,100 300,92 350,90 400,86 450,80 500,75 550,70 600,68 650,65 700,62 700,160 0,160" fill="hsl(var(--c-agent) / .3)"/>
+            <polygon points="0,100 50,95 100,88 150,82 200,78 250,80 300,72 350,70 400,66 450,60 500,55 550,50 600,48 650,45 700,42 700,160 0,160" fill="hsl(var(--c-kb) / .3)"/>
+            <polygon points="0,80 50,75 100,68 150,62 200,58 250,60 300,52 350,50 400,46 450,40 500,35 550,30 600,28 650,25 700,22 700,160 0,160" fill="hsl(var(--c-event) / .3)"/>
+          </svg>
+          <div style="margin-top: 6px; display: flex; gap: 10px; font-family: var(--f-mono); font-size: 10px; flex-wrap: wrap">
+            <span style="color: hsl(var(--c-event))">■ /agents/*/query (1.2k)</span>
+            <span style="color: hsl(var(--c-kb))">■ /kb/search (840)</span>
+            <span style="color: hsl(var(--c-agent))">■ /games/* (620)</span>
+            <span style="color: hsl(var(--c-chat))">■ /sessions/* (380)</span>
+          </div>
+        </div>
+
+        <div class="chart-big" style="color: hsl(var(--c-event))">
+          <h3 style="color: var(--text)">Error rate breakdown · by route · 24h</h3>
+          <div class="sub">5 routes con più errori</div>
+          <svg viewBox="0 0 700 160" preserveAspectRatio="none">
+            <g>
+              <rect x="20" y="40" width="100" height="20" fill="hsl(var(--c-event) / .6)" rx="2"/>
+              <text x="130" y="55" fill="var(--text)" font-family="var(--f-mono)" font-size="12">POST /agents/query · 0.84% (1.8k err)</text>
+              <rect x="20" y="68" width="68" height="20" fill="hsl(var(--c-event) / .5)" rx="2"/>
+              <text x="98" y="83" fill="var(--text)" font-family="var(--f-mono)" font-size="12">POST /pdf/upload · 0.52%</text>
+              <rect x="20" y="96" width="42" height="20" fill="hsl(var(--c-event) / .4)" rx="2"/>
+              <text x="72" y="111" fill="var(--text)" font-family="var(--f-mono)" font-size="12">GET /games/* · 0.18%</text>
+              <rect x="20" y="124" width="22" height="20" fill="hsl(var(--c-event) / .3)" rx="2"/>
+              <text x="52" y="139" fill="var(--text)" font-family="var(--f-mono)" font-size="12">POST /sessions · 0.09%</text>
+            </g>
+          </svg>
+        </div>
+
+        <div class="chart-big" style="color: hsl(var(--c-player))">
+          <h3 style="color: var(--text)">User signups &amp; session starts · trend 24h</h3>
+          <div class="sub">Signup +148 · session start 4.8k</div>
+          <svg viewBox="0 0 700 160" preserveAspectRatio="none">
+            <polyline points="0,80 50,75 100,70 150,68 200,72 250,65 300,60 350,58 400,52 450,48 500,45 550,42 600,40 650,38 700,35" fill="none" stroke="hsl(var(--c-player))" stroke-width="2"/>
+            <polyline points="0,120 50,115 100,110 150,108 200,105 250,100 300,95 350,92 400,88 450,82 500,78 550,72 600,68 650,62 700,55" fill="none" stroke="hsl(var(--c-session))" stroke-width="2"/>
+          </svg>
+          <div style="margin-top: 4px; display: flex; gap: 12px; font-family: var(--f-mono); font-size: 10px">
+            <span style="color: hsl(var(--c-player))">■ Signup +148</span>
+            <span style="color: hsl(var(--c-session))">■ Session start 4.8k</span>
+          </div>
+        </div>
+
+        <div class="chart-big" style="color: hsl(var(--c-session))">
+          <h3 style="color: var(--text)">Game-session duration · histogram</h3>
+          <div class="sub">Median 87 min · P95 4.2h · 487 sessions chiuse</div>
+          <svg viewBox="0 0 700 160" preserveAspectRatio="none">
+            <g>
+              <rect x="0"   y="120" width="50" height="40" fill="hsl(var(--c-session) / .8)"/>
+              <rect x="55"  y="80"  width="50" height="80" fill="hsl(var(--c-session) / .8)"/>
+              <rect x="110" y="40"  width="50" height="120" fill="hsl(var(--c-session) / .8)"/>
+              <rect x="165" y="20"  width="50" height="140" fill="hsl(var(--c-session))"/>
+              <rect x="220" y="50"  width="50" height="110" fill="hsl(var(--c-session) / .8)"/>
+              <rect x="275" y="80"  width="50" height="80" fill="hsl(var(--c-session) / .8)"/>
+              <rect x="330" y="100" width="50" height="60" fill="hsl(var(--c-session) / .7)"/>
+              <rect x="385" y="110" width="50" height="50" fill="hsl(var(--c-session) / .7)"/>
+              <rect x="440" y="120" width="50" height="40" fill="hsl(var(--c-session) / .6)"/>
+              <rect x="495" y="130" width="50" height="30" fill="hsl(var(--c-session) / .6)"/>
+              <rect x="550" y="135" width="50" height="25" fill="hsl(var(--c-session) / .5)"/>
+              <rect x="605" y="145" width="50" height="15" fill="hsl(var(--c-session) / .4)"/>
+            </g>
+            <g font-family="var(--f-mono)" font-size="9" fill="var(--text-muted)">
+              <text x="25" y="156" text-anchor="middle">15m</text>
+              <text x="80" y="156" text-anchor="middle">30m</text>
+              <text x="135" y="156" text-anchor="middle">60m</text>
+              <text x="190" y="156" text-anchor="middle">90m</text>
+              <text x="245" y="156" text-anchor="middle">2h</text>
+              <text x="355" y="156" text-anchor="middle">3h</text>
+              <text x="465" y="156" text-anchor="middle">4h</text>
+              <text x="630" y="156" text-anchor="middle">8h+</text>
+            </g>
+          </svg>
+        </div>
+      </div>
+
+      <div>
+        <div class="admin-panel-head" style="background: var(--bg-card); border: 1px solid var(--border-light); border-bottom: 0; border-radius: 10px 10px 0 0; padding: 10px 14px;">
+          <h3>📡 Live event log <span class="status-chip running info" style="margin-left: 8px">SSE streaming</span></h3>
+          <span class="meta" style="margin-left: auto">487 eventi/min · filter applied: level≥warn</span>
+        </div>
+        <div class="event-log" style="border-top: 0; border-radius: 0 0 10px 10px">
+          <div class="row"><span class="ts">14:23:42</span><span class="lvl ok">OK</span><span class="route">POST /agents/.../query</span><span>200 · 1.32s · agent=a-wingspan · user=u-marco · cost=$0.004</span></div>
+          <div class="row"><span class="ts">14:23:41</span><span class="lvl warn">WARN</span><span class="route">POST /pdf/upload</span><span>OCR low confidence p.47 · doc=d-tg-scan · retry queued</span></div>
+          <div class="row"><span class="ts">14:23:40</span><span class="lvl info">INFO</span><span class="route">SSE /agents/.../stream</span><span>connected · sid=s-7f8a · agent=a-brass-rules</span></div>
+          <div class="row"><span class="ts">14:23:38</span><span class="lvl err">ERROR</span><span class="route">POST /agents/.../query</span><span>500 · LLM timeout 30s · gpt-4o-mini · retry exhausted</span></div>
+          <div class="row"><span class="ts">14:23:37</span><span class="lvl ok">OK</span><span class="route">GET /games/g-wingspan</span><span>200 · 18ms · cached · user=u-davide</span></div>
+          <div class="row"><span class="ts">14:23:36</span><span class="lvl warn">WARN</span><span class="route">SCHED rate-limit-monitor</span><span>IP 82.84.211.17 · 47 req/min · auto-block 15min applied</span></div>
+          <div class="row"><span class="ts">14:23:35</span><span class="lvl info">INFO</span><span class="route">POST /sessions</span><span>created s-spirit-island-3 · 4 players · host=u-marco</span></div>
+          <div class="row"><span class="ts">14:23:34</span><span class="lvl ok">OK</span><span class="route">PATCH /game-nights/.../rsvp</span><span>200 · gn-saturday-3 · u-davide → yes</span></div>
+          <div class="row"><span class="ts">14:23:33</span><span class="lvl info">INFO</span><span class="route">JOB indexer.run</span><span>completed · doc=Wingspan-Oceania-EN · 412 chunks · 13.4s</span></div>
+          <div class="row"><span class="ts">14:23:32</span><span class="lvl warn">WARN</span><span class="route">POST /kb/search</span><span>SmolDocling pool exhausted · degraded mode · 12 in queue</span></div>
+          <div class="row"><span class="ts">14:23:30</span><span class="lvl ok">OK</span><span class="route">POST /auth/login</span><span>200 · u-aaron · 2FA bypassed (superadmin) · ip=… session=… </span></div>
+          <div class="row"><span class="ts">14:23:29</span><span class="lvl err">ERROR</span><span class="route">POST /agents/.../query</span><span>503 · pinecone timeout · index=wingspan-v3</span></div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('monitor');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-notifications.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-notifications.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A9 · Admin Notifications · /admin/notifications</title>
+<!-- @v2 TemplateEditor · TemplatePreviewFrame · VariableHelper -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .nf-grid { display: grid; grid-template-columns: 280px 1fr; gap: 14px; align-items: start; }
+  .tpl-list { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; max-height: calc(100vh - 110px); display: flex; flex-direction: column; position: sticky; top: 76px; }
+  .tpl-row { padding: 10px 14px; border-bottom: 1px solid var(--border-light); cursor: pointer; }
+  .tpl-row:hover { background: var(--bg-muted); }
+  .tpl-row.active { background: hsl(var(--c-event) / .08); border-left: 3px solid hsl(var(--c-event)); padding-left: 11px; }
+  .tpl-row .tname { font-family: var(--f-display); font-weight: 700; font-size: 12.5px; display: flex; align-items: center; gap: 6px; }
+  .tpl-row .tmeta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .channel-chip { padding: 1px 5px; border-radius: 3px; font-family: var(--f-mono); font-size: 9px; font-weight: 700; }
+  .channel-chip.email { background: hsl(var(--c-chat) / .14); color: hsl(var(--c-chat)); }
+  .channel-chip.push { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+  .channel-chip.inapp { background: hsl(var(--c-agent) / .14); color: hsl(var(--c-agent)); }
+  .variant-chip { padding: 1px 5px; border-radius: 3px; font-family: var(--f-mono); font-size: 9px; font-weight: 700; background: var(--bg-muted); color: var(--text-muted); }
+
+  .editor-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+  .preview-frame {
+    width: 380px;
+    margin: 0 auto;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+    background: #fff;
+    color: #1a1612;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+  }
+  .preview-frame .ph-h { background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); padding: 28px 24px; color: #fff; }
+  .preview-frame .ph-h .logo { display: flex; align-items: center; gap: 8px; font-family: var(--f-display); font-weight: 800; font-size: 18px; }
+  .preview-frame .ph-h h1 { font-family: var(--f-display); font-size: 22px; margin: 14px 0 0; }
+  .preview-frame .ph-body { padding: 24px; }
+  .preview-frame .ph-body p { margin: 0 0 12px; font-size: 14px; line-height: 1.55; }
+  .preview-frame .ph-body .var { background: hsl(var(--c-game) / .14); color: hsl(var(--c-game)); padding: 0 4px; border-radius: 3px; font-family: var(--f-mono); font-size: 13px; font-weight: 700; }
+  .preview-frame .ph-cta { display: block; background: hsl(var(--c-game)); color: #fff; text-decoration: none; padding: 12px; text-align: center; border-radius: 6px; font-family: var(--f-display); font-weight: 700; }
+  .preview-frame .ph-foot { background: #f5f0e6; padding: 18px 24px; font-size: 11px; color: #6b5a45; }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Notifications</h1><div class="crumbs">Admin · Templates · 47 attivi · 12 transactional · 8 marketing</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Cerca template…"></div>
+        <button class="btn-admin primary">+ Nuovo template</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="nf-grid">
+
+        <div class="tpl-list">
+          <div style="padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; gap: 4px">
+            <button class="filter-chip active">Tutti</button>
+            <button class="filter-chip">📧 Email</button>
+            <button class="filter-chip">🔔 Push</button>
+            <button class="filter-chip">📨 In-app</button>
+          </div>
+
+          <div style="overflow-y: auto; flex: 1">
+            <div class="tpl-row active">
+              <div class="tname">🎲 game-night-invite <span class="channel-chip email">EMAIL</span></div>
+              <div class="tmeta">"Marco ti ha invitato a una serata" · transactional · last edit 12gg fa</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">✅ rsvp-confirmed <span class="channel-chip email">EMAIL</span> <span class="channel-chip inapp">INAPP</span></div>
+              <div class="tmeta">Confirmation RSVP · transactional</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">⏰ session-reminder <span class="channel-chip push">PUSH</span></div>
+              <div class="tmeta">1h prima della partita · transactional</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">🤖 agent-low-confidence <span class="channel-chip inapp">INAPP</span></div>
+              <div class="tmeta">"Vuoi definire una house rule?" · system</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">📚 kb-indexed <span class="channel-chip push">PUSH</span></div>
+              <div class="tmeta">PDF indicizzato · transactional</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">🆕 weekly-digest <span class="channel-chip email">EMAIL</span></div>
+              <div class="tmeta">Riepilogo settimanale · marketing</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">🎉 new-feature-launch <span class="channel-chip email">EMAIL</span> <span class="channel-chip inapp">INAPP</span></div>
+              <div class="tmeta">Annunci nuove feature · marketing</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">💳 billing-receipt <span class="channel-chip email">EMAIL</span></div>
+              <div class="tmeta">Ricevuta pagamento · transactional</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">⚠️ password-reset <span class="channel-chip email">EMAIL</span></div>
+              <div class="tmeta">Reset password · security</div>
+            </div>
+            <div class="tpl-row">
+              <div class="tname">🚨 security-alert <span class="channel-chip email">EMAIL</span> <span class="channel-chip push">PUSH</span></div>
+              <div class="tmeta">Login da nuovo device · security</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="editor-card">
+          <div style="padding: 14px 18px; border-bottom: 1px solid var(--border-light); background: linear-gradient(180deg, hsl(var(--c-event) / .08), transparent)">
+            <div style="display: flex; align-items: center; gap: 10px">
+              <span style="font-size: 22px">🎲</span>
+              <div style="flex: 1">
+                <div style="font-family: var(--f-display); font-size: 17px; font-weight: 800">game-night-invite</div>
+                <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px">id: <code>tpl-gn-invite-v3</code> · variant: <span class="variant-chip">transactional</span> · v3.2 · last edit 12gg fa by Aaron</div>
+              </div>
+              <div style="display: flex; gap: 6px">
+                <button class="btn-admin sm">⤓ Export</button>
+                <button class="btn-admin sm">📋 Duplicate</button>
+                <button class="btn-admin sm primary">💾 Save</button>
+              </div>
+            </div>
+
+            <div class="admin-tabs" style="margin-top: 14px; margin-bottom: -1px">
+              <button class="admin-tab">📝 Edit</button>
+              <button class="admin-tab active">👁 Preview</button>
+              <button class="admin-tab">📨 Test send</button>
+              <button class="admin-tab">📜 History <span class="count">18</span></button>
+            </div>
+          </div>
+
+          <div style="padding: 18px; display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start">
+            <div>
+              <div style="margin-bottom: 14px">
+                <span class="sf-label" style="font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; display: block; margin-bottom: 5px">Subject</span>
+                <input class="admin-input" value="🎲 {{user.firstName}}, sei invitato alla serata di {{host.firstName}}!" style="font-family: var(--f-body); max-width: none">
+              </div>
+
+              <div>
+                <span class="sf-label" style="font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; display: block; margin-bottom: 5px">Body (markdown)</span>
+                <textarea class="admin-textarea" rows="12" style="font-family: var(--f-mono); font-size: 11.5px; max-width: none; line-height: 1.6">Ciao **{{user.firstName}}**,
+
+**{{host.firstName}}** ti ha invitato alla serata "{{gameNight.title}}"
+in programma **{{gameNight.dateFormatted}}** alle **{{gameNight.timeFormatted}}**
+a {{gameNight.location}}.
+
+Giochi proposti:
+{{#each gameNight.games}}
+- {{title}} ({{minPlayers}}-{{maxPlayers}}p · {{duration}}min)
+{{/each}}
+
+Conferma la tua presenza entro **{{gameNight.rsvpDeadline}}**.
+
+[**Conferma RSVP**]({{rsvpUrl}})
+
+A presto! 🎲
+Il team MeepleAI</textarea>
+              </div>
+
+              <div style="margin-top: 14px; padding: 10px 12px; background: var(--bg-muted); border-radius: 6px; font-family: var(--f-mono); font-size: 11px">
+                <div style="color: var(--text-muted); margin-bottom: 6px; font-weight: 700; font-size: 10px; text-transform: uppercase; letter-spacing: .06em">📌 Variabili disponibili</div>
+                <div style="display: flex; flex-wrap: wrap; gap: 4px">
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{user.firstName}}</span>
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{host.firstName}}</span>
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{gameNight.title}}</span>
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{gameNight.dateFormatted}}</span>
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{gameNight.games}}</span>
+                  <span style="background: var(--bg); padding: 2px 5px; border-radius: 3px; color: hsl(var(--c-game))">{{rsvpUrl}}</span>
+                  <span style="color: var(--text-muted)">+ 14 altre…</span>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <div style="display: flex; gap: 6px; margin-bottom: 10px">
+                <button class="filter-chip active">📧 Email</button>
+                <button class="filter-chip">📱 Mobile</button>
+                <button class="filter-chip">🖥️ Desktop</button>
+                <span style="margin-left: auto; display: flex; gap: 6px">
+                  <button class="filter-chip">☀ Light</button>
+                  <button class="filter-chip active">🌙 Dark</button>
+                </span>
+              </div>
+
+              <div class="preview-frame">
+                <div class="ph-h">
+                  <div class="logo">🎲 MeepleAI</div>
+                  <h1>Sei invitato!</h1>
+                </div>
+                <div class="ph-body">
+                  <p>Ciao <span class="var">Davide</span>,</p>
+                  <p><strong>Marco</strong> ti ha invitato alla serata <strong>"Sabato boardgame con i Padovani"</strong> in programma <strong>sabato 25 maggio</strong> alle <strong>20:30</strong> a casa di Marco (Padova).</p>
+                  <p style="margin-top: 16px; font-weight: 700">Giochi proposti:</p>
+                  <ul style="margin: 6px 0 16px; padding-left: 18px; font-size: 14px; line-height: 1.7">
+                    <li>Twilight Imperium 4E (3-6p · 240min)</li>
+                    <li>Brass: Birmingham (2-4p · 120min)</li>
+                    <li>Wingspan (1-5p · 60min)</li>
+                  </ul>
+                  <p>Conferma la tua presenza entro <strong>venerdì 24 alle 18:00</strong>.</p>
+                  <a href="#" class="ph-cta">Conferma RSVP</a>
+                  <p style="margin-top: 20px; font-size: 12.5px; color: #6b5a45">A presto! 🎲<br/>Il team MeepleAI</p>
+                </div>
+                <div class="ph-foot">
+                  Hai ricevuto questa email perché Marco ti ha aggiunto al gruppo Padovani Boardgame. <a href="#" style="color: hsl(var(--c-game))">Disiscriviti</a> · MeepleAI · Padova IT
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('notifications');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-overview.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-overview.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A1 · Admin Overview · /admin/overview</title>
+<!--
+  @route /admin/overview
+  @pattern Dashboard grid: 4 KPI row · activity feed + alerts row · 4 charts row · quick actions sidebar
+  @persona Aaron superadmin · density alta · dark mode default
+  @v2 components: AdminKPICard · AdminAlertBanner · AdminChartPanel · AdminActivityFeed · QuickActionsPanel
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .overview-grid {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 16px;
+  }
+  .overview-main { display: flex; flex-direction: column; gap: 16px; }
+  .kpi-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+  .feed-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .charts-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+
+  .chart-panel { height: 180px; padding: 12px 14px; }
+  .chart-panel .chart-title { font-family: var(--f-display); font-size: 12px; font-weight: 700; color: var(--text-sec); }
+  .chart-panel .chart-value { font-family: var(--f-display); font-size: 24px; font-weight: 800; line-height: 1.1; margin-top: 2px; }
+  .chart-panel .chart-svg { width: 100%; height: 100px; margin-top: 6px; }
+  .chart-panel .chart-foot { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 4px; }
+
+  .quick-actions { display: flex; flex-direction: column; gap: 1px; }
+  .quick-actions .qa-btn {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 12px; background: var(--bg-card);
+    border: 0; border-bottom: 1px solid var(--border-light);
+    color: var(--text); cursor: pointer;
+    font-family: var(--f-display); font-size: 12.5px; font-weight: 600;
+    text-align: left; width: 100%;
+  }
+  .quick-actions .qa-btn:hover { background: var(--bg-muted); }
+  .quick-actions .qa-btn:last-child { border-bottom: 0; }
+  .quick-actions .qa-btn .em { font-size: 16px; }
+  .quick-actions .qa-btn .desc {
+    display: block; font-family: var(--f-body); font-size: 10.5px;
+    color: var(--text-muted); font-weight: 400; margin-top: 1px;
+  }
+
+  .meeple-pulse {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: hsl(var(--c-toolkit));
+    box-shadow: 0 0 0 4px hsl(var(--c-toolkit) / .2);
+    animation: admin-pulse 2s ease-in-out infinite;
+  }
+
+  @media (max-width: 1280px) {
+    .overview-grid { grid-template-columns: 1fr; }
+    .charts-row { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body class="admin-page">
+
+<!-- Mobile fallback ──────────────────────────────────── -->
+<div class="admin-mobile-fallback">
+  <span class="em">🖥️</span>
+  <h2>Console solo desktop</h2>
+  <p>L'Admin Console di MeepleAI richiede uno schermo desktop (≥1280px). Apri questa pagina dal tuo computer per accedere a tutte le funzioni.</p>
+</div>
+
+<!-- Desktop shell ──────────────────────────────────── -->
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <!-- Topbar ──────────────────────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Overview sistema</h1>
+        <div class="crumbs">Admin · Overview · ultimo refresh 14:23:08 UTC</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="kbd-hint"><kbd>g</kbd>+<kbd>o</kbd> torna qui</div>
+        <button class="btn-admin">⟳ Refresh all <kbd>R</kbd></button>
+        <button class="btn-admin icon" title="Cambia tema" onclick="toggleAdminTheme()">🌗</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+
+      <!-- Alert banner — degraded state ─────────────── -->
+      <div class="alert-banner warning" role="alert" style="margin-bottom: 16px;">
+        <span class="em" aria-hidden="true">⚠️</span>
+        <div style="flex:1">
+          <div class="title">Indexing pipeline degradata</div>
+          <div>SmolDocling: 47% rate ridotto. Ultime 12 ingestion in coda. ETA recovery ~18 min.</div>
+        </div>
+        <div class="actions">
+          <button class="btn-admin sm">Apri runbook</button>
+          <button class="btn-admin sm primary">Vai a queue</button>
+        </div>
+      </div>
+
+      <div class="overview-grid">
+        <div class="overview-main">
+
+          <!-- KPI Row 1 ─────────────────────────────── -->
+          <div class="kpi-row">
+            <div class="admin-kpi e-player">
+              <div class="admin-kpi-label">Utenti totali</div>
+              <div class="admin-kpi-value">12.487</div>
+              <div class="admin-kpi-trend up">↗ +148 oggi · +2.3% 7gg</div>
+              <span class="admin-kpi-icon" aria-hidden="true">👥</span>
+            </div>
+            <div class="admin-kpi e-session">
+              <div class="admin-kpi-label">Partite attive ora</div>
+              <div class="admin-kpi-value">847</div>
+              <div class="admin-kpi-trend up">↗ +18% vs. ora media</div>
+              <span class="admin-kpi-icon" aria-hidden="true">🎯</span>
+            </div>
+            <div class="admin-kpi e-agent">
+              <div class="admin-kpi-label">Agenti live</div>
+              <div class="admin-kpi-value">312</div>
+              <div class="admin-kpi-trend flat">→ 312 · stabile</div>
+              <span class="admin-kpi-icon" aria-hidden="true">🤖</span>
+            </div>
+            <div class="admin-kpi e-kb">
+              <div class="admin-kpi-label">Storage KB</div>
+              <div class="admin-kpi-value">2.4<span style="font-size:14px;color:var(--text-muted)">TB</span></div>
+              <div class="admin-kpi-trend up">↗ +47GB ultima settimana</div>
+              <span class="admin-kpi-icon" aria-hidden="true">📚</span>
+            </div>
+          </div>
+
+          <!-- Feed Row ──────────────────────────────── -->
+          <div class="feed-row">
+            <!-- Activity feed -->
+            <section class="admin-panel">
+              <div class="admin-panel-head">
+                <h3>Activity feed</h3>
+                <span class="meta">ultime 24h · 487 eventi</span>
+              </div>
+              <div class="activity-feed">
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-player) / .15); color: hsl(var(--c-player))">👤</span>
+                  <div class="body"><strong>Marco Rossi</strong> ha aggiornato il ruolo di <strong>Giulia Bianchi</strong> in <span class="role-chip admin">Admin</span></div>
+                  <span class="ts">2m</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-kb) / .15); color: hsl(var(--c-kb))">📚</span>
+                  <div class="body"><strong>Wingspan Asia EN</strong> indicizzato · 347 chunks · 12.4s</div>
+                  <span class="ts">5m</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-event) / .15); color: hsl(var(--c-event))">⚠️</span>
+                  <div class="body">Rate-limit superato per IP <code style="font-family:var(--f-mono);font-size:11px">82.84.211.x</code> — bloccato 15m</div>
+                  <span class="ts">8m</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-agent) / .15); color: hsl(var(--c-agent))">🤖</span>
+                  <div class="body">Agente <strong>Brass Rules Expert v3.1</strong> deployato in prod · A/B 50/50</div>
+                  <span class="ts">14m</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-session) / .15); color: hsl(var(--c-session))">🎯</span>
+                  <div class="body">Session <code style="font-family:var(--f-mono);font-size:11px">s-spirit-island-3-marco</code> chiusa · 3h 24m · winner Marco</div>
+                  <span class="ts">22m</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-toolkit) / .15); color: hsl(var(--c-toolkit))">🧰</span>
+                  <div class="body">Toolkit <strong>OCR-PDF-v2</strong> bumpato a v2.1.0 · breaking change rilevato</div>
+                  <span class="ts">38m</span>
+                </div>
+              </div>
+              <div style="padding: 10px 14px; border-top: 1px solid var(--border-light); text-align: center">
+                <a href="sp5-admin-monitor.html" style="font-family: var(--f-mono); font-size: 11px; color: hsl(var(--c-event)); text-decoration: none; font-weight: 700">Vedi tutti gli eventi →</a>
+              </div>
+            </section>
+
+            <!-- Alerts -->
+            <section class="admin-panel">
+              <div class="admin-panel-head">
+                <h3>Health alerts</h3>
+                <span class="meta">3 attivi · 1 critical</span>
+              </div>
+              <div class="activity-feed">
+                <div class="activity-item" style="border-left: 3px solid hsl(var(--c-event));">
+                  <span class="em" style="background: hsl(var(--c-event) / .15); color: hsl(var(--c-event))">🚨</span>
+                  <div class="body">
+                    <strong>SmolDocling rate ridotto al 47%</strong><br/>
+                    <span style="font-size: 11px; color: var(--text-sec)">12 PDF in coda · ETA recovery 18 min · auto-scale triggered</span>
+                  </div>
+                  <span class="ts">crit</span>
+                </div>
+                <div class="activity-item" style="border-left: 3px solid hsl(38 90% 50%);">
+                  <span class="em" style="background: hsl(38 90% 50% / .15); color: hsl(38 90% 50%)">⚠️</span>
+                  <div class="body">
+                    <strong>API P95 sopra soglia (380ms)</strong><br/>
+                    <span style="font-size: 11px; color: var(--text-sec)">SLO 250ms · degrado durato 12 min · ora 320ms</span>
+                  </div>
+                  <span class="ts">warn</span>
+                </div>
+                <div class="activity-item" style="border-left: 3px solid hsl(38 90% 50%);">
+                  <span class="em" style="background: hsl(38 90% 50% / .15); color: hsl(38 90% 50%)">⚠️</span>
+                  <div class="body">
+                    <strong>Costi AI giornalieri al 87% del budget</strong><br/>
+                    <span style="font-size: 11px; color: var(--text-sec)">$348.20 / $400.00 · proiezione mensile +14%</span>
+                  </div>
+                  <span class="ts">warn</span>
+                </div>
+                <div class="activity-item">
+                  <span class="em" style="background: hsl(var(--c-toolkit) / .15); color: hsl(var(--c-toolkit))">✅</span>
+                  <div class="body"><strong>Tutti i deploy verificati</strong> · last canary 23m fa</div>
+                  <span class="ts">ok</span>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <!-- Charts row ────────────────────────────── -->
+          <div class="charts-row">
+            <div class="admin-panel chart-panel" style="color: hsl(var(--c-toolkit))">
+              <div class="chart-title">Uptime 7gg</div>
+              <div class="chart-value">99.94<span style="font-size:14px;color:var(--text-muted)">%</span></div>
+              <svg class="chart-svg" viewBox="0 0 140 60" preserveAspectRatio="none">
+                <polyline class="spark" points="0,12 14,10 28,11 42,8 56,18 70,9 84,7 98,8 112,9 126,8 140,9"/>
+                <polygon class="spark-fill" points="0,12 14,10 28,11 42,8 56,18 70,9 84,7 98,8 112,9 126,8 140,9 140,60 0,60"/>
+              </svg>
+              <div class="chart-foot">SLO 99.9% · margine 0.04%</div>
+            </div>
+
+            <div class="admin-panel chart-panel" style="color: hsl(var(--c-chat))">
+              <div class="chart-title">Requests/min</div>
+              <div class="chart-value">3.8<span style="font-size:14px;color:var(--text-muted)">k</span></div>
+              <svg class="chart-svg" viewBox="0 0 140 60" preserveAspectRatio="none">
+                <polyline class="spark" points="0,40 14,38 28,32 42,28 56,24 70,18 84,22 98,16 112,14 126,12 140,10"/>
+                <polygon class="spark-fill" points="0,40 14,38 28,32 42,28 56,24 70,18 84,22 98,16 112,14 126,12 140,10 140,60 0,60"/>
+              </svg>
+              <div class="chart-foot">picco oggi 4.1k · h 14:00</div>
+            </div>
+
+            <div class="admin-panel chart-panel" style="color: hsl(var(--c-event))">
+              <div class="chart-title">Error rate</div>
+              <div class="chart-value">0.18<span style="font-size:14px;color:var(--text-muted)">%</span></div>
+              <svg class="chart-svg" viewBox="0 0 140 60" preserveAspectRatio="none">
+                <polyline class="spark" points="0,50 14,48 28,52 42,46 56,42 70,40 84,46 98,50 112,52 126,54 140,52"/>
+                <polygon class="spark-fill" points="0,50 14,48 28,52 42,46 56,42 70,40 84,46 98,50 112,52 126,54 140,52 140,60 0,60"/>
+              </svg>
+              <div class="chart-foot">soglia 1.0% · 0 burst alert</div>
+            </div>
+
+            <div class="admin-panel chart-panel" style="color: hsl(var(--c-agent))">
+              <div class="chart-title">AI cost oggi</div>
+              <div class="chart-value">$348.<span style="font-size:14px;color:var(--text-muted)">20</span></div>
+              <svg class="chart-svg" viewBox="0 0 140 60" preserveAspectRatio="none">
+                <polyline class="spark" points="0,52 14,46 28,40 42,32 56,28 70,22 84,18 98,14 112,12 126,10 140,9"/>
+                <polygon class="spark-fill" points="0,52 14,46 28,40 42,32 56,28 70,22 84,18 98,14 112,12 126,10 140,9 140,60 0,60"/>
+              </svg>
+              <div class="chart-foot">87% budget · alert al 95%</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Quick Actions sidebar dx ─────────────────── -->
+        <aside style="display: flex; flex-direction: column; gap: 12px;">
+          <div class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Quick actions</h3>
+              <span class="meta">superadmin only</span>
+            </div>
+            <div class="quick-actions">
+              <button class="qa-btn">
+                <span class="em">🎭</span>
+                <span><strong>Impersonate user</strong><span class="desc">Apri sessione con role utente</span></span>
+              </button>
+              <button class="qa-btn">
+                <span class="em">⏱️</span>
+                <span><strong>Reset rate limit</strong><span class="desc">Sblocca IP / user / endpoint</span></span>
+              </button>
+              <button class="qa-btn">
+                <span class="em">💨</span>
+                <span><strong>Force cache flush</strong><span class="desc">Redis · CDN · React Query</span></span>
+              </button>
+              <button class="qa-btn">
+                <span class="em">🚦</span>
+                <span><strong>Pausa ingestion</strong><span class="desc">Freeze pipeline tutta</span></span>
+              </button>
+              <button class="qa-btn">
+                <span class="em">📡</span>
+                <span><strong>Broadcast banner</strong><span class="desc">Avviso a tutti gli utenti loggati</span></span>
+              </button>
+              <button class="qa-btn">
+                <span class="em">🧨</span>
+                <span><strong>Emergency shutdown</strong><span class="desc">Modalità manutenzione totale</span></span>
+              </button>
+            </div>
+          </div>
+
+          <div class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Status deployment</h3>
+              <span class="meta">last 24h</span>
+            </div>
+            <div class="admin-panel-body" style="display: flex; flex-direction: column; gap: 10px;">
+              <div style="display: flex; align-items: center; gap: 8px; font-size: 12px;">
+                <span class="meeple-pulse"></span>
+                <span style="flex:1">prod</span>
+                <span class="status-chip healthy">Healthy</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px; font-size: 12px;">
+                <span class="meeple-pulse"></span>
+                <span style="flex:1">staging</span>
+                <span class="status-chip healthy">Healthy</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px; font-size: 12px;">
+                <span class="meeple-pulse" style="background: hsl(38 90% 50%); box-shadow: 0 0 0 4px hsl(38 90% 50% / .2);"></span>
+                <span style="flex:1">workers</span>
+                <span class="status-chip warning">Degraded</span>
+              </div>
+              <div style="margin-top:6px; padding-top: 10px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">
+                Last deploy: <strong>4h 12m fa</strong><br/>
+                Build: <code>web-2026.05.24-a8f3c</code><br/>
+                Commit: <code>e3f7a1c</code> by Marco
+              </div>
+            </div>
+          </div>
+
+          <div class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Keyboard shortcuts</h3>
+            </div>
+            <div class="admin-panel-body" style="display: flex; flex-direction: column; gap: 6px; font-size: 12px;">
+              <div style="display:flex; align-items:center;"><span style="flex:1">Search globale</span><span class="kbd-hint"><kbd>⌘</kbd><kbd>K</kbd></span></div>
+              <div style="display:flex; align-items:center;"><span style="flex:1">Go to Users</span><span class="kbd-hint"><kbd>g</kbd>+<kbd>u</kbd></span></div>
+              <div style="display:flex; align-items:center;"><span style="flex:1">Go to AI / RAG</span><span class="kbd-hint"><kbd>g</kbd>+<kbd>a</kbd></span></div>
+              <div style="display:flex; align-items:center;"><span style="flex:1">Refresh all</span><span class="kbd-hint"><kbd>R</kbd></span></div>
+              <div style="display:flex; align-items:center;"><span style="flex:1">Cambia tema</span><span class="kbd-hint"><kbd>⌘</kbd><kbd>D</kbd></span></div>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script>
+<script>renderAdminNav('overview');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-prompts.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-prompts.html
@@ -1,0 +1,664 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Prompt Management · MeepleAI Admin</title>
+<!-- D4 · AI Tooling & Data Quality → 'prompts' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 PromptListFilter · PromptEditor (variable highlight) · PromptPreview · VersionTimeline
+     · ActivateVersionCTA reuse
+     Endpoints: GET/POST/PUT /api/v1/admin/prompts
+                GET /api/v1/admin/prompts/{id}/versions
+                POST /api/v1/admin/prompts/{id}/versions/{v}/activate
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden;display:flex;flex-direction:column}
+.admin-panel-head{padding:10px 12px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:8px;background:var(--bg);flex-shrink:0}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:12.5px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-select,.admin-input,.admin-textarea{width:100%;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono,.admin-textarea.mono{font-family:var(--f-mono)}
+.admin-tabs{display:flex;gap:0;border-bottom:1px solid var(--border-light);padding:0 14px;background:var(--bg);flex-shrink:0}
+.admin-tab{padding:8px 12px;font-family:var(--f-display);font-size:12px;font-weight:700;color:var(--text-sec);cursor:pointer;border-bottom:2px solid transparent;display:inline-flex;align-items:center;gap:6px;background:transparent;border-top:0;border-left:0;border-right:0}
+.admin-tab:hover{color:var(--text)}
+.admin-tab.active{color:hsl(var(--c-event));border-bottom-color:hsl(var(--c-event))}
+.admin-tab .count{font-family:var(--f-mono);font-size:9px;background:var(--bg-muted);padding:1px 5px;border-radius:99px;color:var(--text-sec);font-weight:700}
+.admin-tab.active .count{background:hsl(var(--c-event)/.14);color:hsl(var(--c-event))}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:16px 20px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+
+/* 3-col layout · viewport-fit */
+.prompt-grid{display:grid;grid-template-columns:300px minmax(0,1fr) 360px;gap:14px;align-items:stretch;height:calc(100vh - 78px)}
+.prompt-grid > .admin-panel{height:100%;overflow:hidden}
+
+/* ── LEFT: templates ────────────────────────────────────────────── */
+.tpl-filter{padding:10px 12px;display:flex;flex-direction:column;gap:8px;border-bottom:1px solid var(--border-light);background:var(--bg)}
+.tpl-filter .field{display:flex;flex-direction:column;gap:2px}
+.tpl-filter .lbl{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.tpl-search{position:relative}
+.tpl-search input{padding-left:28px;font-size:12px;width:100%}
+.tpl-search .ico{position:absolute;left:9px;top:50%;transform:translateY(-50%);color:var(--text-muted);font-size:11px;pointer-events:none}
+
+.tpl-list{flex:1;overflow-y:auto;display:flex;flex-direction:column;padding:6px 6px}
+.tpl-row{padding:9px 10px;border-radius:7px;cursor:pointer;display:flex;flex-direction:column;gap:4px;border:1px solid transparent;margin-bottom:2px}
+.tpl-row:hover{background:var(--bg-muted)}
+.tpl-row.selected{background:hsl(var(--c-event)/.07);border-color:hsl(var(--c-event)/.3);box-shadow:inset 3px 0 0 hsl(var(--c-event))}
+.tpl-row .top{display:flex;align-items:center;gap:6px}
+.tpl-row .nm{font-family:var(--f-display);font-weight:800;font-size:12.5px;color:var(--text);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.tpl-row .kind{font-family:var(--f-mono);font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:1px 5px;border-radius:4px;background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.tpl-row .kind.user{background:hsl(var(--c-player)/.12);color:hsl(var(--c-player))}
+.tpl-row .mid{display:flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.tpl-row .agent-chip{padding:1px 6px;border-radius:4px;background:hsl(var(--e)/.1);color:hsl(var(--e));font-family:var(--f-mono);font-size:9.5px;font-weight:700;letter-spacing:.02em;border:1px solid hsl(var(--e)/.2)}
+.tpl-row .bot{display:flex;align-items:center;justify-content:space-between;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+.tpl-row .ver{font-weight:700;color:var(--text-sec)}
+
+.tpl-foot{padding:8px 12px;border-top:1px solid var(--border-light);background:var(--bg);font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);display:flex;justify-content:space-between}
+
+/* ── CENTER: editor ─────────────────────────────────────────────── */
+.editor-head{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border-light);background:var(--bg);font-family:var(--f-mono);font-size:11px}
+.editor-head .title{display:flex;flex-direction:column;gap:1px;flex:1;min-width:0}
+.editor-head .title .nm{font-family:var(--f-display);font-weight:800;font-size:14px;color:var(--text)}
+.editor-head .title .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.editor-head .right{display:flex;align-items:center;gap:6px}
+
+.editor-toolbar{display:flex;align-items:center;gap:6px;padding:8px 14px;border-bottom:1px solid var(--border-light);background:var(--bg);font-family:var(--f-mono);font-size:11px;color:var(--text-muted);flex-shrink:0;flex-wrap:wrap}
+.editor-toolbar .group{display:inline-flex;align-items:center;gap:4px}
+.editor-toolbar .sep{width:1px;height:18px;background:var(--border-light);margin:0 4px}
+.editor-toolbar .btn-admin.sm{padding:2px 7px;font-size:10.5px}
+.editor-toolbar .var-pill{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:99px;font-family:var(--f-mono);font-size:10px;font-weight:700;background:hsl(var(--c-kb)/.12);color:hsl(var(--c-kb));border:1px solid hsl(var(--c-kb)/.25);cursor:pointer}
+.editor-toolbar .var-pill:hover{background:hsl(var(--c-kb)/.18)}
+.editor-toolbar .spacer{flex:1}
+.editor-toolbar .stats{display:inline-flex;gap:10px;color:var(--text-muted)}
+.editor-toolbar .stats .v{color:var(--text);font-weight:700}
+
+.editor-body{flex:1;overflow:auto;position:relative;background:var(--bg-sunken,var(--bg))}
+.prompt-source{margin:0;padding:18px 22px 12px;font-family:var(--f-mono);font-size:12.5px;line-height:1.7;color:var(--text);white-space:pre-wrap;tab-size:2;caret-color:hsl(var(--c-event));min-height:100%}
+.prompt-source:focus{outline:none}
+.prompt-source .ln{display:inline-block;width:30px;color:var(--text-muted);user-select:none;font-size:10px;text-align:right;padding-right:10px;font-weight:600;opacity:.7}
+
+/* Variable highlight: e-kb tint inline */
+.prompt-source .var{display:inline-flex;align-items:center;padding:0 4px;border-radius:4px;background:hsl(var(--c-kb)/.14);color:hsl(var(--c-kb));border:1px solid hsl(var(--c-kb)/.25);font-weight:700;font-size:11.5px;cursor:pointer}
+.prompt-source .var.opt{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit)/.25)}
+.prompt-source .comment{color:var(--text-muted);font-style:italic;opacity:.85}
+.prompt-source .role{color:hsl(var(--c-event));font-weight:700;text-transform:uppercase;font-size:10px;letter-spacing:.06em;background:hsl(var(--c-event)/.1);padding:1px 6px;border-radius:4px}
+.prompt-source .str{color:hsl(var(--c-toolkit))}
+.prompt-source .caret-here{display:inline-block;width:1px;height:14px;background:hsl(var(--c-event));margin-left:-1px;vertical-align:-3px;animation:caret-blink 1s steps(1) infinite}
+@keyframes caret-blink{50%{opacity:0}}
+
+.editor-foot{padding:9px 14px;border-top:1px solid var(--border-light);background:var(--bg);display:flex;align-items:center;gap:10px;flex-shrink:0}
+.editor-foot .autosave{display:inline-flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted)}
+.editor-foot .autosave .dot{width:7px;height:7px;border-radius:50%;background:hsl(var(--c-agent));animation:admin-pulse 1.4s ease-in-out infinite}
+.editor-foot .autosave .v{color:var(--text);font-weight:700}
+.editor-foot .spacer{flex:1}
+.editor-foot .dirty{font-family:var(--f-mono);font-size:10px;color:hsl(38 90% 50%);font-weight:700}
+
+/* ── RIGHT: preview + versions ──────────────────────────────────── */
+.right-scroll{flex:1;overflow-y:auto;display:flex;flex-direction:column}
+
+.preview-block{padding:12px 14px;border-bottom:1px solid var(--border-light);display:flex;flex-direction:column;gap:8px;background:var(--bg-card)}
+.preview-block h4{font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;display:flex;align-items:center;gap:6px}
+.preview-block h4 .ctrl{margin-left:auto;display:inline-flex;gap:4px;align-items:center}
+
+.preview-vars{display:flex;flex-direction:column;gap:4px;padding:8px 10px;background:var(--bg);border:1px solid var(--border-light);border-radius:7px;font-family:var(--f-mono);font-size:10.5px}
+.preview-vars .pv-row{display:grid;grid-template-columns:108px 1fr;gap:8px;align-items:baseline}
+.preview-vars .pv-row .k{color:hsl(var(--c-kb));font-weight:700;font-size:10px}
+.preview-vars .pv-row .v{color:var(--text);font-weight:600;font-size:10.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+.preview-rendered{padding:10px 12px;background:var(--bg-sunken,var(--bg));border:1px solid var(--border-light);border-radius:7px;font-family:var(--f-mono);font-size:11px;line-height:1.6;color:var(--text-sec);max-height:170px;overflow-y:auto;white-space:pre-wrap}
+.preview-rendered .injected{background:hsl(var(--c-kb)/.14);color:hsl(var(--c-kb));padding:0 4px;border-radius:3px;font-weight:700;font-style:normal}
+.preview-rendered .injected.opt{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.preview-rendered .role{color:hsl(var(--c-event));font-weight:700;text-transform:uppercase;font-size:9px;letter-spacing:.06em;background:hsl(var(--c-event)/.1);padding:1px 5px;border-radius:3px;margin-right:6px}
+
+/* ── Versions timeline ──────────────────────────────────────────── */
+.ver-block{padding:8px 0 12px;display:flex;flex-direction:column;gap:0}
+.ver-block h4{font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;padding:8px 14px 4px;display:flex;align-items:center;gap:6px}
+.ver-block h4 .count{margin-left:auto;color:var(--text);font-weight:700}
+
+.ver-item{padding:10px 14px;display:grid;grid-template-columns:18px 1fr auto;gap:10px;border-bottom:1px solid var(--border-light);position:relative;align-items:flex-start}
+.ver-item:last-child{border-bottom:0}
+.ver-item .rail{position:relative;display:flex;justify-content:center;padding-top:4px}
+.ver-item .rail::after{content:'';position:absolute;top:18px;bottom:-12px;left:50%;width:2px;background:var(--border-light);transform:translateX(-50%)}
+.ver-item:last-child .rail::after{display:none}
+.ver-item .rail .dot{width:12px;height:12px;border-radius:50%;border:2px solid hsl(var(--c-event));background:var(--bg-card);position:relative;z-index:1}
+.ver-item.active .rail .dot{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.2)}
+.ver-item.draft .rail .dot{background:var(--bg-card);border-color:hsl(38 90% 50%)}
+.ver-item.older .rail .dot{background:var(--bg-muted);border-color:var(--border-strong)}
+
+.ver-item .body .v-head{display:flex;align-items:center;gap:6px;margin-bottom:3px;flex-wrap:wrap}
+.ver-item .body .v-tag{font-family:var(--f-mono);font-size:11.5px;font-weight:800;color:var(--text);background:var(--bg);padding:1px 6px;border-radius:4px;border:1px solid var(--border-light);letter-spacing:.02em}
+.ver-item.active .body .v-tag{color:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit)/.4);background:hsl(var(--c-toolkit)/.08)}
+.ver-item .body .author{font-family:var(--f-mono);font-size:10px;color:var(--text-sec);font-weight:700}
+.ver-item .body .date{font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.ver-item .body .diff{display:inline-flex;align-items:center;gap:6px;margin-top:4px;font-family:var(--f-mono);font-size:10px}
+.ver-item .body .diff .add{color:hsl(var(--c-toolkit));font-weight:700}
+.ver-item .body .diff .rem{color:hsl(var(--c-event));font-weight:700}
+.ver-item .body .diff .sep{color:var(--text-muted)}
+.ver-item .body .msg{font-size:10.5px;color:var(--text-sec);margin-top:3px;line-height:1.4}
+
+.ver-item .right{display:flex;flex-direction:column;align-items:flex-end;gap:4px;flex-shrink:0}
+.ver-item .right .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+.ver-item .right .activate-note{font-family:var(--f-mono);font-size:8.5px;color:var(--text-muted);font-weight:700;display:inline-flex;align-items:center;gap:3px}
+.ver-item .right .activate-note .lock{color:hsl(var(--c-event));font-size:9px}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Prompt Management</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › Prompts · 18 template · 142 versioni · 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca prompt, variabile, agente…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">⤓ Export JSON</button>
+          <button class="btn-admin primary">＋ Nuovo template</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body">
+
+        <div class="prompt-grid">
+
+          <!-- ░░░░░░░░░░░ LEFT: Templates ░░░░░░░░░░░ -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Template prompt</h3>
+              <span class="status-chip muted">18</span>
+            </div>
+
+            <div class="tpl-filter">
+              <div class="tpl-search">
+                <span class="ico">🔍</span>
+                <input class="admin-input" placeholder="Filtra nome o id…" />
+              </div>
+              <div class="field">
+                <span class="lbl">Agente</span>
+                <select class="admin-select">
+                  <option>Tutti gli agenti</option>
+                  <option selected>Wingspan Rules Bot</option>
+                  <option>Catan Rules Bot</option>
+                  <option>Generic RAG Bot</option>
+                  <option>Mechanic Explainer</option>
+                  <option>Tutor / Onboarding</option>
+                </select>
+              </div>
+              <div class="field">
+                <span class="lbl">Tipo</span>
+                <select class="admin-select">
+                  <option selected>Tutti</option>
+                  <option>system</option>
+                  <option>user</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="tpl-list">
+
+              <!-- SELECTED -->
+              <div class="tpl-row selected">
+                <div class="top">
+                  <span class="nm">RAG answer</span>
+                  <span class="kind">system</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-chat">Wingspan Rules Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v2.5 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Setup explainer</span>
+                  <span class="kind user">user</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-chat">Wingspan Rules Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v1.8 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Glossary lookup</span>
+                  <span class="kind">system</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-kb">Generic RAG Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v3.1 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Rules clarifier</span>
+                  <span class="kind">system</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-chat">Wingspan Rules Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v0.4 · draft</span>
+                  <span class="status-chip warning">draft</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Toolkit suggester</span>
+                  <span class="kind user">user</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-tool">Generic RAG Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v2.2 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Mechanic extract</span>
+                  <span class="kind">system</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-agent">Mechanic Explainer</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v2.4 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row">
+                <div class="top">
+                  <span class="nm">Onboarding intro</span>
+                  <span class="kind user">user</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-player">Tutor / Onboarding</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v1.2 · attiva</span>
+                  <span class="status-chip healthy">attiva</span>
+                </div>
+              </div>
+
+              <div class="tpl-row" style="opacity:.6">
+                <div class="top">
+                  <span class="nm">Legacy fallback</span>
+                  <span class="kind">system</span>
+                </div>
+                <div class="mid">
+                  <span class="agent-chip e-toolkit">Generic RAG Bot</span>
+                </div>
+                <div class="bot">
+                  <span class="ver">v1.0 · disabilitata</span>
+                  <span class="status-chip muted">off</span>
+                </div>
+              </div>
+
+            </div>
+
+            <div class="tpl-foot">
+              <span>filtrati 7 / 18</span>
+              <span>sort by · updated ↓</span>
+            </div>
+          </section>
+
+          <!-- ░░░░░░░░░░░ CENTER: Editor ░░░░░░░░░░░ -->
+          <section class="admin-panel">
+
+            <div class="editor-head">
+              <div class="title">
+                <span class="nm">RAG answer · system prompt</span>
+                <span class="sub">prompt_rag_ans01 · Wingspan Rules Bot · attiva v2.5 · editing draft v2.6</span>
+              </div>
+              <div class="right">
+                <span class="status-chip warning">unsaved</span>
+                <button class="btn-admin sm">📋 Duplica</button>
+                <button class="btn-admin sm">⤓ Export</button>
+              </div>
+            </div>
+
+            <div class="admin-tabs">
+              <button class="admin-tab active">Edit</button>
+              <button class="admin-tab">Preview</button>
+              <button class="admin-tab">Versioni <span class="count">14</span></button>
+              <button class="admin-tab" style="margin-left:auto">Diff vs v2.5</button>
+            </div>
+
+            <div class="editor-toolbar">
+              <span class="group">
+                <button class="btn-admin sm">＋ Inserisci variabile ▾</button>
+                <span class="var-pill" title="Inserisci">{{context}}</span>
+                <span class="var-pill" title="Inserisci">{{question}}</span>
+                <span class="var-pill" title="Inserisci">{{game.title}}</span>
+                <span class="var-pill" title="Inserisci">{{language}}</span>
+              </span>
+              <span class="sep"></span>
+              <span class="group">
+                <button class="btn-admin sm">⊟ Formatta</button>
+                <button class="btn-admin sm">↪ Riformatta context</button>
+                <button class="btn-admin sm">⟲ Annulla</button>
+              </span>
+              <span class="spacer"></span>
+              <span class="stats">
+                <span>L <span class="v">38</span></span>
+                <span>tok <span class="v">412</span> / 4 096</span>
+                <span>var <span class="v">4 + 1 opt</span></span>
+              </span>
+            </div>
+
+            <div class="editor-body">
+              <pre class="prompt-source" contenteditable="false" spellcheck="false"><span class="ln"> 1</span>  <span class="role">system</span>
+<span class="ln"> 2</span>  Sei il <span class="str">"<span class="var">{{game.title}}</span> Rules Bot"</span>, un assistente esperto del regolamento ufficiale di <span class="var">{{game.title}}</span>.
+<span class="ln"> 3</span>  Rispondi in <span class="var">{{language}}</span> in modo chiaro, conciso e con tono amichevole.
+<span class="ln"> 4</span>
+<span class="ln"> 5</span>  <span class="comment"># Regole d'oro</span>
+<span class="ln"> 6</span>  1. Basa SEMPRE le risposte sui passaggi rilevanti del regolamento forniti nel CONTEXT.
+<span class="ln"> 7</span>  2. Se il CONTEXT non contiene la risposta, dichiaralo esplicitamente — non inventare.
+<span class="ln"> 8</span>  3. Cita la pagina del regolamento alla fine della risposta tra parentesi quadre: [p. N].
+<span class="ln"> 9</span>  4. Se la domanda è ambigua, fai una domanda di chiarimento prima di rispondere.
+<span class="ln">10</span>  5. Mantieni la risposta sotto le 120 parole salvo richiesta esplicita di approfondimento.
+<span class="ln">11</span>
+<span class="ln">12</span>  <span class="comment"># Format</span>
+<span class="ln">13</span>  - Inizia con una frase diretta (no preamboli).
+<span class="ln">14</span>  - Usa elenchi puntati per condizioni o passaggi.
+<span class="ln">15</span>  - <span class="str">**Grassetto**</span> per i termini chiave del gioco.
+<span class="ln">16</span>  - Riferisci le carte / componenti con il loro nome esatto.
+<span class="ln">17</span>
+<span class="ln">18</span>  <span class="comment"># Tone modulation (opzionale)</span>
+<span class="ln">19</span>  Se è stato impostato un tono personalizzato, adatta la risposta a:
+<span class="ln">20</span>  <span class="var opt">{{player.tone?}}</span> (default: <span class="str">"neutro · amichevole"</span>).
+<span class="ln">21</span>
+<span class="ln">22</span>  <span class="role">context</span>
+<span class="ln">23</span>  <span class="var">{{context}}</span>
+<span class="ln">24</span>
+<span class="ln">25</span>  <span class="role">user</span>
+<span class="ln">26</span>  <span class="var">{{question}}</span><span class="caret-here"></span>
+<span class="ln">27</span>
+<span class="ln">28</span>  <span class="comment"># Output guardrails</span>
+<span class="ln">29</span>  - Non rispondere a domande fuori-dominio (es. acquisto, prezzi, classifiche).
+<span class="ln">30</span>  - Se la confidence del retrieval &lt; 0.65, prepara la risposta con: <span class="str">"Su questo</span>
+<span class="ln">31</span>  <span class="str">  punto il regolamento non è chiaro, ma…"</span> e suggerisci una FAQ correlata.</pre>
+            </div>
+
+            <div class="editor-foot">
+              <span class="autosave"><span class="dot"></span>Auto-save in <span class="v">12s</span></span>
+              <span class="dirty">● 4 modifiche non committate</span>
+              <span class="spacer"></span>
+              <button class="btn-admin">⟲ Reset modifiche</button>
+              <button class="btn-admin primary">⤴ Commit versione <kbd>⌘S</kbd></button>
+            </div>
+          </section>
+
+          <!-- ░░░░░░░░░░░ RIGHT: Preview + Versions ░░░░░░░░░░░ -->
+          <aside class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Anteprima &amp; versioni</h3>
+              <span class="status-chip info">RAG answer</span>
+            </div>
+
+            <div class="right-scroll">
+
+              <div class="preview-block">
+                <h4>
+                  Variabili d'esempio
+                  <span class="ctrl">
+                    <button class="btn-admin sm ghost">✎ Modifica</button>
+                  </span>
+                </h4>
+                <div class="preview-vars">
+                  <div class="pv-row"><span class="k">{{game.title}}</span><span class="v">"Wingspan"</span></div>
+                  <div class="pv-row"><span class="k">{{language}}</span><span class="v">"italiano"</span></div>
+                  <div class="pv-row"><span class="k">{{question}}</span><span class="v">"Quanti uccelli posso giocare per turno?"</span></div>
+                  <div class="pv-row"><span class="k">{{context}}</span><span class="v">3 chunk · 1.4 KB · top-5 reranked</span></div>
+                  <div class="pv-row"><span class="k">{{player.tone?}}</span><span class="v">"neutro · amichevole" (default)</span></div>
+                </div>
+              </div>
+
+              <div class="preview-block">
+                <h4>
+                  Prompt renderizzato
+                  <span class="ctrl">
+                    <button class="btn-admin sm ghost">↻ Refresh</button>
+                  </span>
+                </h4>
+                <div class="preview-rendered"><span class="role">system</span>
+Sei il "<span class="injected">Wingspan</span> Rules Bot", un assistente esperto del regolamento ufficiale di <span class="injected">Wingspan</span>.
+Rispondi in <span class="injected">italiano</span> in modo chiaro, conciso e con tono amichevole.
+
+# Regole d'oro
+1. Basa SEMPRE le risposte sui passaggi rilevanti…
+…
+<span class="role">context</span>
+<span class="injected">wingspan p.4 §Turn Structure: "On your turn, take exactly one of the four actions…" · wingspan p.6 §Play a Bird: "pay food cost shown on card + 1 egg per…"</span>
+
+<span class="role">user</span>
+<span class="injected">Quanti uccelli posso giocare per turno?</span>
+
+# Tone modulation
+<span class="injected opt">neutro · amichevole</span></div>
+              </div>
+
+              <div class="ver-block">
+                <h4>Versioni <span class="count">14 totali · 3 più recenti</span></h4>
+
+                <div class="ver-item draft">
+                  <span class="rail"><span class="dot"></span></span>
+                  <div class="body">
+                    <div class="v-head">
+                      <span class="v-tag">v2.6</span>
+                      <span class="status-chip warning">draft · unsaved</span>
+                    </div>
+                    <span class="author">tu · <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="4928283b262709242c2c39252c282067283939">[email&#160;protected]</a></span> · <span class="date">in editing · adesso</span>
+                    <div class="diff"><span class="add">+8</span><span class="sep">/</span><span class="rem">−2</span> <span style="color:var(--text-muted)">· vs v2.5</span></div>
+                    <div class="msg">aggiunto tone-modulation opzionale + guardrail su confidence retrieval &lt; 0.65</div>
+                  </div>
+                  <div class="right">
+                    <button class="btn-admin sm ghost">↻ Scarta</button>
+                  </div>
+                </div>
+
+                <div class="ver-item active">
+                  <span class="rail"><span class="dot"></span></span>
+                  <div class="body">
+                    <div class="v-head">
+                      <span class="v-tag">v2.5</span>
+                      <span class="status-chip healthy">attiva · prod</span>
+                    </div>
+                    <span class="author"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="1e7f7f6c71705e737b7b6e727b7f77307f6e6e">[email&#160;protected]</a></span> · <span class="date">oggi 09:14:02</span>
+                    <div class="diff"><span class="add">+12</span><span class="sep">/</span><span class="rem">−4</span> <span style="color:var(--text-muted)">· vs v2.4</span></div>
+                    <div class="msg">refattorizzato regole d'oro + clamp output 120 parole + cita pagina [p. N]</div>
+                  </div>
+                  <div class="right">
+                    <span class="status-chip healthy">live</span>
+                  </div>
+                </div>
+
+                <div class="ver-item older">
+                  <span class="rail"><span class="dot"></span></span>
+                  <div class="body">
+                    <div class="v-head">
+                      <span class="v-tag">v2.4</span>
+                      <span class="status-chip muted">archiviata</span>
+                    </div>
+                    <span class="author"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="a0c1c1d2cfcee0cdc5c5d0ccc5c1c98ec1d0d0">[email&#160;protected]</a></span> · <span class="date">6g fa · 18 mag 16:42</span>
+                    <div class="diff"><span class="add">+24</span><span class="sep">/</span><span class="rem">−9</span> <span style="color:var(--text-muted)">· vs v2.3</span></div>
+                    <div class="msg">rimosso preambolo, aggiunto contesto multilingua via {{language}}</div>
+                  </div>
+                  <div class="right">
+                    <button class="btn-admin sm">↑ Attiva</button>
+                    <span class="activate-note"><span class="lock">🔒</span>ConfirmModal</span>
+                  </div>
+                </div>
+
+                <div class="ver-item older">
+                  <span class="rail"><span class="dot"></span></span>
+                  <div class="body">
+                    <div class="v-head">
+                      <span class="v-tag">v2.3</span>
+                      <span class="status-chip muted">archiviata</span>
+                    </div>
+                    <span class="author"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="4a272b3829256438253939230a272f2f3a262f2b23642b3a3a">[email&#160;protected]</a></span> · <span class="date">20g fa · 04 mag 11:08</span>
+                    <div class="diff"><span class="add">+6</span><span class="sep">/</span><span class="rem">−1</span> <span style="color:var(--text-muted)">· vs v2.2</span></div>
+                    <div class="msg">tono più amichevole + ammette ignoranza esplicita</div>
+                  </div>
+                  <div class="right">
+                    <button class="btn-admin sm">↑ Attiva</button>
+                    <span class="activate-note"><span class="lock">🔒</span>ConfirmModal</span>
+                  </div>
+                </div>
+
+                <div class="ver-item older">
+                  <span class="rail"><span class="dot"></span></span>
+                  <div class="body">
+                    <div class="v-head">
+                      <span class="v-tag">v2.2</span>
+                      <span class="status-chip muted">archiviata</span>
+                    </div>
+                    <span class="author"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="305d5142535f1e425f434359705d5555405c5551591e514040">[email&#160;protected]</a></span> · <span class="date">38g fa · 16 apr 17:30</span>
+                    <div class="diff"><span class="add">+3</span><span class="sep">/</span><span class="rem">−0</span> <span style="color:var(--text-muted)">· vs v2.1</span></div>
+                    <div class="msg">prima versione con {{context}} structured</div>
+                  </div>
+                  <div class="right">
+                    <button class="btn-admin sm">↑ Attiva</button>
+                    <span class="activate-note"><span class="lock">🔒</span>ConfirmModal</span>
+                  </div>
+                </div>
+
+                <button class="btn-admin sm ghost" style="margin:8px 14px 0;align-self:flex-start;width:max-content">⌄ Mostra altre 9 versioni →</button>
+              </div>
+
+            </div>
+          </aside>
+
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('prompts');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-providers.html
@@ -1,0 +1,653 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>LLM Providers &amp; Circuit Breakers · MeepleAI Admin</title>
+<!-- C3 · Platform & Operations → 'providers' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 ProviderTable · RoutingChainViz · CircuitBreakerGrid · RotateKeyModal (superadmin) reuse
+     Endpoints: GET /api/v1/admin/providers, /admin/openrouter,
+                /admin/circuit-breakers, /admin/llm/config
+                POST /api/v1/admin/providers/{id}/rotate-key (superadmin)
+     Role: admin (rotate-key/disable = superadmin) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+
+/* ── components.css (subset) ────────────────────────────────────── */
+.e-chip{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:var(--r-sm);background:hsl(var(--e)/.12);color:hsl(var(--e));font-size:var(--fs-xs);font-weight:var(--fw-bold);font-family:var(--f-display);text-transform:uppercase;letter-spacing:.04em}
+.e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:8px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.admin-table .menu{width:32px;text-align:right}
+.admin-table .menu button{background:transparent;border:0;cursor:pointer;color:var(--text-sec);padding:4px;border-radius:4px}
+.admin-table .menu button:hover{background:var(--bg-muted);color:var(--text)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+.role-chip{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.role-chip.superadmin{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* Provider name cell */
+.prov-cell{display:flex;align-items:center;gap:10px}
+.prov-mark{width:26px;height:26px;border-radius:7px;background:hsl(var(--e)/.14);color:hsl(var(--e));display:grid;place-items:center;font-family:var(--f-display);font-weight:800;font-size:13px;flex-shrink:0;border:1px solid hsl(var(--e)/.25)}
+.prov-info{display:flex;flex-direction:column;line-height:1.2;min-width:0}
+.prov-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text);display:inline-flex;align-items:center;gap:6px}
+.prov-name .primary-tag{font-family:var(--f-mono);font-size:9px;color:hsl(var(--c-event));background:hsl(var(--c-event)/.1);padding:1px 5px;border-radius:4px;letter-spacing:.04em;font-weight:700;text-transform:uppercase}
+.prov-host{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-top:1px}
+
+.model-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text-sec);background:var(--bg-sunken,var(--bg));padding:2px 6px;border-radius:4px;border:1px solid var(--border-light);display:inline-block}
+
+.lat-cell{font-family:var(--f-mono);font-size:11.5px;font-weight:600;color:var(--text);text-align:right}
+.lat-cell.warn{color:hsl(38 90% 50%)}
+.lat-cell .ms{color:var(--text-muted);font-weight:500;font-size:10px;margin-left:1px}
+
+.err-cell{font-family:var(--f-mono);font-size:11.5px;font-weight:600;color:hsl(var(--c-toolkit))}
+.err-cell.warn{color:hsl(38 90% 50%)}
+.err-cell.crit{color:hsl(var(--c-event))}
+
+/* Menu trigger row */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+.row-actions .btn-admin.sm.danger{}
+.lock-mini{color:hsl(var(--c-event));margin-right:2px}
+
+/* ── Routing chain viz ──────────────────────────────────────────── */
+.routing-body{padding:20px;display:flex;flex-direction:column;gap:20px}
+.routing-chain{display:flex;align-items:stretch;gap:0;flex-wrap:wrap;justify-content:flex-start}
+.rc-node{flex:0 0 auto;min-width:180px;background:var(--bg);border:1px solid hsl(var(--e)/.3);border-left:3px solid hsl(var(--e));border-radius:10px;padding:12px 14px;display:flex;flex-direction:column;gap:6px;position:relative}
+.rc-node .rc-head{display:flex;align-items:center;gap:8px}
+.rc-node .rc-prio{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);background:var(--bg-muted);padding:1px 5px;border-radius:99px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}
+.rc-node .rc-prio.primary{color:hsl(var(--c-event));background:hsl(var(--c-event)/.12)}
+.rc-node .rc-name{font-family:var(--f-display);font-weight:800;font-size:14px;color:var(--text);display:flex;align-items:center;gap:6px;flex:1}
+.rc-node .rc-model{font-family:var(--f-mono);font-size:10.5px;color:hsl(var(--e));font-weight:600}
+.rc-node .rc-meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;gap:10px;flex-wrap:wrap}
+.rc-node .rc-meta .ok{color:hsl(var(--c-toolkit))}
+.rc-node .rc-meta .warn{color:hsl(38 90% 50%)}
+
+.rc-arrow{flex:0 0 auto;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:0 14px;gap:4px;min-width:130px}
+.rc-arrow .gl{font-family:var(--f-mono);font-size:22px;font-weight:700;color:var(--text-muted);line-height:1}
+.rc-arrow .cond{font-family:var(--f-mono);font-size:10px;color:hsl(38 90% 50%);background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.3);padding:2px 8px;border-radius:99px;white-space:nowrap;font-weight:700;letter-spacing:.04em;text-transform:uppercase}
+
+.rc-priority-strip{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:10px 14px;background:var(--bg);border:1px solid var(--border-light);border-radius:8px;font-family:var(--f-mono);font-size:11px}
+.rc-priority-strip .k{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;font-size:9.5px}
+.rc-priority-strip .v{color:var(--text);font-weight:600}
+.rc-priority-strip .sep{color:var(--text-muted);opacity:.5}
+
+/* ── Circuit breaker grid ───────────────────────────────────────── */
+.cb-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;padding:16px}
+.cb-card{background:var(--bg);border:1px solid var(--border-light);border-left:3px solid hsl(var(--e));border-radius:10px;padding:12px;display:flex;flex-direction:column;gap:8px;min-height:160px}
+.cb-card .cb-head{display:flex;align-items:center;justify-content:space-between;gap:6px}
+.cb-card .cb-name{font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.cb-card .cb-state{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;margin-top:2px}
+.cb-stat-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px 12px;margin-top:auto}
+.cb-stat{display:flex;flex-direction:column;gap:1px}
+.cb-stat .l{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700}
+.cb-stat .v{font-family:var(--f-mono);font-size:12px;color:var(--text);font-weight:700;font-variant-numeric:tabular-nums}
+.cb-stat .v.warn{color:hsl(38 90% 50%)}
+.cb-stat .v.crit{color:hsl(var(--c-event))}
+.cb-stat .v.muted{color:var(--text-muted)}
+.cb-cooldown{display:flex;flex-direction:column;gap:4px;margin-top:2px}
+.cb-cooldown .bar{height:5px;border-radius:99px;background:var(--bg-muted);overflow:hidden;position:relative}
+.cb-cooldown .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(38 90% 50%);border-radius:99px;animation:cb-shrink 23s linear forwards}
+@keyframes cb-shrink{from{width:100%}to{width:0%}}
+.cb-cooldown .ll{display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted)}
+.cb-cooldown .ll .now{color:hsl(38 90% 50%);font-weight:700}
+
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>LLM Providers &amp; Circuit Breakers</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Providers · 5 provider · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca provider, modello…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">⚙ Config globale</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Provider attivi</div>
+            <div class="admin-kpi-value">4<span style="font-size:14px;color:var(--text-muted);font-weight:600">/5</span></div>
+            <div class="admin-kpi-trend flat">▬ 1 disabilitato · 0 in cooldown</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,14 L8,14 L16,14 L24,14 L32,8 L40,8 L48,8 L56,8 L64,8 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,14 L8,14 L16,14 L24,14 L32,8 L40,8 L48,8 L56,8 L64,8 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">Richieste 24h</div>
+            <div class="admin-kpi-value">48.3<span style="font-size:14px;color:var(--text-muted);font-weight:600">k</span></div>
+            <div class="admin-kpi-trend up">▲ 12.4% vs ieri</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,18 L24,17 L32,14 L40,15 L48,11 L56,9 L64,8 L70,6 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,18 L24,17 L32,14 L40,15 L48,11 L56,9 L64,8 L70,6"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-event">
+            <div class="admin-kpi-label">Error rate 24h</div>
+            <div class="admin-kpi-value">0.41<span style="font-size:14px;color:var(--text-muted);font-weight:600">%</span></div>
+            <div class="admin-kpi-trend down">▼ -0.12 pts · soglia 1.0%</div>
+            <svg class="admin-kpi-spark e-event" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,8 L8,10 L16,7 L24,12 L32,14 L40,16 L48,18 L56,20 L64,21 L70,22 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,8 L8,10 L16,7 L24,12 L32,14 L40,16 L48,18 L56,20 L64,21 L70,22"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-agent">
+            <div class="admin-kpi-label">Costo 24h</div>
+            <div class="admin-kpi-value">$12.40</div>
+            <div class="admin-kpi-trend up">▲ 8.6% · budget $40/d</div>
+            <svg class="admin-kpi-spark e-agent" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,20 L8,18 L16,17 L24,15 L32,14 L40,13 L48,12 L56,10 L64,9 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,20 L8,18 L16,17 L24,15 L32,14 L40,13 L48,12 L56,10 L64,9 L70,8"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 2) Provider table ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Provider</h3>
+            <span class="status-chip healthy">3 healthy</span>
+            <span class="status-chip warning">1 warn</span>
+            <span class="status-chip muted">1 stopped</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Rotate key / Disabilita → richiede conferma (superadmin)</span>
+              <span class="sep"></span>
+              <span class="meta">llm.config rev 27 · last sync 14:22:51</span>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:22%">Provider</th>
+                <th style="width:11%">Stato</th>
+                <th style="width:18%">Modello default</th>
+                <th style="width:9%;text-align:right">P95 latenza</th>
+                <th style="width:9%;text-align:right">Req 24h</th>
+                <th style="width:8%;text-align:right">Errori</th>
+                <th style="width:13%">Circuit breaker</th>
+                <th style="width:170px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="e-tool">
+                <td>
+                  <div class="prov-cell">
+                    <div class="prov-mark">D</div>
+                    <div class="prov-info">
+                      <span class="prov-name">DeepSeek <span class="primary-tag">primary</span></span>
+                      <span class="prov-host">api.deepseek.com · key sk-…f7a2</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td><span class="model-cell">deepseek-chat</span></td>
+                <td class="lat-cell">412<span class="ms">ms</span></td>
+                <td class="mono" style="text-align:right">28 144</td>
+                <td class="err-cell" style="text-align:right">0.18%</td>
+                <td><span class="status-chip healthy">closed</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost" title="Config">⚙ Config</button>
+                    <button class="btn-admin sm danger" title="Richiede superadmin · mostra key UNA volta"><span class="lock-mini">🔒</span>⤿ Rotate</button>
+                    <button class="btn-admin sm ghost" title="Più azioni">⋯</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-chat">
+                <td>
+                  <div class="prov-cell">
+                    <div class="prov-mark">O</div>
+                    <div class="prov-info">
+                      <span class="prov-name">OpenRouter</span>
+                      <span class="prov-host">openrouter.ai/api/v1 · key sk-or-…9c4b</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td><span class="model-cell">anthropic/claude-3.5-sonnet</span></td>
+                <td class="lat-cell">658<span class="ms">ms</span></td>
+                <td class="mono" style="text-align:right">14 282</td>
+                <td class="err-cell" style="text-align:right">0.32%</td>
+                <td><span class="status-chip healthy">closed</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">⚙ Config</button>
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">⋯</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-toolkit">
+                <td>
+                  <div class="prov-cell">
+                    <div class="prov-mark">⚛</div>
+                    <div class="prov-info">
+                      <span class="prov-name">OpenAI</span>
+                      <span class="prov-host">api.openai.com/v1 · key sk-…12de</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="status-chip warning">latency high</span></td>
+                <td><span class="model-cell">gpt-4o-mini</span></td>
+                <td class="lat-cell warn">1 842<span class="ms">ms</span></td>
+                <td class="mono" style="text-align:right">5 718</td>
+                <td class="err-cell warn" style="text-align:right">2.14%</td>
+                <td><span class="status-chip warning">half-open</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">⚙ Config</button>
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">⋯</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="prov-cell">
+                    <div class="prov-mark">A</div>
+                    <div class="prov-info">
+                      <span class="prov-name">Anthropic</span>
+                      <span class="prov-host">api.anthropic.com · key sk-ant-…58a1</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td><span class="model-cell">claude-3.5-sonnet-20241022</span></td>
+                <td class="lat-cell">842<span class="ms">ms</span></td>
+                <td class="mono" style="text-align:right">186</td>
+                <td class="err-cell" style="text-align:right">0.00%</td>
+                <td><span class="status-chip healthy">closed</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">⚙ Config</button>
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">⋯</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-kb">
+                <td>
+                  <div class="prov-cell">
+                    <div class="prov-mark">L</div>
+                    <div class="prov-info">
+                      <span class="prov-name">Ollama (locale)</span>
+                      <span class="prov-host">localhost:11434 · no key</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="status-chip muted">stopped</span></td>
+                <td><span class="model-cell">llama3.1:8b-instruct</span></td>
+                <td class="lat-cell" style="color:var(--text-muted)">—</td>
+                <td class="mono" style="text-align:right;color:var(--text-muted)">0</td>
+                <td class="mono" style="text-align:right;color:var(--text-muted)">—</td>
+                <td><span class="status-chip muted">disabled</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">⚙ Config</button>
+                    <button class="btn-admin sm success">▶ Abilita</button>
+                    <button class="btn-admin sm ghost">⋯</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Routing chain (fallback) ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Routing chain · fallback</h3>
+            <span class="status-chip info">3 hops · 1 stand-by</span>
+            <div class="head-cluster">
+              <span class="meta">policy=cost-first · retry budget 3 · jitter 250ms</span>
+              <button class="btn-admin sm ghost">✎ Edita catena</button>
+            </div>
+          </div>
+
+          <div class="routing-body">
+            <div class="routing-chain">
+
+              <div class="rc-node e-tool">
+                <div class="rc-head">
+                  <span class="rc-prio primary">primary · p0</span>
+                </div>
+                <div class="rc-name">⛁ DeepSeek</div>
+                <div class="rc-model">deepseek-chat</div>
+                <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 412 ms</span> <span>err 0.18%</span></div>
+              </div>
+
+              <div class="rc-arrow">
+                <span class="gl">→</span>
+                <span class="cond">on 429 / 5xx / timeout&gt;3s</span>
+              </div>
+
+              <div class="rc-node e-chat">
+                <div class="rc-head">
+                  <span class="rc-prio">fallback · p1</span>
+                </div>
+                <div class="rc-name">⤳ OpenRouter</div>
+                <div class="rc-model">anthropic/claude-3.5-sonnet</div>
+                <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 658 ms</span> <span>err 0.32%</span></div>
+              </div>
+
+              <div class="rc-arrow">
+                <span class="gl">→</span>
+                <span class="cond">on 429 / 5xx / quota</span>
+              </div>
+
+              <div class="rc-node e-toolkit">
+                <div class="rc-head">
+                  <span class="rc-prio">fallback · p2</span>
+                </div>
+                <div class="rc-name">⚛ OpenAI</div>
+                <div class="rc-model">gpt-4o-mini</div>
+                <div class="rc-meta"><span class="warn">●</span> half-open <span>p95 1 842 ms</span> <span class="warn">err 2.14%</span></div>
+              </div>
+
+              <div class="rc-arrow">
+                <span class="gl">→</span>
+                <span class="cond">on circuit open</span>
+              </div>
+
+              <div class="rc-node e-agent">
+                <div class="rc-head">
+                  <span class="rc-prio">stand-by · p3</span>
+                </div>
+                <div class="rc-name">A Anthropic</div>
+                <div class="rc-model">claude-3.5-sonnet</div>
+                <div class="rc-meta"><span class="ok">●</span> healthy <span>p95 842 ms</span> <span>used 0.4%</span></div>
+              </div>
+
+            </div>
+
+            <div class="rc-priority-strip">
+              <span class="k">Priority order</span>
+              <span class="v">deepseek</span>
+              <span class="sep">›</span>
+              <span class="v">openrouter</span>
+              <span class="sep">›</span>
+              <span class="v">openai</span>
+              <span class="sep">›</span>
+              <span class="v">anthropic</span>
+              <span class="sep">·</span>
+              <span class="k">Excluded</span>
+              <span class="v" style="color:var(--text-muted)">ollama-local (stopped)</span>
+              <span class="sep">·</span>
+              <span class="k">Updated</span>
+              <span class="v">2026-05-22 11:08 · <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="6c0d0d1e03022c0109091c00090d05420d1c1c">[email&#160;protected]</a></span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ────────── 4) Circuit breakers grid ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Circuit breakers</h3>
+            <span class="status-chip healthy">3 closed</span>
+            <span class="status-chip warning">1 half-open</span>
+            <span class="status-chip muted">1 disabled</span>
+            <div class="head-cluster">
+              <span class="meta">policy: 5 fail in 60s → open · cooldown 30s · half-open probe 1/req</span>
+              <button class="btn-admin sm ghost">⤓ Reset all</button>
+            </div>
+          </div>
+
+          <div class="cb-grid">
+
+            <div class="cb-card e-tool">
+              <div class="cb-head">
+                <div>
+                  <div class="cb-name">DeepSeek</div>
+                  <div class="cb-state">circuit breaker</div>
+                </div>
+                <span class="status-chip healthy">closed</span>
+              </div>
+              <div class="cb-stat-grid">
+                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v">0 / 60s</span></div>
+                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
+                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v muted">—</span></div>
+                <div class="cb-stat"><span class="l">Reset</span><span class="v muted">n/a</span></div>
+              </div>
+            </div>
+
+            <div class="cb-card e-chat">
+              <div class="cb-head">
+                <div>
+                  <div class="cb-name">OpenRouter</div>
+                  <div class="cb-state">circuit breaker</div>
+                </div>
+                <span class="status-chip healthy">closed</span>
+              </div>
+              <div class="cb-stat-grid">
+                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v">1 / 60s</span></div>
+                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
+                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-05-21 22:14</span></div>
+                <div class="cb-stat"><span class="l">Reset</span><span class="v">16h 09m fa</span></div>
+              </div>
+            </div>
+
+            <div class="cb-card e-toolkit">
+              <div class="cb-head">
+                <div>
+                  <div class="cb-name">OpenAI</div>
+                  <div class="cb-state">circuit breaker</div>
+                </div>
+                <span class="status-chip warning">half-open</span>
+              </div>
+              <div class="cb-stat-grid">
+                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v warn">4 / 60s</span></div>
+                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
+                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">14:22:45</span></div>
+                <div class="cb-stat"><span class="l">Probe</span><span class="v warn">1/1 in volo</span></div>
+              </div>
+              <div class="cb-cooldown">
+                <div class="bar"><i></i></div>
+                <div class="ll"><span>cooldown</span><span class="now">23s</span></div>
+              </div>
+            </div>
+
+            <div class="cb-card e-agent">
+              <div class="cb-head">
+                <div>
+                  <div class="cb-name">Anthropic</div>
+                  <div class="cb-state">circuit breaker</div>
+                </div>
+                <span class="status-chip healthy">closed</span>
+              </div>
+              <div class="cb-stat-grid">
+                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v">0 / 60s</span></div>
+                <div class="cb-stat"><span class="l">Soglia</span><span class="v">5</span></div>
+                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v">2026-04-30 09:02</span></div>
+                <div class="cb-stat"><span class="l">Reset</span><span class="v">24g fa</span></div>
+              </div>
+            </div>
+
+            <div class="cb-card e-kb">
+              <div class="cb-head">
+                <div>
+                  <div class="cb-name">Ollama (locale)</div>
+                  <div class="cb-state">circuit breaker</div>
+                </div>
+                <span class="status-chip muted">disabled</span>
+              </div>
+              <div class="cb-stat-grid">
+                <div class="cb-stat"><span class="l">Fail recenti</span><span class="v muted">—</span></div>
+                <div class="cb-stat"><span class="l">Soglia</span><span class="v muted">—</span></div>
+                <div class="cb-stat"><span class="l">Ultima apertura</span><span class="v muted">—</span></div>
+                <div class="cb-stat"><span class="l">Stato</span><span class="v muted">provider off</span></div>
+              </div>
+            </div>
+
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('providers');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-rag-backup.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-rag-backup.html
@@ -1,0 +1,609 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>RAG Backup &amp; Seeding · MeepleAI Admin</title>
+<!-- D5 · AI Tooling & Data Quality → 'rag-backup' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 BackupTable · CreateBackupCTA · SeedingPanel · ReindexAllCTA (typed-confirm) ·
+     IndexingQueueLive (SSE) reuse
+     Endpoints: GET/POST /api/v1/admin/rag-backup
+                POST /api/v1/admin/rag-backup/{id}/restore
+                POST /api/v1/admin/seeding/{reindex-all|seed}
+                SSE  /api/v1/admin/seeding/stream
+     Role: admin (backup CRUD) · superadmin (reindex/seed) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.danger:hover{background:hsl(var(--c-event)/.08)}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb))}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-game{border-left:3px solid hsl(var(--c-game))}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* ── Backup row date cell ───────────────────────────────────────── */
+.dt-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text);font-weight:700}
+.dt-cell .sub{display:block;color:var(--text-muted);font-weight:500;font-size:9.5px;margin-top:1px}
+
+/* Backup type chip (full / incremental) */
+.type-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:99px;font-family:var(--f-mono);font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;border:1px solid hsl(var(--e)/.25);background:hsl(var(--e)/.1);color:hsl(var(--e))}
+.type-chip::before{content:'';width:6px;height:6px;border-radius:50%;background:hsl(var(--e))}
+
+/* Size / embed cells */
+.size-cell{font-family:var(--f-mono);font-size:11.5px;font-weight:700;color:var(--text);font-variant-numeric:tabular-nums;text-align:right}
+.size-cell .sub{display:block;color:var(--text-muted);font-weight:500;font-size:9.5px;margin-top:1px}
+
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+.lock-mini{color:hsl(var(--c-event));font-size:10px}
+
+/* ── Seeding & reindex panel ───────────────────────────────────── */
+.seed-grid{display:grid;grid-template-columns:1.2fr 1fr;gap:18px;padding:16px 18px;align-items:stretch}
+
+.seed-status{display:flex;flex-direction:column;gap:10px;padding:14px 16px;background:var(--bg);border:1px solid var(--border-light);border-left:3px solid hsl(var(--c-kb));border-radius:10px}
+.seed-status .top{display:flex;align-items:center;gap:10px}
+.seed-status .title{font-family:var(--f-display);font-weight:800;font-size:14px;color:var(--text)}
+.seed-status .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-top:1px;font-weight:700}
+.seed-progress{display:flex;flex-direction:column;gap:4px}
+.seed-progress .bar{height:14px;border-radius:99px;background:hsl(var(--c-kb)/.12);overflow:hidden;position:relative}
+.seed-progress .bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--c-kb));border-radius:99px;animation:bar-shimmer 2s ease-in-out infinite}
+@keyframes bar-shimmer{0%,100%{filter:brightness(1)}50%{filter:brightness(1.18)}}
+.seed-progress .ll{display:flex;justify-content:space-between;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.seed-progress .ll .v{color:var(--text);font-weight:700}
+.seed-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:4px}
+.seed-stats .st{display:flex;flex-direction:column;gap:1px;padding:6px 8px;background:var(--bg-card);border:1px solid var(--border-light);border-radius:6px}
+.seed-stats .st .l{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.seed-stats .st .v{font-family:var(--f-mono);font-size:12px;font-weight:700;color:var(--text);font-variant-numeric:tabular-nums}
+
+.seed-actions{display:flex;flex-direction:column;gap:10px;justify-content:center}
+.seed-action-card{display:flex;flex-direction:column;gap:8px;padding:14px 16px;background:var(--bg);border:1px solid var(--border-light);border-radius:10px}
+.seed-action-card.danger{border-color:hsl(var(--c-event)/.35);background:hsl(var(--c-event)/.04);border-left:3px solid hsl(var(--c-event))}
+.seed-action-card .h{display:flex;align-items:center;gap:8px}
+.seed-action-card .h .em{font-size:18px}
+.seed-action-card .h .title{font-family:var(--f-display);font-weight:800;font-size:13.5px;color:var(--text);flex:1}
+.seed-action-card .h .title .desc{display:block;margin-top:1px;font-family:var(--f-body);font-size:11px;font-weight:400;color:var(--text-muted);line-height:1.4}
+.seed-action-card.danger .h .em{color:hsl(var(--c-event))}
+.seed-action-card .cost-row{display:flex;align-items:center;gap:6px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.seed-action-card .cost-row .v{color:var(--text);font-weight:700}
+.seed-action-card.danger .cost-row .v{color:hsl(var(--c-event))}
+.seed-action-card .actions{display:flex;gap:8px;align-items:center}
+.seed-action-card .actions .btn-admin{flex-shrink:0}
+.seed-action-card .typed-hint{font-family:var(--f-mono);font-size:9.5px;color:hsl(var(--c-event));display:inline-flex;align-items:center;gap:5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.seed-action-card .typed-hint .pill{padding:1px 6px;border-radius:4px;background:hsl(var(--c-event)/.15);border:1px dashed hsl(var(--c-event)/.5)}
+
+/* ── Live queue ─────────────────────────────────────────────────── */
+.queue-list{display:flex;flex-direction:column;gap:0}
+.q-row{padding:10px 14px;display:grid;grid-template-columns:200px 110px 1fr auto;gap:12px;align-items:center;border-bottom:1px solid var(--border-light)}
+.q-row:last-child{border-bottom:0}
+.q-row:hover{background:var(--bg-muted)}
+.q-row.running{background:hsl(var(--c-toolkit)/.04)}
+.q-game{display:inline-flex;align-items:center;gap:8px;font-family:var(--f-display);font-weight:800;font-size:13px;color:var(--text)}
+.q-game .gm{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:5px;background:hsl(var(--c-game)/.14);color:hsl(var(--c-game));border:1px solid hsl(var(--c-game)/.25);font-family:var(--f-mono);font-size:9.5px;font-weight:700;letter-spacing:.02em;text-transform:none;flex-shrink:0;min-width:24px;justify-content:center}
+.q-stage{font-family:var(--f-mono);font-size:10.5px;font-weight:700;color:var(--text-sec);text-transform:uppercase;letter-spacing:.04em;display:inline-flex;align-items:center;gap:5px}
+.q-stage .stage-tag{padding:2px 7px;border-radius:4px;background:hsl(var(--e)/.12);color:hsl(var(--e));border:1px solid hsl(var(--e)/.22);font-weight:700}
+.q-bar-wrap{display:flex;align-items:center;gap:10px;min-width:0}
+.q-bar{flex:1;height:7px;border-radius:99px;background:hsl(var(--e)/.12);overflow:hidden;position:relative;max-width:none}
+.q-bar i{position:absolute;left:0;top:0;bottom:0;background:hsl(var(--e));border-radius:99px}
+.q-row.running .q-bar i{animation:bar-shimmer 1.6s ease-in-out infinite}
+.q-pct{font-family:var(--f-mono);font-size:11px;font-weight:700;color:var(--text);min-width:48px;text-align:right;font-variant-numeric:tabular-nums}
+.q-pct.muted{color:var(--text-muted)}
+.q-meta{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:600;min-width:110px;text-align:right}
+.q-meta .v{color:var(--text);font-weight:700}
+
+.live-pill{display:inline-flex;align-items:center;gap:6px;padding:2px 10px;border-radius:999px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em}
+.live-pill::before{content:'';width:6px;height:6px;border-radius:50%;background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>RAG Backup &amp; Seeding</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › RAG Backup · qdrant cluster · aggiornato 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca backup, gioco…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">📜 Audit log</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-kb">
+            <div class="admin-kpi-label">Ultimo backup</div>
+            <div class="admin-kpi-value">03:00<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · oggi</span></div>
+            <div class="admin-kpi-trend up">▲ full · 1.2 GB · 5h 23m fa</div>
+            <svg class="admin-kpi-spark e-kb" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,16 L8,16 L8,8 L16,8 L16,18 L24,18 L24,10 L32,10 L32,16 L40,16 L40,8 L48,8 L48,18 L56,18 L56,10 L64,10 L64,16 L70,16 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,16 L8,16 L8,8 L16,8 L16,18 L24,18 L24,10 L32,10 L32,16 L40,16 L40,8 L48,8 L48,18 L56,18 L56,10 L64,10 L64,16 L70,16"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Dimensione indice</div>
+            <div class="admin-kpi-value">1.18<span style="font-size:14px;color:var(--text-muted);font-weight:600"> GB</span></div>
+            <div class="admin-kpi-trend up">▲ +4.2% 30g · qdrant collection</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,21 L16,19 L24,18 L32,16 L40,14 L48,12 L56,10 L64,8 L70,7 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,21 L16,19 L24,18 L32,16 L40,14 L48,12 L56,10 L64,8 L70,7"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-game">
+            <div class="admin-kpi-label">Giochi indicizzati</div>
+            <div class="admin-kpi-value">113<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · +2 in coda</span></div>
+            <div class="admin-kpi-trend up">▲ +6 questo mese · 0 stale</div>
+            <svg class="admin-kpi-spark e-game" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,21 L16,20 L24,18 L32,17 L40,15 L48,13 L56,11 L64,10 L70,8 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,21 L16,20 L24,18 L32,17 L40,15 L48,13 L56,11 L64,10 L70,8"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-chat">
+            <div class="admin-kpi-label">Embedding totali</div>
+            <div class="admin-kpi-value">8 599<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 768-d</span></div>
+            <div class="admin-kpi-trend up">▲ bge-m3 · cosine · HNSW M=16</div>
+            <svg class="admin-kpi-spark e-chat" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,18 L24,16 L32,14 L40,12 L48,10 L56,8 L64,7 L70,5 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,18 L24,16 L32,14 L40,12 L48,10 L56,8 L64,7 L70,5"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 2) Backup ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Backup</h3>
+            <span class="status-chip healthy">4 healthy</span>
+            <span class="status-chip running">1 running</span>
+            <span class="status-chip danger">1 failed</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Restore → typed-confirm · Delete → ConfirmModal</span>
+              <span class="sep"></span>
+              <span class="meta">storage R2 · retention 30g · cron 0 3 * * *</span>
+              <button class="btn-admin primary">＋ Crea backup ora</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:18%">Data</th>
+                <th style="width:11%">Tipo</th>
+                <th style="width:12%;text-align:right">Dimensione</th>
+                <th style="width:14%;text-align:right">Embeddings</th>
+                <th style="width:18%">Stato</th>
+                <th>Note</th>
+                <th style="width:180px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr>
+                <td class="dt-cell">oggi 03:00:02<span class="sub">5h 23m fa · backup_8f3a4d</span></td>
+                <td><span class="type-chip e-tool">full</span></td>
+                <td class="size-cell">1.18 GB<span class="sub">.qdrant snapshot</span></td>
+                <td class="size-cell">8 599<span class="sub">768-d · cosine</span></td>
+                <td><span class="status-chip healthy">verified · sha256 ✓</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">cron · daily-full</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm danger" title="Typed-confirm"><span class="lock-mini">🔒</span>↺ Restore</button>
+                    <button class="btn-admin sm ghost">⤓</button>
+                    <button class="btn-admin sm ghost" title="ConfirmModal">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">oggi 14:21:08<span class="sub">2m 04s fa · backup_8f3a4e · in volo</span></td>
+                <td><span class="type-chip e-toolkit">incremental</span></td>
+                <td class="size-cell" style="color:var(--text-muted)">— · stima 42 MB</td>
+                <td class="size-cell" style="color:var(--text-muted)">≈ 384</td>
+                <td><span class="status-chip running">running · 64%</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">manual · aaron@</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost" title="solo a completamento" style="opacity:.5;cursor:not-allowed">↺ Restore</button>
+                    <button class="btn-admin sm ghost" style="opacity:.5">⤓</button>
+                    <button class="btn-admin sm">⏸ Cancel</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">ieri 03:00:01<span class="sub">1g 5h fa · backup_8f3a3c</span></td>
+                <td><span class="type-chip e-tool">full</span></td>
+                <td class="size-cell">1.14 GB<span class="sub">.qdrant snapshot</span></td>
+                <td class="size-cell">8 488<span class="sub">768-d · cosine</span></td>
+                <td><span class="status-chip healthy">verified · sha256 ✓</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">cron · daily-full</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>↺ Restore</button>
+                    <button class="btn-admin sm ghost">⤓</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">22 mag 15:08:24<span class="sub">2g fa · backup_8f3a31 · pre-reindex</span></td>
+                <td><span class="type-chip e-tool">full</span></td>
+                <td class="size-cell">1.11 GB<span class="sub">.qdrant snapshot</span></td>
+                <td class="size-cell">8 412<span class="sub">768-d · cosine</span></td>
+                <td><span class="status-chip healthy">verified · sha256 ✓</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">pre-op · aaron@ · tag "pre-reindex-wingspan"</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>↺ Restore</button>
+                    <button class="btn-admin sm ghost">⤓</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">22 mag 03:00:02<span class="sub">2g fa · backup_8f3a2a</span></td>
+                <td><span class="type-chip e-tool">full</span></td>
+                <td class="size-cell">1.11 GB<span class="sub">.qdrant snapshot</span></td>
+                <td class="size-cell">8 401<span class="sub">768-d · cosine</span></td>
+                <td><span class="status-chip healthy">verified · sha256 ✓</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">cron · daily-full</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>↺ Restore</button>
+                    <button class="btn-admin sm ghost">⤓</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">21 mag 03:00:02<span class="sub">3g fa · backup_8f3a1f</span></td>
+                <td><span class="type-chip e-tool">full</span></td>
+                <td class="size-cell" style="color:var(--text-muted)">— · 0 byte</td>
+                <td class="size-cell" style="color:var(--text-muted)">—</td>
+                <td><span class="status-chip danger">failed · R2 timeout</span></td>
+                <td class="mono" style="font-size:10.5px;color:hsl(var(--c-event))">SSL handshake timeout dopo 38s</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm">↻ Retry</button>
+                    <button class="btn-admin sm ghost">📜 Logs</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td class="dt-cell">20 mag 12:14:08<span class="sub">4g fa · backup_8f3a08 · incremental</span></td>
+                <td><span class="type-chip e-toolkit">incremental</span></td>
+                <td class="size-cell">38 MB<span class="sub">delta</span></td>
+                <td class="size-cell">142<span class="sub">delta · vs full</span></td>
+                <td><span class="status-chip healthy">verified · sha256 ✓</span></td>
+                <td class="mono" style="font-size:10.5px;color:var(--text-muted)">manual · marco.rossi@ · "after-wingspan-v2"</td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm danger"><span class="lock-mini">🔒</span>↺ Restore</button>
+                    <button class="btn-admin sm ghost">⤓</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+        </section>
+
+        <!-- ────────── 3) Seeding & Reindex ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Seeding &amp; reindex</h3>
+            <span class="status-chip running">2 in volo · seeding</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Reindex all → typed-confirm "REINDEX" · richiede superadmin</span>
+              <span class="sep"></span>
+              <span class="meta">embed model bge-m3 · batch 256 · throughput 318/s</span>
+            </div>
+          </div>
+
+          <div class="seed-grid">
+
+            <!-- ░ Seeding status -->
+            <div class="seed-status">
+              <div class="top">
+                <span class="status-chip running">seeding · in corso</span>
+                <span style="flex:1"></span>
+                <span class="sensitive-note">eta <span style="color:var(--text);font-weight:700;margin-left:4px">14m 38s</span></span>
+              </div>
+              <div>
+                <div class="title">Seed da snapshot · wingspan-eu-expansion</div>
+                <div class="sub">snapshot_kb_v4_2026-05-18 · 1 482 chunks · 12 PDF</div>
+              </div>
+
+              <div class="seed-progress">
+                <div class="bar"><i style="width:42%"></i></div>
+                <div class="ll"><span class="k">embed batch</span><span class="v">624 / 1 482</span><span class="v" style="color:hsl(var(--c-kb))">42.1%</span></div>
+              </div>
+
+              <div class="seed-stats">
+                <div class="st"><span class="l">Throughput</span><span class="v">318 /s</span></div>
+                <div class="st"><span class="l">Costo finora</span><span class="v">$0.08</span></div>
+                <div class="st"><span class="l">Stima totale</span><span class="v">$0.21</span></div>
+              </div>
+            </div>
+
+            <!-- ░ Actions -->
+            <div class="seed-actions">
+
+              <div class="seed-action-card">
+                <div class="h">
+                  <span class="em">🌱</span>
+                  <div class="title">Seed da snapshot<span class="desc">Ricarica un seed pre-calcolato (embeddings esistenti, niente nuovo costo LLM)</span></div>
+                </div>
+                <div class="cost-row">
+                  <span>costo</span> <span class="v">~$0 · solo storage</span>
+                  <span style="opacity:.5">·</span>
+                  <span>tempo</span> <span class="v">~3–6 min</span>
+                </div>
+                <div class="actions">
+                  <select class="admin-select" style="flex:1;font-size:11.5px;padding:5px 8px">
+                    <option>snapshot_kb_v4_2026-05-18 · 1.42M chunks</option>
+                    <option>snapshot_kb_v3_2026-04-02 · 1.22M chunks</option>
+                    <option>snapshot_pre-reindex-wingspan</option>
+                  </select>
+                  <button class="btn-admin">▶ Seed</button>
+                </div>
+              </div>
+
+              <div class="seed-action-card danger">
+                <div class="h">
+                  <span class="em">⛔</span>
+                  <div class="title" style="color:hsl(var(--c-event))">Reindex all<span class="desc" style="color:var(--text-sec)">Ricostruisce embeddings di tutti i 113 giochi da PDF. Sostituisce l'intera collection.</span></div>
+                </div>
+                <div class="cost-row">
+                  <span>costo</span> <span class="v">~$24.00</span>
+                  <span style="opacity:.5">·</span>
+                  <span>tempo</span> <span class="v">~45 min</span>
+                  <span style="opacity:.5">·</span>
+                  <span>impact</span> <span class="v">read-only durante</span>
+                </div>
+                <div class="actions">
+                  <span class="typed-hint">🔒 digita <span class="pill">REINDEX</span> · superadmin</span>
+                  <span style="flex:1"></span>
+                  <button class="btn-admin danger">⛔ Reindex all</button>
+                </div>
+              </div>
+
+            </div>
+
+          </div>
+        </section>
+
+        <!-- ────────── 4) Live indexing queue ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Coda indicizzazione</h3>
+            <span class="live-pill">● streaming · SSE</span>
+            <div class="head-cluster">
+              <span class="meta">2 running · 4 queued · 38 completati 24h · 0 falliti</span>
+              <button class="btn-admin sm ghost">⏸ Pause stream</button>
+              <button class="btn-admin sm ghost">⤓ ndjson</button>
+            </div>
+          </div>
+
+          <div class="queue-list">
+
+            <div class="q-row running e-kb">
+              <span class="q-game"><span class="gm">W</span>Wingspan</span>
+              <span class="q-stage e-kb"><span class="stage-tag">embed</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:64%"></i></span>
+                <span class="q-pct">64%</span>
+              </span>
+              <span class="q-meta"><span class="v">912 / 1 425</span> chunks · 22s</span>
+            </div>
+
+            <div class="q-row running e-chat">
+              <span class="q-game"><span class="gm">T</span>Terraforming Mars</span>
+              <span class="q-stage e-chat"><span class="stage-tag">index</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:34%"></i></span>
+                <span class="q-pct">34%</span>
+              </span>
+              <span class="q-meta"><span class="v">218 / 644</span> vectors · 11s</span>
+            </div>
+
+            <div class="q-row e-kb">
+              <span class="q-game"><span class="gm">C</span>Catan</span>
+              <span class="q-stage e-chat"><span class="stage-tag">index</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:100%"></i></span>
+                <span class="q-pct" style="color:hsl(var(--c-toolkit))">100%</span>
+              </span>
+              <span class="q-meta"><span class="v" style="color:hsl(var(--c-toolkit))">388 / 388</span> · completato 4s fa</span>
+            </div>
+
+            <div class="q-row e-toolkit">
+              <span class="q-game"><span class="gm">B</span>Brass: Birmingham</span>
+              <span class="q-stage e-toolkit"><span class="stage-tag">queued</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:0"></i></span>
+                <span class="q-pct muted">0%</span>
+              </span>
+              <span class="q-meta">in attesa · pos 1</span>
+            </div>
+
+            <div class="q-row e-toolkit">
+              <span class="q-game"><span class="gm">A</span>Ark Nova</span>
+              <span class="q-stage e-toolkit"><span class="stage-tag">queued</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:0"></i></span>
+                <span class="q-pct muted">0%</span>
+              </span>
+              <span class="q-meta">in attesa · pos 2</span>
+            </div>
+
+            <div class="q-row e-toolkit">
+              <span class="q-game"><span class="gm">S</span>Spirit Island</span>
+              <span class="q-stage e-toolkit"><span class="stage-tag">queued</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:0"></i></span>
+                <span class="q-pct muted">0%</span>
+              </span>
+              <span class="q-meta">in attesa · pos 3</span>
+            </div>
+
+            <div class="q-row e-toolkit">
+              <span class="q-game"><span class="gm">G</span>Gloomhaven: JotL</span>
+              <span class="q-stage e-toolkit"><span class="stage-tag">queued</span></span>
+              <span class="q-bar-wrap">
+                <span class="q-bar"><i style="width:0"></i></span>
+                <span class="q-pct muted">0%</span>
+              </span>
+              <span class="q-meta">in attesa · pos 4</span>
+            </div>
+
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('rag-backup');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-sandbox.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-sandbox.html
@@ -1,0 +1,574 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Agent Sandbox &amp; Debug · MeepleAI Admin</title>
+<!-- D2 · AI Tooling & Data Quality → 'sandbox' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "AI Tooling & Data Quality"). -->
+<!-- @v1 AgentConfigForm · DebugChatStream (SSE) · RetrievalInline · PipelineTrace · WaterfallBar reuse
+     Endpoints: POST /api/v1/admin/agents/debug-chat/stream (SSE)
+                GET  /api/v1/admin/sandbox
+                POST /api/v1/admin/agents/test
+     Role: admin -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--dur-sm:180ms;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+h1,h2,h3,h4{font-family:var(--f-display);font-weight:700;letter-spacing:-.01em;margin:0;line-height:1.2}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:12px;line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted)}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.btn-admin.primary kbd{background:rgba(0,0,0,.18);border-color:rgba(0,0,0,.25)}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden;display:flex;flex-direction:column}
+.admin-panel-head{padding:9px 12px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:8px;background:var(--bg);flex-shrink:0}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:12.5px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-form-row{display:grid;grid-template-columns:1fr;gap:4px;padding:9px 0;border-bottom:1px solid var(--border-light)}
+.admin-form-row:last-of-type{border-bottom:0}
+.admin-form-label{font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-form-label .desc{display:block;margin-top:2px;font-family:var(--f-body);font-size:10.5px;font-weight:400;color:var(--text-muted);line-height:1.4;text-transform:none;letter-spacing:0}
+.admin-input,.admin-select{width:100%;padding:6px 9px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.admin-toggle{position:relative;width:34px;height:18px;background:var(--bg-muted);border:1px solid var(--border);border-radius:999px;cursor:pointer;display:inline-block;flex-shrink:0}
+.admin-toggle::after{content:'';position:absolute;top:2px;left:2px;width:12px;height:12px;border-radius:50%;background:var(--text-sec);transition:.18s var(--ease-out)}
+.admin-toggle.on{background:hsl(var(--c-toolkit)/.25);border-color:hsl(var(--c-toolkit))}
+.admin-toggle.on::after{left:18px;background:hsl(var(--c-toolkit))}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.status-chip.running{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.running::before{background:hsl(var(--c-toolkit));animation:admin-pulse 1.4s ease-in-out infinite}
+@keyframes admin-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.5);opacity:.5}}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:16px 20px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+
+/* Sandbox 3-col grid */
+.sandbox-grid{display:grid;grid-template-columns:280px minmax(0,1fr) 380px;gap:14px;align-items:start;height:calc(100vh - 78px)}
+.sandbox-grid > .admin-panel{height:100%;overflow:hidden}
+
+/* ── LEFT: config ───────────────────────────────────────────────── */
+.cfg-body{padding:6px 14px;overflow-y:auto;flex:1;display:flex;flex-direction:column;gap:0}
+.cfg-body .admin-form-row{padding:8px 0}
+.cfg-body .toggle-row{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 0;border-bottom:1px solid var(--border-light)}
+.cfg-body .toggle-row .lbl{display:flex;flex-direction:column;gap:1px}
+.cfg-body .toggle-row .lbl .nm{font-family:var(--f-display);font-weight:800;font-size:12px;color:var(--text)}
+.cfg-body .toggle-row .lbl .sub{font-family:var(--f-body);font-size:10.5px;color:var(--text-muted)}
+.cfg-foot{padding:10px 14px;border-top:1px solid var(--border-light);background:var(--bg);display:flex;flex-direction:column;gap:6px;flex-shrink:0}
+.cfg-foot .session-id{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);display:flex;justify-content:space-between}
+.cfg-foot .session-id .v{color:var(--text);font-weight:700}
+.cfg-foot .btn-admin{width:100%;justify-content:center}
+
+/* config preset chip */
+.preset-strip{display:flex;flex-direction:column;gap:6px;padding:10px 14px;background:hsl(var(--c-game)/.06);border-bottom:1px solid var(--border-light)}
+.preset-strip .label{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.preset-strip .agent-row{display:flex;align-items:center;gap:8px}
+.preset-strip .agent-mark{width:28px;height:28px;border-radius:7px;background:hsl(var(--c-game)/.16);border:1px solid hsl(var(--c-game)/.3);display:grid;place-items:center;color:hsl(var(--c-game));font-family:var(--f-display);font-weight:800;font-size:13px;flex-shrink:0}
+.preset-strip .agent-name{font-family:var(--f-display);font-weight:800;font-size:13.5px;color:var(--text)}
+.preset-strip .agent-sub{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;margin-top:1px}
+
+/* number-pair (temp + maxtok) */
+.num-pair{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+
+/* ── CENTER: chat ───────────────────────────────────────────────── */
+.chat-scroll{flex:1;overflow-y:auto;padding:14px 18px 12px;display:flex;flex-direction:column;gap:14px;background:var(--bg)}
+.bubble{max-width:78%;display:flex;flex-direction:column;gap:6px}
+.bubble.user{align-self:flex-end;align-items:flex-end}
+.bubble.assistant{align-self:flex-start}
+.bubble .meta{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);font-weight:700;display:flex;align-items:center;gap:6px;text-transform:uppercase;letter-spacing:.04em}
+.bubble.user .meta{justify-content:flex-end}
+.bubble .meta .av{width:18px;height:18px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:800;font-family:var(--f-display)}
+.bubble.user .meta .av{background:hsl(var(--c-player)/.18);color:hsl(var(--c-player))}
+.bubble.assistant .meta .av{background:hsl(var(--c-chat)/.18);color:hsl(var(--c-chat))}
+.bubble .body{padding:10px 14px;border-radius:12px;font-size:13px;line-height:1.55;color:var(--text)}
+.bubble.user .body{background:hsl(var(--c-player)/.12);border:1px solid hsl(var(--c-player)/.25);border-bottom-right-radius:4px;color:var(--text)}
+.bubble.assistant .body{background:hsl(var(--c-chat)/.07);border:1px solid hsl(var(--c-chat)/.25);border-bottom-left-radius:4px}
+.bubble.assistant .body strong{font-weight:800;color:hsl(var(--c-chat))}
+.bubble .body code{background:var(--bg-muted);padding:1px 5px;border-radius:4px;font-size:11.5px}
+.bubble .body .cursor{display:inline-block;width:7px;height:13px;background:hsl(var(--c-chat));margin-left:2px;vertical-align:-2px;animation:caret-blink 1s steps(1) infinite}
+@keyframes caret-blink{50%{opacity:0}}
+
+/* Retrieval inline row */
+.retrieval-inline{margin-top:6px;display:flex;flex-direction:column;gap:6px;padding:8px 10px;background:var(--bg-card);border:1px solid var(--border-light);border-left:2px solid hsl(var(--c-kb));border-radius:7px}
+.retrieval-inline .ri-head{display:flex;align-items:center;gap:8px;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.retrieval-inline .ri-head .chunk-pill{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:99px;background:hsl(var(--c-kb)/.14);color:hsl(var(--c-kb));font-weight:700}
+.retrieval-inline .ri-head .spacer{flex:1}
+.chunk-row{display:grid;grid-template-columns:auto 1fr auto auto;gap:8px;align-items:center;padding:4px 6px;background:var(--bg);border:1px solid var(--border-light);border-radius:6px;font-family:var(--f-mono);font-size:10.5px}
+.chunk-row .src{color:hsl(var(--c-kb));font-weight:700;white-space:nowrap}
+.chunk-row .snip{color:var(--text-sec);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:var(--f-body);font-size:11px}
+.chunk-row .pg{color:var(--text-muted);font-weight:700}
+.chunk-row .score{font-weight:700;color:var(--text);min-width:36px;text-align:right}
+.chunk-row .score.high{color:hsl(var(--c-toolkit))}
+.chunk-row .score.mid{color:hsl(38 90% 50%)}
+.chunk-row .score.low{color:hsl(var(--c-event))}
+
+/* Streaming meta line */
+.stream-meta{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);display:flex;gap:10px;flex-wrap:wrap}
+.stream-meta .seg{display:inline-flex;align-items:center;gap:4px}
+.stream-meta .k{color:var(--text-muted)}
+.stream-meta .v{color:var(--text);font-weight:700}
+
+/* Chat input */
+.chat-input{padding:10px 14px;border-top:1px solid var(--border-light);background:var(--bg);display:flex;align-items:center;gap:8px;flex-shrink:0}
+.chat-input .admin-input{flex:1;padding:8px 10px;font-size:13px}
+.chat-input .hint{font-family:var(--f-mono);font-size:9px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.04em;font-weight:700}
+
+/* ── RIGHT: debug pipeline ──────────────────────────────────────── */
+.debug-scroll{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:0}
+
+.waterfall{padding:12px 14px 10px;border-bottom:1px solid var(--border-light);background:var(--bg-card);display:flex;flex-direction:column;gap:8px}
+.waterfall .wf-title{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;display:flex;align-items:center;gap:6px}
+.waterfall .wf-title .total{margin-left:auto;color:var(--text);font-weight:700;font-size:11px}
+.waterfall .wf-bar{display:flex;height:18px;border-radius:5px;overflow:hidden;background:var(--bg-muted);border:1px solid var(--border-light)}
+.waterfall .seg{display:flex;align-items:center;justify-content:flex-start;padding:0 6px;color:#fff;font-family:var(--f-mono);font-size:9px;font-weight:700;letter-spacing:.04em;white-space:nowrap;background:hsl(var(--e))}
+.waterfall .seg.e-kb{--e:var(--c-kb)}
+.waterfall .seg.e-chat{--e:var(--c-chat)}
+.waterfall .seg.e-tool{--e:var(--c-tool)}
+.waterfall .seg.e-agent{--e:var(--c-agent)}
+.waterfall .seg.e-toolkit{--e:var(--c-toolkit)}
+.waterfall .seg.running{animation:wf-running 1.4s ease-in-out infinite}
+@keyframes wf-running{0%,100%{opacity:1}50%{opacity:.65}}
+.waterfall .wf-legend{display:flex;flex-wrap:wrap;gap:8px;font-family:var(--f-mono);font-size:9.5px}
+.waterfall .wf-legend .lg{display:inline-flex;align-items:center;gap:4px;color:var(--text-sec)}
+.waterfall .wf-legend .lg .sw{width:10px;height:10px;border-radius:2px;background:hsl(var(--e))}
+.waterfall .wf-legend .lg.e-kb{--e:var(--c-kb)}
+.waterfall .wf-legend .lg.e-chat{--e:var(--c-chat)}
+.waterfall .wf-legend .lg.e-tool{--e:var(--c-tool)}
+.waterfall .wf-legend .lg.e-agent{--e:var(--c-agent)}
+.waterfall .wf-legend .lg .v{color:var(--text);font-weight:700;margin-left:2px}
+
+/* Trace tree */
+.trace-tree{padding:6px 0 8px;display:flex;flex-direction:column;gap:0}
+.trace-step{display:grid;grid-template-columns:24px 1fr auto;gap:8px;padding:7px 14px;border-bottom:1px solid var(--border-light);align-items:flex-start;position:relative}
+.trace-step:last-child{border-bottom:0}
+.trace-step .rail{position:relative;display:flex;justify-content:center;padding-top:4px}
+.trace-step .rail::after{content:'';position:absolute;top:18px;bottom:-12px;left:50%;width:2px;background:var(--border-light);transform:translateX(-50%)}
+.trace-step:last-child .rail::after{display:none}
+.trace-step .rail .dot{width:14px;height:14px;border-radius:50%;border:2px solid hsl(var(--e));background:var(--bg-card);display:grid;place-items:center;position:relative;z-index:1}
+.trace-step .rail .dot::after{content:'';width:5px;height:5px;border-radius:50%;background:hsl(var(--e))}
+.trace-step.done .rail .dot{background:hsl(var(--e))}
+.trace-step.done .rail .dot::after{background:#fff}
+.trace-step.running .rail .dot{animation:trace-pulse 1.4s ease-in-out infinite}
+@keyframes trace-pulse{0%,100%{box-shadow:0 0 0 0 hsl(var(--e)/.4)}50%{box-shadow:0 0 0 5px hsl(var(--e)/.05)}}
+.trace-step .body .nm{font-family:var(--f-display);font-weight:800;font-size:12.5px;color:var(--text);display:flex;align-items:center;gap:6px}
+.trace-step .body .nm .badge{font-family:var(--f-mono);font-size:9px;color:hsl(var(--e));background:hsl(var(--e)/.12);padding:1px 5px;border-radius:99px;font-weight:700;letter-spacing:.04em;text-transform:uppercase}
+.trace-step .body .sub{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-top:2px;line-height:1.4}
+.trace-step .body .sub .v{color:var(--text-sec);font-weight:700}
+.trace-step .right{display:flex;flex-direction:column;align-items:flex-end;gap:2px;font-family:var(--f-mono);font-size:11px;font-weight:700;color:var(--text);min-width:62px}
+.trace-step .right .lat{font-variant-numeric:tabular-nums}
+.trace-step .right .lat.warn{color:hsl(38 90% 50%)}
+.trace-step .right .pct{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted)}
+
+/* Debug footer */
+.debug-foot{border-top:1px solid var(--border-light);background:var(--bg);padding:10px 14px;display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;flex-shrink:0}
+.debug-foot .stat{display:flex;flex-direction:column;gap:1px}
+.debug-foot .stat .lbl{font-family:var(--f-mono);font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.debug-foot .stat .v{font-family:var(--f-mono);font-size:13px;font-weight:700;color:var(--text);font-variant-numeric:tabular-nums}
+.debug-foot .stat .v .sub{color:var(--text-muted);font-weight:500;font-size:10px;margin-left:3px}
+.debug-foot .stat .v.cost{color:hsl(var(--c-agent))}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Agent Sandbox &amp; Debug</h1>
+          <div class="crumbs">Admin › AI Tooling &amp; Data Quality › Sandbox · sess_sndbx_a14c · 14:23:08</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca agente, prompt…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin">📋 Da template…</button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body">
+
+        <div class="sandbox-grid">
+
+          <!-- ░░░░░░░░░░░ LEFT: Config ░░░░░░░░░░░ -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Configurazione</h3>
+              <span class="status-chip muted">draft</span>
+            </div>
+
+            <div class="preset-strip">
+              <span class="label">Agente attivo</span>
+              <div class="agent-row">
+                <div class="agent-mark">W</div>
+                <div style="flex:1;min-width:0">
+                  <div class="agent-name">Wingspan Rules Bot</div>
+                  <div class="agent-sub">agent_wing_rb01 · v3 · prod</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="cfg-body">
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Agente</span>
+                <select class="admin-select">
+                  <option selected>Wingspan Rules Bot · v3</option>
+                  <option>Catan Rules Bot · v2</option>
+                  <option>Generic RAG Bot · v5</option>
+                  <option>Tutor / Onboarding · v1</option>
+                  <option>Mechanic Explainer · v2</option>
+                </select>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Gioco</span>
+                <select class="admin-select">
+                  <option selected>Wingspan · base + EU</option>
+                  <option>Wingspan · base</option>
+                  <option>Catan · base 5th ed.</option>
+                  <option>Terraforming Mars</option>
+                </select>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Modello LLM<span class="desc">temperatura/max-token controllati sotto</span></span>
+                <select class="admin-select">
+                  <option selected>deepseek-chat — $0.27/$1.10 1M</option>
+                  <option>openrouter/auto — best-cost</option>
+                  <option>claude-3.5-sonnet — $3/$15 1M</option>
+                  <option>gpt-4o-mini — $0.15/$0.60 1M</option>
+                </select>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">Parametri</span>
+                <div class="num-pair">
+                  <input class="admin-input mono" value="0.20" title="Temperatura" />
+                  <input class="admin-input mono" value="1024" title="Max output token" />
+                </div>
+                <div style="font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);margin-top:2px;display:flex;justify-content:space-between"><span>temperature</span><span>max_tokens</span></div>
+              </div>
+
+              <div class="toggle-row">
+                <div class="lbl">
+                  <span class="nm">Usa RAG</span>
+                  <span class="sub">retrieve da KB del gioco</span>
+                </div>
+                <span class="admin-toggle on" role="switch" aria-checked="true"></span>
+              </div>
+
+              <div class="admin-form-row">
+                <span class="admin-form-label">KB version</span>
+                <select class="admin-select">
+                  <option selected>wingspan-kb · v4 · 2026-05-18</option>
+                  <option>wingspan-kb · v3 · 2026-04-02</option>
+                  <option>wingspan-kb · v2-draft (staging)</option>
+                </select>
+                <div style="font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);margin-top:3px">1 482 chunk · embed bge-m3 · 768-d</div>
+              </div>
+
+              <div class="toggle-row">
+                <div class="lbl">
+                  <span class="nm">Rerank</span>
+                  <span class="sub">bge-reranker top-50 → 5</span>
+                </div>
+                <span class="admin-toggle on" role="switch" aria-checked="true"></span>
+              </div>
+
+              <div class="toggle-row" style="border-bottom:0">
+                <div class="lbl">
+                  <span class="nm">Trace verbose</span>
+                  <span class="sub">log raw chunks + token</span>
+                </div>
+                <span class="admin-toggle on" role="switch" aria-checked="true"></span>
+              </div>
+
+            </div>
+
+            <div class="cfg-foot">
+              <div class="session-id"><span>sandbox session</span><span class="v">sess_sndbx_a14c</span></div>
+              <div class="session-id"><span>turni</span><span class="v">3 · 2 ok · 0 err</span></div>
+              <button class="btn-admin" title="Reset sessione · ConfirmModal leggero">↺ Reset sessione</button>
+            </div>
+          </section>
+
+          <!-- ░░░░░░░░░░░ CENTER: Chat ░░░░░░░░░░░ -->
+          <section class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Chat di test</h3>
+              <span class="status-chip running">● streaming · SSE</span>
+              <div class="meta">turno 3/∞ · 612 ms · 180 tok out</div>
+            </div>
+
+            <div class="chat-scroll">
+
+              <!-- Turn 1 · user -->
+              <div class="bubble user">
+                <div class="meta"><span class="av">A</span>admin · 14:21:08</div>
+                <div class="body">Qual è il setup base di Wingspan per 2 giocatori?</div>
+              </div>
+
+              <!-- Turn 1 · assistant -->
+              <div class="bubble assistant">
+                <div class="meta"><span class="av">W</span>Wingspan Rules Bot · 14:21:09</div>
+                <div class="body">
+                  Per 2 giocatori, ognuno riceve <strong>5 carte uccello</strong>, <strong>2 carte obiettivo bonus</strong> (ne scarta 1), <strong>5 cibi a scelta</strong> e una plancia personale con 4 colonne x 3 habitat. Il dado-pietra dei dadi cibo viene riempito con 5 dadi neutri. Il primo giocatore è il più giovane.
+                </div>
+                <div class="retrieval-inline">
+                  <div class="ri-head">
+                    <span class="chunk-pill">📚 3 chunk usati</span>
+                    <span class="spacer"></span>
+                    <span>top-50 → rerank → 3 · KB v4</span>
+                  </div>
+                  <div class="chunk-row"><span class="src">wingspan p.2</span><span class="snip">"Setup · 2 players: deal each 5 birds, 2 bonus cards…"</span><span class="pg">§ Setup</span><span class="score high">0.92</span></div>
+                  <div class="chunk-row"><span class="src">wingspan p.3</span><span class="snip">"Food tokens: each player starts with 5 food of their choice…"</span><span class="pg">§ Components</span><span class="score high">0.84</span></div>
+                  <div class="chunk-row"><span class="src">wingspan p.2</span><span class="snip">"Bird tray and dice tower setup with 5 dice…"</span><span class="pg">§ Setup</span><span class="score mid">0.71</span></div>
+                </div>
+                <div class="stream-meta">
+                  <span class="seg"><span class="k">ttfb</span><span class="v">412 ms</span></span>
+                  <span class="seg"><span class="k">tokens</span><span class="v">in 2.1k / out 142</span></span>
+                  <span class="seg"><span class="k">cost</span><span class="v">$0.003</span></span>
+                  <span class="seg"><span class="k">model</span><span class="v">deepseek-chat</span></span>
+                </div>
+              </div>
+
+              <!-- Turn 2 · user -->
+              <div class="bubble user">
+                <div class="meta"><span class="av">A</span>admin · 14:22:42</div>
+                <div class="body">Quanti uccelli posso giocare per turno?</div>
+              </div>
+
+              <!-- Turn 2 · assistant streaming -->
+              <div class="bubble assistant">
+                <div class="meta"><span class="av">W</span>Wingspan Rules Bot · 14:23:08 · <span style="color:hsl(var(--c-toolkit));font-weight:800">streaming…</span></div>
+                <div class="body">
+                  In ogni turno puoi giocare <strong>esattamente una carta uccello</strong> usando l'azione "Play a Bird" nella prima colonna della tua plancia. Il costo è il cibo indicato sulla carta più <strong>1 uovo per ogni carta già presente nello stesso habitat oltre la prima</strong>. Non puoi giocare più di una carta per turno, ma puoi attivare le abilità "when played" e poi <span class="cursor"></span>
+                </div>
+                <div class="retrieval-inline">
+                  <div class="ri-head">
+                    <span class="chunk-pill">📚 3 chunk usati</span>
+                    <span class="spacer"></span>
+                    <span>top-50 → rerank → 3 · KB v4 · cache-miss</span>
+                  </div>
+                  <div class="chunk-row"><span class="src">wingspan p.4</span><span class="snip">"On your turn, take exactly one of the four actions…"</span><span class="pg">§ Turn Structure</span><span class="score high">0.88</span></div>
+                  <div class="chunk-row"><span class="src">wingspan p.6</span><span class="snip">"Play a Bird · pay food cost shown on card + 1 egg per…"</span><span class="pg">§ Action: Play a Bird</span><span class="score high">0.81</span></div>
+                  <div class="chunk-row"><span class="src">wingspan p.7</span><span class="snip">"You may activate 'when played' powers immediately…"</span><span class="pg">§ Bird Powers</span><span class="score mid">0.68</span></div>
+                </div>
+                <div class="stream-meta">
+                  <span class="seg"><span class="k">ttfb</span><span class="v">218 ms</span></span>
+                  <span class="seg"><span class="k">streamed</span><span class="v">180 tok</span></span>
+                  <span class="seg"><span class="k">cost (live)</span><span class="v">$0.004</span></span>
+                  <span class="seg" style="color:hsl(var(--c-toolkit))"><span class="k">●</span><span class="v">live</span></span>
+                </div>
+              </div>
+
+            </div>
+
+            <div class="chat-input">
+              <input class="admin-input" placeholder="Scrivi un messaggio per testare l'agente… ⌘K per ricerca prompt" />
+              <span class="hint"><kbd style="padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px">⌥↩</kbd> newline</span>
+              <button class="btn-admin">⤓ JSON</button>
+              <button class="btn-admin primary">▶ Invia <kbd>↵</kbd></button>
+            </div>
+          </section>
+
+          <!-- ░░░░░░░░░░░ RIGHT: Debug pipeline ░░░░░░░░░░░ -->
+          <aside class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>Debug pipeline</h3>
+              <span class="status-chip running">● live</span>
+              <div class="meta">turno 3 · trace_id 8f3a</div>
+            </div>
+
+            <div class="debug-scroll">
+
+              <!-- Waterfall -->
+              <div class="waterfall">
+                <div class="wf-title">
+                  <span>Waterfall · stage timings</span>
+                  <span class="total">853 ms</span>
+                </div>
+                <!-- Total 853ms; widths roughly proportional: embed 41/853=4.8%, search 120/853=14.1%, rerank 80/853=9.4%, llm 612/853=71.7% -->
+                <div class="wf-bar">
+                  <div class="seg e-kb" style="width:4.8%" title="embed · 41ms">e</div>
+                  <div class="seg e-chat" style="width:14.1%" title="search · 120ms">search</div>
+                  <div class="seg e-tool" style="width:9.4%" title="rerank · 80ms">rer</div>
+                  <div class="seg e-agent running" style="width:71.7%" title="llm · 612ms (streaming)">llm · streaming…</div>
+                </div>
+                <div class="wf-legend">
+                  <span class="lg e-kb"><span class="sw"></span>embed <span class="v">41 ms</span></span>
+                  <span class="lg e-chat"><span class="sw"></span>search <span class="v">120 ms</span></span>
+                  <span class="lg e-tool"><span class="sw"></span>rerank <span class="v">80 ms</span></span>
+                  <span class="lg e-agent"><span class="sw"></span>llm <span class="v">612 ms</span></span>
+                </div>
+              </div>
+
+              <!-- Trace tree -->
+              <div class="trace-tree">
+
+                <div class="trace-step done e-kb">
+                  <div class="rail"><span class="dot"></span></div>
+                  <div class="body">
+                    <div class="nm">embed <span class="badge">step 1/5</span></div>
+                    <div class="sub">model <span class="v">bge-m3</span> · dim <span class="v">768</span> · input "Quanti uccelli posso giocare per turno?" (38 tok)</div>
+                  </div>
+                  <div class="right"><span class="lat">41 ms</span><span class="pct">4.8%</span></div>
+                </div>
+
+                <div class="trace-step done e-chat">
+                  <div class="rail"><span class="dot"></span></div>
+                  <div class="body">
+                    <div class="nm">search <span class="badge">step 2/5</span></div>
+                    <div class="sub">index <span class="v">wingspan-kb v4</span> · 1 482 chunk · top-k <span class="v">50</span> · cosine</div>
+                  </div>
+                  <div class="right"><span class="lat">120 ms</span><span class="pct">14.1%</span></div>
+                </div>
+
+                <div class="trace-step done e-tool">
+                  <div class="rail"><span class="dot"></span></div>
+                  <div class="body">
+                    <div class="nm">rerank <span class="badge">step 3/5</span></div>
+                    <div class="sub">model <span class="v">bge-reranker-v2-m3</span> · 50 → <span class="v">5</span> · cutoff <span class="v">0.60</span></div>
+                  </div>
+                  <div class="right"><span class="lat">80 ms</span><span class="pct">9.4%</span></div>
+                </div>
+
+                <div class="trace-step running e-agent">
+                  <div class="rail"><span class="dot"></span></div>
+                  <div class="body">
+                    <div class="nm">llm <span class="badge">step 4/5 · streaming</span></div>
+                    <div class="sub">model <span class="v">deepseek-chat</span> · temp <span class="v">0.20</span> · ctx <span class="v">2 348 / 64k</span> · 180 tok streamed</div>
+                  </div>
+                  <div class="right"><span class="lat">612 ms</span><span class="pct">71.7%</span></div>
+                </div>
+
+                <div class="trace-step e-toolkit">
+                  <div class="rail"><span class="dot" style="background:var(--bg-muted);border-color:var(--border-strong)"></span></div>
+                  <div class="body">
+                    <div class="nm" style="color:var(--text-muted)">postprocess <span class="badge" style="background:var(--bg-muted);color:var(--text-muted)">step 5/5 · in attesa</span></div>
+                    <div class="sub">guardrail · citation injection · md-render — partirà a llm complete</div>
+                  </div>
+                  <div class="right" style="color:var(--text-muted)"><span class="lat">—</span><span class="pct">—</span></div>
+                </div>
+
+              </div>
+
+            </div>
+
+            <div class="debug-foot">
+              <div class="stat">
+                <span class="lbl">Token in / out</span>
+                <span class="v">2.4k <span class="sub">/ 180</span></span>
+              </div>
+              <div class="stat">
+                <span class="lbl">Latenza tot.</span>
+                <span class="v">853 <span class="sub">ms</span></span>
+              </div>
+              <div class="stat">
+                <span class="lbl">Costo turno</span>
+                <span class="v cost">$0.004</span>
+              </div>
+            </div>
+          </aside>
+
+        </div>
+
+      </div>
+    </main>
+  </div>
+
+  <script src="admin-nav.js"></script>
+  <script>renderAdminNav('sandbox');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-secrets.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-secrets.html
@@ -1,0 +1,560 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Secrets Vault · MeepleAI Admin</title>
+<!-- C6 · Platform & Operations → 'secrets' (NAV_ID non ancora presente in admin-nav.js;
+     verrà aggiunto nel gruppo "Platform & Operations"). -->
+<!-- @v1 SecretsTable · MaskedField · RevealModal (step-up 2FA) · RotateModal · TypedConfirmDelete reuse
+     Endpoints: GET/POST/DELETE /api/v1/admin/secrets
+                POST /api/v1/admin/secrets/{name}/{reveal|rotate}
+     Role: superadmin + step-up 2FA
+     ⚠ REGOLA: valori SEMPRE mascherati (••••••••) — nessun valore in chiaro nemmeno fittizio. -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+
+<!-- ═══════════════════ INLINED DS (tokens + components + admin-base) ═══════════════════ -->
+<style>
+/* ── tokens.css ─────────────────────────────────────────────────── */
+:root{
+  --c-game:25 95% 45%;--c-player:262 83% 58%;--c-session:240 60% 55%;--c-agent:38 92% 50%;
+  --c-kb:174 60% 40%;--c-chat:220 80% 55%;--c-event:350 89% 60%;--c-toolkit:142 70% 45%;--c-tool:195 80% 50%;
+  --c-success:142 70% 45%;--c-warning:38 92% 50%;--c-danger:350 89% 60%;--c-info:220 80% 55%;
+  --brand:var(--c-game);--brand-fg:hsl(var(--c-game));
+  --f-display:'Quicksand',system-ui,sans-serif;--f-body:'Nunito',system-ui,sans-serif;--f-mono:'JetBrains Mono',ui-monospace,monospace;
+  --fs-xs:11px;--fs-sm:12px;--fs-base:14px;--fs-md:15px;--fs-lg:17px;--fs-xl:20px;--fs-2xl:24px;--fs-3xl:32px;--fs-4xl:40px;
+  --fw-reg:400;--fw-med:500;--fw-semi:600;--fw-bold:700;--fw-ext:800;
+  --lh-tight:1.2;--lh-snug:1.35;--lh-body:1.5;--lh-relax:1.65;
+  --s-0:0;--s-1:4px;--s-2:8px;--s-3:12px;--s-4:16px;--s-5:20px;--s-6:24px;--s-7:32px;--s-8:40px;--s-9:48px;--s-10:64px;
+  --r-xs:4px;--r-sm:6px;--r-md:10px;--r-lg:14px;--r-xl:18px;--r-2xl:24px;--r-pill:9999px;
+  --ease-out:cubic-bezier(.16,1,.3,1);--ease-in-out:cubic-bezier(.65,0,.35,1);--ease-spring:cubic-bezier(.34,1.56,.64,1);
+  --dur-xs:120ms;--dur-sm:180ms;--dur-md:280ms;--dur-lg:400ms;--dur-xl:600ms;
+  --z-base:0;--z-sticky:10;--z-nav:20;--z-overlay:50;--z-drawer:51;--z-modal:60;--z-toast:70;--z-tooltip:80;
+}
+:root,:root[data-theme="light"]{
+  --bg:#f7f3ee;--bg-card:#fff;--bg-muted:#efe6d9;--bg-sunken:#ede2d0;--bg-hover:rgba(180,130,80,.06);
+  --text:#2b1f12;--text-sec:#5a4a38;--text-muted:#9a8870;
+  --border:rgba(180,130,80,.18);--border-light:rgba(180,130,80,.1);--border-strong:rgba(180,130,80,.32);
+  --shadow-xs:0 1px 2px rgba(90,60,20,.06);--shadow-sm:0 2px 8px rgba(90,60,20,.08);--shadow-md:0 4px 16px rgba(90,60,20,.1);
+  --shadow-lg:0 12px 36px rgba(90,60,20,.14);--shadow-drawer:0 -8px 32px rgba(90,60,20,.12);
+  --glass-bg:rgba(255,255,255,.88);--glass-border:rgba(255,255,255,.6);color-scheme:light;
+}
+:root[data-theme="dark"]{
+  --bg:#14100a;--bg-card:#1e1710;--bg-muted:#241c13;--bg-sunken:#0f0c08;--bg-hover:rgba(255,200,130,.05);
+  --text:#f0e4d2;--text-sec:#c8b896;--text-muted:#8a7860;
+  --border:rgba(224,180,110,.14);--border-light:rgba(224,180,110,.08);--border-strong:rgba(224,180,110,.28);
+  --shadow-xs:0 1px 2px rgba(0,0,0,.3);--shadow-sm:0 2px 8px rgba(0,0,0,.4);--shadow-md:0 4px 16px rgba(0,0,0,.5);
+  --shadow-lg:0 12px 36px rgba(0,0,0,.6);--shadow-drawer:0 -8px 32px rgba(0,0,0,.5);
+  --glass-bg:rgba(30,22,14,.85);--glass-border:rgba(224,180,110,.14);
+  --c-game:28 95% 58%;--c-player:262 75% 70%;--c-session:235 70% 70%;--c-agent:38 92% 62%;--c-kb:174 60% 55%;
+  --c-chat:218 80% 68%;--c-event:350 85% 70%;--c-toolkit:142 60% 58%;--c-tool:195 75% 62%;
+  color-scheme:dark;
+}
+*{box-sizing:border-box}html,body{margin:0;padding:0}
+body{font-family:var(--f-body);background:var(--bg);color:var(--text);font-size:var(--fs-base);line-height:var(--lh-body);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;transition:background var(--dur-md) var(--ease-out),color var(--dur-md) var(--ease-out)}
+h1,h2,h3,h4,h5,h6{font-family:var(--f-display);font-weight:var(--fw-bold);letter-spacing:-.01em;margin:0;line-height:var(--lh-tight)}
+button{font-family:inherit;cursor:pointer}a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--f-mono);font-size:.9em}
+.e-game{--e:var(--c-game)}.e-player{--e:var(--c-player)}.e-session{--e:var(--c-session)}.e-agent{--e:var(--c-agent)}
+.e-kb{--e:var(--c-kb)}.e-chat{--e:var(--c-chat)}.e-event{--e:var(--c-event)}.e-toolkit{--e:var(--c-toolkit)}.e-tool{--e:var(--c-tool)}
+.e-fg{color:hsl(var(--e))}.e-bg{background:hsl(var(--e));color:#fff}
+.e-tint{background:hsl(var(--e)/.1);color:hsl(var(--e))}.e-ring{box-shadow:0 0 0 2px hsl(var(--e)/.35)}
+.spark{stroke:currentColor;stroke-width:1.5;fill:none}.spark-fill{fill:currentColor;opacity:.14}
+
+/* ── admin-base.css ─────────────────────────────────────────────── */
+.admin-page{background:var(--bg);color:var(--text);min-height:100vh;font-family:var(--f-body);font-size:var(--fs-sm);line-height:1.5}
+.admin-shell{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+.admin-nav{background:var(--bg-card);border-right:1px solid var(--border);padding:16px 0;display:flex;flex-direction:column;gap:2px;position:sticky;top:0;height:100vh;overflow-y:auto}
+.admin-nav-brand{padding:4px 16px 16px;display:flex;align-items:center;gap:8px;border-bottom:1px solid var(--border-light);margin-bottom:12px}
+.admin-nav-brand-mark{width:28px;height:28px;border-radius:8px;background:linear-gradient(135deg,hsl(var(--c-game)),hsl(var(--c-event)));color:#fff;display:grid;place-items:center;font-family:var(--f-display);font-weight:900;font-size:14px}
+.admin-nav-brand-name{font-family:var(--f-display);font-weight:800;font-size:14px}
+.admin-nav-brand-tag{font-family:var(--f-mono);font-size:9px;font-weight:700;color:hsl(var(--c-event));text-transform:uppercase;letter-spacing:.08em;padding:2px 6px;border-radius:4px;background:hsl(var(--c-event)/.12);margin-left:auto}
+.admin-nav-group{padding:10px 16px 4px;font-family:var(--f-mono);font-size:9.5px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em}
+.admin-nav-item{display:flex;align-items:center;gap:10px;padding:7px 16px;color:var(--text-sec);font-family:var(--f-display);font-size:13px;font-weight:600;cursor:pointer;border-left:2px solid transparent;text-decoration:none}
+.admin-nav-item:hover{background:var(--bg-muted);color:var(--text)}
+.admin-nav-item.active{background:hsl(var(--c-event)/.08);color:hsl(var(--c-event));border-left-color:hsl(var(--c-event))}
+.admin-nav-item .em{font-size:14px;opacity:.9}
+.admin-nav-item .count{margin-left:auto;font-family:var(--f-mono);font-size:10px;color:var(--text-muted);font-weight:700}
+.admin-nav-foot{margin-top:auto;padding:12px 16px;border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:flex;align-items:center;gap:8px}
+.admin-nav-foot .badge{padding:2px 6px;border-radius:4px;background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit));font-weight:700;font-size:9px;text-transform:uppercase;letter-spacing:.05em}
+.admin-top{background:var(--bg);border-bottom:1px solid var(--border-light);padding:12px 24px;display:flex;align-items:center;gap:16px;position:sticky;top:0;z-index:50;backdrop-filter:blur(12px)}
+.admin-top h1{font-family:var(--f-display);font-size:20px;font-weight:800;margin:0;line-height:1.2}
+.admin-top .crumbs{font-family:var(--f-mono);font-size:11px;color:var(--text-muted);margin-top:2px}
+.admin-top .spacer{flex:1}.admin-top-actions{display:flex;gap:8px;align-items:center}
+.admin-search{display:flex;align-items:center;gap:6px;padding:6px 12px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;width:280px;font-size:12px}
+.admin-search input{flex:1;border:0;background:transparent;color:var(--text);font-family:var(--f-body);font-size:12.5px;outline:0}
+.admin-search kbd{padding:1px 5px;border-radius:4px;background:var(--bg-muted);border:1px solid var(--border);font-family:var(--f-mono);font-size:9px;color:var(--text-muted)}
+.btn-admin{padding:6px 12px;border-radius:6px;font-family:var(--f-display);font-size:12.5px;font-weight:700;cursor:pointer;border:1px solid var(--border);background:var(--bg-card);color:var(--text);display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.btn-admin:hover{background:var(--bg-muted)}
+.btn-admin.primary{background:hsl(var(--c-event));border-color:hsl(var(--c-event));color:#fff;box-shadow:0 2px 6px hsl(var(--c-event)/.3)}
+.btn-admin.primary:hover{filter:brightness(1.08)}
+.btn-admin.danger{background:var(--bg-card);border-color:hsl(var(--c-event)/.5);color:hsl(var(--c-event))}
+.btn-admin.success{background:hsl(var(--c-toolkit));border-color:hsl(var(--c-toolkit));color:#fff}
+.btn-admin.ghost{background:transparent;border-color:transparent}
+.btn-admin.icon{padding:6px;width:28px;height:28px;justify-content:center}
+.btn-admin.sm{padding:3px 8px;font-size:11px}
+.btn-admin kbd{padding:1px 4px;border-radius:3px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.2);font-family:var(--f-mono);font-size:9px;margin-left:4px}
+.admin-kpi{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;padding:14px 16px;display:flex;flex-direction:column;gap:4px;min-height:88px;position:relative}
+.admin-kpi-label{font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em}
+.admin-kpi-value{font-family:var(--f-display);font-size:28px;font-weight:800;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums}
+.admin-kpi-trend{font-family:var(--f-mono);font-size:11px;font-weight:600;display:inline-flex;align-items:center;gap:3px}
+.admin-kpi-trend.up{color:hsl(var(--c-toolkit))}.admin-kpi-trend.down{color:hsl(var(--c-event))}.admin-kpi-trend.flat{color:var(--text-muted)}
+.admin-kpi-spark{position:absolute;right:12px;top:12px;width:70px;height:28px;opacity:.85}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool))}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event))}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb))}
+.admin-panel{background:var(--bg-card);border:1px solid var(--border-light);border-radius:10px;overflow:hidden}
+.admin-panel-head{padding:10px 14px;border-bottom:1px solid var(--border-light);display:flex;align-items:center;gap:10px;background:var(--bg)}
+.admin-panel-head h3{margin:0;font-family:var(--f-display);font-size:13px;font-weight:800}
+.admin-panel-head .meta{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);margin-left:auto}
+.admin-panel-body{padding:14px}
+.admin-table{width:100%;border-collapse:collapse;font-size:12.5px}
+.admin-table th{text-align:left;padding:8px 12px;font-family:var(--f-mono);font-size:10px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-light);background:var(--bg);position:sticky;top:0;white-space:nowrap}
+.admin-table td{padding:9px 12px;border-bottom:1px solid var(--border-light);vertical-align:middle}
+.admin-table tr:hover td{background:var(--bg-muted)}
+.status-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;white-space:nowrap}
+.status-chip::before{content:'';width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.status-chip.healthy{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.status-chip.healthy::before{background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit)/.25)}
+.status-chip.warning{background:hsl(38 90% 56%/.14);color:hsl(38 90% 50%)}
+.status-chip.warning::before{background:hsl(38 90% 50%)}
+.status-chip.danger{background:hsl(var(--c-event)/.12);color:hsl(var(--c-event))}
+.status-chip.danger::before{background:hsl(var(--c-event))}
+.status-chip.muted{background:var(--bg-muted);color:var(--text-muted)}
+.status-chip.muted::before{background:var(--text-muted)}
+.status-chip.info{background:hsl(var(--c-chat)/.12);color:hsl(var(--c-chat))}
+.status-chip.info::before{background:hsl(var(--c-chat))}
+.admin-form-row{display:grid;grid-template-columns:200px 1fr;gap:16px;align-items:flex-start;padding:12px 0;border-bottom:1px solid var(--border-light)}
+.admin-form-row:last-child{border-bottom:0}
+.admin-form-label{font-family:var(--f-display);font-size:12.5px;font-weight:700}
+.admin-form-label .desc{display:block;margin-top:3px;font-family:var(--f-body);font-size:11px;font-weight:400;color:var(--text-muted);line-height:1.4}
+.admin-input,.admin-select,.admin-textarea{width:100%;max-width:360px;padding:6px 10px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;font-family:var(--f-body);font-size:12.5px}
+.admin-input.mono{font-family:var(--f-mono)}
+.alert-banner{display:flex;align-items:flex-start;gap:12px;padding:14px 16px;border-radius:10px;font-size:12.5px}
+.alert-banner.warning{background:hsl(38 90% 56%/.1);border:1px solid hsl(38 90% 56%/.35);color:var(--text)}
+.alert-banner.danger{background:hsl(var(--c-event)/.08);border:1px solid hsl(var(--c-event)/.4);color:var(--text)}
+.alert-banner.info{background:hsl(var(--c-chat)/.08);border:1px solid hsl(var(--c-chat)/.3);color:var(--text)}
+.alert-banner .em{font-size:20px;flex-shrink:0;line-height:1}
+.alert-banner .title{font-family:var(--f-display);font-weight:800;margin-bottom:3px;font-size:13.5px}
+.alert-banner .actions{margin-left:auto;display:flex;gap:6px;align-items:center}
+@media (max-width:880px){
+  .admin-mobile-fallback{display:flex !important;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:32px;text-align:center;gap:16px}
+  .admin-mobile-fallback .em{font-size:56px}
+  .admin-mobile-fallback h2{margin:0;font-family:var(--f-display);font-size:20px}
+  .admin-mobile-fallback p{color:var(--text-sec);max-width:320px;margin:0;line-height:1.5}
+  .admin-shell{display:none}
+}
+.admin-mobile-fallback{display:none}
+.admin-body{padding:20px 24px}
+
+/* ── Page-specific ──────────────────────────────────────────────── */
+.mono{font-family:var(--f-mono);font-variant-numeric:tabular-nums}
+.kpi-strip{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.head-cluster{display:inline-flex;align-items:center;gap:10px;margin-left:auto}
+.head-cluster .sep{width:1px;height:14px;background:var(--border-light)}
+.sensitive-note{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+.sensitive-note .lock{color:hsl(var(--c-event))}
+
+/* Topbar role pill */
+.role-pill{display:inline-flex;align-items:center;gap:5px;padding:3px 8px;border-radius:6px;background:hsl(var(--c-event)/.12);color:hsl(var(--c-event));font-family:var(--f-mono);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em}
+.role-pill::before{content:'🔒';font-size:10px}
+.role-pill .gap{opacity:.5}
+
+/* ── Secret name cell ───────────────────────────────────────────── */
+.sec-cell{display:flex;align-items:center;gap:10px}
+.sec-mark{width:28px;height:28px;border-radius:7px;background:hsl(var(--e)/.12);color:hsl(var(--e));display:grid;place-items:center;font-size:14px;flex-shrink:0;border:1px solid hsl(var(--e)/.25)}
+.sec-info{display:flex;flex-direction:column;line-height:1.2;min-width:0}
+.sec-name{font-family:var(--f-mono);font-weight:700;font-size:12px;color:var(--text);letter-spacing:.01em}
+.sec-kind{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;margin-top:2px}
+
+/* Masked value cell — pattern fisso, nessun valore reale */
+.masked{display:inline-flex;align-items:center;gap:8px;font-family:var(--f-mono);background:var(--bg-sunken,var(--bg));padding:3px 10px;border-radius:6px;border:1px solid var(--border-light);min-width:200px}
+.masked .dots{font-family:var(--f-mono);font-size:14px;color:var(--text-sec);letter-spacing:.04em;line-height:1;user-select:none}
+.masked .len{font-family:var(--f-mono);font-size:9.5px;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-weight:700;margin-left:auto}
+
+/* Date cells */
+.dt-cell{font-family:var(--f-mono);font-size:11.5px;color:var(--text);font-weight:600}
+.dt-cell .sub{display:block;color:var(--text-muted);font-weight:500;font-size:10px;margin-top:1px}
+.dt-cell.warn{color:hsl(38 90% 50%)}
+.dt-cell.crit{color:hsl(var(--c-event))}
+
+/* Row actions */
+.row-actions{display:flex;gap:4px;justify-content:flex-end;align-items:center}
+.row-actions .btn-admin.sm{padding:3px 8px;font-size:10.5px}
+.lock-mini{color:hsl(var(--c-event));font-size:10px}
+
+/* Scope chip variants (info default; staging & all simulated via inline style) */
+.scope-chip.prod{background:hsl(var(--c-event)/.1);color:hsl(var(--c-event))}
+.scope-chip.prod::before{background:hsl(var(--c-event))}
+.scope-chip.staging{background:hsl(var(--c-session)/.12);color:hsl(var(--c-session))}
+.scope-chip.staging::before{background:hsl(var(--c-session))}
+.scope-chip.all{background:hsl(var(--c-toolkit)/.12);color:hsl(var(--c-toolkit))}
+.scope-chip.all::before{background:hsl(var(--c-toolkit))}
+
+/* Aggiungi form */
+.add-form-grid{display:grid;grid-template-columns:1fr 1fr;gap:0 24px;padding:8px 20px 14px}
+.add-form-grid .admin-form-row{grid-template-columns:160px 1fr;padding:10px 0}
+.add-form-grid .admin-input,.add-form-grid .admin-select{max-width:none;width:100%}
+.add-form-foot{display:flex;align-items:center;gap:12px;padding:12px 20px;border-top:1px solid var(--border-light);background:var(--bg)}
+.add-form-foot .grow{flex:1}
+.value-input{display:flex;align-items:center;gap:8px;max-width:100%}
+.value-input input{flex:1}
+.value-input .why{font-family:var(--f-mono);font-size:10px;color:var(--text-muted);display:inline-flex;align-items:center;gap:4px}
+
+/* Audit ribbon */
+.audit-line{display:flex;align-items:center;gap:8px;padding:8px 14px;background:var(--bg);border-top:1px solid var(--border-light);font-family:var(--f-mono);font-size:10.5px;color:var(--text-muted)}
+.audit-line .who{color:hsl(var(--c-event));font-weight:700}
+.audit-line .ev{color:var(--text);font-weight:700}
+</style>
+</head>
+<body class="admin-page">
+
+  <div class="admin-mobile-fallback">
+    <div class="em">🖥️</div>
+    <h2>Console solo desktop</h2>
+    <p>La console admin è ottimizzata per schermi ≥ 880px. Aprila da desktop.</p>
+  </div>
+
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+
+    <main>
+      <header class="admin-top">
+        <div>
+          <h1>Secrets Vault</h1>
+          <div class="crumbs">Admin › Platform &amp; Operations › Secrets · 8 entries · cifratura AES-256-GCM · KMS rotato 12 mar</div>
+        </div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <span class="role-pill">superadmin<span class="gap"> · </span>step-up 2FA</span>
+          <div class="admin-search"><span>🔍</span><input placeholder="Cerca nome secret, scope…"/><kbd>⌘K</kbd></div>
+          <button class="btn-admin">⟳ Refresh <kbd>R</kbd></button>
+          <button class="btn-admin icon" title="Tema">🌗</button>
+        </div>
+      </header>
+
+      <div class="admin-body" style="display:flex;flex-direction:column;gap:14px">
+
+        <!-- ────────── 1) Alert audit-log ────────── -->
+        <div class="alert-banner warning">
+          <span class="em">🔐</span>
+          <div style="flex:1">
+            <div class="title">Operazioni audit-logged</div>
+            <div style="line-height:1.55">Tutte le operazioni sui secret (<strong>Reveal</strong>, <strong>Rotate</strong>, <strong>Delete</strong>, <strong>Create</strong>) richiedono <strong>step-up 2FA</strong> e vengono registrate in <code style="font-family:var(--f-mono);background:var(--bg-muted);padding:1px 5px;border-radius:4px">audit.secret_events</code> con email, IP, user-agent e timestamp UTC. <strong>Reveal</strong> mostra il valore una sola volta nella sessione corrente.</div>
+          </div>
+          <div class="actions">
+            <span class="sensitive-note"><span class="lock">🔒</span> step-up 2FA</span>
+            <button class="btn-admin sm ghost">📜 Apri audit log</button>
+          </div>
+        </div>
+
+        <!-- ────────── 2) KPI strip ────────── -->
+        <section class="kpi-strip">
+          <div class="admin-kpi e-tool">
+            <div class="admin-kpi-label">Secret totali</div>
+            <div class="admin-kpi-value">8</div>
+            <div class="admin-kpi-trend flat">▬ prod 5 · staging 2 · all 1</div>
+            <svg class="admin-kpi-spark e-tool" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,18 L8,18 L16,16 L24,16 L32,14 L40,14 L48,12 L56,12 L64,10 L70,10 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,18 L8,18 L16,16 L24,16 L32,14 L40,14 L48,12 L56,12 L64,10 L70,10"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-event">
+            <div class="admin-kpi-label">In scadenza &lt; 30g</div>
+            <div class="admin-kpi-value">2<span style="font-size:14px;color:var(--text-muted);font-weight:600"> · 1 scaduto</span></div>
+            <div class="admin-kpi-trend down">▼ richiede attenzione · azione &lt; 7g</div>
+            <svg class="admin-kpi-spark e-event" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,22 L8,20 L16,18 L24,18 L32,16 L40,12 L48,10 L56,8 L64,6 L70,4 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,22 L8,20 L16,18 L24,18 L32,16 L40,12 L48,10 L56,8 L64,6 L70,4"/>
+            </svg>
+          </div>
+
+          <div class="admin-kpi e-kb">
+            <div class="admin-kpi-label">Ultima rotazione</div>
+            <div class="admin-kpi-value">3g<span style="font-size:14px;color:var(--text-muted);font-weight:600"> fa</span></div>
+            <div class="admin-kpi-trend up">▲ OPENROUTER_API_KEY · marco.rossi@</div>
+            <svg class="admin-kpi-spark e-kb" viewBox="0 0 70 28">
+              <path class="spark-fill e-fg" d="M0,20 L14,20 L14,8 L28,8 L28,18 L42,18 L42,10 L56,10 L56,16 L70,16 L70,28 L0,28 Z"/>
+              <path class="spark e-fg" d="M0,20 L14,20 L14,8 L28,8 L28,18 L42,18 L42,10 L56,10 L56,16 L70,16"/>
+            </svg>
+          </div>
+        </section>
+
+        <!-- ────────── 3) Secrets table ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Secrets</h3>
+            <span class="status-chip healthy">6 healthy</span>
+            <span class="status-chip warning">1 expiring</span>
+            <span class="status-chip danger">1 expired</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> Reveal / Rotate / Delete → step-up 2FA · valori sempre mascherati</span>
+              <span class="sep"></span>
+              <span class="meta">vault rev 27 · kms key alias/meepleai-secrets</span>
+              <button class="btn-admin sm ghost">⤓ Export manifest</button>
+            </div>
+          </div>
+
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th style="width:24%">Nome</th>
+                <th style="width:8%">Scope</th>
+                <th style="width:22%">Valore</th>
+                <th style="width:12%">Ultima rotazione</th>
+                <th style="width:12%">Scadenza</th>
+                <th style="width:10%">Stato</th>
+                <th style="width:170px;text-align:right">Azioni</th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <tr class="e-tool">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">🔑</div>
+                    <div class="sec-info"><span class="sec-name">DEEPSEEK_API_KEY</span><span class="sec-kind">provider · llm</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip prod">prod</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••••••</span><span class="len">52 ch</span></span></td>
+                <td class="dt-cell">32g fa<span class="sub">2026-04-20 09:14</span></td>
+                <td class="dt-cell">tra 58g<span class="sub">scad. 2026-07-20</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost" title="Step-up 2FA · mostra una volta">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost" title="Typed-confirm">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-chat">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">🔑</div>
+                    <div class="sec-info"><span class="sec-name">OPENROUTER_API_KEY</span><span class="sec-kind">provider · llm</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip prod">prod</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••••••</span><span class="len">73 ch</span></span></td>
+                <td class="dt-cell">3g fa<span class="sub">2026-05-19 17:42</span></td>
+                <td class="dt-cell">tra 87g<span class="sub">scad. 2026-08-19</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-kb">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">🗄</div>
+                    <div class="sec-info"><span class="sec-name">POSTGRES_PASSWORD</span><span class="sec-kind">db · primary</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip all">all</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••</span><span class="len">32 ch</span></span></td>
+                <td class="dt-cell">94g fa<span class="sub">2026-02-18 11:08</span></td>
+                <td class="dt-cell warn">tra 8g<span class="sub">scad. 2026-05-30</span></td>
+                <td><span class="status-chip warning">expiring</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-event">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">⚡</div>
+                    <div class="sec-info"><span class="sec-name">REDIS_PASSWORD</span><span class="sec-kind">cache · acl default</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip all">all</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••</span><span class="len">40 ch</span></span></td>
+                <td class="dt-cell crit">182g fa<span class="sub">2025-11-23 02:00</span></td>
+                <td class="dt-cell crit">scaduto 3g fa<span class="sub">scad. 2026-05-19</span></td>
+                <td><span class="status-chip danger">expired</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm danger">⤿ Rotate ora</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-session">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">✍</div>
+                    <div class="sec-info"><span class="sec-name">JWT_SIGNING_KEY</span><span class="sec-kind">auth · ed25519</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip prod">prod</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••••••••••</span><span class="len">88 ch</span></span></td>
+                <td class="dt-cell">14g fa<span class="sub">2026-05-08 04:00</span></td>
+                <td class="dt-cell">tra 166g<span class="sub">scad. 2026-11-04</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-game">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">☁</div>
+                    <div class="sec-info"><span class="sec-name">S3_R2_CREDENTIALS</span><span class="sec-kind">storage · cloudflare r2</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip prod">prod</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••••••</span><span class="len">64 ch · access+secret</span></span></td>
+                <td class="dt-cell">61g fa<span class="sub">2026-03-22 16:30</span></td>
+                <td class="dt-cell">tra 124g<span class="sub">scad. 2026-09-23</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-toolkit">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">🪝</div>
+                    <div class="sec-info"><span class="sec-name">SLACK_WEBHOOK_URL</span><span class="sec-kind">notif · #ops-alerts</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip prod">prod</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••••••</span><span class="len">68 ch · url</span></span></td>
+                <td class="dt-cell">142g fa<span class="sub">2026-01-01 00:00</span></td>
+                <td class="dt-cell">tra 223g<span class="sub">scad. 2027-01-01</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+              <tr class="e-agent">
+                <td>
+                  <div class="sec-cell">
+                    <div class="sec-mark">⚙</div>
+                    <div class="sec-info"><span class="sec-name">N8N_API_KEY</span><span class="sec-kind">integration · n8n</span></div>
+                  </div>
+                </td>
+                <td><span class="status-chip scope-chip staging">staging</span></td>
+                <td><span class="masked"><span class="dots">••••••••••••</span><span class="len">44 ch</span></span></td>
+                <td class="dt-cell">21g fa<span class="sub">2026-05-01 10:14</span></td>
+                <td class="dt-cell">tra 159g<span class="sub">scad. 2026-10-28</span></td>
+                <td><span class="status-chip healthy">healthy</span></td>
+                <td>
+                  <div class="row-actions">
+                    <button class="btn-admin sm ghost">👁 <span class="lock-mini">🔒</span> Reveal</button>
+                    <button class="btn-admin sm">⤿ Rotate</button>
+                    <button class="btn-admin sm ghost">🗑</button>
+                  </div>
+                </td>
+              </tr>
+
+            </tbody>
+          </table>
+
+          <div class="audit-line">
+            ⤿ Ultima azione · <span class="ev">rotate</span> · <span class="who"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="afceceddc0c1efc2cacadfc3cacec681cedfdf">[email&#160;protected]</a></span> · OPENROUTER_API_KEY · 3g fa · IP 82.49.117.42 · 2FA ✓
+          </div>
+        </section>
+
+        <!-- ────────── 4) Aggiungi secret ────────── -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3>Aggiungi secret</h3>
+            <span class="status-chip info">create · audit-logged</span>
+            <div class="head-cluster">
+              <span class="sensitive-note"><span class="lock">🔒</span> richiede step-up 2FA · valore mai persistito in chiaro</span>
+              <span class="sep"></span>
+              <span class="meta">kms encrypt · client-side mask</span>
+            </div>
+          </div>
+
+          <div class="add-form-grid">
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Nome<span class="desc">SCREAMING_SNAKE_CASE · max 64 char</span></span>
+              <input class="admin-input mono" placeholder="ES. ANTHROPIC_API_KEY" />
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Scope<span class="desc">Ambiente in cui il secret è disponibile</span></span>
+              <select class="admin-select">
+                <option>prod — solo produzione</option>
+                <option>staging — solo staging</option>
+                <option>all — entrambi gli ambienti</option>
+              </select>
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Valore<span class="desc">Non viene mostrato di nuovo dopo il salvataggio</span></span>
+              <div class="value-input">
+                <input class="admin-input mono" type="password" placeholder="••••••••••••••••" />
+                <span class="why">🔒 type=password · mai loggato</span>
+              </div>
+            </div>
+
+            <div class="admin-form-row">
+              <span class="admin-form-label">Scadenza<span class="desc">Forza una rotazione dopo N giorni</span></span>
+              <select class="admin-select">
+                <option>90 giorni — raccomandato</option>
+                <option>30 giorni</option>
+                <option>180 giorni</option>
+                <option>365 giorni</option>
+                <option>Nessuna scadenza (sconsigliato)</option>
+              </select>
+            </div>
+
+            <div class="admin-form-row" style="grid-column:span 2;border-bottom:0">
+              <span class="admin-form-label">Tag (opzionale)<span class="desc">Per organizzazione e audit</span></span>
+              <input class="admin-input mono" placeholder="provider, llm, openrouter" />
+            </div>
+
+          </div>
+
+          <div class="add-form-foot">
+            <span class="sensitive-note"><span class="lock">🔒</span> Il valore viene cifrato con KMS prima di essere salvato. Una volta creato, sarà accessibile solo via Reveal con step-up 2FA.</span>
+            <span class="grow"></span>
+            <button class="btn-admin">Annulla</button>
+            <button class="btn-admin primary">＋ Aggiungi <kbd>↵</kbd></button>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  </div>
+
+  <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="admin-nav.js"></script>
+  <script>renderAdminNav('secrets');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-users.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-users.html
@@ -1,0 +1,470 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A2 · Admin Users · /admin/users</title>
+<!--
+  @route /admin/users
+  @pattern Sidebar-detail: tabella utenti sx (60%) + drill-down dx (40%)
+  @v2 components: AdminDataTable · BulkActionsBar · AdminUserDetail · AuditLogTimeline
+  @keyboard ⌘K search · g+u nav · j/k row up/down · Enter open detail
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .users-grid { display: grid; grid-template-columns: minmax(0, 1.4fr) 460px; gap: 16px; align-items: start; }
+  .users-table-wrap { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+  .users-toolbar {
+    padding: 10px 12px;
+    display: flex; align-items: center; gap: 8px;
+    border-bottom: 1px solid var(--border-light);
+    flex-wrap: wrap;
+  }
+  .filter-chip {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 4px 8px; border-radius: 999px;
+    background: var(--bg-muted); color: var(--text-sec);
+    font-family: var(--f-display); font-size: 11px; font-weight: 600;
+    border: 1px solid var(--border-light);
+    cursor: pointer; white-space: nowrap;
+  }
+  .filter-chip.active {
+    background: hsl(var(--c-event) / .12);
+    color: hsl(var(--c-event));
+    border-color: hsl(var(--c-event) / .3);
+  }
+  .filter-chip .x { opacity: .6; }
+
+  .user-avatar {
+    width: 28px; height: 28px; border-radius: 50%;
+    display: grid; place-items: center;
+    color: #fff; font-family: var(--f-display); font-weight: 700; font-size: 11px;
+    flex-shrink: 0;
+  }
+  .user-cell {
+    display: flex; align-items: center; gap: 8px;
+  }
+  .user-cell .name {
+    font-family: var(--f-display); font-weight: 700; font-size: 12.5px;
+  }
+  .user-cell .em {
+    font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted);
+  }
+
+  /* Detail panel */
+  .detail-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    overflow: hidden;
+    position: sticky; top: 76px;
+    max-height: calc(100vh - 100px);
+    display: flex; flex-direction: column;
+  }
+  .detail-hero {
+    padding: 16px;
+    border-bottom: 1px solid var(--border-light);
+    display: flex; align-items: center; gap: 14px;
+    background: linear-gradient(180deg, hsl(var(--c-player) / .08), transparent);
+  }
+  .detail-hero .avatar-lg {
+    width: 56px; height: 56px; border-radius: 50%;
+    background: linear-gradient(135deg, hsl(var(--c-player)), hsl(var(--c-chat)));
+    display: grid; place-items: center;
+    color: #fff; font-family: var(--f-display); font-weight: 800; font-size: 22px;
+  }
+  .detail-hero h2 {
+    margin: 0; font-family: var(--f-display); font-size: 17px; font-weight: 800;
+  }
+  .detail-hero .meta { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+
+  .detail-body { padding: 14px 16px; overflow-y: auto; flex: 1; }
+
+  .detail-section { margin-bottom: 18px; }
+  .detail-section h4 {
+    margin: 0 0 8px;
+    font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+    color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em;
+  }
+
+  .kv-grid {
+    display: grid; grid-template-columns: 100px 1fr; gap: 4px 10px;
+    font-size: 12px;
+  }
+  .kv-grid dt { color: var(--text-muted); }
+  .kv-grid dd { margin: 0; font-family: var(--f-mono); color: var(--text); }
+
+  .timeline {
+    display: flex; flex-direction: column;
+    border-left: 2px solid var(--border-light);
+    padding-left: 12px; margin-left: 5px;
+  }
+  .tl-item {
+    position: relative;
+    padding: 4px 0 10px 8px;
+    font-size: 12px;
+  }
+  .tl-item::before {
+    content: '';
+    position: absolute; left: -19px; top: 8px;
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--bg-card);
+    border: 2px solid var(--text-muted);
+  }
+  .tl-item.danger::before { border-color: hsl(var(--c-event)); }
+  .tl-item.warn::before   { border-color: hsl(38 90% 50%); }
+  .tl-item.ok::before     { border-color: hsl(var(--c-toolkit)); }
+  .tl-item .ts {
+    font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  }
+
+  .danger-zone {
+    padding: 12px;
+    border: 1px solid hsl(var(--c-event) / .35);
+    border-radius: 8px;
+    background: hsl(var(--c-event) / .04);
+  }
+  .danger-zone .title { color: hsl(var(--c-event)); font-family: var(--f-display); font-weight: 700; font-size: 12px; margin-bottom: 4px; }
+  .danger-zone .desc { font-size: 11.5px; color: var(--text-sec); margin-bottom: 10px; line-height: 1.4; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <span class="em">🖥️</span>
+  <h2>Console solo desktop</h2>
+  <p>Apri dal computer per gestire gli utenti.</p>
+</div>
+
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <header class="admin-top">
+      <div>
+        <h1>Utenti</h1>
+        <div class="crumbs">Admin · Users · 12.487 totali · 8.412 attivi 30gg</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search">
+          <span aria-hidden="true">🔍</span>
+          <input type="search" placeholder="Cerca per email, nome, ID…" value="marco">
+          <kbd>⌘K</kbd>
+        </div>
+        <button class="btn-admin">⤓ Export CSV</button>
+        <button class="btn-admin primary">+ Invita utente</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+
+      <div class="users-grid">
+
+        <!-- Left: table ────────────────────────────────── -->
+        <div>
+          <!-- Bulk actions (visible when selected) -->
+          <div class="bulk-bar">
+            <input type="checkbox" checked>
+            <span><span class="count">3 utenti</span> selezionati</span>
+            <div class="actions">
+              <button class="btn-admin sm">✏️ Cambia ruolo</button>
+              <button class="btn-admin sm">⏸ Sospendi</button>
+              <button class="btn-admin sm">⤓ Export</button>
+              <button class="btn-admin sm danger">🗑 Elimina</button>
+              <button class="btn-admin sm ghost">✕</button>
+            </div>
+          </div>
+
+          <div class="users-table-wrap">
+            <div class="users-toolbar">
+              <span class="filter-chip active">Ruolo: tutti <span class="x">▾</span></span>
+              <span class="filter-chip active">Status: tutti <span class="x">▾</span></span>
+              <span class="filter-chip">Last-seen: 30gg <span class="x">▾</span></span>
+              <span class="filter-chip">Plan: tutti <span class="x">▾</span></span>
+              <span class="filter-chip">+ Aggiungi filtro</span>
+              <div style="margin-left:auto; display:flex; gap:6px; align-items:center;">
+                <span style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">487 risultati</span>
+                <button class="btn-admin sm">⚙ Colonne</button>
+              </div>
+            </div>
+
+            <div style="max-height: calc(100vh - 240px); overflow-y: auto;">
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th class="checkbox"><input type="checkbox"></th>
+                    <th class="sort-desc">Utente</th>
+                    <th>Ruolo</th>
+                    <th>Joined</th>
+                    <th>Last active</th>
+                    <th>Status</th>
+                    <th class="menu"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="selected">
+                    <td class="checkbox"><input type="checkbox" checked></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(262, 83%, 58%), hsl(290, 75%, 50%))">MR</div>
+                        <div>
+                          <div class="name">Marco Rossi</div>
+                          <div class="em">marco.rossi@padovani.it · <code>u-marco</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip premium">Premium</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2024-09-12</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">3m fa</span></td>
+                    <td><span class="status-chip healthy">Attivo</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox" checked></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(220, 80%, 55%), hsl(195, 80%, 50%))">DC</div>
+                        <div>
+                          <div class="name">Davide Conte</div>
+                          <div class="em">davide.conte@gmail.com · <code>u-davide</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip user">User</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2025-02-04</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2h fa</span></td>
+                    <td><span class="status-chip healthy">Attivo</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox" checked></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(348, 78%, 52%), hsl(28, 84%, 55%))">GB</div>
+                        <div>
+                          <div class="name">Giulia Bianchi</div>
+                          <div class="em">giulia.b@studio.io · <code>u-giulia</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip admin">Admin</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2024-06-22</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">12m fa</span></td>
+                    <td><span class="status-chip healthy">Attivo</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox"></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(168, 60%, 38%), hsl(142, 54%, 42%))">LM</div>
+                        <div>
+                          <div class="name">Luca Mancini</div>
+                          <div class="em">luca.mancini@outlook.com · <code>u-luca</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip user">User</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2025-04-18</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">3gg fa</span></td>
+                    <td><span class="status-chip warning">Trial</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox"></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(38, 90%, 56%), hsl(28, 84%, 55%))">A_</div>
+                        <div>
+                          <div class="name">Aaron <span style="font-family: var(--f-mono); color: hsl(var(--c-event)); font-size: 10px; padding: 1px 5px; border-radius: 4px; background: hsl(var(--c-event) / .14); margin-left:4px">YOU</span></div>
+                          <div class="em">badsworm@gmail.com · <code>u-aaron</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip superadmin">SuperAdmin</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2024-01-08</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px; color: hsl(var(--c-toolkit)); font-weight: 700">ora</span></td>
+                    <td><span class="status-chip healthy">Attivo</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox"></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(200, 78%, 52%), hsl(220, 80%, 55%))">SF</div>
+                        <div>
+                          <div class="name">Sara Ferrari</div>
+                          <div class="em">sara.ferrari@libero.it · <code>u-sara</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip user">User</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2025-01-20</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">28gg fa</span></td>
+                    <td><span class="status-chip muted">Inattivo</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox"></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(28, 84%, 55%), hsl(348, 78%, 52%))">EP</div>
+                        <div>
+                          <div class="name">Elena Parisi</div>
+                          <div class="em">elena.parisi@meeple.io · <code>u-elena</code></div>
+                        </div>
+                      </div>
+                    </td>
+                    <td><span class="role-chip premium">Premium</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">2024-11-03</span></td>
+                    <td><span style="font-family: var(--f-mono); font-size: 11px">1h fa</span></td>
+                    <td><span class="status-chip danger">Suspended</span></td>
+                    <td class="menu"><button>⋮</button></td>
+                  </tr>
+                  <tr>
+                    <td class="checkbox"><input type="checkbox"></td>
+                    <td>
+                      <div class="user-cell">
+                        <div class="user-avatar" style="background: linear-gradient(135deg, hsl(142, 54%, 42%), hsl(168, 60%, 38%))">+8</div>
+                        <div>
+                          <div class="name" style="color: var(--text-muted)">+ 8 risultati con "marco"</div>
+                          <div class="em">scroll per caricare altri</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td colspan="4"></td>
+                    <td class="menu"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div style="padding: 8px 14px; border-top: 1px solid var(--border-light); display: flex; align-items: center; gap: 12px; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">
+              <span>Mostrati 1-15 di 487</span>
+              <div style="margin-left:auto; display:flex; gap:6px; align-items:center">
+                <button class="btn-admin sm ghost">‹ Prev</button>
+                <span>1 di 33</span>
+                <button class="btn-admin sm ghost">Next ›</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: detail panel ─────────────────────── -->
+        <aside class="detail-card" aria-label="Dettaglio utente">
+          <div class="detail-hero">
+            <div class="avatar-lg">MR</div>
+            <div style="flex: 1; min-width: 0">
+              <h2>Marco Rossi <span class="role-chip premium" style="margin-left: 6px">Premium</span></h2>
+              <div class="meta">marco.rossi@padovani.it · joined 2024-09-12</div>
+              <div style="margin-top:6px; display:flex; gap:6px; flex-wrap: wrap">
+                <span class="status-chip healthy">Attivo</span>
+                <span style="font-family: var(--f-mono); font-size: 10px; padding: 2px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-sec)">🇮🇹 Padova</span>
+              </div>
+            </div>
+          </div>
+
+          <div style="padding: 0 16px; border-bottom: 1px solid var(--border-light)">
+            <div class="admin-tabs" style="margin-bottom: 0">
+              <button class="admin-tab active">Profilo</button>
+              <button class="admin-tab">Sessioni <span class="count">214</span></button>
+              <button class="admin-tab">Agenti <span class="count">7</span></button>
+              <button class="admin-tab">Audit <span class="count">38</span></button>
+              <button class="admin-tab">Billing</button>
+            </div>
+          </div>
+
+          <div class="detail-body">
+            <div class="detail-section">
+              <h4>Anagrafica</h4>
+              <dl class="kv-grid">
+                <dt>User ID</dt><dd>u-marco</dd>
+                <dt>Nome</dt><dd>Marco Rossi</dd>
+                <dt>Email</dt><dd>marco.rossi@padovani.it</dd>
+                <dt>Telefono</dt><dd>+39 348 ••• ••42</dd>
+                <dt>Gruppo</dt><dd>Padovani Boardgame</dd>
+                <dt>Locale</dt><dd>it-IT · Europe/Rome</dd>
+                <dt>Browser</dt><dd>Chrome 124 · macOS</dd>
+              </dl>
+            </div>
+
+            <div class="detail-section">
+              <h4>Account & sicurezza</h4>
+              <dl class="kv-grid">
+                <dt>Plan</dt><dd>Premium · $9.99/mo · renewal 2026-09-12</dd>
+                <dt>Verified</dt><dd style="color: hsl(var(--c-toolkit))">✓ email verified</dd>
+                <dt>2FA</dt><dd style="color: hsl(38 90% 50%)">⚠ non attivo</dd>
+                <dt>Sessions</dt><dd>3 attive · 1 Mac · 2 iPhone</dd>
+                <dt>API keys</dt><dd>2 attive</dd>
+                <dt>Last login</dt><dd>2026-05-24 14:22 · Padova</dd>
+              </dl>
+            </div>
+
+            <div class="detail-section">
+              <h4>Audit log · ultimi eventi</h4>
+              <div class="timeline">
+                <div class="tl-item ok">
+                  <div><strong>Cambio password</strong> · da app web</div>
+                  <div class="ts">2026-05-22 18:14</div>
+                </div>
+                <div class="tl-item warn">
+                  <div><strong>Login da nuovo device</strong> · iPhone 15 · Padova IT</div>
+                  <div class="ts">2026-05-20 09:02</div>
+                </div>
+                <div class="tl-item ok">
+                  <div><strong>Promosso a Premium</strong> da Aaron (superadmin)</div>
+                  <div class="ts">2026-05-18 11:30</div>
+                </div>
+                <div class="tl-item ok">
+                  <div><strong>Aggiunto Davide Conte</strong> al gruppo Padovani</div>
+                  <div class="ts">2026-05-15 19:48</div>
+                </div>
+                <div class="tl-item danger">
+                  <div><strong>Tentativo login fallito x4</strong> · IP 82.84.211.17 (bloccato)</div>
+                  <div class="ts">2026-05-12 02:14</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="detail-section">
+              <h4>Azioni</h4>
+              <div style="display: flex; flex-wrap: wrap; gap: 6px">
+                <button class="btn-admin sm">🎭 Impersonate</button>
+                <button class="btn-admin sm">📧 Invia magic-link</button>
+                <button class="btn-admin sm">🔑 Reset password</button>
+                <button class="btn-admin sm">⏸ Sospendi</button>
+                <button class="btn-admin sm">⤓ Export dati GDPR</button>
+              </div>
+            </div>
+
+            <div class="detail-section">
+              <h4 style="color: hsl(var(--c-event))">Danger zone</h4>
+              <div class="danger-zone">
+                <div class="title">Forza logout da tutti i device</div>
+                <div class="desc">Invalida tutte le sessioni attive. Marco dovrà ri-loggarsi su web + 2 iPhone.</div>
+                <button class="btn-admin sm danger">Esegui logout</button>
+              </div>
+              <div class="danger-zone" style="margin-top: 8px">
+                <div class="title">Elimina account</div>
+                <div class="desc">Cancella permanentemente l'account, 214 sessioni e 12 agenti personali. GDPR Article 17. Non reversibile.</div>
+                <button class="btn-admin sm danger">Elimina account</button>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script>
+<script>renderAdminNav('users');</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-dev-tools.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-dev-tools.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B8 · Dev Tools · /dev</title>
+<!-- @v2 DevSidebar · ScenarioPicker · AuthRoleSwitcher · FlagRuntimeToggle · StoreInspector -->
+<!-- NB: dev-only, tree-shaken in prod bundle -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .dev-shell { display: grid; grid-template-columns: 200px 1fr; gap: 14px; min-height: calc(100vh - 60px); }
+  .dev-side {
+    background: var(--bg-card); border: 1px solid var(--border-light);
+    border-radius: 10px; padding: 8px 0;
+    position: sticky; top: 76px; max-height: calc(100vh - 100px); overflow-y: auto;
+  }
+  .dev-side-grp { padding: 8px 12px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+  .dev-side-item { padding: 7px 14px; font-family: var(--f-mono); font-size: 11.5px; font-weight: 700; color: var(--text-sec); cursor: pointer; display: flex; align-items: center; gap: 8px; border-left: 2px solid transparent; }
+  .dev-side-item:hover { background: var(--bg-muted); color: var(--text); }
+  .dev-side-item.active { background: hsl(var(--c-toolkit) / .1); color: hsl(var(--c-toolkit)); border-left-color: hsl(var(--c-toolkit)); }
+  .dev-side-foot { padding: 10px 14px; border-top: 1px solid var(--border-light); margin-top: 8px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); line-height: 1.5; }
+
+  .dev-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; margin-bottom: 14px; }
+  .scenario-row { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: grid; grid-template-columns: 22px 1fr 90px 70px; gap: 10px; align-items: center; font-size: 12px; cursor: pointer; }
+  .scenario-row:hover { background: var(--bg-muted); }
+  .scenario-row.active { background: hsl(var(--c-toolkit) / .08); }
+  .scenario-row .radio { width: 16px; height: 16px; border-radius: 50%; border: 2px solid var(--border); display: grid; place-items: center; }
+  .scenario-row.active .radio { border-color: hsl(var(--c-toolkit)); }
+  .scenario-row.active .radio::after { content: ''; width: 8px; height: 8px; border-radius: 50%; background: hsl(var(--c-toolkit)); }
+  .scenario-row .name { font-family: var(--f-display); font-weight: 700; }
+  .scenario-row .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+
+  .role-pill { padding: 6px 14px; border-radius: 999px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 11px; font-weight: 700; cursor: pointer; }
+  .role-pill.active { background: hsl(var(--c-event) / .14); border-color: hsl(var(--c-event)); color: hsl(var(--c-event)); }
+
+  .json-inspect { font-family: var(--f-mono); font-size: 11px; background: var(--bg-sunken); padding: 12px 14px; border-radius: 6px; max-height: 280px; overflow-y: auto; line-height: 1.6; }
+  .json-inspect .key { color: hsl(var(--c-agent)); }
+  .json-inspect .str { color: hsl(var(--c-kb)); }
+  .json-inspect .num { color: hsl(var(--c-event)); }
+  .json-inspect .bool { color: hsl(var(--c-chat)); }
+  .json-inspect .null { color: var(--text-muted); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Dev Tools <span class="role-chip" style="background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); margin-left: 8px">DEV ONLY</span></h1><div class="crumbs">Tools · Dev panel · NODE_ENV=development · NOT in prod bundle</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">📚 Open Storybook ↗</button>
+        <button class="btn-admin danger">⚠ Reset all state</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="dev-shell">
+
+        <aside class="dev-side">
+          <div class="dev-side-grp">Mock data</div>
+          <div class="dev-side-item active">🎭 Scenarios</div>
+          <div class="dev-side-item">👤 Auth</div>
+          <div class="dev-side-item">🚩 Flags</div>
+
+          <div class="dev-side-grp">Inspect</div>
+          <div class="dev-side-item">🔌 API replay</div>
+          <div class="dev-side-item">🧠 Memory store</div>
+          <div class="dev-side-item">💾 Cache</div>
+
+          <div class="dev-side-grp">Danger</div>
+          <div class="dev-side-item" style="color: hsl(var(--c-event))">🔄 Reset</div>
+
+          <div class="dev-side-foot">
+            <strong style="color: hsl(var(--c-toolkit))">env: development</strong><br/>
+            build: <code>web-2026.05.24-a8f3c</code><br/>
+            commit: <code>e3f7a1c</code><br/>
+            <br/>
+            <a href="#" style="color: hsl(var(--c-chat)); text-decoration: none">📚 Storybook ↗</a><br/>
+            <a href="#" style="color: hsl(var(--c-chat)); text-decoration: none">🐛 GitHub issue ↗</a>
+          </div>
+        </aside>
+
+        <div>
+
+          <!-- Active: Scenarios -->
+          <div class="dev-panel">
+            <div class="admin-panel-head"><h3>🎭 MSW Scenarios</h3><span class="meta" style="margin-left: auto">handler attivo: <code>small-library-marco</code></span></div>
+            <div>
+              <div class="scenario-row">
+                <div class="radio"></div>
+                <div><div class="name">empty</div><div class="meta">Stato nuovo utente · 0 games · 0 sessions · 0 agents</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">12 handlers</div>
+                <button class="btn-admin sm">▶ Load</button>
+              </div>
+              <div class="scenario-row active">
+                <div class="radio"></div>
+                <div><div class="name">small-library-marco</div><div class="meta">Marco · 8 games · 214 sessions · 7 agents · 12 KB docs</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">38 handlers</div>
+                <button class="btn-admin sm">▶ Reload</button>
+              </div>
+              <div class="scenario-row">
+                <div class="radio"></div>
+                <div><div class="name">power-user-aaron</div><div class="meta">Aaron · 24 games · 487 sessions · 42 agents · 247 KB docs · 14 toolkit</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">112 handlers</div>
+                <button class="btn-admin sm">▶ Load</button>
+              </div>
+              <div class="scenario-row">
+                <div class="radio"></div>
+                <div><div class="name">alpha-features-on</div><div class="meta">Tutti i feature flag alpha attivi · librogame · agent v2 · hybrid RAG</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">84 handlers</div>
+                <button class="btn-admin sm">▶ Load</button>
+              </div>
+              <div class="scenario-row">
+                <div class="radio"></div>
+                <div><div class="name">degraded-api</div><div class="meta">Tutti gli endpoint con latency artificiale 2-8s + 30% error rate</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">38 handlers</div>
+                <button class="btn-admin sm">▶ Load</button>
+              </div>
+              <div class="scenario-row">
+                <div class="radio"></div>
+                <div><div class="name">offline-mode</div><div class="meta">Tutto offline · network errors · cache-only responses</div></div>
+                <div style="font-family: var(--f-mono); font-size: 10px">0 handlers (bypass)</div>
+                <button class="btn-admin sm">▶ Load</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Auth role switcher -->
+          <div class="dev-panel">
+            <div class="admin-panel-head"><h3>👤 Auth · role switcher</h3><span class="meta" style="margin-left: auto">requires page reload</span></div>
+            <div style="padding: 14px">
+              <div style="display: flex; gap: 8px; flex-wrap: wrap">
+                <button class="role-pill">👻 guest</button>
+                <button class="role-pill">👤 user</button>
+                <button class="role-pill">⭐ premium</button>
+                <button class="role-pill">🛡 admin</button>
+                <button class="role-pill active">👑 superadmin</button>
+              </div>
+              <div style="margin-top: 14px; padding: 10px 12px; background: var(--bg-muted); border-radius: 6px; font-family: var(--f-mono); font-size: 11px">
+                <div style="color: var(--text-muted); font-size: 9.5px; text-transform: uppercase; letter-spacing: .06em; margin-bottom: 6px">Mock JWT payload</div>
+                <pre class="json-inspect" style="margin: 0; padding: 8px 10px; max-height: 160px"><span class="key">"sub"</span>: <span class="str">"u-aaron"</span>,
+<span class="key">"email"</span>: <span class="str">"badsworm@gmail.com"</span>,
+<span class="key">"role"</span>: <span class="str">"superadmin"</span>,
+<span class="key">"premium"</span>: <span class="bool">true</span>,
+<span class="key">"impersonate"</span>: <span class="null">null</span>,
+<span class="key">"exp"</span>: <span class="num">1735689600</span>,
+<span class="key">"iat"</span>: <span class="num">1716543210</span>,
+<span class="key">"features"</span>: [<span class="str">"alpha"</span>, <span class="str">"dev-tools"</span>]</pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- Runtime flags -->
+          <div class="dev-panel">
+            <div class="admin-panel-head"><h3>🚩 Runtime feature flags</h3><span class="meta" style="margin-left: auto">localStorage persisted</span></div>
+            <div style="padding: 14px; display: flex; flex-direction: column; gap: 10px">
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle on"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.alphaMode</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">Sblocca UI alpha</span><span class="status-chip info" style="font-size: 10px">on</span></div>
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle on"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.devTools</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">Sidebar dev visibile in nav</span><span class="status-chip info" style="font-size: 10px">on</span></div>
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.useReactQueryDevtools</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">RQ inspector overlay</span><span class="status-chip muted" style="font-size: 10px">off</span></div>
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle on"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.mockSSE</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">SSE streams da mock JSON</span><span class="status-chip info" style="font-size: 10px">on</span></div>
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.slowMotion</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">Animation ×10 slower (debug)</span><span class="status-chip muted" style="font-size: 10px">off</span></div>
+              <div style="display: flex; align-items: center; gap: 10px; font-size: 12.5px"><div class="admin-toggle on"></div><span style="font-family: var(--f-mono); font-weight: 700">flag.showCommentAnchors</span><span style="color: var(--text-muted); font-size: 11px; flex: 1">Highlight data-comment-anchor in DOM</span><span class="status-chip info" style="font-size: 10px">on</span></div>
+            </div>
+          </div>
+
+          <!-- Memory store / React Query cache (compact) -->
+          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px">
+            <div class="dev-panel">
+              <div class="admin-panel-head"><h3>🧠 Zustand store</h3><span class="meta" style="margin-left: auto">12 stores · 247 keys</span></div>
+              <div style="padding: 14px">
+                <pre class="json-inspect"><span style="color: var(--text-muted)">// cascadeNavigationStore</span>
+<span class="key">"stack"</span>: [
+  { <span class="key">"id"</span>: <span class="str">"day-drawer-22mar"</span>, <span class="key">"open"</span>: <span class="bool">true</span> }
+],
+<span class="key">"history"</span>: [<span class="num">3</span> entries],
+
+<span style="color: var(--text-muted)">// uiPreferencesStore</span>
+<span class="key">"theme"</span>: <span class="str">"dark"</span>,
+<span class="key">"sidebarCollapsed"</span>: <span class="bool">false</span>,
+<span class="key">"density"</span>: <span class="str">"compact"</span>,
+
+<span style="color: var(--text-muted)">// recentsStore</span>
+<span class="key">"recents"</span>: [
+  { <span class="key">"type"</span>: <span class="str">"game"</span>, <span class="key">"id"</span>: <span class="str">"g-wingspan"</span> },
+  { <span class="key">"type"</span>: <span class="str">"session"</span>, <span class="key">"id"</span>: <span class="str">"s-spirit-3"</span> }
+]</pre>
+                <div style="margin-top: 10px; display: flex; gap: 6px"><button class="btn-admin sm">⤓ Snapshot</button><button class="btn-admin sm">↻ Replay</button></div>
+              </div>
+            </div>
+
+            <div class="dev-panel">
+              <div class="admin-panel-head"><h3>💾 React Query cache</h3><span class="meta" style="margin-left: auto">42 queries · 3 stale</span></div>
+              <div style="padding: 14px; font-family: var(--f-mono); font-size: 11.5px">
+                <div style="display: flex; flex-direction: column; gap: 4px">
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip healthy" style="font-size: 9px">fresh</span><span>[games, "g-wingspan"]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">2.1KB</span></div>
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip healthy" style="font-size: 9px">fresh</span><span>[library, {filters: {...}}]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">14KB</span></div>
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip warning" style="font-size: 9px">stale</span><span>[agents, "a-wingspan-rules"]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">3.4KB</span></div>
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip healthy" style="font-size: 9px">fresh</span><span>[notifications, {since}]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">8.2KB</span></div>
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip warning" style="font-size: 9px">stale</span><span>[sessions, "s-spirit-3", "events"]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">42KB</span></div>
+                  <div style="display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 4px"><span class="status-chip warning" style="font-size: 9px">stale</span><span>[kb-globale, q="predator"]</span><span style="margin-left: auto; color: var(--text-muted); font-size: 10px">1.8KB</span></div>
+                </div>
+                <div style="margin-top: 10px; display: flex; gap: 6px"><button class="btn-admin sm">🗑 Invalidate all</button><button class="btn-admin sm">🗑 Invalidate stale</button></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Reset -->
+          <div class="dev-panel" style="border-color: hsl(var(--c-event) / .4); background: hsl(var(--c-event) / .04)">
+            <div class="admin-panel-head" style="background: transparent"><h3 style="color: hsl(var(--c-event))">⚠ Reset state (DEV)</h3></div>
+            <div style="padding: 14px; display: flex; gap: 8px; flex-wrap: wrap">
+              <button class="btn-admin sm danger">🗑 localStorage</button>
+              <button class="btn-admin sm danger">🗑 sessionStorage</button>
+              <button class="btn-admin sm danger">🗑 IndexedDB</button>
+              <button class="btn-admin sm danger">🗑 Cookies (mock auth)</button>
+              <button class="btn-admin sm danger">🗑 Zustand all stores</button>
+              <button class="btn-admin sm danger">🗑 RQ cache</button>
+              <button class="btn-admin sm danger">🔄 Nuke all + reload</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('dev-tools');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-editor.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-editor.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B1 · Editor · /editor</title>
+<!-- @v2 EditorTree · BlockEditor · PreviewFrame · VersionHistoryPanel -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .editor-shell { display: grid; grid-template-columns: 240px 1fr 320px; gap: 12px; height: calc(100vh - 60px); }
+  .ed-col { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+  .ed-toolbar { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 8px; background: var(--bg); font-size: 12px; }
+
+  .tree-row { padding: 5px 12px 5px 28px; font-size: 12.5px; cursor: pointer; color: var(--text-sec); border-left: 2px solid transparent; }
+  .tree-row:hover { background: var(--bg-muted); color: var(--text); }
+  .tree-row.selected { background: hsl(var(--c-game) / .1); color: hsl(var(--c-game)); border-left-color: hsl(var(--c-game)); font-weight: 700; }
+  .tree-group { padding: 6px 12px; font-family: var(--f-display); font-size: 13px; font-weight: 800; display: flex; align-items: center; gap: 6px; }
+  .tree-group .em { font-size: 14px; }
+  .tree-group .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 600; }
+
+  .editor-body { flex: 1; padding: 24px 40px; overflow-y: auto; font-family: var(--f-body); font-size: 14px; line-height: 1.6; }
+  .editor-body h2.doc-h2 { font-family: var(--f-display); font-size: 22px; font-weight: 800; margin: 24px 0 8px; }
+  .editor-body h3.doc-h3 { font-family: var(--f-display); font-size: 16px; font-weight: 700; margin: 18px 0 4px; }
+  .editor-body p { margin: 0 0 10px; }
+  .editor-body .block-row {
+    border-left: 2px solid transparent;
+    padding-left: 12px; margin-left: -14px;
+    position: relative;
+  }
+  .editor-body .block-row:hover { border-left-color: hsl(var(--c-event) / .4); background: var(--bg-muted); }
+  .editor-body .block-row .ed-handle {
+    position: absolute; left: -36px; top: 4px;
+    opacity: 0;
+    display: flex; gap: 2px;
+  }
+  .editor-body .block-row:hover .ed-handle { opacity: 1; }
+  .editor-body .block-row .ed-handle button { width: 18px; height: 18px; border-radius: 4px; background: transparent; border: 0; color: var(--text-muted); cursor: pointer; font-size: 11px; }
+  .editor-body .block-row.editing { background: hsl(var(--c-event) / .04); border-left-color: hsl(var(--c-event)); }
+  .editor-body .keyword { background: hsl(var(--c-kb) / .14); color: hsl(var(--c-kb)); padding: 0 4px; border-radius: 3px; font-weight: 700; }
+
+  .preview-mini {
+    background: var(--bg);
+    border: 1px solid var(--border-light); border-radius: 8px;
+    padding: 14px;
+    font-size: 11.5px;
+    font-family: var(--f-body);
+    line-height: 1.55;
+    max-height: 280px; overflow-y: auto;
+  }
+  .preview-mini h2 { font-family: var(--f-display); font-size: 14px; font-weight: 700; margin: 8px 0 4px; }
+  .preview-mini h3 { font-family: var(--f-display); font-size: 12px; font-weight: 700; margin: 6px 0 3px; }
+  .preview-mini p { margin: 0 0 6px; }
+
+  .toolbar-btn-grp { display: inline-flex; gap: 1px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px; padding: 1px; }
+  .toolbar-btn-grp button { padding: 4px 8px; background: transparent; border: 0; cursor: pointer; color: var(--text-sec); font-size: 12px; border-radius: 4px; }
+  .toolbar-btn-grp button:hover { background: var(--bg-muted); color: var(--text); }
+  .toolbar-btn-grp button.active { background: hsl(var(--c-event) / .15); color: hsl(var(--c-event)); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Content editor</h1><div class="crumbs">Editor · 🎲 Brass Birmingham · Rules · Chapter 2 · v3.2-draft</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <span class="status-chip warning">⚪ Auto-save in 12s</span>
+        <span style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">draft · 14 modifiche dal last commit</span>
+        <button class="btn-admin">👁 Preview</button>
+        <button class="btn-admin">📜 Versions</button>
+        <button class="btn-admin primary">✓ Commit &amp; Publish</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="padding: 12px 16px;">
+      <div class="editor-shell">
+
+        <!-- Left: tree -->
+        <div class="ed-col">
+          <div class="ed-toolbar">
+            <div class="admin-search" style="width: 100%; padding: 4px 8px;"><span>🔍</span><input placeholder="Filtra tree…"></div>
+          </div>
+          <div style="overflow-y: auto">
+            <div class="tree-group"><span class="em">📖</span> Rules <span class="count">14</span></div>
+            <div class="tree-row">Cap.1 Introduzione</div>
+            <div class="tree-row selected">Cap.2 Setup partita ⚪</div>
+            <div class="tree-row">Cap.3 Turno di gioco</div>
+            <div class="tree-row">Cap.4 Azioni</div>
+            <div class="tree-row">Cap.5 Industria</div>
+            <div class="tree-row">Cap.6 Mercato</div>
+            <div class="tree-row">Cap.7 Punti finali</div>
+            <div class="tree-row" style="color: var(--text-muted)">+ 7 capitoli</div>
+
+            <div class="tree-group"><span class="em">❓</span> FAQ <span class="count">42</span></div>
+            <div class="tree-row">FAQ Setup</div>
+            <div class="tree-row">FAQ Mercato</div>
+            <div class="tree-row">FAQ Edge case</div>
+
+            <div class="tree-group"><span class="em">🎭</span> Scenarios <span class="count">3</span></div>
+            <div class="tree-row">Scenario base</div>
+            <div class="tree-row">Scenario solo</div>
+            <div class="tree-row">Scenario 5p</div>
+
+            <div class="tree-group"><span class="em">📑</span> Glossary <span class="count">87</span></div>
+            <div class="tree-row">A-D termini</div>
+            <div class="tree-row">E-K termini</div>
+            <div class="tree-row" style="color: var(--text-muted)">+ 3 sezioni</div>
+          </div>
+        </div>
+
+        <!-- Center: editor -->
+        <div class="ed-col">
+          <div class="ed-toolbar">
+            <div class="toolbar-btn-grp"><button><strong>B</strong></button><button><em>I</em></button><button><u>U</u></button><button><s>S</s></button></div>
+            <div class="toolbar-btn-grp"><button>H2</button><button class="active">H3</button><button>‹/›</button></div>
+            <div class="toolbar-btn-grp"><button>≡</button><button>⊞</button><button>›</button></div>
+            <div class="toolbar-btn-grp"><button>↶</button><button>↷</button></div>
+            <div style="margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">⌘B bold · ⌘K link · ⌘/ commands</div>
+          </div>
+          <div class="editor-body">
+            <h2 class="doc-h2">Capitolo 2 · Setup della partita</h2>
+
+            <div class="block-row">
+              <div class="ed-handle"><button>⠿</button></div>
+              <p>Posiziona il tabellone al centro del tavolo, con il lato <strong>Era del Canale</strong> visibile.
+              Ogni giocatore prende il proprio set di <span class="keyword">tessere industria</span> nel colore scelto e le pone davanti a sé.</p>
+            </div>
+
+            <div class="block-row">
+              <div class="ed-handle"><button>⠿</button></div>
+              <p>Mescola le <span class="keyword">carte luogo</span> (16 carte) e distribuisci 4 carte a ogni giocatore.
+              Le restanti formano il mazzo pesca, da cui si pesca all'inizio di ogni round.</p>
+            </div>
+
+            <div class="block-row editing">
+              <div class="ed-handle"><button>⠿</button><button>+</button></div>
+              <h3 class="doc-h3">Setup per 4 giocatori (consigliato)</h3>
+              <p>In partite a 4 giocatori, il giocatore di sinistra del primo turno parte con <strong>17£</strong> invece di 30£ iniziali. Questo bilancia il vantaggio di prima azione per chi parte secondo.</p>
+              <p style="margin-top: 8px; padding: 8px 12px; background: hsl(var(--c-agent) / .08); border-left: 3px solid hsl(var(--c-agent)); border-radius: 0 6px 6px 0; font-size: 13px; color: var(--text-sec)">
+                💡 <strong>House rule comune:</strong> alcuni gruppi danno 25£ a tutti per evitare squilibri. Vedi Glossary &gt; House rules.
+              </p>
+            </div>
+
+            <div class="block-row">
+              <div class="ed-handle"><button>⠿</button></div>
+              <h3 class="doc-h3">Setup per 3 giocatori</h3>
+              <p>Si rimuovono le tessere "tipo II" dal mazzo industria e si limitano le città disponibili a Birmingham, Coventry, Cannock, Walsall, Wolverhampton, Dudley, Stafford, Stone.</p>
+            </div>
+
+            <div class="block-row">
+              <div class="ed-handle"><button>⠿</button></div>
+              <h3 class="doc-h3">Setup solo</h3>
+              <p>Il gioco solitario richiede l'<em>espansione automa</em>. Vedi <a href="#" style="color: hsl(var(--c-event))">Scenario solo</a> per regole complete.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: preview + metadata + version -->
+        <div class="ed-col">
+          <div class="ed-toolbar"><strong style="font-family: var(--f-display); font-size: 13px">Preview</strong><span class="filter-chip active" style="margin-left:auto">app</span><span class="filter-chip">pdf</span></div>
+          <div style="padding: 12px; flex-shrink: 0">
+            <div class="preview-mini">
+              <h2 style="font-family: var(--f-display); margin: 0 0 6px">Setup della partita</h2>
+              <p>Posiziona il tabellone al centro del tavolo, lato Era del Canale visibile. Ogni giocatore prende le proprie tessere industria…</p>
+              <h3>Setup per 4 giocatori</h3>
+              <p>In partite a 4 giocatori, il giocatore di sinistra del primo turno parte con <strong>17£</strong>.</p>
+              <div style="padding: 6px 8px; background: hsl(var(--c-agent) / .08); border-left: 2px solid hsl(var(--c-agent)); margin-top: 6px; font-size: 10px">💡 House rule: 25£ a tutti</div>
+              <h3>Setup per 3 giocatori</h3>
+              <p>Rimuovi tessere "tipo II"…</p>
+            </div>
+          </div>
+
+          <div style="padding: 0 14px; border-top: 1px solid var(--border-light); padding-top: 12px">
+            <div style="font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin-bottom: 6px">Metadata</div>
+            <dl style="display: grid; grid-template-columns: 80px 1fr; gap: 4px; font-size: 11.5px; margin: 0">
+              <dt style="color: var(--text-muted)">Slug</dt><dd style="margin: 0; font-family: var(--f-mono)">rules/cap-02-setup</dd>
+              <dt style="color: var(--text-muted)">Lingua</dt><dd style="margin: 0">IT</dd>
+              <dt style="color: var(--text-muted)">Tags</dt><dd style="margin: 0; display: flex; gap: 4px; flex-wrap: wrap"><span class="filter-chip" style="padding: 1px 6px; font-size: 10px">setup</span><span class="filter-chip" style="padding: 1px 6px; font-size: 10px">base</span></dd>
+              <dt style="color: var(--text-muted)">Linked</dt><dd style="margin: 0">🧰 Scenario base · 📑 Glossary</dd>
+              <dt style="color: var(--text-muted)">Version</dt><dd style="margin: 0; font-family: var(--f-mono)">v3.2-draft</dd>
+              <dt style="color: var(--text-muted)">Status</dt><dd style="margin: 0"><span class="status-chip warning" style="font-size: 10px">Draft</span></dd>
+            </dl>
+          </div>
+
+          <div style="padding: 12px 14px; border-top: 1px solid var(--border-light); margin-top: 12px">
+            <div style="font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin-bottom: 6px">Recent versions</div>
+            <div style="display: flex; flex-direction: column; gap: 6px; font-size: 11.5px">
+              <div style="display: flex; align-items: center; gap: 6px"><span style="font-family: var(--f-mono); font-size: 10px; color: hsl(38 90% 50%); font-weight: 700">v3.2</span><span style="flex: 1">Setup 4p house rule note</span><span style="color: var(--text-muted)">draft</span></div>
+              <div style="display: flex; align-items: center; gap: 6px"><span style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-toolkit)); font-weight: 700">v3.1</span><span style="flex: 1">Fix typo "Dudley"</span><span style="color: var(--text-muted)">5gg fa</span></div>
+              <div style="display: flex; align-items: center; gap: 6px"><span style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-toolkit)); font-weight: 700">v3.0</span><span style="flex: 1">Aggiunta sezione solo</span><span style="color: var(--text-muted)">22gg</span></div>
+              <div style="display: flex; align-items: center; gap: 6px"><span style="font-family: var(--f-mono); font-size: 10px; color: hsl(var(--c-toolkit)); font-weight: 700">v2.4</span><span style="flex: 1">Setup 3p variant</span><span style="color: var(--text-muted)">2mesi</span></div>
+            </div>
+            <button class="btn-admin sm" style="margin-top: 8px; width: 100%">Vedi tutte (18) →</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('editor');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-kb-upload-flow.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-kb-upload-flow.html
@@ -1,0 +1,436 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 A5b · KB Upload Flow · /admin/knowledge-base/upload</title>
+<!-- @FSM 5 stati: empty · uploading · processing · complete · error · idempotency-warn (sub) -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .upload-flow { max-width: 980px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
+
+  /* State navigation tabs (only in showcase, hidden in real prod) */
+  .state-nav { display: flex; gap: 6px; padding: 6px; background: var(--bg-muted); border-radius: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+  .state-nav button { padding: 5px 10px; border-radius: 6px; background: transparent; border: 0; cursor: pointer; font-family: var(--f-mono); font-size: 11px; color: var(--text-sec); }
+  .state-nav button.active { background: hsl(var(--c-event)); color: #fff; font-weight: 700; }
+
+  .state-block { display: none; flex-direction: column; gap: 14px; }
+  .state-block.active { display: flex; }
+
+  .upload-grid { display: grid; grid-template-columns: 320px 1fr; gap: 14px; align-items: start; }
+
+  /* Idempotency banner */
+  .idem-banner {
+    background: hsl(38 90% 56% / .1);
+    border: 1px solid hsl(38 90% 56% / .4);
+    border-radius: 10px;
+    padding: 14px 16px;
+    display: flex; align-items: flex-start; gap: 12px;
+  }
+  .idem-banner .em { font-size: 22px; }
+  .idem-banner .title { font-family: var(--f-display); font-weight: 800; font-size: 14px; margin-bottom: 3px; color: hsl(38 90% 50%); }
+  .idem-banner .actions { margin-left: auto; display: flex; gap: 6px; }
+
+  /* Dropzone */
+  .dropzone {
+    background: var(--bg-card); border: 2px dashed hsl(var(--c-kb) / .5);
+    border-radius: 12px;
+    padding: 40px 24px;
+    display: flex; flex-direction: column; align-items: center; gap: 12px;
+    text-align: center;
+    min-height: 200px; justify-content: center;
+  }
+  .dropzone .em { font-size: 48px; }
+  .dropzone .title { font-family: var(--f-display); font-size: 16px; font-weight: 800; }
+  .dropzone .desc { font-size: 12px; color: var(--text-sec); max-width: 400px; line-height: 1.4; }
+  .dropzone .or { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin: 6px 0; }
+  .dropzone.uploading { border-style: solid; border-color: hsl(var(--c-kb)); padding: 24px; }
+  .dropzone.error { border-color: hsl(var(--c-event)); }
+
+  /* Settings card */
+  .settings-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px; }
+  .settings-card h3 { margin: 0 0 10px; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+  .sf-row { display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; }
+  .sf-label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+  .sf-control { display: flex; gap: 4px; align-items: center; }
+
+  /* Processing queue */
+  .queue-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; }
+  .queue-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 8px; }
+  .queue-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+  .queue-row { padding: 12px 14px; border-bottom: 1px solid var(--border-light); }
+  .queue-row:last-child { border-bottom: 0; }
+  .queue-row .filename { display: flex; align-items: center; gap: 8px; font-family: var(--f-display); font-size: 13px; font-weight: 700; margin-bottom: 6px; }
+  .queue-row .filename .size { margin-left: auto; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); font-weight: 500; }
+
+  /* Stage progress */
+  .stages { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; align-items: center; }
+  .stage {
+    padding: 6px 8px; border-radius: 6px;
+    background: var(--bg-muted); border: 1px solid var(--border-light);
+    display: flex; flex-direction: column; gap: 3px;
+    position: relative;
+  }
+  .stage .stg-name { font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; }
+  .stage .stg-state { font-family: var(--f-display); font-size: 11px; font-weight: 700; }
+  .stage.done { background: hsl(var(--c-toolkit) / .14); border-color: hsl(var(--c-toolkit) / .35); }
+  .stage.done .stg-state { color: hsl(var(--c-toolkit)); }
+  .stage.running { background: hsl(var(--c-kb) / .14); border-color: hsl(var(--c-kb) / .5); }
+  .stage.running .stg-state { color: hsl(var(--c-kb)); }
+  .stage.running::after { content: ''; position: absolute; bottom: 0; left: 0; right: 0; height: 2px; background: hsl(var(--c-kb)); border-radius: 0 0 5px 5px; animation: progress-shimmer 1.5s linear infinite; transform-origin: left; }
+  .stage.queued .stg-state { color: var(--text-muted); }
+  .stage.error { background: hsl(var(--c-event) / .14); border-color: hsl(var(--c-event) / .5); }
+  .stage.error .stg-state { color: hsl(var(--c-event)); }
+  @keyframes progress-shimmer { 0% { transform: scaleX(0.3); } 100% { transform: scaleX(1); } }
+
+  .progress-bar { height: 8px; background: var(--bg-muted); border-radius: 999px; overflow: hidden; margin-top: 8px; }
+  .progress-bar .fill { height: 100%; background: hsl(var(--c-kb)); border-radius: 999px; transition: width var(--dur-md) var(--ease-out); }
+  .progress-bar .fill.success { background: hsl(var(--c-toolkit)); }
+  .progress-bar .fill.error { background: hsl(var(--c-event)); }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2><p>Upload KB richiede desktop.</p></div>
+
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+
+  <main>
+    <header class="admin-top">
+      <div><h1>Upload &amp; Process</h1><div class="crumbs">Admin · Knowledge Base · Upload</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">📋 History</button>
+        <button class="btn-admin">⚙ Defaults</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="upload-flow">
+
+        <!-- State navigation (showcase only) -->
+        <div class="state-nav" role="tablist">
+          <button class="active" onclick="showState('s1')">01 · Empty</button>
+          <button onclick="showState('s2')">02 · Uploading</button>
+          <button onclick="showState('s3')">03 · Processing</button>
+          <button onclick="showState('s4')">04 · Complete</button>
+          <button onclick="showState('s5')">05 · Error</button>
+          <button onclick="showState('s6')">guard · Warn</button>
+        </div>
+
+        <!-- ═══ STATE 01 — Empty ═══════════════════════════════════ -->
+        <div class="state-block active" id="s1">
+          <div class="upload-grid">
+            <div>
+              <div class="dropzone" tabindex="0" role="button" aria-label="Trascina o seleziona PDF">
+                <span class="em">📁</span>
+                <div class="title">Trascina PDF qui</div>
+                <div class="desc">PDF · max 100MB · multi-file ammessi</div>
+                <div class="or">— oppure —</div>
+                <button class="btn-admin primary">Scegli file</button>
+                <div style="margin-top: 8px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Drop, Enter o Space</div>
+              </div>
+            </div>
+
+            <div>
+              <div class="settings-card">
+                <h3>⚙️ Settings ingestion <span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 400; margin-left: 6px">readonly fino al primo file</span></h3>
+                <div class="sf-row">
+                  <span class="sf-label">Gioco</span>
+                  <select class="admin-select" disabled><option>— scegli un gioco —</option></select>
+                </div>
+                <div class="sf-row">
+                  <span class="sf-label">Lingua</span>
+                  <select class="admin-select"><option>Auto-detect</option><option>EN</option><option>IT</option></select>
+                </div>
+                <div class="sf-row">
+                  <span class="sf-label">Embedder</span>
+                  <select class="admin-select"><option>text-embedding-3-large (default)</option><option>text-embedding-3-small</option><option>cohere-embed-multilingual-v3.0</option></select>
+                </div>
+                <div class="sf-row">
+                  <span class="sf-label">Chunk size (tokens)</span>
+                  <input class="admin-input mono" value="512">
+                </div>
+                <div class="sf-row" style="display: flex; flex-direction: row; align-items: center; gap: 10px">
+                  <div class="admin-toggle" role="switch"></div>
+                  <span class="sf-label" style="text-transform: none; font-family: var(--f-display); font-size: 12px; color: var(--text)">OCR per pagine scannerizzate</span>
+                </div>
+                <div class="sf-row" style="display: flex; flex-direction: row; align-items: center; gap: 10px">
+                  <div class="admin-toggle on" role="switch"></div>
+                  <span class="sf-label" style="text-transform: none; font-family: var(--f-display); font-size: 12px; color: var(--text)">SmolDocling layout-aware</span>
+                </div>
+                <div class="sf-row">
+                  <span class="sf-label">Indexer</span>
+                  <select class="admin-select"><option>v2024.11.18 (stable)</option><option>v2024.12.beta</option></select>
+                </div>
+              </div>
+
+              <div class="queue-card" style="margin-top: 14px">
+                <div class="queue-head">
+                  <h3>Processing queue</h3>
+                  <span class="status-chip muted" style="margin-left: auto">Vuota</span>
+                </div>
+                <div style="padding: 24px; text-align: center; color: var(--text-muted); font-size: 12px">
+                  Nessun upload in corso.<br/>
+                  <span style="font-family: var(--f-mono); font-size: 11px">Trascina un file per iniziare.</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ STATE 02 — Uploading ═══════════════════════════════ -->
+        <div class="state-block" id="s2">
+          <div class="upload-grid">
+            <div>
+              <div class="dropzone uploading">
+                <span class="em">📄</span>
+                <div class="title" style="font-size: 14px; font-family: var(--f-mono); word-break: break-all">Wingspan-Oceania-EN.pdf</div>
+                <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">8.4 MB · 42 pages (preview)</div>
+                <div class="progress-bar" style="width: 100%"><div class="fill" style="width: 67%"></div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px; color: hsl(var(--c-kb)); font-weight: 700">↑ Uploading 67% · 2.1 MB/s · ETA 1s</div>
+                <button class="btn-admin sm danger">Annulla</button>
+              </div>
+            </div>
+            <div>
+              <div class="settings-card">
+                <h3>⚙️ Settings ingestion</h3>
+                <div class="sf-row">
+                  <span class="sf-label">Gioco</span>
+                  <select class="admin-select"><option>🎲 Wingspan (auto-detect)</option></select>
+                </div>
+                <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); padding: 8px; background: var(--bg-muted); border-radius: 6px; line-height: 1.4">
+                  Settings lock al via dell'upload. Le impostazioni applicate sono quelle correnti.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ STATE 03 — Processing ══════════════════════════════ -->
+        <div class="state-block" id="s3">
+          <div class="upload-grid">
+            <div>
+              <div class="dropzone" style="border-style: solid; padding: 24px;">
+                <span class="em">✓</span>
+                <div class="title" style="font-size: 14px; color: hsl(var(--c-toolkit))">Upload completato</div>
+                <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">Pipeline in corso · vedi queue →</div>
+                <button class="btn-admin">+ Aggiungi altro file</button>
+              </div>
+            </div>
+            <div>
+              <div class="queue-card">
+                <div class="queue-head">
+                  <h3>Processing queue</h3>
+                  <span class="status-chip info running" style="margin-left: auto">1 in corso</span>
+                </div>
+                <div class="queue-row">
+                  <div class="filename">
+                    <span style="font-size: 18px">📄</span>
+                    <span>Wingspan-Oceania-EN.pdf</span>
+                    <span class="size">8.4 MB · 42 pages</span>
+                  </div>
+                  <div style="font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); margin-bottom: 8px">EntityChip · 🎲 Wingspan · started 12s fa</div>
+
+                  <div class="stages" role="progressbar" aria-live="polite">
+                    <div class="stage done">
+                      <span class="stg-name">1. Upload</span>
+                      <span class="stg-state">✓ Done · 6.2s</span>
+                    </div>
+                    <div class="stage done">
+                      <span class="stg-name">2. Parse</span>
+                      <span class="stg-state">✓ Unstructured 2.1s</span>
+                    </div>
+                    <div class="stage running">
+                      <span class="stg-name">3. Layout</span>
+                      <span class="stg-state">⟳ SmolDocling 58%</span>
+                    </div>
+                    <div class="stage queued">
+                      <span class="stg-name">4. Embed</span>
+                      <span class="stg-state">⋯ in coda</span>
+                    </div>
+                    <div class="stage queued">
+                      <span class="stg-name">5. Index</span>
+                      <span class="stg-state">⋯ in coda</span>
+                    </div>
+                  </div>
+
+                  <div style="margin-top: 12px; display: flex; gap: 8px; font-family: var(--f-mono); font-size: 11px; align-items: center">
+                    <span style="color: var(--text-muted)">Stage corrente:</span>
+                    <span style="color: hsl(var(--c-kb)); font-weight: 700">parsing tabelle pag.22-31</span>
+                    <span style="margin-left: auto; color: var(--text-muted)">ETA totale ~14s</span>
+                  </div>
+                </div>
+              </div>
+
+              <div style="margin-top: 12px; padding: 10px 12px; background: var(--bg-muted); border-radius: 8px; font-family: var(--f-mono); font-size: 11px; color: var(--text-sec)">
+                <strong style="color: var(--text)">💡 Suggerimento</strong> — Puoi chiudere questa pagina, la pipeline continua in background. Una notifica ti avviserà al completamento.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ STATE 04 — Complete ════════════════════════════════ -->
+        <div class="state-block" id="s4">
+          <div class="alert-banner success">
+            <span class="em">✅</span>
+            <div style="flex: 1">
+              <div class="title">Wingspan-Oceania-EN.pdf indicizzato con successo</div>
+              <div>412 chunks generati · 13.4s totali · cost $0.087 · avg confidence <strong>0.87</strong></div>
+            </div>
+            <div class="actions">
+              <button class="btn-admin sm">View chunks</button>
+              <a href="sp5-admin-kb.html" class="btn-admin sm primary">Vai a KB</a>
+            </div>
+          </div>
+
+          <div class="upload-grid">
+            <div>
+              <div class="dropzone">
+                <span class="em">📁</span>
+                <div class="title">Altro PDF?</div>
+                <div class="desc">Trascina o scegli per continuare ad arricchire la KB Wingspan</div>
+                <button class="btn-admin primary">+ Scegli file</button>
+              </div>
+            </div>
+            <div>
+              <div class="queue-card">
+                <div class="queue-head">
+                  <h3>Processing queue · history</h3>
+                  <span class="status-chip healthy" style="margin-left: auto">Done</span>
+                </div>
+                <div class="queue-row">
+                  <div class="filename">
+                    <span style="font-size: 18px; color: hsl(var(--c-toolkit))">✓</span>
+                    <span>Wingspan-Oceania-EN.pdf</span>
+                    <span class="size">412ch · 13.4s · $0.087</span>
+                  </div>
+                  <div class="stages">
+                    <div class="stage done"><span class="stg-name">1. Upload</span><span class="stg-state">✓ 6.2s</span></div>
+                    <div class="stage done"><span class="stg-name">2. Parse</span><span class="stg-state">✓ 2.1s</span></div>
+                    <div class="stage done"><span class="stg-name">3. Layout</span><span class="stg-state">✓ 2.9s</span></div>
+                    <div class="stage done"><span class="stg-name">4. Embed</span><span class="stg-state">✓ 4.2s</span></div>
+                    <div class="stage done"><span class="stg-name">5. Index</span><span class="stg-state">✓ 0.4s</span></div>
+                  </div>
+
+                  <div style="margin-top: 14px; padding: 10px 12px; background: var(--bg-muted); border-radius: 6px; font-size: 11.5px; line-height: 1.5">
+                    <strong style="font-family: var(--f-display)">First 3 chunks preview:</strong><br/>
+                    <span style="font-family: var(--f-mono); color: var(--text-muted)">c-0001 p.1</span> · "Wingspan Oceania Expansion · Rules supplement…"<br/>
+                    <span style="font-family: var(--f-mono); color: var(--text-muted)">c-0002 p.2</span> · "Setup variants — 2 to 5 players, mixed with base game…"<br/>
+                    <span style="font-family: var(--f-mono); color: var(--text-muted)">c-0003 p.3</span> · "New bird types: nectar feeders. Special power activation…"<br/>
+                    <a href="sp5-admin-kb.html" style="color: hsl(var(--c-event)); text-decoration: none; font-weight: 700">+ vedi altri 409 chunks →</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ STATE 05 — Error ══════════════════════════════════ -->
+        <div class="state-block" id="s5">
+          <div class="alert-banner danger" role="alert">
+            <span class="em">🚨</span>
+            <div style="flex: 1">
+              <div class="title">Errore parsing · Tainted-Grail-IT-scan.pdf</div>
+              <div>OCR ha fallito sulla pagina 47 (immagine corrotta · risoluzione 72dpi sotto soglia 150dpi).<br/>
+                <span style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">Error code: <code>OCR_LOW_RES_E47</code> · request_id: <code>req-4f8a2b1c</code></span>
+              </div>
+            </div>
+            <div class="actions">
+              <button class="btn-admin sm">📋 Copy log</button>
+              <button class="btn-admin sm">⤓ Download log</button>
+              <button class="btn-admin sm primary">↻ Retry (skip p.47)</button>
+            </div>
+          </div>
+
+          <div class="upload-grid">
+            <div>
+              <div class="dropzone error">
+                <span class="em">⚠️</span>
+                <div class="title" style="color: hsl(var(--c-event))">Pipeline fallita</div>
+                <div class="desc">Il file è stato uploaded ma il parsing è fallito. Puoi riprovare con setting diversi.</div>
+                <button class="btn-admin">↻ Retry con OCR off</button>
+                <button class="btn-admin danger">🗑 Rimuovi file</button>
+              </div>
+            </div>
+            <div>
+              <div class="queue-card">
+                <div class="queue-head">
+                  <h3>Processing queue</h3>
+                  <span class="status-chip danger" style="margin-left: auto">Failed</span>
+                </div>
+                <div class="queue-row">
+                  <div class="filename">
+                    <span style="font-size: 18px; color: hsl(var(--c-event))">✕</span>
+                    <span>Tainted-Grail-IT-scan.pdf</span>
+                    <span class="size">42 MB · 184 pages</span>
+                  </div>
+                  <div class="stages">
+                    <div class="stage done"><span class="stg-name">1. Upload</span><span class="stg-state">✓ 21s</span></div>
+                    <div class="stage done"><span class="stg-name">2. Parse</span><span class="stg-state">✓ 12s</span></div>
+                    <div class="stage error"><span class="stg-name">3. OCR</span><span class="stg-state">✕ p.47 fail</span></div>
+                    <div class="stage queued"><span class="stg-name">4. Embed</span><span class="stg-state">— skip</span></div>
+                    <div class="stage queued"><span class="stg-name">5. Index</span><span class="stg-state">— skip</span></div>
+                  </div>
+                  <pre class="ingestion-log" style="margin-top: 12px; font-family: var(--f-mono); font-size: 10.5px; background: var(--bg-sunken); padding: 10px 12px; border-radius: 6px; max-height: 130px; overflow-y: auto; color: hsl(var(--c-event)); line-height: 1.6">[14:24:48] ✕ OCR_LOW_RES_E47 on page 47 (72dpi)
+[14:24:48] Aborting pipeline, partial state discarded
+[14:24:48] Suggestion: re-upload at min 150dpi or run with OCR=off</pre>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ guard · Warn (sub-state) ═══════════════════════════ -->
+        <div class="state-block" id="s6">
+          <div class="idem-banner" role="alert">
+            <span class="em">⚠️</span>
+            <div style="flex: 1">
+              <div class="title">KB già presente per questo gioco</div>
+              <div style="font-size: 12.5px; line-height: 1.5">
+                <strong>🎲 Wingspan</strong> ha già <strong>12 documenti</strong> indicizzati (avg confidence 0.84). Vuoi davvero aggiungere "Wingspan-Asia-EN.pdf"?<br/>
+                <span style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">File hash <code>sha256:8c0f…a2c7</code> matched 1 existing doc al 96% — potenziale duplicate.</span>
+              </div>
+            </div>
+            <div class="actions" style="flex-direction: column; gap: 6px">
+              <a href="sp5-admin-kb.html" class="btn-admin sm">Vai a KB esistente</a>
+              <button class="btn-admin sm">Sovrascrivi</button>
+              <button class="btn-admin sm primary">Aggiungi come nuovo</button>
+              <button class="btn-admin sm ghost">Annulla</button>
+            </div>
+          </div>
+
+          <div class="upload-grid" style="opacity: .4; pointer-events: none">
+            <div>
+              <div class="dropzone">
+                <span class="em">📁</span>
+                <div class="title">Drop zone (locked)</div>
+                <div class="desc">Risolvi l'avviso sopra per procedere</div>
+              </div>
+            </div>
+            <div>
+              <div class="settings-card"><h3>⚙️ Settings</h3>
+                <div style="font-size: 11px; color: var(--text-muted)">In attesa di conferma idempotency…</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+</div>
+
+<script src="admin-nav.js"></script>
+<script>
+  renderAdminNav('kb-upload');
+  function showState(id) {
+    document.querySelectorAll('.state-block').forEach(b => b.classList.toggle('active', b.id === id));
+    document.querySelectorAll('.state-nav button').forEach(b => b.classList.remove('active'));
+    event.currentTarget.classList.add('active');
+  }
+</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-n8n.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-n8n.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B3 · n8n Integrations · /n8n</title>
+<!-- @v2 IntegrationStatusHero · WorkflowTable · WebhookTable · LogStream reuse -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .n8n-hero { background: linear-gradient(135deg, hsl(var(--c-chat) / .14), hsl(var(--c-toolkit) / .08)); border: 1px solid hsl(var(--c-chat) / .3); border-radius: 12px; padding: 20px 24px; display: grid; grid-template-columns: 1fr 280px; gap: 24px; align-items: center; }
+  .n8n-hero h2 { margin: 0 0 6px; font-family: var(--f-display); font-size: 22px; font-weight: 800; display: flex; align-items: center; gap: 10px; }
+  .n8n-hero .endpoint { font-family: var(--f-mono); font-size: 12px; color: var(--text-sec); padding: 4px 8px; background: var(--bg-card); border-radius: 6px; display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; }
+  .wf-row { display: grid; grid-template-columns: 32px 1fr 110px 110px 80px 70px 60px; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border-light); align-items: center; font-size: 12px; }
+  .wf-row .em { font-size: 18px; }
+  .wf-row .name { font-family: var(--f-display); font-weight: 700; }
+  .wf-row .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .wf-row .stat { font-family: var(--f-mono); font-size: 11px; }
+  .rate { display: inline-flex; gap: 1px; }
+  .rate .b { width: 2px; height: 16px; background: hsl(var(--c-toolkit)); border-radius: 1px; }
+  .rate .b.b0 { background: var(--bg-muted); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>n8n Integrations</h1><div class="crumbs">Tools · n8n · 14 workflow · 8 webhook · 24h health</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">⤓ Export events</button>
+        <button class="btn-admin">⚡ Apri n8n</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="display: flex; flex-direction: column; gap: 14px">
+
+      <div class="n8n-hero">
+        <div>
+          <h2>⚡ n8n self-hosted <span class="status-chip healthy" style="font-size: 11px">Connected</span></h2>
+          <div style="font-size: 13px; color: var(--text-sec)">Automazioni esterne · webhook bidirezionali · API key gestione</div>
+          <div class="endpoint">🔗 <code>n8n.meeple.io/api/v1</code> · auth: <code>Bearer ●●●●●</code> · last ping 12s ago</div>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 6px">
+          <button class="btn-admin">📡 Test connection</button>
+          <button class="btn-admin">🔑 Rotate API key</button>
+          <button class="btn-admin danger">⏸ Disconnect</button>
+        </div>
+      </div>
+
+      <div class="admin-tabs">
+        <button class="admin-tab active">🔄 Workflows <span class="count">14</span></button>
+        <button class="admin-tab">📨 Webhooks in entrata <span class="count">8</span></button>
+        <button class="admin-tab">📜 Logs eventi <span class="count">487</span></button>
+        <button class="admin-tab">🔑 API keys <span class="count">2</span></button>
+      </div>
+
+      <div class="admin-panel">
+        <div class="admin-panel-head"><h3>Workflows attivi</h3><span class="meta" style="margin-left: auto">avg success rate 94.8% (24h)</span></div>
+        <div>
+          <div class="wf-row" style="background: var(--bg); font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700">
+            <div></div><div>Workflow</div><div>Trigger</div><div>Last run</div><div style="text-align: right">Runs 24h</div><div style="text-align: right">Success</div><div></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em">📧</div>
+            <div>
+              <div class="name">game-night-invite-email</div>
+              <div class="meta">workflow_id: wf-gn-invite · sends transactional emails for RSVP</div>
+            </div>
+            <div class="stat">webhook<br/><span style="color: var(--text-muted)">/game-nights/...</span></div>
+            <div class="stat">14:21:38<br/><span style="color: var(--text-muted)">2m fa</span></div>
+            <div class="stat" style="text-align: right">147</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-toolkit))">100%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span></span></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em">🤖</div>
+            <div>
+              <div class="name">agent-finetune-job-watcher</div>
+              <div class="meta">wf-finetune-watch · monitor OpenAI fine-tune jobs · notifica Slack</div>
+            </div>
+            <div class="stat">cron<br/><span style="color: var(--text-muted)">*/15 * * * *</span></div>
+            <div class="stat">14:15:00<br/><span style="color: var(--text-muted)">8m fa</span></div>
+            <div class="stat" style="text-align: right">96</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-toolkit))">98.9%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b b0"></span></span></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em">📚</div>
+            <div>
+              <div class="name">bgg-weekly-sync</div>
+              <div class="meta">wf-bgg-sync · ingest BGG nuovi giochi e errata</div>
+            </div>
+            <div class="stat">cron<br/><span style="color: var(--text-muted)">0 2 * * 0</span></div>
+            <div class="stat">dom 02:00<br/><span style="color: var(--text-muted)">5gg fa</span></div>
+            <div class="stat" style="text-align: right">1</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-toolkit))">100%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span></span></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em">💳</div>
+            <div>
+              <div class="name">stripe-webhook-handler</div>
+              <div class="meta">wf-stripe · subscription events · churn alert</div>
+            </div>
+            <div class="stat">webhook<br/><span style="color: var(--text-muted)">/stripe/events</span></div>
+            <div class="stat">14:22:11<br/><span style="color: var(--text-muted)">1m fa</span></div>
+            <div class="stat" style="text-align: right">38</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-toolkit))">100%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span></span></div>
+          </div>
+
+          <div class="wf-row" style="background: hsl(var(--c-event) / .04)">
+            <div class="em" style="color: hsl(var(--c-event))">⚠️</div>
+            <div>
+              <div class="name">discord-game-night-reminder</div>
+              <div class="meta">wf-discord-rem · Discord bot notif · token scaduto, rinnova</div>
+            </div>
+            <div class="stat" style="color: hsl(var(--c-event))">webhook<br/><span style="color: hsl(var(--c-event))">DEAD</span></div>
+            <div class="stat">14:08:42<br/><span style="color: var(--text-muted)">15m fa</span></div>
+            <div class="stat" style="text-align: right">42</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-event))">61.9%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b b0"></span><span class="b"></span><span class="b b0"></span><span class="b"></span><span class="b b0"></span><span class="b"></span></span></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em">📊</div>
+            <div>
+              <div class="name">weekly-analytics-digest</div>
+              <div class="meta">wf-digest · email weekly stats agli admin</div>
+            </div>
+            <div class="stat">cron<br/><span style="color: var(--text-muted)">0 9 * * 1</span></div>
+            <div class="stat">lun 09:00<br/><span style="color: var(--text-muted)">3gg fa</span></div>
+            <div class="stat" style="text-align: right">1</div>
+            <div style="text-align: right; font-weight: 700; color: hsl(var(--c-toolkit))">100%</div>
+            <div style="text-align: right"><span class="rate"><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span><span class="b"></span></span></div>
+          </div>
+
+          <div class="wf-row">
+            <div class="em" style="color: var(--text-muted)">+8</div>
+            <div style="color: var(--text-muted); font-family: var(--f-display)">Altri 8 workflow — scroll per vedere</div>
+            <div></div><div></div><div></div><div></div><div></div>
+          </div>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px">
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>📨 Webhook in entrata · ultimi eventi</h3></div>
+          <div class="event-log" style="border: 0; max-height: 220px; font-family: var(--f-mono); font-size: 11px; background: var(--bg-sunken); border-radius: 0 0 10px 10px">
+            <div style="padding: 6px 14px; border-bottom: 1px solid var(--border-light); color: hsl(var(--c-toolkit))">▸ POST /webhooks/stripe · subscription.updated · 200 · 12s</div>
+            <div style="padding: 6px 14px; border-bottom: 1px solid var(--border-light); color: hsl(var(--c-chat))">▸ POST /webhooks/bgg-thread · new_reply · 200 · 1m</div>
+            <div style="padding: 6px 14px; border-bottom: 1px solid var(--border-light); color: hsl(var(--c-event))">▸ POST /webhooks/discord-bot · 401 unauth · 15m</div>
+            <div style="padding: 6px 14px; border-bottom: 1px solid var(--border-light); color: hsl(var(--c-toolkit))">▸ POST /webhooks/openai-finetune · status.completed · 200 · 18m</div>
+            <div style="padding: 6px 14px; border-bottom: 1px solid var(--border-light); color: hsl(var(--c-chat))">▸ POST /webhooks/typeform · response · 200 · 22m</div>
+            <div style="padding: 6px 14px; color: var(--text-muted)">+ 482 eventi 24h …</div>
+          </div>
+        </div>
+
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>🔑 API keys</h3><button class="btn-admin sm" style="margin-left: auto">+ Genera</button></div>
+          <div style="padding: 12px 14px">
+            <div style="display: flex; flex-direction: column; gap: 8px">
+              <div style="padding: 8px 12px; border-radius: 6px; background: var(--bg-muted); font-family: var(--f-mono); font-size: 11px">
+                <div style="display: flex; align-items: center; gap: 8px"><strong style="font-family: var(--f-display)">n8n-prod-master</strong><span style="margin-left: auto" class="status-chip healthy">Active</span></div>
+                <div style="color: var(--text-muted); margin-top: 4px">key: <code>n8n_••••••••••••a8f3</code> · expires 2026-09-12 · scope: read+write</div>
+              </div>
+              <div style="padding: 8px 12px; border-radius: 6px; background: var(--bg-muted); font-family: var(--f-mono); font-size: 11px">
+                <div style="display: flex; align-items: center; gap: 8px"><strong style="font-family: var(--f-display)">n8n-readonly-dashboard</strong><span style="margin-left: auto" class="status-chip warning">Expiring</span></div>
+                <div style="color: var(--text-muted); margin-top: 4px">key: <code>n8n_••••••••••••e3f7</code> · expires 2026-06-08 · scope: read-only</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('n8n');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-pipeline-builder.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-pipeline-builder.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B2 · Pipeline Builder · /pipeline-builder</title>
+<!-- @v2 FlowCanvas · NodePalette · NodeConfigPanel · PipelineTestOutput -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .pb-shell { display: grid; grid-template-columns: 220px 1fr 300px; gap: 12px; height: calc(100vh - 60px); }
+  .pb-col { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+  .pb-toolbar { padding: 8px 12px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 8px; background: var(--bg); }
+
+  .palette-group { padding: 8px 12px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+  .palette-node { padding: 8px 12px; margin: 0 8px 4px; border-radius: 6px; cursor: grab; font-family: var(--f-display); font-weight: 700; font-size: 12px; display: flex; align-items: center; gap: 8px; }
+  .palette-node:hover { background: var(--bg-muted); }
+  .palette-node .pn-em { font-size: 16px; }
+  .palette-node.retrieval { color: hsl(var(--c-kb)); border-left: 3px solid hsl(var(--c-kb)); }
+  .palette-node.processing { color: hsl(var(--c-toolkit)); border-left: 3px solid hsl(var(--c-toolkit)); }
+  .palette-node.output { color: hsl(var(--c-agent)); border-left: 3px solid hsl(var(--c-agent)); }
+  .palette-node.integration { color: hsl(var(--c-chat)); border-left: 3px solid hsl(var(--c-chat)); }
+
+  .canvas {
+    flex: 1; position: relative;
+    background: var(--bg);
+    background-image:
+      radial-gradient(circle, var(--border-light) 1px, transparent 1px);
+    background-size: 20px 20px;
+    overflow: auto;
+  }
+  .canvas-inner { position: relative; min-width: 1200px; min-height: 700px; }
+  .node {
+    position: absolute;
+    width: 200px;
+    background: var(--bg-card);
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 12px;
+    box-shadow: var(--shadow-md);
+    cursor: grab;
+  }
+  .node.selected { border-color: hsl(var(--c-event)); box-shadow: 0 0 0 3px hsl(var(--c-event) / .2), var(--shadow-md); }
+  .node.error { border-color: hsl(var(--c-event)); }
+  .node .ntype { font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; margin-bottom: 3px; }
+  .node .ntype.retrieval { color: hsl(var(--c-kb)); }
+  .node .ntype.processing { color: hsl(var(--c-toolkit)); }
+  .node .ntype.output { color: hsl(var(--c-agent)); }
+  .node .nname { font-family: var(--f-display); font-weight: 800; font-size: 13px; margin-bottom: 4px; }
+  .node .nprops { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); line-height: 1.4; }
+  .node .ndot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-muted); border: 2px solid var(--bg-card); position: absolute; }
+  .node .ndot.left { left: -5px; top: 50%; transform: translateY(-50%); }
+  .node .ndot.right { right: -5px; top: 50%; transform: translateY(-50%); }
+  .node .ndot.in { background: hsl(var(--c-kb)); }
+  .node .ndot.out { background: hsl(var(--c-agent)); }
+  .node .nstats { display: flex; gap: 8px; font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--border-light); }
+
+  .config-section { padding: 14px; border-bottom: 1px solid var(--border-light); }
+  .config-section h4 { margin: 0 0 8px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+
+  .test-out { padding: 12px 14px; background: var(--bg-sunken); font-family: var(--f-mono); font-size: 11px; color: var(--text-sec); border-radius: 6px; line-height: 1.6; max-height: 200px; overflow-y: auto; }
+  .test-out .k { color: hsl(var(--c-agent)); }
+  .test-out .s { color: hsl(var(--c-kb)); }
+  .test-out .n { color: hsl(var(--c-event)); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Pipeline builder</h1><div class="crumbs">Tools · Pipeline · 🤖 Wingspan Rules RAG v3 · 4 nodi · 1 errore</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">📋 Templates</button>
+        <button class="btn-admin">↶ Undo</button>
+        <button class="btn-admin">💾 Save draft</button>
+        <button class="btn-admin">▶ Test run</button>
+        <button class="btn-admin primary">🚀 Publish</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="padding: 12px 16px">
+      <div class="pb-shell">
+
+        <!-- Left: palette -->
+        <div class="pb-col">
+          <div class="pb-toolbar"><strong style="font-family: var(--f-display); font-size: 13px">Palette nodi</strong></div>
+          <div style="overflow-y: auto">
+            <div class="palette-group">Retrieval</div>
+            <div class="palette-node retrieval"><span class="pn-em">🔍</span> Vector search</div>
+            <div class="palette-node retrieval"><span class="pn-em">📑</span> BM25 keyword</div>
+            <div class="palette-node retrieval"><span class="pn-em">🔀</span> Hybrid retriever</div>
+
+            <div class="palette-group">Processing</div>
+            <div class="palette-node processing"><span class="pn-em">📊</span> Rerank</div>
+            <div class="palette-node processing"><span class="pn-em">🧹</span> Dedupe</div>
+            <div class="palette-node processing"><span class="pn-em">✂️</span> Truncate</div>
+            <div class="palette-node processing"><span class="pn-em">🔁</span> Self-correct</div>
+
+            <div class="palette-group">Output</div>
+            <div class="palette-node output"><span class="pn-em">🤖</span> LLM call</div>
+            <div class="palette-node output"><span class="pn-em">📤</span> Stream output</div>
+            <div class="palette-node output"><span class="pn-em">📋</span> JSON schema</div>
+
+            <div class="palette-group">Integrations</div>
+            <div class="palette-node integration"><span class="pn-em">🔧</span> Tool call</div>
+            <div class="palette-node integration"><span class="pn-em">⚡</span> n8n trigger</div>
+            <div class="palette-node integration"><span class="pn-em">📨</span> Webhook</div>
+          </div>
+        </div>
+
+        <!-- Center: canvas -->
+        <div class="pb-col">
+          <div class="pb-toolbar">
+            <strong style="font-family: var(--f-display); font-size: 13px">Wingspan Rules RAG v3</strong>
+            <span style="font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted)">/pipeline/wingspan-rag-v3</span>
+            <div style="margin-left: auto; display: flex; gap: 6px">
+              <span class="filter-chip">🔍 Zoom 100%</span>
+              <span class="filter-chip">+ Add node</span>
+            </div>
+          </div>
+          <div class="canvas">
+            <div class="canvas-inner">
+              <!-- Edges (SVG) -->
+              <svg style="position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none">
+                <path d="M 220 130 C 280 130, 280 130, 340 130" stroke="hsl(var(--c-agent))" stroke-width="2" fill="none"/>
+                <path d="M 540 130 C 600 130, 600 130, 660 130" stroke="hsl(var(--c-agent))" stroke-width="2" fill="none"/>
+                <path d="M 540 130 C 600 130, 600 280, 660 280" stroke="hsl(var(--c-event))" stroke-width="2" fill="none" stroke-dasharray="5 5"/>
+                <path d="M 860 130 C 920 130, 920 130, 980 130" stroke="hsl(var(--c-agent))" stroke-width="2" fill="none"/>
+              </svg>
+
+              <!-- Nodes -->
+              <div class="node" style="left: 20px; top: 90px">
+                <span class="ndot in left"></span>
+                <div class="ntype retrieval">Retrieval · entry</div>
+                <div class="nname">Query input</div>
+                <div class="nprops">type: text · max 512 tok</div>
+                <span class="ndot out right"></span>
+              </div>
+
+              <div class="node selected" style="left: 340px; top: 90px">
+                <span class="ndot in left"></span>
+                <div class="ntype retrieval">Hybrid retriever</div>
+                <div class="nname">Vector + BM25</div>
+                <div class="nprops">index: wingspan-v3 · top-k 20<br/>α=0.6 · rerank coh-3.5</div>
+                <div class="nstats"><span>⏱ 1.35s</span><span>💸 $0.0008</span><span>📊 95% hit</span></div>
+                <span class="ndot out right"></span>
+              </div>
+
+              <div class="node" style="left: 660px; top: 90px">
+                <span class="ndot in left"></span>
+                <div class="ntype processing">Rerank</div>
+                <div class="nname">Cohere rerank</div>
+                <div class="nprops">model: rerank-3.5<br/>top-n: 5 · cutoff 0.4</div>
+                <div class="nstats"><span>⏱ 0.4s</span><span>💸 $0.0001</span></div>
+                <span class="ndot out right"></span>
+              </div>
+
+              <div class="node error" style="left: 660px; top: 240px">
+                <span class="ndot in left" style="background: hsl(var(--c-event))"></span>
+                <div class="ntype processing" style="color: hsl(var(--c-event))">⚠ Self-correct</div>
+                <div class="nname">House rule check</div>
+                <div class="nprops" style="color: hsl(var(--c-event))">⚠ Property "ruleStore" missing</div>
+                <span class="ndot out right"></span>
+              </div>
+
+              <div class="node" style="left: 980px; top: 90px">
+                <span class="ndot in left"></span>
+                <div class="ntype output">LLM call</div>
+                <div class="nname">GPT-4o-mini</div>
+                <div class="nprops">temp: 0.2 · max-tok 800<br/>system prompt v3.2</div>
+                <div class="nstats"><span>⏱ 2.7s</span><span>💸 $0.0042</span></div>
+                <span class="ndot out right"></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: config + test output -->
+        <div class="pb-col">
+          <div class="pb-toolbar"><strong style="font-family: var(--f-display); font-size: 13px">Config &middot; Hybrid retriever</strong></div>
+          <div style="overflow-y: auto">
+            <div class="config-section">
+              <h4>General</h4>
+              <div class="sf-row" style="display: flex; flex-direction: column; gap: 3px; margin-bottom: 8px"><span class="sf-label" style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase">Node ID</span><input class="admin-input mono" value="n-hybrid-1" style="max-width: none"></div>
+              <div class="sf-row" style="display: flex; flex-direction: column; gap: 3px; margin-bottom: 8px"><span class="sf-label" style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase">Display name</span><input class="admin-input" value="Vector + BM25" style="max-width: none"></div>
+            </div>
+
+            <div class="config-section">
+              <h4>Retrieval params</h4>
+              <div style="display: flex; flex-direction: column; gap: 8px">
+                <div style="display: flex; flex-direction: column; gap: 3px"><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Index name</span><select class="admin-select" style="max-width: none"><option>wingspan-v3</option><option>brass-v2</option><option>tg-foa-v1</option></select></div>
+                <div style="display: flex; flex-direction: column; gap: 3px"><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Top-K</span><input class="admin-input mono" value="20" style="max-width: 100px"></div>
+                <div style="display: flex; flex-direction: column; gap: 3px"><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Alpha (vector vs BM25)</span><input type="range" min="0" max="100" value="60"><span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">0.60 · pesa più vector</span></div>
+                <div style="display: flex; align-items: center; gap: 8px"><div class="admin-toggle on"></div><span style="font-size: 12px">Auto-rerank</span></div>
+              </div>
+            </div>
+
+            <div class="config-section">
+              <h4>Stats run corrente</h4>
+              <dl style="display: grid; grid-template-columns: 90px 1fr; gap: 4px; font-size: 11.5px; margin: 0">
+                <dt style="color: var(--text-muted); font-family: var(--f-mono)">Latency</dt><dd style="margin: 0; font-family: var(--f-mono); font-weight: 700">1.35s</dd>
+                <dt style="color: var(--text-muted); font-family: var(--f-mono)">Cost / call</dt><dd style="margin: 0; font-family: var(--f-mono); font-weight: 700">$0.0008</dd>
+                <dt style="color: var(--text-muted); font-family: var(--f-mono)">Hit rate</dt><dd style="margin: 0; font-family: var(--f-mono); font-weight: 700; color: hsl(var(--c-toolkit))">95%</dd>
+                <dt style="color: var(--text-muted); font-family: var(--f-mono)">Errors 24h</dt><dd style="margin: 0; font-family: var(--f-mono); font-weight: 700">0</dd>
+              </dl>
+            </div>
+          </div>
+
+          <div style="padding: 12px 14px; border-top: 1px solid var(--border-light)">
+            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px"><strong style="font-family: var(--f-display); font-size: 12px">Test run output</strong><span class="status-chip warning" style="margin-left: auto; font-size: 10px">⚠ 1 node error</span></div>
+            <pre class="test-out">{
+  <span class="k">"query"</span>: <span class="s">"power foresta piena?"</span>,
+  <span class="k">"retrieved"</span>: <span class="n">5</span> chunks,
+  <span class="k">"reranked"</span>: <span class="n">3</span> chunks,
+  <span class="k">"top_score"</span>: <span class="n">0.84</span>,
+  <span class="k">"response"</span>: <span class="s">"Sì, l'azione…"</span>,
+  <span class="k">"confidence"</span>: <span class="n">0.92</span>,
+  <span class="k">"warnings"</span>: [
+    <span class="s">"self-correct node skipped"</span>
+  ],
+  <span class="k">"total_latency"</span>: <span class="n">4.45s</span>,
+  <span class="k">"total_cost"</span>: <span class="s">"$0.0051"</span>
+}</pre>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('pipeline');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-play-records.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-play-records.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B5 · Play Records · /play-records</title>
+<!-- @v2 PlayRecordTable · PlayRecordCalendar · PersonalStatsChart -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .pr-row { display: grid; grid-template-columns: 90px 1fr 180px 80px 70px 1fr 24px; gap: 12px; padding: 8px 14px; border-bottom: 1px solid var(--border-light); align-items: center; font-size: 12px; }
+  .pr-row:hover { background: var(--bg-muted); }
+  .pr-row .date { font-family: var(--f-mono); font-size: 11px; }
+  .pr-row .game { font-family: var(--f-display); font-weight: 700; }
+  .pr-row .players { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-sec); }
+  .pr-row .winner { font-family: var(--f-display); font-weight: 700; color: hsl(var(--c-toolkit)); }
+  .pr-row .notes { font-family: var(--f-body); font-size: 11.5px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-style: italic; }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Play Records</h1><div class="crumbs">Tools · Play records · 247 partite · 12 anni storia · Aaron's personal</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Cerca per gioco, giocatore…"></div>
+        <button class="btn-admin">⤓ Export CSV</button>
+        <button class="btn-admin primary">+ Aggiungi record</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="display: flex; flex-direction: column; gap: 14px">
+
+      <div class="admin-tabs">
+        <button class="admin-tab active">📋 List <span class="count">247</span></button>
+        <button class="admin-tab">📅 Calendar</button>
+        <button class="admin-tab">📊 Analytics</button>
+      </div>
+
+      <!-- Filter chip row -->
+      <div style="display: flex; gap: 6px; flex-wrap: wrap">
+        <span class="filter-chip active">Gioco: tutti <span class="x">▾</span></span>
+        <span class="filter-chip active">Periodo: 2026 <span class="x">▾</span></span>
+        <span class="filter-chip">Player: tutti <span class="x">▾</span></span>
+        <span class="filter-chip">Winner: tutti <span class="x">▾</span></span>
+        <span class="filter-chip">Durata: tutte <span class="x">▾</span></span>
+        <span class="filter-chip">Location: casa Marco <span class="x">×</span></span>
+        <span style="margin-left: auto; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">42 risultati</span>
+      </div>
+
+      <!-- Quick analytics row -->
+      <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px">
+        <div class="admin-kpi e-game"><div class="admin-kpi-label">Partite 2026</div><div class="admin-kpi-value">42</div><div class="admin-kpi-trend up">↗ +8 vs 2025</div></div>
+        <div class="admin-kpi e-toolkit"><div class="admin-kpi-label">Win rate</div><div class="admin-kpi-value">38<span style="font-size:13px;color:var(--text-muted)">%</span></div><div class="admin-kpi-trend up">↗ +4% sul 2025</div></div>
+        <div class="admin-kpi e-session"><div class="admin-kpi-label">Durata media</div><div class="admin-kpi-value">2h <span style="font-size:13px;color:var(--text-muted)">12m</span></div><div class="admin-kpi-trend flat">→ stabile</div></div>
+        <div class="admin-kpi e-player"><div class="admin-kpi-label">Opponent top</div><div class="admin-kpi-value" style="font-size: 18px">Marco</div><div class="admin-kpi-trend flat">→ 18 partite insieme</div></div>
+      </div>
+
+      <div class="admin-panel">
+        <div class="admin-panel-head"><h3>Storico partite 2026 · ordina per data</h3><span class="meta" style="margin-left: auto">42 record</span></div>
+        <div>
+          <div class="pr-row" style="background: var(--bg); font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; font-weight: 700">
+            <div>Data ↓</div><div>Gioco</div><div>Giocatori</div><div>Durata</div><div>Winner</div><div>Note</div><div></div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">22 mag<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🦅 Wingspan: Oceania</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">expansion · base 4p</div></div>
+            <div class="players">Aaron · Marco · Giulia · Davide</div>
+            <div style="font-family: var(--f-mono)">1h 48m</div>
+            <div class="winner">Aaron 78</div>
+            <div class="notes">"Strategia nidi+bonus carte, decisive 12pt fine round"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">15 mag<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🏰 Brass: Birmingham</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">base · 4p</div></div>
+            <div class="players">Marco · Davide · Luca · Aaron</div>
+            <div style="font-family: var(--f-mono)">3h 24m</div>
+            <div class="winner">Marco 167</div>
+            <div class="notes">"Cattedrale + ferro rete Walsall. Tight finish (167 vs 158)"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">11 mag<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🌌 Spirit Island</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Branch &amp; Claw · 3 spirit</div></div>
+            <div class="players">Aaron · Sara · Marco</div>
+            <div style="font-family: var(--f-mono)">2h 56m</div>
+            <div class="winner" style="color: hsl(var(--c-event))">PERSO (turn 8)</div>
+            <div class="notes">"Sclerotic Earth + sweep spirits. Fast attack inglesi, non in tempo"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">04 mag<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🦖 Ark Nova</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">base · 4p</div></div>
+            <div class="players">Marco · Giulia · Elena · Aaron</div>
+            <div style="font-family: var(--f-mono)">2h 38m</div>
+            <div class="winner">Elena 184</div>
+            <div class="notes">"Combo università + zoo grande. Elena prima volta che gioca!"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">28 apr<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">📖 Tainted Grail FoA</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Cap.7 - La Grotta dei Goblin</div></div>
+            <div class="players">Aaron (solo · Beor)</div>
+            <div style="font-family: var(--f-mono)">1h 18m</div>
+            <div class="winner">Survived ✓</div>
+            <div class="notes">"Scelta diff Trentino, paragrafo §218 evitato di poco. Magic 3 left"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">22 apr<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🦅 Wingspan</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Europa expansion · 5p</div></div>
+            <div class="players">Marco · Davide · Aaron · Giulia · Luca</div>
+            <div style="font-family: var(--f-mono)">1h 22m</div>
+            <div class="winner">Davide 91</div>
+            <div class="notes">"Power foresta sfruttato bene da Davide, house rule mano 8 attiva"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row">
+            <div class="date">15 apr<br/><span style="color: var(--text-muted)">2026</span></div>
+            <div><div class="game">🏰 Brass: Birmingham</div><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">base · 3p</div></div>
+            <div class="players">Aaron · Marco · Luca</div>
+            <div style="font-family: var(--f-mono)">2h 48m</div>
+            <div class="winner">Aaron 142</div>
+            <div class="notes">"Birra+porto rete sud. Marco -8 a fine partita per cotton sprecato"</div>
+            <div>›</div>
+          </div>
+
+          <div class="pr-row" style="background: var(--bg); color: var(--text-muted); justify-content: center; font-family: var(--f-mono); font-size: 11px; padding: 14px">
+            + 35 partite più vecchie · scroll per caricare
+          </div>
+        </div>
+      </div>
+
+      <!-- Mini analytics chart preview at bottom -->
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px">
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>Wins per gioco · 2026</h3></div>
+          <div style="padding: 14px; display: flex; flex-direction: column; gap: 8px; font-family: var(--f-mono); font-size: 12px">
+            <div style="display: grid; grid-template-columns: 110px 1fr 30px; gap: 8px; align-items: center"><span>🏰 Brass</span><div style="background: var(--bg-muted); border-radius: 4px; height: 16px; overflow: hidden"><div style="background: hsl(var(--c-toolkit)); height: 100%; width: 80%"></div></div><span style="text-align: right">8</span></div>
+            <div style="display: grid; grid-template-columns: 110px 1fr 30px; gap: 8px; align-items: center"><span>🦅 Wingspan</span><div style="background: var(--bg-muted); border-radius: 4px; height: 16px; overflow: hidden"><div style="background: hsl(var(--c-toolkit)); height: 100%; width: 60%"></div></div><span style="text-align: right">6</span></div>
+            <div style="display: grid; grid-template-columns: 110px 1fr 30px; gap: 8px; align-items: center"><span>🌌 Spirit Island</span><div style="background: var(--bg-muted); border-radius: 4px; height: 16px; overflow: hidden"><div style="background: hsl(var(--c-toolkit)); height: 100%; width: 30%"></div></div><span style="text-align: right">3</span></div>
+            <div style="display: grid; grid-template-columns: 110px 1fr 30px; gap: 8px; align-items: center"><span>🦖 Ark Nova</span><div style="background: var(--bg-muted); border-radius: 4px; height: 16px; overflow: hidden"><div style="background: hsl(var(--c-toolkit)); height: 100%; width: 20%"></div></div><span style="text-align: right">2</span></div>
+            <div style="display: grid; grid-template-columns: 110px 1fr 30px; gap: 8px; align-items: center"><span>📖 Tainted Grail</span><div style="background: var(--bg-muted); border-radius: 4px; height: 16px; overflow: hidden"><div style="background: hsl(var(--c-toolkit)); height: 100%; width: 50%"></div></div><span style="text-align: right">5 surv.</span></div>
+          </div>
+        </div>
+
+        <div class="admin-panel">
+          <div class="admin-panel-head"><h3>Top opponents</h3></div>
+          <div style="padding: 14px; display: flex; flex-direction: column; gap: 10px; font-size: 12.5px">
+            <div style="display: flex; align-items: center; gap: 10px"><div style="width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, hsl(262, 83%, 58%), hsl(290, 75%, 50%)); display: grid; place-items: center; color: #fff; font-family: var(--f-display); font-weight: 800; font-size: 13px">MR</div><div style="flex: 1"><strong>Marco Rossi</strong><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">18 partite · 7 wins tuoi · 8 suoi · 3 altri</div></div><span style="font-family: var(--f-mono); font-weight: 700">39%</span></div>
+            <div style="display: flex; align-items: center; gap: 10px"><div style="width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, hsl(220, 80%, 55%), hsl(195, 80%, 50%)); display: grid; place-items: center; color: #fff; font-family: var(--f-display); font-weight: 800; font-size: 13px">DC</div><div style="flex: 1"><strong>Davide Conte</strong><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">14 partite · 5 wins tuoi · 6 suoi · 3 altri</div></div><span style="font-family: var(--f-mono); font-weight: 700">36%</span></div>
+            <div style="display: flex; align-items: center; gap: 10px"><div style="width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, hsl(348, 78%, 52%), hsl(28, 84%, 55%)); display: grid; place-items: center; color: #fff; font-family: var(--f-display); font-weight: 800; font-size: 13px">GB</div><div style="flex: 1"><strong>Giulia Bianchi</strong><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">11 partite · 6 wins tuoi · 3 suoi · 2 altri</div></div><span style="font-family: var(--f-mono); font-weight: 700">55%</span></div>
+            <div style="display: flex; align-items: center; gap: 10px"><div style="width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, hsl(168, 60%, 38%), hsl(142, 54%, 42%)); display: grid; place-items: center; color: #fff; font-family: var(--f-display); font-weight: 800; font-size: 13px">LM</div><div style="flex: 1"><strong>Luca Mancini</strong><div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">8 partite · 3 wins tuoi · 4 suoi · 1 altri</div></div><span style="font-family: var(--f-mono); font-weight: 700">38%</span></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('play-records');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-private-games.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-private-games.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B7 · Private Games · /private-games</title>
+<!-- @v2 PrivateGameCard · PublishChecklist -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .pg-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+  .pg-card {
+    background: var(--bg-card); border: 1px solid var(--border-light);
+    border-radius: 12px; overflow: hidden;
+    position: relative; cursor: pointer;
+    transition: transform var(--dur-sm) var(--ease-out), border-color var(--dur-sm);
+  }
+  .pg-card:hover { transform: translateY(-2px); border-color: hsl(var(--c-game) / .5); }
+  .pg-cover { height: 140px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); display: grid; place-items: center; font-size: 56px; position: relative; }
+  .pg-cover .lock { position: absolute; top: 10px; right: 10px; padding: 4px 8px; background: rgba(0,0,0,.5); color: #fff; font-family: var(--f-mono); font-size: 9px; font-weight: 700; border-radius: 4px; backdrop-filter: blur(4px); }
+  .pg-body { padding: 12px 14px; }
+  .pg-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; margin-bottom: 3px; }
+  .pg-meta { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); margin-bottom: 8px; }
+  .pg-status { display: inline-flex; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; margin-bottom: 8px; }
+  .pg-status.draft { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+  .pg-status.ready { background: hsl(var(--c-chat) / .14); color: hsl(var(--c-chat)); }
+  .pg-status.beta { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+  .pg-status.published { background: hsl(var(--c-toolkit) / .14); color: hsl(var(--c-toolkit)); }
+  .pg-stats { display: flex; gap: 12px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+
+  .new-card {
+    background: var(--bg);
+    border: 2px dashed var(--border);
+    border-radius: 12px;
+    min-height: 260px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px;
+    cursor: pointer; color: var(--text-muted);
+  }
+  .new-card:hover { border-color: hsl(var(--c-game)); color: hsl(var(--c-game)); }
+  .new-card .em { font-size: 36px; }
+
+  .publish-card {
+    background: linear-gradient(135deg, hsl(var(--c-toolkit) / .12), hsl(var(--c-game) / .08));
+    border: 1px solid hsl(var(--c-toolkit) / .35);
+    border-radius: 12px;
+    padding: 20px 24px;
+  }
+  .publish-card h3 { margin: 0 0 6px; font-family: var(--f-display); font-size: 18px; font-weight: 800; }
+  .check-row { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-light); font-size: 12.5px; }
+  .check-row:last-child { border-bottom: 0; }
+  .check-row .cb { width: 20px; height: 20px; border-radius: 4px; border: 2px solid var(--border); display: grid; place-items: center; flex-shrink: 0; font-size: 12px; }
+  .check-row.done .cb { background: hsl(var(--c-toolkit)); border-color: hsl(var(--c-toolkit)); color: #fff; }
+  .check-row.todo .cb { color: var(--text-muted); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Miei giochi privati</h1><div class="crumbs">Tools · Private games · 7 in design · 2 in review · 1 published</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <span class="filter-chip active">Status: tutti <span class="x">▾</span></span>
+        <button class="btn-admin primary">+ Nuovo gioco</button>
+      </div>
+    </header>
+
+    <div class="admin-body" style="display: flex; flex-direction: column; gap: 18px">
+
+      <!-- Publish review highlight -->
+      <div class="publish-card">
+        <div style="display: grid; grid-template-columns: 1fr 280px; gap: 24px; align-items: center">
+          <div>
+            <h3>🎲 "Ant Wars" pronto per la review pubblica</h3>
+            <div style="font-size: 13px; color: var(--text-sec); margin-bottom: 14px">Il tuo gioco soddisfa 7/9 requisiti per il publishing community. Completa gli ultimi 2 per inviarlo alla moderation queue.</div>
+
+            <div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Regole base scritte</strong> · 14 capitoli · 8.4k parole · ultimo update 4gg fa</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Setup chiaro</strong> · diagrammi 1-4 player · 6 immagini caricate</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Punti finali specificati</strong> · 4 condizioni vittoria definite</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Almeno 5 partite test</strong> · 12 sessioni registrate · feedback positivo</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Glossary termini</strong> · 38 termini · esempi per ognuno</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Cover art (min 600x800)</strong> · uploaded 2gg fa</div></div>
+              <div class="check-row done"><div class="cb">✓</div><div><strong>Designer note</strong> · introduzione 200+ parole</div></div>
+              <div class="check-row todo"><div class="cb"></div><div><strong>FAQ minimo 10 domande</strong> · 7/10 al momento <span style="color: hsl(38 90% 50%); font-family: var(--f-mono); font-size: 10px">3 mancanti</span></div></div>
+              <div class="check-row todo"><div class="cb"></div><div><strong>Lingua secondaria</strong> · traduzione EN richiesta per community release <span style="color: hsl(38 90% 50%); font-family: var(--f-mono); font-size: 10px">0% completata</span></div></div>
+            </div>
+          </div>
+          <div>
+            <div style="background: var(--bg-card); border-radius: 10px; padding: 14px; text-align: center">
+              <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Completamento</div>
+              <div style="font-family: var(--f-display); font-size: 36px; font-weight: 800; line-height: 1; margin: 6px 0; color: hsl(var(--c-toolkit))">78%</div>
+              <div style="height: 6px; background: var(--bg-muted); border-radius: 999px; overflow: hidden"><div style="height: 100%; width: 78%; background: hsl(var(--c-toolkit))"></div></div>
+              <button class="btn-admin primary" style="width: 100%; margin-top: 14px" disabled>📤 Submit (2 mancano)</button>
+              <button class="btn-admin" style="width: 100%; margin-top: 6px">👁 Anteprima pubblica</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="pg-grid">
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(28, 84%, 45%), hsl(348, 78%, 42%))"><span>🐜</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Ant Wars</div>
+            <div class="pg-meta">2-4p · 60-90min · medium</div>
+            <span class="pg-status ready">Ready for review</span>
+            <div class="pg-stats"><span>v0.4</span><span>·</span><span>12 partite test</span><span>·</span><span>updated 4gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(235, 64%, 56%), hsl(220, 80%, 35%))"><span>🌌</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Stellar Cartographers</div>
+            <div class="pg-meta">3-5p · 90-120min · heavy</div>
+            <span class="pg-status beta">In playtest</span>
+            <div class="pg-stats"><span>v0.6</span><span>·</span><span>24 partite</span><span>·</span><span>updated 2gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(168, 60%, 38%), hsl(142, 54%, 32%))"><span>🌿</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Garden Keepers</div>
+            <div class="pg-meta">1-4p · 45-60min · light</div>
+            <span class="pg-status draft">Draft</span>
+            <div class="pg-stats"><span>v0.2</span><span>·</span><span>3 partite</span><span>·</span><span>updated 12gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(262, 83%, 58%), hsl(290, 75%, 50%))"><span>🃏</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Diceforge: Padova</div>
+            <div class="pg-meta">2-4p · 30-45min · light-medium</div>
+            <span class="pg-status draft">Draft</span>
+            <div class="pg-stats"><span>v0.1</span><span>·</span><span>1 partita</span><span>·</span><span>updated 18gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(348, 78%, 52%), hsl(28, 84%, 45%))"><span>🔥</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Magma Forge</div>
+            <div class="pg-meta">2-3p · 60min · medium</div>
+            <span class="pg-status beta">In playtest</span>
+            <div class="pg-stats"><span>v0.5</span><span>·</span><span>18 partite</span><span>·</span><span>updated 6gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(38, 90%, 56%), hsl(28, 84%, 45%))"><span>🏜️</span><span class="lock">🔒 PRIVATO</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Desert Caravan</div>
+            <div class="pg-meta">2-6p · 45min · medium</div>
+            <span class="pg-status ready">Ready for review</span>
+            <div class="pg-stats"><span>v0.3</span><span>·</span><span>8 partite</span><span>·</span><span>updated 14gg fa</span></div>
+          </div>
+        </div>
+
+        <div class="pg-card">
+          <div class="pg-cover" style="background: linear-gradient(135deg, hsl(142, 54%, 42%), hsl(168, 60%, 38%))"><span>🏆</span></div>
+          <div class="pg-body">
+            <div class="pg-name">Boardgame Bistro</div>
+            <div class="pg-meta">2-4p · 30min · light</div>
+            <span class="pg-status published">Published 🎉</span>
+            <div class="pg-stats"><span>v1.2 stable</span><span>·</span><span>247 install</span><span>·</span><span>★ 4.6</span></div>
+          </div>
+        </div>
+
+        <div class="new-card">
+          <span class="em">+</span>
+          <div style="font-family: var(--f-display); font-weight: 800; font-size: 14px">Nuovo gioco privato</div>
+          <div style="font-size: 11px; max-width: 200px; text-align: center; line-height: 1.4">Wizard 7 step · template ready · auto-save</div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('private-games');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-upload-advanced.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-upload-advanced.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B4 · Upload avanzato · /upload</title>
+<!-- @v2 UploadDropzone · UploadQueue · ProcessingTimeline · AdminDataTable reuse -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .ua-grid { display: grid; grid-template-columns: 400px 1fr; gap: 14px; align-items: start; }
+  .dropzone-mini { background: var(--bg-card); border: 2px dashed hsl(var(--c-kb) / .4); border-radius: 10px; padding: 24px; text-align: center; }
+  .dropzone-mini .em { font-size: 36px; }
+  .dropzone-mini h3 { margin: 8px 0 4px; font-family: var(--f-display); font-size: 14px; font-weight: 800; }
+  .dropzone-mini .desc { font-size: 11.5px; color: var(--text-sec); margin: 0 0 12px; }
+  .uq-row { padding: 10px 14px; border-bottom: 1px solid var(--border-light); cursor: pointer; }
+  .uq-row:hover { background: var(--bg-muted); }
+  .uq-row.selected { background: hsl(var(--c-kb) / .08); border-left: 3px solid hsl(var(--c-kb)); padding-left: 11px; }
+  .uq-row .name { font-family: var(--f-display); font-weight: 700; font-size: 12.5px; display: flex; align-items: center; gap: 6px; }
+  .uq-row .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+  .pb { height: 4px; background: var(--bg-muted); border-radius: 999px; overflow: hidden; margin-top: 6px; }
+  .pb .fill { height: 100%; background: hsl(var(--c-kb)); }
+  .pb .fill.ok { background: hsl(var(--c-toolkit)); }
+  .pb .fill.err { background: hsl(var(--c-event)); }
+
+  .ptl { display: flex; flex-direction: column; gap: 1px; }
+  .ptl-step { display: grid; grid-template-columns: 40px 1fr 100px 80px; gap: 12px; align-items: center; padding: 10px 14px; border-bottom: 1px solid var(--border-light); font-size: 12px; }
+  .ptl-step:last-child { border-bottom: 0; }
+  .ptl-step .dot { width: 28px; height: 28px; border-radius: 50%; display: grid; place-items: center; font-size: 14px; font-weight: 700; }
+  .ptl-step.done .dot { background: hsl(var(--c-toolkit)); color: #fff; }
+  .ptl-step.running .dot { background: hsl(var(--c-kb)); color: #fff; animation: admin-pulse 2s infinite; }
+  .ptl-step.queued .dot { background: var(--bg-muted); color: var(--text-muted); border: 1px solid var(--border); }
+  .ptl-step.error .dot { background: hsl(var(--c-event)); color: #fff; }
+  .ptl-step .stage-name { font-family: var(--f-display); font-weight: 700; }
+  .ptl-step .stage-sub { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+  .ptl-step .latency { font-family: var(--f-mono); font-size: 11px; text-align: right; font-weight: 700; color: var(--text-sec); }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Upload avanzato</h1><div class="crumbs">Tools · Upload · 3 in queue · 47 completed today</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <button class="btn-admin">⚙ Batch settings</button>
+        <button class="btn-admin">📋 History (487)</button>
+        <button class="btn-admin primary">+ Bulk upload</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="ua-grid">
+
+        <!-- Left: dropzone + queue -->
+        <div>
+          <div class="dropzone-mini">
+            <span class="em">📁</span>
+            <h3>Drag &amp; drop</h3>
+            <p class="desc">PDF, EPUB, DOCX · max 200MB per file · batch multi-file</p>
+            <button class="btn-admin primary">Scegli file</button>
+            <div style="margin-top: 12px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Hold ⇧ per multi-select · Drop → assign gioco</div>
+          </div>
+
+          <div class="admin-panel" style="margin-top: 14px">
+            <div class="admin-panel-head"><h3>Queue · 3 in corso</h3><button class="btn-admin sm" style="margin-left: auto">⏸ Pausa</button></div>
+            <div>
+              <div class="uq-row selected">
+                <div class="name">📄 Wingspan-Oceania-EN.pdf <span class="status-chip info running" style="margin-left: auto; font-size: 9px">indexing</span></div>
+                <div class="meta">8.4MB · 🎲 Wingspan · started 12s · ETA 14s</div>
+                <div class="pb"><div class="fill" style="width: 58%"></div></div>
+              </div>
+              <div class="uq-row">
+                <div class="name">📄 Brass-Lancashire-EN.pdf <span class="status-chip info running" style="margin-left: auto; font-size: 9px">parsing</span></div>
+                <div class="meta">12.1MB · 🎲 Brass · started 4s</div>
+                <div class="pb"><div class="fill" style="width: 18%"></div></div>
+              </div>
+              <div class="uq-row">
+                <div class="name">📄 TG-Chapter-10.pdf <span class="status-chip warning" style="margin-left: auto; font-size: 9px">queued</span></div>
+                <div class="meta">24.8MB · 🎲 Tainted Grail · waiting slot</div>
+                <div class="pb"><div class="fill" style="width: 0%"></div></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="admin-panel" style="margin-top: 14px">
+            <div class="admin-panel-head"><h3>History · today</h3><span class="meta" style="margin-left: auto">47 done · 2 failed</span></div>
+            <div>
+              <div class="uq-row">
+                <div class="name">📄 Ark-Nova-EN.pdf <span style="margin-left: auto; color: hsl(var(--c-toolkit))">✓</span></div>
+                <div class="meta">524ch · 14.2s · $0.092 · 14:08</div>
+              </div>
+              <div class="uq-row">
+                <div class="name">📄 Spirit-Island-rules.pdf <span style="margin-left: auto; color: hsl(var(--c-toolkit))">✓</span></div>
+                <div class="meta">412ch · 12.8s · $0.087 · 13:52</div>
+              </div>
+              <div class="uq-row">
+                <div class="name">📄 TG-Chapter-9-scan.pdf <span style="margin-left: auto; color: hsl(var(--c-event))">✕</span></div>
+                <div class="meta">OCR_LOW_RES_E14 · 13:48</div>
+              </div>
+              <div class="uq-row" style="color: var(--text-muted); font-style: italic">+ 44 altri completati</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: detail processing -->
+        <div class="admin-panel">
+          <div class="admin-panel-head" style="padding: 12px 16px;">
+            <div>
+              <h3 style="font-size: 15px">📄 Wingspan-Oceania-EN.pdf</h3>
+              <div style="font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px">8.4 MB · 42 pages · 🎲 Wingspan · uploaded by Aaron · started 14:23:42</div>
+            </div>
+            <div style="margin-left: auto; display: flex; gap: 6px">
+              <button class="btn-admin sm">⏸ Pause</button>
+              <button class="btn-admin sm">↻ Retry stage</button>
+              <button class="btn-admin sm danger">✕ Cancel</button>
+            </div>
+          </div>
+
+          <div style="padding: 16px 16px 8px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px">
+            <div style="background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 10px 12px"><div style="font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Stage corrente</div><div style="font-family: var(--f-display); font-size: 14px; font-weight: 800; color: hsl(var(--c-kb)); margin-top: 2px">3 / 5 · Layout</div></div>
+            <div style="background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 10px 12px"><div style="font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Progress totale</div><div style="font-family: var(--f-display); font-size: 14px; font-weight: 800; margin-top: 2px">58%</div></div>
+            <div style="background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 10px 12px"><div style="font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">ETA</div><div style="font-family: var(--f-display); font-size: 14px; font-weight: 800; margin-top: 2px">14s</div></div>
+            <div style="background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 10px 12px"><div style="font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Cost stimato</div><div style="font-family: var(--f-display); font-size: 14px; font-weight: 800; margin-top: 2px">$0.087</div></div>
+          </div>
+
+          <div style="padding: 0 16px 16px">
+            <h4 style="margin: 12px 0 8px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em">Pipeline timeline</h4>
+            <div class="ptl">
+              <div class="ptl-step done">
+                <div class="dot">✓</div>
+                <div><div class="stage-name">1. Upload</div><div class="stage-sub">multipart S3 · ricezione binario</div></div>
+                <div class="stage-sub">6.2 MB/s</div>
+                <div class="latency">6.2s</div>
+              </div>
+              <div class="ptl-step done">
+                <div class="dot">✓</div>
+                <div><div class="stage-name">2. Parse · Unstructured.io</div><div class="stage-sub">1.247 elements · 86 tables · 12 figures</div></div>
+                <div class="stage-sub">v0.18.3</div>
+                <div class="latency">2.1s</div>
+              </div>
+              <div class="ptl-step running">
+                <div class="dot">⟳</div>
+                <div><div class="stage-name">3. Layout · SmolDocling</div><div class="stage-sub">parsing tabelle pag.22-31 · 24/42 done</div></div>
+                <div class="stage-sub" style="color: hsl(var(--c-kb)); font-weight: 700">58%</div>
+                <div class="latency">~5s</div>
+              </div>
+              <div class="ptl-step queued">
+                <div class="dot">⋯</div>
+                <div><div class="stage-name">4. Embed · text-embedding-3-large</div><div class="stage-sub">412 chunks attesi · batch 64</div></div>
+                <div class="stage-sub">in coda</div>
+                <div class="latency">~4s</div>
+              </div>
+              <div class="ptl-step queued">
+                <div class="dot">⋯</div>
+                <div><div class="stage-name">5. Index · Pinecone wingspan-v3</div><div class="stage-sub">412 vector upsert</div></div>
+                <div class="stage-sub">in coda</div>
+                <div class="latency">~0.5s</div>
+              </div>
+            </div>
+
+            <div style="margin-top: 16px; display: grid; grid-template-columns: 1fr 1fr; gap: 12px">
+              <div style="padding: 12px; background: var(--bg-muted); border-radius: 6px">
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin-bottom: 6px">Metadata</div>
+                <dl style="display: grid; grid-template-columns: 100px 1fr; gap: 4px; font-size: 11.5px; margin: 0">
+                  <dt style="color: var(--text-muted)">Lingua</dt><dd style="margin: 0">EN (detected)</dd>
+                  <dt style="color: var(--text-muted)">OCR</dt><dd style="margin: 0">no (text-native PDF)</dd>
+                  <dt style="color: var(--text-muted)">Chunk size</dt><dd style="margin: 0">512 tok</dd>
+                  <dt style="color: var(--text-muted)">Indexer</dt><dd style="margin: 0">v2024.11.18</dd>
+                </dl>
+              </div>
+              <div style="padding: 12px; background: var(--bg-muted); border-radius: 6px">
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin-bottom: 6px">Actions</div>
+                <div style="display: flex; flex-direction: column; gap: 4px">
+                  <button class="btn-admin sm">📥 Download original</button>
+                  <button class="btn-admin sm">👁 View extracted text</button>
+                  <button class="btn-admin sm">↻ Retry failed step</button>
+                  <button class="btn-admin sm danger">🗑 Delete from KB</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('upload');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-versions.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-versions.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP5 B6 · Versions · /versions</title>
+<!-- @v2 VersionTimeline · VersionDiffViewer · CompareSelector -->
+<link rel="preconnect" href="https://fonts.googleapis.com"/><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/><link rel="stylesheet" href="components.css"/><link rel="stylesheet" href="admin-base.css"/>
+<style>
+  .v-grid { display: grid; grid-template-columns: 280px 1fr; gap: 14px; align-items: start; }
+  .art-row { padding: 10px 14px; border-bottom: 1px solid var(--border-light); cursor: pointer; }
+  .art-row:hover { background: var(--bg-muted); }
+  .art-row.selected { background: hsl(var(--c-toolkit) / .08); border-left: 3px solid hsl(var(--c-toolkit)); padding-left: 11px; }
+  .art-row .name { font-family: var(--f-display); font-weight: 700; font-size: 12.5px; display: flex; align-items: center; gap: 6px; }
+  .art-row .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+
+  .v-timeline { padding: 14px; }
+  .v-row { display: grid; grid-template-columns: 80px 1fr 100px 80px 28px; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border-light); align-items: center; }
+  .v-row .vtag { font-family: var(--f-mono); font-size: 11px; font-weight: 800; padding: 4px 8px; border-radius: 6px; background: var(--bg-muted); display: inline-block; text-align: center; }
+  .v-row .vtag.published { background: hsl(var(--c-toolkit) / .14); color: hsl(var(--c-toolkit)); }
+  .v-row .vtag.draft { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+  .v-row .commit { font-family: var(--f-display); font-weight: 700; font-size: 13px; }
+  .v-row .commit-meta { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); margin-top: 2px; }
+  .v-row .compare-checkbox { display: flex; gap: 4px; align-items: center; font-family: var(--f-mono); font-size: 10px; }
+
+  .diff-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+  .diff-head { padding: 12px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 12px; background: var(--bg); }
+  .diff-versions { display: flex; align-items: center; gap: 8px; font-family: var(--f-mono); font-size: 12px; }
+  .diff-versions .v1 { color: hsl(var(--c-event)); font-weight: 800; }
+  .diff-versions .v2 { color: hsl(var(--c-toolkit)); font-weight: 800; }
+  .diff-body { display: grid; grid-template-columns: 1fr 1fr; }
+  .diff-side { padding: 12px; font-family: var(--f-mono); font-size: 11.5px; line-height: 1.6; overflow-x: auto; min-height: 320px; }
+  .diff-side.left { border-right: 1px solid var(--border-light); }
+  .diff-line { padding: 2px 8px; border-radius: 3px; white-space: pre-wrap; }
+  .diff-line.add { background: hsl(var(--c-toolkit) / .14); color: hsl(var(--c-toolkit)); }
+  .diff-line.del { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+  .diff-line.neutral { color: var(--text-sec); }
+  .diff-line .lno { display: inline-block; width: 24px; color: var(--text-muted); text-align: right; margin-right: 8px; user-select: none; }
+</style>
+</head>
+<body class="admin-page">
+<div class="admin-mobile-fallback"><span class="em">🖥️</span><h2>Console solo desktop</h2></div>
+<div class="admin-shell">
+  <div data-admin-nav-mount></div>
+  <main>
+    <header class="admin-top">
+      <div><h1>Versioning</h1><div class="crumbs">Tools · Versions · 312 artefatti · 4.8k versions</div></div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <span class="filter-chip active">Tipo: tutti <span class="x">▾</span></span>
+        <button class="btn-admin">⤓ Export</button>
+      </div>
+    </header>
+
+    <div class="admin-body">
+      <div class="v-grid">
+
+        <div class="admin-panel" style="position: sticky; top: 76px; max-height: calc(100vh - 100px); display: flex; flex-direction: column">
+          <div class="admin-panel-head"><h3>Artefatti</h3><span class="meta" style="margin-left: auto">312 totali</span></div>
+          <div class="admin-search" style="margin: 8px 12px"><span>🔍</span><input placeholder="Filtra…"></div>
+          <div style="overflow-y: auto; flex: 1">
+            <div class="art-row selected">
+              <div class="name">🧰 ocr-pdf-toolkit</div>
+              <div class="meta">v2.1.0 published · 18 versions · last edit 38m fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">🧰 wingspan-rules-agent</div>
+              <div class="meta">v3.2.4 published · 24 versions · 2gg fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">📚 brass-birmingham-rulebook</div>
+              <div class="meta">v1.4 published · 12 versions · 5gg fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">🧰 hybrid-retriever-pipeline</div>
+              <div class="meta">v3.0-rc draft · 38 versions · 14m fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">📚 spirit-island-encyclopedia</div>
+              <div class="meta">v2.0 published · 8 versions · 18gg fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">🧰 prompt-template-house-rule</div>
+              <div class="meta">v1.2 published · 6 versions · 12gg fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">📚 tainted-grail-glossary</div>
+              <div class="meta">v1.0.3 published · 22 versions · 28gg fa</div>
+            </div>
+            <div class="art-row">
+              <div class="name">🧰 ocr-fallback-tesseract</div>
+              <div class="meta">v0.4 beta · 4 versions · 32gg fa</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: 14px">
+
+          <div class="admin-panel">
+            <div class="admin-panel-head">
+              <h3>🧰 ocr-pdf-toolkit · timeline versioni</h3>
+              <div style="display: flex; gap: 6px; align-items: center; margin-left: auto">
+                <span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">Compare:</span>
+                <span class="filter-chip active" style="color: hsl(var(--c-event))">v2.0.0</span>
+                <span style="color: var(--text-muted)">↔</span>
+                <span class="filter-chip active" style="color: hsl(var(--c-toolkit))">v2.1.0</span>
+                <button class="btn-admin sm">📑 View diff</button>
+              </div>
+            </div>
+            <div class="v-timeline">
+              <div class="v-row">
+                <div class="vtag draft">v2.2-rc</div>
+                <div><div class="commit">Sperimentale: Tesseract fallback per scan low-res</div><div class="commit-meta">commit a8f3c91 · 38m fa · by Aaron · ⚠ BREAKING (config field renamed)</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px"><span class="status-chip warning" style="font-size: 10px">draft</span></div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">14 changes</div>
+                <div><input type="checkbox" class="compare-checkbox"></div>
+              </div>
+
+              <div class="v-row" style="background: hsl(var(--c-toolkit) / .04); padding: 14px 12px; margin: 0 -12px; border-radius: 6px">
+                <div class="vtag published">v2.1.0</div>
+                <div><div class="commit" style="display: flex; align-items: center; gap: 6px">Improved table extraction in SmolDocling pipeline <span class="status-chip healthy" style="font-size: 10px">PUBLISHED</span></div><div class="commit-meta">commit e3f7a1c · 2026-05-22 · by Marco · 87 install · ratings 4.6 (24)</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px">prod</div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">+18 -3</div>
+                <div><input type="checkbox" checked class="compare-checkbox"></div>
+              </div>
+
+              <div class="v-row">
+                <div class="vtag">v2.0.0</div>
+                <div><div class="commit">SmolDocling primary parser (replaces unstructured-only)</div><div class="commit-meta">commit b1d4e02 · 2026-05-12 · by Marco · 142 install</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px">archived</div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">+84 -52</div>
+                <div><input type="checkbox" checked class="compare-checkbox"></div>
+              </div>
+
+              <div class="v-row">
+                <div class="vtag">v1.4.2</div>
+                <div><div class="commit">Fix encoding UTF-8 in italian PDFs</div><div class="commit-meta">commit f9c2d8a · 2026-04-28 · by Aaron · hotfix</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px">archived</div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">+6 -2</div>
+                <div><input type="checkbox" class="compare-checkbox"></div>
+              </div>
+
+              <div class="v-row">
+                <div class="vtag">v1.4.0</div>
+                <div><div class="commit">Initial SmolDocling support (opt-in flag)</div><div class="commit-meta">commit c8b2e91 · 2026-04-12 · by Marco</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px">archived</div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">+24 -8</div>
+                <div><input type="checkbox" class="compare-checkbox"></div>
+              </div>
+
+              <div class="v-row" style="border-bottom: 0">
+                <div class="vtag">v1.0.0</div>
+                <div><div class="commit">Initial release · Unstructured.io parser</div><div class="commit-meta">commit a1c4f78 · 2026-01-08 · by Marco</div></div>
+                <div style="font-family: var(--f-mono); font-size: 11px">init</div>
+                <div style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">init</div>
+                <div></div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Diff viewer -->
+          <div class="diff-card">
+            <div class="diff-head">
+              <strong style="font-family: var(--f-display); font-size: 14px">📑 Diff viewer</strong>
+              <div class="diff-versions"><span class="v1">v2.0.0</span> → <span class="v2">v2.1.0</span></div>
+              <div style="margin-left: auto; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted)">config/pipeline.yaml · +18 -3</div>
+              <button class="btn-admin sm">⤓ Patch .diff</button>
+              <button class="btn-admin sm">↩ Restore v2.0.0</button>
+            </div>
+            <div class="diff-body">
+              <div class="diff-side left">
+                <div class="diff-line neutral"><span class="lno">14</span>pipeline:</div>
+                <div class="diff-line neutral"><span class="lno">15</span>  parsers:</div>
+                <div class="diff-line del"><span class="lno">16</span>- - unstructured</div>
+                <div class="diff-line del"><span class="lno">17</span>-   version: ^0.18.0</div>
+                <div class="diff-line neutral"><span class="lno">18</span>  layout:</div>
+                <div class="diff-line del"><span class="lno">19</span>- engine: tesseract-only</div>
+                <div class="diff-line neutral"><span class="lno">20</span>  chunker:</div>
+                <div class="diff-line neutral"><span class="lno">21</span>    size: 512</div>
+                <div class="diff-line neutral"><span class="lno">22</span>    overlap: 64</div>
+              </div>
+              <div class="diff-side">
+                <div class="diff-line neutral"><span class="lno">14</span>pipeline:</div>
+                <div class="diff-line neutral"><span class="lno">15</span>  parsers:</div>
+                <div class="diff-line add"><span class="lno">16</span>+ - smol-docling</div>
+                <div class="diff-line add"><span class="lno">17</span>+   version: ^1.2.0</div>
+                <div class="diff-line add"><span class="lno">18</span>+   table_extract: aggressive</div>
+                <div class="diff-line add"><span class="lno">19</span>+ - unstructured</div>
+                <div class="diff-line add"><span class="lno">20</span>+   version: ^0.18.3</div>
+                <div class="diff-line neutral"><span class="lno">21</span>  layout:</div>
+                <div class="diff-line add"><span class="lno">22</span>+ engine: smol-docling</div>
+                <div class="diff-line add"><span class="lno">23</span>+ fallback: tesseract</div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+<script src="admin-nav.js"></script><script>renderAdminNav('versions');</script>
+</body></html>

--- a/admin-mockups/design_handoff_admin/admin/tokens.css
+++ b/admin-mockups/design_handoff_admin/admin/tokens.css
@@ -1,0 +1,201 @@
+/* MeepleAI Design System v1 — Design Tokens
+   Source of truth for all colors, spacing, type, motion.
+   Light & dark variants via [data-theme] attr on <html>. */
+
+:root {
+  /* ─── Entity Colors (HSL triplets for alpha composability) ─── */
+  --c-game:    25 95% 45%;
+  --c-player:  262 83% 58%;
+  --c-session: 240 60% 55%;
+  --c-agent:   38 92% 50%;
+  --c-kb:      174 60% 40%;
+  --c-chat:    220 80% 55%;
+  --c-event:   350 89% 60%;
+  --c-toolkit: 142 70% 45%;
+  --c-tool:    195 80% 50%;
+
+  /* ─── Semantic Colors ─── */
+  --c-success: 142 70% 45%;
+  --c-warning: 38 92% 50%;
+  --c-danger:  350 89% 60%;
+  --c-info:    220 80% 55%;
+
+  /* ─── Brand ─── */
+  --brand: var(--c-game);
+  --brand-fg: hsl(var(--c-game));
+
+  /* ─── Typography ─── */
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body:    'Nunito', system-ui, sans-serif;
+  --f-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --fs-xs:   11px;
+  --fs-sm:   12px;
+  --fs-base: 14px;
+  --fs-md:   15px;
+  --fs-lg:   17px;
+  --fs-xl:   20px;
+  --fs-2xl:  24px;
+  --fs-3xl:  32px;
+  --fs-4xl:  40px;
+
+  --fw-reg:  400;
+  --fw-med:  500;
+  --fw-semi: 600;
+  --fw-bold: 700;
+  --fw-ext:  800;
+
+  --lh-tight: 1.2;
+  --lh-snug:  1.35;
+  --lh-body:  1.5;
+  --lh-relax: 1.65;
+
+  /* ─── Spacing (4px grid) ─── */
+  --s-0: 0;
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-7: 32px;
+  --s-8: 40px;
+  --s-9: 48px;
+  --s-10: 64px;
+
+  /* ─── Radius ─── */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 18px;
+  --r-2xl: 24px;
+  --r-pill: 9999px;
+
+  /* ─── Motion ─── */
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+  --ease-in-out: cubic-bezier(.65, 0, .35, 1);
+  --ease-spring: cubic-bezier(.34, 1.56, .64, 1);
+  --dur-xs: 120ms;
+  --dur-sm: 180ms;
+  --dur-md: 280ms;
+  --dur-lg: 400ms;
+  --dur-xl: 600ms;
+
+  /* ─── Z-index ─── */
+  --z-base: 0;
+  --z-sticky: 10;
+  --z-nav: 20;
+  --z-overlay: 50;
+  --z-drawer: 51;
+  --z-modal: 60;
+  --z-toast: 70;
+  --z-tooltip: 80;
+}
+
+/* ─── LIGHT THEME (default) ─── */
+:root, :root[data-theme="light"] {
+  --bg:        #f7f3ee;
+  --bg-card:   #ffffff;
+  --bg-muted:  #efe6d9;
+  --bg-sunken: #ede2d0;
+  --bg-hover:  rgba(180, 130, 80, 0.06);
+
+  --text:       #2b1f12;
+  --text-sec:   #5a4a38;
+  --text-muted: #9a8870;
+
+  --border:       rgba(180, 130, 80, 0.18);
+  --border-light: rgba(180, 130, 80, 0.1);
+  --border-strong: rgba(180, 130, 80, 0.32);
+
+  --shadow-xs: 0 1px 2px rgba(90, 60, 20, 0.06);
+  --shadow-sm: 0 2px 8px rgba(90, 60, 20, 0.08);
+  --shadow-md: 0 4px 16px rgba(90, 60, 20, 0.1);
+  --shadow-lg: 0 12px 36px rgba(90, 60, 20, 0.14);
+  --shadow-drawer: 0 -8px 32px rgba(90, 60, 20, 0.12);
+
+  --glass-bg: rgba(255, 255, 255, 0.88);
+  --glass-border: rgba(255, 255, 255, 0.6);
+
+  color-scheme: light;
+}
+
+/* ─── DARK THEME ─── */
+:root[data-theme="dark"] {
+  --bg:        #14100a;
+  --bg-card:   #1e1710;
+  --bg-muted:  #241c13;
+  --bg-sunken: #0f0c08;
+  --bg-hover:  rgba(255, 200, 130, 0.05);
+
+  --text:       #f0e4d2;
+  --text-sec:   #c8b896;
+  --text-muted: #8a7860;
+
+  --border:       rgba(224, 180, 110, 0.14);
+  --border-light: rgba(224, 180, 110, 0.08);
+  --border-strong: rgba(224, 180, 110, 0.28);
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6);
+  --shadow-drawer: 0 -8px 32px rgba(0, 0, 0, 0.5);
+
+  --glass-bg: rgba(30, 22, 14, 0.85);
+  --glass-border: rgba(224, 180, 110, 0.14);
+
+  /* lighter entity colors for dark bg contrast */
+  --c-game:    28 95% 58%;
+  --c-player:  262 75% 70%;
+  --c-session: 235 70% 70%;
+  --c-agent:   38 92% 62%;
+  --c-kb:      174 60% 55%;
+  --c-chat:    218 80% 68%;
+  --c-event:   350 85% 70%;
+  --c-toolkit: 142 60% 58%;
+  --c-tool:    195 75% 62%;
+
+  color-scheme: dark;
+}
+
+/* ─── Reset / Base ─── */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--f-body);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--fs-base);
+  line-height: var(--lh-body);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background var(--dur-md) var(--ease-out), color var(--dur-md) var(--ease-out);
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--f-display);
+  font-weight: var(--fw-bold);
+  letter-spacing: -0.01em;
+  margin: 0;
+  line-height: var(--lh-tight);
+}
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: 0.9em; }
+
+/* ─── Entity utility classes ─── */
+.e-game    { --e: var(--c-game); }
+.e-player  { --e: var(--c-player); }
+.e-session { --e: var(--c-session); }
+.e-agent   { --e: var(--c-agent); }
+.e-kb      { --e: var(--c-kb); }
+.e-chat    { --e: var(--c-chat); }
+.e-event   { --e: var(--c-event); }
+.e-toolkit { --e: var(--c-toolkit); }
+.e-tool    { --e: var(--c-tool); }
+
+.e-fg   { color: hsl(var(--e)); }
+.e-bg   { background: hsl(var(--e)); color: #fff; }
+.e-tint { background: hsl(var(--e) / 0.1); color: hsl(var(--e)); }
+.e-ring { box-shadow: 0 0 0 2px hsl(var(--e) / 0.35); }

--- a/docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md
+++ b/docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md
@@ -1,0 +1,223 @@
+# SP5 Admin Console — Consolidamento IA + Re-skin (Design)
+
+**Date:** 2026-05-24
+**Status:** draft (pending user review)
+**Scope:** Integrazione dei mockup admin SP5 nel codebase MeepleAI **non** come rebuild greenfield, ma come (a) consolidamento dell'Information Architecture admin esistente e (b) re-skin verso il look-and-feel SP5, sopra i ~220 componenti admin e i ~90 `page.tsx` già in produzione. Output di questo documento: il design da cui derivare i plan d'implementazione (`writing-plans`). Nessun codice di prodotto è toccato in questa fase.
+**Predecessors:**
+- `admin-mockups/design_handoff_admin/ADMIN_AUDIT.md` — audit read-only del codebase vs handoff (verdetto: non-greenfield, handoff sovrastima, 10 decisioni aperte R1-R10).
+- `admin-mockups/design_handoff_admin/SCREENS.md` — inventario 18 mockup SP5 + 13 surplus, route attese, endpoint, priorità.
+- `admin-mockups/design_handoff_admin/SURPLUS_DESIGN_PROMPTS.md` — prompt-pack + inventario dei 13 mockup "surplus" (funzioni admin reali prive di mockup SP5).
+- Colloquio decisioni **R1-R10** (2026-05-24) — tutte risolte; sintetizzate in §3.
+
+---
+
+## 1. Goal
+
+Trasformare l'admin console attuale — funzionalmente ricca ma con **Information Architecture frammentata** (3 pattern di routing coesistenti, funzioni raggiungibili da 2-3 path, ~90 `page.tsx` ma ~20 voci in nav) — in una console **consolidata e ri-skinnata**:
+
+1. **Un path canonico per funzione**, con redirect dai duplicati (decisione R7).
+2. **Una sidebar unica a 4 gruppi (A/B/C/D)**, filtrata per ruolo, sostituendo il drawer off-canvas + nav curata attuale.
+3. **Re-skin SP5**: token canonici, shell sidebar-persistente (desktop ≥lg) + drawer (mobile), dark default scoped `/admin/*`, density alta.
+4. **Riuso massimo** dei componenti esistenti (~33-36 dei 38 "nuovi" del handoff già coperti), creando solo il delta reale.
+
+Il valore: ridurre il carico cognitivo di navigazione, dare coerenza visiva, e preparare il terreno per le ondate di feature senza moltiplicare la confusione di IA (rischio R7 esplicito nell'audit).
+
+## 2. Non-goals
+
+- ❌ **Rebuild greenfield.** Il handoff lo presume; l'audit lo smentisce. Si lavora sul **delta**.
+- ❌ **Enforcement dell'hardening di sicurezza.** Step-up 2FA strict, schema audit esteso, impersonate token 15min + claim actor, disambiguazione doppia entity `AuditLog` → **track separato** (§7), non bloccante per il re-skin. In questa fase: solo UI-ready dove serve (R5).
+- ❌ **B8 Dev-tools** (`/dev`, scenario/auth-switcher/store-inspector): concetto SP5 assente nel prodotto, P3 dev-only → fuori scope di questa iterazione.
+- ❌ **`MobileFallback` "desktop-only gate"**: la shell è responsive (sidebar↔drawer), non serve un gate desktop-only (decisione colloquio: shell ibrida).
+- ❌ **Normalizzazione del backend** verso le convenzioni del handoff (`/api/admin`, PATCH, cursor, `/me/...`). Il FE si allinea ai **path reali** (`/api/v1`, PUT, page/limit, `/play-records`); il BE resta as-is (R8).
+- ❌ **Content Moderation backend** (gruppo 0% nell'audit). La schermata A3 resta `🟡 partial` finché il BC moderation non esiste; non lo costruiamo in questa iterazione (vedi §5/§9, ondata dedicata o backlog).
+- ❌ Modifica del modello ruoli: si **mantengono i 5 ruoli reali** (`user/editor/creator/admin/superadmin`); `premium` resta `UserTier` (R1).
+
+## 3. Decisioni di contesto (fondamenta già fissate)
+
+Sintesi del colloquio R1-R10 (dettaglio e razionale in `ADMIN_AUDIT.md §9`). Sono **input vincolanti** di questo design, non più aperte:
+
+| Rif | Decisione | Effetto sul design |
+|-----|-----------|--------------------|
+| **R1** | `premium` = `UserTier`, non ruolo | Matrice RBAC su 5 ruoli reali; nessun 4° ruolo `premium`. |
+| **R2** | `editor`/`creator` = accesso parziale curato | Sidebar **filtra le voci per ruolo** (§4.4). |
+| **R3** | Audit as-is ora | Schema audit esteso + disambiguazione doppia entity → track sicurezza (§7). |
+| **R4** | Impersonate riusa as-is | Hardening token 15min + claim actor → track sicurezza (§7). Banner UI può usare `SessionStatusDto`. |
+| **R5** | Step-up UI-ready ora, enforcement dopo | Si predispone la UI del modal step-up; il behavior resta shadow finché §7 non lo rende strict. |
+| **R7** | Sidebar 4 gruppi A/B/C/D + duplicati → canonico + redirect | Cuore del consolidamento (§4.1, §4.2). |
+| **R8** | FE segue i path reali | Contratto API in §8; nessuna modifica BE. |
+| **R9** | Dark default scoped admin | `[data-theme="dark"]` applicato solo sotto `/admin/*` (§4.3). |
+| **R10** | Sequenza fondamenta → pilota (A1→A2) → ondate; sicurezza track separato | Rollout in §9. |
+
+## 4. Architettura del consolidamento
+
+> **Principio guida (input utente 2026-05-24): l'estetica prima della struttura.** Dei mockup SP5/surplus conta la **parte estetica da mantenere** — palette/token, layout visivo, density, trattamento visivo dei componenti. L'**Information Architecture e il routing** possono invece **divergere dal mockup** quando il consolidamento lo richiede (es. hub `?tab=` al posto di voci top-level separate). Questo principio risolve D-1 e governa tutte le scelte di §4: re-skin fedele al look, IA libera di consolidare.
+
+### 4.1 Information Architecture — sidebar a 4 gruppi
+
+31 schermate totali (18 SP5 + 13 surplus) organizzate in 4 gruppi di navigazione. La sorgente di verità della nav è `admin-mockups/design_handoff_admin/admin-nav.js` (già esteso con i gruppi C/D).
+
+| Gruppo | Etichetta nav | Schermate | Focus |
+|--------|---------------|-----------|-------|
+| **A** | Admin Console | A1-A9 (10) | Operatività quotidiana: overview, utenti, moderazione, AI/RAG, KB, catalog, config, monitor, notifiche |
+| **B** | Power-User Tools | B1-B7 (7, B8 escluso) | Editing avanzato: editor, pipeline, n8n, upload, play-records, versions, private-games |
+| **C** | Platform & Operations | C1-C7 (7) | Infra/ops: containers, database-sync, providers, emergency, budget, secrets, alerts |
+| **D** | AI Tooling & Data Quality | D1-D6 (6) | Strumenti AI: mechanic-extractor, sandbox, A/B test, prompts, rag-backup, integrations |
+
+### 4.2 Path canonici + redirect (de-duplicazione IA)
+
+**Principio (R7):** ogni funzione ha **un solo path canonico**; i path alternativi diventano **redirect** (Next.js `redirect()` o `next.config.js` `redirects`). Casi di duplicazione noti dall'audit §6 e canonico proposto:
+
+| Funzione | Path oggi (duplicati) | Canonico proposto | Redirect da → a |
+|----------|-----------------------|-------------------|-----------------|
+| AI/RAG quality (A4) | `/admin/ai?tab=rag` · `/admin/agents/inspector` · `/admin/rag-quality` | `/admin/ai` (hub, tab `rag`/`agents`/`quality`) | `agents/inspector` → `ai?tab=agents`; `rag-quality` → `ai?tab=rag` |
+| KB management (A5) | `/admin/content?tab=kb` · `/admin/knowledge-base` | `/admin/knowledge-base` | `content?tab=kb` → `knowledge-base` |
+| Content (A3) | `/admin/content` (oggi = gestione giochi/KB, **non** moderation) | `/admin/content` per moderation; gestione-giochi resta sotto i propri path | n/a (A3 partial finché BC moderation assente) |
+
+> **Decisione presa (input utente 2026-05-24):** per A4 si adotta l'**hub `?tab=` esistente** come canonico (pattern dominante, 9 tab già implementati), con redirect dai duplicati — **non** si moltiplicano le voci top-level del mockup. Razionale: conta l'estetica, non la struttura nav (principio §4). I restanti deconflitti path (B1/B2/B6 fuori da `/admin`, vedi §5) si risolvono **per ondata** nei rispettivi plan, applicando lo stesso principio canonico+redirect.
+
+### 4.3 Shell + re-skin
+
+- **Shell ibrida** (decisione colloquio): **sidebar persistente** su desktop (≥lg, breakpoint Tailwind) + **drawer off-canvas** su mobile. Punto di partenza: `apps/web/src/components/layout/AdminShell/AdminShell.tsx` (oggi `TopBar` + `AdminSideDrawer` overlay). Si estende `AdminSideDrawer` a comportamento responsive sidebar↔drawer, **non** si crea una shell nuova.
+- **Token**: solo token canonici (`bg-background`, `bg-card`, `bg-muted`, `text-foreground`, `border-border`, entity `bg-entity-*`). Vietato hardcoded color utility (ESLint `local/no-hardcoded-color-utility`, mode error). I mockup SP5/surplus usano già una palette solo-token (`tokens.css` + `admin-base.css`), allineata.
+- **Dark default scoped** (R9): `[data-theme="dark"]` forzato sotto `/admin/*` (es. nel layout admin), mantenendo il **default light** del resto del prodotto. Toggle utente disponibile.
+- **Density alta**: spacing/typography ridotti admin-wide. Da valutare se via utility scoped o (eventuale) density system — è uno dei ~2-3 componenti realmente nuovi (§6).
+
+### 4.4 RBAC e filtro sidebar per ruolo (R2)
+
+- Gate backend **riusati as-is**: `RequireAdminSession()`, `RequireSuperAdminSession()`, `RequireAdminOrEditorSession()`; policy `RequireSuperAdmin`/`RequireAdminOrAbove`/`RequireEditorOrAbove`. Gerarchia `SuperAdmin(4) > Admin(3) > Editor(2) > Creator(1) > User(0)`.
+- **Sidebar filtrata per ruolo**: ogni voce di nav dichiara un `minRole`; la sidebar nasconde le voci sopra il ruolo dell'utente. `editor`/`creator` vedono un sottoinsieme curato (R2). I path `superadmin`-only (es. C2 database-sync, C4 emergency, C6 secrets) restano gated sia in nav sia a livello endpoint.
+- Nessun nuovo meccanismo di gate: per i nuovi endpoint admin si standardizza su quello esistente.
+
+## 5. Mappa schermate (31) — stato FE e path canonico
+
+Stato dall'audit §6 (FE: ✅ full · 🟡 partial · ❌ assente). Per C/D il **backend esiste** (aree admin "EXTRA" dell'audit §5); il lavoro FE è skin/consolidamento.
+
+### Gruppo A — Admin Console
+
+| ID | Funzione | Path canonico | Stato FE | P |
+|----|----------|---------------|----------|---|
+| A1 | Overview | `/admin/overview` | ✅ | P0 |
+| A2 | Users + drill | `/admin/users` · `/admin/users/[id]` | 🟡 (wiring delete/impersonate da verificare) | P0 |
+| A3 | Content moderation | `/admin/content` | 🟡 (BC moderation 0% → no queue) | P1 |
+| A4 | AI/RAG quality | `/admin/ai` (tab) | ✅ | P0 |
+| A5 | KB management | `/admin/knowledge-base` | ✅ | P0 |
+| A5b | KB upload flow | `/admin/knowledge-base/upload` | ✅ | P0 |
+| A6 | Catalog ingestion | `/admin/catalog-ingestion` | ✅ | P1 |
+| A7 | Config/Flags | `/admin/config?tab=flags` | ✅ (dirty-bar da verificare) | P1 |
+| A8 | Monitor + LiveEventLog | `/admin/monitor` | ✅ (LiveEventLog UI da assemblare) | P1 |
+| A9 | Notifications | `/admin/notifications` | 🟡 (template scollegati da compose) | P2 |
+
+### Gruppo B — Power-User Tools
+
+| ID | Funzione | Path canonico (proposto) | Stato FE | P |
+|----|----------|--------------------------|----------|---|
+| B1 | Editor | `/admin/editor/[type]/[id]` (oggi fuori `/admin`, `?gameId=`) | 🟡 | P1 |
+| B2 | Pipeline builder | `/admin/pipeline-builder/[id]` (oggi fuori `/admin`) | 🟡 | P2 |
+| B3 | n8n | `/admin/n8n` | 🟡 (no workflow/webhook log) | P2 |
+| B4 | Upload avanzato | `/admin/upload` (overlap con A5b) | 🟡 | P1 |
+| B5 | Play records | `/play-records` (index mancante) | 🟡 | P2 |
+| B6 | Versions | `/admin/versions/[artifact]` (oggi fuori `/admin`) | 🟡 | P1 |
+| B7 | Private games | `/private-games` (index + checklist mancanti) | 🟡 | P2 |
+| ~~B8~~ | ~~Dev tools~~ | — | ❌ fuori scope | P3 |
+
+### Gruppo C — Platform & Operations (surplus)
+
+| ID | Funzione | Path canonico | Min role | P |
+|----|----------|---------------|----------|---|
+| C1 | Infra/containers | `/admin/monitor/containers` | admin | P1 |
+| C2 | Database-sync | `/admin/database-sync` · `/admin/staging-access` | superadmin | P1 |
+| C3 | Providers | `/admin/providers` | admin (rotate=superadmin) | P0 |
+| C4 | Emergency | `/admin/llm/emergency` | superadmin + step-up | P1 |
+| C5 | Budget | `/admin/business` | admin | P1 |
+| C6 | Secrets | `/admin/secrets` | superadmin + step-up | P1 |
+| C7 | Alerts | `/admin/monitor` (tab alerts) | admin | P1 |
+
+### Gruppo D — AI Tooling & Data Quality (surplus)
+
+| ID | Funzione | Path canonico | Min role | P |
+|----|----------|---------------|----------|---|
+| D1 | Mechanic extractor | `/admin/knowledge-base/mechanic-extractor` | admin | P1 (UI base già a PR#547) |
+| D2 | Sandbox / debug-chat | `/admin/agents/sandbox` · `/admin/agents/debug-chat` | admin | P2 |
+| D3 | A/B testing | `/admin/agents/ab-testing` | admin | P2 |
+| D4 | Prompts | `/admin/agents/prompts` | admin | P2 |
+| D5 | RAG-backup / seeding | `/admin/rag-backup` · `/admin/seeding` | admin (seed=superadmin) | P2 |
+| D6 | Integrations | `/admin/slack` · `/admin/content/email-templates` | admin | P2 |
+
+## 6. Componenti — riuso vs nuovi, collocazione
+
+Dall'audit §7: **~33-36/38 già coperti**. Dettaglio:
+
+- **Riuso diretto (✅):** AdminShell, `TopBar`, `BulkActionBar`, `KPICard`/`KPIStatCard`, `Card`, `Tabs`/`AdminHubTabBar`, `UserRoleBadge` (5 ruoli), `Badge`+status-badge, primitives form, `RetrievedChunkCard`, `WaterfallChart`, `PdfViewerModal`, `PdfStatusTimeline`, `AdminConfirmationDialog`, `AuditTab`/`UserActivityTimeline`, version timeline/diff (`components/diff/`), ReactFlow (`@xyflow/react`, 2 impl.), Tiptap `RichTextEditor`, `FeatureFlagsTab`.
+- **Adattamento/estensione (🟡):** `AdminSideDrawer` → sidebar responsive; `DataTable` → +pagination +virtualization (`react-window ^2.2.7`); KPISparkline (wrapper Recharts); EnvPill, StatusDot, QueryDrillDown, ChunkTable, IngestionLog, SyncStatusHero, DirtyStateBar, LiveEventLog (UI su SSE esistente), `DateRangePicker`+presets, PreviewFrame, `setup-checklist`→PublishChecklist, DangerZoneBox.
+- **Da creare ex-novo (❌, ~2-3):** **KBTree** (tree-view file/cartelle, per A5), **density system** admin-wide (se confermato in §4.3), eventuale parametrizzazione di `AdminConfirmationDialog` (oggi hardcoda `CONFIRM` → serve "type the resource name").
+
+**Collocazione (freeze de-versioning attivo — NO `components/v2/`):**
+- Primitive trasversali → `apps/web/src/components/ui/<primitive>/` (es. `ui/status-dot/`, `ui/sparkline/`; esiste già `ui/admin/`).
+- Composizioni admin → `apps/web/src/components/admin/<feature>/`.
+- ❌ Vietato `components/admin/v2/`, `components/v2/**`, `components/ui/v2/**`.
+
+## 7. Track sicurezza separato (non bloccante)
+
+Hardening tracciato a parte (R3/R4/R5), **non blocca** re-skin/consolidamento. Backlog ordinato:
+
+1. **Schema audit** (R3): aggiungere `impersonated_user_id`, `before_json`, `after_json`, `step_up_token_id`; allargare/sostituire `Details` (1024 char). **Prima** disambiguare la doppia entity `AuditLog` (`Administration` usata vs `SecurityAudit`) — verifica tecnica "quale è canonica".
+2. **Impersonate token** (R4): estendere `Session` con `ImpersonatedByUserId` + `ImpersonatedUntil` + lifetime 15min; banner persistente via `SessionStatusDto`.
+3. **Step-up strict** (R5): `LastTotpVerifiedAt` su `Session`; endpoint challenge → `step_up_token`; header `X-StepUp-Token` + validazione; behavior shadow→strict (403 `STEP_UP_REQUIRED`, MaxAge 30→5); coprire trigger (rotate key, emergency shutdown, mass delete >5, change flag prod, promote→superadmin). UI predisposta già in questa fase (R5).
+
+## 8. Contratto API (FE → path reali, R8)
+
+Il FE consuma i path **reali** del backend, senza chiedere normalizzazione:
+
+| Tema | Handoff SP5 | Reale (il FE usa questo) |
+|------|-------------|--------------------------|
+| Prefisso | `/api/admin/*` | `/api/v1/admin/*` |
+| Update | `PATCH` | `PUT` / `POST .../toggle` |
+| Paginazione | cursor | page/limit |
+| Endpoint personali | `/api/me/play-records`, `/api/me/private-games` | `/play-records`, `/private-games` |
+| Sessione | JWT short-lived | cookie + session table (hash, 30gg) |
+
+Gap endpoint reali da colmare per le rispettive schermate (audit §5): SSE `events/live` globale (A8), `force-logout` + `GET .../sessions` (A2), `flag-hallucination` (A4), `kb/tree` + `docs/{id}/chunks` + `idempotency-check` (A5), `DELETE` play-records (B5), `publish-checklist` private-games (B7). Ciascuno è dettagliato nel plan dell'ondata che lo richiede.
+
+## 9. Sequenza di rollout (R10)
+
+```
+Fondamenta → Pilota A1 → A2 (stress-test sicurezza) → Ondate per gruppo
+```
+
+| Fase | Contenuto | Obiettivo |
+|------|-----------|-----------|
+| **F0 — Fondamenta** | Shell sidebar-responsive + 4 gruppi nav (filtro ruolo) + token/dark scoped + density; redirect de-duplicazione IA (§4.2) | Valida shell + design-system SP5 senza dipendere da nuovi endpoint/RBAC |
+| **F1 — Pilota A1** | Overview re-skin (già full, basso rischio) | Valida il workflow mock SP5 → componente end-to-end |
+| **F2 — A2 Users** | Lista (DataTable +pagination +virtualization) + drill + impersonate (banner) + delete typed-confirm + step-up UI + audit timeline | Stress-test di tutti i pattern rischiosi prima di scalare |
+| **F3 — Ondata KB/AI** | A5 (KBTree), A5b, A4, D1 mechanic-extractor | Cluster knowledge/AI |
+| **F4 — Ondata Ops** | A6, A7, A8 + LiveEventLog, C1/C3/C5/C7 | Operatività/monitoring |
+| **F5 — Ondata Tools** | B1, B4, B6 (rientro sotto `/admin`); A9 notifications | Power-user editing |
+| **F6 — Ondata avanzata** | B2, B3, B5, B7; C2/C4/C6 (superadmin), D2-D6 | Resto + superadmin-gated |
+| **Track ⊥** | Sicurezza (§7) | Parallelo, non bloccante |
+
+A3 Content moderation resta in attesa del BC moderation (fuori scope corrente) → backlog/ondata dedicata.
+
+## 10. Rischi e decisioni residue
+
+| # | Rischio/decisione | Stato |
+|---|-------------------|-------|
+| D-1 | A4: hub `?tab=` canonico vs route separate 1:1 (§4.2) | ✅ **Risolta**: hub canonico — input utente "conta l'estetica, non la struttura nav" (§4 principio guida) |
+| D-2 | Density: utility scoped vs density system dedicato (§4.3) | Da decidere in F0 |
+| D-3 | A3 moderation: BC backend assente → schermata resta partial | Accettato (fuori scope) |
+| D-4 | Doppia entity `AuditLog` canonica | Verifica tecnica nel track sicurezza (§7) |
+| D-5 | Redirect di massa (`agents/inspector`, `rag-quality`, `content?tab=kb`): rischio link rotti interni/esterni | Censire i referrer prima di applicare (plan F0) |
+| D-6 | Stato 🟡 di A2/A7/A8: "da verificare" wiring → confermare con lettura mirata in fase di plan | Risolto nei plan d'ondata |
+
+## 11. Riferimenti
+
+- Audit: `admin-mockups/design_handoff_admin/ADMIN_AUDIT.md`
+- Inventario schermate + endpoint: `admin-mockups/design_handoff_admin/SCREENS.md`
+- Prompt-pack surplus: `admin-mockups/design_handoff_admin/SURPLUS_DESIGN_PROMPTS.md`
+- Nav (sorgente di verità gruppi): `admin-mockups/design_handoff_admin/admin-nav.js`
+- Mockup HTML: `admin-mockups/design_handoff_admin/admin/sp5-*.html`
+- Token: `admin-mockups/design_handoff_admin/admin/tokens.css` + `admin-base.css`
+- Freeze de-versioning + token canonici: `CLAUDE.md` (§ AI Assistant Rules)
+
+---
+
+*Design prodotto da sintesi audit + decisioni R1-R10. Nessuna modifica al codice di prodotto. Prossimo passo: review utente di questo documento → `writing-plans` per i plan d'implementazione (a partire da F0 Fondamenta + F1 Pilota A1).*

--- a/docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md
+++ b/docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md
@@ -54,7 +54,7 @@ Sintesi del colloquio R1-R10 (dettaglio e razionale in `ADMIN_AUDIT.md §9`). So
 
 ### 4.1 Information Architecture — sidebar a 4 gruppi
 
-31 schermate totali (18 SP5 + 13 surplus) organizzate in 4 gruppi di navigazione. La sorgente di verità della nav è `admin-mockups/design_handoff_admin/admin-nav.js` (già esteso con i gruppi C/D).
+31 schermate totali (18 SP5 + 13 surplus) organizzate in 4 gruppi di navigazione. La sorgente di verità della nav è `admin-mockups/design_handoff_admin/admin/admin-nav.js` (già esteso con i gruppi C/D). ⚠️ La copia a livello root `design_handoff_admin/admin-nav.js` è **parziale/stale** (solo gruppi A+B): non usarla — il canonico è quello in `admin/`.
 
 | Gruppo | Etichetta nav | Schermate | Focus |
 |--------|---------------|-----------|-------|
@@ -213,7 +213,7 @@ A3 Content moderation resta in attesa del BC moderation (fuori scope corrente) �
 - Audit: `admin-mockups/design_handoff_admin/ADMIN_AUDIT.md`
 - Inventario schermate + endpoint: `admin-mockups/design_handoff_admin/SCREENS.md`
 - Prompt-pack surplus: `admin-mockups/design_handoff_admin/SURPLUS_DESIGN_PROMPTS.md`
-- Nav (sorgente di verità gruppi): `admin-mockups/design_handoff_admin/admin-nav.js`
+- Nav (sorgente di verità gruppi): `admin-mockups/design_handoff_admin/admin/admin-nav.js` (la copia a livello root è stale: solo A+B)
 - Mockup HTML: `admin-mockups/design_handoff_admin/admin/sp5-*.html`
 - Token: `admin-mockups/design_handoff_admin/admin/tokens.css` + `admin-base.css`
 - Freeze de-versioning + token canonici: `CLAUDE.md` (§ AI Assistant Rules)


### PR DESCRIPTION
Docs-only. Nessun codice di prodotto toccato.

## Cosa contiene

Pacchetto di handoff + design per l'integrazione della **admin console SP5**, traccia **separata dal demo utente** (`admin-mockups/design_handoff/`, PR #1462).

**Commit `2ee3959bf` — handoff** (`admin-mockups/design_handoff_admin/`, 46 file):
- 18 mockup SP5 + 13 mockup "surplus" (gruppi C Platform & Operations + D AI Tooling & Data Quality)
- `ADMIN_AUDIT.md` — audit read-only codebase vs handoff. Verdetto: **non greenfield** (admin console già estesa: ~90 `page.tsx`, ~220 componenti, BC Administration con audit log + impersonate + 2FA TOTP + gate superadmin). Dei ~38 componenti "nuovi" del handoff, ~33-36 già coperti.
- `SURPLUS_DESIGN_PROMPTS.md`, `RBAC.md`, `admin-nav.js`, token/css.

**Commit `cb676abb6` — spec** (`docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md`):
- Consolidamento IA + re-skin (NON rebuild greenfield). Sidebar 4 gruppi A/B/C/D, path canonici + redirect, shell sidebar-responsive (desktop) + drawer (mobile), dark default scoped `/admin/*`.
- Mappa 31 schermate con stato FE; componenti riuso vs nuovi; contratto API (FE segue i path reali `/api/v1`); track sicurezza separato; rollout F0 Fondamenta → F1 Pilota A1 → F2 A2 → ondate F3-F6.
- Decisioni R1-R10 + principio guida: **re-skin fedele all'estetica dei mockup, IA libera di consolidare**.

## Note

- Le due cartelle `design_handoff/` (demo utente, 71 schermate) e `design_handoff_admin/` (admin, 18+13) condividono i nomi-file solo per struttura-pacchetto comune; i contenuti sono distinti. Condividono il design system (token canonici + 9 entity colors).
- GitGuardian: leak-check negativo sui mockup secrets/integrations (push passato pulito).
- Rispetta il freeze de-versioning: nessun `components/v2/**`.

## Prossimi passi (post-merge)

`writing-plans` per **F0 Fondamenta** (shell + sidebar 4 gruppi + token/dark scoped + redirect de-duplicazione IA) e **F1 Pilota A1 Overview**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
