### PR TITLE
fix(admin): hardening — drop ex.Message from MigrateStorage + ImportRagData error payloads

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImportRagData/ImportRagDataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImportRagData/ImportRagDataCommandHandler.cs
@@ -69,6 +69,13 @@ internal sealed class ImportRagDataCommandHandler : IRequestHandler<ImportRagDat
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to deserialize manifest at {Path}", manifestPath);
+            // SECURITY (test-guarded): expose only the exception TYPE in the returned
+            // payload. JsonException.Message includes "Path: $.<property> | LineNumber:
+            // N | BytePositionInLine: N" — leaking the manifest schema and file layout
+            // to admin API callers and log shipping pipelines. The full message + stack
+            // trace are preserved server-side by LogError above. The unit test
+            // ImportRagDataCommandHandlerTests.Handle_WhenManifestDeserializationFails_ShouldNotIncludeRawExceptionMessageInError
+            // enforces this contract.
             return new ImportRagDataResult(
                 TotalDocuments: 0,
                 Imported: 0,
@@ -76,7 +83,7 @@ internal sealed class ImportRagDataCommandHandler : IRequestHandler<ImportRagDat
                 Failed: 0,
                 ReEmbedded: 0,
                 Warnings: warnings,
-                Errors: [$"Failed to deserialize manifest: {ex.Message}"]);
+                Errors: [$"Failed to deserialize manifest ({ex.GetType().Name})"]);
         }
 
         _logger.LogInformation(
@@ -277,7 +284,13 @@ internal sealed class ImportRagDataCommandHandler : IRequestHandler<ImportRagDat
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                errors.Add($"Error importing document {entry.PdfDocumentId}: {ex.Message}");
+                // SECURITY (test-guarded): never embed ex.Message in the per-document
+                // error. EF Core / storage exceptions routinely carry SQL fragments,
+                // parameter values, and backend-internal details (bucket names, request
+                // IDs, etc.). Surface only the exception type; full diagnostic detail
+                // is preserved by the LogWarning below. Enforced by
+                // ImportRagDataCommandHandlerTests.Handle_WhenStorageReadDuringImportThrows_ShouldNotIncludeRawExceptionMessageInError.
+                errors.Add($"Error importing document {entry.PdfDocumentId} ({ex.GetType().Name})");
                 failed++;
                 _logger.LogWarning(ex, "ImportRagData: failed to import document {PdfDocumentId}", entry.PdfDocumentId);
                 // Clear any partially-tracked entities so they do not corrupt the next iteration.

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/MigrateStorageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/MigrateStorageCommandHandler.cs
@@ -148,7 +148,16 @@ internal sealed class MigrateStorageCommandHandler : IRequestHandler<MigrateStor
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 var relativePath = Path.GetRelativePath(localPath, filePath);
-                errors.Add($"Error migrating {relativePath}: {ex.Message}");
+                // SECURITY (test-guarded): expose only the exception TYPE in the per-file error.
+                // Never include `ex.Message` — S3/cloud-provider exception messages routinely
+                // carry bucket names, credential fragments, request IDs, and other internal
+                // infrastructure details that would leak through MigrateStorageResult.Errors
+                // (returned to admin API callers AND propagated into log shipping pipelines).
+                // The full message + stack trace are preserved server-side by the LogWarning
+                // call below. The unit test
+                // MigrateStorageCommandHandlerTests.Handle_WhenStorageServiceThrows_ShouldNotIncludeRawExceptionMessageInError
+                // enforces this contract.
+                errors.Add($"Error migrating {relativePath} ({ex.GetType().Name})");
                 failed++;
                 _logger.LogWarning(ex, "Failed to migrate file {Path}", filePath);
             }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ImportRagDataCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ImportRagDataCommandHandlerTests.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using Api.BoundedContexts.Administration.Application.Commands.ImportRagData;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Defense-in-depth PII / info-leak guards for ImportRagDataCommandHandler.
