### PR TITLE
feat(game-detail): #1471 GameDetailChatTab inline preview in Agents tab

### DIFF
--- a/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/GameDetailView.tsx
@@ -28,6 +28,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
   GameDetailAgentsList,
+  GameDetailChatTab,
   GameDetailCommunityGate,
   GameDetailFaqList,
   GameDetailHero,
@@ -605,6 +606,14 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
     cta: t('pages.gameDetail.stats.communityGateCta'),
   };
 
+  const chatTabLabels = {
+    title: t('pages.gameDetail.chat.title'),
+    empty: t('pages.gameDetail.chat.empty'),
+    openCta: t('pages.gameDetail.chat.openCta'),
+    userPrefix: t('pages.gameDetail.chat.userPrefix'),
+    assistantPrefix: t('pages.gameDetail.chat.assistantPrefix'),
+  };
+
   const houseRulesLabels = {
     title: t('pages.gameDetail.houseRules.title'),
     addCta: t('pages.gameDetail.houseRules.addCta'),
@@ -815,7 +824,15 @@ export function GameDetailView({ gameId }: GameDetailViewProps): ReactElement {
           hidden={tab !== 'agents'}
           data-slot="game-detail-panel-agents"
         >
-          <GameDetailAgentsList state={agentsState} labels={agentsLabels} />
+          <div className="flex flex-col gap-6">
+            <GameDetailAgentsList state={agentsState} labels={agentsLabels} />
+            {/* Inline chat preview (#1471) — empty for now; full chat lives at /library/{id}/agent */}
+            <GameDetailChatTab
+              messages={[]}
+              openHref={`/library/${gameId}/agent`}
+              labels={chatTabLabels}
+            />
+          </div>
         </div>
 
         {/* Documents tab */}

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -940,4 +940,18 @@ describe('GameDetailView — FSM integration tests (Phase 0.5 contract)', () => 
 
     expect(document.querySelector('[data-slot="game-detail-house-rules-list"]')).toBeNull();
   });
+
+  // ─── Issue #1471 — Chat preview in Agents panel regression guard ─────────
+
+  it('Issue #1471: Agents panel contains GameDetailChatTab inline preview', () => {
+    detailMockState.data = makeDetail(); // own variant
+    detailMockState.isSuccess = true;
+    useLibraryGameDetailSpy.mockReturnValue(detailMockState);
+
+    renderWithIntl(<GameDetailView gameId={VALID_GAME_ID} />);
+
+    const agentsPanel = document.querySelector('[data-slot="game-detail-panel-agents"]');
+    expect(agentsPanel).toBeInTheDocument();
+    expect(agentsPanel?.querySelector('[data-slot="game-detail-chat-tab"]')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/GameDetailView.test.tsx
@@ -263,6 +263,12 @@ const MESSAGES: Record<string, string> = {
   'pages.gameDetail.houseRules.deleteConfirmMessage': 'Questa azione non e reversibile.',
   'pages.gameDetail.houseRules.deleteConfirm': 'Elimina',
   'pages.gameDetail.houseRules.empty': 'Nessuna regola',
+  // Issue #1471 — Chat preview (Agents tab)
+  'pages.gameDetail.chat.title': 'Chat',
+  'pages.gameDetail.chat.empty': 'Nessun messaggio',
+  'pages.gameDetail.chat.openCta': 'Apri chat',
+  'pages.gameDetail.chat.userPrefix': 'Tu',
+  'pages.gameDetail.chat.assistantPrefix': 'Agente',
 };
 
 function renderWithIntl(ui: ReactElement) {

--- a/apps/web/src/components/features/game-detail/GameDetailChatTab.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailChatTab.tsx
@@ -17,6 +17,7 @@
 import type { ReactElement } from 'react';
 
 import clsx from 'clsx';
+import Link from 'next/link';
 
 export type GameDetailChatRole = 'user' | 'assistant';
 
@@ -55,13 +56,13 @@ export function GameDetailChatTab(props: GameDetailChatTabProps): ReactElement {
     >
       <div className="mb-3.5 flex items-center justify-between gap-3">
         <h3 className="font-display text-[15px] font-extrabold text-foreground">{labels.title}</h3>
-        <a
+        <Link
           href={openHref}
           data-slot="game-detail-chat-tab-open-cta"
           className="rounded-md border border-border bg-transparent px-2.5 py-1 font-display text-[12px] font-extrabold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {labels.openCta}
-        </a>
+        </Link>
       </div>
 
       {rows.length === 0 ? (

--- a/apps/web/src/components/features/game-detail/GameDetailChatTab.tsx
+++ b/apps/web/src/components/features/game-detail/GameDetailChatTab.tsx
@@ -1,0 +1,102 @@
+/**
+ * GameDetailChatTab - Wave C follow-up (Issue #1471)
+ *
+ * Inline chat preview rendered inside the Agents tab content. Shows the N most
+ * recent messages (caller passes them, default cap 3) + a "Open full chat" CTA
+ * that links to the dedicated chat surface. Pure presentational: data fetching,
+ * loading/error states are the caller's responsibility.
+ *
+ * Scope note: per PILOT_GAP_REPORT § 3.5 #2 the codebase `agents` tab is the
+ * semantic match for the mockup's "Chat" tab. The full chat-unified primitives
+ * (ChatMessageList, CitationBlock, …) are intentionally NOT reused here — this
+ * is a compact preview, not the full chat surface (LibraryGameAgentShell scope).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export type GameDetailChatRole = 'user' | 'assistant';
+
+export interface GameDetailChatPreviewMessage {
+  readonly id: string;
+  readonly role: GameDetailChatRole;
+  readonly content: string;
+  readonly timestamp: string;
+}
+
+export interface GameDetailChatTabLabels {
+  readonly title: string;
+  readonly empty: string;
+  readonly openCta: string;
+  readonly userPrefix: string;
+  readonly assistantPrefix: string;
+}
+
+export interface GameDetailChatTabProps {
+  readonly messages: ReadonlyArray<GameDetailChatPreviewMessage>;
+  readonly openHref: string;
+  readonly labels: GameDetailChatTabLabels;
+  /** Max messages rendered (default 3). */
+  readonly maxItems?: number;
+  readonly className?: string;
+}
+
+export function GameDetailChatTab(props: GameDetailChatTabProps): ReactElement {
+  const { messages, openHref, labels, maxItems = 3, className } = props;
+  const rows = messages.slice(0, maxItems);
+
+  return (
+    <section
+      data-slot="game-detail-chat-tab"
+      className={clsx('rounded-2xl border border-border bg-card p-[18px] shadow-sm', className)}
+    >
+      <div className="mb-3.5 flex items-center justify-between gap-3">
+        <h3 className="font-display text-[15px] font-extrabold text-foreground">{labels.title}</h3>
+        <a
+          href={openHref}
+          data-slot="game-detail-chat-tab-open-cta"
+          className="rounded-md border border-border bg-transparent px-2.5 py-1 font-display text-[12px] font-extrabold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.openCta}
+        </a>
+      </div>
+
+      {rows.length === 0 ? (
+        <p
+          data-slot="game-detail-chat-tab-empty"
+          className="py-6 text-center font-mono text-[11px] text-muted-foreground"
+        >
+          {labels.empty}
+        </p>
+      ) : (
+        <ol role="list" aria-label={labels.title} className="flex flex-col gap-2">
+          {rows.map(msg => (
+            <li
+              key={msg.id}
+              role="listitem"
+              data-slot="game-detail-chat-tab-message"
+              data-role={msg.role}
+              className="flex flex-col gap-1 rounded-xl border border-border bg-background p-3"
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={clsx(
+                    'font-mono text-[9px] font-extrabold uppercase tracking-[0.08em]',
+                    msg.role === 'assistant' ? 'text-entity-agent' : 'text-muted-foreground'
+                  )}
+                >
+                  {msg.role === 'assistant' ? labels.assistantPrefix : labels.userPrefix}
+                </span>
+                <span className="font-mono text-[10px] text-muted-foreground">{msg.timestamp}</span>
+              </div>
+              <p className="line-clamp-3 font-mono text-[12px] text-foreground">{msg.content}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-detail/__tests__/GameDetailChatTab.test.tsx
+++ b/apps/web/src/components/features/game-detail/__tests__/GameDetailChatTab.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GameDetailChatTab, type GameDetailChatPreviewMessage } from '../GameDetailChatTab';
+
+const labels = {
+  title: 'Chat',
+  empty: 'Nessun messaggio',
+  openCta: 'Apri chat',
+  userPrefix: 'Tu',
+  assistantPrefix: 'Agente',
+};
+
+const messages: ReadonlyArray<GameDetailChatPreviewMessage> = [
+  { id: '1', role: 'user', content: 'Quanto dura una partita?', timestamp: '12:01' },
+  { id: '2', role: 'assistant', content: 'Circa 45 minuti.', timestamp: '12:01' },
+  { id: '3', role: 'user', content: 'Grazie!', timestamp: '12:02' },
+];
+
+describe('GameDetailChatTab (Issue #1471)', () => {
+  it('renders title, open CTA with href, and one row per message (capped at maxItems)', () => {
+    render(
+      <GameDetailChatTab
+        messages={messages}
+        openHref="/library/games/g1/agent"
+        labels={labels}
+        maxItems={2}
+      />
+    );
+    expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Apri chat' });
+    expect(cta).toHaveAttribute('href', '/library/games/g1/agent');
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('shows empty state when messages is empty', () => {
+    render(<GameDetailChatTab messages={[]} openHref="/x" labels={labels} />);
+    expect(screen.getByText('Nessun messaggio')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+  });
+
+  it('marks each message with the role prefix and a data-role attribute', () => {
+    const { container } = render(
+      <GameDetailChatTab messages={messages} openHref="/x" labels={labels} />
+    );
+    expect(container.querySelector('[data-role="user"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    expect(screen.getAllByText('Tu').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Agente').length).toBeGreaterThan(0);
+  });
+
+  it('composes className with base classes and uses DS-15 entity-agent token', () => {
+    const { container } = render(
+      <GameDetailChatTab messages={messages} openHref="/x" labels={labels} className="extra" />
+    );
+    const card = container.querySelector('[data-slot="game-detail-chat-tab"]');
+    expect(card).toHaveClass('extra');
+    expect(card).toHaveClass('bg-card');
+    expect(card).toHaveClass('border-border');
+    expect(container.querySelector('.text-entity-agent')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/game-detail/index.ts
+++ b/apps/web/src/components/features/game-detail/index.ts
@@ -90,3 +90,11 @@ export type {
   GameDetailHouseRulesListLabels,
   GameDetailHouseRulesListProps,
 } from '@/components/features/game-detail/GameDetailHouseRulesList';
+
+export { GameDetailChatTab } from '@/components/features/game-detail/GameDetailChatTab';
+export type {
+  GameDetailChatPreviewMessage,
+  GameDetailChatRole,
+  GameDetailChatTabLabels,
+  GameDetailChatTabProps,
+} from '@/components/features/game-detail/GameDetailChatTab';


### PR DESCRIPTION
Implements #1471: an inline chat preview rendered below GameDetailAgentsList in the Agents tab content (codebase semantic match for the mockup's Chat tab per PILOT_GAP_REPORT § 3.5 #2).

## Changes
- GameDetailChatTab.tsx: pure presentational, props (messages + openHref + labels + maxItems=3); empty state; rounded card; role-based DS-15 entity tokens.
- 4 unit tests (render with cap, empty state, role tags, className+token composition).
- Barrel export.
- 5 new i18n keys; MESSAGES test extended.
- GameDetailView integration: rendered after GameDetailAgentsList inside the Agents panel; messages={[]} for now (no thread persistence yet); openHref={`/library/${gameId}/agent`}.

## Scope note
Deliberately does NOT reuse the chat-unified primitives (ChatMessageList/CitationBlock/...) — this is a compact preview, not the full chat surface (LibraryGameAgentShell). The primitives will be the right reuse target when that surface ships.

## Tests / quality
- 4 ChatTab + 23 GameDetailView (no regression). Lint clean.

## Note CI
Likely inherits the AdminSideDrawer baseline failure (PR #1496). Pattern P75 admin-override expected after verification.

Closes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)