### PR TITLE
test(admin): fix AdminSideDrawer baseline to SP5 4-group nav (#1496)

### DIFF
--- a/apps/web/src/__tests__/components/layout/AdminSideDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/layout/AdminSideDrawer.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/hooks/queries/useCurrentUser', () => ({
 }));
 
 import { AdminSideDrawer } from '@/components/layout/AdminSideDrawer/AdminSideDrawer';
+import { ADMIN_NAV_GROUPS } from '@/components/layout/admin-nav/admin-nav-config';
 
 describe('AdminSideDrawer', () => {
   const defaultProps = {
@@ -41,40 +42,28 @@ describe('AdminSideDrawer', () => {
     expect(link).toBeDefined();
   });
 
-  it('renders admin sections Overview, Content, AI, Users', () => {
+  it('renders the four admin nav group labels (SP5 consolidation, #1496)', () => {
     render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.getByText('Overview')).toBeDefined();
-    expect(screen.getByText('Content')).toBeDefined();
-    expect(screen.getByText('AI')).toBeDefined();
-    expect(screen.getByText('Users')).toBeDefined();
+    for (const group of ADMIN_NAV_GROUPS) {
+      expect(screen.getByText(group.label)).toBeDefined();
+    }
   });
 
-  it('renders items inside Overview section', () => {
+  it('renders every nav item an admin is allowed to see', () => {
     render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.getByText('Dashboard')).toBeDefined();
-    expect(screen.getByText('Activity Feed')).toBeDefined();
-    expect(screen.getByText('System Health')).toBeDefined();
+    // The mocked user is a plain admin; only superadmin-gated items are hidden.
+    const adminVisibleItems = ADMIN_NAV_GROUPS.flatMap(g => g.items).filter(
+      item => item.minRole !== 'superadmin'
+    );
+    for (const item of adminVisibleItems) {
+      expect(screen.getByText(item.label)).toBeDefined();
+    }
   });
 
-  it('renders items inside Content section', () => {
+  it('hides superadmin-only items from an admin user', () => {
     render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.getByText('Giochi')).toBeDefined();
-    expect(screen.getByText('Knowledge Base')).toBeDefined();
-    expect(screen.getByText('Email Templates')).toBeDefined();
-  });
-
-  it('renders items inside AI section', () => {
-    render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.getByText('Mission Control')).toBeDefined();
-    expect(screen.getByText('RAG Inspector')).toBeDefined();
-    expect(screen.getByText('Agent Definitions')).toBeDefined();
-  });
-
-  it('renders items inside Users section', () => {
-    render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.getByText('Tutti gli utenti')).toBeDefined();
-    expect(screen.getByText('Invitations')).toBeDefined();
-    expect(screen.getByText('Ruoli & Permessi')).toBeDefined();
+    // "Staging Access" (group C) requires superadmin; an admin must not see it.
+    expect(screen.queryByText('Staging Access')).toBeNull();
   });
 
   it('does not render when closed', () => {
@@ -121,18 +110,5 @@ describe('AdminSideDrawer', () => {
     // The role badge renders the role value; use getAllByText since "admin" appears in multiple places
     const adminElements = screen.getAllByText(/admin/i);
     expect(adminElements.length).toBeGreaterThan(0);
-  });
-
-  it('AI Altro sub-menu is collapsed by default when not on an Altro route', () => {
-    render(<AdminSideDrawer {...defaultProps} />);
-    // These items belong to the AI "Altro" collapsible
-    expect(screen.queryByText('Config')).toBeNull();
-    expect(screen.queryByText('Usage')).toBeNull();
-  });
-
-  it('Users Altro sub-menu is collapsed by default when not on an Altro route', () => {
-    render(<AdminSideDrawer {...defaultProps} />);
-    expect(screen.queryByText('Access Requests')).toBeNull();
-    expect(screen.queryByText('Activity')).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

PR #1496 (SP5 F0a nav consolidation) replaced the admin nav — old sections (Overview / Content / AI / Users) + collapsible "Altro" sub-menus — with the **4-group config-driven structure** (`ADMIN_NAV_GROUPS` + `filterNavByRole`), but did **not** update `AdminSideDrawer.test.tsx`.

Result: `AdminSideDrawer.test.tsx` has been failing **5/15** on `main-dev` ever since, so every clean frontend PR inherits a red `Frontend Tests (shard 3/3)` + `Frontend Fast` and has to be merged with `--admin` override. (`CLAUDE.md` § "Known Flaky Tests" says the baseline is empty — it is not.)

## Fix

Rewrite the stale assertions to be **config-driven** (robust against future nav edits — they read the same source of truth the component renders):

- assert the **4 group labels** (`ADMIN_NAV_GROUPS[].label`): Admin Console, Power-User Tools, Platform & Operations, AI Tooling & Data Quality
- assert **every nav item an admin may see** (`ADMIN_NAV_GROUPS` items minus `minRole: 'superadmin'`)
- assert **role filtering**: superadmin-only `Staging Access` is hidden from an admin

Dropped the 2 obsolete `Altro sub-menu collapsed` tests — that collapsible behaviour no longer exists (the new `AdminNavList` renders all groups flat).

## Verification

- `AdminSideDrawer.test.tsx`: **11/11 green** (was 15 with 5 failing; consolidated 5 hardcoded section tests → 3 config-driven, removed 2 obsolete — coverage improved: now every group + every admin-visible item + role filtering).
- `pnpm typecheck` ✓, lint ✓.
- This unblocks `Frontend Tests (shard 3/3)` so future clean FE PRs no longer need admin-override.

Refs #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)