### PR TITLE
fix(player-detail): #1478 i18n keys + statsLabels + aria-label + axe coverage

### DIFF
--- a/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/_components/PlayerDetailView.tsx
@@ -301,10 +301,10 @@ export function PlayerDetailView({ playerId }: PlayerDetailViewProps): ReactElem
 
   const statsLabels = useMemo<PlayerStatsGridLabels>(
     () => ({
-      sessions: t('pages.playerDetail.sections.stats.title'),
-      wins: t('pages.playerDetail.sections.leaderboard.title'),
-      winRate: t('pages.playerDetail.hero.winRate'),
-      achievements: t('pages.playerDetail.sections.achievements.title'),
+      sessions: t('pages.playerDetail.sections.stats.sessions'),
+      wins: t('pages.playerDetail.sections.stats.wins'),
+      winRate: t('pages.playerDetail.sections.stats.winRate'),
+      achievements: t('pages.playerDetail.sections.stats.achievements'),
     }),
     [t]
   );

--- a/apps/web/src/components/features/player-detail/PlayerLeaderboardCard.tsx
+++ b/apps/web/src/components/features/player-detail/PlayerLeaderboardCard.tsx
@@ -70,15 +70,24 @@ export function PlayerLeaderboardCard({
 
       {/* Rank or no-rank */}
       {rank !== null ? (
-        <div
-          data-slot="player-detail-leaderboard-rank"
-          aria-label={interpolateRank(labels.rankAriaLabel, rank)}
-          className="flex items-baseline gap-1"
-        >
-          <span className="font-display text-4xl font-extrabold leading-none tabular-nums tracking-tight text-amber-700 dark:text-amber-400">
+        <div data-slot="player-detail-leaderboard-rank" className="flex items-baseline gap-1">
+          {/*
+           * Accessible name in a visually-hidden span: ARIA 1.2 prohibits naming
+           * attributes (aria-label) on the generic role of a plain <div>, so the
+           * previous `aria-label` was silently ignored by assistive technology.
+           * The visual spans are aria-hidden to avoid duplicate "3 Rank 3" reads.
+           */}
+          <span className="sr-only">{interpolateRank(labels.rankAriaLabel, rank)}</span>
+          <span
+            aria-hidden="true"
+            className="font-display text-4xl font-extrabold leading-none tabular-nums tracking-tight text-amber-700 dark:text-amber-400"
+          >
             #{rank}
           </span>
-          <span className="font-mono text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+          <span
+            aria-hidden="true"
+            className="font-mono text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
+          >
             {interpolateRank(labels.rank, rank)}
           </span>
         </div>

--- a/apps/web/src/components/features/player-detail/__tests__/AchievementBadgeGrid.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/AchievementBadgeGrid.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, it, expect } from 'vitest';
 
 import { AchievementBadgeGrid } from '../AchievementBadgeGrid';
@@ -52,5 +53,17 @@ describe('AchievementBadgeGrid', () => {
     expect(
       container.querySelector('[data-slot="player-detail-achievement-grid"]')
     ).toBeInTheDocument();
+  });
+
+  it('passes axe a11y scan with badges and empty state', async () => {
+    const withBadges = render(
+      <AchievementBadgeGrid count={5} viewAllHref="/players/p-sara/achievements" labels={labels} />
+    );
+    expect(await axe(withBadges.container)).toHaveNoViolations();
+
+    const emptyState = render(
+      <AchievementBadgeGrid count={0} viewAllHref="/players/p-sara/achievements" labels={labels} />
+    );
+    expect(await axe(emptyState.container)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/player-detail/__tests__/FavoriteAgentCard.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/FavoriteAgentCard.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, it, expect, vi } from 'vitest';
 
 import { FavoriteAgentCard } from '../FavoriteAgentCard';
@@ -43,5 +44,18 @@ describe('FavoriteAgentCard', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Open Azul Rules AI' }));
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes axe a11y scan with an agent set', async () => {
+    const { container } = render(
+      <FavoriteAgentCard
+        agentName="Wingspan Rules AI"
+        gameName="Wingspan"
+        onClick={() => {}}
+        labels={labels}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/player-detail/__tests__/PlayerHero.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/PlayerHero.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, it, expect, vi } from 'vitest';
 
 import { PlayerHero } from '../PlayerHero';
@@ -78,5 +79,20 @@ describe('PlayerHero', () => {
       />
     );
     expect(screen.queryByRole('button', { name: 'Back to players list' })).not.toBeInTheDocument();
+  });
+
+  it('passes axe a11y scan with full hero data', async () => {
+    const { container } = render(
+      <PlayerHero
+        displayName="Sara Rossi"
+        totalSessions={42}
+        totalWins={28}
+        winRate={0.67}
+        onBack={() => {}}
+        labels={labels}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/player-detail/__tests__/PlayerLeaderboardCard.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/PlayerLeaderboardCard.test.tsx
@@ -2,12 +2,16 @@
  * PlayerLeaderboardCard unit tests — Wave 3 /players/[id] v2 (Task 2)
  *
  * Tests:
- *   1. Renders rank with interpolated label when rank is provided
+ *   1. Renders interpolated rank label when rank is provided
  *   2. Renders noRank text when rank is null
- *   3. data-slot and aria-label attributes are present
+ *   3. Exposes the rank to screen readers via a visually-hidden label
+ *      (NOT via aria-label on a generic <div>, which ARIA 1.2 prohibits)
+ *   4. Passes axe a11y scan when ranked
+ *   5. Passes axe a11y scan when not ranked
  */
 
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, it, expect } from 'vitest';
 
 import { PlayerLeaderboardCard } from '../PlayerLeaderboardCard';
@@ -31,10 +35,24 @@ describe('PlayerLeaderboardCard', () => {
     expect(screen.getByText('Not ranked yet')).toBeInTheDocument();
   });
 
-  it('has correct data-slot and aria-label for E2E and a11y', () => {
+  it('exposes the rank to screen readers via a visually-hidden label', () => {
     const { container } = render(<PlayerLeaderboardCard rank={5} labels={labels} />);
     expect(container.querySelector('[data-slot="player-detail-leaderboard"]')).toBeInTheDocument();
-    // The rank element should have aria-label with rank value
-    expect(container.querySelector('[aria-label="Leaderboard position: 5"]')).toBeInTheDocument();
+    // Accessible name lives in a visually-hidden span, not aria-label on a generic <div>
+    // (ARIA 1.2 prohibits naming attributes on generic role; assistive tech ignore them).
+    const srLabel = screen.getByText('Leaderboard position: 5');
+    expect(srLabel).toHaveClass('sr-only');
+  });
+
+  it('passes axe a11y scan when ranked', async () => {
+    const { container } = render(<PlayerLeaderboardCard rank={5} labels={labels} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('passes axe a11y scan when not ranked', async () => {
+    const { container } = render(<PlayerLeaderboardCard rank={null} labels={labels} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/player-detail/__tests__/PlayerStatsGrid.test.tsx
+++ b/apps/web/src/components/features/player-detail/__tests__/PlayerStatsGrid.test.tsx
@@ -9,6 +9,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { describe, it, expect } from 'vitest';
 
 import { PlayerStatsGrid } from '../PlayerStatsGrid';
@@ -78,5 +79,19 @@ describe('PlayerStatsGrid', () => {
       />
     );
     expect(container.querySelector('[data-slot="player-detail-stats-grid"]')).toBeInTheDocument();
+  });
+
+  it('passes axe a11y scan', async () => {
+    const { container } = render(
+      <PlayerStatsGrid
+        totalSessions={42}
+        totalWins={28}
+        winRate={0.67}
+        achievementCount={5}
+        labels={labels}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2219,16 +2219,22 @@
       },
       "sections": {
         "stats": {
-          "title": "Statistics"
+          "title": "Statistics",
+          "sessions": "Sessions",
+          "wins": "Wins",
+          "winRate": "Win rate",
+          "achievements": "Achievements"
         },
         "leaderboard": {
           "title": "Leaderboard",
           "rank": "Rank #{rank}",
-          "ariaLabel": "Leaderboard position: {rank}"
+          "ariaLabel": "Leaderboard position: {rank}",
+          "noRank": "Not ranked yet"
         },
         "favoriteAgent": {
           "title": "Favourite Agent",
-          "none": "No agent used yet"
+          "none": "No agent used yet",
+          "ariaLabel": "Open {agentName}"
         },
         "achievements": {
           "title": "Achievements",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2269,16 +2269,22 @@
       },
       "sections": {
         "stats": {
-          "title": "Statistiche"
+          "title": "Statistiche",
+          "sessions": "Sessioni",
+          "wins": "Vittorie",
+          "winRate": "Win rate",
+          "achievements": "Achievement"
         },
         "leaderboard": {
           "title": "Classifica",
           "rank": "Posizione #{rank}",
-          "ariaLabel": "Posizione in classifica: {rank}"
+          "ariaLabel": "Posizione in classifica: {rank}",
+          "noRank": "Non ancora classificato"
         },
         "favoriteAgent": {
           "title": "Agente Preferito",
-          "none": "Nessun agente usato ancora"
+          "none": "Nessun agente usato ancora",
+          "ariaLabel": "Apri {agentName}"
         },
         "achievements": {
           "title": "Achievement",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -292,11 +292,11 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-player-detail.jsx` | `PlayerHero` | `apps/web/src/components/features/player-detail/PlayerHero.tsx` | `/players/[id]` | pending | — | T A M V | — |
-| `sp4-player-detail.jsx` | `PlayerStatsGrid` | `apps/web/src/components/features/player-detail/PlayerStatsGrid.tsx` | `/players/[id]` | pending | — | T A V | — |
-| `sp4-player-detail.jsx` | `PlayerLeaderboardCard` | `apps/web/src/components/features/player-detail/PlayerLeaderboardCard.tsx` | `/players/[id]` | pending | — | T A V | — |
-| `sp4-player-detail.jsx` | `FavoriteAgentCard` | `apps/web/src/components/features/player-detail/FavoriteAgentCard.tsx` | `/players/[id]` | pending | — | T A V | — |
-| `sp4-player-detail.jsx` | `AchievementBadgeGrid` | `apps/web/src/components/features/player-detail/AchievementBadgeGrid.tsx` | `/players/[id]` | pending | — | T A V | — |
+| `sp4-player-detail.jsx` | `PlayerHero` | `apps/web/src/components/features/player-detail/PlayerHero.tsx` | `/players/[id]` | done | #1539 | T A M V | — |
+| `sp4-player-detail.jsx` | `PlayerStatsGrid` | `apps/web/src/components/features/player-detail/PlayerStatsGrid.tsx` | `/players/[id]` | done | #1539 | T A V | — |
+| `sp4-player-detail.jsx` | `PlayerLeaderboardCard` | `apps/web/src/components/features/player-detail/PlayerLeaderboardCard.tsx` | `/players/[id]` | done | #1539 | T A V | — |
+| `sp4-player-detail.jsx` | `FavoriteAgentCard` | `apps/web/src/components/features/player-detail/FavoriteAgentCard.tsx` | `/players/[id]` | done | #1539 | T A V | — |
+| `sp4-player-detail.jsx` | `AchievementBadgeGrid` | `apps/web/src/components/features/player-detail/AchievementBadgeGrid.tsx` | `/players/[id]` | done | #1539 | T A V | — |
 
 ### Toolkit detail — `/toolkits/[id]` — 6 components — **Tier M**
 


### PR DESCRIPTION
## Summary

Issue #1478 was reported as "5 stubs to implement → impl" but the 5 components were already shipped via PR #1053 (Stage 3 de-versioning). An audit before closing the issue found **3 real bugs visible in production**:

### C1 — 3 i18n keys missing from `en.json` / `it.json` (CRITICAL)
- `pages.playerDetail.sections.leaderboard.noRank` — **visible on every player page** because `leaderboardRank` is always `null` in v1 BE → rendered as the raw key path
- `pages.playerDetail.sections.favoriteAgent.ariaLabel` — aria-label on the open button announces the key path to screen readers
- `pages.playerDetail.sections.stats.{sessions,wins,winRate,achievements}` — added to support I1 fix

### I1 — `PlayerDetailView` wires the wrong i18n keys into `PlayerStatsGrid` (IMPORTANT)
Copy-paste bug at `PlayerDetailView.tsx:304-307`:
- `sessions: t('sections.stats.title')` → tile labelled **"Statistics"** (not "Sessions")
- `wins: t('sections.leaderboard.title')` → tile labelled **"Leaderboard"** (not "Wins")
- `winRate: t('hero.winRate')` → tile labelled **`{rate}% win rate`** (raw template, the `{rate}` placeholder never expands because `KpiTile` renders `label` plainly)

Now wired to the new dedicated `stats.{sessions,wins,winRate,achievements}` keys.

### I2 — `PlayerLeaderboardCard` had `aria-label` on a plain `<div>` (IMPORTANT)
ARIA 1.2 prohibits naming attributes on the *generic* role, so the rank was silently invisible to assistive technology despite a passing unit test (which only asserted the attribute's presence in the DOM, not its delivery to AT).

Replaced with a visually-hidden `<span class="sr-only">` for the accessible name + `aria-hidden` on the visual spans (avoids duplicate "5 Rank 5" SR reads).

### M1 — jest-axe regression coverage
Added 6 axe assertions across the 5 component test files so future a11y regressions like I2 are caught at PR time.

## Test plan

- [x] 24/24 unit tests (was 18; +6 axe) — all green
- [x] `pnpm typecheck` — clean (pre-commit hook)
- [x] `eslint` — clean (pre-commit hook + lint-staged)

The components themselves were already correct DS-15-wise; this PR fixes the labelling and a11y plumbing the prior audit overlooked.

Closes #1478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)