### PR TITLE
feat(game-detail): #1465 GameDetailCommunityGate presentational component

### DIFF
--- a/apps/web/src/components/features/game-detail/GameDetailCommunityGate.stories.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailCommunityGate.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * GameDetailCommunityGate Storybook Stories (Issue #1465)
+ *
+ * Empty-state for the community variant of /games/[id], shown inside locked tabs.
+ * Covers the default game gate (📘) and a discover/community variant (🌐).
+ * Dark theme handled globally via the preview decorator.
+ */
+
+import { GameDetailCommunityGate } from './GameDetailCommunityGate';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/GameDetail/GameDetailCommunityGate',
+  component: GameDetailCommunityGate,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Pure presentational empty-state for community-variant locked tabs. The caller (#1466) renders it inside locked tab content and wires onAdd to the add-to-library mutation. i18n caller-side. DS-15 compliant.',
+      },
+    },
+    chromatic: { viewports: [375, 768, 1024] },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="w-full max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GameDetailCommunityGate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default — game book icon, add-to-library CTA. */
+export const Default: Story = {
+  args: {
+    icon: '📘',
+    title: 'Aggiungi alla tua libreria',
+    description:
+      'Aggiungi questo gioco per registrare le sessioni, sbloccare le statistiche e la classifica giocatori.',
+    ctaLabel: '+ Aggiungi a libreria',
+    onAdd: () => {},
+  },
+};
+
+/** Discover/community variant — globe icon. */
+export const DiscoverCommunity: Story = {
+  args: {
+    icon: '🌐',
+    title: 'Gioco della community',
+    description:
+      'Questo gioco non è ancora nella tua libreria. Aggiungilo per accedere a tutte le funzioni della pagina.',
+    ctaLabel: '+ Aggiungi a libreria',
+    onAdd: () => {},
+  },
+};

