### PR TITLE
feat(game-detail): #1466 GameDetailView refactor — stats tab + community gate

### DIFF
--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -28,10 +28,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
   GameDetailAgentsList,
+  GameDetailCommunityGate,
   GameDetailFaqList,
   GameDetailHero,
   GameDetailKbDocList,
   GameDetailKpiCards,
+  GameDetailLeaderboard,
   GameDetailRulesAccordion,
   GameDetailSessionsRail,
   GameDetailSpecsCard,
@@ -52,6 +54,7 @@ import {
   type LibraryGameDetail,
 } from '@/hooks/queries/useLibrary';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useGameLeaderboard } from '@/lib/domain-hooks/useGameLeaderboard';
 import { deriveGameDetailUiState } from '@/lib/games/game-detail-state';
 import {
   IS_VISUAL_TEST_BUILD,
@@ -84,17 +87,101 @@ export interface GameDetailViewProps {
 
 // ─── Tab config ────────────────────────────────────────────────────────────
 
-function buildTabsConfig(t: ReturnType<typeof useTranslation>['t']): ReadonlyArray<{
+/**
+ * Hybrid 7-tab config (Issue #1466): preserves the 6 codebase tabs and adds `stats`
+ * after `sessions` (mockup-required). In `community` variant, `sessions` and `stats`
+ * are locked (require the game to be in the user's library); the locked tab content
+ * renders a <GameDetailCommunityGate>. Other tabs (info/rules/faqs/agents/documents)
+ * remain accessible as public information.
+ */
+function buildTabsConfig(
+  t: ReturnType<typeof useTranslation>['t'],
+  variant: 'own' | 'community'
+): ReadonlyArray<{
   key: TabKey;
   label: string;
+  locked?: boolean;
 }> {
+  const lockedInCommunity = variant === 'community';
   return [
     { key: 'info' as TabKey, label: t('pages.gameDetail.tabs.info') },
     { key: 'rules' as TabKey, label: t('pages.gameDetail.tabs.rules') },
     { key: 'faqs' as TabKey, label: t('pages.gameDetail.tabs.faqs') },
-    { key: 'sessions' as TabKey, label: t('pages.gameDetail.tabs.sessions') },
+    {
+      key: 'sessions' as TabKey,
+      label: t('pages.gameDetail.tabs.sessions'),
+      locked: lockedInCommunity,
+    },
+    {
+      key: 'stats' as TabKey,
+      label: t('pages.gameDetail.tabs.stats'),
+      locked: lockedInCommunity,
+    },
     { key: 'agents' as TabKey, label: t('pages.gameDetail.tabs.agents') },
     { key: 'documents' as TabKey, label: t('pages.gameDetail.tabs.documents') },
+  ];
+}
+
+// ─── Stats-tab KPI builder (Issue #1466) ───────────────────────────────────
+
+/**
+ * Builds the 3 play-stats KPI cards shown above the leaderboard in the Stats tab.
+ * Data source: LibraryGameDetail.winRate / timesPlayed / lastPlayed (already populated).
+ */
+function buildStatsKpiCards(
+  detail: LibraryGameDetail,
+  t: ReturnType<typeof useTranslation>['t']
+): ReadonlyArray<{
+  key: string;
+  label: string;
+  value: string;
+  unit?: string;
+  accent?: 'rating' | 'complexity' | 'players' | 'time';
+  icon?: string;
+}> {
+  const na = t('pages.gameDetail.kpi.notAvailable');
+
+  // Win rate — winRate is already a formatted string from the BE ("60%"), or null.
+  const winRateValue = detail.winRate ?? na;
+
+  // Plays — integer.
+  const playsValue = String(detail.timesPlayed);
+
+  // Last played — render "Nd g fa" if recent, else "Mai" when null.
+  let lastValue: string;
+  let lastUnit: string | undefined;
+  if (detail.lastPlayed == null) {
+    lastValue = t('pages.gameDetail.stats.lastPlayedNever');
+  } else {
+    const lastDate = new Date(detail.lastPlayed);
+    const days = Math.max(0, Math.floor((Date.now() - lastDate.getTime()) / 86400000));
+    lastValue = String(days);
+    lastUnit = t('pages.gameDetail.stats.lastPlayedDaysAgoUnit');
+  }
+
+  return [
+    {
+      key: 'winRate',
+      label: t('pages.gameDetail.stats.winRate'),
+      value: winRateValue,
+      accent: 'rating' as const,
+      icon: '🏆',
+    },
+    {
+      key: 'timesPlayed',
+      label: t('pages.gameDetail.stats.timesPlayed'),
+      value: playsValue,
+      accent: 'players' as const,
+      icon: '🎯',
+    },
+    {
+      key: 'lastPlayed',
+      label: t('pages.gameDetail.stats.lastPlayed'),
+      value: lastValue,
+      unit: lastUnit,
+      accent: 'time' as const,
+      icon: '📅',
+    },
   ];
 }
 
@@ -333,6 +420,18 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
     enabled: !!gameId && detailQuery.isSuccess && detailQuery.data != null && tab === 'agents',
   });
 
+  // Leaderboard hook (Issue #1466 — lazy, gated by parent + tab + own variant).
+  // Only fetches on the Stats tab AND when the game is in the user's library
+  // (libraryEntryId present). Community variant locks the tab → no fetch.
+  const leaderboardQuery = useGameLeaderboard(gameId ?? '', {
+    enabled:
+      !!gameId &&
+      detailQuery.isSuccess &&
+      detailQuery.data != null &&
+      detailQuery.data.libraryEntryId != null &&
+      tab === 'stats',
+  });
+
   // ── Effective detail (fixture takes priority over real data) ─────────────
   const detail = fixture ?? detailQuery.data ?? null;
 
@@ -383,13 +482,15 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
   // fixture branch also guarantees detail != null
   const safeDetail = detail!;
 
-  const tabsConfig = buildTabsConfig(t);
+  const heroVariant: 'own' | 'community' = safeDetail.libraryEntryId ? 'own' : 'community';
+  const isCommunityVariant = heroVariant === 'community';
+
+  const tabsConfig = buildTabsConfig(t, heroVariant);
   const heroMeta = buildHeroMeta(safeDetail);
   const kpiCards = buildKpiCards(safeDetail, t);
+  const statsKpiCards = buildStatsKpiCards(safeDetail, t);
   const specsItems = buildSpecsItems(safeDetail, t);
   const specsTitle = t('pages.gameDetail.info.specsTitle');
-
-  const heroVariant = safeDetail.libraryEntryId ? 'own' : 'community';
   const heroLabels = {
     back: t('pages.gameDetail.hero.back'),
     backAriaLabel: t('pages.gameDetail.hero.backAriaLabel'),
@@ -467,6 +568,37 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
     statusFailed: t('pages.gameDetail.documents.statusFailed'),
     // Template string: component calls .replace('{pages}', ...) etc.
     statsLineTemplate: '{pages} pag · {chunks} chunk · {size}',
+  };
+
+  const statsLeaderboardLabels = {
+    plays: t('pages.gameDetail.stats.leaderboardPlays'),
+    avgScore: t('pages.gameDetail.stats.leaderboardAvg'),
+    wins: t('pages.gameDetail.stats.leaderboardWins'),
+    empty: t('pages.gameDetail.stats.leaderboardEmpty'),
+  };
+
+  const communityGateLabels = {
+    title: t('pages.gameDetail.stats.communityGateTitle'),
+    description: t('pages.gameDetail.stats.communityGateDescription'),
+    cta: t('pages.gameDetail.stats.communityGateCta'),
+  };
+
+  const handleAddToLibrary = (): void => {
+    if (!gameId || addToLibrary.isPending) return;
+    addToLibrary.mutate(
+      { gameId },
+      {
+        onSuccess: () => {
+          toast.success(`${safeDetail.gameTitle} aggiunto alla tua libreria.`);
+          router.push(`/library/${gameId}`);
+        },
+        onError: error => {
+          toast.error(
+            error instanceof Error ? error.message : 'Impossibile aggiungere il gioco. Riprova.'
+          );
+        },
+      }
+    );
   };
 
   const agentsState: AgentsState = deriveAgentsState(
@@ -583,7 +715,7 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
           <GameDetailFaqList faqs={[]} viewAllHref={`/games/${gameId}/faqs`} labels={faqLabels} />
         </div>
 
-        {/* Sessions tab */}
+        {/* Sessions tab — locked in community variant (#1466) */}
         <div
           role="tabpanel"
           id={panelIdFor('sessions')}
@@ -591,12 +723,63 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
           hidden={tab !== 'sessions'}
           data-slot="game-detail-panel-sessions"
         >
-          <GameDetailSessionsRail
-            sessions={recentSessions}
-            viewAllHref={`/games/${gameId}/sessions`}
-            labels={sessionsLabels}
-            onNewSession={() => router.push(`/sessions/new?gameId=${gameId}`)}
-          />
+          {isCommunityVariant ? (
+            <GameDetailCommunityGate
+              title={communityGateLabels.title}
+              description={communityGateLabels.description}
+              ctaLabel={communityGateLabels.cta}
+              onAdd={handleAddToLibrary}
+            />
+          ) : (
+            <GameDetailSessionsRail
+              sessions={recentSessions}
+              viewAllHref={`/games/${gameId}/sessions`}
+              labels={sessionsLabels}
+              onNewSession={() => router.push(`/sessions/new?gameId=${gameId}`)}
+            />
+          )}
+        </div>
+
+        {/* Stats tab — play-KPI + leaderboard; locked in community variant (#1466) */}
+        <div
+          role="tabpanel"
+          id={panelIdFor('stats')}
+          aria-labelledby={tabIdFor('stats')}
+          hidden={tab !== 'stats'}
+          data-slot="game-detail-panel-stats"
+        >
+          {isCommunityVariant ? (
+            <GameDetailCommunityGate
+              title={communityGateLabels.title}
+              description={communityGateLabels.description}
+              ctaLabel={communityGateLabels.cta}
+              onAdd={handleAddToLibrary}
+            />
+          ) : (
+            <div className="flex flex-col gap-6">
+              <GameDetailKpiCards cards={statsKpiCards} />
+              {leaderboardQuery.isLoading ? (
+                <div
+                  data-slot="game-detail-stats-leaderboard-loading"
+                  aria-busy="true"
+                  className="h-40 w-full animate-pulse rounded-2xl bg-muted"
+                />
+              ) : leaderboardQuery.isError ? (
+                <div
+                  data-slot="game-detail-stats-leaderboard-error"
+                  className="rounded-2xl border border-border bg-card p-4 text-center text-[13px] text-muted-foreground"
+                >
+                  {t('pages.gameDetail.states.error.title')}
+                </div>
+              ) : (
+                <GameDetailLeaderboard
+                  entries={leaderboardQuery.data?.entries ?? []}
+                  title={t('pages.gameDetail.stats.leaderboardTitle')}
+                  labels={statsLeaderboardLabels}
+                />
+              )}
+            </div>
+          )}
         </div>
 
         {/* Agents tab — FSM cells 5-9 */}

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -428,7 +428,8 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
       !!gameId &&
       detailQuery.isSuccess &&
       detailQuery.data != null &&
-      detailQuery.data.libraryEntryId != null &&
+      // Truthy check mirrors the variant derivation (libraryEntryId is '' for community).
+      !!detailQuery.data.libraryEntryId &&
       tab === 'stats',
   });
 
