### PR TITLE
feat(admin): SP5 F0b shell sidebar-responsive (desktop AdminSidebar)

### DIFF
--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from 'react';
 
 import { DashboardEngineProvider } from '@/components/dashboard';
+import { AdminSidebar } from '@/components/layout/AdminSidebar/AdminSidebar';
 import { AdminSideDrawer } from '@/components/layout/AdminSideDrawer/AdminSideDrawer';
 import { SearchOverlay } from '@/components/layout/SearchOverlay';
 import { TopBar } from '@/components/layout/UserShell/TopBar';
@@ -23,9 +24,12 @@ export function AdminShell({ children }: AdminShellProps) {
         adminMode
       />
 
-      <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
-        <DashboardEngineProvider>{children}</DashboardEngineProvider>
-      </main>
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        <AdminSidebar />
+        <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip">
+          <DashboardEngineProvider>{children}</DashboardEngineProvider>
+        </main>
+      </div>
 
       <AdminSideDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />

--- a/apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
+++ b/apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminShell } from '../AdminShell';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+vi.mock('next/navigation', () => ({ usePathname: () => '/admin/overview' }));
+vi.mock('@/components/layout/UserShell/TopBar', () => ({
+  TopBar: () => <div data-testid="topbar" />,
+}));
+vi.mock('@/components/layout/SearchOverlay', () => ({ SearchOverlay: () => null }));
+vi.mock('@/components/dashboard', () => ({
+  DashboardEngineProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AdminShell', () => {
+  beforeEach(() => mockUseCurrentUser.mockReset());
+
+  it('renders the persistent sidebar and the main content', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(
+      <AdminShell>
+        <p>page body</p>
+      </AdminShell>
+    );
+    expect(screen.getByRole('navigation', { name: /admin sidebar/i })).toBeInTheDocument();
+    expect(screen.getByText('page body')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
+++ b/apps/web/src/components/layout/AdminSideDrawer/AdminSideDrawer.tsx
@@ -7,8 +7,8 @@ import { ChevronLeft } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import type { AdminNavItem } from '@/components/layout/admin-nav/admin-nav-config';
 import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
+import { AdminNavList } from '@/components/layout/admin-nav/AdminNavList';
 import { filterNavByRole } from '@/components/layout/admin-nav/filter-nav-by-role';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 
@@ -19,52 +19,6 @@ import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 export interface AdminSideDrawerProps {
   open: boolean;
   onClose: () => void;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function isPathActive(pathname: string, href: string): boolean {
-  // Strip query string for startsWith check
-  const hrefPath = href.split('?')[0];
-  return pathname === hrefPath || pathname.startsWith(hrefPath + '/');
-}
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-interface NavLinkProps {
-  item: AdminNavItem;
-  pathname: string;
-  onClick: () => void;
-  indent?: boolean;
-}
-
-function NavLink({ item, pathname, onClick, indent = false }: NavLinkProps) {
-  const Icon = item.icon;
-  const active = isPathActive(pathname, item.href);
-
-  return (
-    <Link
-      href={item.href}
-      onClick={onClick}
-      aria-current={active ? 'page' : undefined}
-      className={[
-        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-        indent ? 'pl-5' : '',
-        active
-          ? 'bg-[hsla(25,95%,45%,0.12)] text-[hsl(var(--c-game-text))]'
-          : 'text-foreground/70 hover:bg-muted hover:text-foreground',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-    >
-      <Icon className="h-4 w-4 shrink-0" />
-      <span>{item.label}</span>
-    </Link>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -141,35 +95,21 @@ export function AdminSideDrawer({ open, onClose }: AdminSideDrawerProps) {
 
         {/* Navigation — scrollable */}
         <div className="flex-1 overflow-y-auto px-3 py-3">
-          <nav className="flex flex-col gap-0.5">
-            {/* Back to app */}
-            <Link
-              href="/dashboard"
-              onClick={onClose}
-              className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors mb-2"
-              style={{ color: 'hsl(var(--c-kb-text))' }}
-            >
-              <ChevronLeft className="h-4 w-4 shrink-0" />
-              <span>Torna all&apos;app</span>
-            </Link>
+          {/* Back to app */}
+          <Link
+            href="/dashboard"
+            onClick={onClose}
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors mb-2"
+            style={{ color: 'hsl(var(--c-kb-text))' }}
+          >
+            <ChevronLeft className="h-4 w-4 shrink-0" />
+            <span>Torna all&apos;app</span>
+          </Link>
 
-            <div className="border-t mb-1" />
+          <div className="border-t mb-1" />
 
-            {/* Role-filtered 4-group navigation */}
-            {visibleGroups.map(group => (
-              <div key={group.id} className="flex flex-col gap-0.5">
-                <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
-                  <group.icon className="h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    {group.label}
-                  </span>
-                </div>
-                {group.items.map(item => (
-                  <NavLink key={item.href} item={item} pathname={pathname} onClick={onClose} />
-                ))}
-              </div>
-            ))}
-          </nav>
+          {/* Role-filtered 4-group navigation */}
+          <AdminNavList groups={visibleGroups} pathname={pathname} onNavigate={onClose} />
         </div>
       </div>
     </>

--- a/apps/web/src/components/layout/AdminSidebar/AdminSidebar.tsx
+++ b/apps/web/src/components/layout/AdminSidebar/AdminSidebar.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
+import { AdminNavList } from '@/components/layout/admin-nav/AdminNavList';
+import { filterNavByRole } from '@/components/layout/admin-nav/filter-nav-by-role';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
+
+/**
+ * Persistent admin sidebar for desktop (>=lg). On smaller screens it is hidden
+ * (`hidden lg:flex`) and navigation is provided by AdminSideDrawer instead.
+ */
+export function AdminSidebar() {
+  const { data: user } = useCurrentUser();
+  const pathname = usePathname();
+  const visibleGroups = filterNavByRole(ADMIN_NAV_GROUPS, user ?? null);
+
+  return (
+    <aside className="hidden lg:flex w-[280px] shrink-0 flex-col border-r bg-background overflow-y-auto">
+      <div className="px-3 py-3">
+        <AdminNavList groups={visibleGroups} pathname={pathname} ariaLabel="Admin sidebar" />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx
+++ b/apps/web/src/components/layout/AdminSidebar/__tests__/AdminSidebar.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AdminSidebar } from '../AdminSidebar';
+
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/overview',
+}));
+
+describe('AdminSidebar', () => {
+  beforeEach(() => mockUseCurrentUser.mockReset());
+
+  it('renders the four group labels for an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByText('AI Tooling & Data Quality')).toBeInTheDocument();
+  });
+
+  it('hides superadmin-only items from an admin', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    expect(screen.queryByRole('link', { name: /Staging Access/i })).not.toBeInTheDocument();
+  });
+
+  it('is hidden below lg and shown at lg+ (responsive class)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    render(<AdminSidebar />);
+    const aside = screen.getByRole('navigation', { name: /admin sidebar/i }).closest('aside');
+    expect(aside).toHaveClass('hidden');
+    expect(aside).toHaveClass('lg:flex');
+  });
+
+  it('renders nothing meaningful for a null user (no groups)', () => {
+    mockUseCurrentUser.mockReturnValue({ data: null });
+    render(<AdminSidebar />);
+    expect(screen.queryByText('Admin Console')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
+++ b/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 import type { AdminNavGroup, AdminNavItem } from './admin-nav-config';

--- a/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
+++ b/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Link from 'next/link';
+
+import type { AdminNavGroup, AdminNavItem } from './admin-nav-config';
+
+export function isPathActive(pathname: string, href: string): boolean {
+  const hrefPath = href.split('?')[0];
+  return pathname === hrefPath || pathname.startsWith(hrefPath + '/');
+}
+
+interface NavLinkProps {
+  item: AdminNavItem;
+  pathname: string;
+  onClick?: () => void;
+}
+
+function NavLink({ item, pathname, onClick }: NavLinkProps) {
+  const Icon = item.icon;
+  const active = isPathActive(pathname, item.href);
+
+  return (
+    <Link
+      href={item.href}
+      onClick={onClick}
+      aria-current={active ? 'page' : undefined}
+      className={[
+        'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+        active
+          ? 'bg-[hsla(25,95%,45%,0.12)] text-[hsl(var(--c-game-text))]'
+          : 'text-foreground/70 hover:bg-muted hover:text-foreground',
+      ].join(' ')}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <span>{item.label}</span>
+    </Link>
+  );
+}
+
+export interface AdminNavListProps {
+  groups: AdminNavGroup[];
+  pathname: string;
+  onNavigate?: () => void;
+}
+
+/**
+ * Shared rendering of the admin navigation groups. Used by both the mobile
+ * drawer (AdminSideDrawer) and the desktop sidebar (AdminSidebar, F0b Task 2).
+ * Receives already-filtered groups; does not read the user/role itself.
+ */
+export function AdminNavList({ groups, pathname, onNavigate }: AdminNavListProps) {
+  return (
+    <nav className="flex flex-col gap-0.5">
+      {groups.map(group => (
+        <div key={group.id} className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2 px-3 py-1.5 mt-2">
+            <group.icon className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {group.label}
+            </span>
+          </div>
+          {group.items.map(item => (
+            <NavLink key={item.href} item={item} pathname={pathname} onClick={onNavigate} />
+          ))}
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
+++ b/apps/web/src/components/layout/admin-nav/AdminNavList.tsx
@@ -39,6 +39,7 @@ export interface AdminNavListProps {
   groups: AdminNavGroup[];
   pathname: string;
   onNavigate?: () => void;
+  ariaLabel?: string;
 }
 
 /**
@@ -46,9 +47,9 @@ export interface AdminNavListProps {
  * drawer (AdminSideDrawer) and the desktop sidebar (AdminSidebar, F0b Task 2).
  * Receives already-filtered groups; does not read the user/role itself.
  */
-export function AdminNavList({ groups, pathname, onNavigate }: AdminNavListProps) {
+export function AdminNavList({ groups, pathname, onNavigate, ariaLabel }: AdminNavListProps) {
   return (
-    <nav className="flex flex-col gap-0.5">
+    <nav aria-label={ariaLabel} className="flex flex-col gap-0.5">
       {groups.map(group => (
         <div key={group.id} className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2 px-3 py-1.5 mt-2">

--- a/apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx
+++ b/apps/web/src/components/layout/admin-nav/__tests__/AdminNavList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { AdminNavGroup } from '../admin-nav-config';
+import { AdminNavList } from '../AdminNavList';
+
+const GROUPS: AdminNavGroup[] = [
+  {
+    id: 'A',
+    label: 'Admin Console',
+    icon: () => null,
+    items: [{ label: 'Dashboard', href: '/admin/overview', icon: () => null }],
+  },
+];
+
+describe('AdminNavList', () => {
+  it('renders group label and item link', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/overview" />);
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute(
+      'href',
+      '/admin/overview'
+    );
+  });
+
+  it('marks the active item with aria-current', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/overview" />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('does not mark a non-active item', () => {
+    render(<AdminNavList groups={GROUPS} pathname="/admin/users" />);
+    expect(screen.getByRole('link', { name: /Dashboard/i })).not.toHaveAttribute('aria-current');
+  });
+
+  it('calls onNavigate when a link is clicked', () => {
+    const onNavigate = vi.fn();
+    render(<AdminNavList groups={GROUPS} pathname="/admin/users" onNavigate={onNavigate} />);
+    screen.getByRole('link', { name: /Dashboard/i }).click();
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa **F0b — Shell sidebar-responsive (desktop)** della fase Fondamenta SP5 admin. Dipende da F0a (#1496, in main-dev). Plan: `docs/superpowers/plans/2026-05-24-sp5-admin-f0b-shell-responsive.md`.

- **`AdminNavList`** (nuovo): resa nav condivisa estratta dal drawer (DRY drawer ↔ sidebar). Componente presentazionale puro (no `'use client'`), prop opzionale `ariaLabel`. Riceve gruppi già filtrati.
- **`AdminSidebar`** (nuovo): sidebar **persistente su desktop** (`hidden lg:flex`, 280px), riusa `AdminNavList` + `filterNavByRole`. Su `<lg` è nascosta — la nav mobile resta l'`AdminSideDrawer`.
- **`AdminShell`** (refactor): riga flex `[AdminSidebar | main]` sotto la `TopBar`, con `min-h-0` sul wrapper per far funzionare lo scroll di sidebar e main.

## Test Plan

- [x] 25/25 unit test (config 5 + filter 6 + AdminNavList 4 + AdminSidebar 4 + drawer 5 + AdminShell 1)
- [x] `pnpm typecheck` + ESLint puliti
- [ ] Verifica visiva: sidebar persistente a `≥lg`, drawer off-canvas a `<lg`, scroll della sidebar con molte voci

## Note

- Eseguito subagent-driven (TDD, review spec + qualità per ogni task). Fix da code-review applicati: rimosso `'use client'` superfluo da `AdminNavList` (T1); height-fix `min-h-0` sul wrapper shell (T3, dall'issue del review T2).
- Bonus: la dead prop `NavLink.indent` (follow-up noto di F0a) è stata eliminata durante l'estrazione di `AdminNavList`.
- **Follow-up minori non applicati** (non bloccanti): l'hamburger della TopBar resta attivo `≥lg` (apre un drawer ridondante con la sidebar — fuori scope, non tocco TopBar); mock `AdminSideDrawer` nel test della shell; `overflow-x-clip` ora ridondante su `<main>`; test "superadmin vede Staging Access" sulla sidebar (asimmetria col drawer).
- Prossimo: **F0c** (dark scoped admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
