### PR TITLE
feat(admin): SP5 F0c dark scoped admin (container-scoped)

### DIFF
--- a/apps/web/e2e/admin/admin-dark-scope.spec.ts
+++ b/apps/web/e2e/admin/admin-dark-scope.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin dark theme scope (SP5 F0c)', () => {
+  test.beforeEach(() => {
+    process.env.PLAYWRIGHT_AUTH_BYPASS = 'true';
+  });
+
+  test('admin shell is scoped to dark', async ({ page }) => {
+    await page.goto('/admin/overview');
+    const shell = page.locator('[data-admin-shell]');
+    await expect(shell).toHaveAttribute('data-theme', 'dark');
+    // The shell background resolves to the dark token, not the light cream (#f7f3ee).
+    const bg = await shell.evaluate(el => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe('rgb(247, 243, 238)');
+  });
+
+  test('a non-admin route stays light at the document root', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    await expect(page.locator('[data-admin-shell]')).toHaveCount(0);
+  });
+});

--- a/apps/web/src/components/layout/AdminShell/AdminShell.tsx
+++ b/apps/web/src/components/layout/AdminShell/AdminShell.tsx
@@ -17,7 +17,7 @@ export function AdminShell({ children }: AdminShellProps) {
   const [searchOpen, setSearchOpen] = useState(false);
 
   return (
-    <div className="flex min-h-dvh flex-col bg-[var(--bg)]">
+    <div data-admin-shell data-theme="dark" className="flex min-h-dvh flex-col bg-[var(--bg)]">
       <TopBar
         onHamburgerClick={() => setDrawerOpen(true)}
         onSearchClick={() => setSearchOpen(true)}

--- a/apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
+++ b/apps/web/src/components/layout/AdminShell/__tests__/AdminShell.test.tsx
@@ -30,4 +30,16 @@ describe('AdminShell', () => {
     expect(screen.getByRole('navigation', { name: /admin sidebar/i })).toBeInTheDocument();
     expect(screen.getByText('page body')).toBeInTheDocument();
   });
+
+  it('scopes the dark theme to the admin shell root', () => {
+    mockUseCurrentUser.mockReturnValue({ data: { id: 'u', email: 'a@b.c', role: 'admin' } });
+    const { container } = render(
+      <AdminShell>
+        <p>body</p>
+      </AdminShell>
+    );
+    const root = container.querySelector('[data-admin-shell]');
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute('data-theme', 'dark');
+  });
 });

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -162,7 +162,11 @@
 }
 
 /* ─── DARK THEME ─── */
-:root[data-theme="dark"] {
+/* DS: dark tokens apply both on :root (global theme) AND on any container
+   carrying data-theme="dark" (e.g. AdminShell), enabling per-section dark scope
+   without touching <html>. See SP5 F0c plan. */
+:root[data-theme="dark"],
+[data-theme="dark"] {
   --bg:        #14100a;
   --bg-card:   #1e1710;
   --bg-muted:  #241c13;


### PR DESCRIPTION
## Summary

Implementa **F0c — Dark scoped admin** (ultimo plan della fase Fondamenta SP5). Approccio **container-scoped**: niente mutazione di `<html>`, niente lotta con `next-themes`, niente FOUC, niente cleanup all'uscita. Plan: `docs/superpowers/plans/2026-05-24-sp5-admin-f0c-dark-scoped.md`.

3 modifiche:

| # | Cambio | File |
|---|--------|------|
| 1 | Estende il selettore dei token dark da `:root[data-theme="dark"]` anche a `[data-theme="dark"]` su qualsiasi container | `apps/web/src/styles/design-tokens-canonical.css` |
| 2 | Aggiunge `data-admin-shell` + `data-theme="dark"` al root `<div>` di `AdminShell` (+ test unit) | `apps/web/src/components/layout/AdminShell/AdminShell.tsx` (+ test) |
| 3 | E2E Playwright: `/admin/*` carries `data-admin-shell[data-theme=dark]` con bg non-cream, `/dashboard` resta light | `apps/web/e2e/admin/admin-dark-scope.spec.ts` (nuovo) |

## Test Plan

- [x] **26/26 unit test** (incl. il nuovo "scopes the dark theme to the admin shell root")
- [x] `pnpm typecheck` + ESLint puliti (validati dal pre-push build)
- [ ] **E2E** (`admin-dark-scope.spec.ts`): demandato a CI — non eseguito localmente (serve dev server)

## Note

- L'approccio container-scoped è stato scelto rispetto a quello `<html>`-based (entrambi valutati nella spec §4.3): elimina i tre rischi del secondo (conflitto con `next-themes` che gestisce `<html>` con localStorage; FOUC al primo load; cleanup all'uscita dato che App Router non rimonta).
- I 3 task sono stati eseguiti direttamente (modifiche chirurgiche di 1-2 file ciascuna) anziché in subagent-driven, perché durante il code-review di #1501 il rate limit API si è esaurito (4/5 agenti falliti, reset 22:50 Rome).
- **Decisione di scope:** F0c forza dark su admin. Un eventuale toggle light/dark *dentro* l'admin è un follow-up dedicato (R9 chiede "dark default", non un toggle).
- **Ultimo plan della fase Fondamenta.** Dopo il merge: F0 completa, pronti per il **pilota F1 A1 Overview** e per le ondate F2-F6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
