### PR TITLE
fix(admin): restore PII-safe error in BulkImportUsers per-line catch (regression from #1505)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/BulkImportUsersCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/BulkImportUsersCommandHandler.cs
@@ -200,11 +200,19 @@ internal class BulkImportUsersCommandHandler : ICommandHandler<BulkImportUsersCo
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error importing user at line {LineNumber}", lineNumber);
-                // Surface the exception type and message in the per-line error so the
-                // BulkOperationResult.Errors payload exposes the upstream cause to
-                // operators (and to integration tests that cannot read server logs).
-                // The full stack trace remains in the ILogger output only.
-                errors.Add($"Line {lineNumber}: import failed ({ex.GetType().Name}: {ex.Message})");
+                // SECURITY (test-guarded): never include `ex.Message` or any user data
+                // (e.g. the email being imported) in the BulkOperationResult.Errors
+                // payload — that payload is returned to API callers and would leak PII
+                // and raw infrastructure errors (DB constraint messages, etc.). The
+                // unit test `Handle_WhenPerLineImportFails_ShouldNotIncludeEmailInError`
+                // (BulkImportUsersCommandHandlerTests) enforces this contract. Full
+                // diagnostic detail (exception type, message, stack) remains in the
+                // ILogger output above for admin/operator debugging.
+                // Regression-fix history: PR #1505 momentarily inlined ex.Message here
+                // for integration-test convenience; reverted to the generic message
+                // because the test asserts strictly on this and no test consumer
+                // actually depends on the leaked format.
+                errors.Add($"Line {lineNumber}: import failed due to an internal error.");
             }
 #pragma warning restore CA1031
         }


### PR DESCRIPTION
## Problem

After PR #1505 (\`f98064260\`, "fix(integration-tests): repair GameRef fixture drift"), the unit test \`Handle_WhenPerLineImportFails_ShouldNotIncludeEmailInError\` (1 of 17563) started failing on \`main-dev\` — caught during the merge of #1537 (CI ARM64 cross-compile).

## Root cause

PR #1505 changed one line in \`BulkImportUsersCommandHandler.ProcessUserImportsAsync\`:

\`\`\`diff
- errors.Add(\$"Line {lineNumber}: import failed due to an internal error.");
+ errors.Add(\$"Line {lineNumber}: import failed ({ex.GetType().Name}: {ex.Message})");
\`\`\`

This inlines \`ex.Message\` into \`BulkOperationResult.Errors\`, which is returned to API callers. The unit test (added previously as a security guard) asserts that this error payload **never** contains either the user's email (PII) or raw infrastructure exception messages (e.g. DB constraint text like \`"Unique constraint violation on column email"\`). The change violated the second clause and the test fired.

Investigation:
- The added comment claimed the change was "for integration tests that cannot read server logs" — but **no test in the repo (unit or integration) asserts on the leaked format**. \`grep "import failed ("\` and \`grep "Line .*import failed"\` in \`apps/api/tests/\` return zero matches.
- Full diagnostic detail (exception type, message, stack) is already logged via \`_logger.LogError(ex, ...)\` immediately above the offending line — operators and admins have everything for server-side debugging.
- This was a drive-by change inside a PR whose stated scope was GameRef fixtures and PhotoBatchUpload row_version — unrelated to BulkImportUsers.

## Fix

Single-line revert to the original generic message, plus an expanded comment that ties the security contract to its enforcing test so future drive-by changes won't repeat the regression.

## Verification

Locally (\`dotnet test --filter ...\`):
- Previously-failing test: \`Handle_WhenPerLineImportFails_ShouldNotIncludeEmailInError\` ✅ now passes
- All 10 BulkImportUsers tests pass: \`Superato! Passed: 10\`

CI on this PR will re-run \`Backend Fast\` against the fix.

## Rollback

\`git revert\` of this commit restores the leaked format (and re-introduces the PII regression). Not recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)