### PR TITLE
feat(kb-hub): #1481 implement /library/[gameId]/kb hub (8 components)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/__tests__/KbHubContent.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * KbHubContent orchestrator tests (Issue #1481).
+ *
+ * Validates loading/error/empty/default states + delete + reindex flow wiring.
+ * Hooks are mocked to isolate orchestrator FSM and i18n label resolution.
+ * P71: MESSAGES subset covers all new `pages.library.gameDetail.kb.*` keys.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KbHubContent } from '../_content';
+
+// ─── Hook mocks ──────────────────────────────────────────
+const mockUseUserKbStatus = vi.fn();
+const mockUseGamePdfs = vi.fn();
+const mockUseReindexKb = vi.fn();
+const mockUseRebuildRaptor = vi.fn();
+const mockUseDeletePdf = vi.fn();
+
+vi.mock('@/hooks/queries/useKbHub', () => ({
+  useUserKbStatus: (gameId?: string) => mockUseUserKbStatus(gameId),
+  useGamePdfs: (gameId?: string) => mockUseGamePdfs(gameId),
+  useReindexKb: (gameId: string) => mockUseReindexKb(gameId),
+  useRebuildRaptor: (gameId: string) => mockUseRebuildRaptor(gameId),
+  useDeletePdf: (gameId: string) => mockUseDeletePdf(gameId),
+}));
+
+// Mock useTranslation with a lightweight lookup in MESSAGES dict (defined below).
+// Avoids react-intl IntlProvider initialization that becomes pathological under the
+// scale of orchestrator label assembly (~90 t() calls per render).
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) => {
+      const template = MESSAGES[key] ?? key;
+      if (!values) return template;
+      let result = template;
+      for (const [k, v] of Object.entries(values)) {
+        result = result.replace(`{${k}}`, String(v));
+      }
+      return result;
+    },
+    formatMessage: ({ id }: { id: string }) => MESSAGES[id] ?? id,
+    locale: 'it',
+    formatNumber: (n: number) => String(n),
+    formatDate: (d: Date) => d.toISOString(),
+    formatTime: (d: Date) => d.toISOString(),
+    formatRelativeTime: (n: number) => String(n),
+  }),
+  FormattedMessage: () => null,
+  FormattedDate: () => null,
+  FormattedTime: () => null,
+  FormattedNumber: () => null,
+}));
+
+// ─── MESSAGES (P71): mirror src/locales/it.json pages.library.gameDetail.kb.* ─
+const MESSAGES: Record<string, string> = {
+  'pages.library.gameDetail.kb.empty.title': 'Nessun PDF indicizzato',
+  'pages.library.gameDetail.kb.empty.description': 'Carica il primo documento PDF per {gameTitle}.',
+  'pages.library.gameDetail.kb.empty.ctaLabel': 'Carica primo documento',
+  'pages.library.gameDetail.kb.empty.supportedFormats': 'Formati: PDF, max 200 MB',
+  'pages.library.gameDetail.kb.header.titleSuffix': 'Knowledge Base',
+  'pages.library.gameDetail.kb.header.uploadCta': '+ Carica PDF',
+  'pages.library.gameDetail.kb.header.reindexAllCta': 'Re-index all',
+  'pages.library.gameDetail.kb.stats.docs': '{count} documenti',
+  'pages.library.gameDetail.kb.stats.docsLabel': 'Documenti',
+  'pages.library.gameDetail.kb.stats.chunksLabel': 'Chunks',
+  'pages.library.gameDetail.kb.stats.chunksTemplate': '{count} chunks',
+  'pages.library.gameDetail.kb.stats.embeddingsLabel': 'Embeddings',
+  'pages.library.gameDetail.kb.stats.embeddingsTemplate': '{count} embeddings',
+  'pages.library.gameDetail.kb.stats.lastReindexLabel': 'Ultima idx.',
+  'pages.library.gameDetail.kb.stats.lastReindexTemplate': 'ultima reindex {relative}',
+  'pages.library.gameDetail.kb.stats.raptorLabel': 'RAPTOR last',
+  'pages.library.gameDetail.kb.stats.coverageLabel': 'Copertura',
+  'pages.library.gameDetail.kb.stats.coverageStripLabel': 'Copertura: {level}',
+  'pages.library.gameDetail.kb.stats.coverage.None': 'Nessuna',
+  'pages.library.gameDetail.kb.stats.coverage.Basic': 'Base',
+  'pages.library.gameDetail.kb.stats.coverage.Standard': 'Standard',
+  'pages.library.gameDetail.kb.stats.coverage.Complete': 'Completa',
+  'pages.library.gameDetail.kb.stats.cardTitle': 'KB Coverage Stats',
+  'pages.library.gameDetail.kb.stats.cardSubtitle': 'Metriche',
+  'pages.library.gameDetail.kb.stats.lifetimeCostLabel': 'Costo lifetime',
+  'pages.library.gameDetail.kb.stats.sparklineLabel': 'Consumo',
+  'pages.library.gameDetail.kb.stats.sparklineStart': '-7gg',
+  'pages.library.gameDetail.kb.stats.sparklineEnd': 'oggi',
+  'pages.library.gameDetail.kb.stats.columnHeaders.document': 'Documento',
+  'pages.library.gameDetail.kb.stats.columnHeaders.status': 'Stato',
+  'pages.library.gameDetail.kb.stats.columnHeaders.uploaded': 'Caricato',
+  'pages.library.gameDetail.kb.pdfRow.openCta': 'Apri',
+  'pages.library.gameDetail.kb.pdfRow.openAria': 'Apri {pdfName}',
+  'pages.library.gameDetail.kb.pdfRow.chunksTemplate': '{count} chunks',
+  'pages.library.gameDetail.kb.pdfRow.status.ready': 'Ready',
+  'pages.library.gameDetail.kb.pdfRow.status.indexing': 'Indexing',
+  'pages.library.gameDetail.kb.pdfRow.status.stale': 'Stale',
+  'pages.library.gameDetail.kb.pdfRow.status.failed': 'Failed',
+  'pages.library.gameDetail.kb.actionsMenu.headerSubtitle': '{size} · {date}',
+  'pages.library.gameDetail.kb.actionsMenu.open.label': 'Apri dettaglio',
+  'pages.library.gameDetail.kb.actionsMenu.open.description': 'Vedi chunks',
+  'pages.library.gameDetail.kb.actionsMenu.open.icon': '↗',
+  'pages.library.gameDetail.kb.actionsMenu.reindex.label': 'Re-index',
+  'pages.library.gameDetail.kb.actionsMenu.reindex.description': 'Rielabora',
+  'pages.library.gameDetail.kb.actionsMenu.reindex.icon': '⟳',
+  'pages.library.gameDetail.kb.actionsMenu.cost.label': 'Costo',
+  'pages.library.gameDetail.kb.actionsMenu.cost.description': 'Token',
+  'pages.library.gameDetail.kb.actionsMenu.cost.icon': '📋',
+  'pages.library.gameDetail.kb.actionsMenu.move.label': 'Sposta',
+  'pages.library.gameDetail.kb.actionsMenu.move.description': 'Altra KB',
+  'pages.library.gameDetail.kb.actionsMenu.move.icon': '📦',
+  'pages.library.gameDetail.kb.actionsMenu.delete.label': 'Elimina',
+  'pages.library.gameDetail.kb.actionsMenu.delete.description': 'Rimuovi',
+  'pages.library.gameDetail.kb.actionsMenu.delete.icon': '🗑',
+  'pages.library.gameDetail.kb.reindexModal.title': 'Re-index full KB',
+  'pages.library.gameDetail.kb.reindexModal.subtitle': '{gameTitle} · {docCount} documenti',
+  'pages.library.gameDetail.kb.reindexModal.costHeader': 'Stima costo',
+  'pages.library.gameDetail.kb.reindexModal.description': 'Rielabora tutto.',
+  'pages.library.gameDetail.kb.reindexModal.reindexCta': 'Re-index',
+  'pages.library.gameDetail.kb.reindexModal.cancelCta': 'Annulla',
+  'pages.library.gameDetail.kb.reindexModal.runningTitle': 'In corso',
+  'pages.library.gameDetail.kb.reindexModal.jobIdLabel': 'Job ID',
+  'pages.library.gameDetail.kb.reindexModal.progressTemplate': '{processed} / {total} chunks',
+  'pages.library.gameDetail.kb.reindexModal.doneTitle': 'Completato',
+  'pages.library.gameDetail.kb.reindexModal.doneSummaryTemplate':
+    '{chunks} chunks · {embeddings} embeddings · costo {cost}',
+  'pages.library.gameDetail.kb.reindexModal.closeCta': 'Chiudi',
+  'pages.library.gameDetail.kb.raptor.title': 'RAPTOR Rebuild',
+  'pages.library.gameDetail.kb.raptor.description': 'RAPTOR descrizione',
+  'pages.library.gameDetail.kb.raptor.lockedBadge': 'PRO',
+  'pages.library.gameDetail.kb.raptor.activeBadge': 'PRO ✓',
+  'pages.library.gameDetail.kb.raptor.lockedNote': 'Richiede Pro.',
+  'pages.library.gameDetail.kb.raptor.upgradeCta': 'Upgrade',
+  'pages.library.gameDetail.kb.raptor.upgradeLink': 'Scopri Pro',
+  'pages.library.gameDetail.kb.raptor.rebuildCta': 'Rebuild',
+  'pages.library.gameDetail.kb.raptor.metrics.lastRebuild': 'Ultimo',
+  'pages.library.gameDetail.kb.raptor.metrics.summaries': 'Summaries',
+  'pages.library.gameDetail.kb.raptor.estimateLabel': 'Stima',
+  'pages.library.gameDetail.kb.raptor.estimateDescription': '~{chunks} chunks',
+  'pages.library.gameDetail.kb.delete.title': 'Confermi eliminazione PDF?',
+  'pages.library.gameDetail.kb.delete.subtitlePrefix': 'PDF:',
+  'pages.library.gameDetail.kb.delete.listHeader': 'Sarà eliminato:',
+  'pages.library.gameDetail.kb.delete.warning': 'Irreversibile',
+  'pages.library.gameDetail.kb.delete.deleteCta': 'Elimina',
+  'pages.library.gameDetail.kb.delete.cancelCta': 'Annulla',
+  'pages.library.gameDetail.kb.errors.loadFailed': 'Caricamento fallito',
+  'pages.library.gameDetail.kb.errors.reindexFailed': 'Reindex fallito',
+  'pages.library.gameDetail.kb.errors.raptorFailed': 'Raptor fallito',
+  'pages.library.gameDetail.kb.errors.deleteFailed': 'Delete fallito',
+};
+
+function renderWithIntl(node: ReactNode): ReturnType<typeof render> {
+  return render(<>{node}</>);
+}
+
+const GAME_ID = '11111111-1111-1111-1111-111111111111';
+
+function pdfFixture(overrides: Partial<{ id: string; name: string; bytes: number }> = {}): {
+  id: string;
+  name: string;
+  pageCount: number;
+  fileSizeBytes: number;
+  uploadedAt: string;
+  source: 'Custom';
+} {
+  return {
+    id: overrides.id ?? 'p1',
+    name: overrides.name ?? 'Rulebook v2',
+    pageCount: 50,
+    fileSizeBytes: overrides.bytes ?? 47185920,
+    uploadedAt: '2026-05-20T00:00:00Z',
+    source: 'Custom',
+  };
+}
+
+describe('KbHubContent orchestrator (Issue #1481)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReindexKb.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseRebuildRaptor.mockReturnValue({ mutateAsync: vi.fn() });
+    mockUseDeletePdf.mockReturnValue({ mutateAsync: vi.fn() });
+  });
+
+  it('renders skeleton while either query is loading', () => {
+    mockUseUserKbStatus.mockReturnValue({ isLoading: true, data: null, isError: false });
+    mockUseGamePdfs.mockReturnValue({ isLoading: true, data: [], isError: false });
+    const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    expect(container.querySelector('[data-slot="kb-hub-skeleton"]')).toBeInTheDocument();
+  });
+
+  it('renders error alert when status query errors', () => {
+    mockUseUserKbStatus.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: null,
+    });
+    mockUseGamePdfs.mockReturnValue({ isLoading: false, isError: false, data: [] });
+    const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    expect(container.querySelector('[data-slot="kb-hub-error"]')).toBeInTheDocument();
+    expect(screen.getByText('Caricamento fallito')).toBeInTheDocument();
+  });
+
+  it('renders EmptyState when no PDFs', () => {
+    mockUseUserKbStatus.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        gameId: GAME_ID,
+        isIndexed: false,
+        documentCount: 0,
+        coverageScore: 0,
+        coverageLevel: 'None',
+        suggestedQuestions: [],
+      },
+    });
+    mockUseGamePdfs.mockReturnValue({ isLoading: false, isError: false, data: [] });
+    const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    expect(container.querySelector('[data-slot="kb-hub-empty-state"]')).toBeInTheDocument();
+  });
+
+  it('renders HubDefault + KbStatsCard + RaptorPanel when PDFs present', () => {
+    mockUseUserKbStatus.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        gameId: GAME_ID,
+        isIndexed: true,
+        documentCount: 2,
+        coverageScore: 70,
+        coverageLevel: 'Standard',
+        suggestedQuestions: [],
+      },
+    });
+    mockUseGamePdfs.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [pdfFixture({ id: 'p1' }), pdfFixture({ id: 'p2', name: 'Scenario Book' })],
+    });
+    const { container } = renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    expect(container.querySelector('[data-slot="kb-hub-hub-default"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-stats-card"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-raptor-panel"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="kb-hub-pdf-row"]')).toHaveLength(2);
+  });
+
+  it('opens reindex modal when reindex-all CTA clicked', () => {
+    mockUseUserKbStatus.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        gameId: GAME_ID,
+        isIndexed: true,
+        documentCount: 1,
+        coverageScore: 50,
+        coverageLevel: 'Basic',
+        suggestedQuestions: [],
+      },
+    });
+    mockUseGamePdfs.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [pdfFixture()],
+    });
+    renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    expect(document.querySelector('[data-slot="kb-hub-reindex-modal"]')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-index all' }));
+    expect(document.querySelector('[data-slot="kb-hub-reindex-modal"]')).toBeInTheDocument();
+  });
+
+  it('triggers delete mutation when DeleteDialog confirmed', async () => {
+    const deleteMutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockUseDeletePdf.mockReturnValue({ mutateAsync: deleteMutateAsync });
+    mockUseUserKbStatus.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        gameId: GAME_ID,
+        isIndexed: true,
+        documentCount: 1,
+        coverageScore: 50,
+        coverageLevel: 'Basic',
+        suggestedQuestions: [],
+      },
+    });
+    mockUseGamePdfs.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [pdfFixture({ id: 'pdf-to-delete' })],
+    });
+    renderWithIntl(<KbHubContent gameId={GAME_ID} />);
+    // Open actions menu by clicking the pdf row CTA
+    fireEvent.click(screen.getByRole('button', { name: /Apri Rulebook v2/i }));
+    // ActionsMenu open — click delete action via document (portal)
+    const deleteAction = document.querySelector(
+      '[data-slot="kb-hub-actions-menu-delete"]'
+    ) as HTMLElement | null;
+    expect(deleteAction).toBeInTheDocument();
+    if (deleteAction) fireEvent.click(deleteAction);
+    // DeleteDialog open — confirm
+    const confirmBtn = document.querySelector(
+      '[data-slot="kb-hub-delete-confirm"]'
+    ) as HTMLButtonElement | null;
+    expect(confirmBtn).toBeInTheDocument();
+    if (confirmBtn) fireEvent.click(confirmBtn);
+    await waitFor(() => expect(deleteMutateAsync).toHaveBeenCalledWith('pdf-to-delete'));
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -17,6 +17,8 @@
 
 import { useState, type ReactElement } from 'react';
 
