### PR TITLE
feat(lib): #1470 userHue/userHsl deterministic color utility

### DIFF
--- a/apps/web/src/lib/colors/__tests__/user-hue.test.ts
+++ b/apps/web/src/lib/colors/__tests__/user-hue.test.ts
@@ -1,0 +1,77 @@
+/**
+ * userHue / userHsl - Unit tests (Issue #1470).
+ *
+ * Deterministic client-side color utility used where the BE doesn't expose
+ * `User.AccentHue` (avatar background colors in player/leaderboard surfaces).
+ *
+ * Test matrix (Crispin):
+ *   T1. userHue returns an integer hue in [0, 360) for a known id.
+ *   T2. Deterministic — same id → same hue.
+ *   T3. Distributes across many distinct hues (not constant).
+ *   T4. Empty id → 0 (edge case / "unknown user").
+ *   T5. Output stays in [0, 360) across many ids.
+ *   T6. userHsl without alpha → hsl(h, 60%, 55%).
+ *   T7. userHsl with alpha → hsla(h, 60%, 55%, a).
+ *   T8. userHsl on empty id → hsl(0, 60%, 55%).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { userHue, userHsl } from '../user-hue';
+
+describe('userHue (Issue #1470)', () => {
+  // T1
+  it('returns an integer hue in [0, 360) for a known id', () => {
+    const h = userHue('p-marco');
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(360);
+  });
+
+  // T2
+  it('is deterministic — same id yields the same hue', () => {
+    expect(userHue('p-marco')).toBe(userHue('p-marco'));
+    expect(userHue('00000000-0000-0000-0000-000000000001')).toBe(
+      userHue('00000000-0000-0000-0000-000000000001')
+    );
+  });
+
+  // T3
+  it('distributes different ids across many distinct hues', () => {
+    const hues = new Set<number>();
+    for (let i = 0; i < 100; i++) hues.add(userHue(`user-${i}`));
+    // A constant or poorly-distributed hash would collapse to a few buckets.
+    expect(hues.size).toBeGreaterThan(50);
+  });
+
+  // T4
+  it('returns 0 for an empty id', () => {
+    expect(userHue('')).toBe(0);
+  });
+
+  // T5
+  it('keeps every output within [0, 360)', () => {
+    for (let i = 0; i < 200; i++) {
+      const h = userHue(`u-${i}-${i * 7}`);
+      expect(h).toBeGreaterThanOrEqual(0);
+      expect(h).toBeLessThan(360);
+    }
+  });
+});
+
+describe('userHsl (Issue #1470)', () => {
+  // T6
+  it('returns an hsl string tuned for AA when no alpha is given', () => {
+    expect(userHsl('p-marco')).toBe(`hsl(${userHue('p-marco')}, 60%, 55%)`);
+  });
+
+  // T7
+  it('returns an hsla string when alpha is provided', () => {
+    expect(userHsl('p-marco', 0.4)).toBe(`hsla(${userHue('p-marco')}, 60%, 55%, 0.4)`);
+  });
+
+  // T8
+  it('returns hsl with hue 0 for an empty id', () => {
+    expect(userHsl('')).toBe('hsl(0, 60%, 55%)');
+  });
+});

--- a/apps/web/src/lib/colors/user-hue.ts
+++ b/apps/web/src/lib/colors/user-hue.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic color utility for users when the BE doesn't expose `User.AccentHue`.
+ *
+ * FNV-1a 32-bit hash for a fast, deterministic, well-distributed mapping
+ * `userId` → `hue` ∈ [0, 360). Purely visual — no security or crypto guarantees.
+ *
+ * Motivation: the mockups `sp4-game-detail.jsx` / `sp4-player-detail.jsx` use a
+ * per-user hue for avatar backgrounds, but the BE `User` entity does not expose
+ * an `AccentHue` field (PILOT_GAP_REPORT.md § 3.5 decision #5). This module is a
+ * stable client-side replacement so the same user gets the same color across
+ * sessions and devices.
+ *
+ * @see issue #1470
+ * @module
+ */
+
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+/**
+ * Returns a deterministic hue (0-359) for a given user identifier.
+ *
+ * Same input → same output across sessions and platforms. An empty `userId`
+ * returns `0` so consumers can render an "unknown user" uniformly without
+ * branching.
+ *
+ * @example
+ *   userHue('p-marco')  // → stable hue ∈ [0, 360)
+ *   userHue('')         // → 0
+ */
+export function userHue(userId: string): number {
+  if (!userId) return 0;
+  let hash = FNV_OFFSET_BASIS;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+  // `hash` is a signed 32-bit integer after `Math.imul`; mod 360 of its absolute
+  // value yields a value in [0, 360).
+  return Math.abs(hash) % 360;
+}
+
+/**
+ * Returns a full HSL color string for the given user identifier.
+ *
+ * Saturation 60% and lightness 55% are tuned for AA contrast on the project's
+ * light background and remain readable on the dark variant.
+ *
+ * @param userId - see {@link userHue}
+ * @param alpha - optional alpha channel ∈ [0, 1]; when set, returns `hsla()`
+ *
+ * @example
+ *   userHsl('p-marco')        // → 'hsl(<hue>, 60%, 55%)'
+ *   userHsl('p-marco', 0.4)   // → 'hsla(<hue>, 60%, 55%, 0.4)'
+ */
+export function userHsl(userId: string, alpha?: number): string {
+  const h = userHue(userId);
+  return alpha !== undefined ? `hsla(${h}, 60%, 55%, ${alpha})` : `hsl(${h}, 60%, 55%)`;
+}


### PR DESCRIPTION
## Summary

Adds `src/lib/colors/user-hue.ts` — a deterministic client-side color utility (FNV-1a 32-bit hash → hue ∈ [0, 360)):

- `userHue(userId)` — stable hue across sessions/devices; empty id → `0`
- `userHsl(userId, alpha?)` — `hsl(h, 60%, 55%)` / `hsla(...)`, tuned for AA on light bg

Replaces the missing BE `User.AccentHue` field (PILOT_GAP_REPORT.md § 3.5 decision #5), needed for avatar background colors in player/leaderboard surfaces.

## Why a separate PR (vs #1473)

PR #1473 already implements this exact utility but **bundles it with an unrelated `49→0` lint cleanup across 34 files**. This isolated 2-file PR unblocks **#1478 player-detail** (Tier M — `PlayerHero` / `PlayerLeaderboardCard` depend on `userHue`) without carrying the larger blast radius. The implementation is copied verbatim from #1473 so there is no semantic divergence; #1473 can drop the utility and keep just the lint cleanup, or be closed.

## Test plan

- [x] 8 unit tests (TDD red→green): stable/[0,360)/deterministic/distribution/empty→0/range + `userHsl` with/without alpha
- [x] `eslint src/lib/colors/` — 0 warnings
- [x] typecheck (pre-commit hook) — clean

Closes #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)