### PR TITLE
fix(docs): escape JSX anchor in BGG hide spec (unblock Lychee on #1498)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
+++ b/docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
@@ -43,7 +43,7 @@ The goal is to **hide every BGG mention from the non-admin UI surface** while pr
 | # | File | Change |
 |---|------|--------|
 | 1 | `apps/web/src/components/catalog/MeepleGameCatalogCard.tsx` | Remove `if (game.bggId) subtitleParts.push(\`ID: ${game.bggId}\`)` block (lines 194-195) |
-| 2 | `apps/web/src/components/shared-games/SharedGameDetailModal.tsx` | Remove `{game.bggId && <a href="boardgamegeek.com/...">View on BGG</a>}` block (lines 345-348 region) |
+| 2 | `apps/web/src/components/shared-games/SharedGameDetailModal.tsx` | Remove `{game.bggId && <a href={bggUrl}>View on BGG</a>}` block (lines 345-348 region) — the anchor pointed at `boardgamegeek.com/boardgame/{bggId}` |
 | 3 | `apps/web/src/app/(authenticated)/settings/services/page.tsx` | Remove `{ id: 'bgg', label: 'BoardGameGeek', ... }` entry from services array |
 | 4 | `apps/web/src/components/games/BggSearchPanel.tsx` | DELETE (orphan duplicate) |
 | 5 | `apps/web/src/__tests__/components/games/BggSearchPanel.test.tsx` | DELETE (test of orphan) |


### PR DESCRIPTION
## Context

Lychee link check on the release PR [#1498](https://github.com/meepleAi-app/meepleai-monorepo/pull/1498) (main-dev → main-staging) flagged 1 broken link:

```
### Errors in docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
* [ERROR] file:///.../docs/superpowers/specs/boardgamegeek.com/...
```

The snippet on line 46 contained the literal:

```md
`{game.bggId && <a href="boardgamegeek.com/...">View on BGG</a>}`
```

Even though wrapped in inline code, Lychee parses the embedded HTML `<a href="…">` attribute and tries to resolve `boardgamegeek.com/...` as a path relative to the document, producing the `docs/superpowers/specs/boardgamegeek.com/...` 404.

## Fix

Replace the URL-shaped `href` value with a JSX brace expression (`{bggUrl}`) so the attribute value is no longer URL-shaped. Keep the target URL documented in prose right after the snippet (`the anchor pointed at boardgamegeek.com/boardgame/{bggId}`).

## Scope

- 1 file, 1 line, doc-only.
- No code or runtime impact.
- Unblocks Docs Link Check on the release PR #1498 (one of the two structural failures alongside the Branch Policy override the release uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)