### PR TITLE
fix(secrets): quote shell-unsafe .secret.example values + add validator (closes #1574)

### DIFF
--- a/.github/workflows/validate-secrets.yml
+++ b/.github/workflows/validate-secrets.yml
@@ -1,0 +1,36 @@
+name: Validate Secrets
+
+# Issue #1574: ensure every committed *.secret.example template is safe to
+# `source` under `bash -e`. An unquoted value with shell metacharacters
+# (spaces, parentheses, pipes, `<placeholder>`) silently aborts the deploy
+# script's secret-loading loop when `set -e` is active — this broke the
+# 2026-05-26 manual recovery deploy (admin.secret + monitoring.secret).
+#
+# Only *.example templates are validated here (real *.secret files are
+# gitignored and live on the VPS). Local devs / the VPS can run the same
+# check against their real secrets with: bash infra/secrets/validate.sh
+
+on:
+  pull_request:
+    paths:
+      - 'infra/secrets/**'
+      - '.github/workflows/validate-secrets.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-secrets-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-secret-examples:
+    name: Validate .secret.example templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate secret example templates
+        run: bash infra/secrets/validate.sh --examples

--- a/infra/secrets/admin.secret.example
+++ b/infra/secrets/admin.secret.example
@@ -4,12 +4,12 @@
 
 # For secret validation (Program.cs)
 ADMIN_EMAIL=admin@meepleai.app
-ADMIN_DISPLAY_NAME=System Administrator
+ADMIN_DISPLAY_NAME='System Administrator'
 ADMIN_PASSWORD=change_me_min_8_chars_with_uppercase_and_digit # gitguardian:ignore
 
 # For seed command (SeedAdminUserCommandHandler)
 INITIAL_ADMIN_EMAIL=admin@meepleai.app
-INITIAL_ADMIN_DISPLAY_NAME=System Administrator
+INITIAL_ADMIN_DISPLAY_NAME='System Administrator'
 
 # Seed test/E2E user password (used by SeedTestUser + SeedE2ETestUsers)
 # IMPORTANT: Never hardcode in source code — always read from this secret

--- a/infra/secrets/cf-access.secret.example
+++ b/infra/secrets/cf-access.secret.example
@@ -25,5 +25,5 @@
 #   3. Re-run gh secret set commands above
 #   4. Verify deploy success on next run, then revoke old token in CF dashboard
 
-CF_ACCESS_CLIENT_ID=<token-id>.access
-CF_ACCESS_CLIENT_SECRET=<token-secret>
+CF_ACCESS_CLIENT_ID='<token-id>.access'
+CF_ACCESS_CLIENT_SECRET='<token-secret>'

--- a/infra/secrets/storage.secret.example
+++ b/infra/secrets/storage.secret.example
@@ -81,11 +81,11 @@ MINIO_ROOT_PASSWORD=change_me_minio_password
 # Used by the API at startup to fetch rulebook PDFs for seeding.
 # Create a readonly access key for the meepleai-seeds bucket.
 SEED_BUCKET_NAME=meepleai-seeds
-SEED_BUCKET_ENDPOINT=https://<your-account>.r2.cloudflarestorage.com
+SEED_BUCKET_ENDPOINT='https://<your-account>.r2.cloudflarestorage.com'
 SEED_BUCKET_REGION=auto
 SEED_BUCKET_FORCE_PATH_STYLE=false
-SEED_BUCKET_ACCESS_KEY=<readonly_access_key>
-SEED_BUCKET_SECRET_KEY=<readonly_secret_key>
+SEED_BUCKET_ACCESS_KEY='<readonly_access_key>'
+SEED_BUCKET_SECRET_KEY='<readonly_secret_key>'
 
 # ==============================================================================
 # SEED BLOB BUCKET (snapshot publish/fetch)

--- a/infra/secrets/validate.sh
+++ b/infra/secrets/validate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Secrets validation — ensure every .secret / .secret.example file is safe
+# to `source` under `bash -e` (issue #1574).
+#
+# Failure mode this prevents: a single unquoted value with shell metacharacters
+# (parentheses, pipes, ampersands, spaces, `<placeholder>`) aborts the deploy
+# script silently when `set -e` is active. Pre-2026-05-26 this caused
+# admin.secret + monitoring.secret to break the manual recovery deploy of #1498
+# (see audits/2026-05-26-disk-cleanup-1575.md and issue #1574).
+#
+# Usage:
+#   bash infra/secrets/validate.sh              # validate all .secret + .example
+#   bash infra/secrets/validate.sh --examples   # only validate committed *.example
+#   bash infra/secrets/validate.sh --secrets    # only validate local *.secret
+#
+# Exit codes:
+#   0 — all clean
+#   1 — at least one file failed parse or source
+#   64 — bad CLI usage
+
+set -uo pipefail
+
+MODE="all"
+case "${1:-all}" in
+  all|"") MODE="all" ;;
+  --examples) MODE="examples" ;;
+  --secrets) MODE="secrets" ;;
+  -h|--help)
+    sed -n '1,/^set -uo pipefail/p' "$0" | head -20
+    exit 0
+    ;;
+  *)
+    echo "Unknown arg: $1" >&2
+    echo "Usage: $0 [--examples|--secrets]" >&2
+    exit 64
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+problems=0
+checked=0
+
+check_file() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  checked=$((checked + 1))
+  # 1. Syntax check
+  local err
+  err=$(bash -n "$f" 2>&1)
+  if [ -n "$err" ]; then
+    echo "FAIL  $f (syntax)"
+    echo "$err" | head -3 | sed 's/^/      /'
+    problems=$((problems + 1))
+    return 1
+  fi
+  # 2. Source under `set -e` in a subshell — catches `cmd not found` and similar
+  err=$( ( set -e; source "$f" ) 2>&1 )
+  if [ -n "$err" ]; then
+    echo "FAIL  $f (source under set -e)"
+    echo "$err" | head -3 | sed 's/^/      /'
+    problems=$((problems + 1))
+    return 1
+  fi
+  echo "PASS  $f"
+}
+
+echo "=== Secrets validation (mode=$MODE) ==="
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "examples" ]; then
+  for f in *.secret.example; do
+    [ -e "$f" ] || continue
+    check_file "$f"
+  done
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "secrets" ]; then
+  for f in *.secret; do
+    [ -e "$f" ] || continue
+    check_file "$f"
+  done
+fi
+
+echo ""
+echo "=== Result: checked=$checked, problems=$problems ==="
+
+if [ "$problems" -gt 0 ]; then
+  echo ""
+  echo "How to fix:"
+  echo "  Quote values containing shell metacharacters (space, parentheses, pipes,"
+  echo "  redirections like <foo>). Prefer single quotes — they disable expansion:"
+  echo "    GOOD: GRAFANA_PASSWORD='2)09kdW|x'"
+  echo "    BAD:  GRAFANA_PASSWORD=2)09kdW|x"
+  echo "    GOOD: DISPLAY_NAME='System Administrator'"
+  echo "    BAD:  DISPLAY_NAME=System Administrator"
+  echo "    GOOD: TOKEN='<placeholder>'"
+  echo "    BAD:  TOKEN=<placeholder>"
+  echo ""
+  echo "Re-run with --examples or --secrets to scope the check."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Closes #1574

