### PR TITLE
fix(admin): close ex.Message pattern audit — Export + Enqueue/Reverse storage migration (4 catches)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/EnqueueStorageMigrationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/EnqueueStorageMigrationCommandHandler.cs
@@ -85,7 +85,14 @@ internal sealed class EnqueueStorageMigrationCommandHandler
             }
             catch (AmazonS3Exception ex)
             {
-                errors.Add($"S3 list-objects failed: {ex.ErrorCode} — {ex.Message}");
+                // SECURITY (test-guarded): keep ex.ErrorCode (enum-like, e.g.
+                // "SignatureDoesNotMatch", "AccessDenied") but NEVER include
+                // ex.Message — AmazonS3Exception.Message routinely carries
+                // bucket names, RequestId, region/endpoint info, and signature
+                // fragments. Full message + stack remain in ILogger.LogError
+                // server-side. Enforced by
+                // EnqueueStorageMigrationCommandHandlerTests.Handle_WhenS3ListObjectsThrows_ShouldNotIncludeRawExceptionMessageInError.
+                errors.Add($"S3 list-objects failed ({ex.ErrorCode}, {ex.GetType().Name})");
                 _logger.LogError(ex, "S3 list-objects failed for prefix {Prefix}", request.LegacyPrefix);
                 break;
             }