@@ -638,29 +639,7 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
             void navigator.share({ title: safeDetail.gameTitle, url: window.location.href });
           }
         }}
-        onAddToLibrary={
-          heroVariant === 'community' && gameId
-            ? () => {
-                if (addToLibrary.isPending) return;
-                addToLibrary.mutate(
-                  { gameId },
-                  {
-                    onSuccess: () => {
-                      toast.success(`${safeDetail.gameTitle} aggiunto alla tua libreria.`);
-                      router.push(`/library/${gameId}`);
-                    },
-                    onError: error => {
-                      toast.error(
-                        error instanceof Error
-                          ? error.message
-                          : 'Impossibile aggiungere il gioco. Riprova.'
-                      );
-                    },
-                  }
-                );
-              }
-            : undefined
-        }
+        onAddToLibrary={heroVariant === 'community' ? handleAddToLibrary : undefined}
       />
 
       {/* Tab navigation — A11y: role=tablist inside component, role=tabpanel on panels below */}

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -843,4 +843,41 @@ describe('GameDetailView — FSM integration tests (Phase 0.5 contract)', () => 
     const infoPanelAfterRerender = document.querySelector('[data-slot="game-detail-panel-info"]');
     expect(infoPanelAfterRerender).toHaveAttribute('hidden');
   });
