### PR TITLE
docs(admin): SP5 Fondamenta implementation plans (F0a/F0b/F0c)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-sp5-admin-f0a-nav-consolidation.md
+++ b/docs/superpowers/plans/2026-05-24-sp5-admin-f0a-nav-consolidation.md
@@ -1,0 +1,479 @@
+# SP5 Admin F0a — Nav Consolidation (4 gruppi A/B/C/D) + Role Filter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Estrarre la navigazione admin in una config condivisa tipizzata, riorganizzata nei 4 gruppi A/B/C/D della spec, con un campo `minRole` e un filtro per ruolo; far consumare la config (filtrata) all'`AdminSideDrawer` esistente, senza regressioni.
+
+**Architecture:** Config nav = dati puri (array tipizzato di gruppi/voci con `minRole`). Filtro = funzione pura `filterNavByRole(groups, user)`. L'`AdminSideDrawer` smette di hard-codare le `SECTIONS` inline e consuma la config filtrata via `useCurrentUser()`. Separare dati + funzione pura dal componente li rende testabili in isolamento e riutilizzabili dalla futura sidebar desktop (F0b).
+
+**Tech Stack:** Next.js 16 (App Router) · React 19 · TypeScript · Vitest + React Testing Library · lucide-react. Niente nuove dipendenze.
+
+**Spec di riferimento:** `docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md` (§4.1 IA 4 gruppi, §4.4 filtro per ruolo).
+
+**Note di contesto (dall'audit/esplorazione):**
+- Il tipo FE `UserRole` (`apps/web/src/types/auth.ts`) è `'superadmin' | 'admin' | 'editor' | 'user'` — **non** include `creator` (gap noto R2, fuori scope F0a). `minRole` usa quindi solo questi 4 valori.
+- `hasRole(user, requiredRole)` (stesso file) implementa la gerarchia SuperAdmin > Admin > Editor > User e ritorna `false` se `user` è null.
+- I redirect di de-duplicazione IA sono **già implementati** in `next.config.js` (Issue #5040): F0a usa i path canonici già attivi (`/admin/ai`, ecc.), non crea redirect.
+- F0a include **solo le voci con route già esistenti**. Le schermate non ancora implementate (es. C secrets/emergency/budget, D sandbox/prompts) si aggiungono nelle ondate F3-F6 estendendo la stessa config.
+
+---
+
+## File Structure
+
+- **Create** `apps/web/src/components/layout/admin-nav/admin-nav-config.ts` — tipi `AdminNavItem`/`AdminNavGroup` + costante `ADMIN_NAV_GROUPS` (4 gruppi, voci con route esistenti + `minRole`).
+- **Create** `apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts` — funzione pura `filterNavByRole(groups, user)`.
+- **Create** `apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts` — test della funzione pura.
+- **Create** `apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts` — invarianti della config (id unici, href non vuoti, minRole validi).
+- **Modify** `apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx` — consuma `ADMIN_NAV_GROUPS` + `filterNavByRole`, rimuove le `SECTIONS` inline.
+- **Create** `apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx` — test di rendering + filtro per ruolo (non esiste oggi).
+
+---
+
+## Task 1: Config nav condivisa (tipi + 4 gruppi)
+
+**Files:**
+- Create: `apps/web/src/components/layout/admin-nav/admin-nav-config.ts`
+- Test: `apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts`
+
+- [ ] **Step 1: Scrivi il test delle invarianti della config**
+
+```typescript
+// apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
+import { describe, it, expect } from 'vitest';
+
+import { ADMIN_NAV_GROUPS } from '../admin-nav-config';
+
+const VALID_ROLES = ['superadmin', 'admin', 'editor', 'user'];
+
+describe('ADMIN_NAV_GROUPS', () => {
+  it('declares exactly the four groups A, B, C, D in order', () => {
+    expect(ADMIN_NAV_GROUPS.map(g => g.id)).toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('every group has a non-empty label and at least one item', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      expect(group.label.length).toBeGreaterThan(0);
+      expect(group.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every item has a non-empty label and an /admin href', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      for (const item of group.items) {
+        expect(item.label.length).toBeGreaterThan(0);
+        expect(item.href.startsWith('/admin')).toBe(true);
+      }
+    }
+  });
+
+  it('every declared minRole is a valid UserRole', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      for (const item of group.items) {
+        if (item.minRole !== undefined) {
+          expect(VALID_ROLES).toContain(item.minRole);
+        }
+      }
+    }
+  });
+
+  it('has no duplicate hrefs across all groups', () => {
+    const hrefs = ADMIN_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts`
+Expected: FAIL — `Failed to resolve import "../admin-nav-config"` (il modulo non esiste ancora).
+
+- [ ] **Step 3: Crea il modulo di config con tipi e i 4 gruppi**
+
+Mappa solo route già esistenti (verificate). `minRole` omesso = `'admin'` (default applicato dal filtro nel Task 2).
+
+```typescript
+// apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+import {
+  Activity,
+  BarChart2,
+  Bot,
+  BookOpen,
+  Database,
+  FileSearch,
+  Gamepad2,
+  Globe,
+  LayoutDashboard,
+  Mail,
+  MonitorCheck,
+  Settings,
+  Shield,
+  Users,
+  BellRing,
+  UserCheck,
+  Wrench,
+} from 'lucide-react';
+import type { ComponentType } from 'react';
+
+import type { UserRole } from '@/types/auth';
+
+export interface AdminNavItem {
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+  /** Minimum role required to see this item. Defaults to 'admin' when omitted. */
+  minRole?: UserRole;
+}
+
+export interface AdminNavGroup {
+  id: 'A' | 'B' | 'C' | 'D';
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  items: AdminNavItem[];
+}
+
+/**
+ * Canonical admin navigation, organised in the 4 groups of the SP5 consolidation
+ * spec (A Admin Console / B Power-User Tools / C Platform & Operations /
+ * D AI Tooling & Data Quality).
+ *
+ * Only routes that already exist are listed here. New screens land in waves
+ * F3-F6 by extending this array. Paths use the canonical hubs already enforced
+ * by next.config.js redirects (Issue #5040).
+ */
+export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: LayoutDashboard,
+    items: [
+      { label: 'Dashboard', href: '/admin/overview', icon: LayoutDashboard },
+      { label: 'Activity Feed', href: '/admin/overview/activity', icon: Activity },
+      { label: 'System Health', href: '/admin/overview/system', icon: MonitorCheck },
+      { label: 'Users', href: '/admin/users', icon: Users },
+      { label: 'Content', href: '/admin/content', icon: Gamepad2 },
+      { label: 'AI / RAG', href: '/admin/ai', icon: Bot },
+      { label: 'Knowledge Base', href: '/admin/knowledge-base', icon: BookOpen },
+      { label: 'Catalog Ingestion', href: '/admin/catalog-ingestion', icon: Database },
+      { label: 'Config', href: '/admin/config', icon: Settings },
+      { label: 'Monitor', href: '/admin/monitor', icon: MonitorCheck },
+      { label: 'Notifications', href: '/admin/notifications/compose', icon: BellRing },
+    ],
+  },
+  {
+    id: 'B',
+    label: 'Power-User Tools',
+    icon: Wrench,
+    items: [
+      { label: 'Giochi', href: '/admin/shared-games/all', icon: Gamepad2 },
+      { label: 'Email Templates', href: '/admin/content/email-templates', icon: Mail },
+      { label: 'Invitations', href: '/admin/users/invitations', icon: Mail },
+      { label: 'Ruoli & Permessi', href: '/admin/users/roles', icon: Shield },
+    ],
+  },
+  {
+    id: 'C',
+    label: 'Platform & Operations',
+    icon: Globe,
+    items: [
+      { label: 'Providers', href: '/admin/providers', icon: Globe },
+      { label: 'Analytics', href: '/admin/analytics', icon: BarChart2 },
+      { label: 'Staging Access', href: '/admin/staging-access', icon: Shield, minRole: 'superadmin' },
+    ],
+  },
+  {
+    id: 'D',
+    label: 'AI Tooling & Data Quality',
+    icon: Bot,
+    items: [
+      { label: 'Agent Definitions', href: '/admin/agents/definitions', icon: Database },
+      { label: 'RAG Inspector', href: '/admin/agents/inspector', icon: FileSearch },
+      { label: 'RAG Quality', href: '/admin/rag-quality', icon: BarChart2 },
+      { label: 'Mechanic Extractor', href: '/admin/knowledge-base/mechanic-extractor', icon: Wrench },
+      { label: 'A/B Testing', href: '/admin/agents/ab-testing', icon: BarChart2 },
+      { label: 'Agent Usage', href: '/admin/agents/usage', icon: BarChart2 },
+      { label: 'Access Requests', href: '/admin/users/access-requests', icon: UserCheck },
+    ],
+  },
+];
+```
+
+- [ ] **Step 4: Esegui il test e verifica che passi**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts`
+Expected: PASS (5 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/admin-nav/admin-nav-config.ts apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
+git commit -m "feat(admin): add shared admin nav config (4 groups A/B/C/D)"
+```
+
+---
+
+## Task 2: Filtro per ruolo (funzione pura)
+
+**Files:**
+- Create: `apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts`
+- Test: `apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts`
+
+- [ ] **Step 1: Scrivi il test della funzione di filtro**
+
+```typescript
+// apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts
+import { describe, it, expect } from 'vitest';
+
+import type { AuthUser } from '@/types/auth';
+
+import type { AdminNavGroup } from '../admin-nav-config';
+import { filterNavByRole } from '../filter-nav-by-role';
+
+function user(role: string): AuthUser {
+  return { id: 'u1', email: 'a@b.c', role };
+}
+
+const GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: () => null,
+    items: [
+      { label: 'Dashboard', href: '/admin/overview', icon: () => null }, // default admin
+      { label: 'Secrets', href: '/admin/secrets', icon: () => null, minRole: 'superadmin' },
+    ],
+  },
+  {
+    id: 'B',
+    label: 'Editor Tools',
+    icon: () => null,
+    items: [{ label: 'Editor', href: '/admin/editor', icon: () => null, minRole: 'editor' }],
+  },
+];
+
+describe('filterNavByRole', () => {
+  it('superadmin sees every item', () => {
+    const result = filterNavByRole(GROUPS, user('superadmin'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/overview', '/admin/secrets', '/admin/editor']);
+  });
+
+  it('admin sees admin+editor items but not superadmin-only', () => {
+    const result = filterNavByRole(GROUPS, user('admin'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/overview', '/admin/editor']);
+  });
+
+  it('editor sees only editor item; admin-default item is hidden', () => {
+    const result = filterNavByRole(GROUPS, user('editor'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/editor']);
+  });
+
+  it('drops groups that become empty after filtering', () => {
+    const result = filterNavByRole(GROUPS, user('editor'));
+    expect(result.map(g => g.id)).toEqual(['B']);
+  });
+
+  it('returns no groups for a null user', () => {
+    expect(filterNavByRole(GROUPS, null)).toEqual([]);
+  });
+
+  it('treats an item without minRole as requiring admin', () => {
+    const result = filterNavByRole(GROUPS, user('user'));
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts`
+Expected: FAIL — `Failed to resolve import "../filter-nav-by-role"`.
+
+- [ ] **Step 3: Implementa la funzione pura**
+
+```typescript
+// apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts
+import type { AuthUser } from '@/types/auth';
+import { hasRole } from '@/types/auth';
+
+import type { AdminNavGroup } from './admin-nav-config';
+
+const DEFAULT_MIN_ROLE = 'admin' as const;
+
+/**
+ * Returns a copy of `groups` keeping only the items the user is allowed to see
+ * (per item `minRole`, defaulting to 'admin'), and dropping groups left empty.
+ * Pure: does not mutate the input.
+ */
+export function filterNavByRole(
+  groups: AdminNavGroup[],
+  user: AuthUser | null
+): AdminNavGroup[] {
+  return groups
+    .map(group => ({
+      ...group,
+      items: group.items.filter(item => hasRole(user, item.minRole ?? DEFAULT_MIN_ROLE)),
+    }))
+    .filter(group => group.items.length > 0);
+}
+```
+
+- [ ] **Step 4: Esegui il test e verifica che passi**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts`
+Expected: PASS (6 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts
+git commit -m "feat(admin): add role-based nav filter (pure fn)"
+```
+
+---
+
+## Task 3: AdminSideDrawer consuma la config filtrata
+
+Sostituisce le `SECTIONS`/`SYSTEM_ITEMS`/`ANALYTICS_ITEMS` inline e la loro resa con i 4 gruppi filtrati per ruolo. Mantiene il pattern visivo esistente (`NavLink`, label di gruppo, active state via `usePathname`). Rimuove i collassabili `CollapsibleSection`/System/Analytics (le voci confluiscono nei 4 gruppi).
+
+**Files:**
+- Modify: `apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx`
+- Test: `apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx`
+
+- [ ] **Step 1: Scrivi il test del drawer (rendering + filtro ruolo)**
+
+```tsx
+// apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminSideDrawer } from '../AdminSideDrawer';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/overview',
+}));
+
+describe('AdminSideDrawer', () => {
+  beforeEach(() => {
+    mockUseCurrentUser.mockReset();
+  });
+
+  it('renders nothing when closed', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    const { container } = render(<AdminSideDrawer open={false} onClose={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the four group labels for an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByText('Power-User Tools')).toBeInTheDocument();
+    expect(screen.getByText('Platform & Operations')).toBeInTheDocument();
+    expect(screen.getByText('AI Tooling & Data Quality')).toBeInTheDocument();
+  });
+
+  it('hides superadmin-only items from an admin (Staging Access)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.queryByRole('link', { name: /Staging Access/i })).not.toBeInTheDocument();
+  });
+
+  it('shows superadmin-only items to a superadmin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'superadmin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByRole('link', { name: /Staging Access/i })).toBeInTheDocument();
+  });
+
+  it('marks the active route with aria-current', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute('aria-current', 'page');
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx`
+Expected: FAIL — il drawer attuale rende "Overview"/"Content"/"AI"/"Users" e mostra tutto, quindi i test sui 4 gruppi e sul filtro Staging Access falliscono.
+
+- [ ] **Step 3: Refactor del drawer per consumare la config filtrata**
+
+Sostituisci l'intero blocco `Nav definitions` (le costanti `SECTIONS`, `SYSTEM_ITEMS`, `ANALYTICS_ITEMS` alle righe 54-116) e la resa delle sezioni dentro `<nav>` (il `.map` di `SECTIONS` + i due blocchi collassabili System/Analytics, righe 328-405). Tieni invariati: l'header utente, l'overlay, il link "Torna all'app", l'helper `isPathActive`, il sub-componente `NavLink`. Rimuovi `CollapsibleSection`, `isSectionAltroActive`, e gli `useState` `systemOpen`/`analyticsOpen` ormai inutilizzati.
+
+3a. In testa al file, aggiungi gli import della config + filtro e rimuovi le icone non più usate inline:
+
+```tsx
+import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
+import { filterNavByRole } from '@/components/layout/admin-nav/filter-nav-by-role';
+```
+
+3b. Dentro `AdminSideDrawer`, dopo `const pathname = usePathname();`, calcola i gruppi visibili e rimuovi gli `useState` dei collassabili:
+
+```tsx
+const visibleGroups = filterNavByRole(ADMIN_NAV_GROUPS, user ?? null);
+```
+
+3c. Sostituisci il contenuto di `<nav className="flex flex-col gap-0.5">` (dopo il link "Torna all'app" + il `<div className="border-t mb-1" />`) con la resa dei gruppi:
+
+```tsx
+{visibleGroups.map(group => (
+  <div key={group.id} className="flex flex-col gap-0.5">
+    <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
+      <group.icon className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {group.label}
+      </span>
+    </div>
+    {group.items.map(item => (
+      <NavLink key={item.href} item={item} pathname={pathname} onClick={onClose} />
+    ))}
+  </div>
+))}
+```
+
+3d. Verifica che `NavItem` (interfaccia locale usata da `NavLink`) sia strutturalmente compatibile con `AdminNavItem`: `NavLink` legge solo `item.icon`, `item.href`, `item.label`. `AdminNavItem` ha quegli stessi campi (più `minRole`, ignorato da `NavLink`), quindi `NavLink` accetta un `AdminNavItem` senza modifiche. Lascia `NavLink` invariato.
+
+- [ ] **Step 4: Esegui i test del drawer e verifica che passino**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx`
+Expected: PASS (5 test).
+
+- [ ] **Step 5: Esegui typecheck + lint sui file toccati**
+
+Run: `cd apps/web && pnpm typecheck && pnpm exec eslint src/components/layout/admin-nav src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx`
+Expected: nessun errore. In particolare nessun import inutilizzato (le icone rimosse) e nessuna violazione `local/no-hardcoded-color-utility`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx
+git commit -m "refactor(admin): drive AdminSideDrawer from shared 4-group nav config + role filter"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** F0a copre §4.1 (4 gruppi A/B/C/D) e §4.4 (filtro per ruolo) limitatamente alle route esistenti. Shell desktop persistente (§4.3) → F0b. Dark scoped (§4.3) → F0c. Redirect (§4.2) → già fatti (#5040). i18n delle label → non in scope F0a (label inline come oggi), da valutare in un'ondata.
+
+**2. Placeholder scan:** nessun TODO/TBD; ogni step ha codice o comando completo; le icone nuove (`Wrench`) sono importate da lucide-react (già dipendenza).
+
+**3. Type consistency:** `AdminNavItem`/`AdminNavGroup` definiti in Task 1, usati identici in Task 2 e 3. `filterNavByRole(groups, user)` firma costante. `hasRole`/`AuthUser`/`UserRole` da `@/types/auth` (firme verificate). `NavLink` invariato consuma `AdminNavItem` (superset strutturale di `NavItem`).
+
+**Nota di rischio:** la rimozione dei collassabili System/Analytics cambia la UX del drawer (tutte le voci ora visibili sotto i 4 gruppi, niente accordion). È intenzionale (consolidamento IA spec §4.1) ma è un cambiamento visibile — segnalare in PR per review del designer.
+
+---
+
+## Execution Handoff
+
+Plan salvato. Sotto-plan successivi della fase Fondamenta: **F0b** (shell sidebar-responsive desktop, riusa `ADMIN_NAV_GROUPS`), **F0c** (dark scoped admin).

--- a/docs/superpowers/plans/2026-05-24-sp5-admin-f0b-shell-responsive.md
+++ b/docs/superpowers/plans/2026-05-24-sp5-admin-f0b-shell-responsive.md
@@ -1,0 +1,472 @@
+# SP5 Admin F0b — Shell Sidebar-Responsive (desktop) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere una **sidebar admin persistente su desktop (≥lg)** che riusa la config nav a 4 gruppi di F0a, mantenendo il drawer off-canvas su mobile, estraendo la resa della nav in un componente condiviso `AdminNavList` (DRY tra drawer e sidebar).
+
+**Architecture:** Estrai `NavLink` + `isPathActive` + la resa dei gruppi dal drawer in un componente condiviso `AdminNavList`. Crea `AdminSidebar` (visibile solo ≥lg via `hidden lg:flex`) che filtra `ADMIN_NAV_GROUPS` per ruolo e rende `AdminNavList`. Modifica `AdminShell` per disporre `TopBar` sopra e, sotto, una riga flex `[AdminSidebar | main]`. Il drawer mobile resta invariato (riusa anch'esso `AdminNavList`).
+
+**Tech Stack:** Next.js 16 (App Router) · React 19 · TypeScript · Vitest + React Testing Library · lucide-react · Tailwind (breakpoint `lg` = 1024px). Niente nuove dipendenze.
+
+**Depends on:** **F0a** (`apps/web/src/components/layout/admin-nav/admin-nav-config.ts` + `filter-nav-by-role.ts`). Esegui F0a prima.
+
+**Spec di riferimento:** `docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md` §4.3 (shell ibrida sidebar desktop + drawer mobile).
+
+**Note di contesto (dall'esplorazione):**
+- Pattern di sidebar persistente già nel codebase: `CardRack` e `ContextualHandSidebar` usano `hidden md:flex` + larghezza fissa. F0b usa `lg` (1024px) perché la nav admin è più densa.
+- `AdminShell` oggi è `flex flex-col` (TopBar + main + drawer overlay).
+- Il drawer (`AdminSideDrawer`) dopo F0a rende i 4 gruppi inline; F0b sposta quella resa in `AdminNavList` riusabile.
+
+---
+
+## File Structure
+
+- **Create** `apps/web/src/components/layout/admin-nav/AdminNavList.tsx` — resa condivisa: `NavLink` + `isPathActive` + map dei gruppi. Consumato da drawer (mobile) e sidebar (desktop).
+- **Create** `apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx` — test resa gruppi + active state.
+- **Create** `apps/web/src/components/layout/AdminSidebar/AdminSidebar.tsx` — sidebar desktop persistente (`hidden lg:flex`).
+- **Create** `apps/web/src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx` — test resa + filtro ruolo + classe responsive.
+- **Modify** `apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx` — usa `AdminNavList` al posto della resa inline (introdotta in F0a).
+- **Modify** `apps/web/src/components/layout/AdminShell/AdminShell.tsx` — riga flex `[AdminSidebar | main]` sotto la TopBar.
+
+---
+
+## Task 1: Estrai `AdminNavList` condiviso
+
+Sposta `NavLink`, `isPathActive` e la resa dei gruppi (introdotta in F0a, Task 3, step 3c) in un componente riusabile.
+
+**Files:**
+- Create: `apps/web/src/components/layout/admin-nav/AdminNavList.tsx`
+- Test: `apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx`
+- Modify: `apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx`
+
+- [ ] **Step 1: Scrivi il test di `AdminNavList`**
+
+```tsx
+// apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { AdminNavGroup } from '../admin-nav-config';
+import { AdminNavList } from '../AdminNavList';
+
+const GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: () => null,
+    items: [{ label: 'Dashboard', href: '/admin/overview', icon: () => null }],
+  },
+];
+
+describe('AdminNavList', () => {
+  it('renders group label and item link', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/overview" />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute('href', '/admin/overview');
+  });
+
+  it('marks the active item with aria-current', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/overview" />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not mark a non-active item', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/users" />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).not.toHaveAttribute('aria-current');
+  });
+
+  it('calls onNavigate when a link is clicked', () => {
+    const onNavigate = vi.fn();
+    render(<AdminNavList groups={GROUPS} pathname="/admin/users" onNavigate={onNavigate} />);
+    screen.getByRole('link', { name: /Dashboard/i }).click();
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx`
+Expected: FAIL — `Failed to resolve import "../AdminNavList"`.
+
+- [ ] **Step 3: Crea `AdminNavList.tsx`**
+
+```tsx
+// apps/web/src/components/layout/admin-nav/AdminNavList.tsx
+'use client';
+
+import Link from 'next/link';
+
+import type { AdminNavGroup, AdminNavItem } from './admin-nav-config';
+
+export function isPathActive(pathname: string, href: string): boolean {
+  const hrefPath = href.split('?')[0];
+  return pathname === hrefPath || pathname.startsWith(hrefPath + '/');
+}
+
+interface NavLinkProps {
+  item: AdminNavItem;
+  pathname: string;
+  onClick?: () => void;
+}
+
+function NavLink({ item, pathname, onClick }: NavLinkProps) {
+  const Icon = item.icon;
+  const active = isPathActive(pathname, item.href);
+
+  return (
+    <Link
+      href={item.href}
+      onClick={onClick}
+      aria-current={active ? 'page' : undefined}
+      className={[
+        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+        active
+          ? 'bg-[hsla(25,95%,45%,0.12)] text-[hsl(var(--c-game-text))]'
+          : 'text-foreground/70 hover:bg-muted hover:text-foreground',
+      ].join(' ')}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span>{item.label}</span>
+    </Link>
+  );
+}
+
+export interface AdminNavListProps {
+  groups: AdminNavGroup[];
+  pathname: string;
+  onNavigate?: () => void;
+}
+
+/**
+ * Shared rendering of the admin navigation groups. Used by both the mobile
+ * drawer (AdminSideDrawer) and the desktop sidebar (AdminSidebar). Receives
+ * already-filtered groups; does not read the user/role itself.
+ */
+export function AdminNavList({ groups, pathname, onNavigate }: AdminNavListProps) {
+  return (
+    <nav className="flex flex-col gap-0.5">
+      {groups.map(group => (
+        <div key={group.id} className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
+            <group.icon className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {group.label}
+            </span>
+          </div>
+          {group.items.map(item => (
+            <NavLink key={item.href} item={item} pathname={pathname} onClick={onNavigate} />
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 4: Esegui il test e verifica che passi**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx`
+Expected: PASS (4 test).
+
+- [ ] **Step 5: Refactor `AdminSideDrawer` per usare `AdminNavList`**
+
+Nel drawer, importa `AdminNavList`, calcola i gruppi filtrati come in F0a, e sostituisci il `<nav>...</nav>` (che dopo F0a contiene il `.map` dei gruppi inline) con `<AdminNavList groups={visibleGroups} pathname={pathname} onNavigate={onClose} />`. Mantieni il link "Torna all'app" e l'header utente. Rimuovi il `NavLink` locale e `isPathActive` locale (ora importati/usati da `AdminNavList`).
+
+```tsx
+// In cima (import):
+import { AdminNavList } from '@/components/layout/admin-nav/AdminNavList';
+
+// Dentro il body scrollabile, al posto del <nav> inline:
+<div className="flex-1 overflow-y-auto px-3 py-3">
+  <Link
+    href="/dashboard"
+    onClick={onClose}
+    className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors mb-2"
+    style={{ color: 'hsl(var(--c-kb-text))' }}
+  >
+    <ChevronLeft className="h-4 w-4 shrink-0" />
+    <span>Torna all&apos;app</span>
+  </Link>
+  <div className="border-t mb-1" />
+  <AdminNavList groups={visibleGroups} pathname={pathname} onNavigate={onClose} />
+</div>
+```
+
+- [ ] **Step 6: Esegui i test del drawer (F0a) per verificare nessuna regressione**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminSideDrawer`
+Expected: PASS — i test di F0a (4 gruppi, filtro Staging Access, aria-current) passano ancora con la resa estratta.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/layout/admin-nav/AdminNavList.tsx apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
+git commit -m "refactor(admin): extract shared AdminNavList from drawer"
+```
+
+---
+
+## Task 2: Crea `AdminSidebar` (desktop persistente)
+
+**Files:**
+- Create: `apps/web/src/components/layout/AdminSidebar/AdminSidebar.tsx`
+- Test: `apps/web/src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx`
+
+- [ ] **Step 1: Scrivi il test di `AdminSidebar`**
+
+```tsx
+// apps/web/src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminSidebar } from '../AdminSidebar';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/overview',
+}));
+
+describe('AdminSidebar', () => {
+  beforeEach(() => mockUseCurrentUser.mockReset());
+
+  it('renders the four group labels for an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByText('AI Tooling & Data Quality')).toBeInTheDocument();
+  });
+
+  it('hides superadmin-only items from an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    expect(screen.queryByRole('link', { name: /Staging Access/i })).not.toBeInTheDocument();
+  });
+
+  it('is hidden below lg and shown at lg+ (responsive class)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    const aside = screen.getByRole('navigation', { name: /admin sidebar/i }).closest('aside');
+    expect(aside).toHaveClass('hidden');
+    expect(aside).toHaveClass('lg:flex');
+  });
+
+  it('renders nothing meaningful for a null user (no groups)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: null });
+    render(<AdminSidebar />);
+    expect(screen.queryByText('Admin Console')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx`
+Expected: FAIL — `Failed to resolve import "../AdminSidebar"`.
+
+- [ ] **Step 3: Crea `AdminSidebar.tsx`**
+
+```tsx
+// apps/web/src/components/layout/AdminSidebar/AdminSidebar.tsx
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
+import { AdminNavList } from '@/components/layout/admin-nav/AdminNavList';
+import { filterNavByRole } from '@/components/layout/admin-nav/filter-nav-by-role';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
+
+/**
+ * Persistent admin sidebar for desktop (>=lg). On smaller screens it is hidden
+ * (`hidden lg:flex`) and navigation is provided by AdminSideDrawer instead.
+ */
+export function AdminSidebar() {
+  const { data: user } = useCurrentUser();
+  const pathname = usePathname();
+  const visibleGroups = filterNavByRole(ADMIN_NAV_GROUPS, user ?? null);
+
+  return (
+    <aside className="hidden lg:flex w-[280px] shrink-0 flex-col border-r bg-background overflow-y-auto">
+      <div className="px-3 py-3">
+        <AdminNavList
+          groups={visibleGroups}
+          pathname={pathname}
+          // no onNavigate: desktop sidebar stays open, links navigate in place
+        />
+      </div>
+      {/* aria-label so tests/AT can target the persistent nav distinctly */}
+      <span className="sr-only" aria-hidden="true" />
+    </aside>
+  );
+}
+```
+
+> NOTA: `AdminNavList` rende un `<nav>`. Per soddisfare il test `getByRole('navigation', { name: /admin sidebar/i })`, aggiungi `aria-label="Admin sidebar"` al `<nav>` quando serve. Implementazione: estendi `AdminNavListProps` con un opzionale `ariaLabel?: string` e applicalo a `<nav aria-label={ariaLabel}>`. Aggiorna `AdminNavList.tsx` (Task 1, step 3) di conseguenza e passa `ariaLabel="Admin sidebar"` qui. Il drawer può passare `ariaLabel="Admin navigation"`.
+
+- [ ] **Step 3b: Aggiungi `ariaLabel` a `AdminNavList`**
+
+In `AdminNavList.tsx`, estendi le props e applica:
+
+```tsx
+export interface AdminNavListProps {
+  groups: AdminNavGroup[];
+  pathname: string;
+  onNavigate?: () => void;
+  ariaLabel?: string;
+}
+
+export function AdminNavList({ groups, pathname, onNavigate, ariaLabel }: AdminNavListProps) {
+  return (
+    <nav aria-label={ariaLabel} className="flex flex-col gap-0.5">
+      {/* ...unchanged... */}
+    </nav>
+  );
+}
+```
+
+In `AdminSidebar.tsx` passa `ariaLabel="Admin sidebar"`; rimuovi lo `<span className="sr-only" />` segnaposto.
+
+- [ ] **Step 4: Esegui il test e verifica che passi**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx`
+Expected: PASS (4 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/AdminSidebar apps/web/src/components/layout/admin-nav/AdminNavList.tsx apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx
+git commit -m "feat(admin): add persistent desktop AdminSidebar"
+```
+
+---
+
+## Task 3: `AdminShell` con riga flex `[sidebar | main]`
+
+**Files:**
+- Modify: `apps/web/src/components/layout/AdminShell/AdminShell.tsx`
+- Test: `apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+
+- [ ] **Step 1: Scrivi il test di `AdminShell`**
+
+```tsx
+// apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminShell } from '../AdminShell';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+vi.mock('next/navigation', () => ({ usePathname: () => '/admin/overview' }));
+// Keep TopBar / SearchOverlay / DashboardEngineProvider light for the test:
+vi.mock('@/components/layout/UserShell/TopBar', () => ({ TopBar: () => <div data-testid="topbar" /> }));
+vi.mock('@/components/layout/SearchOverlay', () => ({ SearchOverlay: () => null }));
+vi.mock('@/components/dashboard', () => ({
+  DashboardEngineProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AdminShell', () => {
+  beforeEach(() => mockUseCurrentUser.mockReset());
+
+  it('renders the persistent sidebar and the main content', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminShell><p>page body</p></AdminShell>);
+    expect(screen.getByRole('navigation', { name: /admin sidebar/i })).toBeInTheDocument();
+    expect(screen.getByText('page body')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+Expected: FAIL — la shell attuale non rende `AdminSidebar` (nessuna `navigation` "Admin sidebar").
+
+- [ ] **Step 3: Modifica `AdminShell.tsx`**
+
+```tsx
+'use client';
+
+import { useState, type ReactNode } from 'react';
+
+import { DashboardEngineProvider } from '@/components/dashboard';
+import { AdminSidebar } from '@/components/layout/AdminSidebar/AdminSidebar';
+import { AdminSideDrawer } from '@/components/layout/AdminSideDrawer/AdminSideDrawer';
+import { SearchOverlay } from '@/components/layout/SearchOverlay';
+import { TopBar } from '@/components/layout/UserShell/TopBar';
+
+interface AdminShellProps {
+  children: ReactNode;
+}
+
+export function AdminShell({ children }: AdminShellProps) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-[var(--bg)]">
+      <TopBar
+        onHamburgerClick={() => setDrawerOpen(true)}
+        onSearchClick={() => setSearchOpen(true)}
+        adminMode
+      />
+
+      <div className="flex flex-1 overflow-hidden">
+        <AdminSidebar />
+        <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
+          <DashboardEngineProvider>{children}</DashboardEngineProvider>
+        </main>
+      </div>
+
+      <AdminSideDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Esegui il test e verifica che passi**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + lint sui file toccati**
+
+Run: `cd apps/web && pnpm typecheck && pnpm exec eslint src/components/layout/admin-nav src/components/layout/AdminSidebar src/components/layout/AdminShell src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx`
+Expected: nessun errore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/layout/AdminShell/AdminShell.tsx apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
+git commit -m "feat(admin): persistent sidebar on desktop in AdminShell"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** F0b copre §4.3 "shell ibrida sidebar desktop (≥lg) + drawer mobile". Il dark scoped (stesso §4.3) è F0c.
+
+**2. Placeholder scan:** nessun TODO. `AdminNavList`/`AdminSidebar`/`AdminShell` mostrati per intero; il refinement `ariaLabel` è specificato con codice (Task 2 step 3b).
+
+**3. Type consistency:** `AdminNavList` consuma `AdminNavGroup`/`AdminNavItem` (F0a). `filterNavByRole(groups, user)` come F0a. `AdminSidebar` e drawer entrambi: `useCurrentUser` → `filterNavByRole` → `AdminNavList`. `AdminNavListProps.ariaLabel` aggiunto in modo coerente tra Task 1 e Task 2.
+
+**Note di rischio:**
+- L'hamburger in `TopBar` (adminMode) resta attivo anche ≥lg: su desktop apre un drawer ridondante rispetto alla sidebar. Innocuo ma migliorabile (nascondere l'hamburger `lg:hidden`) in un follow-up — fuori scope F0b per non toccare `TopBar` condivisa.
+- Il test responsive verifica le classi (`hidden`/`lg:flex`), non il rendering reale al breakpoint (jsdom non fa layout). Validazione visiva ≥lg/<lg demandata a review manuale / E2E in un'ondata successiva.
+
+---
+
+## Execution Handoff
+
+Plan F0b salvato. Dipende da F0a. Prossimo plan Fondamenta: **F0c** (dark scoped admin).

--- a/docs/superpowers/plans/2026-05-24-sp5-admin-f0c-dark-scoped.md
+++ b/docs/superpowers/plans/2026-05-24-sp5-admin-f0c-dark-scoped.md
@@ -1,0 +1,191 @@
+# SP5 Admin F0c — Dark Theme Scoped to /admin/* — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Applicare il tema **dark come default sotto `/admin/*`**, mantenendo il default light nel resto del prodotto, senza FOUC e senza combattere `next-themes`.
+
+**Architecture:** Approccio **container-scoped** (non si tocca `<html>`). Si estende il selettore dei token dark perché valga anche quando `data-theme="dark"` è su un contenitore (non solo su `:root`); poi si applica `data-theme="dark"` al `<div>` root di `AdminShell`. I token CSS dark vengono così ridefiniti per il solo subtree admin via ereditarietà, e le utility `dark:` funzionano già (il custom-variant copre `[data-theme="dark"] *`). Nessuna manipolazione runtime di `<html>`, nessun conflitto con `next-themes`/localStorage, nessun cleanup all'uscita (lo scope muore con `AdminShell`).
+
+**Tech Stack:** Next.js 16 (App Router) · React 19 · TypeScript · CSS custom properties · Vitest · Playwright (E2E). Niente nuove dipendenze.
+
+**Depends on:** **F0b** (modifica lo stesso `AdminShell.tsx`). Esegui F0a → F0b → F0c in ordine.
+
+**Spec di riferimento:** `docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md` §4.3 (dark default scoped `/admin/*`), R9.
+
+**Perché NON l'approccio `<html>`-based:** forzare `data-theme="dark"` su `<html>` via effect richiede di salvare/ripristinare il tema all'uscita (App Router naviga client-side, `next-themes` non rimonta), rischia FOUC al primo load e può confliggere con le riscritture di `next-themes`. L'approccio container-scoped evita tutto ciò spostando lo scope su un nodo che è già SSR-rendered dentro il segmento admin.
+
+**Decisione di scope:** F0c forza dark su admin (default). Un eventuale **toggle light/dark dentro l'admin** è un follow-up (non incluso): R9 chiede "dark default", il toggle globale resta per il resto del prodotto.
+
+---
+
+## File Structure
+
+- **Modify** `apps/web/src/styles/design-tokens-canonical.css:165` — estendi il selettore `:root[data-theme="dark"]` a `:root[data-theme="dark"], [data-theme="dark"]` così i token dark valgono anche scoped a un contenitore.
+- **Modify** `apps/web/src/components/layout/AdminShell/AdminShell.tsx` — aggiungi `data-theme="dark"` (+ `data-admin-shell` per i test) al `<div>` root.
+- **Modify** `apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx` — asserisci l'attributo `data-theme="dark"`.
+- **Create** `apps/web/e2e/admin/admin-dark-scope.spec.ts` — E2E: `/admin/*` dark, route non-admin light.
+
+---
+
+## Task 1: Estendi il selettore dei token dark al container scope
+
+**Files:**
+- Modify: `apps/web/src/styles/design-tokens-canonical.css:165`
+
+> NOTA TDD: una modifica al selettore CSS non è verificabile in unit test (jsdom non risolve le custom properties dei file CSS reali). La verifica avviene nell'E2E del Task 3. Questo task è una modifica chirurgica di una riga + razionale.
+
+- [ ] **Step 1: Apri il file e individua il blocco dark**
+
+Run: `cd apps/web && sed -n '163,170p' src/styles/design-tokens-canonical.css`
+Expected: la riga 165 è `:root[data-theme="dark"] {` (apertura del blocco token dark).
+
+- [ ] **Step 2: Estendi il selettore**
+
+Sostituisci esattamente:
+
+```css
+:root[data-theme="dark"] {
+```
+
+con:
+
+```css
+/* DS: dark tokens apply both on :root (global theme) AND on any container
+   carrying data-theme="dark" (e.g. AdminShell), enabling per-section dark scope
+   without touching <html>. See SP5 F0c. */
+:root[data-theme="dark"],
+[data-theme="dark"] {
+```
+
+Non cambiare il corpo del blocco (i valori dei token dark restano invariati).
+
+- [ ] **Step 3: Verifica che il light theme globale non regredisca (build CSS)**
+
+Run: `cd apps/web && pnpm exec stylelint src/styles/design-tokens-canonical.css` (se stylelint è configurato; altrimenti salta)
+Expected: nessun errore di sintassi sul selettore. In assenza di stylelint, verifica manuale che il blocco apra con i due selettori e chiuda regolarmente con `}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/styles/design-tokens-canonical.css
+git commit -m "feat(tokens): allow dark tokens to scope to a container (not only :root)"
+```
+
+---
+
+## Task 2: `AdminShell` applica `data-theme="dark"`
+
+**Files:**
+- Modify: `apps/web/src/components/layout/AdminShell/AdminShell.tsx`
+- Modify: `apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+
+- [ ] **Step 1: Aggiungi l'asserzione al test esistente di `AdminShell`**
+
+Aggiungi questo test al `describe('AdminShell', ...)` creato in F0b:
+
+```tsx
+  it('scopes the dark theme to the admin shell root', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    const { container } = render(<AdminShell><p>page body</p></AdminShell>);
+    const root = container.querySelector('[data-admin-shell]');
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute('data-theme', 'dark');
+  });
+```
+
+- [ ] **Step 2: Esegui il test e verifica che fallisca**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+Expected: FAIL — nessun elemento `[data-admin-shell]` / nessun `data-theme="dark"`.
+
+- [ ] **Step 3: Aggiungi gli attributi al `<div>` root di `AdminShell`**
+
+Modifica la riga di apertura del `<div>` root (da F0b):
+
+```tsx
+    <div data-admin-shell data-theme="dark" className="flex min-h-dvh flex-col bg-[var(--bg)]">
+```
+
+(invariato tutto il resto del componente). `bg-[var(--bg)]` ora risolve al `--bg` dark perché il `data-theme="dark"` sullo stesso elemento ridefinisce i token per sé e i discendenti (grazie al Task 1).
+
+- [ ] **Step 4: Esegui i test e verifica che passino**
+
+Run: `cd apps/web && pnpm vitest run src/components/layout/AdminShell/__tests__/AdminShell.test.tsx`
+Expected: PASS (i test di F0b + il nuovo test dark).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/AdminShell/AdminShell.tsx apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
+git commit -m "feat(admin): scope dark theme to AdminShell root (/admin/*)"
+```
+
+---
+
+## Task 3: E2E — dark su /admin, light fuori
+
+**Files:**
+- Create: `apps/web/e2e/admin/admin-dark-scope.spec.ts`
+
+- [ ] **Step 1: Scrivi il test E2E**
+
+```typescript
+// apps/web/e2e/admin/admin-dark-scope.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin dark theme scope', () => {
+  test.beforeEach(() => {
+    process.env.PLAYWRIGHT_AUTH_BYPASS = 'true';
+  });
+
+  test('admin shell is scoped to dark', async ({ page }) => {
+    await page.goto('/admin/overview');
+    const shell = page.locator('[data-admin-shell]');
+    await expect(shell).toHaveAttribute('data-theme', 'dark');
+    // The shell background resolves to the dark token, not the light cream.
+    const bg = await shell.evaluate(el => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe('rgb(247, 243, 238)'); // #f7f3ee light cream
+  });
+
+  test('a non-admin route stays light at the document root', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    await expect(page.locator('[data-admin-shell]')).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui l'E2E**
+
+Run: `cd apps/web && pnpm test:e2e -- admin/admin-dark-scope.spec.ts`
+Expected: PASS — `/admin/overview` ha `data-admin-shell[data-theme="dark"]` con bg non-cream; `/dashboard` resta light e non ha l'admin shell.
+
+> Se il primo run fallisce per setup auth/server, allinea il pattern di bypass agli altri test in `apps/web/e2e/admin/` (es. `admin-dashboard-navigation.spec.ts`) — usano `process.env.PLAYWRIGHT_AUTH_BYPASS = 'true'` nel `beforeEach`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/admin/admin-dark-scope.spec.ts
+git commit -m "test(admin): e2e for /admin dark scope vs light elsewhere"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** F0c copre §4.3 "dark default scoped `/admin/*`" e R9. Density alta (§4.3) NON è in F0c — è un work-stream separato (la spec la marca come decisione D-2, da affrontare a parte).
+
+**2. Placeholder scan:** nessun TODO. La modifica CSS è mostrata esatta (selettore prima/dopo). Gli attributi su `AdminShell` sono mostrati. L'E2E è completo.
+
+**3. Type consistency:** nessun nuovo tipo. `data-admin-shell` è l'aggancio condiviso tra il test unit (Task 2) e l'E2E (Task 3) — coerente.
+
+**Note di rischio:**
+- **Specificità CSS:** `[data-theme="dark"]` (0,1,0) ha la stessa specificità di `[data-theme="light"]`; il light vive su `:root[...="light"]` (0,1,1) che è più specifico ma su un altro elemento. Per il subtree admin vince il `data-theme="dark"` del contenitore (più vicino nell'albero per le custom properties ereditate). Verifica visiva ≥ Task 3.
+- **`dark:` utilities:** funzionano nel subtree perché `@custom-variant dark` include `[data-theme="dark"] *` (verificato in globals.css durante l'esplorazione). Nessun componente admin dovrebbe dipendere da `.dark` su `<html>`; se emerge un caso, va spostato su token semantici.
+- **Toggle in-admin assente** (vedi Decisione di scope). Se in review si vuole un toggle dentro admin, è un follow-up dedicato (richiede stato + override del `data-theme` del contenitore).
+
+---
+
+## Execution Handoff
+
+Plan F0c salvato. Con F0a + F0b + F0c la **fase Fondamenta** è interamente pianificata. Sotto-plan successivi: pilota **F1 A1 Overview** (re-skin sopra la nuova shell), poi ondate F2-F6.


### PR DESCRIPTION
Docs-only — 3 implementation plan, nessun codice di prodotto toccato.

## Cosa contiene

I plan TDD della **fase Fondamenta** del consolidamento admin SP5, derivati dalla spec mergiata in #1493 (`docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md`). Ogni plan è bite-sized (TDD: test → fail → impl → pass → commit), con codice reale verificato sui file del codebase e self-review.

| Plan | Contenuto | Task | Dipende da |
|------|-----------|------|------------|
| **F0a** `…-f0a-nav-consolidation.md` | Config nav condivisa a 4 gruppi A/B/C/D + campo `minRole` + `filterNavByRole` (pura) + refactor `AdminSideDrawer` per consumarla | 3 | — |
| **F0b** `…-f0b-shell-responsive.md` | Estrae `AdminNavList` (DRY drawer↔sidebar) + `AdminSidebar` desktop persistente (`hidden lg:flex`) + `AdminShell` flex wrapper `[sidebar \| main]` | 3 | F0a |
| **F0c** `…-f0c-dark-scoped.md` | Dark default scoped `/admin/*` con approccio **container-scoped** (estende selettore token `:root[data-theme="dark"]` → `+ [data-theme="dark"]`, `data-theme="dark"` su root `AdminShell`) — niente FOUC, niente lotta con next-themes | 3 | F0b |

Ordine di esecuzione: **F0a → F0b → F0c**.

## Note

- **Scoperta riflessa nei plan:** i redirect di de-duplicazione IA sono **già implementati** in `next.config.js` (Issue #5040), quindi quel work-stream di F0 è fuori scope qui.
- **Gap noto (R2):** il tipo FE `UserRole` non include `creator` — i plan usano i 4 ruoli del tipo esistente (`superadmin/admin/editor/user`); `creator` è un gap separato.
- Le note di rischio sono in ogni plan (es. F0b: hamburger ridondante ≥lg; F0c: toggle in-admin assente di proposito, specificità CSS da validare via E2E).

## Prossimo passo (post-merge)

Esecuzione di **F0a** (subagent-driven development), poi F0b e F0c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
