### PR TITLE
fix(toolkits-hub): #1480 mockup-faithful copy for /toolkits

### DIFF
--- a/apps/web/src/app/(authenticated)/toolkits/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkits/page.tsx
@@ -107,8 +107,8 @@ function HubToolkitsContent(): ReactElement {
   const heroLabels = useMemo<HubToolkitsHeroLabels>(
     () => ({
       eyebrow: t('pages.toolkitsHub.eyebrow'),
-      title: t('pages.hub.toolkits.title'),
-      subtitle: t('pages.hub.toolkits.subtitle'),
+      title: t('pages.toolkitsHub.title'),
+      subtitle: t('pages.toolkitsHub.subtitle'),
     }),
     [t]
   );
@@ -119,10 +119,10 @@ function HubToolkitsContent(): ReactElement {
       searchClearAriaLabel: t('pages.toolkitsHub.searchClearAriaLabel'),
       statusTablistAriaLabel: t('pages.toolkitsHub.statusTablistAriaLabel'),
       statusOptions: {
-        all: t('pages.hub.common.filters.all'),
-        featured: t('pages.hub.common.filters.featured'),
-        new: t('pages.hub.common.filters.new'),
-        top: t('pages.hub.common.filters.top'),
+        all: t('pages.toolkitsHub.statusOptions.all'),
+        featured: t('pages.toolkitsHub.statusOptions.featured'),
+        new: t('pages.toolkitsHub.statusOptions.new'),
+        top: t('pages.toolkitsHub.statusOptions.top'),
       },
       sortLabel: t('pages.toolkitsHub.sortLabel'),
       sortOptions: {
@@ -149,8 +149,8 @@ function HubToolkitsContent(): ReactElement {
 
   const emptyLabels = useMemo<HubEmptyFilteredLabels>(
     () => ({
-      title: t('pages.hub.common.filteredEmptyTitle'),
-      body: t('pages.hub.common.filteredEmptyBody'),
+      title: t('pages.toolkitsHub.emptyTitle'),
+      body: t('pages.toolkitsHub.emptyBody'),
       reset: t('pages.toolkitsHub.resetFilters'),
       resetAriaLabel: t('pages.toolkitsHub.resetFiltersAriaLabel'),
     }),

--- a/apps/web/src/components/features/toolkits-index/HubFilters.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubFilters.tsx
@@ -142,10 +142,12 @@ export function HubFilters({
         </select>
       </label>
 
-      {/* Count label */}
-      <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
-        {interpolateCount(labels.countTemplate, count)}
-      </span>
+      {/* Count label — compact (mobile) only, matching the mockup (desktop hides it) */}
+      {compact && (
+        <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+          {interpolateCount(labels.countTemplate, count)}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/features/toolkits-index/__tests__/HubFilters.test.tsx
+++ b/apps/web/src/components/features/toolkits-index/__tests__/HubFilters.test.tsx
@@ -118,10 +118,27 @@ describe('HubFilters (Issue #1480)', () => {
     expect(onSortChange).toHaveBeenCalledWith('title');
   });
 
-  // T6
-  it('renders the count label via countTemplate', () => {
-    renderFilters({ count: 42 });
+  // T6 — count is compact (mobile) only, matching the mockup (desktop hides it)
+  it('renders the count label via countTemplate when compact', () => {
+    render(
+      <HubFilters
+        query=""
+        onQueryChange={() => {}}
+        status="all"
+        onStatusChange={() => {}}
+        sort="popular"
+        onSortChange={() => {}}
+        count={42}
+        labels={labels}
+        compact
+      />
+    );
     expect(screen.getByText('42 toolkit')).toBeInTheDocument();
+  });
+
+  it('hides the count label on desktop (non-compact)', () => {
+    renderFilters({ count: 42 });
+    expect(screen.queryByText('42 toolkit')).not.toBeInTheDocument();
   });
 
   // T7

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1926,6 +1926,8 @@
     },
     "toolkitsHub": {
       "eyebrow": "Hub · /toolkits",
+      "title": "Community toolkits catalog",
+      "subtitle": "Ready-to-use bundles of tools (timer, dice, counter, deck) for your games. Every toolkit is versioned and published by the community.",
       "heroStats": {
         "toolkits": "Toolkits",
         "installs": "Installs",
@@ -1934,6 +1936,12 @@
       },
       "searchClearAriaLabel": "Clear search",
       "statusTablistAriaLabel": "Filter toolkits by status",
+      "statusOptions": {
+        "all": "All",
+        "featured": "Featured",
+        "new": "New",
+        "top": "Top 100"
+      },
       "sortLabel": "Sort",
       "sortOptions": {
         "popular": "Popularity",
@@ -1942,6 +1950,8 @@
         "uses": "Uses"
       },
       "countTemplate": "{count} toolkits",
+      "emptyTitle": "No toolkit found",
+      "emptyBody": "No toolkit matches the current filters. Try adjusting your search.",
       "gameRefFallback": "Universal (multi-game)",
       "installAriaLabel": "Install {title}",
       "toolsLabel": "Tools:",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1976,6 +1976,8 @@
     },
     "toolkitsHub": {
       "eyebrow": "Hub · /toolkits",
+      "title": "Catalogo toolkit community",
+      "subtitle": "Bundle pronti all'uso di strumenti (timer, dadi, counter, deck) per i tuoi giochi. Ogni toolkit è versionato e pubblicato dalla community.",
       "heroStats": {
         "toolkits": "Toolkit",
         "installs": "Installazioni",
@@ -1984,6 +1986,12 @@
       },
       "searchClearAriaLabel": "Pulisci ricerca",
       "statusTablistAriaLabel": "Filtra toolkit per status",
+      "statusOptions": {
+        "all": "Tutti",
+        "featured": "Featured",
+        "new": "Nuovi",
+        "top": "Top 100"
+      },
       "sortLabel": "Ordina",
       "sortOptions": {
         "popular": "Popolarità",
@@ -1992,6 +2000,8 @@
         "uses": "Uses"
       },
       "countTemplate": "{count} toolkit",
+      "emptyTitle": "Nessun toolkit trovato",
+      "emptyBody": "Nessun toolkit corrisponde ai filtri attuali. Prova a modificare la ricerca.",
       "gameRefFallback": "Universale (multi-game)",
       "installAriaLabel": "Installa {title}",
       "toolsLabel": "Strumenti:",


### PR DESCRIPTION
## Summary

Follow-up to #1480 (PR #1563). A **live visual check** (app vs `sp4-hub-toolkits` mockup) caught **copy divergences**: #1480 reused the legacy `/hub/toolkits` i18n keys (`pages.hub.toolkits.*` + shared `pages.hub.common.*`) instead of the mockup copy. The component **structure** matched the mock, but the **text** didn't — and unit tests passed because they inject labels (never assert the resolved i18n values).

## Fixes (new `pages.toolkitsHub.*` keys, en + it)

| Element | Before | After (mockup) |
|---|---|---|
| Title | "Toolkit community" | "Catalogo toolkit community" |
| Subtitle | generic | "Bundle pronti all'uso di strumenti (timer, dadi, counter, deck)…" |
| Filter tabs | "In evidenza" / "Top" | "Featured" / "Top 100" |
| Empty title/body | "Nessun risultato" / "Prova a modificare i filtri…" | "Nessun toolkit trovato" / "Nessun toolkit corrisponde ai filtri attuali…" |
| Result count | always visible | compact (mobile) only — matches mock |

Shared `pages.hub.common.*` left **untouched** (still consumed by `/hub/games` + `/hub/agents` via `HubCatalogView`).

## Out of scope (not copy)

- **4th "Strumenti totali" hero tile** — P83-deferred (`toolCount` not in `RecommendedToolkit` BE schema; no faked data)
- **Zero stat values** — local DB not seeded (data condition, not a code bug)
- **Global navbar** (SP4 horizontal nav vs app `TopBar`+`SideDrawer` shell) — tracked separately in **#1571** (cross-cutting, design decision)

## Test plan

- [x] 58/58 toolkits-index tests green (HubFilters count test split into compact-shows / desktop-hides)
- [x] typecheck + lint clean
- [x] Verified live: served payload contains "Catalogo toolkit community" after no-cache Docker rebuild

Relates to #1480 (page content conformity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)