+/// Mirrors the pattern enforced by
+/// <c>BulkImportUsersCommandHandlerTests.Handle_WhenPerLineImportFails_ShouldNotIncludeEmailInError</c>
+/// and the PR #1532 hardening of BulkImportUsersCommandHandler — the returned
+/// <c>ImportRagDataResult.Errors</c> payload is exposed to admin API callers and
+/// propagated to log shipping pipelines (Loki/Datadog/etc.), so it must never carry
+/// raw <c>ex.Message</c> content. JsonException messages quote the offending JSON
+/// fragment (path leak); EF Core / storage exception messages routinely include
+/// SQL fragments, parameter values, and storage-backend internals.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ImportRagDataCommandHandlerTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"ImportRagDataTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    /// <summary>
+    /// Guard for the catch block around <c>JsonSerializer.Deserialize&lt;RagExportManifest&gt;</c>.
+    /// System.Text.Json's <c>JsonException.Message</c> reliably contains the JSON path,
+    /// line number, and byte position of the failure (e.g. <c>"Path: $.totalDocuments |
+    /// LineNumber: 0 | BytePositionInLine: 47"</c>). These reveal the structure of the
+    /// uploaded manifest to API callers and to log shipping pipelines. The safe format
+    /// (per PR #1532) surfaces only the exception type name.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenManifestDeserializationFails_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — type-mismatch JSON: totalDocuments is declared as int in
+        // RagExportManifest but the JSON provides a string. System.Text.Json
+        // throws a JsonException whose Message includes "Path: $.totalDocuments
+        // | LineNumber: ... | BytePositionInLine: ..." — patterns that would
+        // leak through ImportRagDataResult.Errors if the handler embeds
+        // ex.Message into the returned payload.
+        const string invalidManifestJson =
+            "{\"exportVersion\":\"1.0\",\"totalDocuments\":\"not-an-int\"}";
+        var manifestBytes = Encoding.UTF8.GetBytes(invalidManifestJson);
+
+        var mockStorage = new Mock<IRagBackupStorageService>();
+        mockStorage
+            .Setup(s => s.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(manifestBytes);
+
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenManifestDeserializationFails_ShouldNotIncludeRawExceptionMessageInError));
+        var handler = new ImportRagDataCommandHandler(
+            db,
+            mockStorage.Object,
+            Mock.Of<ILogger<ImportRagDataCommandHandler>>());
+
+        var command = new ImportRagDataCommand { SnapshotPath = "test/snapshot" };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "deserialize failure produces exactly one terminal error");
+
+        // The leaky pattern (pre-fix): JsonException.Message includes "Path: $...",
+        // "LineNumber: N", "BytePositionInLine: N" — none of which should reach API
+        // callers. Post-fix, the error contains only the exception type name.
+        result.Errors[0].Should().NotContain("Path:",
+            because: "JsonException.Message includes 'Path: $.<property>' which leaks " +
+                     "the manifest schema/structure to API callers and log pipelines");
+        result.Errors[0].Should().NotContain("LineNumber:",
+            because: "JsonException.Message includes 'LineNumber: N' which leaks " +
+                     "internal file layout — full diagnostic detail belongs in ILogger output");
+        result.Errors[0].Should().NotContain("BytePositionInLine:",
+            because: "JsonException.Message includes 'BytePositionInLine: N' which leaks " +
+                     "internal file layout — full diagnostic detail belongs in ILogger output");
+    }
+
+    /// <summary>
+    /// Guard for the per-document catch block. A storage / EF Core exception thrown
+    /// while importing a document must not leak its <c>ex.Message</c> (which can carry
+    /// SQL fragments, parameter values, document IDs, or storage-backend internals).
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenStorageReadDuringImportThrows_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — valid manifest with one document entry whose game slug matches a
+        // pre-seeded SharedGame. The per-document try block then calls ReadFileAsync
+        // for metadata.json, which we mock to throw with a SECRET-MARKER message.
+        const string secretInError = "SECRET-MARKER-storage-backend-internal";
+
+        var gameId = Guid.NewGuid();
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenStorageReadDuringImportThrows_ShouldNotIncludeRawExceptionMessageInError));
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            // RagBackupPathHelper.Slugify strips non-alphanumeric chars (including dashes)
+            // before re-hyphenating whitespace, so "testgame" round-trips to itself.
+            Title = "testgame",
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        const string snapshotPath = "rag-exports/2026-05-25";
+        var documentId = Guid.NewGuid();
+        var entryPath = $"{snapshotPath}/documents/{documentId}";
+
+        var validManifestJson = $$"""
+            {
+              "exportVersion": "1.0",
+              "exportedAt": "2026-05-25T00:00:00Z",
+              "totalDocuments": 1,
+              "totalChunks": 0,
+              "totalEmbeddings": 0,
+              "embeddingModel": "test-model",
+              "documents": [{
+                "pdfDocumentId": "{{documentId}}",
+                "gameSlug": "testgame",
+                "gameName": "Test Game",
+                "path": "{{entryPath}}",
+                "chunks": 0,
+                "embeddings": 0,
+                "language": "en"
+              }]
+            }
+            """;
+        var manifestBytes = Encoding.UTF8.GetBytes(validManifestJson);
+        var manifestPath = $"{snapshotPath}/manifest.json";
+        var metadataPath = $"{entryPath}/metadata.json";
+
+        var mockStorage = new Mock<IRagBackupStorageService>();
+        mockStorage
+            .Setup(s => s.ReadFileAsync(manifestPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(manifestBytes);
+        mockStorage
+            .Setup(s => s.ReadFileAsync(metadataPath, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(secretInError));
+
+        var handler = new ImportRagDataCommandHandler(
+            db,
+            mockStorage.Object,
+            Mock.Of<ILogger<ImportRagDataCommandHandler>>());
+
+        var command = new ImportRagDataCommand { SnapshotPath = snapshotPath };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "the single document entry failed; exactly one per-document error is expected");
+
+        result.Errors[0].Should().NotContain("SECRET-MARKER",
+            because: "per-document catch must not embed ex.Message — storage/EF errors " +
+                     "routinely carry SQL fragments, parameter values, and backend internals. " +
+                     "Full diagnostic detail remains in ILogger output (LogWarning).");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/MigrateStorageCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/MigrateStorageCommandHandlerTests.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+[Trait("Category", TestCategories.Unit)]
+public class MigrateStorageCommandHandlerTests
+{
+    /// <summary>
+    /// Defense-in-depth PII / info-leak guard for the per-file catch block.
+    /// Mirrors the pattern enforced by
+    /// <c>BulkImportUsersCommandHandlerTests.Handle_WhenPerLineImportFails_ShouldNotIncludeEmailInError</c>.
+    /// The returned <c>MigrateStorageResult.Errors</c> payload is exposed to admin API callers
+    /// and propagates into log shipping pipelines (Loki/Datadog/etc.), so it must never carry
+    /// raw <c>ex.Message</c> content — S3/cloud provider exception messages routinely include
+    /// bucket names, credential fragments, request IDs, and other internal infrastructure data.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenStorageServiceThrows_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — real temp directory so Directory.GetFiles enumerates exactly one file
+        // with the expected pdf_uploads/{gameId}/{fileId}_{filename} layout.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"meeple-migrate-test-{Guid.NewGuid()}");
+        var gameId = Guid.NewGuid().ToString();
+        Directory.CreateDirectory(Path.Combine(tempDir, gameId));
+        var fileId = Guid.NewGuid().ToString();
+        var filePath = Path.Combine(tempDir, gameId, $"{fileId}_rules.pdf");
+        await File.WriteAllTextAsync(filePath, "fake pdf data");
+
+        try
+        {
+            const string sensitiveProviderMessage =
+                "SECRET-MARKER bucket=internal-prod-bucket credential=AKIA-leaky-fragment";
+
+            var configValues = new Dictionary<string, string?>
+            {
+                ["STORAGE_PROVIDER"] = "s3",
+                ["PDF_STORAGE_PATH"] = tempDir
+            };
+            var config = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+
+            var mockStorage = new Mock<IBlobStorageService>();
+            mockStorage
+                .Setup(s => s.ExistsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<BlobCategory>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException(sensitiveProviderMessage));
+
+            var handler = new MigrateStorageCommandHandler(
+                mockStorage.Object,
+                config,
+                Mock.Of<ILogger<MigrateStorageCommandHandler>>());
+
+            // Act
+            var result = await handler.Handle(
+                new MigrateStorageCommand(DryRun: false),
+                CancellationToken.None);
+
+            // Assert
+            result.Errors.Should().HaveCount(1,
+                because: "the single mock file should produce exactly one per-file error");
+
+            result.Errors[0].Should().NotContain("SECRET-MARKER",
+                because: "raw infrastructure exception messages (bucket names, credential " +
+                         "fragments, internal endpoints) must not be forwarded to API callers " +
+                         "via MigrateStorageResult.Errors — the full message + stack trace " +
+                         "are already captured server-side via ILogger.LogWarning");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two Administration BC handlers exhibited the same PII / info-leak pattern that PR #1532 already fixed in BulkImportUsersCommandHandler (regression caught while merging #1537):

- **MigrateStorageCommandHandler:151** — per-file catch embedded \`ex.Message\` into \`MigrateStorageResult.Errors\`. S3/cloud-provider exception messages routinely carry bucket names, credential fragments, request IDs.
- **ImportRagDataCommandHandler:79** — manifest deserialize catch embedded \`ex.Message\`. \`JsonException.Message\` reliably includes \`"Path: $.<property> | LineNumber: N | BytePositionInLine: N"\` — leaks manifest schema/structure.
- **ImportRagDataCommandHandler:280** — per-document catch embedded \`ex.Message\`. EF Core and storage exceptions carry SQL fragments, parameter values, backend internals.

Both endpoints are admin-only, so direct PII risk is bounded, but errors reach **log shipping pipelines** (Loki/Datadog/SRE tooling) where they're visible to non-admin viewers. Defense-in-depth pattern: sanitize the returned payload regardless of caller trust level.

## Fix (mirrors #1532)

All three catches now use \`errors.Add(\$"...({ex.GetType().Name})")\` instead of \`errors.Add(\$"...{ex.Message}")\`. Full diagnostic detail (type, message, stack) remains in the structured \`ILogger\` output (\`LogError\`/\`LogWarning\`) for operator debugging.

## TDD discipline (3 new tests; ZERO previous test coverage on these handlers)

| Handler | Test | Expected pre-fix | Verified |
|---|---|---|---|
| MigrateStorage | \`Handle_WhenStorageServiceThrows_ShouldNotIncludeRawExceptionMessageInError\` | FAIL: \`Errors[0]\` contains \"SECRET-MARKER\" | RED→GREEN ✅ |
| ImportRagData :79 | \`Handle_WhenManifestDeserializationFails_ShouldNotIncludeRawExceptionMessageInError\` | FAIL: \`Errors[0]\` contains \`Path:\`/\`LineNumber:\`/\`BytePositionInLine:\` | RED→GREEN ✅ |
| ImportRagData :280 | \`Handle_WhenStorageReadDuringImportThrows_ShouldNotIncludeRawExceptionMessageInError\` | FAIL: \`Errors[0]\` contains \"SECRET-MARKER\" | RED→GREEN ✅ |

Each test was confirmed RED before the fix (proof of bug), GREEN after.

## Regression sweep

\`dotnet test --filter Administration&Category=Unit\` → **Superato! Passed: 1386, Failed: 0** (all Administration BC unit tests pass on this branch).

## Out-of-scope follow-up discovered

\`ExportRagDataCommandHandler\` has the same \`errors.Add(\$"...{ex.Message}")\` pattern in its per-document catch. **NOT fixed in this PR** — to fix it without a test would replicate the very anti-pattern (drive-by change without coverage) that PR #1505 introduced in BulkImportUsers and caused this whole episode. Tracked in memory; deserves a parallel TDD-style PR.

## Refs

- Pattern source: PR #1532 (\`fffe55fc7\`) — BulkImportUsers \`ex.GetType().Name\` fix
- Trigger: regression investigation during merge of #1537 (CI ARM64 cross-compile)
- Related memory: \`ex-message-leak-pattern\`, \`backend-fast-pereline-import-fail\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)