### PR TITLE
feat(toolkit-detail): #1479 implement 3 shelf-ready components

### DIFF
--- a/apps/web/src/components/features/toolkit-detail/PromptPreviewBlock.tsx
+++ b/apps/web/src/components/features/toolkit-detail/PromptPreviewBlock.tsx
@@ -1,14 +1,54 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: PromptPreviewBlock
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * PromptPreviewBlock — system-prompt preview for `/toolkits/[id]` Agent tab.
+ *
+ * Wave 3 (#1479). Maps the mockup AgentTab "System prompt (preview)" section
+ * (sp4-toolkit-detail.jsx:560-592). Pure presentational, labels injected.
+ *
+ * Source data: ToolkitAgentSummary.systemPromptPreview. The token count is not
+ * exposed by the v1 backend schema (Gate B) — it is optional and hidden when
+ * absent.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface PromptPreviewBlockProps {
-  // TODO: extract props contract from mockup analysis
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface PromptPreviewBlockLabels {
+  readonly heading: string;
+  readonly tokenCountSuffix: string;
 }
 
-export function PromptPreviewBlock(_props: PromptPreviewBlockProps): ReactElement | null {
-  return null;
+export interface PromptPreviewBlockProps {
+  readonly systemPrompt: string;
+  readonly tokenCount?: number | null;
+  readonly labels: PromptPreviewBlockLabels;
+  readonly className?: string;
+}
+
+export function PromptPreviewBlock({
+  systemPrompt,
+  tokenCount,
+  labels,
+  className,
+}: PromptPreviewBlockProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkit-detail-prompt-preview"
+      className={clsx('flex flex-col gap-2', className)}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="font-bold font-[Quicksand] text-sm text-foreground">{labels.heading}</h3>
+        {tokenCount != null && (
+          <span className="font-mono text-[10px] font-bold text-muted-foreground tabular-nums">
+            {tokenCount} {labels.tokenCountSuffix}
+          </span>
+        )}
+      </div>
+      <pre className="m-0 max-h-[220px] overflow-auto whitespace-pre-wrap rounded-lg border border-border bg-muted p-3.5 font-mono text-[11.5px] leading-relaxed text-foreground">
+        {systemPrompt}
+      </pre>
+    </div>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/RatingBreakdown.tsx
+++ b/apps/web/src/components/features/toolkit-detail/RatingBreakdown.tsx
@@ -1,14 +1,174 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: RatingBreakdown
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * RatingBreakdown — ratings summary + histogram + reviews for `/toolkits/[id]`.
+ *
+ * Wave 3 (#1479). Maps the mockup ReviewsTab (sp4-toolkit-detail.jsx:847-935).
+ * Pure presentational, labels injected, dates pre-formatted by the caller.
+ *
+ * Source data: ToolkitRatingsResponse (averageStars, totalCount,
+ * breakdown.star1..5, items: ToolkitRating[]). The v1 backend (Gate B) returns
+ * a zero/empty stub until the ToolkitRating entity ships — hence the empty
+ * state and the division-by-zero guard on the histogram bars.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface RatingBreakdownProps {
-  // TODO: extract props contract from mockup analysis
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { Stars } from './Stars';
+
+export interface RatingBreakdownReview {
+  readonly id: string;
+  readonly raterDisplayName: string;
+  readonly raterAvatarUrl: string | null;
+  readonly stars: number;
+  readonly comment: string | null;
+  /** Pre-formatted, locale-aware timestamp supplied by the orchestrator. */
+  readonly createdAtLabel: string;
 }
 
-export function RatingBreakdown(_props: RatingBreakdownProps): ReactElement | null {
-  return null;
+export interface RatingBreakdownLabels {
+  readonly reviewsCountLabel: string;
+  readonly empty: string;
+}
+
+export interface RatingBreakdownBuckets {
+  readonly star1: number;
+  readonly star2: number;
+  readonly star3: number;
+  readonly star4: number;
+  readonly star5: number;
+}
+
+export interface RatingBreakdownProps {
+  readonly averageStars: number;
+  readonly totalCount: number;
+  readonly breakdown: RatingBreakdownBuckets;
+  readonly reviews: readonly RatingBreakdownReview[];
+  readonly labels: RatingBreakdownLabels;
+  readonly className?: string;
+}
+
+const STAR_BUCKETS = [5, 4, 3, 2, 1] as const;
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export function RatingBreakdown({
+  averageStars,
+  totalCount,
+  breakdown,
+  reviews,
+  labels,
+  className,
+}: RatingBreakdownProps): JSX.Element {
+  if (totalCount <= 0) {
+    return (
+      <div
+        data-slot="toolkit-detail-rating-breakdown"
+        className={clsx('rounded-lg border border-border bg-card p-6 text-center', className)}
+      >
+        <p className="font-mono text-xs text-muted-foreground">{labels.empty}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="toolkit-detail-rating-breakdown"
+      className={clsx('flex flex-col gap-4', className)}
+    >
+      <div
+        data-slot="toolkit-detail-rating-summary"
+        className="grid grid-cols-[auto_1fr] items-center gap-6 rounded-lg border border-border bg-card p-4"
+      >
+        <div className="text-center">
+          <div className="font-bold font-[Quicksand] text-4xl leading-none text-foreground tabular-nums">
+            {averageStars.toFixed(1)}
+          </div>
+          <div className="mt-1 flex justify-center">
+            <Stars value={averageStars} />
+          </div>
+          <div className="mt-1 font-mono text-[10px] font-bold text-muted-foreground">
+            {totalCount} {labels.reviewsCountLabel}
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {STAR_BUCKETS.map(star => {
+            const count = breakdown[`star${star}` as keyof RatingBreakdownBuckets];
+            const pct = totalCount > 0 ? (count / totalCount) * 100 : 0;
+            return (
+              <div
+                key={star}
+                data-slot="toolkit-detail-rating-row"
+                className="flex items-center gap-2"
+              >
+                <span className="w-5 font-mono text-[11px] font-bold text-muted-foreground">
+                  {star}
+                  <span aria-hidden="true">★</span>
+                </span>
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                  <div
+                    data-slot="toolkit-detail-rating-bar"
+                    className="h-full rounded-full bg-entity-agent"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="w-7 text-right font-mono text-[10px] font-bold text-muted-foreground tabular-nums">
+                  {count}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {reviews.length > 0 && (
+        <ul data-slot="toolkit-detail-reviews" role="list" className="flex flex-col gap-2.5">
+          {reviews.map(r => (
+            <li
+              key={r.id}
+              data-slot="toolkit-detail-review"
+              className="rounded-lg border border-border bg-card p-3.5"
+            >
+              <div className="mb-1.5 flex items-center gap-2.5">
+                {r.raterAvatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={r.raterAvatarUrl}
+                    alt=""
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    className="flex h-8 w-8 items-center justify-center rounded-full bg-muted font-bold font-[Quicksand] text-[11px] text-foreground"
+                  >
+                    {initialsOf(r.raterDisplayName)}
+                  </span>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="font-bold font-[Quicksand] text-sm text-foreground">
+                    {r.raterDisplayName}
+                  </div>
+                  <div className="flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+                    <Stars value={r.stars} />
+                    <span>{r.createdAtLabel}</span>
+                  </div>
+                </div>
+              </div>
+              {r.comment && (
+                <p className="m-0 text-sm leading-relaxed text-foreground">{r.comment}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/VersionTimeline.tsx
+++ b/apps/web/src/components/features/toolkit-detail/VersionTimeline.tsx
@@ -1,14 +1,141 @@
-// TODO: implement per admin-mockups/design_files/sp4-toolkit-detail.jsx
-// Mapped from mockup component: VersionTimeline
-// Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
-// Tracking: docs/frontend/v2-migration-matrix.md (Issue #573)
+/**
+ * VersionTimeline — published version history rail for `/toolkits/[id]`.
+ *
+ * Wave 3 (#1479). Maps the mockup VersionsTab (sp4-toolkit-detail.jsx:743-841).
+ * Pure presentational, labels injected, dates pre-formatted by the caller.
+ *
+ * Source data: ToolkitVersion[] (version, publishedAt, changelog, isCurrent).
+ * The backend has no `kind` field — it is optional, defaulting to the toolkit
+ * accent dot. `changelog` is a single string (not notes[]) and is split on
+ * newlines into bullet lines. Owner actions (edit notes / yank) are deferred:
+ * the v1 backend has no yank workflow yet.
+ */
 
-import type { ReactElement } from 'react';
+'use client';
 
-export interface VersionTimelineProps {
-  // TODO: extract props contract from mockup analysis
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export type VersionKind = 'major' | 'minor' | 'patch';
+
+export interface VersionTimelineItem {
+  readonly version: string;
+  /** Pre-formatted, locale-aware timestamp supplied by the orchestrator. */
+  readonly publishedAtLabel: string;
+  readonly changelog: string;
+  readonly isCurrent: boolean;
+  readonly kind?: VersionKind;
 }
 
-export function VersionTimeline(_props: VersionTimelineProps): ReactElement | null {
-  return null;
+export interface VersionTimelineLabels {
+  readonly currentBadge: string;
+  readonly empty: string;
+}
+
+export interface VersionTimelineProps {
+  readonly versions: readonly VersionTimelineItem[];
+  readonly labels: VersionTimelineLabels;
+  readonly className?: string;
+}
+
+const DOT_CLASS: Record<VersionKind, string> = {
+  major: 'bg-entity-event',
+  minor: 'bg-entity-toolkit',
+  patch: 'bg-muted-foreground',
+};
+
+function changelogLines(changelog: string): readonly string[] {
+  return changelog
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+export function VersionTimeline({
+  versions,
+  labels,
+  className,
+}: VersionTimelineProps): JSX.Element {
+  if (versions.length === 0) {
+    return (
+      <div
+        data-slot="toolkit-detail-version-timeline"
+        className={clsx('rounded-lg border border-border bg-card p-6 text-center', className)}
+      >
+        <p className="font-mono text-xs text-muted-foreground">{labels.empty}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-slot="toolkit-detail-version-timeline" className={clsx('flex flex-col', className)}>
+      {versions.map((v, i) => {
+        const isLast = i === versions.length - 1;
+        const dotClass = v.kind ? DOT_CLASS[v.kind] : 'bg-entity-toolkit';
+        const lines = changelogLines(v.changelog);
+        return (
+          <div
+            key={v.version}
+            data-slot="toolkit-detail-version-item"
+            className={clsx('flex gap-3.5', !isLast && 'pb-3.5')}
+          >
+            <div className="relative flex w-3.5 shrink-0 justify-center pt-1.5">
+              {!isLast && (
+                <div
+                  data-slot="toolkit-detail-version-connector"
+                  aria-hidden="true"
+                  className="absolute bottom-[-14px] left-1/2 top-[18px] w-0.5 -translate-x-1/2 bg-border"
+                />
+              )}
+              <span
+                data-slot="toolkit-detail-version-dot"
+                aria-hidden="true"
+                className={clsx(
+                  'relative z-[1] h-3.5 w-3.5 rounded-full',
+                  dotClass,
+                  v.isCurrent && 'ring-4 ring-entity-toolkit/10'
+                )}
+              />
+            </div>
+
+            <div
+              data-slot="toolkit-detail-version-item-card"
+              className="flex-1 rounded-lg border border-border bg-card p-3.5"
+            >
+              <div className="mb-1 flex flex-wrap items-center gap-2">
+                <h3 className="m-0 font-mono text-sm font-bold text-foreground">v{v.version}</h3>
+                {v.kind && (
+                  <span
+                    data-slot="toolkit-detail-version-kind"
+                    className="rounded-full bg-muted px-2 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-muted-foreground"
+                  >
+                    {v.kind}
+                  </span>
+                )}
+                {v.isCurrent && (
+                  <span
+                    data-slot="toolkit-detail-version-current"
+                    className="rounded-full bg-entity-toolkit/15 px-2 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-entity-toolkit"
+                  >
+                    {labels.currentBadge}
+                  </span>
+                )}
+                <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+                  {v.publishedAtLabel}
+                </span>
+              </div>
+              {lines.length > 0 && (
+                <ul className="m-0 list-disc pl-4 text-[12.5px] leading-relaxed text-muted-foreground">
+                  {lines.map((line, j) => (
+                    <li key={j}>{line}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }

--- a/apps/web/src/components/features/toolkit-detail/__tests__/PromptPreviewBlock.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/PromptPreviewBlock.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * PromptPreviewBlock - Unit tests (Issue #1479).
+ *
+ * Pure presentational system-prompt preview block. Maps from the mockup
+ * AgentTab "System prompt (preview)" section (sp4-toolkit-detail.jsx:560-592).
+ * Source data: ToolkitAgentSummary.systemPromptPreview. `tokenCount` is NOT in
+ * the v1 backend schema → optional, graceful-hide (P83).
+ *
+ * Test matrix (Crispin):
+ *   T1. Renders heading + the system prompt text in a <pre>.
+ *   T2. data-slot attribute present.
+ *   T3. tokenCount provided → renders "{n} {suffix}" badge.
+ *   T4. tokenCount omitted/null → no token badge (graceful hide).
+ *   T5. Multiline prompt content preserved verbatim.
+ *   T6. DS-15 tokens on the <pre> (bg-muted, border-border, text-foreground).
+ *   T7. className composition on root.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PromptPreviewBlock } from '../PromptPreviewBlock';
+
+const labels = {
+  heading: 'System prompt (preview)',
+  tokenCountSuffix: 'token',
+};
+
+const PROMPT = 'Sei "Azul Rules Expert".\nRispondi sempre in italiano.';
+
+describe('PromptPreviewBlock (Issue #1479)', () => {
+  // T1
+  it('renders the heading and the system prompt text', () => {
+    render(<PromptPreviewBlock systemPrompt={PROMPT} labels={labels} />);
+    expect(screen.getByRole('heading', { name: 'System prompt (preview)' })).toBeInTheDocument();
+    expect(screen.getByText(/Azul Rules Expert/)).toBeInTheDocument();
+  });
+
+  // T2
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<PromptPreviewBlock systemPrompt={PROMPT} labels={labels} />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-prompt-preview"]')
+    ).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders the token-count badge when tokenCount is provided', () => {
+    render(<PromptPreviewBlock systemPrompt={PROMPT} tokenCount={342} labels={labels} />);
+    expect(screen.getByText('342 token')).toBeInTheDocument();
+  });
+
+  // T4
+  it('hides the token-count badge when tokenCount is omitted', () => {
+    render(<PromptPreviewBlock systemPrompt={PROMPT} labels={labels} />);
+    expect(screen.queryByText(/token/)).not.toBeInTheDocument();
+  });
+
+  it('hides the token-count badge when tokenCount is null', () => {
+    render(<PromptPreviewBlock systemPrompt={PROMPT} tokenCount={null} labels={labels} />);
+    expect(screen.queryByText(/token/)).not.toBeInTheDocument();
+  });
+
+  // T5
+  it('preserves the multiline prompt content verbatim', () => {
+    const { container } = render(<PromptPreviewBlock systemPrompt={PROMPT} labels={labels} />);
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe(PROMPT);
+  });
+
+  // T6
+  it('uses DS-15 tokens on the pre block', () => {
+    const { container } = render(<PromptPreviewBlock systemPrompt={PROMPT} labels={labels} />);
+    const pre = container.querySelector('pre');
+    expect(pre).toHaveClass('bg-muted');
+    expect(pre).toHaveClass('border-border');
+    expect(pre).toHaveClass('text-foreground');
+  });
+
+  // T7
+  it('composes custom className with base classes on the root', () => {
+    const { container } = render(
+      <PromptPreviewBlock systemPrompt={PROMPT} labels={labels} className="extra" />
+    );
+    const root = container.querySelector('[data-slot="toolkit-detail-prompt-preview"]');
+    expect(root).toHaveClass('extra');
+  });
+});

--- a/apps/web/src/components/features/toolkit-detail/__tests__/RatingBreakdown.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/RatingBreakdown.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * RatingBreakdown - Unit tests (Issue #1479).
+ *
+ * Pure presentational ratings summary. Maps from the mockup ReviewsTab
+ * (sp4-toolkit-detail.jsx:847-935): average + Stars + count, a 5→1 histogram,
+ * and the reviews list. Source data: ToolkitRatingsResponse (averageStars,
+ * totalCount, breakdown.star1..5, items: ToolkitRating[]).
+ *
+ * Test matrix (Crispin):
+ *   T1. Average (toFixed 1) + reviews count label.
+ *   T2. Five histogram rows, one per star bucket, with counts.
+ *   T3. Bar width % is count/totalCount (5★ = 7/10 → 70%).
+ *   T4. EDGE division-by-zero: totalCount=0 → empty state, no NaN, no rows.
+ *   T5. Reviews list: one row per review with name + comment.
+ *   T6. Avatar: img when raterAvatarUrl set; neutral initials otherwise.
+ *   T7. comment null → no comment paragraph.
+ *   T8. data-slot attributes (card + rows).
+ *   T9. DS-15 tokens.
+ *   T10. className composition.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RatingBreakdown, type RatingBreakdownReview } from '../RatingBreakdown';
+
+const labels = {
+  reviewsCountLabel: 'recensioni',
+  empty: 'Ancora nessuna recensione',
+};
+
+function review(over: Partial<RatingBreakdownReview> & { id: string }): RatingBreakdownReview {
+  return {
+    id: over.id,
+    raterDisplayName: over.raterDisplayName ?? 'Marco Rossi',
+    raterAvatarUrl: over.raterAvatarUrl ?? null,
+    stars: over.stars ?? 5,
+    comment: 'comment' in over ? (over.comment ?? null) : 'Ottimo toolkit',
+    createdAtLabel: over.createdAtLabel ?? '20 mag 2026',
+  };
+}
+
+const breakdown = { star1: 0, star2: 0, star3: 1, star4: 2, star5: 7 };
+
+const twoReviews: ReadonlyArray<RatingBreakdownReview> = [
+  review({ id: 'r1', raterDisplayName: 'Marco Rossi', stars: 5, comment: 'Ottimo toolkit' }),
+  review({ id: 'r2', raterDisplayName: 'Lucia Bianchi', stars: 4, comment: 'Molto utile' }),
+];
+
+describe('RatingBreakdown (Issue #1479)', () => {
+  // T1
+  it('renders the average and the reviews count label', () => {
+    render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    expect(screen.getByText('4.3')).toBeInTheDocument();
+    expect(screen.getByText('10 recensioni')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders five histogram rows with their counts', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    expect(container.querySelectorAll('[data-slot="toolkit-detail-rating-row"]')).toHaveLength(5);
+  });
+
+  // T3
+  it('sets bar width to count/totalCount percent (5★ = 70%)', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    // Rows render 5★ → 1★, so the first bar is the 5★ bucket (7/10 = 70%).
+    const bars = container.querySelectorAll('[data-slot="toolkit-detail-rating-bar"]');
+    expect((bars[0] as HTMLElement).style.width).toBe('70%');
+  });
+
+  // T4 — EDGE: division-by-zero guard
+  it('shows the empty state with no NaN when totalCount is 0', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={0}
+        totalCount={0}
+        breakdown={{ star1: 0, star2: 0, star3: 0, star4: 0, star5: 0 }}
+        reviews={[]}
+        labels={labels}
+      />
+    );
+    expect(screen.getByText('Ancora nessuna recensione')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="toolkit-detail-rating-row"]')).toHaveLength(0);
+    expect(container.textContent ?? '').not.toContain('NaN');
+  });
+
+  // T5
+  it('renders one row per review with name and comment', () => {
+    render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText('Marco Rossi')).toBeInTheDocument();
+    expect(screen.getByText('Ottimo toolkit')).toBeInTheDocument();
+    expect(screen.getByText('Lucia Bianchi')).toBeInTheDocument();
+  });
+
+  // T6
+  it('renders an avatar image when raterAvatarUrl is set', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={5}
+        totalCount={1}
+        breakdown={{ star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 }}
+        reviews={[review({ id: 'r1', raterAvatarUrl: 'https://x/a.png' })]}
+        labels={labels}
+      />
+    );
+    expect(container.querySelector('img')).toBeInTheDocument();
+  });
+
+  it('renders neutral initials when raterAvatarUrl is null', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={5}
+        totalCount={1}
+        breakdown={{ star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 }}
+        reviews={[review({ id: 'r1', raterDisplayName: 'Marco Rossi', raterAvatarUrl: null })]}
+        labels={labels}
+      />
+    );
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('MR')).toBeInTheDocument();
+  });
+
+  // T7
+  it('omits the comment paragraph when comment is null', () => {
+    render(
+      <RatingBreakdown
+        averageStars={5}
+        totalCount={1}
+        breakdown={{ star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 }}
+        reviews={[review({ id: 'r1', raterDisplayName: 'No Comment', comment: null })]}
+        labels={labels}
+      />
+    );
+    expect(screen.getByText('No Comment')).toBeInTheDocument();
+    expect(screen.queryByText('Ottimo toolkit')).not.toBeInTheDocument();
+  });
+
+  // T8
+  it('exposes data-slot on the root card', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-rating-breakdown"]')
+    ).toBeInTheDocument();
+  });
+
+  // T9
+  it('uses DS-15 tokens on the breakdown card', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+      />
+    );
+    const card = container.querySelector('[data-slot="toolkit-detail-rating-summary"]');
+    expect(card).toHaveClass('bg-card');
+    expect(card).toHaveClass('border-border');
+  });
+
+  // T10
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <RatingBreakdown
+        averageStars={4.3}
+        totalCount={10}
+        breakdown={breakdown}
+        reviews={twoReviews}
+        labels={labels}
+        className="extra"
+      />
+    );
+    const root = container.querySelector('[data-slot="toolkit-detail-rating-breakdown"]');
+    expect(root).toHaveClass('extra');
+  });
+});

--- a/apps/web/src/components/features/toolkit-detail/__tests__/RatingBreakdown.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/RatingBreakdown.test.tsx
@@ -154,6 +154,19 @@ describe('RatingBreakdown (Issue #1479)', () => {
     expect(screen.getByText('MR')).toBeInTheDocument();
   });
 
+  it('derives two-char initials for a single-word name', () => {
+    render(
+      <RatingBreakdown
+        averageStars={5}
+        totalCount={1}
+        breakdown={{ star1: 0, star2: 0, star3: 0, star4: 0, star5: 1 }}
+        reviews={[review({ id: 'r1', raterDisplayName: 'Mario', raterAvatarUrl: null })]}
+        labels={labels}
+      />
+    );
+    expect(screen.getByText('MA')).toBeInTheDocument();
+  });
+
   // T7
   it('omits the comment paragraph when comment is null', () => {
     render(

--- a/apps/web/src/components/features/toolkit-detail/__tests__/VersionTimeline.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/VersionTimeline.test.tsx
@@ -134,6 +134,27 @@ describe('VersionTimeline (Issue #1479)', () => {
     ).toHaveLength(2);
   });
 
+  it('renders 0 connectors for a single version', () => {
+    const { container } = render(
+      <VersionTimeline versions={[threeVersions[0]!]} labels={labels} />
+    );
+    expect(
+      container.querySelectorAll('[data-slot="toolkit-detail-version-connector"]')
+    ).toHaveLength(0);
+  });
+
+  it('renders no changelog list when the changelog is empty', () => {
+    const { container } = render(
+      <VersionTimeline
+        versions={[
+          { version: '1.0.0', publishedAtLabel: '1 mag 2026', changelog: '', isCurrent: true },
+        ]}
+        labels={labels}
+      />
+    );
+    expect(container.querySelector('ul')).not.toBeInTheDocument();
+  });
+
   // T9
   it('uses DS-15 tokens on the item card', () => {
     const { container } = render(<VersionTimeline versions={threeVersions} labels={labels} />);

--- a/apps/web/src/components/features/toolkit-detail/__tests__/VersionTimeline.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/VersionTimeline.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * VersionTimeline - Unit tests (Issue #1479).
+ *
+ * Pure presentational version history rail. Maps from the mockup VersionsTab
+ * (sp4-toolkit-detail.jsx:743-841). Source data: ToolkitVersion[] (version,
+ * publishedAt, changelog, isCurrent). The backend has NO `kind` field and
+ * gives `changelog` as a single string (not notes[]) — so `kind` is optional
+ * and the changelog is split on newlines into bullet lines.
+ *
+ * Owner actions (edit notes / yank) are deferred: the v1 backend has no yank
+ * workflow, so they are out of scope for this shelf-ready component.
+ *
+ * Test matrix (Crispin):
+ *   T1. One item per version, labelled "v{version}".
+ *   T2. data-slot attributes (root + items).
+ *   T3. isCurrent → current badge shown exactly once.
+ *   T4. kind present → kind badge; kind absent → no kind badge.
+ *   T5. changelog split on newlines into bullet lines.
+ *   T6. publishedAtLabel rendered.
+ *   T7. Empty state (no versions) → labels.empty, no items.
+ *   T8. Rail connector between items: N-1 for N items.
+ *   T9. DS-15 tokens on the item card.
+ *   T10. className composition.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { VersionTimeline, type VersionTimelineItem } from '../VersionTimeline';
+
+const labels = {
+  currentBadge: 'Corrente',
+  empty: 'Nessuna versione pubblicata',
+};
+
+const threeVersions: ReadonlyArray<VersionTimelineItem> = [
+  {
+    version: '1.2.0',
+    publishedAtLabel: '20 mag 2026',
+    changelog: 'Aggiunto supporto X\nMigliorato Y',
+    isCurrent: true,
+    kind: 'minor',
+  },
+  {
+    version: '1.1.0',
+    publishedAtLabel: '10 mag 2026',
+    changelog: 'Fix bug Z',
+    isCurrent: false,
+    kind: 'patch',
+  },
+  {
+    version: '1.0.0',
+    publishedAtLabel: '1 mag 2026',
+    changelog: 'Release iniziale',
+    isCurrent: false,
+    kind: 'major',
+  },
+];
+
+describe('VersionTimeline (Issue #1479)', () => {
+  // T1
+  it('renders one item per version labelled v{version}', () => {
+    render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(screen.getByText('v1.2.0')).toBeInTheDocument();
+    expect(screen.getByText('v1.1.0')).toBeInTheDocument();
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument();
+  });
+
+  // T2
+  it('exposes data-slot on the root and items', () => {
+    const { container } = render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-version-timeline"]')
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="toolkit-detail-version-item"]')).toHaveLength(3);
+  });
+
+  // T3
+  it('shows the current badge exactly once for the current version', () => {
+    render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(screen.getAllByText(/Corrente/)).toHaveLength(1);
+  });
+
+  // T4
+  it('renders the kind badge when kind is provided', () => {
+    const { container } = render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    const kinds = container.querySelectorAll('[data-slot="toolkit-detail-version-kind"]');
+    expect(kinds).toHaveLength(3);
+    expect(screen.getByText('minor')).toBeInTheDocument();
+    expect(screen.getByText('patch')).toBeInTheDocument();
+    expect(screen.getByText('major')).toBeInTheDocument();
+  });
+
+  it('omits the kind badge when kind is undefined', () => {
+    const { container } = render(
+      <VersionTimeline
+        versions={[
+          { version: '1.0.0', publishedAtLabel: '1 mag 2026', changelog: 'x', isCurrent: true },
+        ]}
+        labels={labels}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-version-kind"]')
+    ).not.toBeInTheDocument();
+  });
+
+  // T5
+  it('splits the changelog on newlines into bullet lines', () => {
+    render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(screen.getByText('Aggiunto supporto X')).toBeInTheDocument();
+    expect(screen.getByText('Migliorato Y')).toBeInTheDocument();
+    expect(screen.getByText('Fix bug Z')).toBeInTheDocument();
+  });
+
+  // T6
+  it('renders the published-at label', () => {
+    render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(screen.getByText('20 mag 2026')).toBeInTheDocument();
+  });
+
+  // T7
+  it('renders the empty state and no items when versions is empty', () => {
+    const { container } = render(<VersionTimeline versions={[]} labels={labels} />);
+    expect(screen.getByText('Nessuna versione pubblicata')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="toolkit-detail-version-item"]')).toHaveLength(0);
+  });
+
+  // T8
+  it('renders N-1 rail connectors for N items', () => {
+    const { container } = render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    expect(
+      container.querySelectorAll('[data-slot="toolkit-detail-version-connector"]')
+    ).toHaveLength(2);
+  });
+
+  // T9
+  it('uses DS-15 tokens on the item card', () => {
+    const { container } = render(<VersionTimeline versions={threeVersions} labels={labels} />);
+    const item = container.querySelector('[data-slot="toolkit-detail-version-item-card"]');
+    expect(item).toHaveClass('bg-card');
+    expect(item).toHaveClass('border-border');
+  });
+
+  // T10
+  it('composes custom className with base classes on the root', () => {
+    const { container } = render(
+      <VersionTimeline versions={threeVersions} labels={labels} className="extra" />
+    );
+    const root = container.querySelector('[data-slot="toolkit-detail-version-timeline"]');
+    expect(root).toHaveClass('extra');
+  });
+});

--- a/apps/web/src/components/features/toolkit-detail/index.ts
+++ b/apps/web/src/components/features/toolkit-detail/index.ts
@@ -9,7 +9,25 @@ export {
   type ToolkitIncludesGridProps,
   type ToolkitIncludesGridLabels,
 } from './ToolkitIncludesGrid';
-// Phase-5 stubs (rendered only when corresponding tabs are wired up post-#822/#819):
-export { PromptPreviewBlock, type PromptPreviewBlockProps } from './PromptPreviewBlock';
-export { RatingBreakdown, type RatingBreakdownProps } from './RatingBreakdown';
-export { VersionTimeline, type VersionTimelineProps } from './VersionTimeline';
+// Implemented (#1479) — pure presentational, props-driven. Rendered once the
+// agent / versions / ratings tabs are enabled post-#822/#819 (currently P5
+// disabled shells in ToolkitDetailView).
+export {
+  PromptPreviewBlock,
+  type PromptPreviewBlockProps,
+  type PromptPreviewBlockLabels,
+} from './PromptPreviewBlock';
+export {
+  RatingBreakdown,
+  type RatingBreakdownProps,
+  type RatingBreakdownLabels,
+  type RatingBreakdownReview,
+  type RatingBreakdownBuckets,
+} from './RatingBreakdown';
+export {
+  VersionTimeline,
+  type VersionTimelineProps,
+  type VersionTimelineLabels,
+  type VersionTimelineItem,
+  type VersionKind,
+} from './VersionTimeline';

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -304,9 +304,9 @@ the PR review.
 |--------|-----------|------|-------|--------|----|----|----------|
 | `sp4-toolkit-detail.jsx` | `ToolkitSummaryPanel` | `apps/web/src/components/features/toolkit-detail/ToolkitSummaryPanel.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
 | `sp4-toolkit-detail.jsx` | `ToolkitIncludesGrid` | `apps/web/src/components/features/toolkit-detail/ToolkitIncludesGrid.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
-| `sp4-toolkit-detail.jsx` | `VersionTimeline` | `apps/web/src/components/features/toolkit-detail/VersionTimeline.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
-| `sp4-toolkit-detail.jsx` | `RatingBreakdown` | `apps/web/src/components/features/toolkit-detail/RatingBreakdown.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
-| `sp4-toolkit-detail.jsx` | `PromptPreviewBlock` | `apps/web/src/components/features/toolkit-detail/PromptPreviewBlock.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
+| `sp4-toolkit-detail.jsx` | `VersionTimeline` | `apps/web/src/components/features/toolkit-detail/VersionTimeline.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
+| `sp4-toolkit-detail.jsx` | `RatingBreakdown` | `apps/web/src/components/features/toolkit-detail/RatingBreakdown.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
+| `sp4-toolkit-detail.jsx` | `PromptPreviewBlock` | `apps/web/src/components/features/toolkit-detail/PromptPreviewBlock.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
 | `sp4-toolkit-detail.jsx` | `Stars` | `apps/web/src/components/features/toolkit-detail/Stars.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
 
 ### KB detail — `/kb/[id]` — 6 components — **Tier M**


### PR DESCRIPTION
## Summary

Implements 3 of the 6 `/toolkits/[id]` components from issue #1479 — the ones that were 14-line `return null` stubs:

- **`VersionTimeline`** — version history rail (dot + connector per version, current badge, kind badge, changelog bullets)
- **`RatingBreakdown`** — average + Stars + count, 5→1 histogram, reviews list
- **`PromptPreviewBlock`** — system-prompt preview `<pre>` with optional token-count badge

(`ToolkitSummaryPanel` + `ToolkitIncludesGrid` were already implemented in #1145; `Stars` is canonical via #1469.)

## Scope — shelf-ready (component-only)

Per the spec-panel session, these are **pure presentational, props-driven, labels-injected** components. They are **not wired** into `ToolkitDetailView` yet: the agent / versions / ratings tabs stay **P5 disabled-by-design** pending backend issues #822 / #819. Props are derived from the real BE Zod schemas (`ToolkitVersion`, `ToolkitRatingsResponse`, `ToolkitAgentSummary`), so the future orchestrator wiring is a direct mapping — **no faked data**.

## Mockup-vs-BE gaps handled honestly

- `VersionTimeline`: BE has no `kind` → optional (default toolkit dot); `changelog` is a string (split on newlines into bullets); owner edit/yank deferred (no yank workflow in v1).
- `RatingBreakdown`: histogram bar guards against **division-by-zero** when `totalCount=0` (BE v1 stub) + empty state.
- `PromptPreviewBlock`: `tokenCount` optional (not in BE schema), graceful-hide.

## Test plan

- [x] 30 unit tests (TDD red→green): PromptPreviewBlock (8), RatingBreakdown (11), VersionTimeline (11)
- [x] `pnpm typecheck` — 0 errors
- [x] `eslint` toolkit-detail — 0 warnings (DS-15 compliant, no hardcoded colors)
- [x] Code review — 0 CRITICAL, 0 DS-15 violations, division-by-zero guard confirmed; 3 test-coverage gaps addressed in follow-up commit

Closes part of #1479 (3/6 components). Route stays `pending` in the matrix until tab wiring lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)