### PR TITLE
ci(perf): isolate Lighthouse from self-hosted runner + drop main-staging trigger (#1587)

### DIFF
--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -9,7 +9,15 @@ on:
     # K6: Run nightly at 2 AM UTC (only on main branch)
     - cron: '0 2 * * *'
   pull_request:
-    branches: [main, main-staging]
+    # Issue #1587: dropped main-staging from branches. Release PRs (main-dev →
+    # main-staging) no longer trigger Performance Tests because the deploy-staging
+    # workflow already runs `Snapshot Performance Baseline` + `Compare Performance
+    # Baseline` post-deploy on the live staging environment. Running perf on the
+    # release PR was redundant AND held the single self-hosted runner — when a
+    # post-step log-upload hung (split-brain GHA token expiry), it starved the
+    # Deploy to Staging job that needed the same runner (incident 2026-05-26).
+    # Perf on PRs to main (production release) is preserved.
+    branches: [main]
     paths:
       - 'apps/web/**'
       - 'apps/api/src/Api/Routing/**'
@@ -372,7 +380,13 @@ jobs:
   # ============================================
   lighthouse-build:
     name: Build Next.js (Lighthouse)
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    # Issue #1587: pinned to ubuntu-latest (was: vars.RUNNER fallback). This
+    # job is a pure Next.js production build — it doesn't touch staging and has
+    # no reason to compete with deploy-staging for the single self-hosted runner.
+    # timeout-minutes: 30 added so a hang (Node OOM, network stall) can't tie up
+    # the runner indefinitely.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: changes
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.run_lighthouse != 'false') ||
@@ -421,7 +435,12 @@ jobs:
 
   lighthouse-ci:
     name: Lighthouse CI
-    runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    # Issue #1587: pinned to ubuntu-latest + explicit timeout. Lighthouse autorun
+    # operates on the build artifact served via lhci local server — no staging
+    # dependency. Same rationale as lighthouse-build: no reason to share the
+    # single self-hosted runner used by deploy-staging.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [changes, lighthouse-build]
     continue-on-error: true
     defaults:


### PR DESCRIPTION
## Summary

Three lowest-risk mitigations for #1587 — Performance Tests starving the single self-hosted runner used by `deploy-staging`. Incident root cause: 2026-05-26 k6 post-step log upload hung (split-brain runner state after GHA token expiry) → 1h45m staging schema/code drift.

| # | Change | File:Line |
|---|--------|-----------|
| 1 | `pull_request.branches: [main, main-staging]` → `[main]` | `test-performance.yml:12` |
| 2 | `lighthouse-build`: `vars.RUNNER` → `ubuntu-latest` + `timeout-minutes: 30` | `test-performance.yml:382-386` |
| 3 | `lighthouse-ci`: same pattern | `test-performance.yml:437-441` |

## Why these three (and not the others from the issue body)

- **#1 (drop main-staging trigger)**: `deploy-staging.yml` already runs `Snapshot Performance Baseline` + `Compare Performance Baseline` against live staging post-deploy. Perf on the release PR is redundant. PRs to `main` (prod release) still run perf, as does the nightly schedule.
- **#2/#3 (lighthouse off self-hosted)**: `lighthouse-build` is a pure Next.js build, `lighthouse-ci` operates on the build artifact via lhci's local server. Neither touches staging — no reason to compete for the runner.
- **Both jobs gained explicit `timeout-minutes: 30`**: previously had none. Even if a future hang occurs, it can't hold the runner indefinitely.

## Deferred (out of scope this PR)

- **`k6-tests` on self-hosted**: moving it to `ubuntu-latest` is plausible (postgres+redis services are already declared) but constitutes a behavior change — separate PR with validation.
- **Queue-time watchdog**: tracked in #1573 (architectural rework, not quick win).

## Validation

```
$ python -c "import yaml; doc=yaml.safe_load(open('.github/workflows/test-performance.yml', encoding='utf-8')); ..."
OK: Performance Tests
triggers.pull_request.branches: ['main']
lighthouse-build runs-on: ubuntu-latest | timeout: 30
lighthouse-ci runs-on: ubuntu-latest | timeout: 30
```

Diff: +22 / -3, single file.

## Refs

- #1587 (does not close — k6-tests + watchdog remain open)
- Related: #1573 (deploy concurrency mitigation), audit `audits/2026-05-26-disk-cleanup-1575.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)