+import { toast } from 'sonner';
+
 import {
   ActionsMenu,
   DeleteDialog,
@@ -68,8 +70,9 @@ const STATIC_REINDEX_COST_ROWS: ReadonlyArray<ReindexCostRow> = [
 
 function formatRelativeDate(_iso: string): string {
   // Lightweight relative formatter — production uses date-fns formatDistance().
-  // Replaced with date-fns when wireup expands. For MVP we display the upload date as-is.
-  return new Date(_iso).toLocaleDateString('it-IT');
+  // Replaced with date-fns when wireup expands. For MVP we display the upload date as-is
+  // using the runtime locale (no hardcoded it-IT — caller's IntlProvider drives format).
+  return new Date(_iso).toLocaleDateString();
 }
 
 function formatFileSize(bytes: number): string {
@@ -297,6 +300,9 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
       await reindexMutation.mutateAsync();
       setReindexPhase('done');
     } catch {
+      // Surface the failure to the user; without this the modal closes silently
+      // and the operation appears to vanish.
+      toast.error(t('pages.library.gameDetail.kb.errors.reindexFailed'));
       setReindexOpen(false);
       setReindexPhase('confirm');
     }
@@ -306,8 +312,11 @@ export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
     if (!deletePdfTarget) return;
     try {
       await deleteMutation.mutateAsync(deletePdfTarget.id);
-    } finally {
+      // Only dismiss the dialog on success — keep it open on error so the user
+      // sees the failure and can decide to retry or cancel.
       setDeletePdfTarget(null);
+    } catch {
+      toast.error(t('pages.library.gameDetail.kb.errors.deleteFailed'));
     }
   };
 

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx
@@ -1,0 +1,382 @@
+/**
+ * KbHubContent — orchestrator for `/library/[gameId]/kb` (Issue #1481).
+ *
+ * Wires the kb-hub presentational components to existing user-side BE endpoints:
+ *   - useUserKbStatus    → documentCount, coverageLevel, coverageScore
+ *   - useGamePdfs        → PDF list
+ *   - useReindexKb       → full re-index mutation
+ *   - useRebuildRaptor   → RAPTOR rebuild mutation (Pro tier — backend enforces)
+ *   - useDeletePdf       → delete a PDF (Owner endpoint)
+ *
+ * Deferred props (P83) — chunks, embeddings, lastReindex, raptorLastRebuild,
+ * cost history, PDF row status/chunks, RAPTOR tier — are not wired here.
+ * Components hide their corresponding UI when the prop is undefined.
+ */
+
+'use client';
+
+import { useState, type ReactElement } from 'react';
+
+import {
+  ActionsMenu,
+  DeleteDialog,
+  EmptyState,
+  HubDefault,
+  KbStatsCard,
+  RaptorPanel,
+  ReindexModal,
+  type ActionsMenuLabels,
+  type DeleteDialogLabels,
+  type EmptyStateLabels,
+  type HubDefaultLabels,
+  type KbStatsCardLabels,
+  type KbPdf,
+  type PdfAction,
+  type RaptorPanelLabels,
+  type ReindexCostRow,
+  type ReindexModalLabels,
+  type ReindexPhase,
+} from '@/components/features/kb-hub';
+import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  useDeletePdf,
+  useGamePdfs,
+  useReindexKb,
+  useRebuildRaptor,
+  useUserKbStatus,
+} from '@/hooks/queries/useKbHub';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GamePdfDto } from '@/lib/api/schemas/pdf.schemas';
+
+interface KbHubContentProps {
+  readonly gameId: string;
+}
+
+/**
+ * Static cost breakdown rows for the re-index estimate table.
+ * Real per-game estimates require BE schema enrichment (deferred follow-up issue).
+ */
+const STATIC_REINDEX_COST_ROWS: ReadonlyArray<ReindexCostRow> = [
+  { key: 'chunks', label: 'Chunks da re-embed', value: '—', unit: '' },
+  { key: 'tokensPerChunk', label: 'Tokens per chunk (avg)', value: '~320', unit: 'tokens' },
+  { key: 'tokensTotal', label: 'Tokens totali stimati', value: '—', unit: 'tokens' },
+  { key: 'costPer1M', label: 'Costo per 1M tokens', value: '$0.0001', unit: '/1M' },
+  { key: 'estimatedCost', label: 'Costo stimato', value: '~$0.45', bold: true },
+  { key: 'estimatedDuration', label: 'Durata stimata', value: '3–5 min', bold: true },
+];
+
+function formatRelativeDate(_iso: string): string {
+  // Lightweight relative formatter — production uses date-fns formatDistance().
+  // Replaced with date-fns when wireup expands. For MVP we display the upload date as-is.
+  return new Date(_iso).toLocaleDateString('it-IT');
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+function mapPdfs(pdfs: ReadonlyArray<GamePdfDto>): ReadonlyArray<KbPdf> {
+  return pdfs.map(p => ({
+    id: p.id,
+    name: p.name,
+    sizeFormatted: formatFileSize(p.fileSizeBytes),
+    uploadedAtRelative: formatRelativeDate(p.uploadedAt),
+    // status + chunks deferred (P83 — BE schema doesn't expose them yet)
+  }));
+}
+
+export function KbHubContent({ gameId }: KbHubContentProps): ReactElement {
+  const { t } = useTranslation();
+  const statusQuery = useUserKbStatus(gameId);
+  const pdfsQuery = useGamePdfs(gameId);
+  const reindexMutation = useReindexKb(gameId);
+  const _raptorMutation = useRebuildRaptor(gameId);
+  const deleteMutation = useDeletePdf(gameId);
+
+  const [reindexOpen, setReindexOpen] = useState(false);
+  const [reindexPhase, setReindexPhase] = useState<ReindexPhase>('confirm');
+  const [actionsMenuPdf, setActionsMenuPdf] = useState<GamePdfDto | null>(null);
+  const [deletePdfTarget, setDeletePdfTarget] = useState<GamePdfDto | null>(null);
+
+  // ─── Loading ──────────────────────────────────────────
+  if (statusQuery.isLoading || pdfsQuery.isLoading) {
+    return (
+      <div data-slot="kb-hub-skeleton" className="container mx-auto max-w-6xl space-y-4 px-4 py-8">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  // ─── Error ────────────────────────────────────────────
+  if (statusQuery.isError || pdfsQuery.isError) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-8">
+        <Alert variant="destructive" data-slot="kb-hub-error">
+          <AlertDescription>{t('pages.library.gameDetail.kb.errors.loadFailed')}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const status = statusQuery.data;
+  const pdfs = pdfsQuery.data ?? [];
+  const gameTitle = status?.gameId ?? gameId; // BE schema has no title; consumer falls back to id MVP
+
+  // ─── Labels (caller-side i18n resolution) ─────────────
+  const emptyLabels: EmptyStateLabels = {
+    title: t('pages.library.gameDetail.kb.empty.title'),
+    description: t('pages.library.gameDetail.kb.empty.description'),
+    ctaLabel: t('pages.library.gameDetail.kb.empty.ctaLabel'),
+    supportedFormats: t('pages.library.gameDetail.kb.empty.supportedFormats'),
+  };
+
+  const hubLabels: HubDefaultLabels = {
+    headerSubtitle: t('pages.library.gameDetail.kb.header.titleSuffix'),
+    uploadCta: t('pages.library.gameDetail.kb.header.uploadCta'),
+    reindexAllCta: t('pages.library.gameDetail.kb.header.reindexAllCta'),
+    statsStrip: {
+      docs: t('pages.library.gameDetail.kb.stats.docs', { count: status?.documentCount ?? 0 }),
+      chunks: t('pages.library.gameDetail.kb.stats.chunksTemplate'),
+      embeddings: t('pages.library.gameDetail.kb.stats.embeddingsTemplate'),
+      lastReindex: t('pages.library.gameDetail.kb.stats.lastReindexTemplate'),
+      coverage: t('pages.library.gameDetail.kb.stats.coverageStripLabel'),
+    },
+    coverage: {
+      None: t('pages.library.gameDetail.kb.stats.coverage.None'),
+      Basic: t('pages.library.gameDetail.kb.stats.coverage.Basic'),
+      Standard: t('pages.library.gameDetail.kb.stats.coverage.Standard'),
+      Complete: t('pages.library.gameDetail.kb.stats.coverage.Complete'),
+    },
+    columnHeaders: {
+      document: t('pages.library.gameDetail.kb.stats.columnHeaders.document'),
+      status: t('pages.library.gameDetail.kb.stats.columnHeaders.status'),
+      uploaded: t('pages.library.gameDetail.kb.stats.columnHeaders.uploaded'),
+    },
+    pdfRow: {
+      openCta: t('pages.library.gameDetail.kb.pdfRow.openCta'),
+      openAria: t('pages.library.gameDetail.kb.pdfRow.openAria'),
+      chunksLabel: t('pages.library.gameDetail.kb.pdfRow.chunksTemplate'),
+      status: {
+        ready: t('pages.library.gameDetail.kb.pdfRow.status.ready'),
+        indexing: t('pages.library.gameDetail.kb.pdfRow.status.indexing'),
+        stale: t('pages.library.gameDetail.kb.pdfRow.status.stale'),
+        failed: t('pages.library.gameDetail.kb.pdfRow.status.failed'),
+      },
+    },
+  };
+
+  const statsCardLabels: KbStatsCardLabels = {
+    cardTitle: t('pages.library.gameDetail.kb.stats.cardTitle'),
+    cardSubtitle: t('pages.library.gameDetail.kb.stats.cardSubtitle'),
+    docsLabel: t('pages.library.gameDetail.kb.stats.docsLabel'),
+    chunksLabel: t('pages.library.gameDetail.kb.stats.chunksLabel'),
+    embeddingsLabel: t('pages.library.gameDetail.kb.stats.embeddingsLabel'),
+    lastReindexLabel: t('pages.library.gameDetail.kb.stats.lastReindexLabel'),
+    raptorLabel: t('pages.library.gameDetail.kb.stats.raptorLabel'),
+    coverageLabel: t('pages.library.gameDetail.kb.stats.coverageLabel'),
+    coverage: {
+      None: t('pages.library.gameDetail.kb.stats.coverage.None'),
+      Basic: t('pages.library.gameDetail.kb.stats.coverage.Basic'),
+      Standard: t('pages.library.gameDetail.kb.stats.coverage.Standard'),
+      Complete: t('pages.library.gameDetail.kb.stats.coverage.Complete'),
+    },
+    lifetimeCostLabel: t('pages.library.gameDetail.kb.stats.lifetimeCostLabel'),
+    sparklineLabel: t('pages.library.gameDetail.kb.stats.sparklineLabel'),
+    sparklineStart: t('pages.library.gameDetail.kb.stats.sparklineStart'),
+    sparklineEnd: t('pages.library.gameDetail.kb.stats.sparklineEnd'),
+  };
+
+  const raptorLabels: RaptorPanelLabels = {
+    title: t('pages.library.gameDetail.kb.raptor.title'),
+    description: t('pages.library.gameDetail.kb.raptor.description'),
+    lockedBadge: t('pages.library.gameDetail.kb.raptor.lockedBadge'),
+    activeBadge: t('pages.library.gameDetail.kb.raptor.activeBadge'),
+    lockedNote: t('pages.library.gameDetail.kb.raptor.lockedNote'),
+    upgradeCta: t('pages.library.gameDetail.kb.raptor.upgradeCta'),
+    upgradeLink: t('pages.library.gameDetail.kb.raptor.upgradeLink'),
+    rebuildCta: t('pages.library.gameDetail.kb.raptor.rebuildCta'),
+    metrics: {
+      lastRebuild: t('pages.library.gameDetail.kb.raptor.metrics.lastRebuild'),
+      summaries: t('pages.library.gameDetail.kb.raptor.metrics.summaries'),
+    },
+    estimateLabel: t('pages.library.gameDetail.kb.raptor.estimateLabel'),
+    estimateDescription: t('pages.library.gameDetail.kb.raptor.estimateDescription'),
+  };
+
+  const reindexLabels: ReindexModalLabels = {
+    title: t('pages.library.gameDetail.kb.reindexModal.title'),
+    subtitle: t('pages.library.gameDetail.kb.reindexModal.subtitle', {
+      gameTitle,
+      docCount: status?.documentCount ?? 0,
+    }),
+    costHeader: t('pages.library.gameDetail.kb.reindexModal.costHeader'),
+    description: t('pages.library.gameDetail.kb.reindexModal.description'),
+    reindexCta: t('pages.library.gameDetail.kb.reindexModal.reindexCta'),
+    cancelCta: t('pages.library.gameDetail.kb.reindexModal.cancelCta'),
+    runningTitle: t('pages.library.gameDetail.kb.reindexModal.runningTitle'),
+    jobIdLabel: t('pages.library.gameDetail.kb.reindexModal.jobIdLabel'),
+    progressTemplate: t('pages.library.gameDetail.kb.reindexModal.progressTemplate'),
+    doneTitle: t('pages.library.gameDetail.kb.reindexModal.doneTitle'),
+    doneSummaryTemplate: t('pages.library.gameDetail.kb.reindexModal.doneSummaryTemplate'),
+    closeCta: t('pages.library.gameDetail.kb.reindexModal.closeCta'),
+  };
+
+  const deleteLabels: DeleteDialogLabels = {
+    title: t('pages.library.gameDetail.kb.delete.title'),
+    subtitlePrefix: t('pages.library.gameDetail.kb.delete.subtitlePrefix'),
+    listHeader: t('pages.library.gameDetail.kb.delete.listHeader'),
+    warning: t('pages.library.gameDetail.kb.delete.warning'),
+    deleteCta: t('pages.library.gameDetail.kb.delete.deleteCta'),
+    cancelCta: t('pages.library.gameDetail.kb.delete.cancelCta'),
+  };
+
+  const actionsMenuLabels: ActionsMenuLabels = {
+    headerSubtitle: t('pages.library.gameDetail.kb.actionsMenu.headerSubtitle'),
+    actions: {
+      open: {
+        label: t('pages.library.gameDetail.kb.actionsMenu.open.label'),
+        description: t('pages.library.gameDetail.kb.actionsMenu.open.description'),
+        icon: t('pages.library.gameDetail.kb.actionsMenu.open.icon'),
+      },
+      reindex: {
+        label: t('pages.library.gameDetail.kb.actionsMenu.reindex.label'),
+        description: t('pages.library.gameDetail.kb.actionsMenu.reindex.description'),
+        icon: t('pages.library.gameDetail.kb.actionsMenu.reindex.icon'),
+      },
+      cost: {
+        label: t('pages.library.gameDetail.kb.actionsMenu.cost.label'),
+        description: t('pages.library.gameDetail.kb.actionsMenu.cost.description'),
+        icon: t('pages.library.gameDetail.kb.actionsMenu.cost.icon'),
+      },
+      move: {
+        label: t('pages.library.gameDetail.kb.actionsMenu.move.label'),
+        description: t('pages.library.gameDetail.kb.actionsMenu.move.description'),
+        icon: t('pages.library.gameDetail.kb.actionsMenu.move.icon'),
+      },
+      delete: {
+        label: t('pages.library.gameDetail.kb.actionsMenu.delete.label'),
+        description: t('pages.library.gameDetail.kb.actionsMenu.delete.description'),
+        icon: t('pages.library.gameDetail.kb.actionsMenu.delete.icon'),
+      },
+    },
+  };
+
+  // ─── Action handlers ──────────────────────────────────
+  const isEmpty = pdfs.length === 0;
+  const game = { title: gameTitle, emoji: '📚' };
+
+  const handleUpload = (): void => {
+    // Upload flow is owned by another route; CTA acts as a no-op placeholder for MVP.
+    // Real wireup will route to the existing PDF upload page when the link is decided.
+  };
+
+  const handlePdfActionTrigger = (pdfId: string): void => {
+    const target = pdfs.find(p => p.id === pdfId) ?? null;
+    setActionsMenuPdf(target);
+  };
+
+  const handleActionSelect = (action: PdfAction): void => {
+    const current = actionsMenuPdf;
+    setActionsMenuPdf(null);
+    if (!current) return;
+    if (action === 'delete') {
+      setDeletePdfTarget(current);
+    }
+    // Other actions (open/reindex/cost/move) are deferred to follow-up wiring.
+  };
+
+  const handleReindexConfirm = async (): Promise<void> => {
+    setReindexPhase('running');
+    try {
+      await reindexMutation.mutateAsync();
+      setReindexPhase('done');
+    } catch {
+      setReindexOpen(false);
+      setReindexPhase('confirm');
+    }
+  };
+
+  const handleDeleteConfirm = async (): Promise<void> => {
+    if (!deletePdfTarget) return;
+    try {
+      await deleteMutation.mutateAsync(deletePdfTarget.id);
+    } finally {
+      setDeletePdfTarget(null);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-8">
+      {isEmpty ? (
+        <EmptyState gameTitle={gameTitle} labels={emptyLabels} onUpload={handleUpload} />
+      ) : (
+        <>
+          <HubDefault
+            game={game}
+            documentCount={status?.documentCount ?? 0}
+            coverageLevel={status?.coverageLevel ?? 'None'}
+            pdfs={mapPdfs(pdfs)}
+            labels={hubLabels}
+            onUpload={handleUpload}
+            onReindexAll={() => {
+              setReindexPhase('confirm');
+              setReindexOpen(true);
+            }}
+            onPdfAction={handlePdfActionTrigger}
+          />
+
+          <KbStatsCard
+            documentCount={status?.documentCount ?? 0}
+            coverageLevel={status?.coverageLevel ?? 'None'}
+            coverageScore={status?.coverageScore ?? 0}
+            labels={statsCardLabels}
+          />
+
+          <RaptorPanel tier="free" labels={raptorLabels} />
+        </>
+      )}
+
+      <ReindexModal
+        open={reindexOpen}
+        phase={reindexPhase}
+        labels={reindexLabels}
+        costRows={STATIC_REINDEX_COST_ROWS}
+        onConfirm={handleReindexConfirm}
+        onClose={() => {
+          setReindexOpen(false);
+          setReindexPhase('confirm');
+        }}
+      />
+
+      <DeleteDialog
+        open={!!deletePdfTarget}
+        pdfName={deletePdfTarget?.name ?? ''}
+        labels={deleteLabels}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeletePdfTarget(null)}
+      />
+
+      {actionsMenuPdf && (
+        <ActionsMenu
+          pdf={{
+            name: actionsMenuPdf.name,
+            sizeFormatted: formatFileSize(actionsMenuPdf.fileSizeBytes),
+            uploadedAtRelative: formatRelativeDate(actionsMenuPdf.uploadedAt),
+          }}
+          labels={actionsMenuLabels}
+          onSelect={handleActionSelect}
+          open
+          onOpenChange={open => !open && setActionsMenuPdf(null)}
+        >
+          <span data-slot="kb-hub-actions-menu-anchor" />
+        </ActionsMenu>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/[gameId]/kb/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/kb/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * KB Hub route — /library/[gameId]/kb (Issue #1481).
+ *
+ * Server component: validates params and renders the client orchestrator.
+ * The actual page logic lives in `_content.tsx` to allow direct testing
+ * of the orchestrator without route-level params resolution.
+ */
+
+import { KbHubContent } from './_content';
+
+export default async function KbHubRoute({ params }: { params: Promise<{ gameId: string }> }) {
+  const { gameId } = await params;
+  return <KbHubContent gameId={gameId} />;
+}

--- a/apps/web/src/components/features/kb-hub/ActionsMenu.tsx
+++ b/apps/web/src/components/features/kb-hub/ActionsMenu.tsx
@@ -1,0 +1,125 @@
+/**
+ * ActionsMenu — popover with 5 PDF row actions (open/reindex/cost/move/delete).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` ActionsMenu.
+ *
+ * Wraps Radix DropdownMenu primitive for keyboard nav + ESC close + focus return.
+ * Caller injects trigger via `children` slot.
+ */
+
+'use client';
+
+import type { ReactElement, ReactNode } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/navigation/dropdown-menu';
+
+export type PdfAction = 'open' | 'reindex' | 'cost' | 'move' | 'delete';
+
+export interface ActionsMenuItemLabel {
+  readonly label: string;
+  readonly description: string;
+  readonly icon: string;
+}
+
+export interface ActionsMenuLabels {
+  readonly headerSubtitle: string; // e.g. "{size} · {date}"
+  readonly actions: Record<PdfAction, ActionsMenuItemLabel>;
+}
+
+export interface ActionsMenuPdfHeader {
+  readonly name: string;
+  readonly sizeFormatted: string;
+  readonly uploadedAtRelative: string;
+}
+
+export interface ActionsMenuProps {
+  readonly pdf: ActionsMenuPdfHeader;
+  readonly labels: ActionsMenuLabels;
+  readonly onSelect: (action: PdfAction) => void;
+  readonly children: ReactNode;
+  readonly open?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+const ACTION_ORDER: ReadonlyArray<PdfAction> = ['open', 'reindex', 'cost', 'move', 'delete'];
+
+export function ActionsMenu(props: ActionsMenuProps): ReactElement {
+  const { pdf, labels, onSelect, children, open, onOpenChange } = props;
+  const headerSubtitle = labels.headerSubtitle
+    .replace('{size}', pdf.sizeFormatted)
+    .replace('{date}', pdf.uploadedAtRelative);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent
+        data-slot="kb-hub-actions-menu"
+        align="end"
+        className="w-64 border-entity-kb/20 bg-card shadow-lg"
+      >
+        <DropdownMenuLabel className="border-b border-entity-kb/10 bg-entity-kb/5 px-4 py-2.5">
+          <div className="flex items-center gap-2">
+            <span aria-hidden="true" className="text-sm">
+              📄
+            </span>
+            <div className="min-w-0">
+              <div className="truncate font-display text-xs font-bold text-foreground">
+                {pdf.name}
+              </div>
+              <div className="font-mono text-[10px] text-muted-foreground">{headerSubtitle}</div>
+            </div>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator className="my-0" />
+        {ACTION_ORDER.map((action, i) => {
+          const item = labels.actions[action];
+          const isDestructive = action === 'delete';
+          return (
+            <DropdownMenuItem
+              key={action}
+              data-slot={`kb-hub-actions-menu-${action}`}
+              onSelect={event => {
+                event.preventDefault();
+                onSelect(action);
+              }}
+              className={i > 0 ? 'border-t border-border/50' : undefined}
+            >
+              <div className="flex w-full items-center gap-3 py-1">
+                <span
+                  aria-hidden="true"
+                  className={
+                    isDestructive
+                      ? 'flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-destructive/10 text-sm text-destructive'
+                      : 'flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-entity-kb/10 text-sm text-entity-kb'
+                  }
+                >
+                  {item.icon}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={
+                      isDestructive
+                        ? 'font-display text-xs font-bold text-destructive'
+                        : 'font-display text-xs font-bold text-foreground'
+                    }
+                  >
+                    {item.label}
+                  </div>
+                  <div className="mt-0.5 text-[10px] text-muted-foreground">{item.description}</div>
+                </div>
+              </div>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/DeleteDialog.tsx
+++ b/apps/web/src/components/features/kb-hub/DeleteDialog.tsx
@@ -1,0 +1,106 @@
+/**
+ * DeleteDialog — confirmation dialog for PDF deletion with cleanup preview.
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` DeleteDialog.
+ *
+ * Custom Dialog (not ConfirmModal) because the mockup requires a cleanup list slot
+ * inside the modal body. ConfirmModal's flat title+message contract is insufficient.
+ * The destructive CTA mirrors ConfirmModal's destructive variant for visual parity.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export interface DeleteDialogCleanupItem {
+  readonly key: string;
+  readonly icon: string;
+  readonly label: string;
+}
+
+export interface DeleteDialogLabels {
+  readonly title: string;
+  readonly subtitlePrefix: string; // e.g. "PDF:"
+  readonly listHeader: string;
+  readonly warning: string;
+  readonly deleteCta: string;
+  readonly cancelCta: string;
+}
+
+export interface DeleteDialogProps {
+  readonly open: boolean;
+  readonly pdfName: string;
+  readonly labels: DeleteDialogLabels;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+  /** Optional cleanup metadata (P83 — hide entire block when undefined or empty). */
+  readonly cleanupItems?: ReadonlyArray<DeleteDialogCleanupItem>;
+}
+
+export function DeleteDialog(props: DeleteDialogProps): ReactElement {
+  const { open, pdfName, labels, onConfirm, onCancel, cleanupItems } = props;
+  const hasCleanup = cleanupItems !== undefined && cleanupItems.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen: boolean) => !isOpen && onCancel()}>
+      <DialogContent data-slot="kb-hub-delete-dialog" className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-destructive">{labels.title}</DialogTitle>
+          <DialogDescription>
+            {labels.subtitlePrefix} <span className="font-semibold">{pdfName}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {hasCleanup && (
+          <div
+            data-slot="kb-hub-delete-cleanup-list"
+            className="rounded-md border border-destructive/15 bg-destructive/5 px-4 py-3"
+          >
+            <div className="mb-2 font-mono text-xs font-bold uppercase tracking-wider text-destructive">
+              {labels.listHeader}
+            </div>
+            <ul className="space-y-1">
+              {cleanupItems!.map(item => (
+                <li
+                  key={item.key}
+                  className="flex items-center gap-2 border-b border-border/50 py-1 text-xs text-foreground last:border-b-0"
+                >
+                  <span aria-hidden="true">{item.icon}</span>
+                  <span>{item.label}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div
+          data-slot="kb-hub-delete-warning"
+          className="flex items-center gap-1.5 text-xs font-bold text-destructive"
+        >
+          <span aria-hidden="true">⚠️</span>
+          <span>{labels.warning}</span>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} data-slot="kb-hub-delete-cancel">
+            {labels.cancelCta}
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} data-slot="kb-hub-delete-confirm">
+            {labels.deleteCta}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/EmptyState.tsx
+++ b/apps/web/src/components/features/kb-hub/EmptyState.tsx
@@ -1,0 +1,62 @@
+/**
+ * EmptyState — KB hub empty state (no PDF indexed yet).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` State 2.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export interface EmptyStateLabels {
+  readonly title: string;
+  readonly description: string; // supports {gameTitle} placeholder
+  readonly ctaLabel: string;
+  readonly supportedFormats: string;
+}
+
+export interface EmptyStateProps {
+  readonly gameTitle: string;
+  readonly labels: EmptyStateLabels;
+  readonly onUpload: () => void;
+  readonly className?: string;
+}
+
+export function EmptyState(props: EmptyStateProps): ReactElement {
+  const { gameTitle, labels, onUpload, className } = props;
+  const description = labels.description.replace('{gameTitle}', gameTitle);
+
+  return (
+    <section
+      data-slot="kb-hub-empty-state"
+      className={clsx(
+        'rounded-2xl border border-dashed border-entity-kb/30 bg-card px-10 py-16 text-center shadow-sm',
+        className
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="mx-auto mb-5 inline-flex h-20 w-20 items-center justify-center rounded-full border-2 border-dashed border-entity-kb/25 bg-entity-kb/10 text-4xl"
+      >
+        📚
+      </div>
+      <h3 className="mb-2 font-display text-lg font-bold text-foreground">{labels.title}</h3>
+      <p className="mx-auto mb-6 max-w-sm text-sm leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+      <button
+        type="button"
+        onClick={onUpload}
+        data-slot="kb-hub-empty-upload-cta"
+        className="inline-flex items-center gap-2 rounded-md bg-entity-kb px-6 py-3 font-display text-sm font-bold text-white shadow-md transition-colors hover:bg-entity-kb/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+      >
+        <span aria-hidden="true">📤</span>
+        {labels.ctaLabel}
+      </button>
+      <p className="mt-4 text-xs text-muted-foreground">{labels.supportedFormats}</p>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -1,0 +1,226 @@
+/**
+ * HubDefault — KB hub default view (header + stats strip + PDF list).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` HubDefault.
+ *
+ * Composition of PdfRow children. Stats strip adaptive: hides metrics whose data
+ * is undefined (P83 graceful).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { PdfRow, type KbPdf, type PdfRowLabels } from './PdfRow';
+
+import type { CoverageLevel } from './KbStatsCard';
+
+export interface HubDefaultGameInfo {
+  readonly title: string;
+  readonly emoji?: string;
+  readonly coverGradient?: string; // CSS gradient string for cover thumb (optional)
+}
+
+export interface HubDefaultStatsStripLabels {
+  readonly docs: string; // "{count} documenti"
+  readonly chunks: string;
+  readonly embeddings: string;
+  readonly lastReindex: string; // "ultima reindex {relative}"
+  readonly coverage: string; // "Copertura: {level}"
+}
+
+export interface HubDefaultColumnHeaders {
+  readonly document: string;
+  readonly status: string;
+  readonly uploaded: string;
+}
+
+export interface HubDefaultCoverageLabels {
+  readonly None: string;
+  readonly Basic: string;
+  readonly Standard: string;
+  readonly Complete: string;
+}
+
+export interface HubDefaultLabels {
+  readonly headerSubtitle: string; // "Knowledge Base"
+  readonly uploadCta: string;
+  readonly reindexAllCta: string;
+  readonly statsStrip: HubDefaultStatsStripLabels;
+  readonly coverage: HubDefaultCoverageLabels;
+  readonly columnHeaders: HubDefaultColumnHeaders;
+  readonly pdfRow: PdfRowLabels;
+}
+
+export interface HubDefaultProps {
+  readonly game: HubDefaultGameInfo;
+  readonly documentCount: number;
+  readonly coverageLevel: CoverageLevel;
+  readonly pdfs: ReadonlyArray<KbPdf>;
+  readonly labels: HubDefaultLabels;
+  readonly onUpload: () => void;
+  readonly onReindexAll: () => void;
+  readonly onPdfAction: (pdfId: string) => void;
+  // Deferred (P83):
+  readonly chunks?: number;
+  readonly embeddings?: number;
+  readonly lastReindexRelative?: string;
+  readonly className?: string;
+}
+
+export function HubDefault(props: HubDefaultProps): ReactElement {
+  const {
+    game,
+    documentCount,
+    coverageLevel,
+    pdfs,
+    labels,
+    onUpload,
+    onReindexAll,
+    onPdfAction,
+    chunks,
+    embeddings,
+    lastReindexRelative,
+    className,
+  } = props;
+
+  const formatNumber = (n: number): string => n.toLocaleString('it-IT');
+
+  // Build stats strip dynamically — only include available metrics + coverage
+  const statsStripItems: ReadonlyArray<{ key: string; icon: string; text: string }> = [
+    {
+      key: 'docs',
+      icon: '📄',
+      text: labels.statsStrip.docs.replace('{count}', formatNumber(documentCount)),
+    },
+    ...(chunks !== undefined
+      ? [
+          {
+            key: 'chunks',
+            icon: '🧩',
+            text: labels.statsStrip.chunks.replace('{count}', formatNumber(chunks)),
+          },
+        ]
+      : []),
+    ...(embeddings !== undefined
+      ? [
+          {
+            key: 'embeddings',
+            icon: '🔗',
+            text: labels.statsStrip.embeddings.replace('{count}', formatNumber(embeddings)),
+          },
+        ]
+      : []),
+    ...(lastReindexRelative !== undefined
+      ? [
+          {
+            key: 'lastReindex',
+            icon: '🕐',
+            text: labels.statsStrip.lastReindex.replace('{relative}', lastReindexRelative),
+          },
+        ]
+      : []),
+    {
+      key: 'coverage',
+      icon: '✅',
+      text: labels.statsStrip.coverage.replace('{level}', labels.coverage[coverageLevel]),
+    },
+  ];
+
+  return (
+    <section
+      data-slot="kb-hub-hub-default"
+      className={clsx(
+        'overflow-hidden rounded-2xl border border-entity-kb/20 bg-card shadow-sm',
+        className
+      )}
+    >
+      {/* Header */}
+      <header className="border-b border-entity-kb/15 bg-gradient-to-br from-entity-kb/6 to-transparent px-6 pb-4 pt-5">
+        <div className="mb-2.5 flex items-center gap-3.5">
+          <div
+            aria-hidden="true"
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md border-2 border-foreground/15 text-2xl shadow-md"
+            style={{
+              background:
+                game.coverGradient ?? 'linear-gradient(135deg, hsl(0,35%,28%), hsl(20,30%,20%))',
+            }}
+          >
+            {game.emoji ?? '📚'}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="m-0 font-display text-lg font-extrabold text-foreground">
+                {game.title} · KB
+              </h2>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">{labels.headerSubtitle}</p>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <button
+              type="button"
+              onClick={onUpload}
+              data-slot="kb-hub-default-upload-cta"
+              className="rounded-md border border-entity-kb/25 bg-entity-kb/10 px-3.5 py-2 font-display text-xs font-bold text-entity-kb transition-colors hover:bg-entity-kb/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+            >
+              {labels.uploadCta}
+            </button>
+            <button
+              type="button"
+              onClick={onReindexAll}
+              data-slot="kb-hub-default-reindex-cta"
+              className="rounded-md bg-entity-kb px-3.5 py-2 font-display text-xs font-bold text-white shadow-md transition-colors hover:bg-entity-kb/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+            >
+              {labels.reindexAllCta}
+            </button>
+          </div>
+        </div>
+
+        {/* Stats strip */}
+        <div
+          data-slot="kb-hub-default-stats-strip"
+          className="flex flex-wrap items-center gap-1 rounded-md border border-entity-kb/10 bg-entity-kb/6 px-3.5 py-2.5"
+        >
+          {statsStripItems.map((s, i, arr) => (
+            <span key={s.key} className="inline-flex items-center gap-1">
+              <span aria-hidden="true" className="text-xs">
+                {s.icon}
+              </span>
+              <span className="font-mono text-[11px] font-semibold text-foreground">{s.text}</span>
+              {i < arr.length - 1 && (
+                <span aria-hidden="true" className="mx-1.5 text-muted-foreground opacity-50">
+                  ·
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      {/* Column headers */}
+      <div className="grid grid-cols-[32px_1fr_auto_auto_auto] gap-3 border-b border-border px-4 pb-1.5 pt-2">
+        <div aria-hidden="true" />
+        <div className="font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          {labels.columnHeaders.document}
+        </div>
+        <div className="font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          {labels.columnHeaders.status}
+        </div>
+        <div className="font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          {labels.columnHeaders.uploaded}
+        </div>
+        <div aria-hidden="true" />
+      </div>
+
+      {/* PDF rows */}
+      <div data-slot="kb-hub-default-pdf-list">
+        {pdfs.map(pdf => (
+          <PdfRow key={pdf.id} pdf={pdf} labels={labels.pdfRow} onActionClick={onPdfAction} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -87,7 +87,8 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
     className,
   } = props;
 
-  const formatNumber = (n: number): string => n.toLocaleString('it-IT');
+  // Locale resolved at runtime (caller's IntlProvider); avoids hardcoded it-IT divergence.
+  const formatNumber = (n: number): string => n.toLocaleString();
 
   // Build stats strip dynamically — only include available metrics + coverage
   const statsStripItems: ReadonlyArray<{ key: string; icon: string; text: string }> = [

--- a/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
+++ b/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
@@ -64,7 +64,9 @@ export function KbStatsCard(props: KbStatsCardProps): ReactElement {
     costHistory,
   } = props;
 
-  const formatNumber = (n: number): string => n.toLocaleString('it-IT');
+  // Locale resolved at runtime (caller decides via IntlProvider); avoids hardcoding it-IT
+  // which renders wrong output for English-locale users.
+  const formatNumber = (n: number): string => n.toLocaleString();
 
   // Metric grid items — only include those with data (P83 graceful hide)
   const metrics: ReadonlyArray<{

--- a/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
+++ b/apps/web/src/components/features/kb-hub/KbStatsCard.tsx
@@ -1,0 +1,230 @@
+/**
+ * KbStatsCard — KB coverage stats card (reusable primitive).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` KbStatsCard.
+ *
+ * Deferred fields (P83): chunks, embeddings, lastReindex, raptorLastRebuild, lifetimeCost,
+ * costHistory — hidden gracefully when undefined. BE schema enrichment in follow-up issue.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export type CoverageLevel = 'None' | 'Basic' | 'Standard' | 'Complete';
+
+export interface KbStatsCardLabels {
+  readonly cardTitle: string;
+  readonly cardSubtitle: string;
+  readonly docsLabel: string; // "Documenti"
+  readonly chunksLabel: string; // "Chunks"
+  readonly embeddingsLabel: string; // "Embeddings"
+  readonly lastReindexLabel: string; // "Ultima idx."
+  readonly raptorLabel: string; // "RAPTOR last"
+  readonly coverageLabel: string; // "Copertura"
+  readonly coverage: Record<CoverageLevel, string>;
+  readonly lifetimeCostLabel: string; // "Costo lifetime token"
+  readonly sparklineLabel: string; // "Consumo token · ultimi 7 gg"
+  readonly sparklineStart: string; // "-7gg"
+  readonly sparklineEnd: string; // "oggi"
+}
+
+export interface KbStatsCardProps {
+  readonly documentCount: number;
+  readonly coverageLevel: CoverageLevel;
+  readonly coverageScore: number; // 0-100
+  readonly labels: KbStatsCardLabels;
+  readonly compact?: boolean;
+  readonly className?: string;
+  // Deferred props (P83 — hide UI when undefined):
+  readonly chunks?: number;
+  readonly embeddings?: number;
+  readonly lastReindexRelative?: string;
+  readonly raptorLastRebuildRelative?: string;
+  readonly lifetimeCost?: string;
+  readonly costHistory?: ReadonlyArray<number>;
+}
+
+export function KbStatsCard(props: KbStatsCardProps): ReactElement {
+  const {
+    documentCount,
+    coverageLevel,
+    coverageScore,
+    labels,
+    compact = false,
+    className,
+    chunks,
+    embeddings,
+    lastReindexRelative,
+    raptorLastRebuildRelative,
+    lifetimeCost,
+    costHistory,
+  } = props;
+
+  const formatNumber = (n: number): string => n.toLocaleString('it-IT');
+
+  // Metric grid items — only include those with data (P83 graceful hide)
+  const metrics: ReadonlyArray<{
+    key: string;
+    icon: string;
+    label: string;
+    value: string;
+    color: string;
+  }> = [
+    {
+      key: 'docs',
+      icon: '📄',
+      label: labels.docsLabel,
+      value: formatNumber(documentCount),
+      color: 'text-entity-kb',
+    },
+    ...(chunks !== undefined
+      ? [
+          {
+            key: 'chunks',
+            icon: '🧩',
+            label: labels.chunksLabel,
+            value: formatNumber(chunks),
+            color: 'text-entity-kb',
+          },
+        ]
+      : []),
+    ...(embeddings !== undefined
+      ? [
+          {
+            key: 'embeddings',
+            icon: '🔗',
+            label: labels.embeddingsLabel,
+            value: formatNumber(embeddings),
+            color: 'text-entity-agent',
+          },
+        ]
+      : []),
+    ...(lastReindexRelative !== undefined
+      ? [
+          {
+            key: 'lastReindex',
+            icon: '🕐',
+            label: labels.lastReindexLabel,
+            value: lastReindexRelative,
+            color: 'text-entity-session',
+          },
+        ]
+      : []),
+    ...(raptorLastRebuildRelative !== undefined
+      ? [
+          {
+            key: 'raptor',
+            icon: '🦅',
+            label: labels.raptorLabel,
+            value: raptorLastRebuildRelative,
+            color: 'text-warning',
+          },
+        ]
+      : []),
+  ];
+
+  const maxSparklineVal = costHistory && costHistory.length > 0 ? Math.max(...costHistory) : 1;
+  const showSparkline = !compact && costHistory && costHistory.length > 0;
+  const showLifetimeCost = !compact && lifetimeCost !== undefined;
+  const gridCols =
+    metrics.length >= 4 ? 'grid-cols-4' : metrics.length === 3 ? 'grid-cols-3' : 'grid-cols-2';
+
+  return (
+    <section
+      data-slot="kb-hub-stats-card"
+      className={clsx(
+        'rounded-2xl border border-entity-kb/22 bg-card shadow-sm',
+        compact ? 'p-4' : 'p-5',
+        className
+      )}
+    >
+      {!compact && (
+        <header className="mb-4 flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="flex h-8 w-8 items-center justify-center rounded-md bg-entity-kb/12 text-base"
+          >
+            📊
+          </span>
+          <div>
+            <h3 className="font-display text-[13px] font-bold text-foreground">
+              {labels.cardTitle}
+            </h3>
+            <p className="text-[11px] text-muted-foreground">{labels.cardSubtitle}</p>
+          </div>
+        </header>
+      )}
+
+      {/* Metric grid (adaptive cols) */}
+      <div
+        data-slot="kb-hub-stats-metrics"
+        className={clsx('grid gap-3', gridCols, !compact && 'mb-4')}
+      >
+        {metrics.map(m => (
+          <div
+            key={m.key}
+            data-slot={`kb-hub-stats-metric-${m.key}`}
+            className="rounded-md bg-muted px-3 py-2.5 text-center"
+          >
+            <div aria-hidden="true" className="mb-1 text-lg">
+              {m.icon}
+            </div>
+            <div className={clsx('font-mono text-sm font-bold leading-tight', m.color)}>
+              {m.value}
+            </div>
+            <div className="mt-1 text-[10px] text-muted-foreground">{m.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {!compact && (
+        <div
+          data-slot="kb-hub-stats-coverage"
+          className="mb-3 flex items-center justify-between rounded-md border border-entity-kb/12 bg-entity-kb/6 px-3 py-2.5"
+        >
+          <span className="text-xs text-muted-foreground">{labels.coverageLabel}</span>
+          <span className="font-mono text-sm font-bold text-entity-kb">
+            {labels.coverage[coverageLevel]} · {coverageScore.toFixed(0)}%
+          </span>
+        </div>
+      )}
+
+      {showLifetimeCost && (
+        <div
+          data-slot="kb-hub-stats-lifetime-cost"
+          className="mb-3 flex items-center justify-between rounded-md border border-entity-kb/12 bg-entity-kb/6 px-3 py-2.5"
+        >
+          <span className="text-xs text-muted-foreground">{labels.lifetimeCostLabel}</span>
+          <span className="font-mono text-sm font-bold text-entity-kb">{lifetimeCost}</span>
+        </div>
+      )}
+
+      {showSparkline && (
+        <div data-slot="kb-hub-stats-sparkline">
+          <div className="mb-1.5 text-[10px] text-muted-foreground">{labels.sparklineLabel}</div>
+          <div className="flex items-end gap-1" style={{ height: 32 }}>
+            {costHistory!.map((v, i) => (
+              <div
+                key={i}
+                aria-hidden="true"
+                className={clsx(
+                  'flex-1 rounded-t-sm transition-all',
+                  i === costHistory!.length - 1 ? 'bg-entity-kb' : 'bg-entity-kb/35'
+                )}
+                style={{ height: `${Math.max(4, (v / maxSparklineVal) * 100)}%` }}
+              />
+            ))}
+          </div>
+          <div className="mt-1 flex justify-between font-mono text-[9px] text-muted-foreground">
+            <span>{labels.sparklineStart}</span>
+            <span>{labels.sparklineEnd}</span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/PdfRow.tsx
+++ b/apps/web/src/components/features/kb-hub/PdfRow.tsx
@@ -1,0 +1,120 @@
+/**
+ * PdfRow — single PDF row in KB hub list.
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` PdfRow.
+ *
+ * Status badge + chunks count hidden gracefully when undefined (P83 deferred fields).
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export type PdfStatus = 'ready' | 'indexing' | 'stale' | 'failed';
+
+export interface KbPdf {
+  readonly id: string;
+  readonly name: string;
+  readonly sizeFormatted: string;
+  readonly uploadedAtRelative: string;
+  readonly status?: PdfStatus;
+  readonly chunks?: number;
+}
+
+export interface PdfRowLabels {
+  readonly openCta: string;
+  readonly openAria: string; // supports {pdfName}
+  readonly chunksLabel: string; // supports {count}
+  readonly status: Record<PdfStatus, string>;
+}
+
+export interface PdfRowProps {
+  readonly pdf: KbPdf;
+  readonly labels: PdfRowLabels;
+  readonly onActionClick: (pdfId: string) => void;
+  readonly className?: string;
+}
+
+const STATUS_BG: Record<PdfStatus, string> = {
+  ready: 'bg-emerald-600 text-white',
+  indexing: 'bg-amber-500 text-white',
+  stale: 'bg-slate-500 text-white',
+  failed: 'bg-destructive text-white',
+};
+
+export function PdfRow(props: PdfRowProps): ReactElement {
+  const { pdf, labels, onActionClick, className } = props;
+  const ariaLabel = labels.openAria.replace('{pdfName}', pdf.name);
+
+  return (
+    <div
+      data-slot="kb-hub-pdf-row"
+      data-pdf-id={pdf.id}
+      className={clsx(
+        'grid grid-cols-[32px_1fr_auto_auto_auto] items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-muted/50',
+        className
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="flex h-8 w-8 items-center justify-center rounded-md bg-entity-kb/12 text-base"
+      >
+        📄
+      </div>
+
+      <div className="min-w-0">
+        <div className="truncate font-display text-sm font-semibold text-foreground">
+          {pdf.name}
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          <span>{pdf.sizeFormatted}</span>
+          {pdf.chunks !== undefined && pdf.chunks > 0 && (
+            <span className="ml-2 font-mono text-entity-kb/80">
+              {labels.chunksLabel.replace('{count}', String(pdf.chunks))}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {pdf.status ? (
+        <span
+          data-slot="kb-hub-pdf-status"
+          className={clsx(
+            'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-display text-[10px] font-bold uppercase tracking-wider',
+            STATUS_BG[pdf.status]
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={clsx(
+              // Inherits white text color from the parent badge (STATUS_BG includes text-white)
+              // → bg-current/60 paints the dot in the same color at 60% alpha.
+              'h-1.5 w-1.5 rounded-full bg-current/60',
+              pdf.status === 'indexing' && 'animate-pulse'
+            )}
+          />
+          {labels.status[pdf.status]}
+        </span>
+      ) : (
+        <span data-slot="kb-hub-pdf-status-empty" />
+      )}
+
+      <div className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+        {pdf.uploadedAtRelative}
+      </div>
+
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => onActionClick(pdf.id)}
+        data-slot="kb-hub-pdf-action"
+        className="inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-entity-kb/20 bg-entity-kb/8 px-3 py-1.5 font-display text-xs font-bold text-entity-kb transition-colors hover:bg-entity-kb/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+      >
+        {labels.openCta} →
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/RaptorPanel.tsx
+++ b/apps/web/src/components/features/kb-hub/RaptorPanel.tsx
@@ -1,0 +1,213 @@
+/**
+ * RaptorPanel — RAPTOR rebuild panel (free locked / pro active variants).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` RaptorPanel.
+ *
+ * MVP defaults tier='free' (no user tier data from BE yet). Mockup gold replaced
+ * with semantic `text-warning` / `bg-warning` for AA-safe DS-15 conformity.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+export type RaptorTier = 'free' | 'pro';
+
+export interface RaptorPanelLabels {
+  readonly title: string;
+  readonly description: string;
+  readonly lockedBadge: string;
+  readonly activeBadge: string;
+  readonly lockedNote: string;
+  readonly upgradeCta: string;
+  readonly upgradeLink: string;
+  readonly rebuildCta: string;
+  readonly metrics: {
+    readonly lastRebuild: string;
+    readonly summaries: string;
+  };
+  readonly estimateLabel: string; // "Stima operazione"
+  readonly estimateDescription: string; // supports {chunks}
+}
+
+export interface RaptorPanelProps {
+  readonly tier: RaptorTier;
+  readonly labels: RaptorPanelLabels;
+  readonly onRebuild?: () => void;
+  readonly onUpgrade?: () => void;
+  // Deferred (P83):
+  readonly lastRebuildRelative?: string;
+  readonly summariesCount?: number;
+  readonly estimateChunks?: number;
+  readonly estimatedCost?: string;
+  readonly estimatedDuration?: string;
+  readonly className?: string;
+}
+
+export function RaptorPanel(props: RaptorPanelProps): ReactElement {
+  const {
+    tier,
+    labels,
+    onRebuild,
+    onUpgrade,
+    lastRebuildRelative,
+    summariesCount,
+    estimateChunks,
+    estimatedCost,
+    estimatedDuration,
+    className,
+  } = props;
+
+  const locked = tier === 'free';
+
+  const metrics: ReadonlyArray<{ key: string; label: string; value: string }> = [
+    ...(lastRebuildRelative !== undefined
+      ? [{ key: 'lastRebuild', label: labels.metrics.lastRebuild, value: lastRebuildRelative }]
+      : []),
+    ...(summariesCount !== undefined
+      ? [{ key: 'summaries', label: labels.metrics.summaries, value: String(summariesCount) }]
+      : []),
+  ];
+
+  const showEstimate =
+    !locked &&
+    estimateChunks !== undefined &&
+    (estimatedCost !== undefined || estimatedDuration !== undefined);
+
+  return (
+    <section
+      data-slot="kb-hub-raptor-panel"
+      data-tier={tier}
+      className={clsx(
+        'overflow-hidden rounded-2xl border bg-card shadow-sm',
+        locked ? 'border-border opacity-90' : 'border-warning/35',
+        className
+      )}
+    >
+      <header
+        className={clsx(
+          'flex items-center gap-2.5 border-b px-5 pb-3 pt-4',
+          locked ? 'border-border bg-muted' : 'border-warning/18 bg-warning/6'
+        )}
+      >
+        <span aria-hidden="true" className="text-2xl">
+          🦅
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-display text-sm font-extrabold text-foreground">
+              {labels.title}
+            </span>
+            <span
+              data-slot="kb-hub-raptor-badge"
+              className={clsx(
+                'rounded-full border px-2 py-0.5 font-mono text-[9px] font-extrabold uppercase tracking-wider',
+                locked
+                  ? 'border-warning/25 bg-warning/15 text-warning'
+                  : 'border-warning/0 bg-warning text-white'
+              )}
+            >
+              {locked ? labels.lockedBadge : labels.activeBadge}
+            </span>
+          </div>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">{labels.description}</p>
+        </div>
+      </header>
+
+      <div className="px-5 py-4">
+        {metrics.length > 0 && (
+          <div data-slot="kb-hub-raptor-metrics" className="mb-3.5 grid grid-cols-2 gap-2.5">
+            {metrics.map(m => (
+              <div key={m.key} className="rounded-md bg-muted px-3 py-2">
+                <div
+                  className={clsx(
+                    'font-mono text-sm font-bold',
+                    locked ? 'text-muted-foreground' : 'text-warning'
+                  )}
+                >
+                  {m.value}
+                </div>
+                <div className="mt-0.5 text-[10px] text-muted-foreground">{m.label}</div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {locked ? (
+          <>
+            <div
+              data-slot="kb-hub-raptor-locked-note"
+              className="mb-3.5 flex items-start gap-2.5 rounded-md border border-dashed border-border-strong bg-muted px-3.5 py-2.5"
+            >
+              <span aria-hidden="true" className="shrink-0 text-base">
+                🔒
+              </span>
+              <p className="text-xs leading-relaxed text-muted-foreground">{labels.lockedNote}</p>
+            </div>
+            <button
+              type="button"
+              disabled
+              data-slot="kb-hub-raptor-upgrade-cta"
+              className="w-full cursor-not-allowed rounded-md border border-border bg-muted px-4 py-2.5 font-display text-sm font-bold text-muted-foreground opacity-50"
+            >
+              {labels.upgradeCta}
+            </button>
+            {onUpgrade && (
+              <div className="mt-2.5 text-center">
+                <button
+                  type="button"
+                  onClick={onUpgrade}
+                  data-slot="kb-hub-raptor-upgrade-link"
+                  className="text-xs font-semibold text-warning hover:underline"
+                >
+                  {labels.upgradeLink} →
+                </button>
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            {showEstimate && (
+              <div
+                data-slot="kb-hub-raptor-estimate"
+                className="mb-3.5 flex items-center justify-between rounded-md border border-warning/20 bg-warning/8 px-3.5 py-2.5"
+              >
+                <div>
+                  <div className="text-xs font-bold text-foreground">{labels.estimateLabel}</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    {labels.estimateDescription.replace(
+                      '{chunks}',
+                      estimateChunks!.toLocaleString('it-IT')
+                    )}
+                  </div>
+                </div>
+                <div className="text-right">
+                  {estimatedCost && (
+                    <div className="font-mono text-base font-extrabold text-warning">
+                      {estimatedCost}
+                    </div>
+                  )}
+                  {estimatedDuration && (
+                    <div className="text-[10px] text-muted-foreground">{estimatedDuration}</div>
+                  )}
+                </div>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={onRebuild}
+              data-slot="kb-hub-raptor-rebuild-cta"
+              // eslint-disable-next-line local/no-hardcoded-color-utility -- text-white on bg-warning matches the mockup .e-bg pattern; bg-warning is a semantic token but not in the rule's exempt list (primary/secondary/accent only). Same pattern in line 108 above.
+              className="w-full rounded-md bg-warning px-4 py-2.5 font-display text-sm font-bold text-white shadow-md transition-colors hover:bg-warning/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-warning focus-visible:ring-offset-2"
+            >
+              {labels.rebuildCta}
+            </button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/RaptorPanel.tsx
+++ b/apps/web/src/components/features/kb-hub/RaptorPanel.tsx
@@ -180,7 +180,7 @@ export function RaptorPanel(props: RaptorPanelProps): ReactElement {
                   <div className="text-[11px] text-muted-foreground">
                     {labels.estimateDescription.replace(
                       '{chunks}',
-                      estimateChunks!.toLocaleString('it-IT')
+                      estimateChunks!.toLocaleString()
                     )}
                   </div>
                 </div>

--- a/apps/web/src/components/features/kb-hub/ReindexModal.tsx
+++ b/apps/web/src/components/features/kb-hub/ReindexModal.tsx
@@ -205,8 +205,8 @@ export function ReindexModal(props: ReindexModalProps): ReactElement {
             {summary && (
               <div className="text-xs text-muted-foreground">
                 {labels.doneSummaryTemplate
-                  .replace('{chunks}', summary.chunks.toLocaleString('it-IT'))
-                  .replace('{embeddings}', summary.embeddings.toLocaleString('it-IT'))
+                  .replace('{chunks}', summary.chunks.toLocaleString())
+                  .replace('{embeddings}', summary.embeddings.toLocaleString())
                   .replace('{cost}', summary.actualCost)}
               </div>
             )}

--- a/apps/web/src/components/features/kb-hub/ReindexModal.tsx
+++ b/apps/web/src/components/features/kb-hub/ReindexModal.tsx
@@ -1,0 +1,223 @@
+/**
+ * ReindexModal — re-index full KB modal with FSM (confirm → running → done).
+ *
+ * Pure presentational. Issue #1481.
+ * Mapped from `admin-mockups/design_files/sp4-kb-hub.jsx` ReindexModal.
+ *
+ * FSM contract:
+ *   - phase='confirm': cost breakdown + Re-index/Annulla CTAs
+ *   - phase='running': spinner + progress bar + jobId (optional)
+ *   - phase='done': success badge + summary + Chiudi CTA
+ * Caller owns FSM transitions and mutation lifecycle.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+
+export type ReindexPhase = 'confirm' | 'running' | 'done';
+
+export interface ReindexCostRow {
+  readonly key: string;
+  readonly label: string;
+  readonly value: string;
+  readonly unit?: string;
+  readonly bold?: boolean;
+}
+
+export interface ReindexModalLabels {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly costHeader: string;
+  readonly description: string;
+  readonly reindexCta: string;
+  readonly cancelCta: string;
+  readonly runningTitle: string;
+  readonly jobIdLabel: string;
+  readonly progressTemplate: string; // "{processed} / {total} chunks"
+  readonly doneTitle: string;
+  readonly doneSummaryTemplate: string; // "{chunks} chunks · {embeddings} embeddings · costo reale {cost}"
+  readonly closeCta: string;
+}
+
+export interface ReindexModalProgress {
+  readonly current: number;
+  readonly total: number;
+  readonly jobId?: string;
+}
+
+export interface ReindexModalSummary {
+  readonly chunks: number;
+  readonly embeddings: number;
+  readonly actualCost: string;
+}
+
+export interface ReindexModalProps {
+  readonly open: boolean;
+  readonly phase: ReindexPhase;
+  readonly labels: ReindexModalLabels;
+  readonly costRows: ReadonlyArray<ReindexCostRow>;
+  readonly onConfirm: () => void;
+  readonly onClose: () => void;
+  readonly progress?: ReindexModalProgress;
+  readonly summary?: ReindexModalSummary;
+}
+
+export function ReindexModal(props: ReindexModalProps): ReactElement {
+  const { open, phase, labels, costRows, onConfirm, onClose, progress, summary } = props;
+
+  const handleOpenChange = (isOpen: boolean): void => {
+    if (!isOpen) onClose();
+  };
+
+  const progressPct =
+    progress && progress.total > 0
+      ? Math.min(100, Math.round((progress.current / progress.total) * 100))
+      : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-slot="kb-hub-reindex-modal" data-phase={phase} className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            <span aria-hidden="true" className="mr-2">
+              ⟳
+            </span>
+            {phase === 'confirm'
+              ? labels.title
+              : phase === 'running'
+                ? labels.runningTitle
+                : labels.doneTitle}
+          </DialogTitle>
+          {phase === 'confirm' && <DialogDescription>{labels.subtitle}</DialogDescription>}
+        </DialogHeader>
+
+        {phase === 'confirm' && (
+          <>
+            <div
+              data-slot="kb-hub-reindex-cost-table"
+              className="overflow-hidden rounded-md border border-border bg-muted"
+            >
+              <div className="border-b border-border px-3.5 py-2 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                {labels.costHeader}
+              </div>
+              {costRows.map(row => (
+                <div
+                  key={row.key}
+                  className={
+                    row.bold
+                      ? 'flex items-center justify-between border-b border-border/50 bg-entity-kb/6 px-3.5 py-2 last:border-b-0'
+                      : 'flex items-center justify-between border-b border-border/50 px-3.5 py-2 last:border-b-0'
+                  }
+                >
+                  <span
+                    className={
+                      row.bold
+                        ? 'text-xs font-bold text-foreground'
+                        : 'text-xs text-muted-foreground'
+                    }
+                  >
+                    {row.label}
+                  </span>
+                  <span
+                    className={
+                      row.bold
+                        ? 'font-mono text-[13px] font-extrabold text-entity-kb'
+                        : 'font-mono text-[11px] text-muted-foreground'
+                    }
+                  >
+                    {row.value}
+                    {row.unit && <span className="ml-0.5 text-[9px] opacity-60">{row.unit}</span>}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs leading-relaxed text-muted-foreground">{labels.description}</p>
+            <DialogFooter>
+              <Button variant="outline" onClick={onClose} data-slot="kb-hub-reindex-cancel">
+                {labels.cancelCta}
+              </Button>
+              <Button onClick={onConfirm} data-slot="kb-hub-reindex-confirm">
+                {labels.reindexCta}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {phase === 'running' && (
+          <div
+            data-slot="kb-hub-reindex-running"
+            role="status"
+            aria-live="polite"
+            className="space-y-3 py-2 text-center"
+          >
+            <div
+              aria-hidden="true"
+              className="mx-auto h-12 w-12 animate-spin rounded-full border-[3px] border-entity-kb/20 border-t-entity-kb"
+            />
+            {progress?.jobId && (
+              <div className="text-xs text-muted-foreground">
+                {labels.jobIdLabel}:{' '}
+                <code className="font-mono text-entity-kb">{progress.jobId}</code>
+              </div>
+            )}
+            <div className="h-1.5 overflow-hidden rounded bg-muted">
+              <div
+                aria-hidden="true"
+                className="h-full rounded bg-entity-kb transition-all"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            {progress && (
+              <div className="font-mono text-[11px] text-muted-foreground">
+                {labels.progressTemplate
+                  .replace('{processed}', String(progress.current))
+                  .replace('{total}', String(progress.total))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {phase === 'done' && (
+          <div
+            data-slot="kb-hub-reindex-done"
+            role="status"
+            aria-live="polite"
+            className="space-y-3 py-2 text-center"
+          >
+            <div
+              aria-hidden="true"
+              className="mx-auto flex h-13 w-13 items-center justify-center rounded-full bg-emerald-500 text-2xl text-white"
+              style={{ width: 52, height: 52 }}
+            >
+              ✓
+            </div>
+            {summary && (
+              <div className="text-xs text-muted-foreground">
+                {labels.doneSummaryTemplate
+                  .replace('{chunks}', summary.chunks.toLocaleString('it-IT'))
+                  .replace('{embeddings}', summary.embeddings.toLocaleString('it-IT'))
+                  .replace('{cost}', summary.actualCost)}
+              </div>
+            )}
+            <DialogFooter>
+              <Button onClick={onClose} data-slot="kb-hub-reindex-close">
+                {labels.closeCta}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/features/kb-hub/__tests__/ActionsMenu.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/ActionsMenu.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ActionsMenu } from '../ActionsMenu';
+
+const baseLabels = {
+  headerSubtitle: '{size} · {date}',
+  actions: {
+    open: { label: 'Apri dettaglio', description: 'Visualizza chunks e preview', icon: '↗' },
+    reindex: { label: 'Re-index', description: 'Rielabora embedding PDF', icon: '⟳' },
+    cost: { label: 'Statistiche costo', description: 'Token consumati e costo', icon: '📋' },
+    move: { label: 'Sposta in altro gioco', description: 'Sposta in altra scheda KB', icon: '📦' },
+    delete: { label: 'Elimina', description: 'Rimuovi PDF e cleanup', icon: '🗑' },
+  },
+};
+
+const basePdf = {
+  name: 'Rulebook v2',
+  sizeFormatted: '45 MB',
+  uploadedAtRelative: '2 gg fa',
+};
+
+describe('ActionsMenu (Issue #1481)', () => {
+  it('renders trigger child', () => {
+    render(
+      <ActionsMenu pdf={basePdf} labels={baseLabels} onSelect={() => {}}>
+        <button type="button">trigger</button>
+      </ActionsMenu>
+    );
+    expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();
+  });
+
+  it('renders all 5 actions + header subtitle when open', () => {
+    render(
+      <ActionsMenu pdf={basePdf} labels={baseLabels} onSelect={() => {}} open>
+        <button type="button">trigger</button>
+      </ActionsMenu>
+    );
+    expect(screen.getByText('Apri dettaglio')).toBeInTheDocument();
+    expect(screen.getByText('Re-index')).toBeInTheDocument();
+    expect(screen.getByText('Statistiche costo')).toBeInTheDocument();
+    expect(screen.getByText('Sposta in altro gioco')).toBeInTheDocument();
+    expect(screen.getByText('Elimina')).toBeInTheDocument();
+    expect(screen.getByText('45 MB · 2 gg fa')).toBeInTheDocument();
+  });
+
+  it('invokes onSelect with correct action key when item clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ActionsMenu pdf={basePdf} labels={baseLabels} onSelect={onSelect} open>
+        <button type="button">trigger</button>
+      </ActionsMenu>
+    );
+    fireEvent.click(screen.getByText('Elimina'));
+    expect(onSelect).toHaveBeenCalledWith('delete');
+  });
+
+  it('marks delete action as destructive (uses destructive style data-slot)', () => {
+    render(
+      <ActionsMenu pdf={basePdf} labels={baseLabels} onSelect={() => {}} open>
+        <button type="button">trigger</button>
+      </ActionsMenu>
+    );
+    // DropdownMenuContent renders through a Radix Portal, so we query the document.
+    expect(document.querySelector('[data-slot="kb-hub-actions-menu-delete"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="kb-hub-actions-menu-open"]')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/DeleteDialog.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/DeleteDialog.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DeleteDialog } from '../DeleteDialog';
+
+const baseLabels = {
+  title: 'Confermi eliminazione PDF?',
+  subtitlePrefix: 'PDF:',
+  listHeader: 'Verrà eliminato definitivamente:',
+  warning: 'Operazione irreversibile — nessun backup disponibile',
+  deleteCta: 'Elimina definitivamente',
+  cancelCta: 'Annulla',
+};
+
+describe('DeleteDialog (Issue #1481)', () => {
+  it('does not render content when open=false', () => {
+    render(
+      <DeleteDialog
+        open={false}
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(screen.queryByText('Confermi eliminazione PDF?')).not.toBeInTheDocument();
+  });
+
+  it('renders title, pdfName, warning, and both CTAs when open', () => {
+    render(
+      <DeleteDialog
+        open
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(screen.getByText('Confermi eliminazione PDF?')).toBeInTheDocument();
+    expect(screen.getByText('Rulebook v2')).toBeInTheDocument();
+    expect(screen.getByText(/Operazione irreversibile/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Annulla' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Elimina definitivamente' })).toBeInTheDocument();
+  });
+
+  it('hides cleanup list when cleanupItems undefined (P83)', () => {
+    render(
+      <DeleteDialog
+        open
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    // DialogContent renders through a Radix Portal — query document, not container.
+    expect(
+      document.querySelector('[data-slot="kb-hub-delete-cleanup-list"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders cleanup list when cleanupItems provided', () => {
+    const cleanupItems = [
+      { key: 'pdf', icon: '📄', label: 'PDF file — 45 MB' },
+      { key: 'chunks', icon: '🧩', label: '312 chunk embeddings' },
+    ];
+    render(
+      <DeleteDialog
+        open
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        cleanupItems={cleanupItems}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(document.querySelector('[data-slot="kb-hub-delete-cleanup-list"]')).toBeInTheDocument();
+    expect(screen.getByText('PDF file — 45 MB')).toBeInTheDocument();
+    expect(screen.getByText('312 chunk embeddings')).toBeInTheDocument();
+  });
+
+  it('invokes onConfirm when destructive CTA clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteDialog
+        open
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Elimina definitivamente' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onCancel when cancel CTA clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <DeleteDialog
+        open
+        pdfName="Rulebook v2"
+        labels={baseLabels}
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/EmptyState.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/EmptyState.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EmptyState } from '../EmptyState';
+
+const baseLabels = {
+  title: 'Nessun PDF indicizzato',
+  description: 'Carica il primo documento PDF per indicizzare le regole di {gameTitle}.',
+  ctaLabel: 'Carica primo documento',
+  supportedFormats: 'Formati supportati: PDF · Max 200 MB per file',
+};
+
+describe('EmptyState (Issue #1481)', () => {
+  it('renders title, description (with gameTitle), CTA and supported formats', () => {
+    render(<EmptyState gameTitle="Gloomhaven" labels={baseLabels} onUpload={() => {}} />);
+    expect(screen.getByText('Nessun PDF indicizzato')).toBeInTheDocument();
+    expect(
+      screen.getByText('Carica il primo documento PDF per indicizzare le regole di Gloomhaven.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Carica primo documento/i })).toBeInTheDocument();
+    expect(screen.getByText(/Formati supportati: PDF/)).toBeInTheDocument();
+  });
+
+  it('invokes onUpload when CTA clicked', () => {
+    const onUpload = vi.fn();
+    render(<EmptyState gameTitle="Test" labels={baseLabels} onUpload={onUpload} />);
+    fireEvent.click(screen.getByRole('button', { name: /Carica primo documento/i }));
+    expect(onUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses data-slot attribute for regression guards', () => {
+    const { container } = render(
+      <EmptyState gameTitle="Test" labels={baseLabels} onUpload={() => {}} />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-empty-state"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-empty-upload-cta"]')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HubDefault } from '../HubDefault';
+import type { KbPdf } from '../PdfRow';
+
+const baseLabels = {
+  headerSubtitle: 'Knowledge Base',
+  uploadCta: '+ Carica PDF',
+  reindexAllCta: '⟳ Re-index all',
+  statsStrip: {
+    docs: '{count} documenti',
+    chunks: '{count} chunks',
+    embeddings: '{count} embeddings',
+    lastReindex: 'ultima reindex {relative}',
+    coverage: 'Copertura: {level}',
+  },
+  coverage: {
+    None: 'Nessuna',
+    Basic: 'Base',
+    Standard: 'Standard',
+    Complete: 'Completa',
+  },
+  columnHeaders: {
+    document: 'Documento',
+    status: 'Stato',
+    uploaded: 'Caricato',
+  },
+  pdfRow: {
+    openCta: 'Apri',
+    openAria: 'Apri dettaglio {pdfName}',
+    chunksLabel: '{count} chunks',
+    status: {
+      ready: 'Ready',
+      indexing: 'Indexing',
+      stale: 'Stale',
+      failed: 'Failed',
+    },
+  },
+};
+
+const basePdfs: KbPdf[] = [
+  { id: 'p1', name: 'Rulebook v2', sizeFormatted: '45 MB', uploadedAtRelative: '2 gg fa' },
+  { id: 'p2', name: 'Scenario Book', sizeFormatted: '62 MB', uploadedAtRelative: '5 gg fa' },
+];
+
+const baseGame = { title: 'Gloomhaven', emoji: '⚔️' };
+
+describe('HubDefault (Issue #1481)', () => {
+  it('renders game title with " · KB" suffix and header subtitle', () => {
+    render(
+      <HubDefault
+        game={baseGame}
+        documentCount={12}
+        coverageLevel="Standard"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    expect(screen.getByText('Gloomhaven · KB')).toBeInTheDocument();
+    expect(screen.getByText('Knowledge Base')).toBeInTheDocument();
+  });
+
+  it('renders stats strip with docs + coverage by default (P83 hides others)', () => {
+    const { container } = render(
+      <HubDefault
+        game={baseGame}
+        documentCount={12}
+        coverageLevel="Standard"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-default-stats-strip"]')).toBeInTheDocument();
+    expect(screen.getByText('12 documenti')).toBeInTheDocument();
+    expect(screen.getByText('Copertura: Standard')).toBeInTheDocument();
+    expect(screen.queryByText(/chunks$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/embeddings$/)).not.toBeInTheDocument();
+  });
+
+  it('renders deferred stats strip metrics when chunks/embeddings/lastReindex provided', () => {
+    render(
+      <HubDefault
+        game={baseGame}
+        documentCount={12}
+        coverageLevel="Complete"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        chunks={1247}
+        embeddings={4891}
+        lastReindexRelative="3 gg fa"
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    // Locale-tolerant: jsdom may render "1247" instead of "1.247" (it-IT thousand sep).
+    expect(screen.getByText(/^1[.,]?247 chunks$/)).toBeInTheDocument();
+    expect(screen.getByText(/^4[.,]?891 embeddings$/)).toBeInTheDocument();
+    expect(screen.getByText('ultima reindex 3 gg fa')).toBeInTheDocument();
+  });
+
+  it('renders PDF list with one row per pdf', () => {
+    const { container } = render(
+      <HubDefault
+        game={baseGame}
+        documentCount={2}
+        coverageLevel="Basic"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        onUpload={() => {}}
+        onReindexAll={() => {}}
+        onPdfAction={() => {}}
+      />
+    );
+    expect(container.querySelectorAll('[data-slot="kb-hub-pdf-row"]')).toHaveLength(2);
+    expect(screen.getByText('Rulebook v2')).toBeInTheDocument();
+    expect(screen.getByText('Scenario Book')).toBeInTheDocument();
+  });
+
+  it('invokes onUpload + onReindexAll + onPdfAction handlers', () => {
+    const onUpload = vi.fn();
+    const onReindexAll = vi.fn();
+    const onPdfAction = vi.fn();
+    render(
+      <HubDefault
+        game={baseGame}
+        documentCount={2}
+        coverageLevel="Standard"
+        pdfs={basePdfs}
+        labels={baseLabels}
+        onUpload={onUpload}
+        onReindexAll={onReindexAll}
+        onPdfAction={onPdfAction}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '+ Carica PDF' }));
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: '⟳ Re-index all' }));
+    expect(onReindexAll).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: /Apri dettaglio Rulebook v2/ }));
+    expect(onPdfAction).toHaveBeenCalledWith('p1');
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { KbStatsCard } from '../KbStatsCard';
+
+const baseLabels = {
+  cardTitle: 'KB Coverage Stats',
+  cardSubtitle: 'Metriche indicizzazione',
+  docsLabel: 'Documenti',
+  chunksLabel: 'Chunks',
+  embeddingsLabel: 'Embeddings',
+  lastReindexLabel: 'Ultima idx.',
+  raptorLabel: 'RAPTOR last',
+  coverageLabel: 'Copertura KB',
+  coverage: {
+    None: 'Nessuna',
+    Basic: 'Base',
+    Standard: 'Standard',
+    Complete: 'Completa',
+  },
+  lifetimeCostLabel: 'Costo lifetime token',
+  sparklineLabel: 'Consumo token · ultimi 7 gg',
+  sparklineStart: '-7gg',
+  sparklineEnd: 'oggi',
+};
+
+describe('KbStatsCard (Issue #1481)', () => {
+  it('renders required fields: documentCount, coverageLevel, coverageScore', () => {
+    render(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Standard"
+        coverageScore={73}
+        labels={baseLabels}
+      />
+    );
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('Documenti')).toBeInTheDocument();
+    expect(screen.getByText(/Standard · 73%/)).toBeInTheDocument();
+  });
+
+  it('hides deferred metric tiles when corresponding props undefined (P83)', () => {
+    const { container } = render(
+      <KbStatsCard documentCount={12} coverageLevel="None" coverageScore={0} labels={baseLabels} />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-stats-metric-docs"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-chunks"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-embeddings"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-lastReindex"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-raptor"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders deferred metric tiles when corresponding props provided', () => {
+    const { container } = render(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Complete"
+        coverageScore={100}
+        chunks={1247}
+        embeddings={4891}
+        lastReindexRelative="3 gg fa"
+        raptorLastRebuildRelative="12 gg fa"
+        labels={baseLabels}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-stats-metric-chunks"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-embeddings"]')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-metric-lastReindex"]')
+    ).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-stats-metric-raptor"]')).toBeInTheDocument();
+    // Locale-tolerant: jsdom may fall back to en-US (no thousand separator) even when
+    // toLocaleString('it-IT') is requested. Match either "1.247" or "1,247" or "1247".
+    expect(screen.getByText(/1[.,]?247/)).toBeInTheDocument();
+    expect(screen.getByText(/4[.,]?891/)).toBeInTheDocument();
+    expect(screen.getByText('3 gg fa')).toBeInTheDocument();
+  });
+
+  it('renders lifetime cost and sparkline only when both data + non-compact', () => {
+    const { container, rerender } = render(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Standard"
+        coverageScore={73}
+        lifetimeCost="$2.84"
+        costHistory={[0.12, 0.38, 0.22, 0.45, 0.19, 0.84, 0.64]}
+        labels={baseLabels}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-stats-lifetime-cost"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-stats-sparkline"]')).toBeInTheDocument();
+    expect(screen.getByText('$2.84')).toBeInTheDocument();
+
+    rerender(
+      <KbStatsCard
+        documentCount={12}
+        coverageLevel="Standard"
+        coverageScore={73}
+        lifetimeCost="$2.84"
+        costHistory={[0.12, 0.38, 0.22, 0.45, 0.19, 0.84, 0.64]}
+        compact
+        labels={baseLabels}
+      />
+    );
+    // Compact mode hides lifetime cost + sparkline + header
+    expect(
+      container.querySelector('[data-slot="kb-hub-stats-lifetime-cost"]')
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-stats-sparkline"]')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/PdfRow.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/PdfRow.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PdfRow, type KbPdf } from '../PdfRow';
+
+const baseLabels = {
+  openCta: 'Apri dettaglio',
+  openAria: 'Apri dettaglio {pdfName}',
+  chunksLabel: '{count} chunks',
+  status: {
+    ready: 'Ready',
+    indexing: 'Indexing',
+    stale: 'Stale',
+    failed: 'Failed',
+  },
+};
+
+const basePdf: KbPdf = {
+  id: 'pdf-1',
+  name: 'Rulebook v2',
+  sizeFormatted: '45 MB',
+  uploadedAtRelative: '2 gg fa',
+};
+
+describe('PdfRow (Issue #1481)', () => {
+  it('renders name, size, date and CTA with aria-label', () => {
+    render(<PdfRow pdf={basePdf} labels={baseLabels} onActionClick={() => {}} />);
+    expect(screen.getByText('Rulebook v2')).toBeInTheDocument();
+    expect(screen.getByText('45 MB')).toBeInTheDocument();
+    expect(screen.getByText('2 gg fa')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apri dettaglio Rulebook v2' })).toBeInTheDocument();
+  });
+
+  it('hides status badge when status is undefined (P83 deferred)', () => {
+    const { container } = render(
+      <PdfRow pdf={basePdf} labels={baseLabels} onActionClick={() => {}} />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-pdf-status"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kb-hub-pdf-status-empty"]')).toBeInTheDocument();
+  });
+
+  it('renders status badge with localized label when status provided', () => {
+    render(
+      <PdfRow
+        pdf={{ ...basePdf, status: 'indexing' }}
+        labels={baseLabels}
+        onActionClick={() => {}}
+      />
+    );
+    expect(screen.getByText('Indexing')).toBeInTheDocument();
+  });
+
+  it('renders chunks suffix when chunks > 0', () => {
+    render(
+      <PdfRow pdf={{ ...basePdf, chunks: 312 }} labels={baseLabels} onActionClick={() => {}} />
+    );
+    expect(screen.getByText('312 chunks')).toBeInTheDocument();
+  });
+
+  it('omits chunks suffix when chunks is undefined or zero', () => {
+    const { rerender } = render(
+      <PdfRow pdf={basePdf} labels={baseLabels} onActionClick={() => {}} />
+    );
+    expect(screen.queryByText(/chunks$/)).not.toBeInTheDocument();
+    rerender(
+      <PdfRow pdf={{ ...basePdf, chunks: 0 }} labels={baseLabels} onActionClick={() => {}} />
+    );
+    expect(screen.queryByText(/chunks$/)).not.toBeInTheDocument();
+  });
+
+  it('invokes onActionClick with pdf.id', () => {
+    const onActionClick = vi.fn();
+    render(<PdfRow pdf={basePdf} labels={baseLabels} onActionClick={onActionClick} />);
+    fireEvent.click(screen.getByRole('button', { name: /Apri dettaglio Rulebook v2/ }));
+    expect(onActionClick).toHaveBeenCalledWith('pdf-1');
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/RaptorPanel.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/RaptorPanel.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RaptorPanel } from '../RaptorPanel';
+
+const baseLabels = {
+  title: 'RAPTOR Rebuild',
+  description: 'Recursive Abstractive Processing Tree Of Retrieval',
+  lockedBadge: 'PRO',
+  activeBadge: 'PRO ✓',
+  lockedNote: 'RAPTOR richiede piano Pro.',
+  upgradeCta: 'Upgrade to Pro',
+  upgradeLink: 'Scopri piano Pro',
+  rebuildCta: 'Rebuild RAPTOR',
+  metrics: {
+    lastRebuild: 'Ultimo rebuild',
+    summaries: 'Summaries gen.',
+  },
+  estimateLabel: 'Stima operazione',
+  estimateDescription: '~{chunks} chunks → summaries gerarchici',
+};
+
+describe('RaptorPanel (Issue #1481)', () => {
+  it('renders locked state for free tier with disabled CTA', () => {
+    const { container } = render(<RaptorPanel tier="free" labels={baseLabels} />);
+    expect(screen.getByText('RAPTOR Rebuild')).toBeInTheDocument();
+    expect(screen.getByText('PRO')).toBeInTheDocument(); // locked badge
+    expect(screen.getByText('RAPTOR richiede piano Pro.')).toBeInTheDocument();
+    const upgradeBtn = container.querySelector(
+      '[data-slot="kb-hub-raptor-upgrade-cta"]'
+    ) as HTMLButtonElement;
+    expect(upgradeBtn).toBeInTheDocument();
+    expect(upgradeBtn).toBeDisabled();
+  });
+
+  it('renders active state for pro tier with enabled rebuild CTA', () => {
+    const onRebuild = vi.fn();
+    render(<RaptorPanel tier="pro" labels={baseLabels} onRebuild={onRebuild} />);
+    expect(screen.getByText('PRO ✓')).toBeInTheDocument();
+    const rebuildBtn = screen.getByRole('button', { name: 'Rebuild RAPTOR' });
+    expect(rebuildBtn).toBeInTheDocument();
+    fireEvent.click(rebuildBtn);
+    expect(onRebuild).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides metrics block when no metrics props provided (P83)', () => {
+    const { container } = render(<RaptorPanel tier="free" labels={baseLabels} />);
+    expect(container.querySelector('[data-slot="kb-hub-raptor-metrics"]')).not.toBeInTheDocument();
+  });
+
+  it('renders metrics block when lastRebuild + summaries provided', () => {
+    const { container } = render(
+      <RaptorPanel
+        tier="pro"
+        labels={baseLabels}
+        lastRebuildRelative="12 gg fa"
+        summariesCount={147}
+      />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-raptor-metrics"]')).toBeInTheDocument();
+    expect(screen.getByText('12 gg fa')).toBeInTheDocument();
+    expect(screen.getByText('147')).toBeInTheDocument();
+  });
+
+  it('renders estimate block only when pro tier + estimateChunks + (cost or duration)', () => {
+    const { container, rerender } = render(
+      <RaptorPanel tier="pro" labels={baseLabels} estimateChunks={1247} estimatedCost="$1.20" />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-raptor-estimate"]')).toBeInTheDocument();
+    expect(screen.getByText('$1.20')).toBeInTheDocument();
+    // Locale-tolerant: jsdom may render "1247" instead of "1.247" (it-IT thousand sep).
+    expect(
+      screen.getByText(text => /^~1[.,]?247 chunks → summaries gerarchici$/.test(text))
+    ).toBeInTheDocument();
+
+    // Free tier: estimate hidden even if data provided
+    rerender(
+      <RaptorPanel tier="free" labels={baseLabels} estimateChunks={1247} estimatedCost="$1.20" />
+    );
+    expect(container.querySelector('[data-slot="kb-hub-raptor-estimate"]')).not.toBeInTheDocument();
+  });
+
+  it('invokes onUpgrade when upgrade link clicked (free tier)', () => {
+    const onUpgrade = vi.fn();
+    render(<RaptorPanel tier="free" labels={baseLabels} onUpgrade={onUpgrade} />);
+    fireEvent.click(screen.getByRole('button', { name: /Scopri piano Pro/ }));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/kb-hub/__tests__/ReindexModal.test.tsx
+++ b/apps/web/src/components/features/kb-hub/__tests__/ReindexModal.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReindexModal, type ReindexCostRow } from '../ReindexModal';
+
+const baseLabels = {
+  title: 'Re-index full KB',
+  subtitle: 'Gloomhaven · 12 documenti',
+  costHeader: 'Stima costo operazione',
+  description: 'Questa operazione rielabora tutti i chunk e rigenera gli embedding.',
+  reindexCta: 'Re-index',
+  cancelCta: 'Annulla',
+  runningTitle: 'Re-index in corso',
+  jobIdLabel: 'Job ID',
+  progressTemplate: '{processed} / {total} chunks',
+  doneTitle: 'Re-index completato',
+  doneSummaryTemplate: '{chunks} chunks · {embeddings} embeddings · costo reale {cost}',
+  closeCta: 'Chiudi',
+};
+
+const baseCostRows: ReindexCostRow[] = [
+  { key: 'chunks', label: 'Chunks da re-embed', value: '1,247' },
+  { key: 'total', label: 'Costo stimato', value: '~$0.45', bold: true },
+];
+
+describe('ReindexModal (Issue #1481)', () => {
+  it('does not render content when open=false', () => {
+    render(
+      <ReindexModal
+        open={false}
+        phase="confirm"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.queryByText('Re-index full KB')).not.toBeInTheDocument();
+  });
+
+  it('phase=confirm: renders title, cost table, description, both CTAs', () => {
+    render(
+      <ReindexModal
+        open
+        phase="confirm"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText('Re-index full KB')).toBeInTheDocument();
+    // DialogContent renders in a Radix Portal — query document, not container.
+    expect(document.querySelector('[data-slot="kb-hub-reindex-cost-table"]')).toBeInTheDocument();
+    expect(screen.getByText('Chunks da re-embed')).toBeInTheDocument();
+    expect(screen.getByText('1,247')).toBeInTheDocument();
+    expect(screen.getByText('~$0.45')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Re-index' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Annulla' })).toBeInTheDocument();
+  });
+
+  it('phase=confirm: invokes onConfirm when Re-index button clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ReindexModal
+        open
+        phase="confirm"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={onConfirm}
+        onClose={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Re-index' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('phase=running: renders spinner + jobId + progress', () => {
+    render(
+      <ReindexModal
+        open
+        phase="running"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        progress={{ current: 474, total: 1247, jobId: 'job_xk92m3p' }}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText('Re-index in corso')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="kb-hub-reindex-running"]')).toBeInTheDocument();
+    expect(screen.getByText('job_xk92m3p')).toBeInTheDocument();
+    expect(screen.getByText('474 / 1247 chunks')).toBeInTheDocument();
+  });
+
+  it('phase=done: renders success badge, summary, close CTA', () => {
+    const onClose = vi.fn();
+    render(
+      <ReindexModal
+        open
+        phase="done"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        summary={{ chunks: 1247, embeddings: 4891, actualCost: '$0.43' }}
+        onConfirm={() => {}}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText('Re-index completato')).toBeInTheDocument();
+    // Locale-tolerant: vitest jsdom may use en-US fallback even when toLocaleString('it-IT')
+    // is requested. Assert via text content predicate that survives "1.247" vs "1,247".
+    expect(
+      screen.getByText(
+        text => text.includes('chunks') && text.includes('embeddings') && text.includes('$0.43')
+      )
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Chiudi' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('phase=running: progress optional (no progress prop → no chunks line)', () => {
+    render(
+      <ReindexModal
+        open
+        phase="running"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.queryByText(/chunks$/)).not.toBeInTheDocument();
+  });
+
+  it('FSM data-phase attribute reflects current phase', () => {
+    const { rerender } = render(
+      <ReindexModal
+        open
+        phase="confirm"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    // DialogContent is rendered through a Radix Portal, so RTL's container scope
+    // does not include it. Query document directly (or via screen.getByRole('dialog')).
+    expect(document.querySelector('[data-phase="confirm"]')).toBeInTheDocument();
+
+    rerender(
+      <ReindexModal
+        open
+        phase="running"
+        labels={baseLabels}
+        costRows={baseCostRows}
+        onConfirm={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(document.querySelector('[data-phase="running"]')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/kb-hub/index.ts
+++ b/apps/web/src/components/features/kb-hub/index.ts
@@ -1,0 +1,54 @@
+/**
+ * kb-hub feature module barrel (Issue #1481)
+ *
+ * Pure presentational components for the /library/[gameId]/kb route.
+ * Orchestrator and hooks live separately.
+ */
+
+export { EmptyState } from './EmptyState';
+export type { EmptyStateLabels, EmptyStateProps } from './EmptyState';
+
+export { PdfRow } from './PdfRow';
+export type { KbPdf, PdfStatus, PdfRowLabels, PdfRowProps } from './PdfRow';
+
+export { KbStatsCard } from './KbStatsCard';
+export type { CoverageLevel, KbStatsCardLabels, KbStatsCardProps } from './KbStatsCard';
+
+export { RaptorPanel } from './RaptorPanel';
+export type { RaptorTier, RaptorPanelLabels, RaptorPanelProps } from './RaptorPanel';
+
+export { ActionsMenu } from './ActionsMenu';
+export type {
+  PdfAction,
+  ActionsMenuItemLabel,
+  ActionsMenuLabels,
+  ActionsMenuProps,
+  ActionsMenuPdfHeader,
+} from './ActionsMenu';
+
+export { DeleteDialog } from './DeleteDialog';
+export type {
+  DeleteDialogCleanupItem,
+  DeleteDialogLabels,
+  DeleteDialogProps,
+} from './DeleteDialog';
+
+export { ReindexModal } from './ReindexModal';
+export type {
+  ReindexPhase,
+  ReindexCostRow,
+  ReindexModalLabels,
+  ReindexModalProgress,
+  ReindexModalSummary,
+  ReindexModalProps,
+} from './ReindexModal';
+
+export { HubDefault } from './HubDefault';
+export type {
+  HubDefaultGameInfo,
+  HubDefaultStatsStripLabels,
+  HubDefaultColumnHeaders,
+  HubDefaultCoverageLabels,
+  HubDefaultLabels,
+  HubDefaultProps,
+} from './HubDefault';

--- a/apps/web/src/hooks/queries/__tests__/useKbHub.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbHub.test.tsx
@@ -65,6 +65,11 @@ describe('useKbHub (Issue #1481)', () => {
     expect(mockGetUserGameKbStatus).not.toHaveBeenCalled();
   });
 
+  it('useGamePdfs is disabled when gameId is undefined', () => {
+    renderHook(() => useGamePdfs(undefined), { wrapper });
+    expect(mockGetGamePdfs).not.toHaveBeenCalled();
+  });
+
   it('useUserKbStatus fetches when gameId provided', async () => {
     mockGetUserGameKbStatus.mockResolvedValueOnce({
       gameId: GAME_ID,

--- a/apps/web/src/hooks/queries/__tests__/useKbHub.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbHub.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * useKbHub hooks tests (Issue #1481).
+ *
+ * Validates query keys, enablement gating, and cache invalidation post-mutation.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  kbHubKeys,
+  useDeletePdf,
+  useGamePdfs,
+  useReindexKb,
+  useRebuildRaptor,
+  useUserKbStatus,
+} from '../useKbHub';
+
+const mockGetUserGameKbStatus = vi.fn();
+const mockGetGamePdfs = vi.fn();
+const mockReindexKb = vi.fn();
+const mockRebuildRaptor = vi.fn();
+const mockAdminDeletePdf = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    knowledgeBase: {
+      getUserGameKbStatus: (...args: unknown[]) => mockGetUserGameKbStatus(...args),
+      reindexKb: (...args: unknown[]) => mockReindexKb(...args),
+      rebuildRaptor: (...args: unknown[]) => mockRebuildRaptor(...args),
+    },
+    library: {
+      getGamePdfs: (...args: unknown[]) => mockGetGamePdfs(...args),
+    },
+    pdf: {
+      adminDeletePdf: (...args: unknown[]) => mockAdminDeletePdf(...args),
+    },
+  },
+}));
+
+const GAME_ID = 'game-123';
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useKbHub (Issue #1481)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('kbHubKeys produces stable, isolated cache keys', () => {
+    expect(kbHubKeys.all).toEqual(['kbHub']);
+    expect(kbHubKeys.status(GAME_ID)).toEqual(['kbHub', 'status', GAME_ID]);
+    expect(kbHubKeys.pdfs(GAME_ID)).toEqual(['kbHub', 'pdfs', GAME_ID]);
+  });
+
+  it('useUserKbStatus is disabled when gameId is undefined', () => {
+    renderHook(() => useUserKbStatus(undefined), { wrapper });
+    expect(mockGetUserGameKbStatus).not.toHaveBeenCalled();
+  });
+
+  it('useUserKbStatus fetches when gameId provided', async () => {
+    mockGetUserGameKbStatus.mockResolvedValueOnce({
+      gameId: GAME_ID,
+      isIndexed: true,
+      documentCount: 12,
+      coverageScore: 73,
+      coverageLevel: 'Standard',
+      suggestedQuestions: [],
+    });
+    const { result } = renderHook(() => useUserKbStatus(GAME_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetUserGameKbStatus).toHaveBeenCalledWith(GAME_ID);
+    expect(result.current.data?.documentCount).toBe(12);
+  });
+
+  it('useGamePdfs fetches PDF list when gameId provided', async () => {
+    mockGetGamePdfs.mockResolvedValueOnce([
+      {
+        id: 'p1',
+        name: 'Rulebook',
+        pageCount: 50,
+        fileSizeBytes: 12345,
+        uploadedAt: '2026-01-01T00:00:00Z',
+        source: 'Custom',
+      },
+    ]);
+    const { result } = renderHook(() => useGamePdfs(GAME_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetGamePdfs).toHaveBeenCalledWith(GAME_ID);
+    expect(result.current.data?.[0]?.id).toBe('p1');
+  });
+
+  it('useReindexKb invokes mutation and resolves', async () => {
+    mockReindexKb.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useReindexKb(GAME_ID), { wrapper });
+    await result.current.mutateAsync();
+    expect(mockReindexKb).toHaveBeenCalledWith(GAME_ID);
+  });
+
+  it('useRebuildRaptor invokes mutation and resolves', async () => {
+    mockRebuildRaptor.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useRebuildRaptor(GAME_ID), { wrapper });
+    await result.current.mutateAsync();
+    expect(mockRebuildRaptor).toHaveBeenCalledWith(GAME_ID);
+  });
+
+  it('useDeletePdf invokes adminDeletePdf endpoint with pdfId', async () => {
+    mockAdminDeletePdf.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useDeletePdf(GAME_ID), { wrapper });
+    await result.current.mutateAsync('pdf-1');
+    expect(mockAdminDeletePdf).toHaveBeenCalledWith('pdf-1');
+  });
+});

--- a/apps/web/src/hooks/queries/useKbHub.ts
+++ b/apps/web/src/hooks/queries/useKbHub.ts
@@ -1,0 +1,105 @@
+/**
+ * useKbHub — consolidated React Query hooks for KB Hub route (Issue #1481).
+ *
+ * - useUserKbStatus(gameId): KB stats (documentCount, coverageLevel)
+ * - useGamePdfs(gameId): PDF list for the game
+ * - useReindexKb(gameId): trigger full re-index
+ * - useRebuildRaptor(gameId): trigger RAPTOR rebuild (Pro tier only — backend enforces)
+ * - useDeletePdf(gameId): delete a PDF (Owner/Admin endpoint)
+ *
+ * Cache keys isolated under `kbHub.*` namespace to avoid cross-feature
+ * invalidation surprises. Mutations invalidate both status + pdfs lists
+ * because re-index/delete change derived counts.
+ */
+
+'use client';
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { UserGameKbStatus } from '@/lib/api/schemas/knowledge-base.schemas';
+import type { GamePdfDto } from '@/lib/api/schemas/pdf.schemas';
+
+export const kbHubKeys = {
+  all: ['kbHub'] as const,
+  status: (gameId: string) => [...kbHubKeys.all, 'status', gameId] as const,
+  pdfs: (gameId: string) => [...kbHubKeys.all, 'pdfs', gameId] as const,
+};
+
+/**
+ * Fetch user-facing KB status (documentCount, coverageLevel, coverageScore).
+ * Disabled when gameId is undefined.
+ */
+export function useUserKbStatus(
+  gameId: string | undefined
+): UseQueryResult<UserGameKbStatus | null> {
+  return useQuery({
+    queryKey: gameId ? kbHubKeys.status(gameId) : [...kbHubKeys.all, 'status', '__skip'],
+    queryFn: () => api.knowledgeBase.getUserGameKbStatus(gameId as string),
+    enabled: !!gameId,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Fetch indexed PDFs for the game.
+ * Disabled when gameId is undefined.
+ */
+export function useGamePdfs(gameId: string | undefined): UseQueryResult<GamePdfDto[]> {
+  return useQuery({
+    queryKey: gameId ? kbHubKeys.pdfs(gameId) : [...kbHubKeys.all, 'pdfs', '__skip'],
+    queryFn: () => api.library.getGamePdfs(gameId as string),
+    enabled: !!gameId,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Trigger full KB re-index. Invalidates status + pdfs on success
+ * (chunk/embedding counts change post-reindex).
+ */
+export function useReindexKb(gameId: string): UseMutationResult<void, Error, void> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.knowledgeBase.reindexKb(gameId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+      qc.invalidateQueries({ queryKey: kbHubKeys.pdfs(gameId) });
+    },
+  });
+}
+
+/**
+ * Trigger RAPTOR hierarchical clustering rebuild. Invalidates status only.
+ * Backend enforces Pro tier — call may 403 for free users.
+ */
+export function useRebuildRaptor(gameId: string): UseMutationResult<void, Error, void> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.knowledgeBase.rebuildRaptor(gameId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+    },
+  });
+}
+
+/**
+ * Delete a PDF document. Invalidates pdfs + status on success.
+ * The underlying endpoint is `DELETE /api/v1/pdf/{pdfId}` (Owner/Admin enforced server-side).
+ */
+export function useDeletePdf(gameId: string): UseMutationResult<void, Error, string> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (pdfId: string) => api.pdf.adminDeletePdf(pdfId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.pdfs(gameId) });
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
+++ b/apps/web/src/lib/api/clients/knowledgeBaseClient.ts
@@ -247,5 +247,23 @@ export function createKnowledgeBaseClient({ httpClient }: CreateKnowledgeBaseCli
       );
       return result ?? [];
     },
+
+    /**
+     * KB Hub (#1481): Trigger full KB re-index for a game
+     * Returns a job ID for async progress polling (status endpoint TBD in MVP).
+     * @param gameId Game ID (GUID format)
+     */
+    async reindexKb(gameId: string): Promise<void> {
+      await httpClient.post(`/api/v1/games/${encodeURIComponent(gameId)}/kb/reindex`, {});
+    },
+
+    /**
+     * KB Hub (#1481): Trigger RAPTOR hierarchical clustering rebuild
+     * Available for Pro tier only (backend enforces). Returns job ID.
+     * @param gameId Game ID (GUID format)
+     */
+    async rebuildRaptor(gameId: string): Promise<void> {
+      await httpClient.post(`/api/v1/games/${encodeURIComponent(gameId)}/kb/raptor/rebuild`, {});
+    },
   };
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1652,6 +1652,146 @@
           "subtitle": "Something went wrong. Please try again in a moment.",
           "cta": "Retry"
         }
+      },
+      "gameDetail": {
+        "kb": {
+          "metadata": {
+            "title": "{gameTitle} · Knowledge Base — MeepleAI",
+            "description": "Manage PDFs, indexing and RAPTOR for the {gameTitle} knowledge base."
+          },
+          "header": {
+            "titleSuffix": "Knowledge Base",
+            "uploadCta": "+ Upload PDF",
+            "reindexAllCta": "⟳ Re-index all"
+          },
+          "stats": {
+            "docs": "{count, plural, =0 {No documents} =1 {1 document} other {# documents}}",
+            "docsLabel": "Documents",
+            "chunksLabel": "Chunks",
+            "chunksTemplate": "{count} chunks",
+            "embeddingsLabel": "Embeddings",
+            "embeddingsTemplate": "{count} embeddings",
+            "lastReindexLabel": "Last idx.",
+            "lastReindexTemplate": "last reindex {relative}",
+            "raptorLabel": "RAPTOR last",
+            "coverageLabel": "Coverage",
+            "coverageStripLabel": "Coverage: {level}",
+            "coverage": {
+              "None": "None",
+              "Basic": "Basic",
+              "Standard": "Standard",
+              "Complete": "Complete"
+            },
+            "cardTitle": "KB Coverage Stats",
+            "cardSubtitle": "Indexing metrics",
+            "lifetimeCostLabel": "Lifetime token cost",
+            "sparklineLabel": "Token usage · last 7 days",
+            "sparklineStart": "-7d",
+            "sparklineEnd": "today",
+            "columnHeaders": {
+              "document": "Document",
+              "status": "Status",
+              "uploaded": "Uploaded"
+            }
+          },
+          "empty": {
+            "title": "No PDFs indexed yet",
+            "description": "Upload the first PDF document to index the rules of {gameTitle} and enable AI agent RAG chat.",
+            "ctaLabel": "Upload first document",
+            "supportedFormats": "Supported formats: PDF · Max 200 MB per file"
+          },
+          "pdfRow": {
+            "openCta": "Open detail",
+            "openAria": "Open detail {pdfName}",
+            "chunksTemplate": "{count} chunks",
+            "status": {
+              "ready": "Ready",
+              "indexing": "Indexing",
+              "stale": "Stale",
+              "failed": "Failed"
+            }
+          },
+          "actionsMenu": {
+            "headerSubtitle": "{size} · {date}",
+            "open": {
+              "label": "Open detail",
+              "description": "View chunks and preview",
+              "icon": "↗"
+            },
+            "reindex": {
+              "label": "Re-index",
+              "description": "Re-embed PDF",
+              "icon": "⟳"
+            },
+            "cost": {
+              "label": "Cost stats",
+              "description": "Tokens consumed and cost",
+              "icon": "📋"
+            },
+            "move": {
+              "label": "Move to other game",
+              "description": "Move to another KB",
+              "icon": "📦"
+            },
+            "delete": {
+              "label": "Delete",
+              "description": "Remove PDF and cleanup",
+              "icon": "🗑"
+            }
+          },
+          "reindexModal": {
+            "title": "Re-index full KB",
+            "subtitle": "{gameTitle} · {docCount} documents",
+            "costHeader": "Operation cost estimate",
+            "description": "This operation re-processes all chunks and regenerates embeddings. Existing chats will keep working during the process.",
+            "reindexCta": "⟳ Re-index",
+            "cancelCta": "Cancel",
+            "runningTitle": "Re-indexing…",
+            "jobIdLabel": "Job ID",
+            "progressTemplate": "{processed} / {total} chunks",
+            "doneTitle": "Re-index complete",
+            "doneSummaryTemplate": "{chunks} chunks · {embeddings} embeddings · actual cost {cost}",
+            "closeCta": "Close",
+            "costRows": {
+              "chunksToReembed": "Chunks to re-embed",
+              "tokensPerChunk": "Tokens per chunk (avg)",
+              "tokensTotal": "Total tokens (estimated)",
+              "costPer1M": "Cost per 1M tokens",
+              "estimatedCost": "Estimated cost",
+              "estimatedDuration": "Estimated duration"
+            }
+          },
+          "raptor": {
+            "title": "RAPTOR Rebuild",
+            "description": "Recursive Abstractive Processing Tree Of Retrieval",
+            "lockedBadge": "🔒 PRO",
+            "activeBadge": "PRO ✓",
+            "lockedNote": "RAPTOR requires Pro plan. Enables hierarchical clustering for advanced Q&A retrieval.",
+            "upgradeCta": "🔒 Rebuild RAPTOR — Upgrade to Pro",
+            "upgradeLink": "Discover Pro plan",
+            "rebuildCta": "🦅 Rebuild RAPTOR",
+            "metrics": {
+              "lastRebuild": "Last rebuild",
+              "summaries": "Summaries generated"
+            },
+            "estimateLabel": "Operation estimate",
+            "estimateDescription": "~{chunks} chunks → hierarchical summaries"
+          },
+          "delete": {
+            "title": "Confirm PDF deletion?",
+            "subtitlePrefix": "PDF:",
+            "listHeader": "Will be permanently deleted:",
+            "warning": "Irreversible operation — no backup available",
+            "deleteCta": "🗑 Delete permanently",
+            "cancelCta": "Cancel"
+          },
+          "errors": {
+            "loadFailed": "Unable to load knowledge base. Please retry.",
+            "reindexFailed": "Re-index failed. Please try again in a moment.",
+            "raptorFailed": "RAPTOR rebuild failed.",
+            "deleteFailed": "Unable to delete PDF."
+          }
+        }
       }
     },
     "discover": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1702,6 +1702,146 @@
           "subtitle": "Si è verificato un errore. Riprova tra qualche istante.",
           "cta": "Riprova"
         }
+      },
+      "gameDetail": {
+        "kb": {
+          "metadata": {
+            "title": "{gameTitle} · Knowledge Base — MeepleAI",
+            "description": "Gestisci PDF, indicizzazione e RAPTOR per la knowledge base di {gameTitle}."
+          },
+          "header": {
+            "titleSuffix": "Knowledge Base",
+            "uploadCta": "+ Carica PDF",
+            "reindexAllCta": "⟳ Re-index all"
+          },
+          "stats": {
+            "docs": "{count, plural, =0 {Nessun documento} =1 {1 documento} other {# documenti}}",
+            "docsLabel": "Documenti",
+            "chunksLabel": "Chunks",
+            "chunksTemplate": "{count} chunks",
+            "embeddingsLabel": "Embeddings",
+            "embeddingsTemplate": "{count} embeddings",
+            "lastReindexLabel": "Ultima idx.",
+            "lastReindexTemplate": "ultima reindex {relative}",
+            "raptorLabel": "RAPTOR last",
+            "coverageLabel": "Copertura",
+            "coverageStripLabel": "Copertura: {level}",
+            "coverage": {
+              "None": "Nessuna",
+              "Basic": "Base",
+              "Standard": "Standard",
+              "Complete": "Completa"
+            },
+            "cardTitle": "KB Coverage Stats",
+            "cardSubtitle": "Metriche indicizzazione",
+            "lifetimeCostLabel": "Costo lifetime token",
+            "sparklineLabel": "Consumo token · ultimi 7 gg",
+            "sparklineStart": "-7gg",
+            "sparklineEnd": "oggi",
+            "columnHeaders": {
+              "document": "Documento",
+              "status": "Stato",
+              "uploaded": "Caricato"
+            }
+          },
+          "empty": {
+            "title": "Nessun PDF indicizzato",
+            "description": "Carica il primo documento PDF per indicizzare le regole di {gameTitle} e abilitare il RAG chat con l'AI agent.",
+            "ctaLabel": "Carica primo documento",
+            "supportedFormats": "Formati supportati: PDF · Max 200 MB per file"
+          },
+          "pdfRow": {
+            "openCta": "Apri dettaglio",
+            "openAria": "Apri dettaglio {pdfName}",
+            "chunksTemplate": "{count} chunks",
+            "status": {
+              "ready": "Ready",
+              "indexing": "Indexing",
+              "stale": "Stale",
+              "failed": "Failed"
+            }
+          },
+          "actionsMenu": {
+            "headerSubtitle": "{size} · {date}",
+            "open": {
+              "label": "Apri dettaglio",
+              "description": "Visualizza chunks e preview",
+              "icon": "↗"
+            },
+            "reindex": {
+              "label": "Re-index",
+              "description": "Rielabora embedding PDF",
+              "icon": "⟳"
+            },
+            "cost": {
+              "label": "Statistiche costo",
+              "description": "Token consumati e costo",
+              "icon": "📋"
+            },
+            "move": {
+              "label": "Sposta in altro gioco",
+              "description": "Sposta in altra scheda KB",
+              "icon": "📦"
+            },
+            "delete": {
+              "label": "Elimina",
+              "description": "Rimuovi PDF e cleanup",
+              "icon": "🗑"
+            }
+          },
+          "reindexModal": {
+            "title": "Re-index full KB",
+            "subtitle": "{gameTitle} · {docCount} documenti",
+            "costHeader": "Stima costo operazione",
+            "description": "Questa operazione rielabora tutti i chunk e rigenera gli embedding. Le chat esistenti continueranno a funzionare durante il processo.",
+            "reindexCta": "⟳ Re-index",
+            "cancelCta": "Annulla",
+            "runningTitle": "Re-index in corso…",
+            "jobIdLabel": "Job ID",
+            "progressTemplate": "{processed} / {total} chunks",
+            "doneTitle": "Re-index completato",
+            "doneSummaryTemplate": "{chunks} chunks · {embeddings} embeddings · costo reale {cost}",
+            "closeCta": "Chiudi",
+            "costRows": {
+              "chunksToReembed": "Chunks da re-embed",
+              "tokensPerChunk": "Tokens per chunk (avg)",
+              "tokensTotal": "Tokens totali stimati",
+              "costPer1M": "Costo per 1M tokens",
+              "estimatedCost": "Costo stimato",
+              "estimatedDuration": "Durata stimata"
+            }
+          },
+          "raptor": {
+            "title": "RAPTOR Rebuild",
+            "description": "Recursive Abstractive Processing Tree Of Retrieval",
+            "lockedBadge": "🔒 PRO",
+            "activeBadge": "PRO ✓",
+            "lockedNote": "RAPTOR richiede piano Pro. Abilita clustering gerarchico per retrieval Q&A avanzato.",
+            "upgradeCta": "🔒 Rebuild RAPTOR — Upgrade to Pro",
+            "upgradeLink": "Scopri piano Pro",
+            "rebuildCta": "🦅 Rebuild RAPTOR",
+            "metrics": {
+              "lastRebuild": "Ultimo rebuild",
+              "summaries": "Summaries generate"
+            },
+            "estimateLabel": "Stima operazione",
+            "estimateDescription": "~{chunks} chunks → summaries gerarchici"
+          },
+          "delete": {
+            "title": "Confermi eliminazione PDF?",
+            "subtitlePrefix": "PDF:",
+            "listHeader": "Verrà eliminato definitivamente:",
+            "warning": "Operazione irreversibile — nessun backup disponibile",
+            "deleteCta": "🗑 Elimina definitivamente",
+            "cancelCta": "Annulla"
+          },
+          "errors": {
+            "loadFailed": "Impossibile caricare la knowledge base. Riprova.",
+            "reindexFailed": "Re-index fallito. Riprova tra qualche istante.",
+            "raptorFailed": "Rebuild RAPTOR fallito.",
+            "deleteFailed": "Impossibile eliminare il PDF."
+          }
+        }
       }
     },
     "discover": {

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -396,14 +396,14 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-kb-hub.jsx` | `KbStatsCard` | `apps/web/src/components/features/kb-hub/KbStatsCard.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `PdfRow` | `apps/web/src/components/features/kb-hub/PdfRow.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `HubDefault` | `apps/web/src/components/features/kb-hub/HubDefault.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `EmptyState` | `apps/web/src/components/features/kb-hub/EmptyState.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `ActionsMenu` | `apps/web/src/components/features/kb-hub/ActionsMenu.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `ReindexModal` | `apps/web/src/components/features/kb-hub/ReindexModal.tsx` | `/knowledge-base` | pending | — | T A M V | — |
-| `sp4-kb-hub.jsx` | `RaptorPanel` | `apps/web/src/components/features/kb-hub/RaptorPanel.tsx` | `/knowledge-base` | pending | — | T A V | — |
-| `sp4-kb-hub.jsx` | `DeleteDialog` | `apps/web/src/components/features/kb-hub/DeleteDialog.tsx` | `/knowledge-base` | pending | — | T A M V | — |
+| `sp4-kb-hub.jsx` | `KbStatsCard` | `apps/web/src/components/features/kb-hub/KbStatsCard.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `PdfRow` | `apps/web/src/components/features/kb-hub/PdfRow.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `HubDefault` | `apps/web/src/components/features/kb-hub/HubDefault.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `EmptyState` | `apps/web/src/components/features/kb-hub/EmptyState.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `ActionsMenu` | `apps/web/src/components/features/kb-hub/ActionsMenu.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `ReindexModal` | `apps/web/src/components/features/kb-hub/ReindexModal.tsx` | `/library/[gameId]/kb` | done | #1481 | T A M V | — |
+| `sp4-kb-hub.jsx` | `RaptorPanel` | `apps/web/src/components/features/kb-hub/RaptorPanel.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
+| `sp4-kb-hub.jsx` | `DeleteDialog` | `apps/web/src/components/features/kb-hub/DeleteDialog.tsx` | `/library/[gameId]/kb` | done | #1481 | T A M V | — |
 
 ### KB globale — `/knowledge-base/global` (F1b) — 10 components — **Tier L** ⚠️ Phase 0.5 likely required
 

--- a/docs/superpowers/specs/2026-05-25-kb-hub-impl-design.md
+++ b/docs/superpowers/specs/2026-05-25-kb-hub-impl-design.md
@@ -1,0 +1,600 @@
+# KB Hub Implementation — `/library/[gameId]/kb`
+
+**Issue**: [#1481](https://github.com/meepleAi-app/meepleai-monorepo/issues/1481) — `feat(kb-hub): implement /knowledge-base hub — 8 components Tier M`
+**Epic**: [#1475](https://github.com/meepleAi-app/meepleai-monorepo/issues/1475) — User-facing UI completion
+**Date**: 2026-05-25
+**Tier**: M (~6-8h)
+**Mockup**: `admin-mockups/design_files/sp4-kb-hub.{html,jsx}` (1072 LOC reference impl)
+
+## Decisione di scope
+
+### Routing — Opzione A1 (standalone game-scoped)
+
+L'issue title menziona "knowledge-base hub" ma il mockup `sp4-kb-hub.jsx` è esplicitamente game-scoped (`/library/private/[gameId]/kb | /games/[id]/kb` nel comment header). La rotta `/knowledge-base` attuale è solo un `redirect('/library')`.
+
+**Decisione**: creiamo una NUOVA rotta `/library/[gameId]/kb` (standalone), NON modifichiamo `/knowledge-base`. Pattern coerente con sibling `/library/[gameId]/toolbox`.
+
+- `/library/[gameId]/kb` (NUOVA) — orchestrator + 8 componenti del mockup
+- `/knowledge-base/page.tsx` (immutato — resta redirect)
+- `/library/[gameId]?tab=*` (immutato — i 5 tab esistenti restano)
+
+`GameDetailKbDocList.tsx` (esistente, lightweight) **coexiste** (decisione F2): resta per il Info tab card del game detail. `HubDefault` (nuovo) è il rendering full-page del nuovo route.
+
+### Scope BE — Opzione X1 (Component-only shelf-ready + BE follow-up)
+
+**Pattern P83 spec-panel-scope-reduction-via-BE-reality** (precedente: #1484): il mockup mostra 8 stati con 13+ campi di dati; il BE user-side espone solo 3 campi via `UserGameKbStatusSchema` + `GamePdfDto`.
+
+**Approccio**: 8 componenti pure presentational con **props complete del mockup** (future-proof), orchestrator wires SOLO dati BE disponibili oggi, componenti **hide gracefully** UI per props undefined. Aprirò follow-up BE issue per arricchire lo schema.
+
+| Dato mockup | BE user-side | Strategia |
+|---|---|---|
+| `documentCount` | `UserGameKbStatus.documentCount` ✅ | wired |
+| `coverageLevel/Score` | `UserGameKbStatus.coverageLevel/Score` ✅ | wired |
+| PDF list | `libraryClient.getGamePdfs(gameId)` ✅ | wired |
+| Reindex action | `POST /api/v1/games/{gameId}/kb/reindex` ✅ | wired |
+| RAPTOR rebuild | `POST /api/v1/games/{gameId}/kb/raptor/rebuild` ✅ | wired (button disabled in free MVP) |
+| Delete PDF | `DELETE /api/v1/pdf/{pdfId}` ✅ | wired |
+| `chunks` | – | deferred, prop optional, hide |
+| `embeddings` | – | deferred, prop optional, hide |
+| `lastReindex` | – | deferred, prop optional, hide |
+| `raptorLastRebuild` | – | deferred, prop optional, hide |
+| `lifetimeCost` | – | deferred, prop optional, hide |
+| `costHistory[]` | – | deferred, prop optional, hide sparkline |
+| PDF `status` (ready/indexing/stale/failed) | – | deferred, prop optional, hide badge |
+| PDF `chunks` count | – | deferred, prop optional, hide |
+| User `tier` (free/pro) | – | default `'free'` MVP, follow-up issue |
+| Cleanup metadata (chunks/raptor/edges count) | – | deferred, prop optional, hide list |
+
+## Architettura
+
+```
+apps/web/src/app/(authenticated)/library/[gameId]/kb/
+├── page.tsx        # Server route, awaits params, renders <KbHubPage gameId={...} />
+└── _content.tsx    # 'use client', KbHubPage orchestrator
+
+apps/web/src/components/features/kb-hub/
+├── index.ts                  # barrel export
+├── KbStatsCard.tsx
+├── PdfRow.tsx
+├── HubDefault.tsx
+├── EmptyState.tsx
+├── ActionsMenu.tsx
+├── ReindexModal.tsx
+├── RaptorPanel.tsx
+├── DeleteDialog.tsx
+└── __tests__/                # vitest + RTL + jest-axe
+    ├── KbStatsCard.test.tsx
+    ├── PdfRow.test.tsx
+    ├── HubDefault.test.tsx
+    ├── EmptyState.test.tsx
+    ├── ActionsMenu.test.tsx
+    ├── ReindexModal.test.tsx
+    ├── RaptorPanel.test.tsx
+    └── DeleteDialog.test.tsx
+
+apps/web/src/hooks/queries/
+└── useKbHub.ts              # query keys + 5 hooks consolidated
+
+apps/web/messages/{it,en}/messages.json
+└── pages.library.gameDetail.kb.*   # NEW namespace
+```
+
+## Component contracts
+
+Tutti i componenti sono **pure presentational** (props-only, no `useQuery`/`useMutation` interni). Labels passate caller-side (i18n risolta nell'orchestrator). Pattern coerente con `GameDetailLeaderboard` / `GameDetailHouseRulesList` / `GameDetailChatTab`.
+
+### KbStatsCard
+
+```ts
+interface KbStatsCardProps {
+  readonly documentCount: number;
+  readonly coverageLevel: 'None' | 'Basic' | 'Standard' | 'Complete';
+  readonly coverageScore: number;          // 0-100
+  readonly labels: KbStatsCardLabels;
+  // Deferred (hide if undefined):
+  readonly chunks?: number;
+  readonly embeddings?: number;
+  readonly lastReindex?: string;           // human-relative "3 gg fa"
+  readonly raptorLastRebuild?: string;
+  readonly lifetimeCost?: string;          // "$2.84"
+  readonly costHistory?: ReadonlyArray<number>;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+```
+
+### PdfRow
+
+```ts
+type PdfStatus = 'ready' | 'indexing' | 'stale' | 'failed';
+
+interface PdfRowProps {
+  readonly pdf: {
+    readonly id: string;
+    readonly name: string;
+    readonly sizeFormatted: string;
+    readonly uploadedAtRelative: string;
+    readonly status?: PdfStatus;       // hide badge if undefined
+    readonly chunks?: number;          // hide "N chunks" suffix if undefined
+  };
+  readonly labels: PdfRowLabels;
+  readonly onActionClick: (pdfId: string) => void;
+}
+```
+
+### HubDefault
+
+```ts
+interface HubDefaultProps {
+  readonly game: { readonly title: string; readonly cover?: string; readonly emoji?: string };
+  readonly documentCount: number;
+  readonly coverageLevel: 'None' | 'Basic' | 'Standard' | 'Complete';
+  readonly pdfs: ReadonlyArray<PdfRowProps['pdf']>;
+  readonly labels: HubDefaultLabels;
+  readonly onUpload: () => void;
+  readonly onReindexAll: () => void;
+  readonly onPdfAction: (pdfId: string) => void;
+  // Deferred:
+  readonly chunks?: number;
+  readonly embeddings?: number;
+  readonly lastReindexRelative?: string;
+}
+```
+
+### EmptyState
+
+```ts
+interface EmptyStateProps {
+  readonly gameTitle: string;
+  readonly labels: EmptyStateLabels;
+  readonly onUpload: () => void;
+}
+```
+
+### ActionsMenu
+
+```ts
+type PdfAction = 'open' | 'reindex' | 'cost' | 'move' | 'delete';
+
+interface ActionsMenuProps {
+  readonly pdf: PdfRowProps['pdf'];
+  readonly labels: ActionsMenuLabels;       // 5 actions × { label, description }
+  readonly onSelect: (action: PdfAction) => void;
+  readonly children: ReactNode;             // trigger element (DropdownMenuTrigger)
+}
+```
+
+Implementazione: wrap di `DropdownMenu` Radix esistente (`components/ui/navigation/dropdown-menu.tsx`).
+
+### ReindexModal
+
+```ts
+type ReindexPhase = 'confirm' | 'running' | 'done';
+
+interface ReindexModalProps {
+  readonly open: boolean;
+  readonly phase: ReindexPhase;
+  readonly labels: ReindexModalLabels;
+  readonly costRows: ReadonlyArray<{ readonly key: string; readonly label: string; readonly value: string; readonly bold?: boolean }>;
+  readonly onConfirm: () => void;
+  readonly onClose: () => void;
+  // Running phase optional:
+  readonly progress?: { readonly current: number; readonly total: number; readonly jobId?: string };
+  // Done phase optional:
+  readonly summary?: { readonly chunks: number; readonly embeddings: number; readonly actualCost: string };
+}
+```
+
+FSM contract (Gherkin):
+
+```gherkin
+Given user opens ReindexModal phase="confirm"
+Then dialog shows cost breakdown table + Re-index / Annulla CTAs
+
+When user clicks Re-index
+Then orchestrator triggers useReindexKb.mutateAsync() AND sets phase="running"
+And modal shows spinner + progress bar + job ID (if returned)
+
+When mutation resolves successfully
+Then orchestrator sets phase="done"
+And modal shows success badge + summary + Chiudi CTA
+
+When user clicks Chiudi
+Then orchestrator sets open=false AND phase="confirm" (reset for next invocation)
+```
+
+### RaptorPanel
+
+```ts
+type RaptorTier = 'free' | 'pro';
+
+interface RaptorPanelProps {
+  readonly tier: RaptorTier;
+  readonly labels: RaptorPanelLabels;
+  readonly onRebuild?: () => void;          // only invoked if tier='pro'
+  // Deferred metrics:
+  readonly lastRebuildRelative?: string;
+  readonly summariesCount?: number;
+  readonly estimatedCost?: string;
+  readonly estimatedDuration?: string;
+}
+```
+
+Variant routing (Gherkin):
+
+```gherkin
+Given tier='free'
+Then panel shows locked state with "🔒 PRO" badge + lockedNote + disabled CTA + upgrade link
+
+Given tier='pro'
+Then panel shows active state with "PRO ✓" badge + cost/duration row + enabled CTA
+And clicking CTA invokes onRebuild
+```
+
+### DeleteDialog
+
+```ts
+interface DeleteDialogProps {
+  readonly open: boolean;
+  readonly pdfName: string;
+  readonly labels: DeleteDialogLabels;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+  // Deferred cleanup metadata (hide list if undefined):
+  readonly cleanupItems?: ReadonlyArray<{ readonly key: string; readonly icon: string; readonly label: string }>;
+}
+```
+
+Implementazione: estende `ConfirmModal` con slot `<DialogDescription>` custom contenente cleanup list + warning. Variant=`destructive`.
+
+## Hook contracts — `useKbHub.ts`
+
+```ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { knowledgeBaseClient } from '@/lib/api/clients/knowledgeBaseClient';
+import { libraryClient } from '@/lib/api/clients/libraryClient';
+import { pdfClient } from '@/lib/api/clients/pdfClient';
+
+export const kbHubKeys = {
+  all: ['kbHub'] as const,
+  status: (gameId: string) => [...kbHubKeys.all, 'status', gameId] as const,
+  pdfs: (gameId: string) => [...kbHubKeys.all, 'pdfs', gameId] as const,
+};
+
+// READ
+export function useUserGameKbStatus(gameId: string | undefined) {
+  return useQuery({
+    queryKey: gameId ? kbHubKeys.status(gameId) : ['kbHub', 'status', '__skip'],
+    queryFn: () => knowledgeBaseClient.getUserGameKbStatus(gameId!),
+    enabled: !!gameId,
+  });
+}
+
+export function useGamePdfs(gameId: string | undefined) {
+  return useQuery({
+    queryKey: gameId ? kbHubKeys.pdfs(gameId) : ['kbHub', 'pdfs', '__skip'],
+    queryFn: () => libraryClient.getGamePdfs(gameId!),
+    enabled: !!gameId,
+  });
+}
+
+// MUTATIONS — cache invalidation strategy
+export function useReindexKb(gameId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => knowledgeBaseClient.reindexKb(gameId), // NEW client method (existing endpoint)
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+      qc.invalidateQueries({ queryKey: kbHubKeys.pdfs(gameId) });
+    },
+  });
+}
+
+export function useRebuildRaptor(gameId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => knowledgeBaseClient.rebuildRaptor(gameId), // NEW client method (existing endpoint)
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+    },
+  });
+}
+
+export function useDeletePdf(gameId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (pdfId: string) => pdfClient.deletePdf(pdfId), // existing
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbHubKeys.pdfs(gameId) });
+      qc.invalidateQueries({ queryKey: kbHubKeys.status(gameId) });
+    },
+  });
+}
+```
+
+**NB**: `knowledgeBaseClient.reindexKb()` e `.rebuildRaptor()` non esistono ancora — vanno aggiunti (thin wrappers `POST /api/v1/games/{gameId}/kb/reindex` e `POST /api/v1/games/{gameId}/kb/raptor/rebuild`).
+
+## Orchestrator — `_content.tsx`
+
+```tsx
+'use client';
+
+export function KbHubPage({ gameId }: { gameId: string }) {
+  const { t } = useTranslation();
+  const { data: status, isLoading: statusLoading } = useUserGameKbStatus(gameId);
+  const { data: pdfs = [], isLoading: pdfsLoading } = useGamePdfs(gameId);
+  const { data: game } = useGameDetail(gameId);
+  const reindexMutation = useReindexKb(gameId);
+  const raptorMutation = useRebuildRaptor(gameId);
+  const deleteMutation = useDeletePdf(gameId);
+
+  const [reindexOpen, setReindexOpen] = useState(false);
+  const [reindexPhase, setReindexPhase] = useState<ReindexPhase>('confirm');
+  const [actionsMenuPdfId, setActionsMenuPdfId] = useState<string | null>(null);
+  const [deletePdfTarget, setDeletePdfTarget] = useState<GamePdfDto | null>(null);
+
+  if (statusLoading || pdfsLoading) return <KbHubSkeleton />;
+  
+  const isEmpty = pdfs.length === 0;
+  const gameInfo = { title: game?.title ?? '', emoji: '📚' };
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-6xl space-y-6">
+      {isEmpty ? (
+        <EmptyState gameTitle={gameInfo.title} labels={...} onUpload={handleUpload} />
+      ) : (
+        <HubDefault 
+          game={gameInfo}
+          documentCount={status?.documentCount ?? 0}
+          coverageLevel={status?.coverageLevel ?? 'None'}
+          pdfs={mapPdfs(pdfs)}
+          labels={...}
+          onUpload={handleUpload}
+          onReindexAll={() => { setReindexOpen(true); setReindexPhase('confirm'); }}
+          onPdfAction={setActionsMenuPdfId}
+        />
+      )}
+
+      {!isEmpty && (
+        <KbStatsCard
+          documentCount={status?.documentCount ?? 0}
+          coverageLevel={status?.coverageLevel ?? 'None'}
+          coverageScore={status?.coverageScore ?? 0}
+          labels={...}
+          // chunks/embeddings/lastReindex/etc. undefined → hidden gracefully
+        />
+      )}
+
+      {!isEmpty && (
+        <RaptorPanel
+          tier="free"  // MVP: no tier data from BE
+          labels={...}
+          // metrics undefined → hidden
+        />
+      )}
+
+      <ReindexModal
+        open={reindexOpen}
+        phase={reindexPhase}
+        labels={...}
+        costRows={STATIC_REINDEX_COST_ROWS}  // hardcoded MVP (BE doesn't expose per-game estimate)
+        onConfirm={async () => {
+          setReindexPhase('running');
+          try {
+            await reindexMutation.mutateAsync();
+            setReindexPhase('done');
+          } catch {
+            setReindexOpen(false);
+            setReindexPhase('confirm');
+          }
+        }}
+        onClose={() => { setReindexOpen(false); setReindexPhase('confirm'); }}
+      />
+
+      <DeleteDialog
+        open={!!deletePdfTarget}
+        pdfName={deletePdfTarget?.name ?? ''}
+        labels={...}
+        onConfirm={async () => {
+          if (!deletePdfTarget) return;
+          await deleteMutation.mutateAsync(deletePdfTarget.id);
+          setDeletePdfTarget(null);
+        }}
+        onCancel={() => setDeletePdfTarget(null)}
+      />
+
+      {/* ActionsMenu è popover bound a PdfRow trigger — wireup interno HubDefault */}
+    </div>
+  );
+}
+```
+
+## Testing strategy
+
+### Unit tests (vitest + RTL)
+
+Target: **~40 test** (mirror conteggio component breakdown).
+
+Per ogni component:
+- Default render (props richiesti)
+- Optional props rendering (deferred fields → hide UI when undefined)
+- Event callbacks (onAction, onClick, onSelect, ecc.)
+- Edge cases (empty list, error variant, locked tier)
+
+### A11y tests (jest-axe)
+
+- ReindexModal: 3 phases × dialog + focus trap + ESC = 6+ checks
+- DeleteDialog: dialog + focus trap + destructive variant = 4+ checks
+- ActionsMenu: popover focus return + ESC + arrow nav = 3+ checks
+
+### Integration tests
+
+- Orchestrator: loading state → empty/default routing
+- Orchestrator: mutation success → cache invalidation
+- Orchestrator: mutation error → modal reset
+
+### i18n MESSAGES test extension (P71)
+
+Aggiornare `apps/web/src/lib/i18n/__tests__/messages.test.tsx` per coprire le nuove key `pages.library.gameDetail.kb.*`.
+
+## i18n keys (preview)
+
+Namespace: `pages.library.gameDetail.kb`
+
+```json
+"kb": {
+  "title": "{gameTitle} · Knowledge Base",
+  "entityLabel": "Knowledge Base",
+  "uploadCta": "+ Carica PDF",
+  "reindexAllCta": "⟳ Re-index all",
+  "stats": {
+    "docs": "{count, plural, one {# documento} other {# documenti}}",
+    "coverage": {
+      "None": "Nessuna",
+      "Basic": "Base",
+      "Standard": "Standard",
+      "Complete": "Completa"
+    }
+  },
+  "empty": {
+    "title": "Nessun PDF indicizzato",
+    "description": "Carica il primo documento PDF per indicizzare le regole di {gameTitle}.",
+    "ctaLabel": "Carica primo documento",
+    "supportedFormats": "Formati supportati: PDF · Max 200 MB per file"
+  },
+  "pdfRow": {
+    "openCta": "Apri dettaglio",
+    "openAria": "Apri dettaglio {pdfName}",
+    "chunksLabel": "{count} chunks",
+    "status": {
+      "ready": "Ready",
+      "indexing": "Indexing",
+      "stale": "Stale",
+      "failed": "Failed"
+    }
+  },
+  "actionsMenu": {
+    "open": { "label": "Apri dettaglio", "description": "Visualizza chunks e preview" },
+    "reindex": { "label": "Re-index", "description": "Rielabora embedding PDF" },
+    "cost": { "label": "Statistiche costo", "description": "Token consumati e costo" },
+    "move": { "label": "Sposta in altro gioco", "description": "Sposta in altra scheda KB" },
+    "delete": { "label": "Elimina", "description": "Rimuovi PDF e cleanup" }
+  },
+  "reindexModal": {
+    "title": "Re-index full KB",
+    "subtitle": "{gameTitle} · {docCount} documenti",
+    "costHeader": "Stima costo operazione",
+    "description": "Questa operazione rielabora tutti i chunk e rigenera gli embedding. Le chat esistenti continueranno a funzionare durante il processo.",
+    "reindexCta": "⟳ Re-index",
+    "cancelCta": "Annulla",
+    "runningTitle": "Re-index in corso…",
+    "jobIdLabel": "Job ID",
+    "doneTitle": "Re-index completato",
+    "closeCta": "Chiudi"
+  },
+  "raptor": {
+    "title": "RAPTOR Rebuild",
+    "description": "Recursive Abstractive Processing Tree Of Retrieval",
+    "lockedBadge": "🔒 PRO",
+    "activeBadge": "PRO ✓",
+    "lockedNote": "RAPTOR richiede piano Pro. Abilita clustering gerarchico per retrieval Q&A avanzato.",
+    "upgradeCta": "Rebuild RAPTOR — Upgrade to Pro",
+    "upgradeLink": "Scopri piano Pro",
+    "rebuildCta": "Rebuild RAPTOR",
+    "metrics": {
+      "lastRebuild": "Ultimo rebuild",
+      "summaries": "Summaries generate"
+    }
+  },
+  "delete": {
+    "title": "Confermi eliminazione PDF?",
+    "subtitle": "{pdfName}",
+    "listHeader": "Verrà eliminato definitivamente:",
+    "warning": "Operazione irreversibile — nessun backup disponibile",
+    "deleteCta": "Elimina definitivamente",
+    "cancelCta": "Annulla"
+  }
+}
+```
+
+EN mirror.
+
+## DS-15 tokens
+
+- KB entity: `bg-entity-kb`, `text-entity-kb`, `border-entity-kb`, `text-entity-kb/[opacity]` (canonical `--c-kb` teal 174 60% 40% light / 174 60% 55% dark)
+- Destructive (delete): `bg-destructive`, `text-destructive`, `border-destructive`
+- RAPTOR gold: usa `text-warning`, `bg-warning`, `border-warning` (AA-safe semantic, sostituisce mockup hardcoded `hsl(43,92%,52%)`)
+- Cards: `bg-card`, `border-border`, `text-foreground`, `text-muted-foreground`
+- NO hardcoded color utilities (ESLint rule `local/no-hardcoded-color-utility` enforced)
+
+## Out of scope (deferred follow-up issues)
+
+1. **BE schema enrichment** — apro 1 follow-up issue P2/P3:
+   - Extend `UserGameKbStatusSchema` con: `chunks, embeddings, lastReindexAt, raptorLastRebuildAt, lifetimeCostUsd, costHistoryLast7Days[]`
+   - Extend `GamePdfDtoSchema` con: `processingStatus, chunkCount`
+   - New endpoint per cleanup metadata: `GET /api/v1/pdf/{pdfId}/cleanup-preview`
+2. **User tier detection** (free/pro) — apro 1 follow-up issue se non esiste già
+3. **Reindex job polling** — server emette job ID, FE polling endpoint disponibile (`/kb/reindex/{jobId}/status`) ma non integrato in MVP; running phase usa optimistic mock progress
+4. **PDF upload flow** — già esistente in altro flow, CTA Upload link out (out of scope qui)
+5. **Mockup state #6 KB Coverage Stats Card "compact" variant** — `compact` prop esposto nel mockup ma orchestrator render solo full size
+
+## File list
+
+### NEW (FE)
+- `apps/web/src/app/(authenticated)/library/[gameId]/kb/page.tsx`
+- `apps/web/src/app/(authenticated)/library/[gameId]/kb/_content.tsx`
+- `apps/web/src/components/features/kb-hub/index.ts`
+- `apps/web/src/components/features/kb-hub/KbStatsCard.tsx`
+- `apps/web/src/components/features/kb-hub/PdfRow.tsx`
+- `apps/web/src/components/features/kb-hub/HubDefault.tsx`
+- `apps/web/src/components/features/kb-hub/EmptyState.tsx`
+- `apps/web/src/components/features/kb-hub/ActionsMenu.tsx`
+- `apps/web/src/components/features/kb-hub/ReindexModal.tsx`
+- `apps/web/src/components/features/kb-hub/RaptorPanel.tsx`
+- `apps/web/src/components/features/kb-hub/DeleteDialog.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/KbStatsCard.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/PdfRow.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/HubDefault.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/EmptyState.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/ActionsMenu.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/ReindexModal.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/RaptorPanel.test.tsx`
+- `apps/web/src/components/features/kb-hub/__tests__/DeleteDialog.test.tsx`
+- `apps/web/src/hooks/queries/useKbHub.ts`
+- `apps/web/src/hooks/queries/__tests__/useKbHub.test.tsx`
+
+### MODIFIED (FE)
+- `apps/web/messages/it/messages.json` — add `pages.library.gameDetail.kb.*`
+- `apps/web/messages/en/messages.json` — add `pages.library.gameDetail.kb.*` (EN mirror)
+- `apps/web/src/lib/i18n/__tests__/messages.test.tsx` — extend MESSAGES coverage (P71)
+- `apps/web/src/lib/api/clients/knowledgeBaseClient.ts` — add `reindexKb(gameId)` + `rebuildRaptor(gameId)` thin wrappers
+- `apps/web/src/hooks/queries/index.ts` — export from useKbHub
+
+### MODIFIED (matrix)
+- `docs/for-developers/frontend/v2-migration-matrix.md` — `pending` → `done` for `/library/[gameId]/kb` row (or new row if absent)
+
+## Effort estimate
+
+| Phase | Time |
+|---|---|
+| Spec doc (this file) + commit | ~30m ✅ |
+| Branch + barrel scaffolding | ~15m |
+| 8 components TDD (red → green per component) | ~3-4h |
+| useKbHub hook + tests | ~30m |
+| _content orchestrator + integration tests | ~1h |
+| i18n keys + MESSAGES test extension | ~30m |
+| Matrix update + spec link | ~10m |
+| Code review subagent + apply IMPORTANT | ~30-45m |
+| PR + CI + merge | ~30m-1h |
+| **Total** | **~6-8h** (Tier M aligned) |
+
+## References
+
+- Mockup: `admin-mockups/design_files/sp4-kb-hub.{html,jsx}`
+- Issue body: [#1481](https://github.com/meepleAi-app/meepleai-monorepo/issues/1481)
+- Epic: [#1475](https://github.com/meepleAi-app/meepleai-monorepo/issues/1475)
+- Pattern reference (game-detail siblings): `apps/web/src/components/features/game-detail/`
+- ConfirmModal precedent: PR #1516 (Issue #1464 HouseRulesList CRUD)
+- DS-15 token canonical: `docs/for-developers/specs/2026-05-12-token-canonicalization.md`
+- v2 migration spec: `docs/for-developers/specs/2026-04-26-v2-design-migration.md`
+- Pattern P83 (scope reduction): MEMORY.md 2026-05-25 #1484 EncounterCheatsheetView entry


### PR DESCRIPTION
## Summary

Implements [#1481](https://github.com/meepleAi-app/meepleai-monorepo/issues/1481) (Epic [#1475](https://github.com/meepleAi-app/meepleai-monorepo/issues/1475)): KB Hub for `/library/[gameId]/kb`, 8 pure presentational components + orchestrator + hook, all wired to existing user-side BE endpoints.

## Design decisions

- **Routing A1**: NEW route `/library/[gameId]/kb` standalone (game-scoped, matches mockup header `Gloomhaven · KB`). `/knowledge-base/` route untouched (still `redirect('/library')`). Pattern coerente con sibling `/library/[gameId]/toolbox`. `GameDetailKbDocList.tsx` (esistente, lightweight) coesiste invariato.

- **Scope X1 / Pattern P83**: 8 componenti accettano props complete del mockup; orchestrator wires SOLO i dati BE disponibili oggi (`documentCount`, `coverageLevel`, `coverageScore`, PDF list, 3 mutations); deferred props (chunks, embeddings, lastReindex, raptorLast, cost, costHistory, PDF row status/chunks, RAPTOR tier, cleanup metadata) **hide gracefully** quando undefined. Follow-up BE issue planned per arricchire `UserGameKbStatusSchema` + `GamePdfDtoSchema`.

- **Componenti pure presentational**: props-only, no hooks dentro, labels caller-side i18n. Mirror pattern di `GameDetailLeaderboard` / `GameDetailHouseRulesList` / `GameDetailChatTab`.

- **Modal primitives**: ReindexModal + DeleteDialog usano `Dialog` primitive (custom slots non disponibili in ConfirmModal); ActionsMenu = Radix `DropdownMenu` esistente.

- **DS-15 tokens**: `bg-entity-kb`, `text-entity-kb`, `text-destructive`, `text-warning` (RAPTOR gold AA-safe). 0 lint errors.

## File list

**NEW (FE)**:
- `apps/web/src/app/(authenticated)/library/[gameId]/kb/page.tsx` + `_content.tsx`
- `apps/web/src/components/features/kb-hub/` (8 components + barrel + 8 tests)
- `apps/web/src/hooks/queries/useKbHub.ts` + test (8 tests)

**MODIFIED (FE)**:
- `apps/web/src/lib/api/clients/knowledgeBaseClient.ts` (+ `reindexKb` + `rebuildRaptor` thin wrappers)
- `apps/web/src/locales/{it,en}.json` (+ namespace `pages.library.gameDetail.kb.*`)
- `docs/for-developers/frontend/v2-migration-matrix.md` (8 rows → done + route → `/library/[gameId]/kb`)

**NEW (docs)**:
- `docs/superpowers/specs/2026-05-25-kb-hub-impl-design.md`

## Tests

| Suite | Files | Tests |
|---|---|---|
| Components (kb-hub/__tests__) | 8 | 41 |
| Hook (useKbHub) | 1 | 8 |
| Orchestrator integration | 1 | 6 |
| **Total** | **10** | **55 ✅** |

## Code review applied

Code review subagent surfacing 1 falsamente CRITICAL (P74 verify-reviewer-claims: `bg-slate-500` doesn't actually trigger ESLint error in real run) + 4 IMPORTANT, tutti applicati in commit `f6c6cd231`:
1. **Reindex error toast** — uses pre-existing `errors.reindexFailed` i18n key (era unused)
2. **Delete dialog stays open on error** + toast `errors.deleteFailed`
3. **Hardcoded `it-IT` locale removed** across 5 call sites (uses runtime locale)
4. **`useGamePdfs` disabled-state test** symmetry with `useUserKbStatus`

## Out of scope (deferred follow-up issues)

- BE schema enrichment (chunks, embeddings, lastReindex, raptorLast, cost, costHistory, PDF status, cleanup metadata) — opening follow-up issue post-merge
- User tier detection (free/pro) — RAPTOR defaults to `free` in MVP
- Reindex job polling — emits job ID via BE but client polling deferred

## Test plan
- [x] `pnpm test` — 55/55 green su kb-hub + hook + orchestrator
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint <kb-hub paths>` — 0 errors (only pre-existing warnings repo-wide)
- [ ] CI Frontend Tests (Vitest shards 1-3) + Frontend Static (lint/typecheck/Storybook)
- [ ] CI Frontend Fast Gate
- [ ] Mockup-vs-live designer review post-merge (visual regression suite retired)

Closes #1481

🤖 Generated with [Claude Code](https://claude.com/claude-code)