### PR TITLE
fix(deploy): concurrency cancel-in-progress=true to break orphaned-job lock (#1573 quick mitigation)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,10 +46,30 @@ on:
           - warn
           - fail
 
-# Only one staging deployment at a time
+# Only one staging deployment at a time.
+#
+# cancel-in-progress: true (changed from false, issue #1573).
+# Rationale: on 2026-05-26 the Deploy job orphaned in the self-hosted runner
+# queue (runner=None, never picked) while the run stayed "completed/failure".
+# With cancel-in-progress: false, every subsequent `gh workflow run` / push
+# queued *behind* that zombie and 500'd — the lock was unbreakable without an
+# in-place SSH deploy (see audits/2026-05-26-disk-cleanup-1575.md + #1573).
+#
+# Switching to true makes a fresh trigger CANCEL the stuck run and start clean,
+# so the pipeline is self-healing. This is safe because every stage is
+# idempotent and re-runnable:
+#   - migrate-db: `dotnet ef migrations script --idempotent` (each migration
+#     wrapped in IF NOT EXISTS vs __EFMigrationsHistory) → re-run is a no-op.
+#   - deploy: `docker compose up --force-recreate` converges to the target
+#     image regardless of partial prior state.
+# A mid-flight cancel therefore can't corrupt staging; the next run re-converges.
+#
+# NOTE: this is the quick mitigation. The deeper rework (split migrate-db out
+# of the deploy critical path; add a queue-time watchdog for self-hosted jobs)
+# stays tracked in #1573.
 concurrency:
   group: deploy-staging
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Refs #1573 (quick mitigation — does NOT close)

## Problem recap

On 2026-05-26 (PR #1498 deploy), the `Deploy to Staging` job orphaned in the self-hosted runner queue (`runner=None`, never picked) while the run was marked `completed/failure`. With `concurrency.cancel-in-progress: false`:

| Attempt | Result |
|---------|--------|
| `gh run rerun --failed` | `cannot be retried` |
| `gh workflow run deploy-staging.yml` | HTTP 500 (lock held by zombie) |
| `gh api …/cancel` / `force-cancel` | HTTP 409 |

The `deploy-staging` concurrency lock was **unbreakable** without a manual in-place SSH deploy.

## Fix

```diff
 concurrency:
   group: deploy-staging
-  cancel-in-progress: false
+  cancel-in-progress: true
```

A fresh trigger now **cancels** the stuck run and starts clean → self-healing pipeline.

## Why this is safe (idempotency)

Every stage re-runs cleanly:

| Stage | Idempotency |
|-------|-------------|
| `migrate-db` | `dotnet ef migrations script --idempotent` — each migration wrapped in `IF NOT EXISTS` vs `__EFMigrationsHistory`; re-run = no-op |
| `deploy` | `docker compose up --force-recreate` converges to the target image regardless of partial prior state |

A mid-flight cancel cannot corrupt staging; the next run re-converges. The idempotent-migration design is documented inline in the `migrate-db` job (lines ~469-482).

## Scope boundary

This is the **quick mitigation**. The architectural rework stays open in #1573:
- Split `migrate-db` out of the deploy critical path (avoid migrating before a deploy that may not happen).
- Add a queue-time watchdog that fails self-hosted jobs not picked within N minutes (the orphan root cause).

## Validation

```bash
$ python -c 'import yaml; print(yaml.safe_load(open(.github/workflows/deploy-staging.yml))[concurrency])'
{'group': 'deploy-staging', 'cancel-in-progress': True}
```

## Definition of Done

- [x] concurrency.cancel-in-progress = true
- [x] Inline rationale documents idempotency safety + links #1573
- [x] YAML parses clean
- [ ] CI checks pass
- [ ] Merged to main-dev
- [ ] #1573 remains open for architectural rework

🤖 Generated with [Claude Code](https://claude.com/claude-code)