## Problem

The deploy-staging.yml secret-loading loop is:
```bash
set -a
for f in secrets/*.secret; do source "$f" 2>/dev/null; done
set +a
```

Under `set -e` (e.g. the manual recovery script during the 2026-05-26 incident), a single `source` failure aborts the whole deploy. Three committed templates + two real VPS secrets had unquoted values with shell metacharacters.

## Offenders fixed

| File | Variable | Issue |
|------|----------|-------|
| `admin.secret.example` | `ADMIN_DISPLAY_NAME`, `INITIAL_ADMIN_DISPLAY_NAME` | `System Administrator` → space makes bash run `Administrator` as a command |
| `cf-access.secret.example` | `CF_ACCESS_CLIENT_ID/SECRET` | `<token-id>` → angle brackets = input redirection |
| `storage.secret.example` | `SEED_BUCKET_ENDPOINT/ACCESS_KEY/SECRET_KEY` | same `<placeholder>` redirection |
| `admin.secret` (VPS, real) | display names | same as template — **fixed in-place via SSH** |
| `monitoring.secret` (VPS, real) | `GRAFANA_ADMIN_PASSWORD` | `2)09kdWJR\|,wcorA` → parenthesis + pipe |

All quoted with single quotes (disable expansion).

## New tooling

### `infra/secrets/validate.sh`
`bash -n` + `( set -e; source f )` over every `*.secret` / `*.secret.example`. Clear remediation guidance on failure. Modes: `--examples`, `--secrets`, or both.

### `.github/workflows/validate-secrets.yml`
Runs `validate.sh --examples` on PRs touching `infra/secrets/**`. Only templates are validated in CI (real `*.secret` are gitignored).

## Validation

```bash
# Templates (local + CI):
$ bash infra/secrets/validate.sh --examples
=== Result: checked=26, problems=0 ===

# Real secrets on VPS (post in-place fix):
$ ssh meepleai-staging bash /opt/meepleai/repo/infra/secrets/validate.sh --secrets
PASS admin.secret … PASS monitoring.secret  (18/18, was 2 failures)
```

VPS `.secret` files were backed up (`*.bak.<timestamp>`) before the in-place fix and re-validated with `set -e; source` → clean.

## Note on VPS state

The 3 `.example` fixes in this PR will reach the VPS at the next deploy (`git reset --hard`) or `git pull`. The 2 **real** `.secret` files were already fixed manually so the runtime is safe now — this PR makes the templates correct so future `make secrets-setup` produces valid files.

## Definition of Done

- [x] All `*.secret.example` pass `validate.sh --examples` (26/26)
- [x] Real VPS `*.secret` fixed in-place + backed up + re-validated (18/18)
- [x] Validator script committed + executable
- [x] CI workflow validates templates on `infra/secrets/**` PRs
- [ ] CI checks pass
- [ ] Merged to main-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)