### PR TITLE
feat(toolkits-hub): #1480 implement /toolkits hub with 7 mockup components

### DIFF
--- a/apps/web/src/app/(authenticated)/hub/toolkits/page.tsx
+++ b/apps/web/src/app/(authenticated)/hub/toolkits/page.tsx
@@ -1,121 +1,14 @@
 /**
- * /hub/toolkits — authenticated community toolkits catalog (Stage 3 #1166).
+ * /hub/toolkits — redirect to canonical `/toolkits` (Issue #1480).
  *
- * Authenticated route. Uses `useDiscoverRecommendedToolkits({ limit: 50 })`
- * per Path C top-50 listing.
+ * The toolkit hub was originally shipped at `/hub/toolkits` (#1166) using
+ * `HubCatalogView`. The SP4 mockup (sp4-hub-toolkits) requires `/toolkits` as
+ * the canonical path with a richer 7-component implementation; this redirect
+ * preserves back-links from chat/email/external sources.
  */
 
-'use client';
+import { redirect } from 'next/navigation';
 
-import { Suspense, useCallback, useMemo, type ReactElement } from 'react';
-
-import {
-  HubCatalogView,
-  HubToolkitCard,
-  type HubFilter,
-  type HubKpi,
-} from '@/components/features/hub';
-import { useDiscoverRecommendedToolkits } from '@/hooks/queries/useDiscoverRecommendedToolkits';
-import { useTranslation } from '@/hooks/useTranslation';
-import { trackEvent } from '@/lib/analytics/track-event';
-import type { RecommendedToolkit } from '@/lib/api/schemas/discover-cross-cutting.schemas';
-
-function matchToolkit(toolkit: RecommendedToolkit, filter: HubFilter, q: string): boolean {
-  if (q) {
-    const needle = q.toLowerCase();
-    const hay = `${toolkit.name} ${toolkit.authorName ?? ''}`.toLowerCase();
-    if (!hay.includes(needle)) return false;
-  }
-  if (filter === 'all') return true;
-  if (filter === 'featured') return (toolkit.ratingAverage ?? 0) >= 4;
-  if (filter === 'new') return true; // permissive in v1
-  if (filter === 'top') return (toolkit.ratingAverage ?? 0) >= 4.5 && toolkit.ratingCount >= 5;
-  return true;
-}
-
-function HubToolkitsContent(): ReactElement {
-  const { t } = useTranslation();
-  const query = useDiscoverRecommendedToolkits({ limit: 50 });
-  const items = useMemo<ReadonlyArray<RecommendedToolkit>>(() => query.data ?? [], [query.data]);
-
-  const kpi = useMemo<ReadonlyArray<HubKpi>>(() => {
-    const total = items.length;
-    const featured = items.filter(t => (t.ratingAverage ?? 0) >= 4).length;
-    const totalInstalls = items.reduce((sum, t) => sum + t.installCount, 0);
-    return [
-      { label: t('pages.hub.toolkits.kpi.total'), value: total },
-      { label: t('pages.hub.toolkits.kpi.featured'), value: featured },
-      { label: t('pages.hub.toolkits.kpi.installs'), value: totalInstalls },
-    ];
-  }, [items, t]);
-
-  const handleCardClick = useCallback((id: string) => {
-    trackEvent('hub_card_clicked', { entity: 'toolkits', itemId: id });
-  }, []);
-
-  const handleInstall = useCallback((id: string) => {
-    trackEvent('hub_install_clicked', { entity: 'toolkits', itemId: id });
-  }, []);
-
-  const cardLabels = {
-    installLabel: t('pages.hub.toolkits.installLabel'),
-    toolsTemplate: t('pages.hub.toolkits.toolsTemplate'),
-    installsTemplate: t('pages.hub.toolkits.installsTemplate'),
-  };
-
-  const labels = {
-    badge: t('pages.hub.toolkits.badge'),
-    title: t('pages.hub.toolkits.title'),
-    subtitle: t('pages.hub.toolkits.subtitle'),
-    searchPlaceholder: t('pages.hub.common.searchPlaceholder'),
-    filterAriaLabel: t('pages.hub.common.filterAriaLabel'),
-    filterLabels: {
-      all: t('pages.hub.common.filters.all'),
-      featured: t('pages.hub.common.filters.featured'),
-      new: t('pages.hub.common.filters.new'),
-      top: t('pages.hub.common.filters.top'),
-    },
-    emptyTitle: t('pages.hub.toolkits.emptyTitle'),
-    emptyBody: t('pages.hub.toolkits.emptyBody'),
-    filteredEmptyTitle: t('pages.hub.common.filteredEmptyTitle'),
-    filteredEmptyBody: t('pages.hub.common.filteredEmptyBody'),
-    errorTitle: t('pages.hub.common.errorTitle'),
-    errorBody: t('pages.hub.common.errorBody'),
-    retryLabel: t('pages.hub.common.retry'),
-    resultsCountTemplate: t('pages.hub.common.resultsCountTemplate'),
-  };
-
-  return (
-    <HubCatalogView<RecommendedToolkit>
-      entity="toolkit"
-      labels={labels}
-      kpi={kpi}
-      items={items}
-      itemMatches={matchToolkit}
-      renderCard={toolkit => (
-        <HubToolkitCard
-          toolkit={toolkit}
-          labels={cardLabels}
-          onClick={handleCardClick}
-          onInstall={handleInstall}
-        />
-      )}
-      getItemKey={toolkit => toolkit.id}
-      isLoading={query.isLoading}
-      isError={query.isError}
-      onRetry={() => query.refetch()}
-      onSearchCommitted={q => trackEvent('hub_search_committed', { entity: 'toolkits', q })}
-      onFilterChanged={(from, to) =>
-        trackEvent('hub_filter_changed', { entity: 'toolkits', from, to })
-      }
-    />
-  );
-}
-
-export default function HubToolkitsPage() {
-  return (
-    <Suspense fallback={null}>
-      <HubToolkitsContent />
-    </Suspense>
-  );
+export default function HubToolkitsLegacyRedirect(): never {
+  redirect('/toolkits');
 }

--- a/apps/web/src/app/(authenticated)/toolkits/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/page.tsx
@@ -37,6 +37,9 @@ function matchToolkit(toolkit: RecommendedToolkit, status: HubFiltersStatus, q: 
   }
   if (status === 'all') return true;
   if (status === 'featured') return (toolkit.ratingAverage ?? 0) >= 4;
+  // P83 deferred: RecommendedToolkit v1 schema has no createdAt/publishedAt field,
+  // so "new" cannot be filtered yet — returns all items. Follow-up: extend BE schema
+  // with a createdAt cursor so this branch can filter to e.g. last 30 days.
   if (status === 'new') return true;
   if (status === 'top') return (toolkit.ratingAverage ?? 0) >= 4.5 && toolkit.ratingCount >= 5;
   return true;

--- a/apps/web/src/app/(authenticated)/toolkits/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/page.tsx
@@ -1,0 +1,214 @@
+/**
+ * /toolkits — community toolkits catalog hub (canonical SP4 route, Issue #1480).
+ *
+ * Renders the 7-component mockup (sp4-hub-toolkits.jsx) implementation under
+ * `features/toolkits-index/`. Replaces the legacy `/hub/toolkits` route (which
+ * now redirects here). Same `useDiscoverRecommendedToolkits` hook (limit 50)
+ * with FE-side filter + sort + KPI derivation.
+ */
+
+'use client';
+
+import { Suspense, useCallback, useMemo, useState, type ReactElement } from 'react';
+
+import {
+  HubToolkitsBody,
+  type HubEmptyFilteredLabels,
+  type HubFiltersLabels,
+  type HubFiltersSort,
+  type HubFiltersStatus,
+  type HubToolkitCardGridLabels,
+  type HubToolkitCardItem,
+  type HubToolkitsBodyState,
+  type HubToolkitsHeroLabels,
+  type HubToolkitsHeroStat,
+  type ErrorStateLabels,
+} from '@/components/features/toolkits-index';
+import { useDiscoverRecommendedToolkits } from '@/hooks/queries/useDiscoverRecommendedToolkits';
+import { useTranslation } from '@/hooks/useTranslation';
+import { trackEvent } from '@/lib/analytics/track-event';
+import type { RecommendedToolkit } from '@/lib/api/schemas/discover-cross-cutting.schemas';
+
+function matchToolkit(toolkit: RecommendedToolkit, status: HubFiltersStatus, q: string): boolean {
+  if (q) {
+    const needle = q.toLowerCase();
+    const hay = `${toolkit.name} ${toolkit.authorName ?? ''}`.toLowerCase();
+    if (!hay.includes(needle)) return false;
+  }
+  if (status === 'all') return true;
+  if (status === 'featured') return (toolkit.ratingAverage ?? 0) >= 4;
+  if (status === 'new') return true;
+  if (status === 'top') return (toolkit.ratingAverage ?? 0) >= 4.5 && toolkit.ratingCount >= 5;
+  return true;
+}
+
+function sortToolkits(
+  list: ReadonlyArray<RecommendedToolkit>,
+  sort: HubFiltersSort
+): ReadonlyArray<RecommendedToolkit> {
+  const copy = [...list];
+  if (sort === 'rating') {
+    copy.sort((a, b) => (b.ratingAverage ?? 0) - (a.ratingAverage ?? 0));
+  } else if (sort === 'title') {
+    copy.sort((a, b) => a.name.localeCompare(b.name));
+  } else {
+    copy.sort((a, b) => b.installCount - a.installCount);
+  }
+  return copy;
+}
+
+function mapToCardItem(toolkit: RecommendedToolkit): HubToolkitCardItem {
+  return {
+    id: toolkit.id,
+    title: toolkit.name,
+    authorName: toolkit.authorName,
+    installCount: toolkit.installCount,
+    ratingAverage: toolkit.ratingAverage,
+    ratingCount: toolkit.ratingCount,
+    coverImageUrl: toolkit.coverImageUrl,
+    // P83 deferred fields (version / toolCount / useCount / gameName / badge) intentionally
+    // omitted — RecommendedToolkit doesn't expose them in v1 (Gate B). Component gracefully
+    // hides them when undefined. Follow-up issues will extend the schema.
+  };
+}
+
+function HubToolkitsContent(): ReactElement {
+  const { t } = useTranslation();
+  const query = useDiscoverRecommendedToolkits({ limit: 50 });
+  const items = useMemo<ReadonlyArray<RecommendedToolkit>>(() => query.data ?? [], [query.data]);
+
+  const [searchQ, setSearchQ] = useState('');
+  const [status, setStatus] = useState<HubFiltersStatus>('all');
+  const [sort, setSort] = useState<HubFiltersSort>('popular');
+
+  const filtered = useMemo(() => {
+    const matched = items.filter(t => matchToolkit(t, status, searchQ));
+    return sortToolkits(matched, sort);
+  }, [items, status, searchQ, sort]);
+
+  const toolkits = useMemo<ReadonlyArray<HubToolkitCardItem>>(
+    () => filtered.map(mapToCardItem),
+    [filtered]
+  );
+
+  const heroStats = useMemo<ReadonlyArray<HubToolkitsHeroStat>>(() => {
+    const totalInstalls = items.reduce((sum, x) => sum + x.installCount, 0);
+    const featuredCount = items.filter(x => (x.ratingAverage ?? 0) >= 4).length;
+    return [
+      { label: t('pages.toolkitsHub.heroStats.toolkits'), value: items.length },
+      { label: t('pages.toolkitsHub.heroStats.installs'), value: totalInstalls.toLocaleString() },
+      { label: t('pages.toolkitsHub.heroStats.featured'), value: featuredCount },
+    ];
+  }, [items, t]);
+
+  const heroLabels = useMemo<HubToolkitsHeroLabels>(
+    () => ({
+      eyebrow: t('pages.toolkitsHub.eyebrow'),
+      title: t('pages.hub.toolkits.title'),
+      subtitle: t('pages.hub.toolkits.subtitle'),
+    }),
+    [t]
+  );
+
+  const filterLabels = useMemo<HubFiltersLabels>(
+    () => ({
+      searchPlaceholder: t('pages.hub.common.searchPlaceholder'),
+      searchClearAriaLabel: t('pages.toolkitsHub.searchClearAriaLabel'),
+      statusTablistAriaLabel: t('pages.toolkitsHub.statusTablistAriaLabel'),
+      statusOptions: {
+        all: t('pages.hub.common.filters.all'),
+        featured: t('pages.hub.common.filters.featured'),
+        new: t('pages.hub.common.filters.new'),
+        top: t('pages.hub.common.filters.top'),
+      },
+      sortLabel: t('pages.toolkitsHub.sortLabel'),
+      sortOptions: {
+        popular: t('pages.toolkitsHub.sortOptions.popular'),
+        rating: t('pages.toolkitsHub.sortOptions.rating'),
+        title: t('pages.toolkitsHub.sortOptions.title'),
+        uses: t('pages.toolkitsHub.sortOptions.uses'),
+      },
+      countTemplate: t('pages.toolkitsHub.countTemplate'),
+    }),
+    [t]
+  );
+
+  const cardLabels = useMemo<HubToolkitCardGridLabels>(
+    () => ({
+      gameRefFallback: t('pages.toolkitsHub.gameRefFallback'),
+      installCta: t('pages.hub.toolkits.installLabel'),
+      installAriaLabel: t('pages.toolkitsHub.installAriaLabel'),
+      toolsLabel: t('pages.toolkitsHub.toolsLabel'),
+      usesLabel: t('pages.toolkitsHub.usesLabel'),
+    }),
+    [t]
+  );
+
+  const emptyLabels = useMemo<HubEmptyFilteredLabels>(
+    () => ({
+      title: t('pages.hub.common.filteredEmptyTitle'),
+      body: t('pages.hub.common.filteredEmptyBody'),
+      reset: t('pages.toolkitsHub.resetFilters'),
+      resetAriaLabel: t('pages.toolkitsHub.resetFiltersAriaLabel'),
+    }),
+    [t]
+  );
+
+  const errorLabels = useMemo<ErrorStateLabels>(
+    () => ({
+      title: t('pages.hub.common.errorTitle'),
+      body: t('pages.hub.common.errorBody'),
+      retry: t('pages.hub.common.retry'),
+      retryAriaLabel: t('pages.toolkitsHub.retryAriaLabel'),
+    }),
+    [t]
+  );
+
+  const fsmState: HubToolkitsBodyState = query.isError
+    ? 'error'
+    : query.isLoading
+      ? 'loading'
+      : 'default';
+
+  const handleInstall = useCallback((id: string) => {
+    trackEvent('hub_install_clicked', { entity: 'toolkits', itemId: id });
+  }, []);
+
+  const handleCardClick = useCallback((id: string) => {
+    trackEvent('hub_card_clicked', { entity: 'toolkits', itemId: id });
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    void query.refetch();
+  }, [query]);
+
+  return (
+    <HubToolkitsBody
+      state={fsmState}
+      toolkits={toolkits}
+      heroStats={heroStats}
+      query={searchQ}
+      onQueryChange={setSearchQ}
+      status={status}
+      onStatusChange={setStatus}
+      sort={sort}
+      onSortChange={setSort}
+      onInstall={handleInstall}
+      onCardClick={handleCardClick}
+      onRetry={handleRetry}
+      heroLabels={heroLabels}
+      filterLabels={filterLabels}
+      cardLabels={cardLabels}
+      emptyLabels={emptyLabels}
+      errorLabels={errorLabels}
+    />
+  );
+}
+
+export default function ToolkitsHubPage(): ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <HubToolkitsContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/ErrorState.tsx
+++ b/apps/web/src/components/features/toolkits-index/ErrorState.tsx
@@ -1,0 +1,60 @@
+/**
+ * ErrorState — error banner for `/toolkits` hub catalog fetch failure.
+ *
+ * Wave 4 (#1480). Maps the mockup ErrorState (sp4-hub-toolkits.jsx:422-452).
+ * Grid-spanning (`col-span-full`) card with destructive accent + retry CTA.
+ * Pure presentational, labels injected.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface ErrorStateLabels {
+  readonly title: string;
+  readonly body: string;
+  readonly retry: string;
+  readonly retryAriaLabel: string;
+}
+
+export interface ErrorStateProps {
+  readonly labels: ErrorStateLabels;
+  readonly onRetry: () => void;
+  readonly className?: string;
+}
+
+export function ErrorState({ labels, onRetry, className }: ErrorStateProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkits-index-error-state"
+      role="alert"
+      className={clsx(
+        'col-span-full flex flex-col items-center rounded-xl border border-destructive/30 bg-destructive/10 p-8 text-center sm:p-12',
+        className
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/15 text-2xl text-destructive"
+      >
+        ⚠
+      </div>
+      <h3 className="m-0 mb-1 font-bold font-[Quicksand] text-base text-foreground">
+        {labels.title}
+      </h3>
+      <p className="m-0 mb-4 max-w-sm text-[12.5px] text-muted-foreground leading-relaxed">
+        {labels.body}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        aria-label={labels.retryAriaLabel}
+        className="rounded-md bg-destructive px-4 py-2 font-bold font-[Quicksand] text-xs text-white"
+      >
+        {labels.retry}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/HubEmptyFiltered.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubEmptyFiltered.tsx
@@ -1,0 +1,63 @@
+/**
+ * HubEmptyFiltered — empty state when filters produce no results in `/toolkits` hub.
+ *
+ * Wave 4 (#1480). Maps the mockup HubEmptyFiltered (sp4-hub-toolkits.jsx:387-420).
+ * Grid-spanning (`col-span-full`) dashed card with 🔎 icon + title + body + reset CTA.
+ * Pure presentational, labels injected.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface HubEmptyFilteredLabels {
+  readonly title: string;
+  readonly body: string;
+  readonly reset: string;
+  readonly resetAriaLabel: string;
+}
+
+export interface HubEmptyFilteredProps {
+  readonly labels: HubEmptyFilteredLabels;
+  readonly onReset: () => void;
+  readonly className?: string;
+}
+
+export function HubEmptyFiltered({
+  labels,
+  onReset,
+  className,
+}: HubEmptyFilteredProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkits-index-empty-filtered"
+      className={clsx(
+        'col-span-full flex flex-col items-center rounded-xl border border-dashed border-border-strong bg-card p-10 text-center sm:p-16',
+        className
+      )}
+    >
+      <div
+        aria-hidden="true"
+        className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-entity-toolkit/15 text-3xl text-entity-toolkit sm:h-20 sm:w-20 sm:text-4xl"
+      >
+        🔎
+      </div>
+      <h3 className="m-0 mb-1.5 font-bold font-[Quicksand] text-base text-foreground sm:text-lg">
+        {labels.title}
+      </h3>
+      <p className="m-0 mb-4 max-w-sm text-sm text-muted-foreground leading-relaxed">
+        {labels.body}
+      </p>
+      <button
+        type="button"
+        onClick={onReset}
+        aria-label={labels.resetAriaLabel}
+        className="rounded-md bg-entity-toolkit px-4 py-2.5 font-bold font-[Quicksand] text-sm text-white shadow-lg"
+      >
+        {labels.reset}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/HubFilters.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubFilters.tsx
@@ -1,0 +1,151 @@
+/**
+ * HubFilters — sticky filter bar for `/toolkits` hub.
+ *
+ * Wave 4 (#1480). Maps the mockup HubFilters (sp4-hub-toolkits.jsx:298-384).
+ * Search input + 4 status tabs (all/featured/new/top) + sort dropdown
+ * (popular/rating/title/uses) + result count. Pure presentational, state and
+ * labels injected from the orchestrator (no internal debounce; orchestrator
+ * owns that).
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export type HubFiltersStatus = 'all' | 'featured' | 'new' | 'top';
+export type HubFiltersSort = 'popular' | 'rating' | 'title' | 'uses';
+
+const STATUS_ORDER: readonly HubFiltersStatus[] = ['all', 'featured', 'new', 'top'] as const;
+const SORT_ORDER: readonly HubFiltersSort[] = ['popular', 'rating', 'title', 'uses'] as const;
+
+export interface HubFiltersLabels {
+  readonly searchPlaceholder: string;
+  readonly searchClearAriaLabel: string;
+  readonly statusTablistAriaLabel: string;
+  readonly statusOptions: Readonly<Record<HubFiltersStatus, string>>;
+  readonly sortLabel: string;
+  readonly sortOptions: Readonly<Record<HubFiltersSort, string>>;
+  /** Template with `{count}` placeholder, e.g. `"{count} toolkit"`. */
+  readonly countTemplate: string;
+}
+
+export interface HubFiltersProps {
+  readonly query: string;
+  readonly onQueryChange: (query: string) => void;
+  readonly status: HubFiltersStatus;
+  readonly onStatusChange: (status: HubFiltersStatus) => void;
+  readonly sort: HubFiltersSort;
+  readonly onSortChange: (sort: HubFiltersSort) => void;
+  readonly count: number;
+  readonly labels: HubFiltersLabels;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+function interpolateCount(template: string, count: number): string {
+  return template.replace('{count}', String(count));
+}
+
+export function HubFilters({
+  query,
+  onQueryChange,
+  status,
+  onStatusChange,
+  sort,
+  onSortChange,
+  count,
+  labels,
+  compact = false,
+  className,
+}: HubFiltersProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkits-index-filters"
+      className={clsx(
+        'sticky top-0 z-10 flex flex-col items-stretch gap-2.5 border-b border-border bg-background/80 px-4 py-3 backdrop-blur-md',
+        'sm:flex-row sm:items-center sm:gap-3 sm:px-8 sm:py-3.5',
+        className
+      )}
+    >
+      {/* Search input */}
+      <label className="flex flex-1 items-center gap-2 rounded-md border border-border bg-card px-3 py-2 sm:max-w-sm">
+        <span aria-hidden="true" className="text-muted-foreground">
+          🔍
+        </span>
+        <input
+          type="text"
+          value={query}
+          onChange={e => onQueryChange(e.target.value)}
+          placeholder={labels.searchPlaceholder}
+          className="min-w-0 flex-1 border-0 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        />
+        {query.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onQueryChange('')}
+            aria-label={labels.searchClearAriaLabel}
+            className="border-0 bg-transparent p-0 text-sm text-muted-foreground"
+          >
+            ✕
+          </button>
+        )}
+      </label>
+
+      {/* Status tabs */}
+      <div
+        role="tablist"
+        aria-label={labels.statusTablistAriaLabel}
+        className="inline-flex shrink-0 rounded-md bg-muted p-0.5"
+      >
+        {STATUS_ORDER.map(opt => {
+          const active = status === opt;
+          return (
+            <button
+              key={opt}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onStatusChange(opt)}
+              className={clsx(
+                'rounded font-bold font-[Quicksand] whitespace-nowrap transition-all',
+                compact ? 'px-2 py-1.5 text-[11px]' : 'px-3 py-1.5 text-xs',
+                active
+                  ? 'bg-card text-entity-toolkit shadow-sm'
+                  : 'bg-transparent text-muted-foreground'
+              )}
+            >
+              {labels.statusOptions[opt]}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Spacer */}
+      <div className="hidden sm:block sm:flex-1" />
+
+      {/* Sort dropdown */}
+      <label className="inline-flex items-center gap-1.5 font-mono text-[11px] font-semibold text-muted-foreground">
+        <span className="uppercase tracking-wider">{labels.sortLabel}</span>
+        <select
+          aria-label={labels.sortLabel}
+          value={sort}
+          onChange={e => onSortChange(e.target.value as HubFiltersSort)}
+          className="rounded border border-border bg-card px-2.5 py-1.5 font-[Quicksand] text-xs font-bold text-foreground"
+        >
+          {SORT_ORDER.map(opt => (
+            <option key={opt} value={opt}>
+              {labels.sortOptions[opt]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {/* Count label */}
+      <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+        {interpolateCount(labels.countTemplate, count)}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
@@ -1,0 +1,201 @@
+/**
+ * HubToolkitCardGrid — single toolkit card for the `/toolkits` hub grid.
+ *
+ * Wave 4 (#1480). Maps the mockup HubToolkitCardGrid (sp4-hub-toolkits.jsx:104-228).
+ * Despite the mockup name, this is the per-item card, NOT a grid container —
+ * the orchestrator renders many of these inside a CSS grid.
+ *
+ * Props derive verbatim from `RecommendedToolkit` (BE Zod schema). Several
+ * mockup fields are P83 deferred (no BE backing yet — version / toolCount /
+ * useCount / gameName / badge); the component gracefully hides them when
+ * undefined so wiring to richer BE later requires no component refactor.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { Stars } from '@/components/ui/feedback/Stars';
+
+export interface HubToolkitCardItem {
+  readonly id: string;
+  readonly title: string;
+  readonly authorName: string;
+  readonly installCount: number;
+  readonly ratingAverage: number | null;
+  readonly ratingCount: number;
+  readonly coverImageUrl: string | null;
+  /** FE-side emoji fallback when coverImageUrl is null. */
+  readonly coverEmoji?: string;
+  // P83 deferred fields (no BE backing yet — graceful hide when undefined)
+  readonly version?: number;
+  readonly toolCount?: number;
+  readonly useCount?: number;
+  readonly gameName?: string | null;
+  readonly badge?: string;
+}
+
+export interface HubToolkitCardGridLabels {
+  readonly gameRefFallback: string;
+  readonly installCta: string;
+  /** Template with `{title}` placeholder, e.g. `"Installa {title}"`. */
+  readonly installAriaLabel: string;
+  readonly toolsLabel: string;
+  readonly usesLabel: string;
+}
+
+export interface HubToolkitCardGridProps {
+  readonly toolkit: HubToolkitCardItem;
+  readonly onInstall?: (id: string) => void;
+  readonly onClick?: (id: string) => void;
+  readonly labels: HubToolkitCardGridLabels;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+function interpolate(template: string, vars: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, k: string) => String(vars[k] ?? ''));
+}
+
+export function HubToolkitCardGrid({
+  toolkit,
+  onInstall,
+  onClick,
+  labels,
+  compact = false,
+  className,
+}: HubToolkitCardGridProps): JSX.Element {
+  const installLabel = interpolate(labels.installAriaLabel, { title: toolkit.title });
+  return (
+    <article
+      data-slot="toolkits-index-card"
+      tabIndex={0}
+      onClick={() => onClick?.(toolkit.id)}
+      className={clsx(
+        'group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-toolkit/40',
+        className
+      )}
+    >
+      {/* Cover */}
+      <div
+        className={clsx(
+          'relative flex items-center justify-center overflow-hidden bg-muted',
+          compact ? 'aspect-[4/3]' : 'aspect-[5/3]'
+        )}
+      >
+        {toolkit.coverImageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={toolkit.coverImageUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <span
+            aria-hidden="true"
+            className={clsx('drop-shadow-lg', compact ? 'text-5xl' : 'text-6xl')}
+          >
+            {toolkit.coverEmoji ?? '🧰'}
+          </span>
+        )}
+        {toolkit.badge && (
+          // Decorative overlay on a variable cover image — must stay dark in both
+          // light and dark themes for legibility; no semantic DS-15 token maps to
+          // "always dark", so the literal colors are intentional here.
+          // eslint-disable-next-line local/no-hardcoded-color-utility
+          <span className="absolute top-2 left-2 rounded-full bg-black/50 px-2 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-white backdrop-blur-sm">
+            {toolkit.badge}
+          </span>
+        )}
+        <span className="absolute top-2 right-2 inline-flex items-center gap-1 rounded-full bg-entity-toolkit/95 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-white">
+          <span aria-hidden="true">🧰</span>Toolkit
+        </span>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-2/5 bg-gradient-to-b from-transparent to-black/35" />
+        {/*
+          Decorative install-count pill on cover image — must stay light in both
+          themes for legibility against the dark gradient overlay; no semantic
+          DS-15 token maps to "always light".
+        */}
+        {/* eslint-disable-next-line local/no-hardcoded-color-utility */}
+        <div className="absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-full bg-white/90 px-2 py-0.5 font-mono text-[10px] font-bold text-foreground">
+          <span aria-hidden="true">⬇</span>
+          <span className="tabular-nums">{toolkit.installCount}</span>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className={clsx('flex flex-1 flex-col', compact ? 'gap-1.5 p-2.5' : 'gap-2 p-3.5')}>
+        <div>
+          <h2
+            className={clsx(
+              'm-0 mb-0.5 line-clamp-1 font-bold font-[Quicksand] text-foreground leading-tight',
+              compact ? 'text-[13px]' : 'text-[15px]'
+            )}
+          >
+            {toolkit.title}
+          </h2>
+          <div className="font-mono text-[10px] font-semibold text-muted-foreground">
+            {toolkit.authorName}
+          </div>
+          {toolkit.ratingAverage !== null && (
+            <div
+              data-slot="toolkits-index-card-rating"
+              className="mt-1 flex items-center gap-1.5 font-mono text-[10px] font-semibold text-muted-foreground"
+            >
+              <Stars value={Math.round(toolkit.ratingAverage)} />
+              <span className="tabular-nums">{toolkit.ratingAverage.toFixed(1)}</span>
+              {toolkit.version !== undefined && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>v{toolkit.version}.0</span>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+        {(toolkit.toolCount !== undefined || toolkit.useCount !== undefined) && (
+          <div className="font-mono text-[10px] font-semibold text-foreground">
+            {toolkit.toolCount !== undefined && (
+              <>
+                <span className="text-muted-foreground">{labels.toolsLabel}</span>{' '}
+                {toolkit.toolCount}
+              </>
+            )}
+            {toolkit.toolCount !== undefined && toolkit.useCount !== undefined && ' · '}
+            {toolkit.useCount !== undefined && (
+              <>
+                <span className="text-muted-foreground">{labels.usesLabel}</span> {toolkit.useCount}
+              </>
+            )}
+          </div>
+        )}
+        {toolkit.gameName ? (
+          <div className="inline-flex items-center gap-1 font-mono text-[10px] font-bold text-entity-game">
+            <span aria-hidden="true">🎲</span>
+            <span className="truncate">{toolkit.gameName}</span>
+          </div>
+        ) : (
+          <div className="font-mono text-[10px] font-bold italic text-muted-foreground">
+            {labels.gameRefFallback}
+          </div>
+        )}
+      </div>
+
+      {/* Hover install button */}
+      <button
+        type="button"
+        aria-label={installLabel}
+        onClick={e => {
+          e.stopPropagation();
+          onInstall?.(toolkit.id);
+        }}
+        className={clsx(
+          'absolute left-3.5 right-3.5 translate-y-2 rounded-md bg-entity-toolkit px-3 py-2 font-bold font-[Quicksand] text-xs text-white opacity-0 shadow-lg transition-all',
+          'group-hover:translate-y-0 group-hover:opacity-100 focus-visible:translate-y-0 focus-visible:opacity-100',
+          compact ? 'bottom-2.5' : 'bottom-3.5'
+        )}
+      >
+        {labels.installCta}
+      </button>
+    </article>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
@@ -73,6 +73,12 @@ export function HubToolkitCardGrid({
       data-slot="toolkits-index-card"
       tabIndex={0}
       onClick={() => onClick?.(toolkit.id)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.(toolkit.id);
+        }
+      }}
       className={clsx(
         'group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-toolkit/40',
@@ -141,7 +147,7 @@ export function HubToolkitCardGrid({
               data-slot="toolkits-index-card-rating"
               className="mt-1 flex items-center gap-1.5 font-mono text-[10px] font-semibold text-muted-foreground"
             >
-              <Stars value={Math.round(toolkit.ratingAverage)} />
+              <Stars value={toolkit.ratingAverage} />
               <span className="tabular-nums">{toolkit.ratingAverage.toFixed(1)}</span>
               {toolkit.version !== undefined && (
                 <>

--- a/apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx
@@ -1,0 +1,147 @@
+/**
+ * HubToolkitsBody — orchestrator wrapper for `/toolkits` hub.
+ *
+ * Wave 4 (#1480). Maps the mockup HubToolkitsBody (sp4-hub-toolkits.jsx:500-567).
+ * Composes Hero + Filters + (Grid | SkeletonGrid | EmptyFiltered | ErrorState)
+ * based on the `state` prop. Pure presentational — filter state and FSM are
+ * controlled by the parent page orchestrator (which owns the React Query call,
+ * the filter logic, and the analytics tracking).
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+import { ErrorState, type ErrorStateLabels } from './ErrorState';
+import { HubEmptyFiltered, type HubEmptyFilteredLabels } from './HubEmptyFiltered';
+import {
+  HubFilters,
+  type HubFiltersLabels,
+  type HubFiltersSort,
+  type HubFiltersStatus,
+} from './HubFilters';
+import {
+  HubToolkitCardGrid,
+  type HubToolkitCardGridLabels,
+  type HubToolkitCardItem,
+} from './HubToolkitCardGrid';
+import {
+  HubToolkitsHero,
+  type HubToolkitsHeroLabels,
+  type HubToolkitsHeroStat,
+} from './HubToolkitsHero';
+import { SkeletonCard } from './SkeletonCard';
+
+export type HubToolkitsBodyState = 'default' | 'loading' | 'error';
+
+export interface HubToolkitsBodyProps {
+  readonly state: HubToolkitsBodyState;
+  readonly toolkits: readonly HubToolkitCardItem[];
+  readonly heroStats: readonly HubToolkitsHeroStat[];
+  // Filter state (controlled)
+  readonly query: string;
+  readonly onQueryChange: (query: string) => void;
+  readonly status: HubFiltersStatus;
+  readonly onStatusChange: (status: HubFiltersStatus) => void;
+  readonly sort: HubFiltersSort;
+  readonly onSortChange: (sort: HubFiltersSort) => void;
+  readonly onRetry: () => void;
+  readonly onInstall?: (id: string) => void;
+  readonly onCardClick?: (id: string) => void;
+  // Labels (one set per child)
+  readonly heroLabels: HubToolkitsHeroLabels;
+  readonly filterLabels: HubFiltersLabels;
+  readonly cardLabels: HubToolkitCardGridLabels;
+  readonly emptyLabels: HubEmptyFilteredLabels;
+  readonly errorLabels: ErrorStateLabels;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+const SKELETON_COUNT_DESKTOP = 12;
+const SKELETON_COUNT_COMPACT = 6;
+
+export function HubToolkitsBody({
+  state,
+  toolkits,
+  heroStats,
+  query,
+  onQueryChange,
+  status,
+  onStatusChange,
+  sort,
+  onSortChange,
+  onRetry,
+  onInstall,
+  onCardClick,
+  heroLabels,
+  filterLabels,
+  cardLabels,
+  emptyLabels,
+  errorLabels,
+  compact = false,
+  className,
+}: HubToolkitsBodyProps): JSX.Element {
+  const isError = state === 'error';
+  const isLoading = state === 'loading';
+  const skeletonCount = compact ? SKELETON_COUNT_COMPACT : SKELETON_COUNT_DESKTOP;
+  const gridCols = compact ? 'grid-cols-2' : 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-4';
+
+  function resetFilters(): void {
+    onQueryChange('');
+    onStatusChange('all');
+  }
+
+  return (
+    <div data-slot="toolkits-index-body" className={clsx('flex flex-col', className)}>
+      <HubToolkitsHero stats={heroStats} labels={heroLabels} compact={compact} />
+
+      {!isError && (
+        <HubFilters
+          query={query}
+          onQueryChange={onQueryChange}
+          status={status}
+          onStatusChange={onStatusChange}
+          sort={sort}
+          onSortChange={onSortChange}
+          count={toolkits.length}
+          labels={filterLabels}
+          compact={compact}
+        />
+      )}
+
+      <div className={clsx(compact ? 'px-4 pb-6 pt-3.5' : 'px-8 pb-16 pt-6')}>
+        {isError && <ErrorState labels={errorLabels} onRetry={onRetry} />}
+
+        {!isError && isLoading && (
+          <div className={clsx('grid gap-3 sm:gap-4', gridCols)}>
+            {Array.from({ length: skeletonCount }).map((_, i) => (
+              <SkeletonCard key={i} compact={compact} />
+            ))}
+          </div>
+        )}
+
+        {!isError && !isLoading && toolkits.length === 0 && (
+          <HubEmptyFiltered labels={emptyLabels} onReset={resetFilters} />
+        )}
+
+        {!isError && !isLoading && toolkits.length > 0 && (
+          <div className={clsx('grid gap-3 sm:gap-4', gridCols)}>
+            {toolkits.map(t => (
+              <HubToolkitCardGrid
+                key={t.id}
+                toolkit={t}
+                labels={cardLabels}
+                onInstall={onInstall}
+                onClick={onCardClick}
+                compact={compact}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx
@@ -92,6 +92,7 @@ export function HubToolkitsBody({
   function resetFilters(): void {
     onQueryChange('');
     onStatusChange('all');
+    onSortChange('popular');
   }
 
   return (

--- a/apps/web/src/components/features/toolkits-index/HubToolkitsHero.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitsHero.tsx
@@ -1,0 +1,98 @@
+/**
+ * HubToolkitsHero — top hero for `/toolkits` hub.
+ *
+ * Wave 4 (#1480). Maps the mockup HubToolkitsHero (sp4-hub-toolkits.jsx:233-280).
+ * Gradient bg with entity-toolkit accent + eyebrow chip + h1 + subtitle + N stat
+ * tiles. Pure presentational, labels and stats injected.
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface HubToolkitsHeroStat {
+  readonly label: string;
+  readonly value: string | number;
+  readonly unit?: string;
+}
+
+export interface HubToolkitsHeroLabels {
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly subtitle: string;
+}
+
+export interface HubToolkitsHeroProps {
+  readonly stats: readonly HubToolkitsHeroStat[];
+  readonly labels: HubToolkitsHeroLabels;
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+export function HubToolkitsHero({
+  stats,
+  labels,
+  compact = false,
+  className,
+}: HubToolkitsHeroProps): JSX.Element {
+  return (
+    <header
+      data-slot="toolkits-index-hero"
+      className={clsx(
+        'border-b border-border bg-gradient-to-b from-entity-toolkit/10 to-transparent',
+        compact ? 'px-4 pt-5 pb-4' : 'px-8 pt-8 pb-5',
+        className
+      )}
+    >
+      <div className="mb-2.5 flex items-center gap-1.5">
+        <span className="inline-flex items-center gap-1 rounded-full bg-entity-toolkit/15 px-2 py-1 font-mono text-[9px] font-bold uppercase tracking-wider text-entity-toolkit">
+          <span aria-hidden="true">🧰</span>
+          {labels.eyebrow}
+        </span>
+      </div>
+      <h1
+        className={clsx(
+          'm-0 mb-1.5 font-bold font-[Quicksand] tracking-tight text-foreground leading-tight',
+          compact ? 'text-2xl' : 'text-3xl sm:text-4xl'
+        )}
+      >
+        {labels.title}
+      </h1>
+      <p
+        className={clsx(
+          'mb-3.5 max-w-xl text-muted-foreground leading-relaxed',
+          compact ? 'text-[13px]' : 'text-sm'
+        )}
+      >
+        {labels.subtitle}
+      </p>
+      <dl
+        className={clsx(
+          'm-0 flex flex-wrap gap-x-5 gap-y-2 font-mono',
+          compact ? 'text-[11px]' : 'text-xs'
+        )}
+      >
+        {stats.map(s => (
+          <div key={s.label} data-slot="toolkits-index-hero-stat" className="flex flex-col gap-0.5">
+            <dt className="text-[9px] font-bold uppercase tracking-wider text-muted-foreground">
+              {s.label}
+            </dt>
+            <dd
+              className={clsx(
+                'm-0 flex items-baseline gap-1 font-bold font-[Quicksand] leading-none text-foreground tabular-nums',
+                compact ? 'text-lg' : 'text-xl'
+              )}
+            >
+              <span>{s.value}</span>
+              {s.unit && (
+                <span className="text-[11px] font-semibold text-muted-foreground">{s.unit}</span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </header>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/SkeletonCard.tsx
+++ b/apps/web/src/components/features/toolkits-index/SkeletonCard.tsx
@@ -1,0 +1,49 @@
+/**
+ * SkeletonCard — loading placeholder per card in `/toolkits` hub.
+ *
+ * Wave 4 (#1480). Maps the mockup SkeletonCard (sp4-hub-toolkits.jsx:454-471).
+ * Used by the orchestrator while `useDiscoverRecommendedToolkits` is loading.
+ *
+ * Purely decorative — `aria-hidden="true"` so the skeleton is invisible to AT
+ * (the orchestrator handles `aria-busy`/`aria-live` at grid level).
+ */
+
+'use client';
+
+import type { JSX } from 'react';
+
+import clsx from 'clsx';
+
+export interface SkeletonCardProps {
+  readonly compact?: boolean;
+  readonly className?: string;
+}
+
+export function SkeletonCard({ compact = false, className }: SkeletonCardProps): JSX.Element {
+  return (
+    <div
+      data-slot="toolkits-index-skeleton-card"
+      aria-hidden="true"
+      className={clsx('overflow-hidden rounded-lg border border-border bg-card', className)}
+    >
+      <div
+        data-slot="toolkits-index-skeleton-cover"
+        className={clsx('animate-pulse bg-muted', compact ? 'aspect-[4/3]' : 'aspect-[5/3]')}
+      />
+      <div className={clsx('flex flex-col gap-1.5', compact ? 'p-2.5' : 'p-3.5')}>
+        <div
+          data-slot="toolkits-index-skeleton-line"
+          className="h-3.5 w-[72%] animate-pulse rounded bg-muted"
+        />
+        <div
+          data-slot="toolkits-index-skeleton-line"
+          className="h-2.5 w-[52%] animate-pulse rounded bg-muted"
+        />
+        <div
+          data-slot="toolkits-index-skeleton-line"
+          className="h-2.5 w-[40%] animate-pulse rounded bg-muted"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/toolkits-index/__tests__/ErrorState.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/ErrorState.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * ErrorState - Unit tests (Issue #1480).
+ *
+ * Pure presentational error banner. Maps from sp4-hub-toolkits.jsx:422-452
+ * (function ErrorState). Grid-spanning (1/-1) error card with icon + title +
+ * subtitle + retry CTA. Used when the hub catalog fetch fails.
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Renders title + subtitle from labels.
+ *   T3. Renders retry CTA with label.
+ *   T4. Retry button fires onRetry callback.
+ *   T5. DS-15 danger tokens on root.
+ *   T6. className composition.
+ *   T7. Passes axe a11y scan.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ErrorState } from '../ErrorState';
+
+const labels = {
+  title: 'Impossibile caricare il catalogo',
+  body: 'Si è verificato un errore di rete. Verifica la connessione e riprova.',
+  retry: '↻ Riprova',
+  retryAriaLabel: 'Riprova a caricare il catalogo',
+};
+
+describe('ErrorState (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<ErrorState labels={labels} onRetry={() => {}} />);
+    expect(container.querySelector('[data-slot="toolkits-index-error-state"]')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders title and subtitle from labels', () => {
+    render(<ErrorState labels={labels} onRetry={() => {}} />);
+    expect(screen.getByRole('heading', { name: labels.title })).toBeInTheDocument();
+    expect(screen.getByText(labels.body)).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders the retry CTA with its label', () => {
+    render(<ErrorState labels={labels} onRetry={() => {}} />);
+    expect(screen.getByRole('button', { name: labels.retryAriaLabel })).toBeInTheDocument();
+  });
+
+  // T4
+  it('fires onRetry when the retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ErrorState labels={labels} onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: labels.retryAriaLabel }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // T5
+  it('uses DS-15 destructive tokens on the root', () => {
+    const { container } = render(<ErrorState labels={labels} onRetry={() => {}} />);
+    const root = container.querySelector('[data-slot="toolkits-index-error-state"]');
+    expect(root).toHaveClass('border-destructive/30');
+  });
+
+  // T6
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <ErrorState labels={labels} onRetry={() => {}} className="extra" />
+    );
+    const root = container.querySelector('[data-slot="toolkits-index-error-state"]');
+    expect(root).toHaveClass('extra');
+  });
+
+  // T7
+  it('passes axe a11y scan', async () => {
+    const { container } = render(<ErrorState labels={labels} onRetry={() => {}} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubEmptyFiltered.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubEmptyFiltered.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * HubEmptyFiltered - Unit tests (Issue #1480).
+ *
+ * Pure presentational empty-state shown when filters produce no results.
+ * Maps from sp4-hub-toolkits.jsx:387-420 (function HubEmptyFiltered).
+ * Grid-spanning (1/-1) dashed card with 🔎 icon + title + body + reset CTA.
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Renders title + body from labels.
+ *   T3. Renders reset CTA with label.
+ *   T4. Reset button fires onReset callback.
+ *   T5. DS-15 dashed border + entity-toolkit accent.
+ *   T6. className composition.
+ *   T7. Passes axe a11y scan.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HubEmptyFiltered } from '../HubEmptyFiltered';
+
+const labels = {
+  title: 'Nessun toolkit trovato',
+  body: 'Nessun toolkit corrisponde ai filtri attuali. Prova a modificare la ricerca.',
+  reset: 'Azzera filtri',
+  resetAriaLabel: 'Azzera tutti i filtri di ricerca',
+};
+
+describe('HubEmptyFiltered (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<HubEmptyFiltered labels={labels} onReset={() => {}} />);
+    expect(
+      container.querySelector('[data-slot="toolkits-index-empty-filtered"]')
+    ).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders title and body from labels', () => {
+    render(<HubEmptyFiltered labels={labels} onReset={() => {}} />);
+    expect(screen.getByRole('heading', { name: labels.title })).toBeInTheDocument();
+    expect(screen.getByText(labels.body)).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders the reset CTA with its label', () => {
+    render(<HubEmptyFiltered labels={labels} onReset={() => {}} />);
+    expect(screen.getByRole('button', { name: labels.resetAriaLabel })).toBeInTheDocument();
+  });
+
+  // T4
+  it('fires onReset when the reset button is clicked', () => {
+    const onReset = vi.fn();
+    render(<HubEmptyFiltered labels={labels} onReset={onReset} />);
+    fireEvent.click(screen.getByRole('button', { name: labels.resetAriaLabel }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  // T5
+  it('uses dashed border-strong + entity-toolkit accent', () => {
+    const { container } = render(<HubEmptyFiltered labels={labels} onReset={() => {}} />);
+    const root = container.querySelector('[data-slot="toolkits-index-empty-filtered"]');
+    expect(root).toHaveClass('border-dashed');
+    expect(root).toHaveClass('border-border-strong');
+  });
+
+  // T6
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <HubEmptyFiltered labels={labels} onReset={() => {}} className="extra" />
+    );
+    const root = container.querySelector('[data-slot="toolkits-index-empty-filtered"]');
+    expect(root).toHaveClass('extra');
+  });
+
+  // T7
+  it('passes axe a11y scan', async () => {
+    const { container } = render(<HubEmptyFiltered labels={labels} onReset={() => {}} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubFilters.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubFilters.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * HubFilters - Unit tests (Issue #1480).
+ *
+ * Pure presentational filter bar (search + status tabs + sort dropdown + count).
+ * Maps from sp4-hub-toolkits.jsx:298-384 (function HubFilters).
+ * Sticky at top via backdrop-blur. Labels + state injected (no internal state).
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Search input renders with placeholder and value; fires onQueryChange.
+ *   T3. Clear button hidden when query is empty; visible + fires onQueryChange('') when query non-empty.
+ *   T4. 4 status tabs render with labels; aria-selected on active; click fires onStatusChange.
+ *   T5. Sort dropdown renders 4 options; current value selected; fires onSortChange.
+ *   T6. Result count rendered via labels.countTemplate.
+ *   T7. className composition.
+ *   T8. Passes axe a11y scan.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HubFilters, type HubFiltersStatus, type HubFiltersSort } from '../HubFilters';
+
+const labels = {
+  searchPlaceholder: 'Cerca per nome, gioco, categoria…',
+  searchClearAriaLabel: 'Pulisci ricerca',
+  statusTablistAriaLabel: 'Filtra toolkit per status',
+  statusOptions: { all: 'Tutti', featured: 'Featured', new: 'Nuovi', top: 'Top 100' },
+  sortLabel: 'Ordina',
+  sortOptions: { popular: 'Popolarità', rating: 'Rating', title: 'Titolo A-Z', uses: 'Uses' },
+  countTemplate: '{count} toolkit',
+};
+
+function renderFilters(overrides?: {
+  query?: string;
+  status?: HubFiltersStatus;
+  sort?: HubFiltersSort;
+  count?: number;
+  onQueryChange?: (q: string) => void;
+  onStatusChange?: (s: HubFiltersStatus) => void;
+  onSortChange?: (s: HubFiltersSort) => void;
+}) {
+  return render(
+    <HubFilters
+      query={overrides?.query ?? ''}
+      onQueryChange={overrides?.onQueryChange ?? (() => {})}
+      status={overrides?.status ?? 'all'}
+      onStatusChange={overrides?.onStatusChange ?? (() => {})}
+      sort={overrides?.sort ?? 'popular'}
+      onSortChange={overrides?.onSortChange ?? (() => {})}
+      count={overrides?.count ?? 24}
+      labels={labels}
+    />
+  );
+}
+
+describe('HubFilters (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = renderFilters();
+    expect(container.querySelector('[data-slot="toolkits-index-filters"]')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders search input with placeholder and value; fires onQueryChange', () => {
+    const onQueryChange = vi.fn();
+    renderFilters({ query: 'azul', onQueryChange });
+    const input = screen.getByPlaceholderText(labels.searchPlaceholder);
+    expect(input).toHaveValue('azul');
+    fireEvent.change(input, { target: { value: 'wingspan' } });
+    expect(onQueryChange).toHaveBeenCalledWith('wingspan');
+  });
+
+  // T3
+  it('hides clear button when empty; shows + fires onQueryChange("") when non-empty', () => {
+    const onQueryChange = vi.fn();
+    const { rerender } = renderFilters({ query: '', onQueryChange });
+    expect(
+      screen.queryByRole('button', { name: labels.searchClearAriaLabel })
+    ).not.toBeInTheDocument();
+    rerender(
+      <HubFilters
+        query="azul"
+        onQueryChange={onQueryChange}
+        status="all"
+        onStatusChange={() => {}}
+        sort="popular"
+        onSortChange={() => {}}
+        count={24}
+        labels={labels}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: labels.searchClearAriaLabel }));
+    expect(onQueryChange).toHaveBeenCalledWith('');
+  });
+
+  // T4
+  it('renders 4 status tabs; aria-selected on active; click fires onStatusChange', () => {
+    const onStatusChange = vi.fn();
+    const { container } = renderFilters({ status: 'featured', onStatusChange });
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs).toHaveLength(4);
+    expect(screen.getByRole('tab', { name: 'Featured' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tutti' })).toHaveAttribute('aria-selected', 'false');
+    fireEvent.click(screen.getByRole('tab', { name: 'Top 100' }));
+    expect(onStatusChange).toHaveBeenCalledWith('top');
+  });
+
+  // T5
+  it('renders sort dropdown with 4 options; current value selected; fires onSortChange', () => {
+    const onSortChange = vi.fn();
+    renderFilters({ sort: 'rating', onSortChange });
+    const select = screen.getByRole('combobox', { name: labels.sortLabel });
+    expect(select).toHaveValue('rating');
+    expect(select.querySelectorAll('option')).toHaveLength(4);
+    fireEvent.change(select, { target: { value: 'title' } });
+    expect(onSortChange).toHaveBeenCalledWith('title');
+  });
+
+  // T6
+  it('renders the count label via countTemplate', () => {
+    renderFilters({ count: 42 });
+    expect(screen.getByText('42 toolkit')).toBeInTheDocument();
+  });
+
+  // T7
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <HubFilters
+        query=""
+        onQueryChange={() => {}}
+        status="all"
+        onStatusChange={() => {}}
+        sort="popular"
+        onSortChange={() => {}}
+        count={0}
+        labels={labels}
+        className="extra"
+      />
+    );
+    const root = container.querySelector('[data-slot="toolkits-index-filters"]');
+    expect(root).toHaveClass('extra');
+  });
+
+  // T8
+  it('passes axe a11y scan', async () => {
+    const { container } = renderFilters({ query: 'azul', count: 3 });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitCardGrid.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitCardGrid.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * HubToolkitCardGrid - Unit tests (Issue #1480).
+ *
+ * Pure presentational card for a single toolkit in the `/toolkits` hub grid.
+ * Maps from sp4-hub-toolkits.jsx:104-228 (function HubToolkitCardGrid).
+ * Note: despite the name, this is the CARD (per-item), NOT a grid container.
+ * The orchestrator renders many of these inside a CSS grid.
+ *
+ * Props derived from `RecommendedToolkit` (BE Zod schema). Several mockup
+ * fields are P83 deferred (no BE backing yet): version, toolCount, useCount,
+ * gameName, badge. The component gracefully hides them when undefined.
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Renders title + authorName + installCount.
+ *   T3. ratingAverage non-null → Stars + numeric value rendered; null → no rating row.
+ *   T4. P83 deferred fields (version/toolCount/useCount): present → rendered, absent → hidden.
+ *   T5. gameName present → rendered; null/undefined → fallback "Universale" label.
+ *   T6. badge present → rendered; absent → no badge.
+ *   T7. Install button click → onInstall callback with toolkit id.
+ *   T8. className composition + axe a11y scan.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HubToolkitCardGrid, type HubToolkitCardItem } from '../HubToolkitCardGrid';
+
+const labels = {
+  gameRefFallback: 'Universale (multi-game)',
+  installCta: '+ Installa toolkit',
+  installAriaLabel: 'Installa {title}',
+  toolsLabel: 'Strumenti:',
+  usesLabel: 'Uses:',
+};
+
+function makeToolkit(over?: Partial<HubToolkitCardItem>): HubToolkitCardItem {
+  return {
+    id: over?.id ?? 'tk-1',
+    title: over?.title ?? 'Azul Tools',
+    authorName: over?.authorName ?? 'Marco Rossi',
+    installCount: over?.installCount ?? 42,
+    ratingAverage: over && 'ratingAverage' in over ? (over.ratingAverage as number | null) : 4.5,
+    ratingCount: over?.ratingCount ?? 18,
+    coverImageUrl: over?.coverImageUrl ?? null,
+    coverEmoji: over?.coverEmoji ?? '🧰',
+    ...(over?.version !== undefined ? { version: over.version } : {}),
+    ...(over?.toolCount !== undefined ? { toolCount: over.toolCount } : {}),
+    ...(over?.useCount !== undefined ? { useCount: over.useCount } : {}),
+    ...(over?.gameName !== undefined ? { gameName: over.gameName } : {}),
+    ...(over?.badge !== undefined ? { badge: over.badge } : {}),
+  };
+}
+
+describe('HubToolkitCardGrid (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} />);
+    expect(container.querySelector('[data-slot="toolkits-index-card"]')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders title, authorName, and installCount', () => {
+    render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} />);
+    expect(screen.getByText('Azul Tools')).toBeInTheDocument();
+    expect(screen.getByText('Marco Rossi')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders rating row when ratingAverage is non-null', () => {
+    const { container } = render(
+      <HubToolkitCardGrid toolkit={makeToolkit({ ratingAverage: 4.3 })} labels={labels} />
+    );
+    expect(container.querySelector('[data-slot="toolkits-index-card-rating"]')).toBeInTheDocument();
+    expect(screen.getByText('4.3')).toBeInTheDocument();
+  });
+
+  it('hides rating row when ratingAverage is null (P83)', () => {
+    const { container } = render(
+      <HubToolkitCardGrid
+        toolkit={makeToolkit({ ratingAverage: null, ratingCount: 0 })}
+        labels={labels}
+      />
+    );
+    expect(
+      container.querySelector('[data-slot="toolkits-index-card-rating"]')
+    ).not.toBeInTheDocument();
+  });
+
+  // T4
+  it('renders version + toolCount + useCount when present (P83)', () => {
+    render(
+      <HubToolkitCardGrid
+        toolkit={makeToolkit({ version: 2, toolCount: 5, useCount: 137 })}
+        labels={labels}
+      />
+    );
+    expect(screen.getByText('v2.0')).toBeInTheDocument();
+    expect(screen.getByText(/Strumenti:/)).toBeInTheDocument();
+    expect(screen.getByText(/Uses:/)).toBeInTheDocument();
+  });
+
+  it('hides version/toolCount/useCount when undefined (P83 graceful hide)', () => {
+    render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} />);
+    expect(screen.queryByText(/v\d+\.\d/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Strumenti:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Uses:/)).not.toBeInTheDocument();
+  });
+
+  // T5
+  it('renders gameName when present', () => {
+    render(<HubToolkitCardGrid toolkit={makeToolkit({ gameName: 'Azul' })} labels={labels} />);
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+  });
+
+  it('renders gameRefFallback when gameName is null', () => {
+    render(<HubToolkitCardGrid toolkit={makeToolkit({ gameName: null })} labels={labels} />);
+    expect(screen.getByText(labels.gameRefFallback)).toBeInTheDocument();
+  });
+
+  // T6
+  it('renders badge when present', () => {
+    render(<HubToolkitCardGrid toolkit={makeToolkit({ badge: 'Featured' })} labels={labels} />);
+    expect(screen.getByText('Featured')).toBeInTheDocument();
+  });
+
+  // T7
+  it('fires onInstall with toolkit id when install button clicked', () => {
+    const onInstall = vi.fn();
+    render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} onInstall={onInstall} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Installa Azul Tools' }));
+    expect(onInstall).toHaveBeenCalledWith('tk-1');
+  });
+
+  // T8
+  it('composes className and passes axe a11y scan', async () => {
+    const { container } = render(
+      <HubToolkitCardGrid
+        toolkit={makeToolkit({ ratingAverage: 4.3, gameName: 'Azul', version: 2 })}
+        labels={labels}
+        className="extra"
+      />
+    );
+    const root = container.querySelector('[data-slot="toolkits-index-card"]');
+    expect(root).toHaveClass('extra');
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitCardGrid.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitCardGrid.test.tsx
@@ -134,6 +134,22 @@ describe('HubToolkitCardGrid (Issue #1480)', () => {
     expect(onInstall).toHaveBeenCalledWith('tk-1');
   });
 
+  it('fires onClick on Enter key when card has focus (keyboard a11y)', () => {
+    const onClick = vi.fn();
+    render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} onClick={onClick} />);
+    const card = screen.getByRole('article');
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledWith('tk-1');
+  });
+
+  it('fires onClick on Space key when card has focus (keyboard a11y)', () => {
+    const onClick = vi.fn();
+    render(<HubToolkitCardGrid toolkit={makeToolkit()} labels={labels} onClick={onClick} />);
+    const card = screen.getByRole('article');
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(onClick).toHaveBeenCalledWith('tk-1');
+  });
+
   // T8
   it('composes className and passes axe a11y scan', async () => {
     const { container } = render(

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
@@ -167,13 +167,33 @@ describe('HubToolkitsBody (Issue #1480)', () => {
   });
 
   // T7
-  it('HubEmptyFiltered onReset triggers onQueryChange("") + onStatusChange("all")', () => {
+  it('HubEmptyFiltered onReset triggers full reset (query + status + sort)', () => {
     const onQueryChange = vi.fn();
     const onStatusChange = vi.fn();
-    renderBody({ state: 'default', toolkits: [], onQueryChange, onStatusChange });
+    const onSortChange = vi.fn();
+    render(
+      <HubToolkitsBody
+        state="default"
+        toolkits={[]}
+        heroStats={heroStats}
+        query=""
+        onQueryChange={onQueryChange}
+        status="all"
+        onStatusChange={onStatusChange}
+        sort="popular"
+        onSortChange={onSortChange}
+        onRetry={() => {}}
+        heroLabels={heroLabels}
+        filterLabels={filterLabels}
+        cardLabels={cardLabels}
+        emptyLabels={emptyLabels}
+        errorLabels={errorLabels}
+      />
+    );
     fireEvent.click(screen.getByRole('button', { name: emptyLabels.resetAriaLabel }));
     expect(onQueryChange).toHaveBeenCalledWith('');
     expect(onStatusChange).toHaveBeenCalledWith('all');
+    expect(onSortChange).toHaveBeenCalledWith('popular');
   });
 
   // T8

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsBody.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * HubToolkitsBody - Unit tests (Issue #1480).
+ *
+ * Pure presentational orchestrator wrapper for `/toolkits` hub.
+ * Maps from sp4-hub-toolkits.jsx:500-567 (function HubToolkitsBody).
+ * Composes Hero + Filters + (Grid | SkeletonGrid | EmptyFiltered | ErrorState)
+ * based on the `state` prop. Filter state is controlled (parent owns).
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Hero always rendered.
+ *   T3. state="error" → ErrorState; no Filters; no grid; no toolkits cards.
+ *   T4. state="loading" → SkeletonCard grid; no toolkits cards; no empty state.
+ *   T5. state="default" + toolkits empty → HubEmptyFiltered.
+ *   T6. state="default" + toolkits non-empty → HubToolkitCardGrid per item.
+ *   T7. HubEmptyFiltered onReset → onQueryChange('') + onStatusChange('all').
+ *   T8. ErrorState onRetry → onRetry callback.
+ *   T9. className + axe scan on default state.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HubToolkitsBody } from '../HubToolkitsBody';
+import type { HubToolkitCardItem } from '../HubToolkitCardGrid';
+
+const heroLabels = {
+  eyebrow: 'Hub · /toolkits',
+  title: 'Catalogo toolkit community',
+  subtitle: 'Bundle pronti.',
+};
+
+const filterLabels = {
+  searchPlaceholder: 'Cerca…',
+  searchClearAriaLabel: 'Pulisci',
+  statusTablistAriaLabel: 'Filtra',
+  statusOptions: { all: 'Tutti', featured: 'Featured', new: 'Nuovi', top: 'Top 100' },
+  sortLabel: 'Ordina',
+  sortOptions: { popular: 'Popolarità', rating: 'Rating', title: 'Titolo', uses: 'Uses' },
+  countTemplate: '{count} toolkit',
+};
+
+const cardLabels = {
+  gameRefFallback: 'Universale',
+  installCta: '+ Installa',
+  installAriaLabel: 'Installa {title}',
+  toolsLabel: 'Strumenti:',
+  usesLabel: 'Uses:',
+};
+
+const emptyLabels = {
+  title: 'Nessun toolkit',
+  body: 'Nessun risultato.',
+  reset: 'Azzera',
+  resetAriaLabel: 'Azzera filtri',
+};
+
+const errorLabels = {
+  title: 'Errore catalogo',
+  body: 'Verifica connessione.',
+  retry: '↻ Riprova',
+  retryAriaLabel: 'Riprova',
+};
+
+const heroStats = [
+  { label: 'Toolkit', value: 24 },
+  { label: 'Installazioni', value: '12k' },
+];
+
+const sampleToolkits: readonly HubToolkitCardItem[] = [
+  {
+    id: 'tk-1',
+    title: 'Azul Tools',
+    authorName: 'Marco',
+    installCount: 42,
+    ratingAverage: 4.3,
+    ratingCount: 18,
+    coverImageUrl: null,
+  },
+  {
+    id: 'tk-2',
+    title: 'Wingspan Helper',
+    authorName: 'Lucia',
+    installCount: 99,
+    ratingAverage: 4.7,
+    ratingCount: 25,
+    coverImageUrl: null,
+  },
+];
+
+function renderBody(overrides?: {
+  state?: 'default' | 'loading' | 'error';
+  toolkits?: readonly HubToolkitCardItem[];
+  onQueryChange?: (q: string) => void;
+  onStatusChange?: (s: 'all' | 'featured' | 'new' | 'top') => void;
+  onRetry?: () => void;
+}) {
+  return render(
+    <HubToolkitsBody
+      state={overrides?.state ?? 'default'}
+      toolkits={overrides?.toolkits ?? sampleToolkits}
+      heroStats={heroStats}
+      query=""
+      onQueryChange={overrides?.onQueryChange ?? (() => {})}
+      status="all"
+      onStatusChange={overrides?.onStatusChange ?? (() => {})}
+      sort="popular"
+      onSortChange={() => {}}
+      onRetry={overrides?.onRetry ?? (() => {})}
+      heroLabels={heroLabels}
+      filterLabels={filterLabels}
+      cardLabels={cardLabels}
+      emptyLabels={emptyLabels}
+      errorLabels={errorLabels}
+    />
+  );
+}
+
+describe('HubToolkitsBody (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = renderBody();
+    expect(container.querySelector('[data-slot="toolkits-index-body"]')).toBeInTheDocument();
+  });
+
+  // T2
+  it('always renders the Hero', () => {
+    renderBody({ state: 'error' });
+    expect(screen.getByRole('heading', { level: 1, name: heroLabels.title })).toBeInTheDocument();
+  });
+
+  // T3
+  it('state=error → ErrorState; no Filters; no toolkit cards', () => {
+    const { container } = renderBody({ state: 'error' });
+    expect(container.querySelector('[data-slot="toolkits-index-error-state"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="toolkits-index-filters"]')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="toolkits-index-card"]')).toHaveLength(0);
+  });
+
+  // T4
+  it('state=loading → SkeletonCard grid; no toolkit cards; no empty state', () => {
+    const { container } = renderBody({ state: 'loading' });
+    const skeletons = container.querySelectorAll('[data-slot="toolkits-index-skeleton-card"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-slot="toolkits-index-card"]')).toHaveLength(0);
+    expect(
+      container.querySelector('[data-slot="toolkits-index-empty-filtered"]')
+    ).not.toBeInTheDocument();
+  });
+
+  // T5
+  it('state=default + toolkits empty → HubEmptyFiltered', () => {
+    const { container } = renderBody({ state: 'default', toolkits: [] });
+    expect(
+      container.querySelector('[data-slot="toolkits-index-empty-filtered"]')
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="toolkits-index-card"]')).toHaveLength(0);
+  });
+
+  // T6
+  it('state=default + toolkits non-empty → renders one card per item', () => {
+    const { container } = renderBody({ state: 'default', toolkits: sampleToolkits });
+    expect(container.querySelectorAll('[data-slot="toolkits-index-card"]')).toHaveLength(2);
+    expect(screen.getByText('Azul Tools')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan Helper')).toBeInTheDocument();
+  });
+
+  // T7
+  it('HubEmptyFiltered onReset triggers onQueryChange("") + onStatusChange("all")', () => {
+    const onQueryChange = vi.fn();
+    const onStatusChange = vi.fn();
+    renderBody({ state: 'default', toolkits: [], onQueryChange, onStatusChange });
+    fireEvent.click(screen.getByRole('button', { name: emptyLabels.resetAriaLabel }));
+    expect(onQueryChange).toHaveBeenCalledWith('');
+    expect(onStatusChange).toHaveBeenCalledWith('all');
+  });
+
+  // T8
+  it('ErrorState onRetry triggers onRetry callback', () => {
+    const onRetry = vi.fn();
+    renderBody({ state: 'error', onRetry });
+    fireEvent.click(screen.getByRole('button', { name: errorLabels.retryAriaLabel }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // T9
+  it('passes axe a11y scan on default state', async () => {
+    const { container } = renderBody({ state: 'default', toolkits: sampleToolkits });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsHero.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubToolkitsHero.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * HubToolkitsHero - Unit tests (Issue #1480).
+ *
+ * Pure presentational hero for `/toolkits` hub. Maps from sp4-hub-toolkits.jsx:
+ * 233-280 (function HubToolkitsHero). Gradient bg + eyebrow + h1 + subtitle +
+ * N stat tiles.
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Renders eyebrow + h1 + subtitle from labels.
+ *   T3. Renders each stat tile (label + value [+ unit]).
+ *   T4. DS-15 tokens (bg gradient with entity-toolkit, border-bottom-border).
+ *   T5. className composition.
+ *   T6. Passes axe a11y scan.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { HubToolkitsHero } from '../HubToolkitsHero';
+
+const labels = {
+  eyebrow: 'Hub · /toolkits',
+  title: 'Catalogo toolkit community',
+  subtitle: "Bundle pronti all'uso di strumenti per i tuoi giochi.",
+};
+
+const stats = [
+  { label: 'Toolkit', value: 24 },
+  { label: 'Installazioni', value: '12.4k' },
+  { label: 'Featured', value: 6 },
+  { label: 'Strumenti totali', value: 142, unit: 'tools' },
+];
+
+describe('HubToolkitsHero (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<HubToolkitsHero labels={labels} stats={stats} />);
+    expect(container.querySelector('[data-slot="toolkits-index-hero"]')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders eyebrow, h1, and subtitle from labels', () => {
+    render(<HubToolkitsHero labels={labels} stats={stats} />);
+    expect(screen.getByText(labels.eyebrow)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: labels.title })).toBeInTheDocument();
+    expect(screen.getByText(labels.subtitle)).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders each stat tile with its label, value, and optional unit', () => {
+    const { container } = render(<HubToolkitsHero labels={labels} stats={stats} />);
+    const tiles = container.querySelectorAll('[data-slot="toolkits-index-hero-stat"]');
+    expect(tiles).toHaveLength(4);
+    expect(screen.getByText('Toolkit')).toBeInTheDocument();
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(screen.getByText('12.4k')).toBeInTheDocument();
+    expect(screen.getByText('tools')).toBeInTheDocument();
+  });
+
+  // T4
+  it('uses entity-toolkit accent and border-bottom DS-15 tokens', () => {
+    const { container } = render(<HubToolkitsHero labels={labels} stats={stats} />);
+    const root = container.querySelector('[data-slot="toolkits-index-hero"]');
+    expect(root).toHaveClass('border-b');
+    expect(root).toHaveClass('border-border');
+  });
+
+  // T5
+  it('composes custom className with base classes', () => {
+    const { container } = render(
+      <HubToolkitsHero labels={labels} stats={stats} className="extra" />
+    );
+    const root = container.querySelector('[data-slot="toolkits-index-hero"]');
+    expect(root).toHaveClass('extra');
+  });
+
+  // T6
+  it('passes axe a11y scan', async () => {
+    const { container } = render(<HubToolkitsHero labels={labels} stats={stats} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/__tests__/SkeletonCard.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/SkeletonCard.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * SkeletonCard - Unit tests (Issue #1480).
+ *
+ * Pure presentational loading placeholder per card. Maps from
+ * sp4-hub-toolkits.jsx:454-471 (function SkeletonCard).
+ *
+ * Test matrix (Crispin):
+ *   T1. data-slot on root.
+ *   T2. Default aspect-ratio 5/3 (desktop).
+ *   T3. Compact aspect-ratio 4/3 (mobile).
+ *   T4. Renders 3 line placeholders.
+ *   T5. DS-15 tokens on root (bg-card, border-border).
+ *   T6. className composition on root.
+ *   T7. Passes axe a11y scan.
+ */
+
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { SkeletonCard } from '../SkeletonCard';
+
+describe('SkeletonCard (Issue #1480)', () => {
+  // T1
+  it('exposes a data-slot on the root', () => {
+    const { container } = render(<SkeletonCard />);
+    expect(
+      container.querySelector('[data-slot="toolkits-index-skeleton-card"]')
+    ).toBeInTheDocument();
+  });
+
+  // T2
+  it('uses 5/3 aspect ratio by default (desktop)', () => {
+    const { container } = render(<SkeletonCard />);
+    const cover = container.querySelector('[data-slot="toolkits-index-skeleton-cover"]');
+    expect(cover).toHaveClass('aspect-[5/3]');
+  });
+
+  // T3
+  it('uses 4/3 aspect ratio when compact (mobile)', () => {
+    const { container } = render(<SkeletonCard compact />);
+    const cover = container.querySelector('[data-slot="toolkits-index-skeleton-cover"]');
+    expect(cover).toHaveClass('aspect-[4/3]');
+  });
+
+  // T4
+  it('renders 3 line placeholders', () => {
+    const { container } = render(<SkeletonCard />);
+    expect(container.querySelectorAll('[data-slot="toolkits-index-skeleton-line"]')).toHaveLength(
+      3
+    );
+  });
+
+  // T5
+  it('uses DS-15 tokens on the root', () => {
+    const { container } = render(<SkeletonCard />);
+    const root = container.querySelector('[data-slot="toolkits-index-skeleton-card"]');
+    expect(root).toHaveClass('bg-card');
+    expect(root).toHaveClass('border-border');
+  });
+
+  // T6
+  it('composes custom className with base classes', () => {
+    const { container } = render(<SkeletonCard className="extra" />);
+    const root = container.querySelector('[data-slot="toolkits-index-skeleton-card"]');
+    expect(root).toHaveClass('extra');
+  });
+
+  // T7
+  it('passes axe a11y scan', async () => {
+    const { container } = render(<SkeletonCard />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/toolkits-index/index.ts
+++ b/apps/web/src/components/features/toolkits-index/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Barrel exports for /toolkits hub feature (Issue #1480).
+ * 7 components mapped from sp4-hub-toolkits mockup.
+ */
+
+export { SkeletonCard, type SkeletonCardProps } from './SkeletonCard';
+export { ErrorState, type ErrorStateProps, type ErrorStateLabels } from './ErrorState';
+export {
+  HubEmptyFiltered,
+  type HubEmptyFilteredProps,
+  type HubEmptyFilteredLabels,
+} from './HubEmptyFiltered';
+export {
+  HubToolkitsHero,
+  type HubToolkitsHeroProps,
+  type HubToolkitsHeroLabels,
+  type HubToolkitsHeroStat,
+} from './HubToolkitsHero';
+export {
+  HubFilters,
+  type HubFiltersProps,
+  type HubFiltersLabels,
+  type HubFiltersStatus,
+  type HubFiltersSort,
+} from './HubFilters';
+export {
+  HubToolkitCardGrid,
+  type HubToolkitCardGridProps,
+  type HubToolkitCardGridLabels,
+  type HubToolkitCardItem,
+} from './HubToolkitCardGrid';
+export {
+  HubToolkitsBody,
+  type HubToolkitsBodyProps,
+  type HubToolkitsBodyState,
+} from './HubToolkitsBody';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1924,6 +1924,32 @@
         "emptyBody": "The community has not published any toolkits yet."
       }
     },
+    "toolkitsHub": {
+      "eyebrow": "Hub · /toolkits",
+      "heroStats": {
+        "toolkits": "Toolkits",
+        "installs": "Installs",
+        "featured": "Featured",
+        "totalTools": "Total tools"
+      },
+      "searchClearAriaLabel": "Clear search",
+      "statusTablistAriaLabel": "Filter toolkits by status",
+      "sortLabel": "Sort",
+      "sortOptions": {
+        "popular": "Popularity",
+        "rating": "Rating",
+        "title": "Title A-Z",
+        "uses": "Uses"
+      },
+      "countTemplate": "{count} toolkits",
+      "gameRefFallback": "Universal (multi-game)",
+      "installAriaLabel": "Install {title}",
+      "toolsLabel": "Tools:",
+      "usesLabel": "Uses:",
+      "resetFilters": "Reset filters",
+      "resetFiltersAriaLabel": "Reset all search filters",
+      "retryAriaLabel": "Retry loading the catalog"
+    },
     "dashboard": {
       "hero": {
         "guestName": "friend",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1974,6 +1974,32 @@
         "emptyBody": "La community non ha ancora pubblicato toolkit."
       }
     },
+    "toolkitsHub": {
+      "eyebrow": "Hub · /toolkits",
+      "heroStats": {
+        "toolkits": "Toolkit",
+        "installs": "Installazioni",
+        "featured": "Featured",
+        "totalTools": "Strumenti totali"
+      },
+      "searchClearAriaLabel": "Pulisci ricerca",
+      "statusTablistAriaLabel": "Filtra toolkit per status",
+      "sortLabel": "Ordina",
+      "sortOptions": {
+        "popular": "Popolarità",
+        "rating": "Rating",
+        "title": "Titolo A-Z",
+        "uses": "Uses"
+      },
+      "countTemplate": "{count} toolkit",
+      "gameRefFallback": "Universale (multi-game)",
+      "installAriaLabel": "Installa {title}",
+      "toolsLabel": "Strumenti:",
+      "usesLabel": "Uses:",
+      "resetFilters": "Azzera filtri",
+      "resetFiltersAriaLabel": "Azzera tutti i filtri di ricerca",
+      "retryAriaLabel": "Riprova a caricare il catalogo"
+    },
     "dashboard": {
       "hero": {
         "guestName": "amico",

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -377,13 +377,13 @@ the PR review.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-hub-toolkits.jsx` | `HubToolkitsHero` | `apps/web/src/components/features/toolkits-index/HubToolkitsHero.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `HubFilters` | `apps/web/src/components/features/toolkits-index/HubFilters.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `HubToolkitCardGrid` | `apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `HubToolkitsBody` | `apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `HubEmptyFiltered` | `apps/web/src/components/features/toolkits-index/HubEmptyFiltered.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `ErrorState` | `apps/web/src/components/features/toolkits-index/ErrorState.tsx` | `/toolkits` | pending | — | T A V | — |
-| `sp4-hub-toolkits.jsx` | `SkeletonCard` | `apps/web/src/components/features/toolkits-index/SkeletonCard.tsx` | `/toolkits` | pending | — | T A V | — |
+| `sp4-hub-toolkits.jsx` | `HubToolkitsHero` | `apps/web/src/components/features/toolkits-index/HubToolkitsHero.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `HubFilters` | `apps/web/src/components/features/toolkits-index/HubFilters.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `HubToolkitCardGrid` | `apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `HubToolkitsBody` | `apps/web/src/components/features/toolkits-index/HubToolkitsBody.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `HubEmptyFiltered` | `apps/web/src/components/features/toolkits-index/HubEmptyFiltered.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `ErrorState` | `apps/web/src/components/features/toolkits-index/ErrorState.tsx` | `/toolkits` | done | #1563 | T A V | — |
+| `sp4-hub-toolkits.jsx` | `SkeletonCard` | `apps/web/src/components/features/toolkits-index/SkeletonCard.tsx` | `/toolkits` | done | #1563 | T A V | — |
 
 ### KB hub — `/knowledge-base` (F1a) — 8 components — **Tier M**
 


### PR DESCRIPTION
## Summary

Implements the canonical `/toolkits` hub route from the SP4 mockup (`sp4-hub-toolkits.jsx`), with the **legacy `/hub/toolkits` now redirecting to `/toolkits`** (back-link preservation).

## 7 new components

All under `apps/web/src/components/features/toolkits-index/`:

| Component | Role | Mockup ref |
|---|---|---|
| `HubToolkitsHero` | Eyebrow + h1 + subtitle + N stat tiles | jsx:233-280 |
| `HubFilters` | Sticky bar: search + 4 status tabs + sort + count | jsx:298-384 |
| `HubToolkitCardGrid` | Per-item card (despite name, NOT a grid container) | jsx:104-228 |
| `HubToolkitsBody` | Orchestrator FSM (default/loading/error) | jsx:500-567 |
| `HubEmptyFiltered` | Grid-spanning empty state | jsx:387-420 |
| `ErrorState` | Grid-spanning error state with retry | jsx:422-452 |
| `SkeletonCard` | Shimmer placeholder per card | jsx:454-471 |

## Architecture decisions

- **P83 graceful-hide** for mockup fields not in BE `RecommendedToolkit` Zod schema (`version` / `toolCount` / `useCount` / `gameName` / `badge`). Components accept optional props and skip rendering when undefined → wiring richer BE later requires no component refactor.
- Page orchestrator at `/toolkits/page.tsx` reuses `useDiscoverRecommendedToolkits({ limit: 50 })` + FE-side filter + sort + analytics tracking from the legacy hub.
- **Heading-order axe fix**: card title is `h2` (was `h3`) — page hero `h1` + card `h2` direct hierarchy.
- 2 `eslint-disable-next-line local/no-hardcoded-color-utility` for decorative `bg-black/50` overlay + `bg-white/90` install-count pill on cover images (no semantic DS-15 token maps to "always dark/light" for image overlays).

## i18n

- New namespace `pages.toolkitsHub.*` (~15 keys: eyebrow, sort, install template, aria labels, hero stats)
- Reuses existing `pages.hub.common.*` (search placeholder, filters, error/empty common) + `pages.hub.toolkits.{title, subtitle, installLabel, kpi}` for hub-shared semantics.

## Test plan

- [x] **55 unit tests** across 7 component files (~600 LOC test), every file includes a jest-axe assertion
- [x] ESLint clean (3 hardcoded-color allowances inline-documented for image overlays)
- [x] Mockup-faithful (matches sp4-hub-toolkits.jsx down to filter/sort taxonomy + grid responsive cols)

## Follow-up backlog (post-merge)

Schema gaps tracked separately — components are ready to consume the data when BE ships `version` / `toolCount` / `useCount` / `gameName` / `badge` / `featured` flag fields.

Closes #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)