### PR TITLE
feat(admin): SP5 F2 A2 Users re-skin (UserCell + filter-chips)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/users/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/page.tsx
@@ -17,7 +17,6 @@ import {
   PlusIcon,
   RefreshCwIcon,
   SearchIcon,
-  UsersIcon,
   XIcon,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -26,6 +25,7 @@ import { toast } from 'sonner';
 import { InvitationStatusBadge } from '@/components/admin/invitations/InvitationStatusBadge';
 import { InviteUserDialog } from '@/components/admin/invitations/InviteUserDialog';
 import { InlineRoleSelect } from '@/components/admin/users/InlineRoleSelect';
+import { UserCell } from '@/components/admin/users/UserCell';
 import { Badge } from '@/components/ui/data-display/badge';
 import {
   Select,
@@ -178,28 +178,60 @@ export default function AdminUsersPage() {
       </div>
 
       {/* Search + Filter Bar */}
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1">
-          <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Cerca per nome o email..."
-            value={search}
-            onChange={e => handleSearchChange(e.target.value)}
-            className="pl-9"
-          />
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Cerca per nome o email..."
+              value={search}
+              onChange={e => handleSearchChange(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          {/* Select fallback only on small screens — chips replace it from md+ */}
+          <div className="md:hidden">
+            <Select value={roleFilter} onValueChange={handleRoleChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Ruolo" />
+              </SelectTrigger>
+              <SelectContent>
+                {ROLE_OPTIONS.map(role => (
+                  <SelectItem key={role} value={role}>
+                    {role === 'all' ? 'Tutti i ruoli' : displayRole(role)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
-        <Select value={roleFilter} onValueChange={handleRoleChange}>
-          <SelectTrigger className="w-full sm:w-40">
-            <SelectValue placeholder="Ruolo" />
-          </SelectTrigger>
-          <SelectContent>
-            {ROLE_OPTIONS.map(role => (
-              <SelectItem key={role} value={role}>
-                {role === 'all' ? 'Tutti i ruoli' : displayRole(role)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+
+        {/* Filter chips for role — mockup A2 .filter-chip pattern */}
+        <div
+          className="hidden md:flex items-center gap-2 flex-wrap"
+          data-testid="role-filter-chips"
+        >
+          {ROLE_OPTIONS.map(role => {
+            const active = roleFilter === role;
+            const label = role === 'all' ? 'Tutti' : displayRole(role);
+            return (
+              <button
+                key={role}
+                type="button"
+                onClick={() => handleRoleChange(role)}
+                aria-pressed={active}
+                data-testid={`role-chip-${role}`}
+                className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold font-quicksand border transition-colors ${
+                  active
+                    ? 'bg-muted text-foreground border-border'
+                    : 'bg-transparent text-muted-foreground border-border/60 hover:bg-muted/60 hover:text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Table */}
@@ -279,17 +311,14 @@ export default function AdminUsersPage() {
                   className="border-b border-border/50 transition-colors hover:bg-muted/50"
                 >
                   <td className="px-3 py-2">
-                    <Link
-                      href={`/admin/users/${u.id}`}
-                      className="flex items-center gap-2 hover:underline"
-                    >
-                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                        <UsersIcon className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <div className="font-medium">{u.displayName || u.email}</div>
-                        <div className="text-xs text-muted-foreground">{u.email}</div>
-                      </div>
+                    <Link href={`/admin/users/${u.id}`} className="hover:underline">
+                      <UserCell
+                        user={{
+                          displayName: u.displayName,
+                          email: u.email,
+                          role: u.role,
+                        }}
+                      />
                     </Link>
                   </td>
                   <td className="px-3 py-2">

--- a/apps/web/src/components/admin/users/UserCell.tsx
+++ b/apps/web/src/components/admin/users/UserCell.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable local/no-hardcoded-color-utility -- text-white on the entity-tinted gradient avatar; mockup .user-avatar pattern. */
+import React from 'react';
+
+export interface UserCellUser {
+  displayName: string | null;
+  email: string;
+  role?: string;
+}
+
+export interface UserCellProps {
+  user: UserCellUser;
+}
+
+/**
+ * Compact user cell for admin tables: gradient avatar (player→chat tokens) +
+ * display name + truncated email. Mirrors the `.user-cell` pattern from the
+ * SP5 A2 mockup. Presentational only — receives a plain user-shaped object.
+ */
+export function UserCell({ user }: UserCellProps) {
+  const initial = (user.displayName?.charAt(0) ?? user.email.charAt(0) ?? '?').toUpperCase();
+
+  return (
+    <div className="flex items-center gap-2 min-w-0" data-testid="user-cell">
+      <span
+        data-testid="user-cell-avatar"
+        className="shrink-0 grid place-items-center w-7 h-7 rounded-full text-white text-[11px] font-bold"
+        style={{
+          background: 'linear-gradient(135deg, hsl(var(--c-player)), hsl(var(--c-chat)))',
+        }}
+        aria-hidden="true"
+      >
+        {initial}
+      </span>
+      <span className="flex flex-col min-w-0">
+        <span className="font-quicksand text-[12.5px] font-bold leading-tight truncate">
+          {user.displayName ?? user.email}
+        </span>
+        {user.displayName && (
+          <span className="font-mono text-[10.5px] text-muted-foreground truncate">
+            {user.email}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+export default UserCell;

--- a/apps/web/src/components/admin/users/__tests__/UserCell.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/UserCell.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { UserCell } from '../UserCell';
+
+describe('UserCell', () => {
+  it('renders displayName, email and an avatar initial', () => {
+    render(<UserCell user={{ displayName: 'Aaron D.', email: 'aaron@example.com' }} />);
+    expect(screen.getByText('Aaron D.')).toBeInTheDocument();
+    expect(screen.getByText('aaron@example.com')).toBeInTheDocument();
+    expect(screen.getByTestId('user-cell-avatar')).toHaveTextContent('A');
+  });
+
+  it('falls back to email initial when displayName is null', () => {
+    render(<UserCell user={{ displayName: null, email: 'maria@example.com' }} />);
+    expect(screen.getByText('maria@example.com')).toBeInTheDocument();
+    expect(screen.getByTestId('user-cell-avatar')).toHaveTextContent('M');
+  });
+
+  it('truncates long emails via CSS class', () => {
+    render(<UserCell user={{ displayName: 'X', email: 'very.long.email.address@example.com' }} />);
+    const email = screen.getByText('very.long.email.address@example.com');
+    expect(email).toHaveClass('truncate');
+  });
+});


### PR DESCRIPTION
## Summary

Implementa **F2 A2 Users re-skin** (scope conservativo, plan #1515). 2 task chirurgici presentazionali sulla pagina `/admin/users`, senza cambio di IA né di sicurezza.

| # | Cambio | Commit |
|---|--------|--------|
| 1 | Nuovo `UserCell` presentational (avatar gradient `--c-player`→`--c-chat` + name + email truncate) — fallback all'email quando `displayName` è null per evitare duplicazione visiva | `653a07d33` |
| 2 | Filter-chips per il ruolo (mockup A2 `.filter-chip`) sopra la search bar a `md+`; `Select` originale wrappato in `md:hidden` come fallback; `UserCell` integrato nelle righe della tabella; import `UsersIcon` rimosso (ora unused) | `3a1ff2e43` |

## Test Plan

- [x] **41/41 test verdi**: 3 nuovi (`UserCell.test.tsx`) + 38 esistenti (`UsersPage`, `page` users, invitations, role-card, permissions-matrix, activity-table) — nessuna regressione.
- [x] Pre-push build verde (typecheck + ESLint).
- [ ] Verifica visiva: avatar gradient, filter-chips a `md+`, `Select` ruolo a `<md`, drill `/admin/users/[id]` invariato.

## Decisioni di scope (documentate)

Token semantici (`bg-muted`/`text-foreground`/`border-border`) per il chip attivo, anziché `bg-entity-event/12` (mapping `entity-event` non garantito sui token canonici — più sicuro semantic). Equivalente visivo.

**Non-goals di F2 — confermati come da plan:**

- ❌ Side-by-side list + detail panel 460px (decisione UX rimandata a plan dedicato)
- ❌ Step-up UI modal per delete/impersonate (track ⊥ sicurezza)
- ❌ Audit timeline esteso (richiede schema audit R3 + side-by-side)
- ❌ Virtualization, keyboard shortcuts

## Note

- Eseguito direttamente (chirurgico) — rate limit API attivo.
- `UserCell` è riusabile per pagine admin future che mostrano utenti (es. permissions-matrix, activity-table).
- Prossimo: review+merge → poi ondate F3-F6 / track ⊥ sicurezza / plan side-by-side detail panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
