### PR TITLE
feat(api): #1467 GET /games/{id}/leaderboard — social game leaderboard

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Repositories/IGroupMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Repositories/IGroupMemoryRepository.cs
@@ -9,6 +9,13 @@ internal interface IGroupMemoryRepository
 {
     Task<GroupMemory?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task<IReadOnlyList<GroupMemory>> GetByCreatorIdAsync(Guid creatorId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the ids of the groups the given user is a member of (the inverse of
+    /// <see cref="GetByCreatorIdAsync"/>). Used by the game leaderboard (#1467) to resolve
+    /// the set of Group-visible play records the user is allowed to see.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetGroupIdsForUserAsync(Guid userId, CancellationToken ct = default);
     Task AddAsync(GroupMemory memory, CancellationToken ct = default);
     Task UpdateAsync(GroupMemory memory, CancellationToken ct = default);
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepository.cs
@@ -45,6 +45,36 @@ internal sealed class GroupMemoryRepository : RepositoryBase, IGroupMemoryReposi
         return entities.Select(MapToDomain).ToList();
     }
 
+    public async Task<IReadOnlyList<Guid>> GetGroupIdsForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            return Array.Empty<Guid>();
+        }
+
+        // Members are persisted as a JSONB blob (MembersJson), not a relational table, so
+        // membership cannot be filtered in SQL. Load candidate groups and filter in-memory.
+        // Acceptable for MVP volumes; revisit with a JSONB containment query if group counts grow.
+        var candidates = await DbContext.GroupMemories
+            .AsNoTracking()
+            .Where(e => e.MembersJson != null)
+            .Select(e => new { e.Id, e.MembersJson })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var groupIds = new List<Guid>();
+        foreach (var candidate in candidates)
+        {
+            var members = JsonSerializer.Deserialize<List<GroupMemberDto>>(candidate.MembersJson!);
+            if (members != null && members.Any(m => m.UserId == userId))
+            {
+                groupIds.Add(candidate.Id);
+            }
+        }
+
+        return groupIds;
+    }
+
     public async Task AddAsync(GroupMemory memory, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(memory);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/Leaderboard/GameLeaderboardResponse.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/Leaderboard/GameLeaderboardResponse.cs
@@ -1,0 +1,46 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.Leaderboard;
+
+/// <summary>
+/// One ranked player in a game leaderboard (#1467).
+/// Only registered users are ranked; <see cref="PlayerId"/> is the user id.
+/// </summary>
+public sealed record GameLeaderboardEntryDto
+{
+    /// <summary>Registered user id of the player.</summary>
+    public required Guid PlayerId { get; init; }
+
+    /// <summary>Display name taken from the player's most recent in-scope record.</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Up to two uppercase initials derived from <see cref="DisplayName"/>.</summary>
+    public required string Initials { get; init; }
+
+    /// <summary>Total of the "wins" scoring dimension summed across the player's in-scope records.</summary>
+    public required int Wins { get; init; }
+
+    /// <summary>Number of in-scope completed records the player took part in.</summary>
+    public required int Plays { get; init; }
+
+    /// <summary>Average of the "points" dimension across in-scope records; null when never scored on points.</summary>
+    public double? AvgScore { get; init; }
+
+    /// <summary>Most recent session date among the player's in-scope records.</summary>
+    public required DateTime LastPlayedAt { get; init; }
+}
+
+/// <summary>
+/// Game leaderboard response (#1467). Top-N players ranked by wins, then average score, then plays.
+/// Scope is "social": the caller's own records plus records of groups the caller belongs to.
+/// </summary>
+public sealed record GameLeaderboardResponse
+{
+    public required Guid GameId { get; init; }
+
+    public required IReadOnlyList<GameLeaderboardEntryDto> Entries { get; init; }
+
+    /// <summary>Number of entries actually returned (top-N), not the total player population.</summary>
+    public required int ReturnedCount { get; init; }
+
+    /// <summary>Echo of the optional temporal filter applied to SessionDate.</summary>
+    public DateTime? Since { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQuery.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.Leaderboard;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
+
+/// <summary>
+/// Query for a game's social leaderboard (#1467): the top players ranked by wins across the
+/// play records visible to the caller (own records + records of the caller's groups).
+/// </summary>
+/// <param name="GameId">Catalog game id (route).</param>
+/// <param name="CurrentUserId">Authenticated caller; determines visibility scope.</param>
+/// <param name="Since">Optional lower bound on <c>SessionDate</c>.</param>
+/// <param name="Limit">Top-N size (1..50, default 10).</param>
+internal sealed record GetGameLeaderboardQuery(
+    Guid GameId,
+    Guid CurrentUserId,
+    DateTime? Since = null,
+    int Limit = 10
+) : IQuery<GameLeaderboardResponse>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryHandler.cs
@@ -1,0 +1,139 @@
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Application.DTOs.Leaderboard;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
+
+/// <summary>
+/// Handles the game social leaderboard query (#1467): ranks the registered players across the
+/// play records the caller is allowed to see (own records + records of the caller's groups).
+/// </summary>
+internal sealed class GetGameLeaderboardQueryHandler : IQueryHandler<GetGameLeaderboardQuery, GameLeaderboardResponse>
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly MeepleAiDbContext _context;
+    private readonly IGroupMemoryRepository _groupRepository;
+    private readonly IHybridCacheService _cache;
+
+    public GetGameLeaderboardQueryHandler(
+        MeepleAiDbContext context,
+        IGroupMemoryRepository groupRepository,
+        IHybridCacheService cache)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _groupRepository = groupRepository ?? throw new ArgumentNullException(nameof(groupRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task<GameLeaderboardResponse> Handle(GetGameLeaderboardQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // Response varies per caller (visibility scope) and per filter, so the cache key includes both.
+        var cacheKey = $"game-leaderboard:{query.GameId}:user:{query.CurrentUserId}:since:{query.Since?.Ticks ?? 0}:limit:{query.Limit}";
+
+        return await _cache.GetOrCreateAsync(
+            cacheKey,
+            ct => ComputeLeaderboardAsync(query, ct),
+            tags: [$"game:{query.GameId}", "leaderboard"],
+            expiration: CacheTtl,
+            ct: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GameLeaderboardResponse> ComputeLeaderboardAsync(GetGameLeaderboardQuery query, CancellationToken ct)
+    {
+        var groupIds = (await _groupRepository.GetGroupIdsForUserAsync(query.CurrentUserId, ct).ConfigureAwait(false)).ToList();
+
+        var completed = (int)PlayRecordStatus.Completed;
+        var groupVisibility = (int)PlayRecordVisibility.Group;
+
+        var records = await _context.PlayRecords
+            .AsNoTracking()
+            .Include(r => r.Players)
+                .ThenInclude(p => p.Scores)
+            .Where(r => r.GameId == query.GameId
+                        && r.Status == completed
+                        && (query.Since == null || r.SessionDate >= query.Since.Value)
+                        && (r.CreatedByUserId == query.CurrentUserId
+                            || (r.Visibility == groupVisibility
+                                && r.GroupId.HasValue
+                                && groupIds.Contains(r.GroupId.Value))))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var entries = records
+            .SelectMany(r => r.Players
+                .Where(p => p.UserId.HasValue)
+                .Select(p => new PlayerParticipation(p.UserId!.Value, p.DisplayName, r.SessionDate, p)))
+            .GroupBy(x => x.UserId)
+            .Select(ToEntry)
+            .OrderByDescending(e => e.Wins)
+            .ThenByDescending(e => e.AvgScore ?? double.MinValue)
+            .ThenByDescending(e => e.Plays)
+            .ThenBy(e => e.PlayerId)
+            .Take(query.Limit)
+            .ToList();
+
+        return new GameLeaderboardResponse
+        {
+            GameId = query.GameId,
+            Entries = entries,
+            ReturnedCount = entries.Count,
+            Since = query.Since,
+        };
+    }
+
+    private static GameLeaderboardEntryDto ToEntry(IGrouping<Guid, PlayerParticipation> group)
+    {
+        var wins = group
+            .SelectMany(x => x.Player.Scores
+                .Where(s => string.Equals(s.Dimension, ScoringDimensions.Wins, StringComparison.OrdinalIgnoreCase))
+                .Select(s => s.Value))
+            .Sum();
+
+        var pointValues = group
+            .SelectMany(x => x.Player.Scores
+                .Where(s => string.Equals(s.Dimension, ScoringDimensions.Points, StringComparison.OrdinalIgnoreCase))
+                .Select(s => (double)s.Value))
+            .ToList();
+
+        var mostRecent = group.OrderByDescending(x => x.SessionDate).First();
+
+        return new GameLeaderboardEntryDto
+        {
+            PlayerId = group.Key,
+            DisplayName = mostRecent.DisplayName,
+            Initials = ComputeInitials(mostRecent.DisplayName),
+            Wins = wins,
+            Plays = group.Count(),
+            AvgScore = pointValues.Count > 0 ? pointValues.Average() : null,
+            LastPlayedAt = group.Max(x => x.SessionDate),
+        };
+    }
+
+    private static string ComputeInitials(string displayName)
+    {
+        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return "?";
+        }
+
+        if (parts.Length == 1)
+        {
+            var single = parts[0];
+            return (single.Length >= 2 ? single[..2] : single[..1]).ToUpperInvariant();
+        }
+
+        return $"{parts[0][0]}{parts[1][0]}".ToUpperInvariant();
+    }
+
+    private readonly record struct PlayerParticipation(Guid UserId, string DisplayName, DateTime SessionDate, RecordPlayerEntity Player);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryHandler.cs
@@ -36,6 +36,13 @@ internal sealed class GetGameLeaderboardQueryHandler : IQueryHandler<GetGameLead
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        // Normalize the optional filter to UTC so the cache key is timezone-stable and the echoed
+        // value serializes with a 'Z' offset (the FE Zod schema requires an offset).
+        if (query.Since.HasValue)
+        {
+            query = query with { Since = DateTime.SpecifyKind(query.Since.Value, DateTimeKind.Utc) };
+        }
+
         // Response varies per caller (visibility scope) and per filter, so the cache key includes both.
         var cacheKey = $"game-leaderboard:{query.GameId}:user:{query.CurrentUserId}:since:{query.Since?.Ticks ?? 0}:limit:{query.Limit}";
 
@@ -114,7 +121,8 @@ internal sealed class GetGameLeaderboardQueryHandler : IQueryHandler<GetGameLead
             Wins = wins,
             Plays = group.Count(),
             AvgScore = pointValues.Count > 0 ? pointValues.Average() : null,
-            LastPlayedAt = group.Max(x => x.SessionDate),
+            // Force UTC kind so System.Text.Json emits a 'Z' offset (the FE Zod schema requires it).
+            LastPlayedAt = DateTime.SpecifyKind(group.Max(x => x.SessionDate), DateTimeKind.Utc),
         };
     }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/Leaderboard/GetGameLeaderboardQueryValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
+
+/// <summary>
+/// Validator for <see cref="GetGameLeaderboardQuery"/> (#1467).
+/// </summary>
+internal sealed class GetGameLeaderboardQueryValidator : AbstractValidator<GetGameLeaderboardQuery>
+{
+    public GetGameLeaderboardQueryValidator()
+    {
+        RuleFor(x => x.GameId)
+            .NotEmpty()
+            .WithMessage("Game ID is required.");
+
+        RuleFor(x => x.CurrentUserId)
+            .NotEmpty()
+            .WithMessage("Current user ID is required.");
+
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 50)
+            .WithMessage("Limit must be between 1 and 50.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ScoringDimensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ScoringDimensions.cs
@@ -6,6 +6,13 @@ namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 /// </summary>
 internal static class ScoringDimensions
 {
+    /// <summary>
+    /// Win count for a record (typically 0 or 1, but the model permits higher values, e.g. a
+    /// best-of series). The leaderboard SUMS this dimension across a player's records to get
+    /// total wins — intentional, to mirror the "total wins" figure in the game-detail mockup.
+    /// </summary>
     public const string Wins = "wins";
+
+    /// <summary>Numeric score; the leaderboard averages this dimension across a player's records.</summary>
     public const string Points = "points";
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ScoringDimensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/ScoringDimensions.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+/// <summary>
+/// Canonical scoring dimension names used by play-record aggregations (statistics, leaderboard).
+/// Matches the dimensions produced by <see cref="RecordScore.Wins"/> and <see cref="RecordScore.Points"/>.
+/// </summary>
+internal static class ScoringDimensions
+{
+    public const string Wins = "wins";
+    public const string Points = "points";
+}

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -328,6 +328,11 @@ internal static class GameEndpoints
         CancellationToken ct)
     {
         var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
         var query = new GetGameLeaderboardQuery(id, userId, since, limit ?? 10);
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
 

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -4,7 +4,9 @@ using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.GameManagement.Application;
 using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.DTOs;
+using Api.BoundedContexts.GameManagement.Application.DTOs.Leaderboard;
 using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
@@ -84,6 +86,16 @@ internal static class GameEndpoints
         .WithTags("Games", "Rules")
         .WithSummary("Get game rule specifications")
         .WithDescription("Returns all rule specification versions for a game. Supports Rules tab in Game Detail Page. Requires authentication.");
+
+        // Get social leaderboard for a game (DDD/CQRS)
+        // Issue #1467: Supports the Stats-tab leaderboard in the Game Detail Page
+        group.MapGet("/games/{id}/leaderboard", HandleGetGameLeaderboard)
+        .RequireAuthenticatedUser()
+        .Produces<GameLeaderboardResponse>(200)
+        .Produces(401)
+        .WithTags("Games")
+        .WithSummary("Get game social leaderboard")
+        .WithDescription("Returns the top registered players ranked by wins across the play records visible to the caller (own records plus records of groups the caller belongs to). Supports ?since= and ?limit= (1..50, default 10). Requires authentication.");
 
         // Get AI agents available for a game
         // Issue #2677: Frontend uses this endpoint for game detail page agent list
@@ -305,6 +317,21 @@ internal static class GameEndpoints
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
 
         return result != null ? Results.Ok(result) : Results.NotFound();
+    }
+
+    private static async Task<IResult> HandleGetGameLeaderboard(
+        Guid id,
+        [FromQuery] DateTime? since,
+        [FromQuery] int? limit,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var userId = httpContext.User.GetUserId();
+        var query = new GetGameLeaderboardQuery(id, userId, since, limit ?? 10);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+
+        return Results.Ok(result);
     }
 
     private static async Task<IResult> HandleGetGameRules(

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepositoryMembershipTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Infrastructure/Persistence/GroupMemoryRepositoryMembershipTests.cs
@@ -1,0 +1,114 @@
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.AgentMemory.Infrastructure.Persistence;
+
+/// <summary>
+/// Tests for the membership read-port <see cref="GroupMemoryRepository.GetGroupIdsForUserAsync"/>
+/// added for the game leaderboard (#1467). Membership is the inverse of <c>GetByCreatorIdAsync</c>:
+/// "which groups is this user a member of". Members are persisted as JSONB, so the lookup
+/// deserializes in-memory.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "AgentMemory")]
+[Trait("Issue", "1467")]
+public sealed class GroupMemoryRepositoryMembershipTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly GroupMemoryRepository _repo;
+
+    public GroupMemoryRepositoryMembershipTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"GroupMembership_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+        _repo = new GroupMemoryRepository(_db, new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task GetGroupIdsForUserAsync_ReturnsOnlyGroupsWhereUserIsMember()
+    {
+        var targetUser = Guid.NewGuid();
+        var otherUser = Guid.NewGuid();
+
+        var mine = GroupMemory.Create(Guid.NewGuid(), "My Group");
+        mine.AddMember(targetUser);
+        var theirs = GroupMemory.Create(Guid.NewGuid(), "Other Group");
+        theirs.AddMember(otherUser);
+
+        await _repo.AddAsync(mine, TestContext.Current.CancellationToken);
+        await _repo.AddAsync(theirs, TestContext.Current.CancellationToken);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _repo.GetGroupIdsForUserAsync(targetUser, TestContext.Current.CancellationToken);
+
+        result.Should().ContainSingle().Which.Should().Be(mine.Id);
+    }
+
+    [Fact]
+    public async Task GetGroupIdsForUserAsync_UserInMultipleGroups_ReturnsAll()
+    {
+        var targetUser = Guid.NewGuid();
+
+        var g1 = GroupMemory.Create(Guid.NewGuid(), "Group 1");
+        g1.AddMember(targetUser);
+        var g2 = GroupMemory.Create(Guid.NewGuid(), "Group 2");
+        g2.AddMember(targetUser);
+
+        await _repo.AddAsync(g1, TestContext.Current.CancellationToken);
+        await _repo.AddAsync(g2, TestContext.Current.CancellationToken);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _repo.GetGroupIdsForUserAsync(targetUser, TestContext.Current.CancellationToken);
+
+        result.Should().BeEquivalentTo(new[] { g1.Id, g2.Id });
+    }
+
+    [Fact]
+    public async Task GetGroupIdsForUserAsync_NoMembership_ReturnsEmpty()
+    {
+        var g = GroupMemory.Create(Guid.NewGuid(), "Group");
+        g.AddMember(Guid.NewGuid());
+        await _repo.AddAsync(g, TestContext.Current.CancellationToken);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _repo.GetGroupIdsForUserAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetGroupIdsForUserAsync_GuestMembersAreIgnored()
+    {
+        var g = GroupMemory.Create(Guid.NewGuid(), "Group");
+        g.AddGuestMember("Marco");
+        await _repo.AddAsync(g, TestContext.Current.CancellationToken);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _repo.GetGroupIdsForUserAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetGroupIdsForUserAsync_EmptyUserId_ReturnsEmpty()
+    {
+        var result = await _repo.GetGroupIdsForUserAsync(Guid.Empty, TestContext.Current.CancellationToken);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Leaderboard/GetGameLeaderboardQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Leaderboard/GetGameLeaderboardQueryHandlerTests.cs
@@ -1,0 +1,338 @@
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Application.DTOs.Leaderboard;
+using Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Services;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Leaderboard;
+
+/// <summary>
+/// Handler tests for the game leaderboard (#1467). Covers the social-visibility predicate,
+/// registered-only aggregation, ranking, top-N, temporal filter and degenerate cases.
+/// Membership is stubbed via <see cref="IGroupMemoryRepository"/>; cache executes the factory.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1467")]
+public sealed class GetGameLeaderboardQueryHandlerTests : IDisposable
+{
+    private static readonly Guid Game = Guid.NewGuid();
+    private static readonly Guid Me = Guid.NewGuid();
+
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IGroupMemoryRepository> _groupRepoMock = new();
+    private readonly Mock<IHybridCacheService> _cacheMock = new();
+
+    public GetGameLeaderboardQueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"Leaderboard_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
+        // Default: caller belongs to no groups.
+        _groupRepoMock
+            .Setup(r => r.GetGroupIdsForUserAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+
+        // Cache executes the factory (exercises real logic).
+        _cacheMock
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task<GameLeaderboardResponse>>>(),
+                It.IsAny<string[]>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, Func<CancellationToken, Task<GameLeaderboardResponse>>, string[], TimeSpan?, CancellationToken>(
+                (_, factory, _, _, ct) => factory(ct));
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private GetGameLeaderboardQueryHandler CreateHandler() =>
+        new(_db, _groupRepoMock.Object, _cacheMock.Object);
+
+    private PlayRecordEntity AddRecord(
+        Guid? gameId,
+        Guid createdBy,
+        PlayRecordVisibility visibility,
+        Guid? groupId,
+        PlayRecordStatus status,
+        DateTime sessionDate,
+        params (Guid? userId, string name, int? wins, int? points)[] players)
+    {
+        var rec = new PlayRecordEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            GameName = "Game",
+            CreatedByUserId = createdBy,
+            Visibility = (int)visibility,
+            GroupId = groupId,
+            Status = (int)status,
+            SessionDate = sessionDate,
+            ScoringConfigJson = "{}",
+            CreatedAt = sessionDate,
+            UpdatedAt = sessionDate,
+        };
+
+        foreach (var p in players)
+        {
+            var player = new RecordPlayerEntity
+            {
+                Id = Guid.NewGuid(),
+                PlayRecordId = rec.Id,
+                UserId = p.userId,
+                DisplayName = p.name,
+            };
+            if (p.wins.HasValue)
+            {
+                player.Scores.Add(new RecordScoreEntity { Id = Guid.NewGuid(), RecordPlayerId = player.Id, Dimension = "wins", Value = p.wins.Value });
+            }
+            if (p.points.HasValue)
+            {
+                player.Scores.Add(new RecordScoreEntity { Id = Guid.NewGuid(), RecordPlayerId = player.Id, Dimension = "points", Value = p.points.Value });
+            }
+            rec.Players.Add(player);
+        }
+
+        _db.PlayRecords.Add(rec);
+        return rec;
+    }
+
+    private Task SaveAsync() => _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+    private Task<GameLeaderboardResponse> Run(int limit = 10, DateTime? since = null) =>
+        CreateHandler().Handle(new GetGameLeaderboardQuery(Game, Me, since, limit), TestContext.Current.CancellationToken);
+
+    // ── Ranking ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Ranking_OrdersByWinsThenAvgScore()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Alice", 1, 80), (b, "Bob", 0, 90));
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 2),
+            (a, "Alice", 1, 90), (b, "Bob", 1, 70));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().HaveCount(2);
+        result.Entries[0].PlayerId.Should().Be(a);  // 2 wins
+        result.Entries[0].Wins.Should().Be(2);
+        result.Entries[0].Plays.Should().Be(2);
+        result.Entries[0].AvgScore.Should().Be(85);
+        result.Entries[1].PlayerId.Should().Be(b);  // 1 win
+        result.Entries[1].Wins.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EmptyData_ReturnsEmptyResponse()
+    {
+        var result = await Run();
+
+        result.GameId.Should().Be(Game);
+        result.Entries.Should().BeEmpty();
+        result.ReturnedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LimitCapsResults()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+                (Guid.NewGuid(), $"P{i}", i, 10 * i));
+        }
+        await SaveAsync();
+
+        var result = await Run(limit: 2);
+
+        result.Entries.Should().HaveCount(2);
+        result.ReturnedCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SinceFilter_ExcludesOlderRecords()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2025, 1, 1),
+            (a, "Alice", 1, 50));
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 6, 1),
+            (a, "Alice", 1, 90));
+        await SaveAsync();
+
+        var result = await Run(since: new DateTime(2026, 1, 1));
+
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].Plays.Should().Be(1);
+        result.Entries[0].AvgScore.Should().Be(90);
+    }
+
+    // ── Visibility ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Privacy_OtherUsersPrivateRecordIsExcluded()
+    {
+        var other = Guid.NewGuid();
+        var x = Guid.NewGuid();
+        AddRecord(Game, other, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (x, "Stranger", 5, 100));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GroupRecord_IncludedWhenCallerIsMember()
+    {
+        var group = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        var x = Guid.NewGuid();
+        _groupRepoMock
+            .Setup(r => r.GetGroupIdsForUserAsync(Me, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { group });
+        AddRecord(Game, other, PlayRecordVisibility.Group, group, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (x, "Teammate", 3, 75));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].PlayerId.Should().Be(x);
+        result.Entries[0].Wins.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GroupRecord_ExcludedWhenCallerNotMember()
+    {
+        var group = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        AddRecord(Game, other, PlayRecordVisibility.Group, group, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (Guid.NewGuid(), "Outsider", 3, 75));
+        await SaveAsync();
+
+        var result = await Run();  // default: no groups
+
+        result.Entries.Should().BeEmpty();
+    }
+
+    // ── Aggregation rules ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GuestPlayer_IsExcluded()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Alice", 1, 80), (null, "Guest", 1, 99));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].PlayerId.Should().Be(a);
+    }
+
+    [Fact]
+    public async Task NoWinsDimension_WinsAreZero()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Alice", null, 80));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries[0].Wins.Should().Be(0);
+        result.Entries[0].Plays.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NoPointsDimension_AvgScoreIsNull()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Alice", 1, null));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries[0].AvgScore.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task NonCompletedRecord_IsExcluded()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.InProgress, new DateTime(2026, 1, 1),
+            (a, "Alice", 1, 80));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FreeFormRecord_IsExcluded()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(null, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Alice", 1, 80));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DisplayName_TakenFromMostRecentRecord()
+    {
+        var a = Guid.NewGuid();
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (a, "Marco", 1, 80));
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 3, 1),
+            (a, "Marco Rossi", 1, 80));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries[0].DisplayName.Should().Be("Marco Rossi");
+        result.Entries[0].Initials.Should().Be("MR");
+        result.Entries[0].LastPlayedAt.Should().Be(new DateTime(2026, 3, 1));
+    }
+
+    [Fact]
+    public async Task TieBreak_IsDeterministicByUserId()
+    {
+        var lower = new Guid("00000000-0000-0000-0000-000000000001");
+        var higher = new Guid("00000000-0000-0000-0000-000000000002");
+        AddRecord(Game, Me, PlayRecordVisibility.Private, null, PlayRecordStatus.Completed, new DateTime(2026, 1, 1),
+            (higher, "H", 1, 50), (lower, "L", 1, 50));
+        await SaveAsync();
+
+        var result = await Run();
+
+        result.Entries.Should().HaveCount(2);
+        result.Entries[0].PlayerId.Should().Be(lower);
+        result.Entries[1].PlayerId.Should().Be(higher);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Leaderboard/GetGameLeaderboardQueryValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Leaderboard/GetGameLeaderboardQueryValidatorTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.Leaderboard;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Leaderboard;
+
+/// <summary>
+/// Validator tests for <see cref="GetGameLeaderboardQuery"/> (#1467):
+/// GameId/CurrentUserId required, Limit constrained to 1..50.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1467")]
+public sealed class GetGameLeaderboardQueryValidatorTests
+{
+    private readonly GetGameLeaderboardQueryValidator _validator = new();
+
+    [Fact]
+    public void Valid_DefaultLimit_Passes()
+    {
+        var query = new GetGameLeaderboardQuery(Guid.NewGuid(), Guid.NewGuid());
+
+        _validator.Validate(query).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EmptyGameId_Fails()
+    {
+        var query = new GetGameLeaderboardQuery(Guid.Empty, Guid.NewGuid());
+
+        _validator.Validate(query).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EmptyCurrentUserId_Fails()
+    {
+        var query = new GetGameLeaderboardQuery(Guid.NewGuid(), Guid.Empty);
+
+        _validator.Validate(query).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LimitZero_Fails()
+    {
+        var query = new GetGameLeaderboardQuery(Guid.NewGuid(), Guid.NewGuid(), Limit: 0);
+
+        _validator.Validate(query).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LimitAbove50_Fails()
+    {
+        var query = new GetGameLeaderboardQuery(Guid.NewGuid(), Guid.NewGuid(), Limit: 51);
+
+        _validator.Validate(query).IsValid.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(50)]
+    public void LimitWithinRange_Passes(int limit)
+    {
+        var query = new GetGameLeaderboardQuery(Guid.NewGuid(), Guid.NewGuid(), Limit: limit);
+
+        _validator.Validate(query).IsValid.Should().BeTrue();
+    }
+}

--- a/apps/web/src/lib/api/clients/__tests__/gamesClient.leaderboard.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/gamesClient.leaderboard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { createGamesClient } from '../gamesClient';
+import { GameLeaderboardResponseSchema } from '../../schemas';
+
+import type { HttpClient } from '../../core/httpClient';
+
+/**
+ * Tests for gamesClient.getLeaderboard (#1467).
+ * The leaderboard client method must hit the v1-prefixed game-scoped endpoint
+ * with optional since/limit query params and validate via the Zod schema.
+ */
+describe('gamesClient.getLeaderboard (#1467)', () => {
+  const mockResponse = {
+    gameId: '11111111-1111-1111-1111-111111111111',
+    entries: [],
+    returnedCount: 0,
+    since: null,
+  };
+
+  function setup() {
+    const httpClient = { get: vi.fn().mockResolvedValue(mockResponse) };
+    const client = createGamesClient({ httpClient: httpClient as unknown as HttpClient });
+    return { client, httpClient };
+  }
+
+  it('calls the v1 leaderboard endpoint with the schema and no query string by default', async () => {
+    const { client, httpClient } = setup();
+
+    await client.getLeaderboard('game-1');
+
+    expect(httpClient.get).toHaveBeenCalledWith(
+      '/api/v1/games/game-1/leaderboard',
+      GameLeaderboardResponseSchema
+    );
+  });
+
+  it('appends since and limit query params when provided', async () => {
+    const { client, httpClient } = setup();
+
+    await client.getLeaderboard('game-1', { since: '2026-01-01T00:00:00.000Z', limit: 5 });
+
+    const url = httpClient.get.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/games/game-1/leaderboard?');
+    expect(url).toContain('since=');
+    expect(url).toContain('limit=5');
+  });
+
+  it('returns the response from the http client', async () => {
+    const { client } = setup();
+
+    const result = await client.getLeaderboard('game-1');
+
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/apps/web/src/lib/api/clients/gamesClient.ts
+++ b/apps/web/src/lib/api/clients/gamesClient.ts
@@ -12,6 +12,7 @@ import {
   AgentDtoSchema,
   EditorLockSchema,
   GameFAQSchema,
+  GameLeaderboardResponseSchema,
   GameSchema,
   GameSessionDtoSchema,
   GameReviewDtoSchema,
@@ -30,6 +31,7 @@ import {
   type EditorLock,
   type Game,
   type GameFAQ,
+  type GameLeaderboardResponse,
   type GameReviewDto,
   type GameSessionDto,
   type GetGameFAQsResult,
@@ -285,6 +287,27 @@ export function createGamesClient({ httpClient }: CreateGamesClientParams) {
       const url = `/api/v1/games/${encodeURIComponent(gameId)}/sessions${queryString}`;
       const response = await httpClient.get(url, z.array(GameSessionDtoSchema));
       return response ?? [];
+    },
+
+    /**
+     * Get the social leaderboard for a game (Issue #1467)
+     * GET /api/v1/games/{gameId}/leaderboard?since=&limit=
+     *
+     * Returns the top registered players ranked by wins across the play records
+     * visible to the caller (own records plus records of the caller's groups).
+     * @param gameId Game ID (GUID format)
+     * @param options Optional `since` (ISO date) and `limit` (1..50, default 10)
+     */
+    async getLeaderboard(
+      gameId: string,
+      options?: { since?: string; limit?: number }
+    ): Promise<GameLeaderboardResponse | null> {
+      const params = new URLSearchParams();
+      if (options?.since) params.append('since', options.since);
+      if (options?.limit) params.append('limit', options.limit.toString());
+      const queryString = params.toString() ? `?${params.toString()}` : '';
+      const url = `/api/v1/games/${encodeURIComponent(gameId)}/leaderboard${queryString}`;
+      return httpClient.get(url, GameLeaderboardResponseSchema);
     },
 
     /**

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -55,6 +55,29 @@ export type PaginatedGamesResponse = z.infer<typeof PaginatedGamesResponseSchema
 export const GamesArrayResponseSchema = z.array(GameSchema);
 export type GamesArrayResponse = z.infer<typeof GamesArrayResponseSchema>;
 
+// ========== Game Leaderboard (Issue #1467) ==========
+
+export const GameLeaderboardEntrySchema = z.object({
+  playerId: z.string().uuid(),
+  displayName: z.string(),
+  initials: z.string(),
+  wins: z.number().int().nonnegative(),
+  plays: z.number().int().nonnegative(),
+  avgScore: z.number().nullable(),
+  lastPlayedAt: z.string().datetime({ offset: true }),
+});
+
+export type GameLeaderboardEntry = z.infer<typeof GameLeaderboardEntrySchema>;
+
+export const GameLeaderboardResponseSchema = z.object({
+  gameId: z.string().uuid(),
+  entries: z.array(GameLeaderboardEntrySchema),
+  returnedCount: z.number().int().nonnegative(),
+  since: z.string().datetime({ offset: true }).nullable(),
+});
+
+export type GameLeaderboardResponse = z.infer<typeof GameLeaderboardResponseSchema>;
+
 // ========== Game Sessions ==========
 
 export const SessionPlayerDtoSchema = z.object({

--- a/apps/web/src/lib/domain-hooks/__tests__/useGameLeaderboard.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useGameLeaderboard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+import { useGameLeaderboard, GAME_LEADERBOARD_QUERY_KEY } from '../useGameLeaderboard';
+import { createTestQueryClient } from '@/__tests__/utils/query-test-utils';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    games: {
+      getLeaderboard: vi.fn(),
+    },
+  },
+}));
+
+const mockResponse = {
+  gameId: '11111111-1111-1111-1111-111111111111',
+  entries: [
+    {
+      playerId: '22222222-2222-2222-2222-222222222222',
+      displayName: 'Marco Rossi',
+      initials: 'MR',
+      wins: 8,
+      plays: 14,
+      avgScore: 87.5,
+      lastPlayedAt: '2026-05-20T12:00:00.000Z',
+    },
+  ],
+  returnedCount: 1,
+  since: null,
+};
+
+describe('useGameLeaderboard (#1467)', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    return ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.clearAllMocks();
+  });
+
+  it('generates a stable query key with since/limit defaults', () => {
+    expect(GAME_LEADERBOARD_QUERY_KEY('game-1')).toEqual(['game-leaderboard', 'game-1', null, 10]);
+    expect(GAME_LEADERBOARD_QUERY_KEY('game-1', '2026-01-01T00:00:00.000Z', 5)).toEqual([
+      'game-leaderboard',
+      'game-1',
+      '2026-01-01T00:00:00.000Z',
+      5,
+    ]);
+  });
+
+  it('fetches the leaderboard via the games client', async () => {
+    const { api } = await import('@/lib/api');
+    vi.mocked(api.games.getLeaderboard).mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useGameLeaderboard('game-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockResponse);
+    expect(api.games.getLeaderboard).toHaveBeenCalledWith('game-1', undefined);
+  });
+
+  it('forwards since/limit options to the client', async () => {
+    const { api } = await import('@/lib/api');
+    vi.mocked(api.games.getLeaderboard).mockResolvedValueOnce(mockResponse);
+    const options = { since: '2026-01-01T00:00:00.000Z', limit: 5 };
+
+    const { result } = renderHook(() => useGameLeaderboard('game-1', options), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.games.getLeaderboard).toHaveBeenCalledWith('game-1', options);
+  });
+
+  it('is disabled when gameId is empty', () => {
+    const { result } = renderHook(() => useGameLeaderboard(''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/web/src/lib/domain-hooks/useGameLeaderboard.ts
+++ b/apps/web/src/lib/domain-hooks/useGameLeaderboard.ts
@@ -1,0 +1,37 @@
+/**
+ * Game Leaderboard Hook (Issue #1467)
+ *
+ * React Query hook for the social game leaderboard. Fetches the top registered
+ * players ranked by wins across the play records visible to the caller.
+ * Consumed by the Stats-tab leaderboard component (#1468).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { GameLeaderboardResponse } from '@/lib/api/schemas';
+
+export interface GameLeaderboardOptions {
+  /** ISO date lower bound on the play record session date. */
+  since?: string;
+  /** Top-N size (1..50, default 10). */
+  limit?: number;
+}
+
+export const GAME_LEADERBOARD_QUERY_KEY = (gameId: string, since?: string, limit?: number) =>
+  ['game-leaderboard', gameId, since ?? null, limit ?? 10] as const;
+
+/**
+ * Fetches the social leaderboard for a game.
+ * @param gameId Game ID (GUID format)
+ * @param options Optional since/limit filters
+ */
+export function useGameLeaderboard(gameId: string, options?: GameLeaderboardOptions) {
+  return useQuery<GameLeaderboardResponse | null, Error>({
+    queryKey: GAME_LEADERBOARD_QUERY_KEY(gameId, options?.since, options?.limit),
+    queryFn: () => api.games.getLeaderboard(gameId, options),
+    staleTime: 5 * 60 * 1000, // 5 minutes (matches backend cache)
+    retry: 2,
+    enabled: !!gameId,
+  });
+}


### PR DESCRIPTION
## Summary

Implements #1467: the social game leaderboard endpoint `GET /api/v1/games/{id}/leaderboard`. Spec hardened via `/sc:spec-panel` (5.5 → 8.5/10) before implementation, built with TDD.

Ranks registered players by wins across the play records the caller can see. Key domain facts that shaped the design (verified against code, not assumed):
- `PlayRecordVisibility` has only `Private`/`Group` — **no `Public`** → the leaderboard is authenticated and per-caller (own records + records of the caller's groups).
- `RecordPlayer.UserId` is nullable (guests) → only registered players are ranked.
- Scoring is multi-dimensional string-keyed (`wins`/`points`); reuses `GetPlayerStatisticsQueryHandler` semantics via shared `ScoringDimensions` constants.

## Decisions ratified (spec-panel)

- **Scope**: social aggregate — `CreatedByUserId == me OR (Visibility == Group AND GroupId ∈ myGroups)`.
- **Identity**: registered-only, aggregated by `UserId`.
- **Ranking**: `wins → avgScore → plays → userId`, top-N via `?limit=` (1..50, default 10), `?since=` temporal filter on `SessionDate`.

## Changes

**Backend** (GameManagement BC):
- `GetGameLeaderboardQuery` + validator + handler (visibility predicate, registered-only aggregation, ranking, top-N, per-user `HybridCache`)
- `GameLeaderboardResponse` DTO + `ScoringDimensions` shared constants
- `IGroupMemoryRepository.GetGroupIdsForUserAsync` read-port (membership, inverse of `GetByCreatorIdAsync`; JSONB members filtered in-memory)
- Endpoint in `GameEndpoints` (`.RequireAuthenticatedUser`)

**Frontend**:
- `GameLeaderboardResponse` Zod schema
- `gamesClient.getLeaderboard` + `useGameLeaderboard` React Query hook

## Tests

- **27 BE unit**: 5 membership + 8 validator + 14 handler (visibility/privacy, guest excluded, status filter, free-form excluded, ranking, tie-break, since, limit cap, empty=200, displayName-from-most-recent)
- **7 FE**: 3 client + 4 hook
- DI auto-registered (MediatR `RegisterServicesFromAssembly` + FluentValidation assembly scan). OpenAPI generated at runtime (no committed `openapi.json`).

## Deviations / follow-ups

- **Integration test (Testcontainers) deferred**: the visibility predicate is EF-standard (no custom SQL functions like `ILike`) and fully covered by InMemory unit tests; membership resolution loads + deserializes JSONB in-memory. Tracked as a follow-up rather than blocking this PR.
- **`404 game-not-found` not implemented**: an empty leaderboard (200) is semantically acceptable and the game-detail page already 404s a missing game. Documented out-of-scope in the issue.
- **Membership query loads candidate groups in-memory** (JSONB members can't be SQL-filtered) — acceptable for MVP volumes; revisit with a JSONB containment query if group counts grow.

Unblocks #1468 (`GameDetailLeaderboard` component).

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
