### PR TITLE
fix(docs): remove literal anchor tag in BGG spec (Lychee, follow-up to #1562)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
+++ b/docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
@@ -43,7 +43,7 @@ The goal is to **hide every BGG mention from the non-admin UI surface** while pr
 | # | File | Change |
 |---|------|--------|
 | 1 | `apps/web/src/components/catalog/MeepleGameCatalogCard.tsx` | Remove `if (game.bggId) subtitleParts.push(\`ID: ${game.bggId}\`)` block (lines 194-195) |
-| 2 | `apps/web/src/components/shared-games/SharedGameDetailModal.tsx` | Remove `{game.bggId && <a href={bggUrl}>View on BGG</a>}` block (lines 345-348 region) — the anchor pointed at `boardgamegeek.com/boardgame/{bggId}` |
+| 2 | `apps/web/src/components/shared-games/SharedGameDetailModal.tsx` | Remove the "View on BGG" anchor block (lines 345-348 region) — it linked to `boardgamegeek.com/boardgame/{bggId}` |
 | 3 | `apps/web/src/app/(authenticated)/settings/services/page.tsx` | Remove `{ id: 'bgg', label: 'BoardGameGeek', ... }` entry from services array |
 | 4 | `apps/web/src/components/games/BggSearchPanel.tsx` | DELETE (orphan duplicate) |
 | 5 | `apps/web/src/__tests__/components/games/BggSearchPanel.test.tsx` | DELETE (test of orphan) |


### PR DESCRIPTION
## Context

Follow-up to #1562. That PR swapped the broken `<a href="boardgamegeek.com/...">` to `<a href={bggUrl}>`, but Lychee **still** failed on PR #1498 — it parses the anchor's `href` attribute regardless of the value and resolved `{bggUrl}` as a relative path:

```
### Errors in docs/superpowers/specs/2026-05-22-hide-bgg-user-facing-design.md
* [ERROR] file:///.../docs/superpowers/specs/%7BbggUrl%7D | Cannot find file
```

## Root cause

The literal `<a href=` **token** is what Lychee extracts, not its value. The sibling file `docs/superpowers/plans/2026-05-22-hide-bgg-user-facing.md:84` survives only because it uses a fully-qualified `https://boardgamegeek.com/...` URL (a reachable host).

## Fix

Drop the inline anchor markup entirely; describe the removed block in prose and keep the target domain in inline code (`boardgamegeek.com/boardgame/{bggId}`) — the exact backtick form already used on **line 13** of the same file, which Lychee ignores. No external HTTP probe ⇒ no network flakiness.

```diff
-| 2 | ... | Remove `{game.bggId && <a href={bggUrl}>View on BGG</a>}` block ... |
+| 2 | ... | Remove the "View on BGG" anchor block (lines 345-348 region) — it linked to `boardgamegeek.com/boardgame/{bggId}` |
```

## Scope
- 1 file, 1 line, doc-only. No code/runtime impact.
- Unblocks Docs Link Check on release PR #1498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)