### PR TITLE
feat(monitoring): Prometheus alerts on root filesystem disk pressure (#1575 deferred D — final)

### DIFF
--- a/infra/prometheus/alerts/infrastructure.yml
+++ b/infra/prometheus/alerts/infrastructure.yml
@@ -22,3 +22,63 @@ groups:
             The API may be approaching memory limits.
             Check for memory leaks or increase container resources.
           dashboard_url: "http://localhost:3001/d/infrastructure"
+
+      # WARNING: Disk space below 15 GB on staging VPS root filesystem (#1575).
+      # 15 GB = ~80% used on a 75 GB disk. Triggers when the daily prune is
+      # no longer keeping pace with growth (the exact canary failure mode
+      # we hit on 2026-05-25/26 — see audits/2026-05-26-disk-cleanup-1575.md).
+      # Sustained for 10 min to filter out transient deploy-time spikes.
+      - alert: DiskSpaceLowOnRoot
+        expr: |
+          node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay|squashfs"} < 15 * 1024 * 1024 * 1024
+        for: 10m
+        labels:
+          severity: warning
+          service: vps
+          category: resources
+          component: infrastructure
+        annotations:
+          summary: "VPS root filesystem below 15 GB available"
+          description: |
+            Available disk: {{ $value | humanize1024 }}B on mountpoint /.
+            The daily prune (infra/scripts/daily-disk-prune.sh) is no longer
+            keeping the VPS in safe range. Investigate top consumers:
+              sudo du -h --max-depth=2 /home/deploy /var/lib/docker /var/log | sort -rh | head
+            See audits/2026-05-26-disk-cleanup-1575.md for the playbook.
+          dashboard_url: "http://localhost:3001/d/infrastructure"
+
+  # CRITICAL: separate group so the route can match severity=critical and
+  # send immediate notification (alertmanager.yml routes critical with
+  # group_wait=0s, repeat_interval=15m).
+  - name: infrastructure_critical_alerts
+    interval: 30s
+    rules:
+      # CRITICAL: disk below 5 GB on root — within the disk-full reproduction
+      # window for incident #1348. At this point the next deploy WILL fail
+      # (Build Images pull ~1.5 GB + Database Migration ~0.5–1 GB + headroom).
+      # The pre-deploy disk gate (#1577) blocks at 10 GB, so reaching 5 GB
+      # means either the gate is disabled or growth between deploys is
+      # uncontrolled — page on-call.
+      - alert: DiskSpaceCriticalOnRoot
+        expr: |
+          node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay|squashfs"} < 5 * 1024 * 1024 * 1024
+        for: 5m
+        labels:
+          severity: critical
+          service: vps
+          category: resources
+          component: infrastructure
+        annotations:
+          summary: "VPS root filesystem CRITICAL — below 5 GB available"
+          description: |
+            Available disk: {{ $value | humanize1024 }}B on mountpoint /.
+            Within incident #1348 disk-full reproduction window. The next
+            deploy will fail at Build Images or Database Migration. Pre-deploy
+            disk gate (#1577) blocks at 10 GB — reaching 5 GB means the gate
+            is disabled or growth between deploys is uncontrolled.
+
+            Immediate actions:
+              1. bash /opt/meepleai/repo/infra/scripts/daily-disk-prune.sh
+              2. Check #1575 audit doc for stale _diag/blocks cleanup commands.
+              3. If repeated: open follow-up issue (likely #1578 AI image drift).
+          dashboard_url: "http://localhost:3001/d/infrastructure"


### PR DESCRIPTION
## Closes #1575 deferred D (final deferred follow-up)

## What

Add two Prometheus alert rules for the staging VPS root filesystem so disk pressure is visible **before** the next incident:

| Rule | Severity | Threshold | for | Alertmanager route |
|------|----------|-----------|-----|---------------------|
| `DiskSpaceLowOnRoot` | warning | < 15 GB | 10 m | warning-alerts (throttled, 2h repeat) |
| `DiskSpaceCriticalOnRoot` | critical | < 5 GB | 5 m | critical-alerts (group_wait=0s, 15m repeat) |

Both metrics: `node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay|squashfs"}`. node-exporter is already running on the staging VPS (compose profile `monitoring-essential`).

## Threshold rationale on a 75 GB disk

- **15 GB warning**: matches the existing `reclaimed=0 AND disk_free<15GB` exit code in `daily-disk-prune.sh` (#1576). If the daily prune logs an alert, this rule fires the metric path too.
- **5 GB critical**: within the #1348 disk-full reproduction window. The pre-deploy disk gate (#1577) blocks deploys at 10 GB, so reaching 5 GB means the gate is disabled or growth between deploys is uncontrolled — page on-call.

## Validation

```bash
# YAML structure
$ python -c 'import yaml; print(yaml.safe_load(open("infra/prometheus/alerts/infrastructure.yml")))'
Groups: 2
  [infrastructure_warning_alerts] HighMemoryUsage (severity=warning, for=5m)
  [infrastructure_warning_alerts] DiskSpaceLowOnRoot (severity=warning, for=10m)
  [infrastructure_critical_alerts] DiskSpaceCriticalOnRoot (severity=critical, for=5m)

# promtool lint
$ docker run --rm --entrypoint promtool -v …/infrastructure.yml:/etc/prometheus/alerts.yml:ro prom/prometheus:v3.7.0 check rules /etc/prometheus/alerts.yml
Checking /etc/prometheus/alerts.yml
  SUCCESS: 3 rules found

# Threshold evaluation against current real metric (staging)
$ curl …/api/v1/query?query=node_filesystem_avail_bytes{mountpoint="/"}
value: 17.28 GB
  vs 15 GB: ABOVE (no alert)
  vs  5 GB: ABOVE (no alert)
```

If staging fell back to the 2026-05-26 incident value (5.2 GB), the warning rule would fire after 10 min and the critical rule after 5 min.

## Alertmanager routing

No `alertmanager.yml` changes required — the file already has child routes for `severity=warning` and `severity=critical` (both deliver to API webhook + Slack via existing receivers). The new rules just plug into that flow.

## Pipeline summary (full #1575 closure)

| PR | Purpose | Status |
|----|---------|--------|
| #1576 | `_diag` rotation + alert exit code | ✅ merged |
| #1577 | Pre-deploy disk gate in workflow | ✅ merged |
| #1580 | Image-aware staging retention via DEPLOYMENT.json | ✅ merged |
| #1582 (this) | Prometheus alerts on `node_filesystem_avail_bytes` | ⏳ in review |
| #1578 | AI service image drift (architectural follow-up) | 📋 open, separate scope |

## Definition of Done

- [x] YAML clean (`python yaml.safe_load`)
- [x] `promtool check rules` SUCCESS
- [x] Thresholds verified against current real metric (no false positive)
- [x] Critical rule placed in dedicated group for correct alertmanager routing
- [x] Annotations include cleanup commands and links to playbook
- [ ] CI checks pass
- [ ] Merged to main-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)