+
+  // ─── Issue #1466 — Stats tab + community gate ────────────────────────────
+
+  it('Issue #1466: community variant renders GameDetailCommunityGate inside Sessions and Stats panels', () => {
+    detailMockState.data = makeDetail({ libraryEntryId: '' });
+    detailMockState.isSuccess = true;
+    useLibraryGameDetailSpy.mockReturnValue(detailMockState);
+
+    renderWithIntl(<GameDetailView gameId={VALID_GAME_ID} />);
+
+    // Two gates rendered: one inside sessions panel, one inside stats panel.
+    const gates = document.querySelectorAll('[data-slot="game-detail-community-gate"]');
+    expect(gates).toHaveLength(2);
+
+    // The non-locked content must NOT be present in those panels.
+    const sessionsPanel = document.querySelector('[data-slot="game-detail-panel-sessions"]');
+    expect(sessionsPanel?.querySelector('[data-slot="game-detail-sessions-rail"]')).toBeNull();
+  });
+
+  it('Issue #1466: own variant exposes the Stats tab with KpiCards (no gate)', () => {
+    detailMockState.data = makeDetail(); // default own variant
+    detailMockState.isSuccess = true;
+    useLibraryGameDetailSpy.mockReturnValue(detailMockState);
+
+    renderWithIntl(<GameDetailView gameId={VALID_GAME_ID} />);
+
+    // Stats tab button is present and NOT locked
+    const statsTab = document.querySelector('[data-tab-key="stats"]');
+    expect(statsTab).toBeInTheDocument();
+    expect(statsTab).toHaveAttribute('data-locked', 'false');
+
+    // Stats panel exists in the DOM (hidden until clicked, but its content is the own-variant flow,
+    // not the gate).
+    const statsPanel = document.querySelector('[data-slot="game-detail-panel-stats"]');
+    expect(statsPanel).toBeInTheDocument();
+    expect(statsPanel?.querySelector('[data-slot="game-detail-community-gate"]')).toBeNull();
+  });
 });

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -98,6 +98,18 @@ vi.mock('@/hooks/queries/useGameAgents', () => ({
   useGameAgents: (opts: { gameId: string | null; enabled?: boolean }) => useGameAgentsSpy(opts),
 }));
 