@@ -131,7 +138,11 @@ internal sealed class EnqueueStorageMigrationCommandHandler
                 catch (Exception ex)
                 {
                     failed++;
-                    errors.Add($"Enqueue failed for {legacyKey}: {ex.Message}");
+                    // SECURITY (test-guarded): never embed ex.Message — EF Core /
+                    // npgsql exceptions carry SQL fragments and parameter values.
+                    // Full message + stack remain in ILogger.LogWarning. Enforced by
+                    // EnqueueStorageMigrationCommandHandlerTests.Handle_WhenOutboxEnqueueThrows_ShouldNotIncludeRawExceptionMessageInError.
+                    errors.Add($"Enqueue failed for {legacyKey} ({ex.GetType().Name})");
                     _logger.LogWarning(ex, "Enqueue failed for {LegacyKey}", legacyKey);
                 }
 #pragma warning restore CA1031

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ExportRagData/ExportRagDataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ExportRagData/ExportRagDataCommandHandler.cs
@@ -150,7 +150,13 @@ internal sealed class ExportRagDataCommandHandler : IRequestHandler<ExportRagDat
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                errors.Add($"Error exporting document {vectorDoc.PdfDocumentId}: {ex.Message}");
+                // SECURITY (test-guarded): never embed ex.Message in the per-document
+                // error. Storage backend (dual-write S3 + local) and EF Core exceptions
+                // routinely carry bucket names, credential fragments, SQL parameters,
+                // and request IDs. Surface only the exception type; full diagnostic
+                // detail is preserved by the LogWarning below. Enforced by
+                // ExportRagDataCommandHandlerTests.Handle_WhenExportServiceThrows_ShouldNotIncludeRawExceptionMessageInError.
+                errors.Add($"Error exporting document {vectorDoc.PdfDocumentId} ({ex.GetType().Name})");
                 failed++;
                 _logger.LogWarning(ex, "Failed to export document {PdfDocumentId}", vectorDoc.PdfDocumentId);
             }

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ReverseStorageMigrationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ReverseStorageMigrationCommandHandler.cs
@@ -126,7 +126,13 @@ internal sealed class ReverseStorageMigrationCommandHandler
                         catch (Exception ex)
                         {
                             failed++;
-                            errors.Add($"Reverse failed for {row.NewKey}: {ex.Message}");
+                            // SECURITY (test-guarded): never embed ex.Message — the
+                            // underlying S3 Copy/DeleteObjectAsync throw
+                            // AmazonS3Exception carrying bucket names, RequestId,
+                            // region and other infrastructure details. Full diagnostic
+                            // detail remains in ILogger.LogWarning. Enforced by
+                            // ReverseStorageMigrationCommandHandlerTests.Handle_WhenS3CopyObjectThrowsForSentRow_ShouldNotIncludeRawExceptionMessageInError.
+                            errors.Add($"Reverse failed for {row.NewKey} ({ex.GetType().Name})");
                             _logger.LogWarning(ex, "Reverse failed for {NewKey}", row.NewKey);
                         }
 #pragma warning restore CA1031

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/EnqueueStorageMigrationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/EnqueueStorageMigrationCommandHandlerTests.cs
@@ -1,0 +1,158 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Defense-in-depth PII / info-leak guards for EnqueueStorageMigrationCommandHandler.
+/// Mirrors the pattern enforced by the BulkImportUsers / MigrateStorage / ImportRagData
+/// / ExportRagData test suites (PRs #1532, #1543, #1545). The returned
+/// <c>EnqueueStorageMigrationResult.Errors</c> payload reaches admin API callers and
+/// log shipping pipelines; raw <c>AmazonS3Exception.Message</c> in particular routinely
+/// carries bucket names, region/endpoint info, request IDs, and presigned-URL fragments.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class EnqueueStorageMigrationCommandHandlerTests
+{
+    private const string TestBucket = "test-bucket";
+
+    private static S3BlobStorageService CreateS3Storage(IAmazonS3 s3Client)
+    {
+        var options = new S3StorageOptions
+        {
+            Endpoint = "https://test.example.com",
+            AccessKey = "AKIA-test-key",
+            SecretKey = "test-secret",
+            BucketName = TestBucket,
+        };
+        return new S3BlobStorageService(
+            s3Client,
+            options,
+            Mock.Of<ILogger<S3BlobStorageService>>());
+    }
+
+    /// <summary>
+    /// Guard for the catch around <c>s3Client.ListObjectsV2Async</c> (catch on
+    /// <see cref="AmazonS3Exception"/>). Pre-fix the per-line error embedded
+    /// both <c>ex.ErrorCode</c> and <c>ex.Message</c> — AmazonS3Exception
+    /// messages routinely include bucket names + RequestId + service endpoint.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenS3ListObjectsThrows_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange
+        const string secretInS3Message =
+            "SECRET-MARKER bucket=internal-prod region=us-east-1 RequestId=ABC123";
+
+        var s3Mock = new Mock<IAmazonS3>();
+        s3Mock
+            .Setup(c => c.ListObjectsV2Async(
+                It.IsAny<ListObjectsV2Request>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception(secretInS3Message)
+            {
+                ErrorCode = "SignatureDoesNotMatch",
+            });
+
+        var s3Storage = CreateS3Storage(s3Mock.Object);
+        var handler = new EnqueueStorageMigrationCommandHandler(
+            s3Storage,
+            Mock.Of<IStorageOperationOutboxService>(),
+            Mock.Of<ILogger<EnqueueStorageMigrationCommandHandler>>());
+
+        var command = new EnqueueStorageMigrationCommand(
+            MigrationId: Guid.NewGuid(),
+            LegacyPrefix: "pdf_uploads/",
+            Category: BlobCategory.Pdf,
+            DryRun: false);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "the S3 list call throws once and the handler then breaks the loop");
+
+        result.Errors[0].Should().NotContain("SECRET-MARKER",
+            because: "AmazonS3Exception.Message carries bucket names, RequestId, region " +
+                     "and other internal infrastructure data — embedding it in the returned " +
+                     "errors payload leaks to admin API callers and log shipping pipelines. " +
+                     "Full diagnostic detail remains in the ILogger.LogError output.");
+    }
+
+    /// <summary>
+    /// Guard for the catch around <c>_outbox.EnqueueAsync</c>. Pre-fix embedded
+    /// <c>ex.Message</c> for each per-object enqueue failure — EF Core / npgsql
+    /// exceptions carry SQL fragments and parameter values.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenOutboxEnqueueThrows_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — S3 list returns one valid object whose key parses into a
+        // resourceKey; the outbox enqueue then throws with a SECRET-MARKER message.
+        const string secretInDbMessage =
+            "SECRET-MARKER duplicate key value violates unique constraint";
+
+        var s3Mock = new Mock<IAmazonS3>();
+        s3Mock
+            .Setup(c => c.ListObjectsV2Async(
+                It.IsAny<ListObjectsV2Request>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ListObjectsV2Response
+            {
+                IsTruncated = false,
+                S3Objects = new List<S3Object>
+                {
+                    new()
+                    {
+                        Key = "pdf_uploads/game-abc/file-xyz_rules.pdf",
+                        BucketName = TestBucket,
+                    },
+                },
+                NextContinuationToken = null,
+            });
+
+        var outboxMock = new Mock<IStorageOperationOutboxService>();
+        outboxMock
+            .Setup(o => o.EnqueueAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<BlobCategory>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(secretInDbMessage));
+
+        var s3Storage = CreateS3Storage(s3Mock.Object);
+        var handler = new EnqueueStorageMigrationCommandHandler(
+            s3Storage,
+            outboxMock.Object,
+            Mock.Of<ILogger<EnqueueStorageMigrationCommandHandler>>());
+
+        var command = new EnqueueStorageMigrationCommand(
+            MigrationId: Guid.NewGuid(),
+            LegacyPrefix: "pdf_uploads/",
+            Category: BlobCategory.Pdf,
+            DryRun: false);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "the single S3 object triggered one enqueue failure");
+
+        result.Errors[0].Should().NotContain("SECRET-MARKER",
+            because: "EF Core / npgsql exception messages embed SQL fragments and parameter " +
+                     "values; the returned Errors payload must not leak them. The full " +
+                     "exception is still captured server-side by ILogger.LogWarning.");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ExportRagDataCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ExportRagDataCommandHandlerTests.cs
@@ -1,0 +1,139 @@
+using Api.BoundedContexts.Administration.Application.Commands.ExportRagData;
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Defense-in-depth PII / info-leak guard for the per-document catch in
+/// <c>ExportRagDataCommandHandler.Handle</c>. Mirrors the pattern enforced by
+/// the BulkImportUsersCommandHandler / MigrateStorage / ImportRagData test suites
+/// (PRs #1532, #1543) — the returned <c>ExportRagDataResult.Errors</c> payload is
+/// exposed to admin API callers and propagated to log shipping pipelines, so it
+/// must never carry raw <c>ex.Message</c> content. Storage backends (the dual-
+/// write S3 + local in <c>IRagExportService</c>) throw exceptions whose Message
+/// routinely includes bucket names, credential fragments, request IDs, and
+/// internal paths.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ExportRagDataCommandHandlerTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"ExportRagDataTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenExportServiceThrows_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — populate a single completed VectorDocument so the per-document
+        // foreach iterates exactly one entry; mock IRagExportService.ExportDocumentBundleAsync
+        // to throw with a SECRET-MARKER message, which (pre-fix) would leak into
+        // ExportRagDataResult.Errors[0] via `errors.Add($"...{ex.Message}")`.
+        const string secretInError = "SECRET-MARKER-bucket=internal-prod-credentials";
+
+        var gameId = Guid.NewGuid();
+        var pdfDocId = Guid.NewGuid();
+        var vectorDocId = Guid.NewGuid();
+
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenExportServiceThrows_ShouldNotIncludeRawExceptionMessageInError));
+
+        var game = new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "testgame",
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+        };
+        var pdfDoc = new PdfDocumentEntity
+        {
+            Id = pdfDocId,
+            FileName = "rules.pdf",
+            FilePath = "test/rules.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            Language = "en",
+            SharedGameId = gameId,
+        };
+        var vectorDoc = new VectorDocumentEntity
+        {
+            Id = vectorDocId,
+            GameId = gameId,
+            PdfDocumentId = pdfDocId,
+            IndexingStatus = "completed",
+            EmbeddingModel = "test-model",
+            EmbeddingDimensions = 768,
+            ChunkCount = 1,
+            IndexedAt = DateTime.UtcNow,
+            Game = game,
+            PdfDocument = pdfDoc,
+        };
+        var chunk = new TextChunkEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            PdfDocumentId = pdfDocId,
+            Content = "chunk content",
+            ChunkIndex = 0,
+            CharacterCount = 13,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        db.SharedGames.Add(game);
+        db.PdfDocuments.Add(pdfDoc);
+        db.VectorDocuments.Add(vectorDoc);
+        db.TextChunks.Add(chunk);
+        await db.SaveChangesAsync();
+
+        var mockExportService = new Mock<IRagExportService>();
+        mockExportService
+            .Setup(s => s.ExportDocumentBundleAsync(
+                It.IsAny<string>(),
+                It.IsAny<VectorDocumentEntity>(),
+                It.IsAny<PdfDocumentEntity>(),
+                It.IsAny<string>(),
+                It.IsAny<List<TextChunkEntity>>(),
+                It.IsAny<List<PgVectorEmbeddingEntity>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(secretInError));
+
+        var handler = new ExportRagDataCommandHandler(
+            db,
+            mockExportService.Object,
+            Mock.Of<ILogger<ExportRagDataCommandHandler>>());
+
+        var command = new ExportRagDataCommand { DryRun = false };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "the single completed vector document triggers exactly one per-document error");
+
+        result.Errors[0].Should().NotContain("SECRET-MARKER",
+            because: "per-document catch must not embed ex.Message — storage/EF exceptions " +
+                     "routinely carry bucket names, credential fragments, SQL parameters, " +
+                     "and backend internals. Full diagnostic detail is preserved server-side " +
+                     "by the existing LogWarning(ex, ...) call.");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ReverseStorageMigrationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/ReverseStorageMigrationCommandHandlerTests.cs
@@ -1,0 +1,121 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Entities;
+using Api.Infrastructure;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Defense-in-depth PII / info-leak guard for the per-row catch in
+/// <c>ReverseStorageMigrationCommandHandler</c>. Mirrors the pattern enforced by
+/// the BulkImportUsers / MigrateStorage / ImportRagData / ExportRagData /
+/// EnqueueStorageMigration test suites (PRs #1532, #1543, #1545). The returned
+/// <c>ReverseStorageMigrationResult.Errors</c> payload is exposed to admin API
+/// callers and propagated to log shipping pipelines; <c>AmazonS3Exception.Message</c>
+/// (raised by the underlying <c>CopyObjectAsync</c>/<c>DeleteObjectAsync</c> calls
+/// in <c>ReverseSentRowAsync</c>) carries bucket names, region/endpoint info, and
+/// internal infrastructure details.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ReverseStorageMigrationCommandHandlerTests
+{
+    private const string TestBucket = "test-bucket";
+
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"ReverseStorageTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    private static S3BlobStorageService CreateS3Storage(IAmazonS3 s3Client)
+    {
+        var options = new S3StorageOptions
+        {
+            Endpoint = "https://test.example.com",
+            AccessKey = "AKIA-test-key",
+            SecretKey = "test-secret",
+            BucketName = TestBucket,
+        };
+        return new S3BlobStorageService(
+            s3Client,
+            options,
+            Mock.Of<ILogger<S3BlobStorageService>>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenS3CopyObjectThrowsForSentRow_ShouldNotIncludeRawExceptionMessageInError()
+    {
+        // Arrange — seed one Sent outbox row; mock CopyObjectAsync (called by the
+        // private ReverseSentRowAsync) to throw with a SECRET-MARKER message.
+        const string secretInS3Message =
+            "SECRET-MARKER bucket=internal-prod region=eu-west-1 RequestId=R3v3R5e123";
+
+        var migrationId = Guid.NewGuid();
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenS3CopyObjectThrowsForSentRow_ShouldNotIncludeRawExceptionMessageInError));
+
+        var row = new StorageOperationOutboxEntity
+        {
+            Id = Guid.NewGuid(),
+            MigrationId = migrationId,
+            LegacyKey = "pdf_uploads/game-abc/file-xyz_rules.pdf",
+            NewKey = "pdfs/game-abc/file-xyz_rules.pdf",
+            Category = nameof(BlobCategory.Pdf),
+            ResourceKey = "game-abc",
+            ScheduledAt = DateTime.UtcNow.AddMinutes(-10),
+            CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+            Status = "Sent",
+            SentAt = DateTime.UtcNow.AddMinutes(-5),
+            AttemptCount = 1,
+        };
+        db.StorageOperationOutbox.Add(row);
+        await db.SaveChangesAsync();
+
+        var s3Mock = new Mock<IAmazonS3>();
+        s3Mock
+            .Setup(c => c.CopyObjectAsync(
+                It.IsAny<CopyObjectRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception(secretInS3Message)
+            {
+                ErrorCode = "AccessDenied",
+            });
+
+        var s3Storage = CreateS3Storage(s3Mock.Object);
+        var handler = new ReverseStorageMigrationCommandHandler(
+            db,
+            s3Storage,
+            Mock.Of<ILogger<ReverseStorageMigrationCommandHandler>>());
+
+        var command = new ReverseStorageMigrationCommand(
+            MigrationId: migrationId,
+            DryRun: false);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Errors.Should().HaveCount(1,
+            because: "the single Sent row triggers exactly one per-row reverse failure");
+
+        result.Errors[0].Should().NotContain("SECRET-MARKER",
+            because: "AmazonS3Exception.Message routinely carries bucket names, RequestId, " +
+                     "region and other internal infrastructure data — the returned errors " +
+                     "payload must not leak them to admin API callers or log shipping. " +
+                     "Full diagnostic detail remains in ILogger.LogWarning output.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the full \`errors.Add(\$"...{ex.Message}")\` pattern audit across the Administration BC. Started as a 1-line fix for ExportRagData; **code review caught 3 more residual sites** in sibling storage-migration handlers (same vector: \`AmazonS3Exception.Message\` with bucket names, RequestId, region info). Extended the PR to fix them all.

## Fixes (4 catches across 3 handlers)

| Handler:line | Catch type | Risk |
|---|---|---|
| \`ExportRagDataCommandHandler:153\` | generic Exception (per-document) | dual-write S3+local storage errors |
| \`EnqueueStorageMigrationCommandHandler:88\` | \`AmazonS3Exception\` (S3 list) | bucket/RequestId/signature in Message |
| \`EnqueueStorageMigrationCommandHandler:134\` | generic Exception (outbox enqueue) | EF Core/npgsql SQL fragments |
| \`ReverseStorageMigrationCommandHandler:129\` | generic Exception (S3 reverse copy/delete) | \`AmazonS3Exception\` carrying infra details |

All four mirror PRs #1532 / #1543: surface only \`ex.GetType().Name\` in the returned payload; \`_logger.LogError/LogWarning(ex, ...)\` preserves full diagnostic detail server-side. The \`Enqueue:88\` fix retains \`ex.ErrorCode\` (enum-like, not PII).

## NOT fixed — VectorReembeddingService:89 (audit false alarm — verified)

Code review also flagged \`VectorReembeddingService.cs:89\`. Investigation showed its \`errors\` list is **locally scoped and never propagated** out of \`ExecuteAsync\` (\`Task\` return; only \`errors.Count\` appears in the summary log). No active leak vector. Fixing it without a verifiable test would replicate the very anti-pattern of PR #1505 that started this investigation. Documented in memory as a follow-up if/when ExecuteAsync changes to expose errors.

## TDD discipline (4 new tests; ZERO prior coverage on these handlers)

| Test | Pre-fix | Verified |
|---|---|---|
| \`ExportRagData Handle_WhenExportServiceThrows_...\` | RED (SECRET-MARKER leaks) | GREEN ✅ |
| \`Enqueue Handle_WhenS3ListObjectsThrows_...\` | RED | GREEN ✅ |
| \`Enqueue Handle_WhenOutboxEnqueueThrows_...\` | RED | GREEN ✅ |
| \`Reverse Handle_WhenS3CopyObjectThrowsForSentRow_...\` | RED | GREEN ✅ |

## Regression sweep

\`dotnet test --filter Administration&Category=Unit\` → **Superato! Passed: 1390, Failed: 0** (+4 vs the post-#1543 baseline of 1386 = the 4 new guard tests).

## Pattern audit — Administration BC now consistent

All six handlers / eight catches in the Administration BC that catch storage/EF exceptions and return error payloads now apply the PII-safe pattern:

- ✅ \`BulkImportUsersCommandHandler\` (PR #1532)
- ✅ \`MigrateStorageCommandHandler\` (PR #1543)
- ✅ \`ImportRagDataCommandHandler\` ×2 catches (PR #1543)
- ✅ \`ExportRagDataCommandHandler\` (this PR)
- ✅ \`EnqueueStorageMigrationCommandHandler\` ×2 catches (this PR)
- ✅ \`ReverseStorageMigrationCommandHandler\` (this PR)

## Future-proof hardening (out of scope — tracked in memory)

A Roslyn analyzer banning \`errors.Add(\$"...{ex.Message}")\` would prevent future regressions BC-wide and beyond. Manual greps + targeted tests are sufficient for now but won't scale as the codebase grows.

## Refs

- Pattern origin: PR #1505 drive-by regression (\`f98064260\`)
- Pattern source: PR #1532 → \`ex.GetType().Name\` fix
- Related: PR #1543 → MigrateStorage + ImportRagData hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)