### PR TITLE
feat(gamebook): #1484 EncounterCheatsheetView (parse-centric MVP)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
@@ -74,8 +74,10 @@ export function Content({
     [t, paragraphMarker]
   );
 
+  // `from` is expected as a bare integer ("147"); strip a leading § defensively
+  // so a caller passing "§147" does not render "§§147".
   const storyContext: EncounterStoryContext | null = fromLabel
-    ? { paragraphLabel: `§${fromLabel}`, excerpt: excerpt ?? '' }
+    ? { paragraphLabel: `§${fromLabel.replace(/^§/, '')}`, excerpt: excerpt ?? '' }
     : null;
 
   const status = deriveEncounterStatus(parse.status);

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useMemo, type ReactElement } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  EncounterCheatsheetView,
+  type EncounterCheatsheetLabels,
+  type EncounterStoryContext,
+} from '@/components/features/gamebook';
+import { useTranslation } from '@/hooks/useTranslation';
+import { deriveEncounterStatus, mapEncounterError } from '@/lib/gamebook/encounter-fsm';
+import { useEncounterParse } from '@/lib/gamebook/hooks/useEncounterParse';
+
+/**
+ * Orchestrator for the `/library/[gameId]/play/[campaignId]/encounter` route
+ * (Issue #1484). Resolves i18n labels, drives the parse mutation, and maps its
+ * state to the pure {@link EncounterCheatsheetView} FSM. State D (resolution)
+ * is out of scope: `onResolve` navigates back to the play session.
+ */
+export function Content({
+  gameId,
+  campaignId,
+  photoId,
+  paragraphNumber,
+  gameBookId,
+  fromLabel,
+  excerpt,
+}: {
+  gameId: string;
+  campaignId: string;
+  photoId: string;
+  paragraphNumber: number;
+  gameBookId: string;
+  fromLabel: string | null;
+  excerpt: string | null;
+}): ReactElement {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const parse = useEncounterParse(campaignId, photoId);
+
+  const paragraphMarker = paragraphNumber > 0 ? `§${paragraphNumber}` : '';
+
+  const labels: EncounterCheatsheetLabels = useMemo(
+    () => ({
+      entryStoryMeta: t('gamebook.encounter.entryStoryMeta'),
+      entryRefTitle: t('gamebook.encounter.entryRefTitle', { paragraph: paragraphMarker }),
+      entryRefHint: t('gamebook.encounter.entryRefHint'),
+      entryCta: t('gamebook.encounter.entryCta', { paragraph: paragraphMarker }),
+      entryCtaHint: t('gamebook.encounter.entryCtaHint'),
+      loadingTitle: t('gamebook.encounter.loadingTitle'),
+      loadingHint: t('gamebook.encounter.loadingHint'),
+      cancel: t('gamebook.encounter.cancel'),
+      optionsTitle: t('gamebook.encounter.optionsTitle'),
+      conditionsWin: t('gamebook.encounter.conditionsWin'),
+      conditionsLoss: t('gamebook.encounter.conditionsLoss'),
+      parseConfidence: t('gamebook.encounter.parseConfidence'),
+      lowConfidenceHint: t('gamebook.encounter.lowConfidenceHint'),
+      ephemeralNote: t('gamebook.encounter.ephemeralNote'),
+      retake: t('gamebook.encounter.retake'),
+      glossary: t('gamebook.encounter.glossary'),
+      resolve: t('gamebook.encounter.resolve'),
+      errorParseFailed: t('gamebook.encounter.errorParseFailed'),
+      errorNotFound: t('gamebook.encounter.errorNotFound'),
+      errorGeneric: t('gamebook.encounter.errorGeneric'),
+      retry: t('gamebook.encounter.retry'),
+      confidence: {
+        high: t('gamebook.encounter.confidence.high'),
+        medium: t('gamebook.encounter.confidence.medium'),
+        low: t('gamebook.encounter.confidence.low'),
+      },
+    }),
+    [t, paragraphMarker]
+  );
+
+  const storyContext: EncounterStoryContext | null = fromLabel
+    ? { paragraphLabel: `§${fromLabel}`, excerpt: excerpt ?? '' }
+    : null;
+
+  const status = deriveEncounterStatus(parse.status);
+  const errorKind = parse.error ? mapEncounterError(parse.error) : undefined;
+
+  return (
+    <main className="min-h-[calc(100vh-var(--app-topbar-height,64px))]">
+      <EncounterCheatsheetView
+        status={status}
+        cheatsheet={parse.data ?? null}
+        errorKind={errorKind}
+        storyContext={storyContext}
+        labels={labels}
+        onParse={() => parse.mutate({ paragraphNumber, gameBookId })}
+        onResolve={() => router.push(`/library/${gameId}/play/${campaignId}`)}
+        onCancel={() => parse.reset()}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/page.tsx
@@ -1,0 +1,45 @@
+import { Content } from './_content';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Encounter Book | MeepleAI',
+};
+
+/**
+ * Encounter cheatsheet route — Issue #1484.
+ *
+ * The parse inputs (`photoId`, target paragraph, `gameBookId`) and the optional
+ * originating-story context (`from`, `excerpt`) arrive as query params from the
+ * preceding runthrough step. They are resolved server-side and forwarded as
+ * typed props so the client orchestrator avoids a `useSearchParams` Suspense
+ * boundary.
+ */
+export default async function EncounterPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ gameId: string; campaignId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { gameId, campaignId } = await params;
+  const sp = await searchParams;
+
+  const str = (v: string | string[] | undefined): string => (typeof v === 'string' ? v : '');
+
+  const paragraphNumber = Number.parseInt(str(sp.to) || str(sp.paragraphNumber), 10) || 0;
+  const fromLabel = str(sp.from) || null;
+  const excerpt = str(sp.excerpt) || null;
+
+  return (
+    <Content
+      gameId={gameId}
+      campaignId={campaignId}
+      photoId={str(sp.photoId)}
+      paragraphNumber={paragraphNumber}
+      gameBookId={str(sp.gameBookId)}
+      fromLabel={fromLabel}
+      excerpt={excerpt}
+    />
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/page.tsx
@@ -27,6 +27,10 @@ export default async function EncounterPage({
 
   const str = (v: string | string[] | undefined): string => (typeof v === 'string' ? v : '');
 
+  // `to` is the target encounter paragraph per the mockup URL contract
+  // (`…/encounter?from=147&to=218`); `paragraphNumber` is an explicit fallback
+  // matching the BE body field name. `from` is the originating Storybook
+  // paragraph (bare integer) used only for the optional story-context card.
   const paragraphNumber = Number.parseInt(str(sp.to) || str(sp.paragraphNumber), 10) || 0;
   const fromLabel = str(sp.from) || null;
   const excerpt = str(sp.excerpt) || null;

--- a/apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx
+++ b/apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx
@@ -1,0 +1,446 @@
+/**
+ * EncounterCheatsheetView — Issue #1484 (consumes BE #1520).
+ *
+ * Mapped from `admin-mockups/design_files/librogame-runthrough-encounter-cheatsheet.html`.
+ * Renders the on-demand Encounter Book cheatsheet for the Nanolith libro-game
+ * runthrough. Pure component: all i18n strings are injected via `labels` and
+ * the FSM is driven entirely by props (the orchestrator owns the parse hook).
+ *
+ * FSM (parse-centric MVP — spec hardened 2026-05-25):
+ *   idle     → entry CTA (+ optional story context) that triggers `onParse`
+ *   parsing  → busy loading indicator (+ optional cancel)
+ *   rendered → cheatsheet card (enemy stats, options w/ dice, win/loss, confidence)
+ *   error    → recoverable message (parse-failed 409 / not-found 404 / generic) + retry
+ *
+ * State D (resolved/consequences) is intentionally out of scope: there is no BE
+ * encounter-resolution command, so `onResolve` navigates back to the play
+ * session where dice/save-state mechanics live (mirrors the mockup's "Risolvi"
+ * which navigates away).
+ *
+ * Ephemeral by design (spec §9.1): nothing is persisted; the card lives only
+ * for the active session. Confidence < 0.6 on any cluster surfaces a manual-
+ * verification hint (§9.1 forced-manual fallback).
+ *
+ * Encounter accent = `entity-event` (mockup `--c-event`). data-slot attributes
+ * support E2E selectors.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import type { EncounterCheatsheet, EncounterDiceRoll } from '@/lib/api/gamebook-encounter';
+import { classifyConfidence } from '@/lib/gamebook-upload';
+
+import { ConfidenceBadge, type ConfidenceBadgeLabels } from './ConfidenceBadge';
+
+export type EncounterStatus = 'idle' | 'parsing' | 'rendered' | 'error';
+
+export type EncounterErrorKind = 'parse-failed' | 'not-found' | 'generic';
+
+/** Confidence threshold below which a cluster forces manual verification (§9.1). */
+const MANUAL_INPUT_THRESHOLD = 0.6;
+
+export interface EncounterStoryContext {
+  /** Originating Storybook paragraph marker, e.g. "§147". */
+  readonly paragraphLabel: string;
+  /** Short narrative excerpt that referenced the encounter. */
+  readonly excerpt: string;
+}
+
+export interface EncounterCheatsheetLabels {
+  // entry (A)
+  readonly entryStoryMeta: string;
+  readonly entryRefTitle: string;
+  readonly entryRefHint: string;
+  readonly entryCta: string;
+  readonly entryCtaHint: string;
+  // parsing (B)
+  readonly loadingTitle: string;
+  readonly loadingHint: string;
+  readonly cancel: string;
+  // rendered (C)
+  readonly optionsTitle: string;
+  readonly conditionsWin: string;
+  readonly conditionsLoss: string;
+  readonly parseConfidence: string;
+  readonly lowConfidenceHint: string;
+  readonly ephemeralNote: string;
+  readonly retake: string;
+  readonly glossary: string;
+  readonly resolve: string;
+  // error
+  readonly errorParseFailed: string;
+  readonly errorNotFound: string;
+  readonly errorGeneric: string;
+  readonly retry: string;
+  // reused ConfidenceBadge SR labels
+  readonly confidence: ConfidenceBadgeLabels;
+}
+
+export interface EncounterCheatsheetViewProps {
+  readonly status: EncounterStatus;
+  readonly cheatsheet: EncounterCheatsheet | null;
+  readonly errorKind?: EncounterErrorKind;
+  readonly storyContext?: EncounterStoryContext | null;
+  readonly labels: EncounterCheatsheetLabels;
+  /** Entry CTA + retry + retake all (re)trigger the parse. */
+  readonly onParse: () => void;
+  /** Navigate back to the play session to resolve the encounter (state D). */
+  readonly onResolve: () => void;
+  readonly onOpenGlossary?: () => void;
+  readonly onCancel?: () => void;
+  readonly className?: string;
+}
+
+/** Formats a dice roll like "1d6+2" (modifier omitted when zero). */
+function formatDice(d: EncounterDiceRoll): string {
+  const mod = d.modifier > 0 ? `+${d.modifier}` : d.modifier < 0 ? `${d.modifier}` : '';
+  return `${d.count}d${d.sides}${mod}`;
+}
+
+export function EncounterCheatsheetView({
+  status,
+  cheatsheet,
+  errorKind = 'generic',
+  storyContext,
+  labels,
+  onParse,
+  onResolve,
+  onOpenGlossary,
+  onCancel,
+  className,
+}: EncounterCheatsheetViewProps): ReactElement {
+  return (
+    <section
+      data-slot="encounter-cheatsheet-view"
+      data-status={status}
+      className={clsx('mx-auto flex w-full max-w-[640px] flex-col gap-3 p-4', className)}
+    >
+      {status === 'idle' && (
+        <EntryState storyContext={storyContext} labels={labels} onParse={onParse} />
+      )}
+      {status === 'parsing' && <LoadingState labels={labels} onCancel={onCancel} />}
+      {status === 'error' && <ErrorState errorKind={errorKind} labels={labels} onParse={onParse} />}
+      {status === 'rendered' && cheatsheet && (
+        <RenderedState
+          cheatsheet={cheatsheet}
+          labels={labels}
+          onParse={onParse}
+          onResolve={onResolve}
+          onOpenGlossary={onOpenGlossary}
+        />
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// State A — entry from story
+// ---------------------------------------------------------------------------
+
+function EntryState({
+  storyContext,
+  labels,
+  onParse,
+}: {
+  storyContext?: EncounterStoryContext | null;
+  labels: EncounterCheatsheetLabels;
+  onParse: () => void;
+}): ReactElement {
+  return (
+    <div data-slot="encounter-entry" className="flex flex-col gap-4">
+      {storyContext && (
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="font-mono text-2xl font-bold tabular-nums text-entity-event">
+              {storyContext.paragraphLabel}
+            </span>
+            <span className="font-mono text-xs text-muted-foreground">{labels.entryStoryMeta}</span>
+          </div>
+          <p className="text-sm italic leading-relaxed text-muted-foreground">
+            {storyContext.excerpt}
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 rounded-lg border border-dashed border-entity-event/40 bg-entity-event/8 p-3">
+        <span aria-hidden="true" className="text-2xl">
+          ⚔️
+        </span>
+        <div className="flex-1 text-sm">
+          <strong className="block font-bold text-entity-event">{labels.entryRefTitle}</strong>
+          <span className="text-muted-foreground">{labels.entryRefHint}</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onParse}
+        aria-label={labels.entryCta}
+        data-slot="encounter-entry-cta"
+        className={clsx(
+          'flex items-center justify-between gap-3 rounded-lg bg-entity-event px-5 py-4 text-left text-white shadow-sm',
+          'font-bold transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none'
+        )}
+      >
+        <span aria-hidden="true" className="text-2xl">
+          📷
+        </span>
+        <span className="flex-1">
+          <span className="block">{labels.entryCta}</span>
+          <span className="mt-0.5 block text-xs font-normal opacity-90">{labels.entryCtaHint}</span>
+        </span>
+        <span aria-hidden="true">›</span>
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// State B — photo segmenting / parsing
+// ---------------------------------------------------------------------------
+
+function LoadingState({
+  labels,
+  onCancel,
+}: {
+  labels: EncounterCheatsheetLabels;
+  onCancel?: () => void;
+}): ReactElement {
+  return (
+    <div
+      data-slot="encounter-loading"
+      role="status"
+      aria-busy="true"
+      className="flex flex-col items-center gap-4 py-10 text-center"
+    >
+      <span
+        aria-hidden="true"
+        className="h-10 w-10 animate-spin rounded-full border-2 border-entity-event/30 border-t-entity-event motion-reduce:animate-none"
+      />
+      <div>
+        <h3 className="font-bold text-foreground">{labels.loadingTitle}</h3>
+        <p className="mt-1 text-sm text-muted-foreground">{labels.loadingHint}</p>
+      </div>
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-border bg-muted px-3 py-2 text-sm font-semibold text-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.cancel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+function ErrorState({
+  errorKind,
+  labels,
+  onParse,
+}: {
+  errorKind: EncounterErrorKind;
+  labels: EncounterCheatsheetLabels;
+  onParse: () => void;
+}): ReactElement {
+  const message =
+    errorKind === 'parse-failed'
+      ? labels.errorParseFailed
+      : errorKind === 'not-found'
+        ? labels.errorNotFound
+        : labels.errorGeneric;
+
+  return (
+    <div
+      data-slot="encounter-error"
+      role="alert"
+      className="flex flex-col items-center gap-4 rounded-lg border border-destructive/30 bg-destructive/10 p-6 text-center"
+    >
+      <span aria-hidden="true" className="text-3xl">
+        ⚠️
+      </span>
+      <p className="text-sm text-foreground">{message}</p>
+      <button
+        type="button"
+        onClick={onParse}
+        className="rounded-md bg-entity-event px-4 py-2 text-sm font-semibold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {labels.retry}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// State C — cheatsheet rendered
+// ---------------------------------------------------------------------------
+
+function RenderedState({
+  cheatsheet,
+  labels,
+  onParse,
+  onResolve,
+  onOpenGlossary,
+}: {
+  cheatsheet: EncounterCheatsheet;
+  labels: EncounterCheatsheetLabels;
+  onParse: () => void;
+  onResolve: () => void;
+  onOpenGlossary?: () => void;
+}): ReactElement {
+  const { enemies, options, conditions, confidence } = cheatsheet;
+  const optionsLevel = classifyConfidence(confidence.options) ?? 'low';
+  const minConfidence = Math.min(confidence.enemies, confidence.options, confidence.conditions);
+  const lowConfidence = minConfidence < MANUAL_INPUT_THRESHOLD;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {enemies.map((enemy, i) => (
+        <div
+          key={`${enemy.name}-${i}`}
+          data-slot="encounter-enemy"
+          className="overflow-hidden rounded-xl border border-entity-event/30 bg-card"
+        >
+          <div className="flex items-center gap-3 border-b border-entity-event/20 bg-entity-event/8 px-4 py-3">
+            <span aria-hidden="true" className="text-3xl">
+              {enemy.icon ?? '⚔️'}
+            </span>
+            <span className="flex-1 text-lg font-bold text-foreground">{enemy.name}</span>
+            {enemy.paragraphMarker && (
+              <span className="rounded-full bg-entity-event/15 px-2 py-0.5 font-mono text-sm font-bold text-entity-event">
+                {enemy.paragraphMarker}
+              </span>
+            )}
+          </div>
+          <div className="grid grid-cols-4 gap-px bg-border">
+            <Stat value={enemy.hp} label="HP" />
+            <Stat value={enemy.atk} label="ATK" />
+            <Stat value={enemy.def} label="DEF" />
+            <Stat value={enemy.mov} label="MOV" />
+          </div>
+        </div>
+      ))}
+
+      <div className="flex items-center justify-between px-1">
+        <span className="text-sm font-bold text-foreground">{labels.optionsTitle}</span>
+        <span data-slot="encounter-confidence" className="inline-flex items-center gap-1.5">
+          <ConfidenceBadge level={optionsLevel} labels={labels.confidence} />
+          <span className="font-mono text-[10px] font-bold tabular-nums text-muted-foreground">
+            {labels.parseConfidence} {confidence.options.toFixed(2)}
+          </span>
+        </span>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {options.map((option, i) => (
+          <li key={`${option.label}-${i}`}>
+            <div
+              data-slot="encounter-option"
+              className="flex items-center gap-3 rounded-md border border-border bg-card px-4 py-3"
+            >
+              {option.diceRoll && (
+                <span
+                  aria-hidden="true"
+                  className="flex h-11 w-11 shrink-0 flex-col items-center justify-center rounded-md bg-entity-event/10 font-mono text-xs font-bold leading-tight text-entity-event"
+                >
+                  <span>{formatDice(option.diceRoll)}</span>
+                  <span>≥ {option.diceRoll.threshold}</span>
+                </span>
+              )}
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-foreground">{option.label}</span>
+                {option.outcome && (
+                  <span className="mt-0.5 block font-mono text-xs text-muted-foreground">
+                    {option.outcome}
+                  </span>
+                )}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {conditions.win && (
+          <div className="rounded-md border border-success/30 bg-success/10 p-3">
+            <span className="mb-1 block font-mono text-[10px] font-bold uppercase tracking-wide text-success">
+              {labels.conditionsWin}
+            </span>
+            <span className="block text-sm leading-snug text-foreground">{conditions.win}</span>
+          </div>
+        )}
+        {conditions.loss && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3">
+            <span className="mb-1 block font-mono text-[10px] font-bold uppercase tracking-wide text-destructive">
+              {labels.conditionsLoss}
+            </span>
+            <span className="block text-sm leading-snug text-foreground">{conditions.loss}</span>
+          </div>
+        )}
+      </div>
+
+      {lowConfidence && (
+        <p
+          data-slot="encounter-low-confidence"
+          className="rounded-md border border-dashed border-warning/40 bg-warning/10 p-3 font-mono text-xs text-warning"
+        >
+          {labels.lowConfidenceHint}
+        </p>
+      )}
+
+      <p className="rounded-md border border-dashed border-border bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+        {labels.ephemeralNote}
+      </p>
+
+      <div
+        data-slot="encounter-toolbar"
+        className="flex flex-wrap items-center justify-between gap-2 border-t border-border pt-3"
+      >
+        <button
+          type="button"
+          onClick={onParse}
+          className="rounded-md border border-border bg-card px-3 py-2 text-sm font-semibold text-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.retake}
+        </button>
+        {onOpenGlossary && (
+          <button
+            type="button"
+            onClick={onOpenGlossary}
+            className="rounded-md border border-border bg-muted px-3 py-2 text-sm font-semibold text-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {labels.glossary}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onResolve}
+          className="rounded-md bg-entity-event px-4 py-2 text-sm font-semibold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.resolve}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ value, label }: { value: string; label: string }): ReactElement {
+  return (
+    <div className="bg-card p-3 text-center">
+      <span className="block font-mono text-2xl font-bold leading-none text-entity-event">
+        {value}
+      </span>
+      <span className="mt-1 block font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/__tests__/EncounterCheatsheetView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/EncounterCheatsheetView.test.tsx
@@ -276,6 +276,20 @@ describe('EncounterCheatsheetView', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
+  it('has no axe violations in the parsing state', async () => {
+    const { container } = render(
+      <EncounterCheatsheetView
+        status="parsing"
+        cheatsheet={null}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+        onCancel={noop}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it('has no axe violations in the rendered cheatsheet state', async () => {
     const { container } = render(
       <EncounterCheatsheetView

--- a/apps/web/src/components/features/gamebook/__tests__/EncounterCheatsheetView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/EncounterCheatsheetView.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EncounterCheatsheet } from '@/lib/api/gamebook-encounter';
+
+import {
+  EncounterCheatsheetView,
+  type EncounterCheatsheetLabels,
+} from '../EncounterCheatsheetView';
+
+const labels: EncounterCheatsheetLabels = {
+  entryStoryMeta: 'Storybook · ultimo paragrafo letto',
+  entryRefTitle: '→ Encounter §218',
+  entryRefHint: 'Fotografa l’Encounter Book',
+  entryCta: 'Fotografa Encounter §218',
+  entryCtaHint: 'card pronta in ~6s · nessun salvataggio',
+  loadingTitle: 'Analizzo l’Encounter',
+  loadingHint: 'Estraggo stats e opzioni',
+  cancel: 'Annulla',
+  optionsTitle: 'Le tue opzioni',
+  conditionsWin: '🏆 Vittoria',
+  conditionsLoss: '💀 Sconfitta',
+  parseConfidence: 'Affidabilità parse',
+  lowConfidenceHint: 'Bassa affidabilità — verifica manualmente',
+  ephemeralNote: 'Card ephemeral — non salvata',
+  retake: 'Rifotografa',
+  glossary: 'Glossario',
+  resolve: 'Risolvi',
+  errorParseFailed: 'Non sono riuscito a leggere l’encounter',
+  errorNotFound: 'Foto o paragrafo non trovati',
+  errorGeneric: 'Qualcosa è andato storto',
+  retry: 'Riprova',
+  confidence: {
+    high: 'Alta affidabilità',
+    medium: 'Media affidabilità',
+    low: 'Bassa affidabilità',
+  },
+};
+
+const cheatsheet: EncounterCheatsheet = {
+  enemies: [
+    {
+      name: 'Goblin Scout (×3)',
+      icon: '⚔️',
+      paragraphMarker: '§218',
+      hp: '8',
+      atk: '+3',
+      def: '12',
+      mov: '5',
+    },
+  ],
+  options: [
+    {
+      label: 'Attacca subito',
+      diceRoll: { sides: 6, count: 1, modifier: 0, threshold: 4 },
+      outcome: 'Successo → §223',
+    },
+    { label: 'Tenta di parlare', diceRoll: null, outcome: null },
+  ],
+  conditions: { win: 'KO tutti i Goblin', loss: 'Party HP ≤ 0 → §247' },
+  confidence: { enemies: 0.94, options: 0.94, conditions: 0.88 },
+};
+
+function noop() {
+  /* no-op */
+}
+
+describe('EncounterCheatsheetView', () => {
+  // --- State A: idle / entry ------------------------------------------------
+  it('renders the entry CTA and triggers onParse when clicked', async () => {
+    const onParse = vi.fn();
+    render(
+      <EncounterCheatsheetView
+        status="idle"
+        cheatsheet={null}
+        labels={labels}
+        onParse={onParse}
+        onResolve={noop}
+      />
+    );
+
+    const cta = screen.getByRole('button', { name: labels.entryCta });
+    expect(cta).toBeInTheDocument();
+    await userEvent.click(cta);
+    expect(onParse).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the optional story context excerpt in the entry state', () => {
+    render(
+      <EncounterCheatsheetView
+        status="idle"
+        cheatsheet={null}
+        storyContext={{ paragraphLabel: '§147', excerpt: 'Vedi tre figure incappucciate.' }}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+
+    expect(screen.getByText('§147')).toBeInTheDocument();
+    expect(screen.getByText(/tre figure incappucciate/)).toBeInTheDocument();
+  });
+
+  // --- State B: parsing / loading -------------------------------------------
+  it('renders a busy loading state with a cancel control', async () => {
+    const onCancel = vi.fn();
+    render(
+      <EncounterCheatsheetView
+        status="parsing"
+        cheatsheet={null}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+        onCancel={onCancel}
+      />
+    );
+
+    expect(screen.getByText(labels.loadingTitle)).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+    await userEvent.click(screen.getByRole('button', { name: labels.cancel }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // --- State C: rendered / cheatsheet ---------------------------------------
+  it('renders the enemy stat block (HP/ATK/DEF/MOV) verbatim', () => {
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+
+    expect(screen.getByText('Goblin Scout (×3)')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('+3')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders options with inline dice roll and outcome', () => {
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+
+    expect(screen.getByText('Attacca subito')).toBeInTheDocument();
+    expect(screen.getByText(/1d6/)).toBeInTheDocument();
+    expect(screen.getByText(/≥\s*4/)).toBeInTheDocument();
+    expect(screen.getByText('Successo → §223')).toBeInTheDocument();
+    // narrative option (no diceRoll) still renders its label
+    expect(screen.getByText('Tenta di parlare')).toBeInTheDocument();
+  });
+
+  it('renders win and loss conditions', () => {
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+
+    expect(screen.getByText('KO tutti i Goblin')).toBeInTheDocument();
+    expect(screen.getByText('Party HP ≤ 0 → §247')).toBeInTheDocument();
+  });
+
+  it('wires resolve, retake and glossary toolbar actions', async () => {
+    const onResolve = vi.fn();
+    const onParse = vi.fn();
+    const onOpenGlossary = vi.fn();
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={onParse}
+        onResolve={onResolve}
+        onOpenGlossary={onOpenGlossary}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: labels.resolve }));
+    await userEvent.click(screen.getByRole('button', { name: labels.retake }));
+    await userEvent.click(screen.getByRole('button', { name: labels.glossary }));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onParse).toHaveBeenCalledTimes(1);
+    expect(onOpenGlossary).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT show the low-confidence hint when every cluster is ≥ 0.6', () => {
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+    expect(screen.queryByText(labels.lowConfidenceHint)).not.toBeInTheDocument();
+  });
+
+  it('shows the low-confidence hint (§9.1) when any cluster is < 0.6', () => {
+    render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={{
+          ...cheatsheet,
+          confidence: { enemies: 0.94, options: 0.94, conditions: 0.45 },
+        }}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+    expect(screen.getByText(labels.lowConfidenceHint)).toBeInTheDocument();
+  });
+
+  // --- Error paths ----------------------------------------------------------
+  it('renders the parse-failed message (409) with a retry that calls onParse', async () => {
+    const onParse = vi.fn();
+    render(
+      <EncounterCheatsheetView
+        status="error"
+        cheatsheet={null}
+        errorKind="parse-failed"
+        labels={labels}
+        onParse={onParse}
+        onResolve={noop}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(labels.errorParseFailed);
+    await userEvent.click(screen.getByRole('button', { name: labels.retry }));
+    expect(onParse).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the not-found message (404)', () => {
+    render(
+      <EncounterCheatsheetView
+        status="error"
+        cheatsheet={null}
+        errorKind="not-found"
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(labels.errorNotFound);
+  });
+
+  // --- Accessibility (axe across the visible states) ------------------------
+  it('has no axe violations in the entry state', async () => {
+    const { container } = render(
+      <EncounterCheatsheetView
+        status="idle"
+        cheatsheet={null}
+        storyContext={{ paragraphLabel: '§147', excerpt: 'Vedi tre figure.' }}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations in the rendered cheatsheet state', async () => {
+    const { container } = render(
+      <EncounterCheatsheetView
+        status="rendered"
+        cheatsheet={cheatsheet}
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+        onOpenGlossary={noop}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations in the error state', async () => {
+    const { container } = render(
+      <EncounterCheatsheetView
+        status="error"
+        cheatsheet={null}
+        errorKind="parse-failed"
+        labels={labels}
+        onParse={noop}
+        onResolve={noop}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/gamebook/index.ts
+++ b/apps/web/src/components/features/gamebook/index.ts
@@ -144,3 +144,13 @@ export type {
 // Issue #952 — Glossary editor modal (4 in-scope states; state-04 collision deferred to #952-followup)
 export { GlossaryEditorModal } from '@/components/features/gamebook/GlossaryEditorModal';
 export type { GlossaryEditorModalProps } from '@/components/features/gamebook/GlossaryEditorModal';
+
+// Issue #1484 — Encounter Book cheatsheet (parse-centric MVP, consumes BE #1520)
+export { EncounterCheatsheetView } from '@/components/features/gamebook/EncounterCheatsheetView';
+export type {
+  EncounterCheatsheetViewProps,
+  EncounterCheatsheetLabels,
+  EncounterStoryContext,
+  EncounterStatus,
+  EncounterErrorKind,
+} from '@/components/features/gamebook/EncounterCheatsheetView';

--- a/apps/web/src/lib/api/__tests__/gamebook-encounter.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook-encounter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  EncounterCheatsheetSchema,
+  EncounterParseError,
+  parseEncounter,
+} from '../gamebook-encounter';
+
+// Valid v4 UUIDs: position 14 = [1-8], position 19 = [89ab]
+const CAMPAIGN_ID = '11111111-1111-4111-a111-111111111111';
+const PHOTO_ID = '22222222-2222-4222-a222-222222222222';
+const BOOK_ID = '44444444-4444-4444-a444-444444444444';
+
+const validCheatsheet = {
+  enemies: [
+    {
+      name: 'Goblin Scout (×3)',
+      icon: '⚔️',
+      paragraphMarker: '§218',
+      hp: '8',
+      atk: '+3',
+      def: '12',
+      mov: '5',
+    },
+  ],
+  options: [
+    {
+      label: '⚔️ Attacca subito',
+      diceRoll: { sides: 6, count: 1, modifier: 0, threshold: 4 },
+      outcome: 'Successo → §223 · Fallimento → §241',
+    },
+    {
+      label: '💬 Tenta di parlare',
+      diceRoll: null,
+      outcome: null,
+    },
+  ],
+  conditions: {
+    win: 'Riduci tutti i Goblin a 0 HP — drop: Voidstone × 2',
+    loss: 'Party HP ≤ 0 → §247 (cattura)',
+  },
+  confidence: { enemies: 0.94, options: 0.9, conditions: 0.88 },
+};
+
+// ---------------------------------------------------------------------------
+// Schema tests
+// ---------------------------------------------------------------------------
+
+describe('EncounterCheatsheetSchema', () => {
+  it('parses a valid cheatsheet', () => {
+    const result = EncounterCheatsheetSchema.parse(validCheatsheet);
+    expect(result.enemies).toHaveLength(1);
+    expect(result.enemies[0].hp).toBe('8');
+    expect(result.options).toHaveLength(2);
+    expect(result.confidence.enemies).toBeCloseTo(0.94);
+  });
+
+  it('accepts an optional null diceRoll on an option', () => {
+    const result = EncounterCheatsheetSchema.parse(validCheatsheet);
+    expect(result.options[1].diceRoll).toBeNull();
+  });
+
+  it('accepts null win/loss conditions', () => {
+    const result = EncounterCheatsheetSchema.parse({
+      ...validCheatsheet,
+      conditions: { win: null, loss: null },
+    });
+    expect(result.conditions.win).toBeNull();
+    expect(result.conditions.loss).toBeNull();
+  });
+
+  it('normalises a missing enemies array to empty', () => {
+    const result = EncounterCheatsheetSchema.parse({ ...validCheatsheet, enemies: null });
+    expect(result.enemies).toEqual([]);
+  });
+
+  it('rejects a non-numeric confidence', () => {
+    expect(() =>
+      EncounterCheatsheetSchema.parse({
+        ...validCheatsheet,
+        confidence: { enemies: 'high', options: 0.9, conditions: 0.9 },
+      })
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseEncounter fetch behaviour
+// ---------------------------------------------------------------------------
+
+describe('parseEncounter', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs JSON body to the encounter-parse sub-resource with credentials', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(validCheatsheet), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await parseEncounter(CAMPAIGN_ID, PHOTO_ID, {
+      paragraphNumber: 218,
+      gameBookId: BOOK_ID,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(
+      `/api/v1/gamebook/campaigns/${CAMPAIGN_ID}/photos/${PHOTO_ID}/encounter-parse`
+    );
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body as string)).toEqual({
+      paragraphNumber: 218,
+      gameBookId: BOOK_ID,
+    });
+    expect(result.enemies[0].name).toBe('Goblin Scout (×3)');
+  });
+
+  it('throws EncounterParseError with status 409 when the LLM cannot extract a payload', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('parse failed', { status: 409 }));
+
+    await expect(
+      parseEncounter(CAMPAIGN_ID, PHOTO_ID, { paragraphNumber: 218, gameBookId: BOOK_ID })
+    ).rejects.toMatchObject({ name: 'EncounterParseError', status: 409 });
+  });
+
+  it('throws EncounterParseError with status 404 when the photo/segment is missing', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+    await expect(
+      parseEncounter(CAMPAIGN_ID, PHOTO_ID, { paragraphNumber: 218, gameBookId: BOOK_ID })
+    ).rejects.toMatchObject({ name: 'EncounterParseError', status: 404 });
+  });
+
+  it('exposes EncounterParseError as an Error subclass', () => {
+    const err = new EncounterParseError(409, 'boom');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(409);
+  });
+});

--- a/apps/web/src/lib/api/gamebook-encounter.ts
+++ b/apps/web/src/lib/api/gamebook-encounter.ts
@@ -1,0 +1,158 @@
+/**
+ * Gamebook Encounter API client — Issue #1484 (consumes BE #1520).
+ *
+ * Endpoint:
+ *   - POST /api/v1/gamebook/campaigns/{campaignId}/photos/{photoId}/encounter-parse
+ *
+ * Synchronous, ephemeral cheatsheet extraction: the BE returns a fully-formed
+ * {@link EncounterCheatsheet} in a single response and persists nothing
+ * (Encounter Book privacy, spec §9.1). Unlike the SSE translate flow there is
+ * no streaming and no long-term cache.
+ *
+ * All stat values are strings: the LLM extractor preserves raw textual tokens
+ * (e.g. "+3", "5+1", "—", "see §220") and the FE renders them verbatim.
+ */
+
+import { z } from 'zod';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+/**
+ * Typed error carrying the HTTP status so the orchestrator can distinguish the
+ * recoverable branches surfaced by the BE: 409 (LLM parse failure → retry),
+ * 404 (photo/segment missing → re-capture), 403/401 (auth/ownership).
+ */
+export class EncounterParseError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'EncounterParseError';
+    this.status = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Schemas (mirror EncounterCheatsheetDto, camelCase-serialised)
+// ---------------------------------------------------------------------------
+
+export const EncounterDiceRollSchema = z.object({
+  sides: z.number().int(),
+  count: z.number().int(),
+  modifier: z.number().int(),
+  threshold: z.number().int(),
+});
+
+export type EncounterDiceRoll = z.infer<typeof EncounterDiceRollSchema>;
+
+export const EncounterEnemySchema = z.object({
+  name: z.string(),
+  icon: z
+    .string()
+    .nullish()
+    .transform(v => v ?? null),
+  paragraphMarker: z
+    .string()
+    .nullish()
+    .transform(v => v ?? null),
+  hp: z.string(),
+  atk: z.string(),
+  def: z.string(),
+  mov: z.string(),
+});
+
+export type EncounterEnemy = z.infer<typeof EncounterEnemySchema>;
+
+export const EncounterOptionSchema = z.object({
+  label: z.string(),
+  diceRoll: EncounterDiceRollSchema.nullish().transform(v => v ?? null),
+  outcome: z
+    .string()
+    .nullish()
+    .transform(v => v ?? null),
+});
+
+export type EncounterOption = z.infer<typeof EncounterOptionSchema>;
+
+export const EncounterConditionsSchema = z.object({
+  win: z
+    .string()
+    .nullish()
+    .transform(v => v ?? null),
+  loss: z
+    .string()
+    .nullish()
+    .transform(v => v ?? null),
+});
+
+export type EncounterConditions = z.infer<typeof EncounterConditionsSchema>;
+
+export const EncounterConfidenceSchema = z.object({
+  enemies: z.number(),
+  options: z.number(),
+  conditions: z.number(),
+});
+
+export type EncounterConfidence = z.infer<typeof EncounterConfidenceSchema>;
+
+export const EncounterCheatsheetSchema = z.object({
+  enemies: z
+    .array(EncounterEnemySchema)
+    .nullable()
+    .default([])
+    .transform(v => v ?? []),
+  options: z
+    .array(EncounterOptionSchema)
+    .nullable()
+    .default([])
+    .transform(v => v ?? []),
+  conditions: EncounterConditionsSchema,
+  confidence: EncounterConfidenceSchema,
+});
+
+export type EncounterCheatsheet = z.infer<typeof EncounterCheatsheetSchema>;
+
+// ---------------------------------------------------------------------------
+// API function
+// ---------------------------------------------------------------------------
+
+export interface ParseEncounterBody {
+  /** 1-based paragraph number within the photographed encounter page. */
+  paragraphNumber: number;
+  /** GameBook the campaign is currently playing (scopes the parse). */
+  gameBookId: string;
+}
+
+/**
+ * Parse an encounter cheatsheet from a previously-segmented photo paragraph.
+ *
+ * @throws {EncounterParseError} on any non-2xx response, carrying the status.
+ */
+export async function parseEncounter(
+  campaignId: string,
+  photoId: string,
+  body: ParseEncounterBody
+): Promise<EncounterCheatsheet> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(campaignId)}/photos/${encodeURIComponent(photoId)}/encounter-parse`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        paragraphNumber: body.paragraphNumber,
+        gameBookId: body.gameBookId,
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new EncounterParseError(
+      res.status,
+      `parseEncounter failed ${res.status}: ${text || res.statusText}`
+    );
+  }
+
+  return EncounterCheatsheetSchema.parse(await res.json());
+}

--- a/apps/web/src/lib/gamebook/__tests__/encounter-fsm.test.ts
+++ b/apps/web/src/lib/gamebook/__tests__/encounter-fsm.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { EncounterParseError } from '@/lib/api/gamebook-encounter';
+
+import { deriveEncounterStatus, mapEncounterError } from '../encounter-fsm';
+
+describe('deriveEncounterStatus', () => {
+  it('maps an untouched mutation to the entry state', () => {
+    expect(deriveEncounterStatus('idle')).toBe('idle');
+  });
+
+  it('maps a pending mutation to the parsing state', () => {
+    expect(deriveEncounterStatus('pending')).toBe('parsing');
+  });
+
+  it('maps a successful mutation to the rendered state', () => {
+    expect(deriveEncounterStatus('success')).toBe('rendered');
+  });
+
+  it('maps a failed mutation to the error state', () => {
+    expect(deriveEncounterStatus('error')).toBe('error');
+  });
+});
+
+describe('mapEncounterError', () => {
+  it('maps a 409 EncounterParseError to parse-failed', () => {
+    expect(mapEncounterError(new EncounterParseError(409, 'nope'))).toBe('parse-failed');
+  });
+
+  it('maps a 404 EncounterParseError to not-found', () => {
+    expect(mapEncounterError(new EncounterParseError(404, 'gone'))).toBe('not-found');
+  });
+
+  it('maps other EncounterParseError statuses to generic', () => {
+    expect(mapEncounterError(new EncounterParseError(500, 'boom'))).toBe('generic');
+  });
+
+  it('maps a non-EncounterParseError to generic', () => {
+    expect(mapEncounterError(new Error('network'))).toBe('generic');
+    expect(mapEncounterError(null)).toBe('generic');
+  });
+});

--- a/apps/web/src/lib/gamebook/encounter-fsm.ts
+++ b/apps/web/src/lib/gamebook/encounter-fsm.ts
@@ -1,0 +1,48 @@
+/**
+ * Encounter route FSM helpers — Issue #1484.
+ *
+ * Pure mappers shared by the `/library/[gameId]/play/[campaignId]/encounter`
+ * orchestrator (`_content.tsx`). Kept separate from the JSX glue so the
+ * non-trivial state/error mapping is unit-testable in isolation.
+ */
+
+import type {
+  EncounterErrorKind,
+  EncounterStatus,
+} from '@/components/features/gamebook/EncounterCheatsheetView';
+import { EncounterParseError } from '@/lib/api/gamebook-encounter';
+
+/** React Query mutation status values consumed by {@link deriveEncounterStatus}. */
+export type MutationStatus = 'idle' | 'pending' | 'success' | 'error';
+
+/**
+ * Maps the parse mutation status to the component's FSM state. The rename is
+ * intentional (pending→parsing, success→rendered) to keep the view vocabulary
+ * aligned with the mockup states rather than React Query internals.
+ */
+export function deriveEncounterStatus(status: MutationStatus): EncounterStatus {
+  switch (status) {
+    case 'pending':
+      return 'parsing';
+    case 'success':
+      return 'rendered';
+    case 'error':
+      return 'error';
+    case 'idle':
+    default:
+      return 'idle';
+  }
+}
+
+/**
+ * Classifies a parse failure into the recoverable error kind surfaced to the
+ * user: 409 → parse-failed (retry the photo), 404 → not-found (re-capture),
+ * everything else → generic.
+ */
+export function mapEncounterError(error: unknown): EncounterErrorKind {
+  if (error instanceof EncounterParseError) {
+    if (error.status === 409) return 'parse-failed';
+    if (error.status === 404) return 'not-found';
+  }
+  return 'generic';
+}

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useEncounterParse.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useEncounterParse.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+import * as encounterApi from '@/lib/api/gamebook-encounter';
+
+import { useEncounterParse } from '../useEncounterParse';
+
+vi.mock('@/lib/api/gamebook-encounter', async importOriginal => {
+  const actual = await importOriginal<typeof encounterApi>();
+  return { ...actual, parseEncounter: vi.fn() };
+});
+
+const CAMPAIGN_ID = '11111111-1111-4111-a111-111111111111';
+const PHOTO_ID = '22222222-2222-4222-a222-222222222222';
+const BOOK_ID = '44444444-4444-4444-a444-444444444444';
+
+const fakeCheatsheet: encounterApi.EncounterCheatsheet = {
+  enemies: [
+    {
+      name: 'Goblin Scout (×3)',
+      icon: '⚔️',
+      paragraphMarker: '§218',
+      hp: '8',
+      atk: '+3',
+      def: '12',
+      mov: '5',
+    },
+  ],
+  options: [{ label: '⚔️ Attacca subito', diceRoll: null, outcome: '→ §223' }],
+  conditions: { win: 'KO tutti i Goblin', loss: 'Party a 0 HP' },
+  confidence: { enemies: 0.94, options: 0.9, conditions: 0.88 },
+};
+
+function makeWrapper(qc: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useEncounterParse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls parseEncounter with the route ids + mutation variables and returns the cheatsheet', async () => {
+    vi.mocked(encounterApi.parseEncounter).mockResolvedValueOnce(fakeCheatsheet);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useEncounterParse(CAMPAIGN_ID, PHOTO_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    result.current.mutate({ paragraphNumber: 218, gameBookId: BOOK_ID });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(encounterApi.parseEncounter).toHaveBeenCalledWith(CAMPAIGN_ID, PHOTO_ID, {
+      paragraphNumber: 218,
+      gameBookId: BOOK_ID,
+    });
+    expect(result.current.data?.enemies[0].name).toBe('Goblin Scout (×3)');
+  });
+
+  it('surfaces an EncounterParseError (status 409) as the mutation error', async () => {
+    vi.mocked(encounterApi.parseEncounter).mockRejectedValueOnce(
+      new encounterApi.EncounterParseError(409, 'parse failed')
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useEncounterParse(CAMPAIGN_ID, PHOTO_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    result.current.mutate({ paragraphNumber: 218, gameBookId: BOOK_ID });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(encounterApi.EncounterParseError);
+    expect((result.current.error as encounterApi.EncounterParseError).status).toBe(409);
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/useEncounterParse.ts
+++ b/apps/web/src/lib/gamebook/hooks/useEncounterParse.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  parseEncounter,
+  type EncounterCheatsheet,
+  type ParseEncounterBody,
+} from '@/lib/api/gamebook-encounter';
+
+/**
+ * useEncounterParse — Issue #1484.
+ *
+ * Ephemeral, on-demand encounter cheatsheet parse. Modelled as a mutation (not
+ * a query) because it is an explicit user action with no caching: per spec
+ * §9.1 the Encounter Book result is session-scoped and never persisted, so
+ * there is no query key to invalidate or revalidate.
+ *
+ * The route ids (`campaignId`, `photoId`) are bound at hook construction; the
+ * per-invocation variables (`paragraphNumber`, `gameBookId`) are passed to
+ * `mutate`. Errors are surfaced as {@link import('@/lib/api/gamebook-encounter').EncounterParseError}
+ * so the orchestrator can branch on `status` (409 parse-fail / 404 missing).
+ */
+export function useEncounterParse(campaignId: string, photoId: string) {
+  return useMutation<EncounterCheatsheet, Error, ParseEncounterBody>({
+    mutationFn: vars => parseEncounter(campaignId, photoId, vars),
+  });
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2965,6 +2965,38 @@
         "sidePanelLabel": "Conflicting entry"
       }
     },
+    "encounter": {
+      "meta": {
+        "title": "Encounter Book | MeepleAI",
+        "description": "On-demand Encounter Book cheatsheet for the gamebook session"
+      },
+      "entryStoryMeta": "Storybook · last paragraph read",
+      "entryRefTitle": "→ Encounter {paragraph}",
+      "entryRefHint": "You need stats and options — photograph the Encounter Book",
+      "entryCta": "Photograph Encounter {paragraph}",
+      "entryCtaHint": "card ready in seconds · nothing saved long-term",
+      "loadingTitle": "Analyzing the encounter",
+      "loadingHint": "Extracting enemy name, combat stats and options",
+      "cancel": "Cancel",
+      "optionsTitle": "Your options",
+      "conditionsWin": "🏆 Victory",
+      "conditionsLoss": "💀 Defeat",
+      "parseConfidence": "parse",
+      "lowConfidenceHint": "Low confidence on some fields — verify manually against the Encounter Book.",
+      "ephemeralNote": "Temporary card (this session only) — the Encounter Book is not saved.",
+      "retake": "🔄 Retake photo",
+      "glossary": "📒 Glossary",
+      "resolve": "✓ Resolve →",
+      "errorParseFailed": "I couldn't read the encounter from the photo. Retry or retake the page.",
+      "errorNotFound": "Photo or paragraph not found. Retake the Encounter Book page.",
+      "errorGeneric": "Something went wrong during analysis. Please retry.",
+      "retry": "Retry",
+      "confidence": {
+        "high": "High confidence",
+        "medium": "Medium confidence",
+        "low": "Low confidence"
+      }
+    },
     "play": {
       "loading": "Loading...",
       "pageNumber": "Page {num}",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3018,6 +3018,38 @@
         "sidePanelLabel": "Voce in conflitto"
       }
     },
+    "encounter": {
+      "meta": {
+        "title": "Encounter Book | MeepleAI",
+        "description": "Cheatsheet on-demand dell'Encounter Book per la sessione libro game"
+      },
+      "entryStoryMeta": "Storybook · ultimo paragrafo letto",
+      "entryRefTitle": "→ Encounter {paragraph}",
+      "entryRefHint": "Servono stats e opzioni — fotografa l'Encounter Book",
+      "entryCta": "Fotografa Encounter {paragraph}",
+      "entryCtaHint": "card pronta in pochi secondi · nessun salvataggio long-term",
+      "loadingTitle": "Sto analizzando l'encounter",
+      "loadingHint": "Estraggo nome nemico, stats di combattimento e opzioni",
+      "cancel": "Annulla",
+      "optionsTitle": "Le tue opzioni",
+      "conditionsWin": "🏆 Vittoria",
+      "conditionsLoss": "💀 Sconfitta",
+      "parseConfidence": "parse",
+      "lowConfidenceHint": "Affidabilità bassa su alcuni campi — verifica manualmente sull'Encounter Book.",
+      "ephemeralNote": "Card temporanea (solo questa sessione) — l'Encounter Book non viene salvato.",
+      "retake": "🔄 Rifotografa",
+      "glossary": "📒 Glossario",
+      "resolve": "✓ Risolvi →",
+      "errorParseFailed": "Non sono riuscito a leggere l'encounter dalla foto. Riprova o rifotografa la pagina.",
+      "errorNotFound": "Foto o paragrafo non trovati. Rifotografa la pagina dell'Encounter Book.",
+      "errorGeneric": "Qualcosa è andato storto durante l'analisi. Riprova.",
+      "retry": "Riprova",
+      "confidence": {
+        "high": "Affidabilità alta",
+        "medium": "Affidabilità media",
+        "low": "Affidabilità bassa"
+      }
+    },
     "play": {
       "loading": "Caricamento...",
       "pageNumber": "Pagina {num}",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -136,7 +136,7 @@ Each route is classified by **Tier** (S/M/L) which gates implementation strategy
 | `/gamebook` | **M** | `sp6-libro-game-index.html` | Libro-game index: Hero + QuotaWidget + Card grid + EmptyState | ✅ done (SP6 Phase B, PR #792) |
 | `/gamebook/upload` | **L** | `sp4-upload-wizard-extended.html` + `sp6-libro-game-photo-upload.html` | 3-step wizard: game search + camera + indexing — 14-state FSM + camera permission matrix + offline retry | ✅ done (SP6 Phase C, contract PR #794 + Foundation PR #796 + Interactions PR #800) — [`contracts/gamebook-upload-hooks.md`](contracts/gamebook-upload-hooks.md) |
 | `/library/[gameId]/play/[campaignId]/translate` | **S** | `librogame-runthrough-translate-viewer.html` | Nanolith demo — paragraph translate via chat-stream workaround. Route consolidated from `/library/games/[gameId]/translate` under campaign in IA refactor #871. | ✅ done (SP6 Phase A, PR #790; route refactored in #871) |
-| `/library/[gameId]/play/[campaignId]/encounter` | **S** | `librogame-runthrough-encounter-cheatsheet.html` | Nanolith dogfood — Encounter Book photo→cheatsheet on-demand (4 stati: entry-from-story · segmenting · cheatsheet-rendered · resolved-back). Ephemeral parse (no long-term cache, §9.1). Single hook `useEncounterParse`, linear FSM. | pending (post-Stage-2 unfreeze) |
+| `/library/[gameId]/play/[campaignId]/encounter` | **S** | `librogame-runthrough-encounter-cheatsheet.html` | Nanolith dogfood — Encounter Book photo→cheatsheet on-demand. Ephemeral parse (no long-term cache, §9.1). Hook `useEncounterParse`, FSM idle→parsing→rendered→error. | ✅ done (parse-centric MVP, PR #1525) — state D (resolution/consequences) deferred (no BE command) |
 | `/kb/[id]` | **M** | `sp4-kb-detail.html` | KB header + chunks + search | **deferred** — pivot legale 2026-05-10, vedi `2026-05-10-citation-pdf-viewer-design.md` (G4 v3) |
 
 **Anti-pattern**: dispatchare implementation subagent senza Phase 0.5 per route Tier L. Wave C.1 PR #697 ha esattamente questo come root cause (vedi [post-mortem](../specs/2026-04-26-v2-design-migration.md#34-phase-05--sub-hook-contract-per-tier-l-routes-only)).
@@ -479,13 +479,13 @@ the PR review.
 
 | Mockup | Component | Tier | Path | Route | Status | PR | AC |
 |--------|-----------|------|------|-------|--------|----|----|
-| `librogame-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | **S** | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | pending | — | T A M V |
+| `librogame-runthrough-encounter-cheatsheet.html` | `EncounterCheatsheetView` | **S** | `apps/web/src/components/features/gamebook/EncounterCheatsheetView.tsx` | `/library/[gameId]/play/[campaignId]/encounter` | ✅ done (parse-centric MVP) | #1525 | T A (M unit; V retired) |
 | `librogame-runthrough-game-onboarding.html` | `LibroGameOnboardingPanel` | **L** ⚠️ | `apps/web/src/components/features/gamebook/LibroGameOnboardingPanel.tsx` | `/library/[gameId]` (libro variant — prereq gate) | pending | — | T A M V |
 | `librogame-runthrough-error-states.html` | `GamebookErrorBanner` | **S** (primitive-like) | `apps/web/src/components/features/gamebook/GamebookErrorBanner.tsx` | cross-cutting (chat, translate, encounter) | pending | — | T A V |
 
 **Stato di copertura** (4 stati ciascuno, mobile + desktop parity):
 
-- **`EncounterCheatsheetView`** (BLOCKER · Tier S): entry-from-story / photo-segmenting / cheatsheet-rendered / resolved-back. Ephemeral card (no long-term cache, §9.1 spec). Single hook `useEncounterParse({photoId, paragraphRef})` + linear FSM 5-state. Bundle budget < +50 KB.
+- **`EncounterCheatsheetView`** (✅ done, PR #1525 · Tier S): parse-centric MVP — FSM `idle` (entry CTA + optional story context) / `parsing` / `rendered` (cheatsheet) / `error` (409 parse-failed · 404 not-found · generic + retry). Hook `useEncounterParse(campaignId, photoId)` → `mutate({paragraphNumber, gameBookId})` (consumes BE #1520). Ephemeral (no long-term cache, §9.1); confidence < 0.6 surfaces manual-verification hint. **State D (resolution/consequences) deferred** — no BE encounter-resolution command; "Risolvi" navigates back to the play session.
 - **`LibroGameOnboardingPanel`** (NICE-TO-HAVE · Tier L): prereq-missing / pdf-uploading / kb-indexing / ready. Replace della CTA "Avvia libro game" quando prerequisiti non soddisfatti. Composition: drop-zone + upload-row + index-detail + step-list primitives. Multi-hook ≥3 (`useGamePrerequisites` + `usePdfUpload` + `useKbIndexing`) → Phase 0.5 sub-hook contract OBBLIGATORIA prima di implementation (vedi `contracts/library-id-onboarding-hooks.md` TBD). Bundle budget < +120 KB.
 - **`GamebookErrorBanner`** (NICE-TO-HAVE · Tier S primitive-like): stream-timeout / ocr-fail / llm-503 / segmentation-fail. Trasversale alle 3 route gamebook (chat, translate, encounter). Cost-note "non addebitato" + ≥2 azioni di recupero + telemetry dogfood. Componente "primitive-like" candidato a `components/ui/error-banner/` se generalizzato post-Iter-1.
 
@@ -656,7 +656,7 @@ instead.
 | `/library/[gameId]/play` | `librogame-runthrough-resume-picker.html` + `sp6-libro-game-resume-state.html` | Libro-game |
 | `/library/[gameId]/play/[campaignId]` | `librogame-runthrough-play-session.html` + `sp6-libro-game-index.html` | — |
 | `/library/[gameId]/play/[campaignId]/translate` | `librogame-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` | Tier S done (PR #790) |
-| `/library/[gameId]/play/[campaignId]/encounter` | `librogame-runthrough-encounter-cheatsheet.html` | Tier S pending (BLOCKER §9.1 gap-coverage 2026-05-12) |
+| `/library/[gameId]/play/[campaignId]/encounter` | `librogame-runthrough-encounter-cheatsheet.html` | Tier S done (PR #1525, parse-centric MVP; state D deferred) |
 | `/library/[gameId]/toolbox` · `/toolkit` · `/toolkit/[sessionId]` | `sp4-toolkit-detail.html` ↻ | — |
 
 > **Note**: `/library/v2` decommissionata 2026-05-12 (era demo orfana con SEED hard-coded).


### PR DESCRIPTION
## Summary

Implements `EncounterCheatsheetView` for `/library/[gameId]/play/[campaignId]/encounter` (issue #1484), consuming the BE encounter-parse endpoint shipped in #1520.

**Scope decision (parse-centric MVP)**: the mockup describes a 4-state flow (entry → segmenting → cheatsheet → resolved), but the BE `encounter-parse` endpoint only provides the **cheatsheet** data. Spec-panel review (Wiegers/Fowler/Nygard/Crispin/Adzic/Cockburn) surfaced that **state D (resolution: dice + consequences + save-state mutation) has no BE command** — only a parse endpoint exists. Per product decision, this PR ships the unblocked, fully-functional parse flow and defers state D.

FSM: `idle` (entry CTA + optional story context) → `parsing` (loading) → `rendered` (cheatsheet) → `error` (409 parse-failed / 404 not-found / generic + retry). The "Risolvi" action navigates back to the play session (mirrors the mockup, where it navigates away).

## What's implemented

| Layer | File |
|---|---|
| Client | `lib/api/gamebook-encounter.ts` — `parseEncounter()` + Zod schemas + `EncounterParseError` (typed status) |
| Hook | `lib/gamebook/hooks/useEncounterParse.ts` — React Query mutation (ephemeral, no cache per §9.1) |
| FSM | `lib/gamebook/encounter-fsm.ts` — `deriveEncounterStatus` + `mapEncounterError` |
| Component | `components/features/gamebook/EncounterCheatsheetView.tsx` — pure, labels injected, `ConfidenceBadge` + `classifyConfidence` reuse |
| Route | `…/encounter/page.tsx` + `_content.tsx` — orchestrator (i18n + hook wiring) |
| i18n | `gamebook.encounter.*` (it + en) |

## Contract (aligned to BE #1520)

`POST /api/v1/gamebook/campaigns/{campaignId}/photos/{photoId}/encounter-parse` body `{paragraphNumber, gameBookId}` → `{enemies[], options[] (optional diceRoll), conditions{win?,loss?}, confidence{enemies,options,conditions}}`. Confidence < 0.6 on any cluster surfaces a manual-verification hint (§9.1).

## Tests — 34 unit, all green

- Client: 9 (schema + 409/404 + POST contract)
- Hook: 2 (mutate success + EncounterParseError surfacing)
- Component: 15 (all 4 visible states + retry/error/low-confidence + 4 jest-axe a11y assertions)
- FSM helpers: 8

Verified locally: `pnpm typecheck` ✓, `pnpm lint` 0 errors ✓ (DS-15 token rule compliant), no regressions in the 805-test gamebook+locales suite.

## Code review

Self-review via subagent: 2 IMPORTANT + 1 MINOR. Applied: added parsing-state axe coverage (the `role="status"` live region passes axe — no `aria-label` added to avoid SR double-announce, verified empirically), documented the `to`/`paragraphNumber`/`from` query-param contract, defensive `§` strip on the from-label.

## Deferred (out of scope, documented)

- **State D (resolution/consequences)**: needs a BE encounter-resolution command (does not exist) — follow-up.
- **E2E**: the component is comprehensively unit-tested (incl. a11y); a full route E2E needs the dev server + BE LLM + photo fixtures (or a `?fixture=` hatch). The project's visual-conformity E2E suite was retired (CLAUDE.md). Deferred with rationale.

Closes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)