+// Issue #1466 — Leaderboard hook mock (Stats tab). Default empty/success; tests
+// focused on FSM/Phase 0.5 do not care about leaderboard data.
+vi.mock('@/lib/domain-hooks/useGameLeaderboard', () => ({
+  useGameLeaderboard: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  }),
+  GAME_LEADERBOARD_QUERY_KEY: (gameId: string) => ['game-leaderboard', gameId, null, 10] as const,
+}));
+
 // ─── Visual fixture mock ──────────────────────────────────────────────────
 
 let mockIsVisualTestBuild = false;
@@ -120,6 +132,7 @@ const MESSAGES: Record<string, string> = {
   'pages.gameDetail.tabs.rules': 'Regole',
   'pages.gameDetail.tabs.faqs': 'FAQ',
   'pages.gameDetail.tabs.sessions': 'Sessioni',
+  'pages.gameDetail.tabs.stats': 'Statistiche',
   'pages.gameDetail.tabs.agents': 'Agenti',
   'pages.gameDetail.tabs.documents': 'Documenti',
   'pages.gameDetail.states.loading.ariaLabel': 'Caricamento gioco',
@@ -207,6 +220,21 @@ const MESSAGES: Record<string, string> = {
   'pages.gameDetail.info.specsPublisher': 'Editore',
   'pages.gameDetail.info.specsRatingBgg': 'Rating BGG',
   'pages.gameDetail.info.specsMinutesUnit': 'min',
+  // Issue #1466 — Stats tab (play-KPI + leaderboard + community gate)
+  'pages.gameDetail.stats.winRate': 'Win rate',
+  'pages.gameDetail.stats.timesPlayed': 'Partite',
+  'pages.gameDetail.stats.lastPlayed': 'Ultima',
+  'pages.gameDetail.stats.lastPlayedNever': 'Mai',
+  'pages.gameDetail.stats.lastPlayedDaysAgoUnit': 'g fa',
+  'pages.gameDetail.stats.leaderboardTitle': 'Classifica giocatori',
+  'pages.gameDetail.stats.leaderboardPlays': 'partite',
+  'pages.gameDetail.stats.leaderboardAvg': 'avg',
+  'pages.gameDetail.stats.leaderboardWins': 'vittorie',
+  'pages.gameDetail.stats.leaderboardEmpty': 'Nessuna classifica disponibile',
+  'pages.gameDetail.stats.communityGateTitle': 'Aggiungi alla tua libreria',
+  'pages.gameDetail.stats.communityGateDescription':
+    'Aggiungi questo gioco per sbloccare statistiche e classifica giocatori.',
+  'pages.gameDetail.stats.communityGateCta': '+ Aggiungi a libreria',
 };
 
 function renderWithIntl(ui: ReactElement) {

--- a/apps/web/src/components/features/game-detail/GameDetailTabsAnimated.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailTabsAnimated.tsx
@@ -36,7 +36,7 @@ import clsx from 'clsx';
 
 import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 
-export type TabKey = 'info' | 'rules' | 'faqs' | 'sessions' | 'agents' | 'documents';
+export type TabKey = 'info' | 'rules' | 'faqs' | 'sessions' | 'stats' | 'agents' | 'documents';
 
 export interface GameDetailTabConfig<TKey extends string = string> {
   readonly key: TKey;

--- a/apps/web/src/lib/domain-hooks/__tests__/useGameLeaderboard.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useGameLeaderboard.test.ts
@@ -65,7 +65,9 @@ describe('useGameLeaderboard (#1467)', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual(mockResponse);
-    expect(api.games.getLeaderboard).toHaveBeenCalledWith('game-1', undefined);
+    // After the #1466 `enabled` option destructure, no-options calls forward `{}`
+    // (semantically equivalent to undefined — no since/limit params).
+    expect(api.games.getLeaderboard).toHaveBeenCalledWith('game-1', {});
   });
 
   it('forwards since/limit options to the client', async () => {

--- a/apps/web/src/lib/domain-hooks/useGameLeaderboard.ts
+++ b/apps/web/src/lib/domain-hooks/useGameLeaderboard.ts
@@ -16,6 +16,8 @@ export interface GameLeaderboardOptions {
   since?: string;
   /** Top-N size (1..50, default 10). */
   limit?: number;
+  /** External gating (Issue #1466: lazy fetch only when tab is active). Default true. */
+  enabled?: boolean;
 }
 
 export const GAME_LEADERBOARD_QUERY_KEY = (gameId: string, since?: string, limit?: number) =>
@@ -24,14 +26,15 @@ export const GAME_LEADERBOARD_QUERY_KEY = (gameId: string, since?: string, limit
 /**
  * Fetches the social leaderboard for a game.
  * @param gameId Game ID (GUID format)
- * @param options Optional since/limit filters
+ * @param options Optional since/limit filters; `enabled` for lazy gating (default true).
  */
 export function useGameLeaderboard(gameId: string, options?: GameLeaderboardOptions) {
+  const { enabled = true, ...apiOptions } = options ?? {};
   return useQuery<GameLeaderboardResponse | null, Error>({
-    queryKey: GAME_LEADERBOARD_QUERY_KEY(gameId, options?.since, options?.limit),
-    queryFn: () => api.games.getLeaderboard(gameId, options),
+    queryKey: GAME_LEADERBOARD_QUERY_KEY(gameId, apiOptions.since, apiOptions.limit),
+    queryFn: () => api.games.getLeaderboard(gameId, apiOptions),
     staleTime: 5 * 60 * 1000, // 5 minutes (matches backend cache)
     retry: 2,
-    enabled: !!gameId,
+    enabled: !!gameId && enabled,
   });
 }


### PR DESCRIPTION
## Summary

Implements #1466: refactor `GameDetailView` to add the **Stats tab** (mockup-required) with play-KPI + `GameDetailLeaderboard`, and to **lock Sessions/Stats tabs in community variant** with `GameDetailCommunityGate` inside each locked panel. Spec hardened via `/sc:spec-panel`.

## Decisions ratified (spec-panel)

The hardening reduced the original scope: `variant` own/community was **already derived internally** (`libraryEntryId`), `locked` was **already supported per-tab** in `GameDetailTabsAnimated`, and `LibraryGameDetail` already has the play-stats. Final decisions:

- **D1**: blocked on #1465 (now MERGED → unblocked).
- **D2**: stats tab = play-KPI (Win rate / Partite / Ultima from `winRate`/`timesPlayed`/`lastPlayed`) + leaderboard. Avg score globale omitted (not in `LibraryGameDetail`).
- **D3**: **no `variant` prop** — derivation kept internal (`libraryEntryId → own/community`).
- API: use the existing per-tab `locked?: boolean` flag (not a new `locked?: TabKey[]` prop).

## Changes

- `TabKey`: add `'stats'`.
- `useGameLeaderboard`: optional `enabled` for lazy gating (mirror `useGameAgents`); backward-compatible default `true`.
- `GameDetailView`:
  - `heroVariant` (already derived) now drives `buildTabsConfig(t, variant)` with `sessions`/`stats` `locked: true` in community.
  - `buildStatsKpiCards(detail, t)` — Win rate / Partite / Ultima.
  - `leaderboardQuery = useGameLeaderboard(gameId, { enabled: …isSuccess + data != null + libraryEntryId != null + tab === 'stats' })` (lazy, mirrors `useGameAgents` Cell 4 guard).
  - New **Stats panel**: community → `<GameDetailCommunityGate>`; own → `<GameDetailKpiCards>` + leaderboard with loading/error/success states around the presentational component.
  - **Sessions panel** made community-aware (gate vs rail).
  - `handleAddToLibrary` helper shared by Hero CTA and gate `onAdd`.
- i18n: 14 new `pages.gameDetail.{tabs.stats, stats.*}` keys.
- Test: mock `useGameLeaderboard` (default empty/success). **19/19 existing FSM tests still green** (Phase 0.5 contract preserved). MESSAGES dict extended with the new keys (mitigates P71 RangeError pattern).

## Tests / quality

- 19/19 existing `GameDetailView.test.tsx` (Phase 0.5/FSM) **green** — no regression.
- ESLint 0 errors on the changed files (2 pre-existing warnings inherited, not mine).
- Typecheck clean.

## Note CI

This PR likely inherits the **main-dev baseline failure** on `AdminSideDrawer.test.tsx` (5/15 fail, introduced by PR #1496 SP5 nav consolidation — unrelated to this refactor). Pattern P75: verify the fail converges only on AdminSideDrawer before considering admin-override.

## Follow-ups (not in this PR)

- 4 new test scenarios for the new behavior (stats tab content in own, gate in community for sessions/stats) — added if review requests them.

Closes #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
