### PR TITLE
feat(admin): SP5 F1 pilot A1 Overview re-skin

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/overview/KPIStatsRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/KPIStatsRow.tsx
@@ -13,7 +13,7 @@ export interface KPIStatsRowProps {
   totalUsers: number;
   activeUsers?: number;
   pendingApprovals: number;
-  /** Backend gap — wire when available */
+  /** Backend gap — wire when available. Falls back to 0 in the 4-up overview tile. */
   totalDocuments?: number;
   /** Backend gap — wire when available */
   queueDepth?: number;
@@ -25,6 +25,13 @@ export interface KPIStatsRowProps {
 // Component
 // ============================================================================
 
+/**
+ * 4-up KPI row for the admin Overview pilot (SP5 F1, mockup A1).
+ * Always renders the four cards (Giochi · Documenti · Utenti · Pendenti) in a
+ * 2-col mobile / 4-col desktop grid, matching the mockup `.kpi-row` layout.
+ * Empty/missing data falls back to 0 (e.g. totalDocuments while the backend
+ * gap is open) so the layout stays consistent.
+ */
 export function KPIStatsRow({
   totalGames,
   totalUsers,
@@ -34,29 +41,15 @@ export function KPIStatsRow({
   queueDepth,
   recentSubmissions,
 }: KPIStatsRowProps) {
-  const showDocuments = totalDocuments !== undefined;
-  const showPending = pendingApprovals > 0;
-
-  // Compute active-user ratio as a proxy trend indicator
+  // Active-user ratio as a trend indicator on the Users card.
   const activeRatio =
     activeUsers !== undefined && totalUsers > 0
       ? Math.round((activeUsers / totalUsers) * 100)
       : undefined;
 
-  // Compute the number of visible cards to set responsive grid cols
-  const cardCount = 2 + (showDocuments ? 1 : 0) + (showPending ? 1 : 0);
-  const gridColsClass: Record<number, string> = {
-    2: 'lg:grid-cols-2',
-    3: 'lg:grid-cols-3',
-    4: 'lg:grid-cols-4',
-  };
-
   return (
-    <div
-      className={`grid grid-cols-2 ${gridColsClass[cardCount] ?? 'lg:grid-cols-4'} gap-4`}
-      data-testid="kpi-stats-row"
-    >
-      {/* Card 1: Giochi — always visible */}
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4" data-testid="kpi-stats-row">
+      {/* Card 1: Giochi */}
       <KPICard
         title="Giochi"
         value={totalGames}
@@ -71,20 +64,18 @@ export function KPIStatsRow({
         data-testid="kpi-games"
       />
 
-      {/* Card 2: Documenti — only when totalDocuments is provided */}
-      {showDocuments && (
-        <KPICard
-          title="Documenti"
-          value={totalDocuments}
-          icon={<FileText className="h-5 w-5" />}
-          subtitle="processati"
-          badge={queueDepth && queueDepth > 0 ? `${queueDepth} in coda` : undefined}
-          badgeVariant="warning"
-          data-testid="kpi-documents"
-        />
-      )}
+      {/* Card 2: Documenti — always visible (fallback 0 while backend gap is open) */}
+      <KPICard
+        title="Documenti"
+        value={totalDocuments ?? 0}
+        icon={<FileText className="h-5 w-5" />}
+        subtitle="processati"
+        badge={queueDepth && queueDepth > 0 ? `${queueDepth} in coda` : undefined}
+        badgeVariant="warning"
+        data-testid="kpi-documents"
+      />
 
-      {/* Card 3: Utenti — always visible */}
+      {/* Card 3: Utenti */}
       <KPICard
         title="Utenti"
         value={totalUsers}
@@ -97,16 +88,14 @@ export function KPIStatsRow({
         data-testid="kpi-users"
       />
 
-      {/* Card 4: Pendenti — only when pendingApprovals > 0 */}
-      {showPending && (
-        <KPICard
-          title="Pendenti"
-          value={pendingApprovals}
-          icon={<UserPlus className="h-5 w-5" />}
-          subtitle="richieste di accesso"
-          data-testid="kpi-pending"
-        />
-      )}
+      {/* Card 4: Pendenti — always visible (shows 0 when no approvals are queued) */}
+      <KPICard
+        title="Pendenti"
+        value={pendingApprovals}
+        icon={<UserPlus className="h-5 w-5" />}
+        subtitle="richieste di accesso"
+        data-testid="kpi-pending"
+      />
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/overview/QuickActionsGrid.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/QuickActionsGrid.tsx
@@ -21,6 +21,15 @@ interface ActionConfig {
   href?: string;
 }
 
+export interface QuickActionsGridProps {
+  /**
+   * Layout variant.
+   * - `'grid'` (default, retro-compat): 2/3-col card grid for full-width usage.
+   * - `'sidebar'`: vertical compact list for the overview right-sidebar (SP5 F1 A1 mockup `.quick-actions`).
+   */
+  variant?: 'grid' | 'sidebar';
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -79,7 +88,7 @@ const ACTIONS: ActionConfig[] = [
 // Component
 // ============================================================================
 
-export function QuickActionsGrid() {
+export function QuickActionsGrid({ variant = 'grid' }: QuickActionsGridProps = {}) {
   const router = useRouter();
   const [inviteOpen, setInviteOpen] = useState(false);
 
@@ -90,6 +99,37 @@ export function QuickActionsGrid() {
       setInviteOpen(true);
     }
   };
+
+  if (variant === 'sidebar') {
+    return (
+      <>
+        <div
+          className="flex flex-col rounded-2xl border border-border/60 bg-card/70 overflow-hidden"
+          data-testid="quick-actions-sidebar"
+        >
+          {ACTIONS.map(action => (
+            <button
+              key={action.id}
+              data-testid={`quick-action-${action.id}`}
+              onClick={() => handleAction(action)}
+              className="flex items-center gap-3 px-3 py-2.5 text-left bg-transparent border-b border-border/40 last:border-b-0 hover:bg-muted transition-colors"
+            >
+              <span className="shrink-0">{action.icon}</span>
+              <span className="flex flex-col min-w-0">
+                <span className="font-quicksand text-sm font-semibold truncate">
+                  {action.label}
+                </span>
+                <span className="font-nunito text-xs text-muted-foreground truncate">
+                  {action.description}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+        <InviteUserDialog open={inviteOpen} onOpenChange={setInviteOpen} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/web/src/app/admin/(dashboard)/overview/__tests__/KPIStatsRow.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/__tests__/KPIStatsRow.test.tsx
@@ -26,10 +26,11 @@ describe('KPIStatsRow', () => {
     expect(screen.getByTestId('kpi-users-value')).toHaveTextContent('150');
   });
 
-  it('hides pending card when pendingApprovals is 0', () => {
+  it('renders pending card with 0 when no approvals are queued (4-up layout)', () => {
     render(<KPIStatsRow {...baseProps} pendingApprovals={0} />);
 
-    expect(screen.queryByTestId('kpi-pending')).not.toBeInTheDocument();
+    expect(screen.getByTestId('kpi-pending')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-pending-value')).toHaveTextContent('0');
   });
 
   it('shows pending card when pendingApprovals > 0', () => {
@@ -40,10 +41,11 @@ describe('KPIStatsRow', () => {
     expect(screen.getByTestId('kpi-pending-value')).toHaveTextContent('5');
   });
 
-  it('hides documents card when totalDocuments is not provided', () => {
+  it('renders documents card with 0 fallback when totalDocuments is not provided (backend gap)', () => {
     render(<KPIStatsRow {...baseProps} />);
 
-    expect(screen.queryByTestId('kpi-documents')).not.toBeInTheDocument();
+    expect(screen.getByTestId('kpi-documents')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-documents-value')).toHaveTextContent('0');
   });
 
   it('shows documents card when totalDocuments is provided', () => {
@@ -85,12 +87,12 @@ describe('KPIStatsRow', () => {
     expect(screen.getByTestId('kpi-pending')).toBeInTheDocument();
   });
 
-  it('renders only games and users cards by default', () => {
+  it('always renders the four cards (Giochi · Documenti · Utenti · Pendenti) in 4-up layout', () => {
     render(<KPIStatsRow totalGames={10} totalUsers={200} pendingApprovals={0} />);
 
     expect(screen.getByTestId('kpi-games')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-documents')).toBeInTheDocument();
     expect(screen.getByTestId('kpi-users')).toBeInTheDocument();
-    expect(screen.queryByTestId('kpi-documents')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('kpi-pending')).not.toBeInTheDocument();
+    expect(screen.getByTestId('kpi-pending')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/overview/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/page.tsx
@@ -161,40 +161,45 @@ export default function OverviewPage() {
         </div>
       )}
 
-      <KPIStatsRow
-        totalGames={data?.stats?.totalGames ?? 0}
-        totalUsers={data?.stats?.totalUsers ?? 0}
-        activeUsers={data?.stats?.activeUsers}
-        pendingApprovals={data?.stats?.pendingApprovals ?? 0}
-        recentSubmissions={data?.stats?.recentSubmissions}
-      />
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_280px] gap-6">
+        <div className="flex flex-col gap-6">
+          <KPIStatsRow
+            totalGames={data?.stats?.totalGames ?? 0}
+            totalUsers={data?.stats?.totalUsers ?? 0}
+            activeUsers={data?.stats?.activeUsers}
+            pendingApprovals={data?.stats?.pendingApprovals ?? 0}
+            recentSubmissions={data?.stats?.recentSubmissions}
+          />
 
-      <PendingRequestsBanner
-        requests={data?.pendingRequests.items ?? []}
-        totalCount={data?.pendingRequests.totalCount ?? 0}
-      />
+          <PendingRequestsBanner
+            requests={data?.pendingRequests.items ?? []}
+            totalCount={data?.pendingRequests.totalCount ?? 0}
+          />
 
-      <ProcessingQueueWidget />
+          <ProcessingQueueWidget />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <LibrarySummaryCard
-          totalGames={data?.stats?.totalGames ?? 0}
-          recentGames={data?.recentGames ?? []}
-        />
-        <UsersSummaryCard
-          totalUsers={data?.stats?.totalUsers ?? 0}
-          activeUsers={data?.stats?.activeUsers ?? 0}
-          pendingInvitations={data?.pendingInvitationCount ?? 0}
-          recentUsers={data?.recentUsers ?? []}
-        />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <LibrarySummaryCard
+              totalGames={data?.stats?.totalGames ?? 0}
+              recentGames={data?.recentGames ?? []}
+            />
+            <UsersSummaryCard
+              totalUsers={data?.stats?.totalUsers ?? 0}
+              activeUsers={data?.stats?.activeUsers ?? 0}
+              pendingInvitations={data?.pendingInvitationCount ?? 0}
+              recentUsers={data?.recentUsers ?? []}
+            />
+          </div>
+        </div>
+
+        <aside className="flex flex-col gap-4" data-testid="overview-sidebar">
+          <h2 className="font-quicksand text-sm font-semibold uppercase tracking-wider text-muted-foreground px-3">
+            Azioni rapide
+          </h2>
+          <QuickActionsGrid variant="sidebar" />
+          <TechActionsBar />
+        </aside>
       </div>
-
-      <div>
-        <h2 className="font-quicksand text-lg font-semibold text-foreground mb-4">Azioni Rapide</h2>
-        <QuickActionsGrid />
-      </div>
-
-      <TechActionsBar />
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/overview/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/page.tsx
@@ -116,13 +116,16 @@ export default function OverviewPage() {
   if (isLoading) {
     return (
       <div className="space-y-8">
-        <div>
-          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-            Dashboard
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Centro operativo: richieste, libreria e gestione utenti
-          </p>
+        <div
+          className="flex items-start justify-between gap-4 pb-2 border-b border-border"
+          data-testid="overview-topbar"
+        >
+          <div>
+            <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+              Overview sistema
+            </h1>
+            <p className="text-xs text-muted-foreground mt-1 font-mono">Admin · Overview</p>
+          </div>
         </div>
         <div className="grid grid-cols-3 gap-4">
           {[1, 2, 3].map(i => (
@@ -139,13 +142,23 @@ export default function OverviewPage() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          Dashboard
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Centro operativo: richieste, libreria e gestione utenti
-        </p>
+      <div
+        className="flex items-start justify-between gap-4 pb-2 border-b border-border"
+        data-testid="overview-topbar"
+      >
+        <div>
+          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+            Overview sistema
+          </h1>
+          <p className="text-xs text-muted-foreground mt-1 font-mono">
+            Admin · Overview
+            {data?.stats ? ` · ultimo refresh ${new Date().toLocaleTimeString('it-IT')}` : ''}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          <RefreshCwIcon className="h-3.5 w-3.5 mr-1.5" />
+          Refresh
+        </Button>
       </div>
 
       {isError && (


### PR DESCRIPTION
## Summary

Implementa **F1 — Pilota A1 Overview re-skin** (primo applicativo della shell consolidata di F0a/b/c). Plan: `docs/superpowers/plans/2026-05-24-sp5-admin-f1-pilot-a1-overview.md` (mergiato in #1504). Il pilota valida il workflow di re-skin mock-→-componente; **scope ridotto ai 3 pattern-chiave** del mockup A1.

| # | Task | Commit |
|---|------|--------|
| 1 | `KPIStatsRow` sempre **4-up** (Giochi · Documenti · Utenti · Pendenti); fallback a 0 per gap backend (totalDocuments) e nessuna richiesta pendente | `940dfc682` |
| 2 | Layout **2-col `[main 1fr | quick-actions sidebar 280px]`** attivo da breakpoint `xl`; `QuickActionsGrid` guadagna prop `variant: 'grid' \| 'sidebar'` (retro-compat) | `7e6d45ba8` |
| 3 | **Topbar** "Overview sistema" + crumbs (`Admin · Overview · ultimo refresh …`) + bottone **Refresh** che invoca `refetch()` (loading state coerente) | `6ec7a759a` |

## Test Plan

- [x] **52/52 unit test** dell'overview verdi (incl. 10 KPIStatsRow aggiornati per la nuova 4-up + 9 QuickActionsGrid retro-compat con la variant 'grid' default)
- [x] `pnpm typecheck` + ESLint puliti via pre-push build
- [ ] Verifica visiva: KPI 4-up a `lg+`, sidebar quick-actions a `xl+`, topbar h1+crumbs+Refresh, dark scoped admin (eredita da F0c)

## Non-goals del pilota (rimandati alle ondate)

- ❌ Charts row 4-up (servono dati metric/series non ancora disponibili)
- ❌ Activity-feed + alerts-feed 2-up (richiede SSE `events/live`, gap §5)
- ❌ Mobile fallback "Console solo desktop" (fuori scope per decisione di colloquio)
- ❌ Pixel-perfect col mockup — il pilota valida il workflow, non il pixel

## Note

- **Follow-up tracked:** `page.test.tsx` d'integrazione differito (mock pesante di `@/lib/api`, `fetch`, `next/navigation`); la copertura unitaria dei sotto-componenti (52 test) è invariata e copre il grosso. Da aggiungere quando una pagina admin successiva richiede coverage E2E.
- Eseguito direttamente (chirurgico) anziché subagent-driven per rate limit API attivo.
- Prossimo dopo merge: **F2 A2 Users** (stress-test sicurezza: DataTable + impersonate + step-up + audit) → ondate F3-F6 + track ⊥ sicurezza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
