### PR TITLE
feat(infra): image-aware staging-* retention via DEPLOYMENT.json (#1575 deferred C)

### DIFF
--- a/infra/scripts/daily-disk-prune.sh
+++ b/infra/scripts/daily-disk-prune.sh
@@ -2,6 +2,10 @@
 # Daily Docker + runner _diag prune — keep VPS disk under control
 # Runs from cron at 05:00 (after 03:00 backup, before any morning activity).
 #
+# Usage: daily-disk-prune.sh [--dry-run]
+#   --dry-run    Log what would be removed without executing destructive ops.
+#                Useful for testing the stale-staging detection logic.
+#
 # Cron: 0 5 * * * cd /opt/meepleai/repo/infra && bash scripts/daily-disk-prune.sh >> /var/log/meepleai-disk-prune.log 2>&1
 #
 # Exit codes:
@@ -12,12 +16,24 @@
 # Scope (issue #1575):
 # - Docker images > 72h (kept) + builder cache > 24h + stopped containers +
 #   unused networks.
+# - Stale staging-* images: removed regardless of mtime if NOT the
+#   currently-deployed tag per DEPLOYMENT.json (with 3 safeguards to never
+#   touch the running container's image — see prune_stale_staging_images).
 # - Runner _diag rotation: top-level logs > 7d, blocks/pages > 1d
 #   (the runner self-hosted on this VPS accumulated 14GB in _diag/blocks
 #    because maintenance.sh hardcoded a wrong path — see #1575).
 # - DOES NOT touch docker volumes (pgdata/redis/loki — never auto-prune).
 
 set -uo pipefail  # NOTE: no `-e` — pruning failures should not abort the chain.
+
+# Parse flags
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    *) echo "Unknown arg: $arg" >&2; exit 64 ;;
+  esac
+done
 
 log() {
   echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*"
@@ -26,6 +42,81 @@ log() {
 # Capture disk_free in MB (numeric) for end-of-run comparison.
 disk_free_mb() {
   df -BM / | awk 'NR==2 {gsub(/M/,"",$4); print $4}'
+}
+
+# Remove staging-* images that are NOT currently deployed.
+# Three safeguards (per spec-panel critique on #1575):
+#   1. DEPLOYMENT.json must exist (skip otherwise — never blanket-prune).
+#   2. api_image + web_image must be non-empty strings.
+#   3. Running containers (meepleai-api, meepleai-web) must match the
+#      DEPLOYMENT.json declarations (defends against a stale json file
+#      from an aborted deploy, e.g. issue #1573).
+# Image-aware retention bypasses the standard `--filter "until=72h"`
+# because staging-{date}-{sha} tags are immutable: once superseded, they
+# will never be referenced again, so 72h is unnecessary slack.
+prune_stale_staging_images() {
+  log "=== Stale staging-* image prune ==="
+  local deployment_json="/opt/meepleai/repo/infra/DEPLOYMENT.json"
+
+  if [ ! -f "$deployment_json" ]; then
+    log "SKIP: $deployment_json not found (no deployment record — refusing to guess)"
+    return 0
+  fi
+
+  # Prefer jq when available; python3 is the universal fallback.
+  local current_api_image="" current_web_image=""
+  if command -v jq >/dev/null 2>&1; then
+    current_api_image=$(jq -r '.api_image // empty' "$deployment_json" 2>/dev/null)
+    current_web_image=$(jq -r '.web_image // empty' "$deployment_json" 2>/dev/null)
+  elif command -v python3 >/dev/null 2>&1; then
+    current_api_image=$(python3 -c "import json,sys; print(json.load(open('$deployment_json')).get('api_image',''))" 2>/dev/null)
+    current_web_image=$(python3 -c "import json,sys; print(json.load(open('$deployment_json')).get('web_image',''))" 2>/dev/null)
+  else
+    log "SKIP: neither jq nor python3 available — cannot parse DEPLOYMENT.json"
+    return 0
+  fi
+
+  if [ -z "$current_api_image" ] || [ -z "$current_web_image" ]; then
+    log "SKIP: DEPLOYMENT.json missing api_image or web_image"
+    return 0
+  fi
+
+  # Paranoia check: the json must agree with what's actually running.
+  local running_api running_web
+  running_api=$(docker inspect meepleai-api --format '{{.Config.Image}}' 2>/dev/null || echo "")
+  running_web=$(docker inspect meepleai-web --format '{{.Config.Image}}' 2>/dev/null || echo "")
+  if [ "$running_api" != "$current_api_image" ] || [ "$running_web" != "$current_web_image" ]; then
+    log "SKIP: DEPLOYMENT.json (api=$current_api_image, web=$current_web_image) does not match running containers (api=$running_api, web=$running_web)"
+    log "      A deploy may be in progress, aborted, or DEPLOYMENT.json is stale — refusing to prune."
+    return 0
+  fi
+
+  log "Currently deployed: api=$current_api_image, web=$current_web_image"
+
+  local removed=0 considered=0
+  while IFS= read -r img; do
+    [ -z "$img" ] && continue
+    considered=$((considered + 1))
+    if [ "$img" = "$current_api_image" ] || [ "$img" = "$current_web_image" ]; then
+      # Never touch the currently-deployed images.
+      continue
+    fi
+    if [ "$DRY_RUN" = "1" ]; then
+      log "DRY-RUN: would remove $img"
+      removed=$((removed + 1))
+    else
+      if docker rmi "$img" >/dev/null 2>&1; then
+        log "Removed stale: $img"
+        removed=$((removed + 1))
+      else
+        log "WARN: could not remove $img (still referenced?)"
+      fi
+    fi
+  done < <(docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep -E ':staging-[0-9]{8}-[a-f0-9]+$' \
+            | grep -v '<none>')
+
+  log "Stale-staging prune complete: $removed removed / $considered considered (dry-run=$DRY_RUN)"
 }
 
 DISK_BEFORE_MB=$(disk_free_mb)
@@ -46,6 +137,13 @@ docker container prune -f 2>&1 || log "WARN: container prune had non-zero exit"
 
 # Networks: prune unused
 docker network prune -f 2>&1 || log "WARN: network prune had non-zero exit"
+
+# Image-aware staging-* retention (issue #1575 deferred C).
+# This runs AFTER `docker image prune --filter until=72h`, so it only catches
+# superseded staging tags that the time filter skipped. With three safeguards
+# (DEPLOYMENT.json present + non-empty tags + matches running containers),
+# this never touches a currently-deployed image.
+prune_stale_staging_images
 
 # DO NOT prune volumes — they contain pgdata/redis/loki/grafana/prometheus.
 # Only manual `docker volume prune` allowed.


### PR DESCRIPTION
## Closes #1575 deferred C (spec-panel Hightower P1)

## What

Immutable `staging-YYYYMMDD-SHA` tags don't need the standard `docker image prune --filter until=72h` safety window — once superseded by a newer deploy they will **never** be referenced again. Add a separate retention pass that:

1. Reads currently-deployed tag from `/opt/meepleai/repo/infra/DEPLOYMENT.json` (api_image + web_image).
2. `docker rmi` every other `staging-*` image regardless of mtime.
3. Logs every action; respects new `--dry-run` flag.

## Three safeguards (Crispin)

| # | Check | Behaviour on failure |
|---|-------|---------------------|
| 1 | `DEPLOYMENT.json` exists | `SKIP` (never blanket-prune) |
| 2 | `api_image` + `web_image` non-empty | `SKIP` |
| 3 | Running containers (`meepleai-api`, `meepleai-web`) match the JSON declarations | `SKIP` with detailed log |

Safeguard 3 is the critical one: it defends against a stale `DEPLOYMENT.json` left by an aborted deploy (e.g. the limbo Deploy job in #1573). If JSON says 'we are on tag X' but the running container is still on tag Y, we refuse to prune — we don't know which is correct.

## Validation on staging

```bash
$ bash daily-disk-prune.sh --dry-run
[…] === Stale staging-* image prune ===
[…] Currently deployed: api=staging-20260526-d144d37, web=staging-20260526-d144d37
[…] Stale-staging prune complete: 0 removed / 2 considered (dry-run=1)
```

0 removed because manual cleanup this morning already deleted the only two stale tags. When the next deploy happens, this code path will catch the new superseded tags **immediately**, not after 72h.

## Adzic scenarios (executable spec)

```gherkin
Scenario: Stale staging tags are pruned regardless of mtime
  Given the running API image is 'api:staging-20260526-d144d37'
    And DEPLOYMENT.json declares the same
    And there exists 'api:staging-20260521-ccaa72d' (5 days old)
   When daily-disk-prune.sh runs
   Then 'staging-20260521-ccaa72d' SHOULD be removed
    And 'staging-20260526-d144d37' SHOULD remain

Scenario: Safe-default when DEPLOYMENT.json is stale
  Given DEPLOYMENT.json declares 'staging-X'
    But the running container is on 'staging-Y'
   When daily-disk-prune.sh runs
   Then NO staging-* image SHOULD be removed
    And log SHOULD contain 'SKIP: DEPLOYMENT.json […] does not match running containers'

Scenario: Safe-default when DEPLOYMENT.json is missing
  Given DEPLOYMENT.json does not exist
   When daily-disk-prune.sh runs
   Then NO staging-* image SHOULD be removed
    And log SHOULD contain 'SKIP: […] not found'
```

## Dependencies

- `jq` (preferred) or `python3` (fallback) — both already on the VPS.
- Regex `:staging-[0-9]{8}-[a-f0-9]+$` matches the convention used by `deploy-staging.yml` Build Images job; will also match future format changes only after a corresponding regex update (intentional, safe-by-default).

## Out of scope (still deferred from #1575)

- **D**: Grafana alert on `node_filesystem_avail_bytes < 10 GB` (last remaining).
- **B**: AI service image drift (#1578 — escalated as architectural).

## Definition of Done

- [x] `bash -n` clean
- [x] Dry-run on staging confirms DEPLOYMENT.json parsing + cross-check works
- [x] Safeguard 3 (running matches json) tested implicitly (current state of staging)
- [x] `--dry-run` flag documented in header
- [ ] CI checks pass
- [ ] Merged to main-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)