### PR TITLE
feat(game-detail): #1468 GameDetailLeaderboard presentational component

### DIFF
--- a/apps/web/src/components/features/game-detail/GameDetailLeaderboard.stories.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailLeaderboard.stories.tsx
@@ -1,0 +1,124 @@
+/**
+ * GameDetailLeaderboard Storybook Stories (Issue #1468)
+ *
+ * Visual fixtures for the Stats-tab leaderboard. Covers: many players, single player,
+ * empty state, and a null avgScore row. Avatar colors are driven by the `hueFor` prop
+ * (the caller injects `userHue` #1470; here a demo hash is used).
+ * Dark theme variant handled globally via the preview decorator.
+ */
+
+import type { GameLeaderboardEntry } from '@/lib/api/schemas';
+
+import { GameDetailLeaderboard } from './GameDetailLeaderboard';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const labels = {
+  plays: 'partite',
+  avgScore: 'avg',
+  wins: 'vittorie',
+  empty: 'Nessuna classifica disponibile',
+};
+
+// Demo hue mapper — deterministic per playerId. The real caller passes userHue (#1470).
+const demoHueFor = (playerId: string): number => {
+  let h = 0;
+  for (const ch of playerId) {
+    h = (h * 31 + ch.charCodeAt(0)) % 360;
+  }
+  return h;
+};
+
+function makeEntry(
+  playerId: string,
+  displayName: string,
+  initials: string,
+  wins: number,
+  plays: number,
+  avgScore: number | null
+): GameLeaderboardEntry {
+  return {
+    playerId,
+    displayName,
+    initials,
+    wins,
+    plays,
+    avgScore,
+    lastPlayedAt: '2026-05-20T12:00:00.000Z',
+  };
+}
+
+const manyPlayers: ReadonlyArray<GameLeaderboardEntry> = [
+  makeEntry('marco', 'Marco Rossi', 'MR', 12, 18, 91.2),
+  makeEntry('lucia', 'Lucia Bianchi', 'LB', 9, 15, 84.0),
+  makeEntry('gianni', 'Gianni Verdi', 'GV', 7, 14, 78.5),
+  makeEntry('sara', 'Sara Neri', 'SN', 5, 11, 72.0),
+  makeEntry('paolo', 'Paolo Gallo', 'PG', 3, 8, null),
+];
+
+const meta = {
+  title: 'Components/GameDetail/GameDetailLeaderboard',
+  component: GameDetailLeaderboard,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Pure presentational leaderboard. Ranks registered players by wins; the caller owns the useGameLeaderboard hook (#1467) and passes entries + a hueFor mapper (userHue #1470). DS-15 compliant.',
+      },
+    },
+    chromatic: { viewports: [375, 768, 1024] },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="w-full max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GameDetailLeaderboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Many players with colored avatars (hueFor injected). */
+export const ManyPlayers: Story = {
+  args: {
+    entries: manyPlayers,
+    title: 'Classifica giocatori',
+    labels,
+    hueFor: demoHueFor,
+  },
+};
+
+/** Single player — trophy rank, colored avatar. */
+export const SinglePlayer: Story = {
+  args: {
+    entries: [makeEntry('marco', 'Marco Rossi', 'MR', 4, 6, 88.0)],
+    title: 'Classifica giocatori',
+    labels,
+    hueFor: demoHueFor,
+  },
+};
+
+/** Empty state — no entries, localized empty label. */
+export const Empty: Story = {
+  args: {
+    entries: [],
+    title: 'Classifica giocatori',
+    labels,
+  },
+};
+
+/** Null avgScore — em-dash placeholder; neutral avatars (no hueFor). */
+export const NullAvgScoreNeutralAvatars: Story = {
+  args: {
+    entries: [
+      makeEntry('marco', 'Marco Rossi', 'MR', 8, 14, null),
+      makeEntry('lucia', 'Lucia Bianchi', 'LB', 5, 12, null),
+    ],
+    title: 'Classifica giocatori',
+    labels,
+  },
+};

