### PR TITLE
feat(admin): SP5 F0a nav consolidation (4 groups + role filter)

### DIFF
--- a/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
+++ b/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
@@ -1,32 +1,15 @@
 /* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or decorative inline gradient; mockup .e-bg pattern. Will be re-evaluated in DS-15 finalization audit. */
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-import {
-  Activity,
-  BarChart2,
-  Bot,
-  ChevronLeft,
-  ChevronRight,
-  Database,
-  LayoutDashboard,
-  Mail,
-  MonitorCheck,
-  Settings,
-  Shield,
-  Users,
-  Gamepad2,
-  BellRing,
-  FileSearch,
-  BookOpen,
-  UserCheck,
-  Heart,
-  Globe,
-} from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import type { AdminNavItem } from '@/components/layout/admin-nav/admin-nav-config';
+import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
+import { filterNavByRole } from '@/components/layout/admin-nav/filter-nav-by-role';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 
 // ---------------------------------------------------------------------------
@@ -38,83 +21,6 @@ export interface AdminSideDrawerProps {
   onClose: () => void;
 }
 
-interface NavItem {
-  label: string;
-  href: string;
-  icon: React.ElementType;
-}
-
-interface NavSection {
-  label: string;
-  icon: React.ElementType;
-  items: NavItem[];
-  altroItems?: NavItem[];
-}
-
-// ---------------------------------------------------------------------------
-// Nav definitions
-// ---------------------------------------------------------------------------
-
-const SECTIONS: NavSection[] = [
-  {
-    label: 'Overview',
-    icon: LayoutDashboard,
-    items: [
-      { label: 'Dashboard', href: '/admin/overview', icon: LayoutDashboard },
-      { label: 'Activity Feed', href: '/admin/overview/activity', icon: Activity },
-      { label: 'System Health', href: '/admin/overview/system', icon: MonitorCheck },
-    ],
-  },
-  {
-    label: 'Content',
-    icon: Gamepad2,
-    items: [
-      { label: 'Giochi', href: '/admin/shared-games/all', icon: Gamepad2 },
-      { label: 'Knowledge Base', href: '/admin/knowledge-base', icon: BookOpen },
-      { label: 'Email Templates', href: '/admin/content/email-templates', icon: Mail },
-    ],
-  },
-  {
-    label: 'AI',
-    icon: Bot,
-    items: [
-      { label: 'Mission Control', href: '/admin/agents', icon: Bot },
-      { label: 'RAG Inspector', href: '/admin/agents/inspector', icon: FileSearch },
-      { label: 'Agent Definitions', href: '/admin/agents/definitions', icon: Database },
-    ],
-    altroItems: [
-      { label: 'Config', href: '/admin/agents/config', icon: Settings },
-      { label: 'Usage', href: '/admin/agents/usage', icon: BarChart2 },
-      { label: 'Analytics', href: '/admin/agents/analytics', icon: BarChart2 },
-    ],
-  },
-  {
-    label: 'Users',
-    icon: Users,
-    items: [
-      { label: 'Tutti gli utenti', href: '/admin/users', icon: Users },
-      { label: 'Invitations', href: '/admin/users/invitations', icon: Mail },
-      { label: 'Ruoli & Permessi', href: '/admin/users/roles', icon: Shield },
-    ],
-    altroItems: [
-      { label: 'Access Requests', href: '/admin/users/access-requests', icon: UserCheck },
-      { label: 'Activity', href: '/admin/users/activity', icon: Activity },
-    ],
-  },
-];
-
-const SYSTEM_ITEMS: NavItem[] = [
-  { label: 'Monitor', href: '/admin/monitor', icon: MonitorCheck },
-  { label: 'Providers', href: '/admin/providers', icon: Globe },
-  { label: 'Config', href: '/admin/config', icon: Settings },
-  { label: 'Notifications', href: '/admin/notifications/compose', icon: BellRing },
-];
-
-const ANALYTICS_ITEMS: NavItem[] = [
-  { label: 'Overview', href: '/admin/analytics', icon: BarChart2 },
-  { label: 'Audit', href: '/admin/analytics?tab=audit', icon: Heart },
-];
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -125,17 +31,12 @@ function isPathActive(pathname: string, href: string): boolean {
   return pathname === hrefPath || pathname.startsWith(hrefPath + '/');
 }
 