--- a/apps/web/src/components/features/game-detail/GameDetailCommunityGate.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailCommunityGate.tsx
@@ -33,7 +33,7 @@ export function GameDetailCommunityGate(props: GameDetailCommunityGateProps): Re
   const { icon = '📘', title, description, ctaLabel, onAdd, className } = props;
 
   return (
-    <div
+    <section
       data-slot="game-detail-community-gate"
       className={clsx(
         'flex flex-col items-center rounded-2xl border border-dashed border-border-strong bg-card px-6 py-10 text-center',
@@ -58,6 +58,6 @@ export function GameDetailCommunityGate(props: GameDetailCommunityGateProps): Re
       >
         {ctaLabel}
       </button>
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/components/features/game-detail/GameDetailCommunityGate.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailCommunityGate.tsx
@@ -1,0 +1,63 @@
+/**
+ * GameDetailCommunityGate - Wave C follow-up (Issue #1465)
+ *
+ * Mapped from `admin-mockups/design_files/sp4-game-detail.jsx` (CommunityGate, lines 596-626).
+ * Tracking: epic #1475; design-handoff PILOT_GAP_REPORT § 2.4.
+ *
+ * Pure presentational empty-state shown in the locked tabs of a community-variant game
+ * (not in the user's library). The caller (#1466 GameDetailView refactor) renders it inside
+ * locked tab content and wires `onAdd` to the add-to-library mutation. i18n is caller-side.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export interface GameDetailCommunityGateProps {
+  /** Emoji icon shown in the circle. Defaults to 📘. */
+  readonly icon?: string;
+  /** Localized title, resolved upstream (caller-side i18n). */
+  readonly title: string;
+  /** Localized description, resolved upstream. */
+  readonly description: string;
+  /** Localized CTA label, resolved upstream (no hardcoded fallback). */
+  readonly ctaLabel: string;
+  /** Invoked when the CTA is clicked (e.g. add-to-library mutation). */
+  readonly onAdd: () => void;
+  readonly className?: string;
+}
+
+export function GameDetailCommunityGate(props: GameDetailCommunityGateProps): ReactElement {
+  const { icon = '📘', title, description, ctaLabel, onAdd, className } = props;
+
+  return (
+    <div
+      data-slot="game-detail-community-gate"
+      className={clsx(
+        'flex flex-col items-center rounded-2xl border border-dashed border-border-strong bg-card px-6 py-10 text-center',
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="mb-3.5 inline-flex h-16 w-16 items-center justify-center rounded-full bg-entity-game/12 text-[28px] text-entity-game"
+      >
+        {icon}
+      </span>
+      <h3 className="mb-1.5 font-display text-base font-extrabold text-foreground">{title}</h3>
+      <p className="mb-4 max-w-[360px] text-[12.5px] leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+      <button
+        type="button"
+        onClick={onAdd}
+        data-slot="game-detail-community-gate-cta"
+        className="rounded-md border-none bg-entity-game px-[18px] py-2.5 font-display text-[13px] font-extrabold text-white shadow-md transition-shadow hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {ctaLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailCommunityGate.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailCommunityGate.test.tsx
@@ -60,10 +60,15 @@ describe('GameDetailCommunityGate (Issue #1465)', () => {
   });
 
   // T5
-  it('uses DS-15 entity-game tokens', () => {
+  it('uses DS-15 entity-game tokens (tinted circle + solid CTA)', () => {
     const { container } = render(<GameDetailCommunityGate {...baseProps} />);
-    expect(container.querySelector('.text-entity-game')).toBeInTheDocument();
-    expect(container.querySelector('.bg-entity-game')).toBeInTheDocument();
+    // Icon circle: tinted background + entity foreground.
+    const circle = container.querySelector('[aria-hidden="true"]');
+    expect(circle).toHaveClass('bg-entity-game/12');
+    expect(circle).toHaveClass('text-entity-game');
+    // CTA: solid entity background.
+    const cta = container.querySelector('[data-slot="game-detail-community-gate-cta"]');
+    expect(cta).toHaveClass('bg-entity-game');
   });
 
   // T6

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailCommunityGate.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailCommunityGate.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * GameDetailCommunityGate - Unit tests (Issue #1465).
+ *
+ * Pure presentational empty-state for the community variant of /games/[id].
+ * Test matrix (Crispin):
+ *   T1. Renders default icon + title + description + cta.
+ *   T2. Custom icon override.
+ *   T3. onAdd fires on CTA click.
+ *   T4. data-slot attributes.
+ *   T5. DS-15 entity-game token.
+ *   T6. className composition.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GameDetailCommunityGate } from '../GameDetailCommunityGate';
+
+const baseProps = {
+  title: 'Aggiungi alla libreria',
+  description: 'Aggiungi questo gioco per sbloccare sessioni e statistiche.',
+  ctaLabel: '+ Aggiungi a libreria',
+  onAdd: () => {},
+};
+
+describe('GameDetailCommunityGate (Issue #1465)', () => {
+  // T1
+  it('renders default icon, title, description and cta', () => {
+    render(<GameDetailCommunityGate {...baseProps} />);
+    expect(screen.getByText('📘')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Aggiungi alla libreria' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Aggiungi questo gioco per sbloccare sessioni e statistiche.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Aggiungi a libreria' })).toBeInTheDocument();
+  });
+
+  // T2
+  it('honors a custom icon', () => {
+    render(<GameDetailCommunityGate {...baseProps} icon="🌐" />);
+    expect(screen.getByText('🌐')).toBeInTheDocument();
+    expect(screen.queryByText('📘')).not.toBeInTheDocument();
+  });
+
+  // T3
+  it('fires onAdd when the CTA is clicked', () => {
+    const onAdd = vi.fn();
+    render(<GameDetailCommunityGate {...baseProps} onAdd={onAdd} />);
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi a libreria' }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  // T4
+  it('exposes data-slot for the card and cta', () => {
+    const { container } = render(<GameDetailCommunityGate {...baseProps} />);
+    expect(container.querySelector('[data-slot="game-detail-community-gate"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="game-detail-community-gate-cta"]')
+    ).toBeInTheDocument();
+  });
+
+  // T5
+  it('uses DS-15 entity-game tokens', () => {
+    const { container } = render(<GameDetailCommunityGate {...baseProps} />);
+    expect(container.querySelector('.text-entity-game')).toBeInTheDocument();
+    expect(container.querySelector('.bg-entity-game')).toBeInTheDocument();
+  });
+
+  // T6
+  it('composes custom className with base classes', () => {
+    const { container } = render(<GameDetailCommunityGate {...baseProps} className="extra" />);
+    const card = container.querySelector('[data-slot="game-detail-community-gate"]');
+    expect(card).toHaveClass('extra');
+    expect(card).toHaveClass('bg-card');
+    expect(card).toHaveClass('border-dashed');
+  });
+});

--- a/apps/web/src/components/features/game-detail/index.ts
+++ b/apps/web/src/components/features/game-detail/index.ts
@@ -81,3 +81,6 @@ export type {
   GameDetailLeaderboardLabels,
   GameDetailLeaderboardProps,
 } from '@/components/features/game-detail/GameDetailLeaderboard';
+
+export { GameDetailCommunityGate } from '@/components/features/game-detail/GameDetailCommunityGate';
+export type { GameDetailCommunityGateProps } from '@/components/features/game-detail/GameDetailCommunityGate';


### PR DESCRIPTION
## Summary

Implements #1465: `GameDetailCommunityGate` presentational empty-state for the community variant of `/games/[id]` (shown inside locked tabs). Spec hardened via `/sc:spec-panel`, built with TDD.

**Pure presentational** (mirrors `GameDetailLeaderboard`/`GameDetailSpecsCard`): `icon` (default 📘) + `title` + `description` + `ctaLabel` (caller-side i18n) + `onAdd` callback.

## Resolves the apparent #1465 ↔ #1466 circular dependency

The epic listed "#1465 depends on #1466" while #1466 depends on #1465. The spec-panel resolved this: **#1465 is the standalone presentational component** (this PR); the **integration/wireup** (variant routing, rendering the gate inside locked tabs) lives in **#1466**. The duplicated "Integration in GameDetailView" AC was removed from #1465. #1465 now unblocks #1466.

## Changes

- `GameDetailCommunityGate.tsx` — dashed `border-border-strong` card, `bg-entity-game/12` icon circle, `bg-entity-game` CTA, `data-slot` selectors, DS-15 tokens.
- 6 unit tests (default render, custom icon, onAdd click, data-slot, entity tokens, className).
- Storybook: 2 variants (📘 default / 🌐 discover).
- Barrel export in `game-detail/index.ts`.

## Tests / quality

- 6 unit tests green. ESLint 0 errors (`text-white` on `bg-entity-game` CTA — `.e-bg` pattern). Typecheck clean.

## Out of scope

- Integration in `GameDetailView` (variant routing, locked tabs) → #1466.

Closes #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
