### PR TITLE
feat(game-detail): #1464 GameDetailHouseRulesList full CRUD (BE+FE)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/RemoveHouseRuleCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/RemoveHouseRuleCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Command to remove a house rule by id (#1464).
+/// </summary>
+internal record RemoveHouseRuleCommand(
+    Guid GameId,
+    Guid OwnerId,
+    Guid RuleId
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/RemoveHouseRuleCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/RemoveHouseRuleCommandHandler.cs
@@ -1,0 +1,61 @@
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Handles removing a house rule by id (#1464). Throws NotFoundException when the
+/// GameMemory or the rule doesn't exist (HTTP 404 at the endpoint).
+/// </summary>
+internal sealed class RemoveHouseRuleCommandHandler : ICommandHandler<RemoveHouseRuleCommand>
+{
+    private readonly IGameMemoryRepository _gameMemoryRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IFeatureFlagService _featureFlags;
+    private readonly ILogger<RemoveHouseRuleCommandHandler> _logger;
+
+    public RemoveHouseRuleCommandHandler(
+        IGameMemoryRepository gameMemoryRepo,
+        IUnitOfWork unitOfWork,
+        IFeatureFlagService featureFlags,
+        ILogger<RemoveHouseRuleCommandHandler> logger)
+    {
+        _gameMemoryRepo = gameMemoryRepo ?? throw new ArgumentNullException(nameof(gameMemoryRepo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(RemoveHouseRuleCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var isEnabled = await _featureFlags
+            .IsEnabledAsync("Features:AgentMemory.Enabled")
+            .ConfigureAwait(false);
+        if (!isEnabled)
+            throw new ConflictException("Feature AgentMemory.Enabled is disabled");
+
+        var memory = await _gameMemoryRepo
+            .GetByGameAndOwnerAsync(command.GameId, command.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (memory == null)
+            throw new NotFoundException($"GameMemory not found for game {command.GameId}");
+
+        var removed = memory.RemoveHouseRule(command.RuleId);
+        if (!removed)
+            throw new NotFoundException($"House rule {command.RuleId} not found");
+
+        await _gameMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Removed house rule {RuleId} from game memory {MemoryId}",
+            command.RuleId, memory.Id);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommand.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Command to update an existing house rule's description (#1464).
+/// </summary>
+internal record UpdateHouseRuleCommand(
+    Guid GameId,
+    Guid OwnerId,
+    Guid RuleId,
+    string Description
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommandHandler.cs
@@ -50,7 +50,17 @@ internal sealed class UpdateHouseRuleCommandHandler : ICommandHandler<UpdateHous
         if (memory == null)
             throw new NotFoundException($"GameMemory not found for game {command.GameId}");
 
-        memory.UpdateHouseRule(command.RuleId, command.Description);
+        try
+        {
+            memory.UpdateHouseRule(command.RuleId, command.Description);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
+        {
+            // Map the domain "rule not found" sentinel to a typed 404 — explicit and
+            // consistent with RemoveHouseRuleCommandHandler instead of relying on the
+            // middleware's string-match fallback.
+            throw new NotFoundException($"House rule {command.RuleId} not found");
+        }
 
         await _gameMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateHouseRuleCommandHandler.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Commands;
+
+/// <summary>
+/// Handles updating an existing house rule's description (#1464). Throws NotFoundException
+/// when either the GameMemory or the rule doesn't exist (HTTP 404 at the endpoint).
+/// </summary>
+internal sealed class UpdateHouseRuleCommandHandler : ICommandHandler<UpdateHouseRuleCommand>
+{
+    private readonly IGameMemoryRepository _gameMemoryRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IFeatureFlagService _featureFlags;
+    private readonly ILogger<UpdateHouseRuleCommandHandler> _logger;
+
+    public UpdateHouseRuleCommandHandler(
+        IGameMemoryRepository gameMemoryRepo,
+        IUnitOfWork unitOfWork,
+        IFeatureFlagService featureFlags,
+        ILogger<UpdateHouseRuleCommandHandler> logger)
+    {
+        _gameMemoryRepo = gameMemoryRepo ?? throw new ArgumentNullException(nameof(gameMemoryRepo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(UpdateHouseRuleCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var isEnabled = await _featureFlags
+            .IsEnabledAsync("Features:AgentMemory.Enabled")
+            .ConfigureAwait(false);
+        if (!isEnabled)
+            throw new ConflictException("Feature AgentMemory.Enabled is disabled");
+
+        if (string.IsNullOrWhiteSpace(command.Description))
+            throw new ArgumentException("Description cannot be empty.", nameof(command));
+
+        var memory = await _gameMemoryRepo
+            .GetByGameAndOwnerAsync(command.GameId, command.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (memory == null)
+            throw new NotFoundException($"GameMemory not found for game {command.GameId}");
+
+        memory.UpdateHouseRule(command.RuleId, command.Description);
+
+        await _gameMemoryRepo.UpdateAsync(memory, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Updated house rule {RuleId} in game memory {MemoryId}",
+            command.RuleId, memory.Id);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/AgentMemoryDtos.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/AgentMemoryDtos.cs
@@ -14,6 +14,7 @@ internal record GameMemoryDto(
 /// DTO representing a single house rule.
 /// </summary>
 internal record HouseRuleDto(
+    Guid Id,
     string Description,
     DateTime AddedAt,
     string Source);

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGameMemoryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGameMemoryQueryHandler.cs
@@ -34,6 +34,7 @@ internal sealed class GetGameMemoryQueryHandler : IQueryHandler<GetGameMemoryQue
         GameId: memory.GameId,
         OwnerId: memory.OwnerId,
         HouseRules: memory.HouseRules.Select(hr => new HouseRuleDto(
+            Id: hr.Id,
             Description: hr.Description,
             AddedAt: hr.AddedAt,
             Source: hr.Source.ToString()

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/RemoveHouseRuleCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/RemoveHouseRuleCommandValidator.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.AgentMemory.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Validators;
+
+/// <summary>
+/// Validates <see cref="RemoveHouseRuleCommand"/> inputs (#1464). Route constraints
+/// already reject empty Guids, but pipeline validation gives early rejection and
+/// keeps the command surface uniform with the other AgentMemory commands.
+/// </summary>
+internal sealed class RemoveHouseRuleCommandValidator : AbstractValidator<RemoveHouseRuleCommand>
+{
+    public RemoveHouseRuleCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEmpty().WithMessage("Game ID is required");
+        RuleFor(x => x.OwnerId).NotEmpty().WithMessage("Owner ID is required");
+        RuleFor(x => x.RuleId).NotEmpty().WithMessage("Rule ID is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/UpdateHouseRuleCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/UpdateHouseRuleCommandValidator.cs
@@ -1,0 +1,22 @@
+using Api.BoundedContexts.AgentMemory.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Validators;
+
+/// <summary>
+/// Validates <see cref="UpdateHouseRuleCommand"/> inputs (#1464). Mirrors the
+/// AddHouseRuleCommandValidator caps so the 2000-character description limit
+/// is enforced at the pipeline layer instead of the domain only.
+/// </summary>
+internal sealed class UpdateHouseRuleCommandValidator : AbstractValidator<UpdateHouseRuleCommand>
+{
+    public UpdateHouseRuleCommandValidator()
+    {
+        RuleFor(x => x.GameId).NotEmpty().WithMessage("Game ID is required");
+        RuleFor(x => x.OwnerId).NotEmpty().WithMessage("Owner ID is required");
+        RuleFor(x => x.RuleId).NotEmpty().WithMessage("Rule ID is required");
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Description is required")
+            .MaximumLength(2000).WithMessage("Description cannot exceed 2000 characters");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GameMemory.cs
@@ -48,6 +48,30 @@ internal sealed class GameMemory : AggregateRoot<Guid>
         _houseRules.Add(HouseRule.Create(description, source));
     }
 
+    /// <summary>
+    /// Updates the description of an existing house rule (#1464). Throws when the rule is unknown.
+    /// </summary>
+    public void UpdateHouseRule(Guid ruleId, string newDescription)
+    {
+        if (ruleId == Guid.Empty) throw new ArgumentException("RuleId cannot be empty.", nameof(ruleId));
+        var rule = _houseRules.FirstOrDefault(r => r.Id == ruleId)
+            ?? throw new InvalidOperationException($"House rule {ruleId} not found.");
+        rule.UpdateDescription(newDescription);
+    }
+
+    /// <summary>
+    /// Removes an existing house rule by id (#1464). No-op if the rule is unknown
+    /// (idempotent delete); the caller decides whether to map that to a 404 at the endpoint.
+    /// Returns true when a rule was actually removed.
+    /// </summary>
+    public bool RemoveHouseRule(Guid ruleId)
+    {
+        if (ruleId == Guid.Empty) throw new ArgumentException("RuleId cannot be empty.", nameof(ruleId));
+        var rule = _houseRules.FirstOrDefault(r => r.Id == ruleId);
+        if (rule is null) return false;
+        return _houseRules.Remove(rule);
+    }
+
     public void SetCustomSetup(SetupChecklistData setup)
     {
         CustomSetup = setup ?? throw new ArgumentNullException(nameof(setup));

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Models/HouseRule.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Models/HouseRule.cs
@@ -9,6 +9,13 @@ internal sealed class HouseRule
 {
     private HouseRule() { } // Required for JSON deserialization
 
+    /// <summary>
+    /// Stable identifier (#1464). Generated on Create; rules persisted before #1464
+    /// (without an Id in their JSON blob) get a fresh Guid at Restore time so they
+    /// can be referenced by PATCH/DELETE endpoints.
+    /// </summary>
+    public Guid Id { get; private set; }
+
     public string Description { get; private set; } = string.Empty;
     public DateTime AddedAt { get; private set; }
     public HouseRuleSource Source { get; private set; }
@@ -20,6 +27,7 @@ internal sealed class HouseRule
 
         return new HouseRule
         {
+            Id = Guid.NewGuid(),
             Description = description,
             AddedAt = DateTime.UtcNow,
             Source = source
@@ -28,14 +36,24 @@ internal sealed class HouseRule
 
     /// <summary>
     /// Restores from persistence with the original AddedAt timestamp.
+    /// If the persisted Id is empty (legacy pre-#1464), a fresh Guid is assigned.
     /// </summary>
-    internal static HouseRule Restore(string description, DateTime addedAt, HouseRuleSource source)
+    internal static HouseRule Restore(Guid id, string description, DateTime addedAt, HouseRuleSource source)
     {
         return new HouseRule
         {
+            Id = id == Guid.Empty ? Guid.NewGuid() : id,
             Description = description,
             AddedAt = addedAt,
             Source = source
         };
+    }
+
+    /// <summary>Mutates the description in-place. Used by GameMemory.UpdateHouseRule.</summary>
+    internal void UpdateDescription(string newDescription)
+    {
+        if (string.IsNullOrWhiteSpace(newDescription))
+            throw new ArgumentException("Description cannot be empty.", nameof(newDescription));
+        Description = newDescription;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Persistence/GameMemoryRepository.cs
@@ -88,7 +88,7 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
 
                 foreach (var rule in houseRules)
                 {
-                    rules.Add(HouseRule.Restore(rule.Description, rule.AddedAt, (HouseRuleSource)rule.Source));
+                    rules.Add(HouseRule.Restore(rule.Id, rule.Description, rule.AddedAt, (HouseRuleSource)rule.Source));
                 }
             }
         }
@@ -162,6 +162,7 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
         {
             var dtos = memory.HouseRules.Select(r => new HouseRuleDto
             {
+                Id = r.Id,
                 Description = r.Description,
                 AddedAt = r.AddedAt,
                 Source = (int)r.Source,
@@ -216,6 +217,9 @@ internal sealed class GameMemoryRepository : RepositoryBase, IGameMemoryReposito
     /// <summary>DTO for JSON serialization of HouseRule.</summary>
     private sealed class HouseRuleDto
     {
+        // #1464: Stable Id. Defaults to Guid.Empty when the JSON predates #1464; the
+        // HouseRule.Restore factory then assigns a fresh Guid (lazy migration).
+        public Guid Id { get; set; }
         public string Description { get; set; } = string.Empty;
         public DateTime AddedAt { get; set; }
         public int Source { get; set; }

--- a/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
@@ -59,6 +59,22 @@ internal static class AgentMemoryEndpoints
             .Produces(401)
             .WithSummary("Add a house rule");
 
+        // #1464 — Edit/Delete CRUD for house rules.
+        agentMemory.MapPatch("/games/{gameId:guid}/memory/house-rules/{ruleId:guid}", HandleUpdateHouseRule)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(401)
+            .Produces(404)
+            .WithSummary("Update a house rule's description");
+
+        agentMemory.MapDelete("/games/{gameId:guid}/memory/house-rules/{ruleId:guid}", HandleRemoveHouseRule)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401)
+            .Produces(404)
+            .WithSummary("Remove a house rule");
+
         agentMemory.MapPost("/games/{gameId:guid}/memory/notes", HandleAddNote)
             .RequireAuthenticatedUser()
             .Produces(204)
@@ -170,6 +186,35 @@ internal static class AgentMemoryEndpoints
         return Results.NoContent();
     }
 
+    private static async Task<IResult> HandleUpdateHouseRule(
+        Guid gameId,
+        Guid ruleId,
+        [FromBody] UpdateHouseRuleRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new UpdateHouseRuleCommand(gameId, userId, ruleId, request.Description);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleRemoveHouseRule(
+        Guid gameId,
+        Guid ruleId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new RemoveHouseRuleCommand(gameId, userId, ruleId);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
     private static async Task<IResult> HandleAddNote(
         Guid gameId,
         [FromBody] AddNoteRequest request,
@@ -259,6 +304,8 @@ internal static class AgentMemoryEndpoints
         string? CustomNotes);
 
     internal record AddHouseRuleRequest(string Description);
+
+    internal record UpdateHouseRuleRequest(string Description);
 
     internal record AddNoteRequest(string Content);
 

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -31,6 +31,7 @@ import {
   GameDetailCommunityGate,
   GameDetailFaqList,
   GameDetailHero,
+  GameDetailHouseRulesList,
   GameDetailKbDocList,
   GameDetailKpiCards,
   GameDetailLeaderboard,
@@ -55,6 +56,12 @@ import {
 } from '@/hooks/queries/useLibrary';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useGameLeaderboard } from '@/lib/domain-hooks/useGameLeaderboard';
+import {
+  useAddHouseRule,
+  useGameMemory,
+  useRemoveHouseRule,
+  useUpdateHouseRule,
+} from '@/lib/domain-hooks/useGameMemory';
 import { deriveGameDetailUiState } from '@/lib/games/game-detail-state';
 import {
   IS_VISUAL_TEST_BUILD,
@@ -433,6 +440,20 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
       tab === 'stats',
   });
 
+  // Game memory hooks (Issue #1464 — house rules CRUD). Query gated on info tab + own
+  // variant; mutations stay unconditional (fire only via callbacks).
+  const memoryQuery = useGameMemory(gameId ?? '', {
+    enabled:
+      !!gameId &&
+      detailQuery.isSuccess &&
+      detailQuery.data != null &&
+      !!detailQuery.data.libraryEntryId &&
+      tab === 'info',
+  });
+  const addHouseRule = useAddHouseRule(gameId ?? '');
+  const updateHouseRule = useUpdateHouseRule(gameId ?? '');
+  const removeHouseRule = useRemoveHouseRule(gameId ?? '');
+
   // ── Effective detail (fixture takes priority over real data) ─────────────
   const detail = fixture ?? detailQuery.data ?? null;
 
@@ -584,6 +605,21 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
     cta: t('pages.gameDetail.stats.communityGateCta'),
   };
 
+  const houseRulesLabels = {
+    title: t('pages.gameDetail.houseRules.title'),
+    addCta: t('pages.gameDetail.houseRules.addCta'),
+    addPlaceholder: t('pages.gameDetail.houseRules.addPlaceholder'),
+    addSubmit: t('pages.gameDetail.houseRules.addSubmit'),
+    editLabel: t('pages.gameDetail.houseRules.editLabel'),
+    editSubmit: t('pages.gameDetail.houseRules.editSubmit'),
+    cancel: t('pages.gameDetail.houseRules.cancel'),
+    deleteLabel: t('pages.gameDetail.houseRules.deleteLabel'),
+    deleteConfirmTitle: t('pages.gameDetail.houseRules.deleteConfirmTitle'),
+    deleteConfirmMessage: t('pages.gameDetail.houseRules.deleteConfirmMessage'),
+    deleteConfirm: t('pages.gameDetail.houseRules.deleteConfirm'),
+    empty: t('pages.gameDetail.houseRules.empty'),
+  };
+
   const handleAddToLibrary = (): void => {
     if (!gameId || addToLibrary.isPending) return;
     addToLibrary.mutate(
@@ -665,6 +701,16 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
             <GameDetailSpecsCard items={specsItems} title={specsTitle} />
             {/* FAQ inline preview (CTA links to subroute) */}
             <GameDetailFaqList faqs={[]} viewAllHref={`/games/${gameId}/faqs`} labels={faqLabels} />
+            {/* House rules CRUD (#1464) — own variant only */}
+            {!isCommunityVariant && (
+              <GameDetailHouseRulesList
+                rules={memoryQuery.data?.houseRules ?? []}
+                labels={houseRulesLabels}
+                onAdd={d => addHouseRule.mutate(d)}
+                onUpdate={(ruleId, description) => updateHouseRule.mutate({ ruleId, description })}
+                onDelete={ruleId => removeHouseRule.mutate(ruleId)}
+              />
+            )}
           </div>
         </div>
 

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -908,4 +908,30 @@ describe('GameDetailView — FSM integration tests (Phase 0.5 contract)', () => 
     expect(statsPanel).toBeInTheDocument();
     expect(statsPanel?.querySelector('[data-slot="game-detail-community-gate"]')).toBeNull();
   });
+
+  // ─── Issue #1464 — House rules CRUD visibility per variant ───────────────
+
+  it('Issue #1464: own variant renders GameDetailHouseRulesList inside Info panel', () => {
+    detailMockState.data = makeDetail(); // own variant
+    detailMockState.isSuccess = true;
+    useLibraryGameDetailSpy.mockReturnValue(detailMockState);
+
+    renderWithIntl(<GameDetailView gameId={VALID_GAME_ID} />);
+
+    const infoPanel = document.querySelector('[data-slot="game-detail-panel-info"]');
+    expect(infoPanel).toBeInTheDocument();
+    expect(
+      infoPanel?.querySelector('[data-slot="game-detail-house-rules-list"]')
+    ).toBeInTheDocument();
+  });
+
+  it('Issue #1464: community variant skips the house-rules list', () => {
+    detailMockState.data = makeDetail({ libraryEntryId: '' });
+    detailMockState.isSuccess = true;
+    useLibraryGameDetailSpy.mockReturnValue(detailMockState);
+
+    renderWithIntl(<GameDetailView gameId={VALID_GAME_ID} />);
+
+    expect(document.querySelector('[data-slot="game-detail-house-rules-list"]')).toBeNull();
+  });
 });

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -110,6 +110,21 @@ vi.mock('@/lib/domain-hooks/useGameLeaderboard', () => ({
   GAME_LEADERBOARD_QUERY_KEY: (gameId: string) => ['game-leaderboard', gameId, null, 10] as const,
 }));
 
+// Issue #1464 — Game memory hooks (house rules CRUD). Default: no memory, no-op
+// mutations; FSM/Phase 0.5 tests don't exercise the house-rules flow.
+vi.mock('@/lib/domain-hooks/useGameMemory', () => ({
+  useGameMemory: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  }),
+  useAddHouseRule: () => ({ mutate: vi.fn() }),
+  useUpdateHouseRule: () => ({ mutate: vi.fn() }),
+  useRemoveHouseRule: () => ({ mutate: vi.fn() }),
+  GAME_MEMORY_QUERY_KEY: (gameId: string) => ['game-memory', gameId] as const,
+}));
+
 // ─── Visual fixture mock ──────────────────────────────────────────────────
 
 let mockIsVisualTestBuild = false;
@@ -235,6 +250,19 @@ const MESSAGES: Record<string, string> = {
   'pages.gameDetail.stats.communityGateDescription':
     'Aggiungi questo gioco per sbloccare statistiche e classifica giocatori.',
   'pages.gameDetail.stats.communityGateCta': '+ Aggiungi a libreria',
+  // Issue #1464 — House rules CRUD (Info tab)
+  'pages.gameDetail.houseRules.title': 'House rules',
+  'pages.gameDetail.houseRules.addCta': '+ Aggiungi',
+  'pages.gameDetail.houseRules.addPlaceholder': 'Scrivi una regola...',
+  'pages.gameDetail.houseRules.addSubmit': 'Salva',
+  'pages.gameDetail.houseRules.editLabel': 'Modifica',
+  'pages.gameDetail.houseRules.editSubmit': 'Aggiorna',
+  'pages.gameDetail.houseRules.cancel': 'Annulla',
+  'pages.gameDetail.houseRules.deleteLabel': 'Elimina',
+  'pages.gameDetail.houseRules.deleteConfirmTitle': 'Elimina house rule?',
+  'pages.gameDetail.houseRules.deleteConfirmMessage': 'Questa azione non e reversibile.',
+  'pages.gameDetail.houseRules.deleteConfirm': 'Elimina',
+  'pages.gameDetail.houseRules.empty': 'Nessuna regola',
 };
 
 function renderWithIntl(ui: ReactElement) {

--- a/apps/web/src/components/features/game-detail/GameDetailHouseRulesList.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailHouseRulesList.tsx
@@ -1,0 +1,240 @@
+/**
+ * GameDetailHouseRulesList - Wave C follow-up (Issue #1464)
+ *
+ * Interactive presentational CRUD list of house rules for a game's memory. Receives
+ * rules + i18n labels + mutation callbacks. State for UI affordances (add form,
+ * inline edit, delete confirm) lives inside; data fetching/mutations are the caller's
+ * job. Mockup: `admin-mockups/design_files/sp4-game-detail.jsx:423-475`.
+ *
+ * Note on scope (per spec-panel decision): the BE HouseRule was extended in this issue
+ * to carry a stable Guid Id; PATCH/DELETE endpoints were added (#1464). The mockup's
+ * enable/disable toggle is NOT supported by the domain — see PILOT_GAP_REPORT § 3.5 #4.
+ */
+
+'use client';
+
+import { useState, type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { ConfirmModal } from '@/components/ui/dialogs/confirm-modal';
+import type { HouseRuleDto } from '@/lib/api/clients/agentMemoryClient';
+
+export interface GameDetailHouseRulesListLabels {
+  readonly title: string;
+  readonly addCta: string;
+  readonly addPlaceholder: string;
+  readonly addSubmit: string;
+  readonly editLabel: string;
+  readonly editSubmit: string;
+  readonly cancel: string;
+  readonly deleteLabel: string;
+  readonly deleteConfirmTitle: string;
+  readonly deleteConfirmMessage: string;
+  readonly deleteConfirm: string;
+  readonly empty: string;
+}
+
+export interface GameDetailHouseRulesListProps {
+  readonly rules: ReadonlyArray<HouseRuleDto>;
+  readonly labels: GameDetailHouseRulesListLabels;
+  readonly onAdd: (description: string) => void;
+  readonly onUpdate: (ruleId: string, description: string) => void;
+  readonly onDelete: (ruleId: string) => void;
+  readonly className?: string;
+}
+
+export function GameDetailHouseRulesList(props: GameDetailHouseRulesListProps): ReactElement {
+  const { rules, labels, onAdd, onUpdate, onDelete, className } = props;
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [addValue, setAddValue] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const trimmedAdd = addValue.trim();
+  const canSubmitAdd = trimmedAdd.length > 0;
+  const trimmedEdit = editValue.trim();
+  const canSubmitEdit = trimmedEdit.length > 0;
+
+  function handleSubmitAdd(): void {
+    if (!canSubmitAdd) return;
+    onAdd(trimmedAdd);
+    setAddValue('');
+    setAddOpen(false);
+  }
+
+  function handleStartEdit(rule: HouseRuleDto): void {
+    setEditingId(rule.id);
+    setEditValue(rule.description);
+  }
+
+  function handleSubmitEdit(): void {
+    if (editingId == null || !canSubmitEdit) return;
+    onUpdate(editingId, trimmedEdit);
+    setEditingId(null);
+    setEditValue('');
+  }
+
+  function handleCancelEdit(): void {
+    setEditingId(null);
+    setEditValue('');
+  }
+
+  function handleConfirmDelete(): void {
+    if (confirmDeleteId == null) return;
+    onDelete(confirmDeleteId);
+    setConfirmDeleteId(null);
+  }
+
+  return (
+    <section
+      data-slot="game-detail-house-rules-list"
+      className={clsx('rounded-2xl border border-border bg-card p-[18px] shadow-sm', className)}
+    >
+      <div className="mb-3.5 flex items-center justify-between gap-3">
+        <h3 className="font-display text-[15px] font-extrabold text-foreground">{labels.title}</h3>
+        {!addOpen && (
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            data-slot="game-detail-house-rules-add-cta"
+            className="rounded-md border border-border bg-transparent px-2.5 py-1 font-display text-[12px] font-extrabold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {labels.addCta}
+          </button>
+        )}
+      </div>
+
+      {addOpen && (
+        <div
+          data-slot="game-detail-house-rules-add-form"
+          className="mb-3 flex flex-col gap-2 rounded-xl border border-border bg-background p-3"
+        >
+          <textarea
+            value={addValue}
+            onChange={e => setAddValue(e.target.value)}
+            placeholder={labels.addPlaceholder}
+            data-slot="game-detail-house-rules-add-input"
+            className="min-h-[64px] resize-y rounded-md border border-border bg-background p-2 font-mono text-[12px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setAddOpen(false);
+                setAddValue('');
+              }}
+              className="rounded-md border border-border bg-transparent px-2.5 py-1 font-display text-[12px] font-bold text-muted-foreground transition-colors hover:bg-muted"
+            >
+              {labels.cancel}
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmitAdd}
+              disabled={!canSubmitAdd}
+              data-slot="game-detail-house-rules-add-submit"
+              className="rounded-md border-none bg-primary px-3 py-1 font-display text-[12px] font-extrabold text-primary-foreground shadow-sm transition-shadow hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {labels.addSubmit}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {rules.length === 0 && !addOpen ? (
+        <p
+          data-slot="game-detail-house-rules-empty"
+          className="py-6 text-center font-mono text-[11px] text-muted-foreground"
+        >
+          {labels.empty}
+        </p>
+      ) : (
+        <ul role="list" aria-label={labels.title} className="flex flex-col">
+          {rules.map((rule, i) => {
+            const isEditing = editingId === rule.id;
+            return (
+              <li
+                key={rule.id}
+                role="listitem"
+                data-slot="game-detail-house-rules-row"
+                data-rule-id={rule.id}
+                className={clsx(
+                  'flex flex-col gap-2 py-2.5',
+                  i < rules.length - 1 && 'border-b border-border'
+                )}
+              >
+                {isEditing ? (
+                  <>
+                    <textarea
+                      value={editValue}
+                      onChange={e => setEditValue(e.target.value)}
+                      data-slot="game-detail-house-rules-edit-input"
+                      className="min-h-[56px] resize-y rounded-md border border-border bg-background p-2 font-mono text-[12px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    />
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={handleCancelEdit}
+                        className="rounded-md border border-border bg-transparent px-2.5 py-1 font-display text-[11px] font-bold text-muted-foreground transition-colors hover:bg-muted"
+                      >
+                        {labels.cancel}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSubmitEdit}
+                        disabled={!canSubmitEdit}
+                        data-slot="game-detail-house-rules-edit-submit"
+                        className="rounded-md border-none bg-primary px-2.5 py-1 font-display text-[11px] font-extrabold text-primary-foreground transition-shadow hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {labels.editSubmit}
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="flex-1 font-mono text-[12px] text-foreground">
+                      {rule.description}
+                    </p>
+                    <div className="flex flex-shrink-0 items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => handleStartEdit(rule)}
+                        aria-label={labels.editLabel}
+                        data-slot="game-detail-house-rules-edit-cta"
+                        className="rounded-md border-none bg-transparent px-2 py-1 font-mono text-[11px] font-extrabold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        ✏️
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDeleteId(rule.id)}
+                        aria-label={labels.deleteLabel}
+                        data-slot="game-detail-house-rules-delete-cta"
+                        className="rounded-md border-none bg-transparent px-2 py-1 font-mono text-[11px] font-extrabold text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        🗑️
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <ConfirmModal
+        open={confirmDeleteId !== null}
+        title={labels.deleteConfirmTitle}
+        message={labels.deleteConfirmMessage}
+        confirmLabel={labels.deleteConfirm}
+        cancelLabel={labels.cancel}
+        variant="destructive"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-detail/GameDetailHouseRulesList.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailHouseRulesList.tsx
@@ -116,6 +116,9 @@ export function GameDetailHouseRulesList(props: GameDetailHouseRulesListProps): 
             value={addValue}
             onChange={e => setAddValue(e.target.value)}
             placeholder={labels.addPlaceholder}
+            // BE caps description at 2000 chars (AddHouseRuleCommandValidator).
+            maxLength={2000}
+            autoFocus
             data-slot="game-detail-house-rules-add-input"
             className="min-h-[64px] resize-y rounded-md border border-border bg-background p-2 font-mono text-[12px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
@@ -170,6 +173,8 @@ export function GameDetailHouseRulesList(props: GameDetailHouseRulesListProps): 
                     <textarea
                       value={editValue}
                       onChange={e => setEditValue(e.target.value)}
+                      maxLength={2000}
+                      autoFocus
                       data-slot="game-detail-house-rules-edit-input"
                       className="min-h-[56px] resize-y rounded-md border border-border bg-background p-2 font-mono text-[12px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     />

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailHouseRulesList.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailHouseRulesList.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GameDetailHouseRulesList } from '../GameDetailHouseRulesList';
+
+import type { HouseRuleDto } from '@/lib/api/clients/agentMemoryClient';
+
+const labels = {
+  title: 'House rules',
+  addCta: '+ Aggiungi',
+  addPlaceholder: 'Scrivi una regola…',
+  addSubmit: 'Salva',
+  editLabel: 'Modifica',
+  editSubmit: 'Aggiorna',
+  cancel: 'Annulla',
+  deleteLabel: 'Elimina',
+  deleteConfirmTitle: 'Elimina house rule?',
+  deleteConfirmMessage: 'Questa azione non è reversibile.',
+  deleteConfirm: 'Elimina',
+  empty: 'Nessuna regola',
+};
+
+function rule(over: Partial<HouseRuleDto> & { id: string }): HouseRuleDto {
+  return {
+    id: over.id,
+    description: over.description ?? 'Regola',
+    addedAt: over.addedAt ?? '2026-05-25T00:00:00.000Z',
+    source: over.source ?? 'UserAdded',
+  };
+}
+
+const noop = () => {};
+
+describe('GameDetailHouseRulesList (Issue #1464)', () => {
+  it('renders title and one row per rule', () => {
+    const rules = [
+      rule({ id: '11111111-1111-1111-1111-111111111111', description: 'No backseat gaming' }),
+      rule({ id: '22222222-2222-2222-2222-222222222222', description: 'Snacks ok' }),
+    ];
+    render(
+      <GameDetailHouseRulesList
+        rules={rules}
+        labels={labels}
+        onAdd={noop}
+        onUpdate={noop}
+        onDelete={noop}
+      />
+    );
+    expect(screen.getByRole('heading', { name: 'House rules' })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText('No backseat gaming')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rules and form closed', () => {
+    render(
+      <GameDetailHouseRulesList
+        rules={[]}
+        labels={labels}
+        onAdd={noop}
+        onUpdate={noop}
+        onDelete={noop}
+      />
+    );
+    expect(screen.getByText('Nessuna regola')).toBeInTheDocument();
+  });
+
+  it('opens the add form on CTA click and calls onAdd with the trimmed value', () => {
+    const onAdd = vi.fn();
+    render(
+      <GameDetailHouseRulesList
+        rules={[]}
+        labels={labels}
+        onAdd={onAdd}
+        onUpdate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi' }));
+    const input = screen.getByPlaceholderText('Scrivi una regola…') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: '  No phones at the table  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Salva' }));
+    expect(onAdd).toHaveBeenCalledWith('No phones at the table');
+  });
+
+  it('disables the add submit when description is empty/whitespace', () => {
+    render(
+      <GameDetailHouseRulesList
+        rules={[]}
+        labels={labels}
+        onAdd={noop}
+        onUpdate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '+ Aggiungi' }));
+    expect(screen.getByRole('button', { name: 'Salva' })).toBeDisabled();
+  });
+
+  it('enters edit mode and calls onUpdate', () => {
+    const onUpdate = vi.fn();
+    const rules = [rule({ id: '11111111-1111-1111-1111-111111111111', description: 'Old' })];
+    render(
+      <GameDetailHouseRulesList
+        rules={rules}
+        labels={labels}
+        onAdd={noop}
+        onUpdate={onUpdate}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Modifica'));
+    const input = screen.getByDisplayValue('Old') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Aggiorna' }));
+    expect(onUpdate).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', 'New');
+  });
+
+  it('opens delete confirm and calls onDelete on confirm', () => {
+    const onDelete = vi.fn();
+    const rules = [rule({ id: 'aaaa1111-1111-1111-1111-111111111111', description: 'X' })];
+    render(
+      <GameDetailHouseRulesList
+        rules={rules}
+        labels={labels}
+        onAdd={noop}
+        onUpdate={noop}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Elimina'));
+    // Confirm modal becomes visible
+    expect(screen.getByText('Elimina house rule?')).toBeInTheDocument();
+    // The destructive "Elimina" inside the modal — disambiguate by role+name.
+    const confirmBtns = screen.getAllByRole('button', { name: 'Elimina' });
+    fireEvent.click(confirmBtns[confirmBtns.length - 1]); // the modal CTA is the last one rendered
+    expect(onDelete).toHaveBeenCalledWith('aaaa1111-1111-1111-1111-111111111111');
+  });
+});

--- a/apps/web/src/components/features/game-detail/index.ts
+++ b/apps/web/src/components/features/game-detail/index.ts
@@ -84,3 +84,9 @@ export type {
 
 export { GameDetailCommunityGate } from '@/components/features/game-detail/GameDetailCommunityGate';
 export type { GameDetailCommunityGateProps } from '@/components/features/game-detail/GameDetailCommunityGate';
+
+export { GameDetailHouseRulesList } from '@/components/features/game-detail/GameDetailHouseRulesList';
+export type {
+  GameDetailHouseRulesListLabels,
+  GameDetailHouseRulesListProps,
+} from '@/components/features/game-detail/GameDetailHouseRulesList';

--- a/apps/web/src/components/ui/dialogs/__tests__/confirm-modal.test.tsx
+++ b/apps/web/src/components/ui/dialogs/__tests__/confirm-modal.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConfirmModal } from '../confirm-modal';
+
+const baseProps = {
+  title: 'Conferma',
+  message: 'Sei sicuro?',
+  confirmLabel: 'Sì',
+  cancelLabel: 'Annulla',
+  onConfirm: () => {},
+  onCancel: () => {},
+};
+
+describe('ConfirmModal (Issue #1464)', () => {
+  it('renders title, message and both CTA labels when open', () => {
+    render(<ConfirmModal {...baseProps} open />);
+    expect(screen.getByText('Conferma')).toBeInTheDocument();
+    expect(screen.getByText('Sei sicuro?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sì' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Annulla' })).toBeInTheDocument();
+  });
+
+  it('fires onConfirm when the confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmModal {...baseProps} open onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sì' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onCancel when the cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmModal {...baseProps} open onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/ui/dialogs/confirm-modal.tsx
+++ b/apps/web/src/components/ui/dialogs/confirm-modal.tsx
@@ -1,0 +1,76 @@
+/**
+ * ConfirmModal - Generic confirm/cancel dialog (Issue #1464).
+ *
+ * Pure presentational. Caller controls open state and i18n labels.
+ * Wraps the shared Dialog primitives; the destructive variant uses the
+ * Button's `destructive` styling for the confirm CTA.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export interface ConfirmModalProps {
+  /** Whether the dialog is open. */
+  readonly open: boolean;
+  /** Localized title (caller-side i18n). */
+  readonly title: string;
+  /** Localized message/body. */
+  readonly message: string;
+  /** Localized confirm CTA label. */
+  readonly confirmLabel: string;
+  /** Localized cancel CTA label. */
+  readonly cancelLabel: string;
+  /** When 'destructive', the confirm CTA renders in red (delete-like flows). */
+  readonly variant?: 'default' | 'destructive';
+  /** Invoked when user confirms. Caller is responsible for closing the dialog. */
+  readonly onConfirm: () => void;
+  /** Invoked when user cancels or the dialog requests close (Esc / overlay click). */
+  readonly onCancel: () => void;
+}
+
+export function ConfirmModal(props: ConfirmModalProps): ReactElement {
+  const {
+    open,
+    title,
+    message,
+    confirmLabel,
+    cancelLabel,
+    variant = 'default',
+    onConfirm,
+    onCancel,
+  } = props;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen: boolean) => !isOpen && onCancel()}>
+      <DialogContent data-slot="confirm-modal" className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} data-slot="confirm-modal-cancel">
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={variant === 'destructive' ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            data-slot="confirm-modal-confirm"
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/api/clients/agentMemoryClient.ts
+++ b/apps/web/src/lib/api/clients/agentMemoryClient.ts
@@ -12,6 +12,9 @@ import type { HttpClient } from '../core/httpClient';
 // --- Zod Schemas ---
 
 export const HouseRuleDtoSchema = z.object({
+  // #1464: stable id used by PATCH/DELETE endpoints. Server backfills empty
+  // legacy values at restore time, so id is always present in responses.
+  id: z.string().uuid(),
   description: z.string(),
   addedAt: z.string(),
   source: z.string(),
@@ -120,6 +123,21 @@ export function createAgentMemoryClient({ httpClient }: CreateAgentMemoryClientP
 
     async addHouseRule(gameId: string, description: string): Promise<void> {
       await httpClient.post(`${BASE}/games/${gameId}/memory/house-rules`, { description });
+    },
+
+    /** Issue #1464: update an existing house rule's description. */
+    async updateHouseRule(gameId: string, ruleId: string, description: string): Promise<void> {
+      await httpClient.patch(
+        `${BASE}/games/${encodeURIComponent(gameId)}/memory/house-rules/${encodeURIComponent(ruleId)}`,
+        { description }
+      );
+    },
+
+    /** Issue #1464: remove a house rule by id. */
+    async removeHouseRule(gameId: string, ruleId: string): Promise<void> {
+      await httpClient.delete(
+        `${BASE}/games/${encodeURIComponent(gameId)}/memory/house-rules/${encodeURIComponent(ruleId)}`
+      );
     },
 
     async addNote(gameId: string, content: string): Promise<void> {

--- a/apps/web/src/lib/domain-hooks/useGameMemory.ts
+++ b/apps/web/src/lib/domain-hooks/useGameMemory.ts
@@ -1,0 +1,53 @@
+/**
+ * Game Memory Hook (Issue #1464)
+ *
+ * React Query hooks for the AgentMemory game-memory aggregate: query + 3 mutations
+ * (add/update/remove house rules) with cache invalidation. Mirror useGameAgents
+ * lazy-gating pattern; mutations invalidate the cached game-memory entry.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { GameMemoryDto } from '@/lib/api/clients/agentMemoryClient';
+
+export const GAME_MEMORY_QUERY_KEY = (gameId: string) => ['game-memory', gameId] as const;
+
+export interface UseGameMemoryOptions {
+  enabled?: boolean;
+}
+
+export function useGameMemory(gameId: string, options?: UseGameMemoryOptions) {
+  const enabled = options?.enabled !== false;
+  return useQuery<GameMemoryDto | null, Error>({
+    queryKey: GAME_MEMORY_QUERY_KEY(gameId),
+    queryFn: () => api.agentMemory.getGameMemory(gameId),
+    staleTime: 5 * 60 * 1000,
+    enabled: !!gameId && enabled,
+  });
+}
+
+export function useAddHouseRule(gameId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (description: string) => api.agentMemory.addHouseRule(gameId, description),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: GAME_MEMORY_QUERY_KEY(gameId) }),
+  });
+}
+
+export function useUpdateHouseRule(gameId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { ruleId: string; description: string }) =>
+      api.agentMemory.updateHouseRule(gameId, vars.ruleId, vars.description),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: GAME_MEMORY_QUERY_KEY(gameId) }),
+  });
+}
+
+export function useRemoveHouseRule(gameId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (ruleId: string) => api.agentMemory.removeHouseRule(gameId, ruleId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: GAME_MEMORY_QUERY_KEY(gameId) }),
+  });
+}


### PR DESCRIPTION
Implements full CRUD for game house rules per spec-panel D1 (Full CRUD ora — Tier XL).

## Backend (AgentMemory BC)
- HouseRule: stable Guid Id (backward-compat lazy migration for pre-#1464 JSON)
- GameMemory: UpdateHouseRule + RemoveHouseRule methods
- UpdateHouseRuleCommand/Handler + RemoveHouseRuleCommand/Handler (404 on miss)
- AgentMemoryEndpoints: MapPatch + MapDelete /games/{gameId}/memory/house-rules/{ruleId}
- HouseRuleDto exposes Id

## Frontend
- ConfirmModal: generic destructive/default confirm dialog (over shared Dialog primitive); 3 unit tests
- agentMemoryClient: updateHouseRule + removeHouseRule; HouseRuleDtoSchema extended with id
- useGameMemory hooks: query + 3 mutations with React Query cache invalidation
- GameDetailHouseRulesList: interactive presentational (add form, inline edit, delete confirm); 6 unit tests
- Barrel export
- GameDetailView integration: lazy-gated useGameMemory (info tab + own variant); rendered after FAQ; community variant skipped; mocked in test
- i18n: 12 new pages.gameDetail.houseRules.* keys; MESSAGES test dict extended

## Tests / quality
- 3 ConfirmModal + 6 HouseRulesList + 21 GameDetailView (no regression). Lint 0 errors (FE) + BE build clean.

## Note CI
Likely inherits AdminSideDrawer baseline failure (PR #1496 owner sp5-admin). Pattern P75 admin-override expected after verification.

## Note mockup mismatch
The toggle/enable UI in the mockup is NOT supported by the BE domain (HouseRule has no enabled flag); delivered as add/edit/delete CRUD instead — documented in the component header (PILOT_GAP_REPORT § 3.5 #4).

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)