-function isSectionAltroActive(pathname: string, altroItems?: NavItem[]): boolean {
-  if (!altroItems) return false;
-  return altroItems.some(item => isPathActive(pathname, item.href));
-}
-
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
 interface NavLinkProps {
-  item: NavItem;
+  item: AdminNavItem;
   pathname: string;
   onClick: () => void;
   indent?: boolean;
@@ -166,76 +67,6 @@ function NavLink({ item, pathname, onClick, indent = false }: NavLinkProps) {
   );
 }
 
-interface CollapsibleSectionProps {
-  label: string;
-  icon: React.ElementType;
-  items: NavItem[];
-  altroItems?: NavItem[];
-  pathname: string;
-  onNavigate: () => void;
-}
-
-function CollapsibleSection({
-  label,
-  icon: SectionIcon,
-  items,
-  altroItems,
-  pathname,
-  onNavigate,
-}: CollapsibleSectionProps) {
-  const altroActive = isSectionAltroActive(pathname, altroItems);
-  const [altroOpen, setAltroOpen] = useState(altroActive);
-
-  return (
-    <div className="flex flex-col gap-0.5">
-      {/* Section label */}
-      <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
-        <SectionIcon className="h-3.5 w-3.5 text-muted-foreground" />
-        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          {label}
-        </span>
-      </div>
-
-      {/* Items */}
-      {items.map(item => (
-        <NavLink key={item.href} item={item} pathname={pathname} onClick={onNavigate} />
-      ))}
-
-      {/* Altro collapsible */}
-      {altroItems && altroItems.length > 0 && (
-        <>
-          <button
-            type="button"
-            onClick={() => setAltroOpen(prev => !prev)}
-            className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium text-foreground/60 hover:bg-muted hover:text-foreground transition-colors"
-            aria-expanded={altroOpen}
-          >
-            <span className="text-xs">Altro</span>
-            <ChevronRight
-              className="h-3.5 w-3.5 shrink-0 transition-transform duration-200"
-              style={{ transform: altroOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}
-            />
-          </button>
-
-          {altroOpen && (
-            <div className="flex flex-col gap-0.5 pl-2">
-              {altroItems.map(item => (
-                <NavLink
-                  key={item.href}
-                  item={item}
-                  pathname={pathname}
-                  onClick={onNavigate}
-                  indent
-                />
-              ))}
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // AdminSideDrawer
 // ---------------------------------------------------------------------------
@@ -244,8 +75,7 @@ export function AdminSideDrawer({ open, onClose }: AdminSideDrawerProps) {
   const { data: user } = useCurrentUser();
   const pathname = usePathname();
 
-  const [systemOpen, setSystemOpen] = useState(false);
-  const [analyticsOpen, setAnalyticsOpen] = useState(false);
+  const visibleGroups = filterNavByRole(ADMIN_NAV_GROUPS, user ?? null);
 
   // Prevent body scroll when drawer is open
   useEffect(() => {
@@ -325,84 +155,20 @@ export function AdminSideDrawer({ open, onClose }: AdminSideDrawerProps) {
 
             <div className="border-t mb-1" />
 
-            {/* Main admin sections */}
-            {SECTIONS.map(section => (
-              <CollapsibleSection
-                key={section.label}
-                label={section.label}
-                icon={section.icon}
-                items={section.items}
-                altroItems={section.altroItems}
-                pathname={pathname}
-                onNavigate={onClose}
-              />
+            {/* Role-filtered 4-group navigation */}
+            {visibleGroups.map(group => (
+              <div key={group.id} className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
+                  <group.icon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {group.label}
+                  </span>
+                </div>
+                {group.items.map(item => (
+                  <NavLink key={item.href} item={item} pathname={pathname} onClick={onClose} />
+                ))}
+              </div>
             ))}
-
-            <div className="border-t my-2" />
-
-            {/* System collapsible */}
-            <div className="flex flex-col gap-0.5">
-              <button
-                type="button"
-                onClick={() => setSystemOpen(prev => !prev)}
-                className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
-                aria-expanded={systemOpen}
-              >
-                <div className="flex items-center gap-2">
-                  <Settings className="h-4 w-4 shrink-0" />
-                  <span>System</span>
-                </div>
-                <ChevronRight
-                  className="h-4 w-4 shrink-0 transition-transform duration-200"
-                  style={{ transform: systemOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}
-                />
-              </button>
-              {systemOpen && (
-                <div className="flex flex-col gap-0.5 pl-2">
-                  {SYSTEM_ITEMS.map(item => (
-                    <NavLink
-                      key={item.href}
-                      item={item}
-                      pathname={pathname}
-                      onClick={onClose}
-                      indent
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Analytics collapsible */}
-            <div className="flex flex-col gap-0.5">
-              <button
-                type="button"
-                onClick={() => setAnalyticsOpen(prev => !prev)}
-                className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm font-medium text-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
-                aria-expanded={analyticsOpen}
-              >
-                <div className="flex items-center gap-2">
-                  <BarChart2 className="h-4 w-4 shrink-0" />
-                  <span>Analytics</span>
-                </div>
-                <ChevronRight
-                  className="h-4 w-4 shrink-0 transition-transform duration-200"
-                  style={{ transform: analyticsOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}
-                />
-              </button>
-              {analyticsOpen && (
-                <div className="flex flex-col gap-0.5 pl-2">
-                  {ANALYTICS_ITEMS.map(item => (
-                    <NavLink
-                      key={item.href}
-                      item={item}
-                      pathname={pathname}
-                      onClick={onClose}
-                      indent
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
           </nav>
         </div>
       </div>

--- a/apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx
+++ b/apps/web/src/components/layout/AdminSideDrawer/__tests__/AdminSideDrawer.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminSideDrawer } from '../AdminSideDrawer';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/overview',
+}));
+
+describe('AdminSideDrawer', () => {
+  beforeEach(() => {
+    mockUseCurrentUser.mockReset();
+  });
+
+  it('renders nothing when closed', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    const { container } = render(<AdminSideDrawer open={false} onClose={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the four group labels for an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByText('Power-User Tools')).toBeInTheDocument();
+    expect(screen.getByText('Platform & Operations')).toBeInTheDocument();
+    expect(screen.getByText('AI Tooling & Data Quality')).toBeInTheDocument();
+  });
+
+  it('hides superadmin-only items from an admin (Staging Access)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.queryByRole('link', { name: /Staging Access/i })).not.toBeInTheDocument();
+  });
+
+  it('shows superadmin-only items to a superadmin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'superadmin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByRole('link', { name: /Staging Access/i })).toBeInTheDocument();
+  });
+
+  it('marks the active route with aria-current', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSideDrawer open onClose={() => {}} />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
+++ b/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { ADMIN_NAV_GROUPS } from '../admin-nav-config';
+
+const VALID_ROLES = ['superadmin', 'admin', 'editor', 'user'];
+
+describe('ADMIN_NAV_GROUPS', () => {
+  it('declares exactly the four groups A, B, C, D in order', () => {
+    expect(ADMIN_NAV_GROUPS.map(g => g.id)).toEqual(['A', 'B', 'C', 'D']);
+  });
+
+  it('every group has a non-empty label and at least one item', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      expect(group.label.length).toBeGreaterThan(0);
+      expect(group.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every item has a non-empty label and an /admin href', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      for (const item of group.items) {
+        expect(item.label.length).toBeGreaterThan(0);
+        expect(item.href.startsWith('/admin')).toBe(true);
+      }
+    }
+  });
+
+  it('every declared minRole is a valid UserRole', () => {
+    for (const group of ADMIN_NAV_GROUPS) {
+      for (const item of group.items) {
+        if (item.minRole !== undefined) {
+          expect(VALID_ROLES).toContain(item.minRole);
+        }
+      }
+    }
+  });
+
+  it('has no duplicate hrefs across all groups', () => {
+    const hrefs = ADMIN_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});

--- a/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
+++ b/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
+import type { UserRole } from '@/types/auth';
+
 import { ADMIN_NAV_GROUPS } from '../admin-nav-config';
 
-const VALID_ROLES = ['superadmin', 'admin', 'editor', 'user'];
+const VALID_ROLES: UserRole[] = ['superadmin', 'admin', 'editor', 'user'];
 
 describe('ADMIN_NAV_GROUPS', () => {
   it('declares exactly the four groups A, B, C, D in order', () => {

--- a/apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts
+++ b/apps/web/src/components/layout/admin-nav/__tests__/filter-nav-by-role.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import type { AuthUser } from '@/types/auth';
+
+import type { AdminNavGroup } from '../admin-nav-config';
+import { filterNavByRole } from '../filter-nav-by-role';
+
+function user(role: string): AuthUser {
+  return { id: 'u1', email: 'a@b.c', role };
+}
+
+const GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: () => null,
+    items: [
+      { label: 'Dashboard', href: '/admin/overview', icon: () => null }, // default admin
+      { label: 'Secrets', href: '/admin/secrets', icon: () => null, minRole: 'superadmin' },
+    ],
+  },
+  {
+    id: 'B',
+    label: 'Editor Tools',
+    icon: () => null,
+    items: [{ label: 'Editor', href: '/admin/editor', icon: () => null, minRole: 'editor' }],
+  },
+];
+
+describe('filterNavByRole', () => {
+  it('superadmin sees every item', () => {
+    const result = filterNavByRole(GROUPS, user('superadmin'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/overview', '/admin/secrets', '/admin/editor']);
+  });
+
+  it('admin sees admin+editor items but not superadmin-only', () => {
+    const result = filterNavByRole(GROUPS, user('admin'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/overview', '/admin/editor']);
+  });
+
+  it('editor sees only editor item; admin-default item is hidden', () => {
+    const result = filterNavByRole(GROUPS, user('editor'));
+    const hrefs = result.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toEqual(['/admin/editor']);
+  });
+
+  it('drops groups that become empty after filtering', () => {
+    const result = filterNavByRole(GROUPS, user('editor'));
+    expect(result.map(g => g.id)).toEqual(['B']);
+  });
+
+  it('returns no groups for a null user', () => {
+    expect(filterNavByRole(GROUPS, null)).toEqual([]);
+  });
+
+  it('treats an item without minRole as requiring admin', () => {
+    const result = filterNavByRole(GROUPS, user('user'));
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -1,0 +1,112 @@
+import type { ComponentType } from 'react';
+
+import {
+  Activity,
+  BarChart2,
+  Bot,
+  BookOpen,
+  Database,
+  FileSearch,
+  Gamepad2,
+  Globe,
+  LayoutDashboard,
+  Mail,
+  MonitorCheck,
+  Settings,
+  Shield,
+  Users,
+  BellRing,
+  UserCheck,
+  Wrench,
+} from 'lucide-react';
+
+import type { UserRole } from '@/types/auth';
+
+export interface AdminNavItem {
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+  /** Minimum role required to see this item. Defaults to 'admin' when omitted. */
+  minRole?: UserRole;
+}
+
+export interface AdminNavGroup {
+  id: 'A' | 'B' | 'C' | 'D';
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  items: AdminNavItem[];
+}
+
+/**
+ * Canonical admin navigation, organised in the 4 groups of the SP5 consolidation
+ * spec (A Admin Console / B Power-User Tools / C Platform & Operations /
+ * D AI Tooling & Data Quality).
+ *
+ * Only routes that already exist are listed here. New screens land in waves
+ * F3-F6 by extending this array. Paths use the canonical hubs already enforced
+ * by next.config.js redirects (Issue #5040).
+ */
+export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: LayoutDashboard,
+    items: [
+      { label: 'Dashboard', href: '/admin/overview', icon: LayoutDashboard },
+      { label: 'Activity Feed', href: '/admin/overview/activity', icon: Activity },
+      { label: 'System Health', href: '/admin/overview/system', icon: MonitorCheck },
+      { label: 'Users', href: '/admin/users', icon: Users },
+      { label: 'Content', href: '/admin/content', icon: Gamepad2 },
+      { label: 'AI / RAG', href: '/admin/ai', icon: Bot },
+      { label: 'Knowledge Base', href: '/admin/knowledge-base', icon: BookOpen },
+      { label: 'Catalog Ingestion', href: '/admin/catalog-ingestion', icon: Database },
+      { label: 'Config', href: '/admin/config', icon: Settings },
+      { label: 'Monitor', href: '/admin/monitor', icon: MonitorCheck },
+      { label: 'Notifications', href: '/admin/notifications/compose', icon: BellRing },
+    ],
+  },
+  {
+    id: 'B',
+    label: 'Power-User Tools',
+    icon: Wrench,
+    items: [
+      { label: 'Giochi', href: '/admin/shared-games/all', icon: Gamepad2 },
+      { label: 'Email Templates', href: '/admin/content/email-templates', icon: Mail },
+      { label: 'Invitations', href: '/admin/users/invitations', icon: Mail },
+      { label: 'Ruoli & Permessi', href: '/admin/users/roles', icon: Shield },
+    ],
+  },
+  {
+    id: 'C',
+    label: 'Platform & Operations',
+    icon: Globe,
+    items: [
+      { label: 'Providers', href: '/admin/providers', icon: Globe },
+      { label: 'Analytics', href: '/admin/analytics', icon: BarChart2 },
+      {
+        label: 'Staging Access',
+        href: '/admin/staging-access',
+        icon: Shield,
+        minRole: 'superadmin',
+      },
+    ],
+  },
+  {
+    id: 'D',
+    label: 'AI Tooling & Data Quality',
+    icon: Bot,
+    items: [
+      { label: 'Agent Definitions', href: '/admin/agents/definitions', icon: Database },
+      { label: 'RAG Inspector', href: '/admin/agents/inspector', icon: FileSearch },
+      { label: 'RAG Quality', href: '/admin/rag-quality', icon: BarChart2 },
+      {
+        label: 'Mechanic Extractor',
+        href: '/admin/knowledge-base/mechanic-extractor',
+        icon: Wrench,
+      },
+      { label: 'A/B Testing', href: '/admin/agents/ab-testing', icon: BarChart2 },
+      { label: 'Agent Usage', href: '/admin/agents/usage', icon: BarChart2 },
+      { label: 'Access Requests', href: '/admin/users/access-requests', icon: UserCheck },
+    ],
+  },
+];

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -105,7 +105,6 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
         href: '/admin/knowledge-base/mechanic-extractor',
         icon: Wrench,
       },
-      { label: 'A/B Testing', href: '/admin/agents/ab-testing', icon: BarChart2 },
       { label: 'Agent Usage', href: '/admin/agents/usage', icon: BarChart2 },
     ],
   },

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -74,6 +74,7 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
       { label: 'Email Templates', href: '/admin/content/email-templates', icon: Mail },
       { label: 'Invitations', href: '/admin/users/invitations', icon: Mail },
       { label: 'Ruoli & Permessi', href: '/admin/users/roles', icon: Shield },
+      { label: 'Access Requests', href: '/admin/users/access-requests', icon: UserCheck },
     ],
   },
   {
@@ -106,7 +107,6 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
       },
       { label: 'A/B Testing', href: '/admin/agents/ab-testing', icon: BarChart2 },
       { label: 'Agent Usage', href: '/admin/agents/usage', icon: BarChart2 },
-      { label: 'Access Requests', href: '/admin/users/access-requests', icon: UserCheck },
     ],
   },
 ];

--- a/apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts
+++ b/apps/web/src/components/layout/admin-nav/filter-nav-by-role.ts
@@ -1,0 +1,20 @@
+import type { AuthUser } from '@/types/auth';
+import { hasRole } from '@/types/auth';
+
+import type { AdminNavGroup } from './admin-nav-config';
+
+const DEFAULT_MIN_ROLE = 'admin' as const;
+
+/**
+ * Returns a copy of `groups` keeping only the items the user is allowed to see
+ * (per item `minRole`, defaulting to 'admin'), and dropping groups left empty.
+ * Pure: does not mutate the input.
+ */
+export function filterNavByRole(groups: AdminNavGroup[], user: AuthUser | null): AdminNavGroup[] {
+  return groups
+    .map(group => ({
+      ...group,
+      items: group.items.filter(item => hasRole(user, item.minRole ?? DEFAULT_MIN_ROLE)),
+    }))
+    .filter(group => group.items.length > 0);
+}


### PR DESCRIPTION
## Summary

Implementa **F0a — Nav Consolidation** (fase Fondamenta della migrazione admin SP5) — primo codice di prodotto della migrazione. Plan: `docs/superpowers/plans/2026-05-24-sp5-admin-f0a-nav-consolidation.md` (mergiato in #1495); spec in #1493.

- **`admin-nav-config.ts`** (nuovo): config nav admin condivisa, riorganizzata nei 4 gruppi A/B/C/D della spec, con campo `minRole`. Include solo route già esistenti (le ondate F3-F6 estenderanno l'array).
- **`filter-nav-by-role.ts`** (nuovo): funzione pura `filterNavByRole(groups, user)` — applica la gerarchia ruoli (`hasRole`), default `minRole='admin'`, droppa i gruppi che restano vuoti. Nessuna mutazione dell'input.
- **`AdminSideDrawer`** (refactor): ora data-driven dai 4 gruppi filtrati per ruolo. Rimossi `SECTIONS`/`SYSTEM_ITEMS`/`ANALYTICS_ITEMS` inline + i collassabili System/Analytics (−254 righe). Aggiungere un gruppo/voce ora è una modifica al solo file di config.

## Test Plan

- [x] 16/16 unit test (Vitest): `admin-nav-config` 5 + `filter-nav-by-role` 6 + `AdminSideDrawer` 5
- [x] `pnpm typecheck` pulito; ESLint pulito sui file toccati
- [ ] Verifica visiva del drawer: 4 gruppi resi, `Staging Access` nascosto agli admin / visibile ai superadmin, `aria-current` sull'item attivo

## Note

- **Behavioral change intenzionale:** il drawer mostra ora i 4 gruppi piatti (niente più accordion System/Analytics) — è l'obiettivo di consolidamento IA della spec §4.1. Merita una review del designer.
- Eseguito con subagent-driven development (TDD, review spec + qualità per ogni task). Il code review del Task 1 ha prodotto 2 fix (Access Requests → gruppo B; `VALID_ROLES` tipato).
- **Follow-up minori non bloccanti** (dal code review del Task 3): `NavLink.indent` prop ora morta da rimuovere; `filterNavByRole` calcolato prima del guard `if (!open)`; manca un test per lo stato loading/null-user.
- **Gap noto (R2):** il tipo FE `UserRole` non include `creator`.
- Prossimo: **F0b** (shell sidebar-responsive desktop, riusa la config via `AdminNavList`) → **F0c** (dark scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