--- a/apps/web/src/components/features/game-detail/GameDetailLeaderboard.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailLeaderboard.tsx
@@ -26,6 +26,11 @@ export interface GameDetailLeaderboardLabels {
 }
 
 export interface GameDetailLeaderboardProps {
+  /**
+   * Leaderboard rows, already sorted by the backend (#1467: wins desc, then avgScore,
+   * plays, userId). Rank is assigned by array index — row 0 receives the trophy — so the
+   * caller must not re-order or client-side-filter without re-sorting.
+   */
   readonly entries: ReadonlyArray<GameLeaderboardEntry>;
   /** Localized card title, resolved upstream (caller-side i18n). */
   readonly title: string;

--- a/apps/web/src/components/features/game-detail/GameDetailLeaderboard.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailLeaderboard.tsx
@@ -1,0 +1,122 @@
+/**
+ * GameDetailLeaderboard - Wave C follow-up (Issue #1468)
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-detail.jsx` (Leaderboard, lines 759-812).
+ * Tracking: epic #1475; design-handoff PILOT_GAP_REPORT § 2.3.
+ *
+ * Pure presentational leaderboard. Ranks registered players by wins. The caller owns the
+ * `useGameLeaderboard` hook (#1467) and passes `entries` already fetched, plus a `hueFor`
+ * mapper (e.g. `userHue`, #1470) for avatar colors. Loading/error states are the caller's
+ * responsibility (mirror `GameDetailSpecsCard` / `GameDetailKpiCards`).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { GameLeaderboardEntry } from '@/lib/api/schemas';
+
+export interface GameDetailLeaderboardLabels {
+  readonly plays: string;
+  readonly avgScore: string;
+  readonly wins: string;
+  readonly empty: string;
+}
+
+export interface GameDetailLeaderboardProps {
+  readonly entries: ReadonlyArray<GameLeaderboardEntry>;
+  /** Localized card title, resolved upstream (caller-side i18n). */
+  readonly title: string;
+  /** Localized labels, resolved upstream. */
+  readonly labels: GameDetailLeaderboardLabels;
+  /** Maps a playerId to an HSL hue (0..360) for the avatar. Caller injects userHue (#1470); omitted => neutral. */
+  readonly hueFor?: (playerId: string) => number;
+  /** Max rows rendered (default 10). */
+  readonly maxItems?: number;
+  readonly className?: string;
+}
+
+const EM_DASH = '—';
+
+export function GameDetailLeaderboard(props: GameDetailLeaderboardProps): ReactElement {
+  const { entries, title, labels, hueFor, maxItems = 10, className } = props;
+  const rows = entries.slice(0, maxItems);
+
+  return (
+    <section
+      data-slot="game-detail-leaderboard"
+      className={clsx('rounded-2xl border border-border bg-card p-[18px] shadow-sm', className)}
+    >
+      <h3 className="mb-3.5 font-display text-[15px] font-extrabold text-foreground">{title}</h3>
+
+      {rows.length === 0 ? (
+        <p
+          data-slot="game-detail-leaderboard-empty"
+          className="py-6 text-center font-mono text-[11px] text-muted-foreground"
+        >
+          {labels.empty}
+        </p>
+      ) : (
+        <ol role="list" aria-label={title} className="flex flex-col">
+          {rows.map((e, i) => {
+            const hue = hueFor?.(e.playerId);
+            const isFirst = i === 0;
+            return (
+              <li
+                key={e.playerId}
+                role="listitem"
+                data-slot="game-detail-leaderboard-row"
+                className={clsx(
+                  'flex items-center gap-3 py-2.5',
+                  i < rows.length - 1 && 'border-b border-border'
+                )}
+              >
+                <span
+                  className={clsx(
+                    'w-[22px] shrink-0 text-center font-mono text-[13px] font-extrabold',
+                    isFirst ? 'text-entity-agent' : 'text-muted-foreground'
+                  )}
+                >
+                  {isFirst ? '🏆' : `#${i + 1}`}
+                </span>
+
+                <span
+                  data-slot="game-detail-leaderboard-avatar"
+                  aria-hidden="true"
+                  className={clsx(
+                    'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-display text-[11px] font-extrabold',
+                    hue === undefined ? 'bg-muted text-muted-foreground' : 'text-white'
+                  )}
+                  style={hue === undefined ? undefined : { background: `hsl(${hue}, 60%, 55%)` }}
+                >
+                  {e.initials}
+                </span>
+
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-display text-[13px] font-extrabold text-foreground">
+                    {e.displayName}
+                  </div>
+                  <div className="font-mono text-[10px] font-semibold text-muted-foreground">
+                    {e.plays} {labels.plays} · {labels.avgScore}{' '}
+                    <span>{e.avgScore === null ? EM_DASH : e.avgScore}</span>
+                  </div>
+                </div>
+
+                <div className="flex flex-col items-end">
+                  <span className="font-display text-[16px] font-extrabold leading-none tabular-nums text-entity-player">
+                    {e.wins}
+                  </span>
+                  <span className="mt-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.06em] text-muted-foreground">
+                    {labels.wins}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailLeaderboard.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailLeaderboard.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * GameDetailLeaderboard - Unit tests (Issue #1468).
+ *
+ * Pure presentational leaderboard. Test matrix (Crispin):
+ *   T1. Renders one row per entry.
+ *   T2. data-slot attributes (card + rows).
+ *   T3. Rank: 🏆 for #1, "#N" for the rest.
+ *   T4. avgScore null → "—".
+ *   T5. Empty state (no entries) → labels.empty, no rows.
+ *   T6. maxItems caps rows.
+ *   T7. hueFor applied to avatar when provided; neutral otherwise.
+ *   T8. DS-15 entity tokens.
+ *   T9. className composition.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GameDetailLeaderboard } from '../GameDetailLeaderboard';
+
+import type { GameLeaderboardEntry } from '@/lib/api/schemas';
+
+const labels = {
+  plays: 'partite',
+  avgScore: 'avg',
+  wins: 'vittorie',
+  empty: 'Nessuna classifica disponibile',
+};
+
+function entry(over: Partial<GameLeaderboardEntry> & { playerId: string }): GameLeaderboardEntry {
+  return {
+    playerId: over.playerId,
+    displayName: over.displayName ?? 'Player',
+    initials: over.initials ?? 'PL',
+    wins: over.wins ?? 0,
+    plays: over.plays ?? 0,
+    avgScore: over.avgScore ?? null,
+    lastPlayedAt: over.lastPlayedAt ?? '2026-05-20T12:00:00.000Z',
+  };
+}
+
+const threeEntries: ReadonlyArray<GameLeaderboardEntry> = [
+  entry({
+    playerId: 'p1',
+    displayName: 'Marco Rossi',
+    initials: 'MR',
+    wins: 8,
+    plays: 14,
+    avgScore: 87.5,
+  }),
+  entry({
+    playerId: 'p2',
+    displayName: 'Lucia Bianchi',
+    initials: 'LB',
+    wins: 5,
+    plays: 12,
+    avgScore: 80,
+  }),
+  entry({
+    playerId: 'p3',
+    displayName: 'Guest One',
+    initials: 'GO',
+    wins: 2,
+    plays: 9,
+    avgScore: null,
+  }),
+];
+
+describe('GameDetailLeaderboard (Issue #1468)', () => {
+  // T1
+  it('renders one row per entry', () => {
+    render(<GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByText('Marco Rossi')).toBeInTheDocument();
+    expect(screen.getByText('MR')).toBeInTheDocument();
+  });
+
+  // T2
+  it('exposes data-slot for card and rows', () => {
+    const { container } = render(
+      <GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />
+    );
+    expect(container.querySelector('[data-slot="game-detail-leaderboard"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="game-detail-leaderboard-row"]')).toHaveLength(3);
+  });
+
+  // T3
+  it('shows a trophy for rank #1 and #N for the rest', () => {
+    render(<GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />);
+    expect(screen.getByText('🏆')).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    expect(screen.getByText('#3')).toBeInTheDocument();
+  });
+
+  // T4
+  it('renders an em-dash when avgScore is null', () => {
+    render(
+      <GameDetailLeaderboard
+        entries={[
+          entry({ playerId: 'p3', displayName: 'No Score', initials: 'NS', avgScore: null }),
+        ]}
+        title="Classifica"
+        labels={labels}
+      />
+    );
+    expect(screen.getByText(/—/)).toBeInTheDocument();
+  });
+
+  // T5
+  it('renders the empty label and no rows when entries is empty', () => {
+    render(<GameDetailLeaderboard entries={[]} title="Classifica" labels={labels} />);
+    expect(screen.getByText('Nessuna classifica disponibile')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+
+  // T6
+  it('caps rows at maxItems', () => {
+    render(
+      <GameDetailLeaderboard
+        entries={threeEntries}
+        title="Classifica"
+        labels={labels}
+        maxItems={2}
+      />
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  // T7
+  it('applies an hsl background to the avatar when hueFor is provided', () => {
+    const { container } = render(
+      <GameDetailLeaderboard
+        entries={threeEntries}
+        title="Classifica"
+        labels={labels}
+        hueFor={() => 200}
+      />
+    );
+    const avatar = container.querySelector(
+      '[data-slot="game-detail-leaderboard-avatar"]'
+    ) as HTMLElement;
+    // jsdom normalizes hsl(...) to rgb(...); assert a background is applied (not neutral).
+    expect(avatar.style.background).not.toBe('');
+    expect(avatar.className).not.toContain('bg-muted');
+  });
+
+  it('uses a neutral avatar when hueFor is omitted', () => {
+    const { container } = render(
+      <GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />
+    );
+    const avatar = container.querySelector(
+      '[data-slot="game-detail-leaderboard-avatar"]'
+    ) as HTMLElement;
+    expect(avatar.getAttribute('style') ?? '').not.toContain('hsl(');
+    expect(avatar.className).toContain('bg-muted');
+  });
+
+  // T8
+  it('uses DS-15 entity tokens for wins and rank-1', () => {
+    const { container } = render(
+      <GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />
+    );
+    expect(container.querySelector('.text-entity-player')).toBeInTheDocument();
+    expect(container.querySelector('.text-entity-agent')).toBeInTheDocument();
+  });
+
+  // T9
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <GameDetailLeaderboard
+        entries={threeEntries}
+        title="Classifica"
+        labels={labels}
+        className="extra"
+      />
+    );
+    const card = container.querySelector('[data-slot="game-detail-leaderboard"]');
+    expect(card).toHaveClass('extra');
+    expect(card).toHaveClass('bg-card');
+    expect(card).toHaveClass('border-border');
+  });
+
+  it('renders title as heading and wins/plays meta', () => {
+    render(<GameDetailLeaderboard entries={threeEntries} title="Classifica" labels={labels} />);
+    expect(screen.getByRole('heading', { name: 'Classifica' })).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument(); // wins of first player
+  });
+});

--- a/apps/web/src/components/features/game-detail/index.ts
+++ b/apps/web/src/components/features/game-detail/index.ts
@@ -75,3 +75,9 @@ export type {
 } from '@/components/features/game-detail/GameDetailSpecsCard';
 
 export { buildSpecsItems } from '@/components/features/game-detail/buildSpecsItems';
+
+export { GameDetailLeaderboard } from '@/components/features/game-detail/GameDetailLeaderboard';
+export type {
+  GameDetailLeaderboardLabels,
+  GameDetailLeaderboardProps,
+} from '@/components/features/game-detail/GameDetailLeaderboard';


### PR DESCRIPTION
## Summary

Implements #1468: `GameDetailLeaderboard` presentational component for the game-detail Stats tab. Spec hardened via `/sc:spec-panel` (6.0 → 8.5/10), built with TDD.

Ranks registered players by wins. **Pure presentational** (mirrors `GameDetailSpecsCard`/`GameDetailKpiCards`): receives `entries` (the `GameLeaderboardEntry` type from #1467), caller-side i18n labels, and an optional `hueFor` mapper for avatar colors.

## Decisions ratified (spec-panel)

- **Presentational puro**: no internal hook/fetch; loading/error are the caller's responsibility (the `useGameLeaderboard` hook already exists from #1467).
- **Avatar color via `hueFor` prop** → #1470 (`userHue`) declassed from blocking to non-blocking; the caller injects it when it lands, neutral avatar otherwise.
- **Standalone scope**: component + Storybook + tests + barrel. Stats-tab integration deferred to #1466 (OPEN).

## Changes

- `GameDetailLeaderboard.tsx` — rank 🏆 (#1) / `#N`, avatar (initials + `hueFor` hue, neutral fallback), `avgScore === null` → "—", empty state, entity tokens (DS-15), `data-slot` selectors.
- 11 unit tests (rows, data-slot, rank, null avgScore, empty, maxItems cap, hueFor present/absent, entity tokens, className).
- Storybook: 4 variants (many players / single / empty / null avgScore).
- Barrel export in `game-detail/index.ts`.

## Tests / quality

- 11 unit tests green. Reuses `GameLeaderboardEntry` from `@/lib/api/schemas` (no redeclaration).
- ESLint 0 errors (DS-15 token rule passes; `text-white` only on colored avatar — `.e-bg` pattern). Typecheck clean.

## Out of scope

- **Stats-tab integration** (`GameDetailView`) — deferred to #1466 (OPEN). When it lands, the caller mounts `<GameDetailLeaderboard>` with `entries` from `useGameLeaderboard` + `hueFor={userHue}` + loading/error.
- **`userHue`** (#1470) — injected via `hueFor`.

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
