### PR TITLE
feat(2fa): SP5 S3 — strict 2FA enforcement cutover for admin commands

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommand.cs
@@ -41,7 +41,10 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
     Level = 2,
     UserIdSource = AuditUserIdSource.ResourceId)]
 [AtomicAudit]
-[RequireTwoFactor(Reason = "Impersonate other user; HIGH RISK — full target-user session granted.")]
+// SP5 S3 — D-S3-7: tighter 5-min TOTP recency for impersonation (vs the 30-min default for
+// DeleteUser/ChangeRole/Suspend). Impersonation grants a full target-user session, so it
+// warrants the freshest step-up.
+[RequireTwoFactor(MaxAgeMinutes = 5, Reason = "Impersonate other user; HIGH RISK — full target-user session granted.")]
 internal record ImpersonationStartCommand(
     Guid TargetUserId,
     Guid RequestingUserId,

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommandHandler.cs
@@ -1,9 +1,11 @@
 using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.Enums;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Administration.Application.Commands;
@@ -31,17 +33,20 @@ internal sealed class ImpersonationStartCommandHandler
     private readonly IUserRepository _userRepository;
     private readonly IMediator _mediator;
     private readonly TimeProvider _timeProvider;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<ImpersonationStartCommandHandler> _logger;
 
     public ImpersonationStartCommandHandler(
         IUserRepository userRepository,
         IMediator mediator,
         TimeProvider timeProvider,
+        IHttpContextAccessor httpContextAccessor,
         ILogger<ImpersonationStartCommandHandler> logger)
     {
         _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -116,13 +121,20 @@ internal sealed class ImpersonationStartCommandHandler
         // requester (actor); ImpersonatedUntil caps the lifetime to DurationMinutes (D-S2-4).
         // No more magic-string IpAddress="impersonated" — the dual-principal columns carry the
         // impersonation state explicitly.
+        //
+        // SP5 S3 spike §5: inherit the actor's LastTotpVerifiedAt into the new impersonate
+        // session. The impersonation MaxAge clock starts from the actor's most recent TOTP
+        // verification — semantically correct (the admin's step-up gates impersonate behavior,
+        // not the target's enrollment).
         var impersonatedUntil = _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(command.DurationMinutes);
+        var actorLastTotpVerifiedAt = ExtractCallerLastTotpVerifiedAt();
         var createSessionCommand = new CreateSessionCommand(
             UserId: command.TargetUserId,
             IpAddress: null,
             UserAgent: $"Impersonation by superadmin {requester.DisplayName ?? requester.Email.Value}",
             ImpersonatedByUserId: command.RequestingUserId,
-            ImpersonatedUntil: impersonatedUntil);
+            ImpersonatedUntil: impersonatedUntil,
+            LastTotpVerifiedAt: actorLastTotpVerifiedAt);
 
         var sessionResponse = await _mediator.Send(createSessionCommand, cancellationToken)
             .ConfigureAwait(false);
@@ -140,5 +152,32 @@ internal sealed class ImpersonationStartCommandHandler
             ImpersonatedUserId: command.TargetUserId,
             ImpersonatedUntil: impersonatedUntil,
             ExpiresAt: sessionResponse.ExpiresAt);
+    }
+
+    /// <summary>
+    /// Reads the acting admin's <c>LastTotpVerifiedAt</c> from the current request's session
+    /// (HttpContext-populated by <c>SessionAuthenticationMiddleware</c>). Returns null when no
+    /// session is in scope (defensive; the endpoint is gated by <c>RequireSuperAdmin</c> so this
+    /// path is normally unreachable) or when the actor has no recorded TOTP verification.
+    ///
+    /// SP5 S3 spike §5: enables the new impersonate session to inherit the actor's TOTP recency
+    /// so the strict <c>TwoFactorEnforcementBehavior</c> can gate subsequent commands without a
+    /// separate step-up.
+    /// </summary>
+    private DateTime? ExtractCallerLastTotpVerifiedAt()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return null;
+        }
+
+        if (httpContext.Items.TryGetValue(nameof(SessionStatusDto), out var value)
+            && value is SessionStatusDto { IsValid: true } sessionStatus)
+        {
+            return sessionStatus.LastTotpVerifiedAt;
+        }
+
+        return null;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs
@@ -1,8 +1,12 @@
 using System.Reflection;
 using Api.BoundedContexts.Authentication.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.Configuration;
 using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.Infrastructure.Security;
+using Api.Middleware.Exceptions;
+using Api.Services;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.BoundedContexts.Authentication.Application.Behaviors;
 
@@ -23,21 +27,38 @@ namespace Api.BoundedContexts.Authentication.Application.Behaviors;
 ///   (or domain-specific TwoFactorRequiredException).
 /// - Add session schema field LastTotpVerifiedAt to track recency precisely.
 ///
-/// Note: this behavior is intentionally permissive while we collect telemetry.
-/// Do NOT replicate the resilience pattern from AuditLoggingBehavior: failures
-/// here ARE the desired outcome (visibility); we only log + proceed.
+/// SP5 Admin Security S3 (strict cutover):
+/// - Gated by the <c>TwoFactor:StrictMode</c> dynamic flag (default false). When false, the
+///   shadow behavior above is preserved (log + proceed). When true, a missing 2FA enrollment or
+///   stale TOTP recency throws <see cref="TwoFactorRequiredException"/> (mapped to 401 + subcode).
+/// - 2FA enforcement is an AUTHORIZATION check, so it reads <c>Principal.EffectiveActor</c> (the
+///   real acting admin during impersonation), NOT <c>Subject</c>. The session's
+///   <c>LastTotpVerifiedAt</c> is the actor's recency (inherited at impersonation start — S3 T1).
+/// - On a strict block, a forensic <c>TwoFactorRequired</c> audit is emitted from a FRESH DI scope
+///   so it commits independently of the command's (possibly <c>[AtomicAudit]</c>) transaction,
+///   which rolls back when this behavior throws. Consistent with the existing 2FA audit family
+///   (<c>TotpService</c> uses <c>AuditService.LogAsync</c> direct-write).
 /// </summary>
 internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ITwoFactorEnforcementConfiguration _twoFactorConfig;
+    private readonly TimeProvider _timeProvider;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<TwoFactorEnforcementBehavior<TRequest, TResponse>> _logger;
 
     public TwoFactorEnforcementBehavior(
         IHttpContextAccessor httpContextAccessor,
+        ITwoFactorEnforcementConfiguration twoFactorConfig,
+        TimeProvider timeProvider,
+        IServiceScopeFactory scopeFactory,
         ILogger<TwoFactorEnforcementBehavior<TRequest, TResponse>> logger)
     {
         _httpContextAccessor = httpContextAccessor;
+        _twoFactorConfig = twoFactorConfig;
+        _timeProvider = timeProvider;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -48,7 +69,7 @@ internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipel
     {
         var attr = typeof(TRequest).GetCustomAttribute<RequireTwoFactorAttribute>();
 
-        // Skip if command is not decorated with [RequireTwoFactor]
+        // S3-7 regression guard: commands NOT decorated with [RequireTwoFactor] are never gated.
         if (attr is null)
         {
             return await next().ConfigureAwait(false);
@@ -64,8 +85,11 @@ internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipel
             return await next().ConfigureAwait(false);
         }
 
-        var user = session.Principal?.Subject;
-        if (user is null)
+        // 2FA enforcement is an AUTHORIZATION check → read EffectiveActor (the acting admin during
+        // an impersonation), NOT Subject. During impersonate, Subject is the target user (who may
+        // have no 2FA at all); the security gate applies to the real actor.
+        var actor = session.Principal?.EffectiveActor;
+        if (actor is null)
         {
             // Anonymous request hit a 2FA-required command — outer authorization layer
             // should have stopped this. Log defensively and proceed.
@@ -75,26 +99,97 @@ internal sealed class TwoFactorEnforcementBehavior<TRequest, TResponse> : IPipel
             return await next().ConfigureAwait(false);
         }
 
-        // Shadow-mode check: log if user lacks 2FA enrollment for a sensitive command.
-        // Strict mode will reject; for now we only emit telemetry.
-        if (!user.IsTwoFactorEnabled)
+        var strictMode = await _twoFactorConfig.GetStrictModeAsync(cancellationToken).ConfigureAwait(false);
+        if (!strictMode)
+        {
+            LogShadow(actor, attr);
+            return await next().ConfigureAwait(false);
+        }
+
+        // ── STRICT MODE (D-S3-1) ──────────────────────────────────────────────────────────────
+        // D-S3-5: hard block when the actor has no 2FA enrolled at all.
+        if (!actor.IsTwoFactorEnabled)
         {
             _logger.LogWarning(
-                "TwoFactorEnforcementBehavior[shadow]: user {UserId} ({Email}) invoked 2FA-required command "
-                + "{CommandType} WITHOUT 2FA enabled. Reason: {Reason}. MaxAge: {MaxAgeMinutes}min",
-                user.Id, DataMasking.MaskEmail(user.Email), typeof(TRequest).Name, attr.Reason ?? "(unspecified)", attr.MaxAgeMinutes);
+                "TwoFactorEnforcementBehavior[strict]: actor {UserId} ({Email}) BLOCKED on {CommandType} — 2FA not enrolled.",
+                actor.Id, DataMasking.MaskEmail(actor.Email), typeof(TRequest).Name);
+            await EmitTwoFactorRequiredAuditAsync(actor, attr, "enroll_required", cancellationToken).ConfigureAwait(false);
+            throw new TwoFactorRequiredException(
+                TwoFactorRequiredSubcode.EnrollRequired,
+                $"Two-factor authentication must be enabled to perform this action. {attr.Reason}".Trim());
         }
-        else
+
+        // D-S3-1/D-S3-7: block when the TOTP recency exceeds the per-command MaxAgeMinutes.
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var lastVerified = session.LastTotpVerifiedAt;
+        var isRecent = lastVerified is not null
+            && (now - lastVerified.Value) <= TimeSpan.FromMinutes(attr.MaxAgeMinutes);
+        if (!isRecent)
         {
-            // User has 2FA enabled. In strict mode we'd verify session.LastTotpVerifiedAt
-            // is within attr.MaxAgeMinutes. For shadow mode we just record participation.
-            _logger.LogInformation(
-                "TwoFactorEnforcementBehavior[shadow]: user {UserId} invoked 2FA-required command "
-                + "{CommandType} with 2FA enabled. (Strict-mode recency check pending session schema update.)",
-                user.Id, typeof(TRequest).Name);
+            _logger.LogWarning(
+                "TwoFactorEnforcementBehavior[strict]: actor {UserId} BLOCKED on {CommandType} — TOTP stale "
+                + "(lastVerified={LastVerified}, maxAge={MaxAgeMinutes}min). Step-up required.",
+                actor.Id, typeof(TRequest).Name, lastVerified, attr.MaxAgeMinutes);
+            await EmitTwoFactorRequiredAuditAsync(actor, attr, "step_up_required", cancellationToken).ConfigureAwait(false);
+            throw new TwoFactorRequiredException(
+                TwoFactorRequiredSubcode.StepUpRequired,
+                $"Recent two-factor verification is required for this action. {attr.Reason}".Trim());
         }
 
         return await next().ConfigureAwait(false);
+    }
+
+    private void LogShadow(UserDto actor, RequireTwoFactorAttribute attr)
+    {
+        if (!actor.IsTwoFactorEnabled)
+        {
+            _logger.LogWarning(
+                "TwoFactorEnforcementBehavior[shadow]: actor {UserId} ({Email}) invoked 2FA-required command "
+                + "{CommandType} WITHOUT 2FA enabled. Reason: {Reason}. MaxAge: {MaxAgeMinutes}min",
+                actor.Id, DataMasking.MaskEmail(actor.Email), typeof(TRequest).Name, attr.Reason ?? "(unspecified)", attr.MaxAgeMinutes);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "TwoFactorEnforcementBehavior[shadow]: actor {UserId} invoked 2FA-required command "
+                + "{CommandType} with 2FA enabled. (Strict mode OFF — not enforcing recency.)",
+                actor.Id, typeof(TRequest).Name);
+        }
+    }
+
+    /// <summary>
+    /// Emits the forensic <c>TwoFactorRequired</c> audit from a FRESH DI scope so it commits
+    /// independently of the command's (possibly <c>[AtomicAudit]</c>) transaction — which rolls
+    /// back when this behavior throws. Best-effort: <c>AuditService.LogAsync</c> swallows its own
+    /// failures, and this wrapper additionally guards against scope/resolution errors so the
+    /// security gate (the throw) is never suppressed by an audit-side problem. D-S3-6.
+    /// </summary>
+    private async Task EmitTwoFactorRequiredAuditAsync(
+        UserDto actor, RequireTwoFactorAttribute attr, string subcode, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var scope = _scopeFactory.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
+            {
+                var auditService = scope.ServiceProvider.GetRequiredService<AuditService>();
+                await auditService.LogAsync(
+                    userId: actor.Id.ToString(),
+                    action: "TwoFactorRequired",
+                    resource: typeof(TRequest).Name,
+                    resourceId: null,
+                    result: "Blocked",
+                    details: $"subcode={subcode}; maxAgeMinutes={attr.MaxAgeMinutes}",
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+#pragma warning disable CA1031 // forensic audit must never suppress the security gate (the throw)
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex,
+                "Failed to emit TwoFactorRequired forensic audit for {CommandType}", typeof(TRequest).Name);
+        }
     }
 
     private SessionStatusDto? ExtractSession()

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommand.cs
@@ -13,7 +13,8 @@ internal record CreateSessionCommand(
     string? IpAddress = null,
     string? UserAgent = null,
     Guid? ImpersonatedByUserId = null,    // SP5 S2: actor (admin) when this session is an impersonation
-    DateTime? ImpersonatedUntil = null    // SP5 S2: auto-expiry timestamp for impersonate sessions
+    DateTime? ImpersonatedUntil = null,   // SP5 S2: auto-expiry timestamp for impersonate sessions
+    DateTime? LastTotpVerifiedAt = null   // SP5 S3: pre-seeded TOTP recency (impersonate inherits actor's value)
 ) : ICommand<CreateSessionResponse>;
 
 internal record CreateSessionResponse(

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommandHandler.cs
@@ -61,7 +61,8 @@ internal class CreateSessionCommandHandler : ICommandHandler<CreateSessionComman
             ipAddress: command.IpAddress,
             userAgent: command.UserAgent,
             impersonatedByUserId: command.ImpersonatedByUserId,
-            impersonatedUntil: command.ImpersonatedUntil
+            impersonatedUntil: command.ImpersonatedUntil,
+            lastTotpVerifiedAt: command.LastTotpVerifiedAt    // SP5 S3: pre-seed for impersonate inheritance
         );
 
         await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommand.cs
@@ -4,14 +4,18 @@ using Api.SharedKernel.Application.Interfaces;
 namespace Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
 
 /// <summary>
-/// Outcome of a step-up TOTP verification. The endpoint maps these to HTTP:
-/// Success → 200, InvalidCode → 401, LockedOut → 429. SP5 Admin Security S3 — D-S3-4.
+/// Outcome of a step-up TOTP verification. The endpoint maps these to HTTP via the shared 2FA error
+/// vocabulary (SP5 S3 — Option B, aligned with the enforcement filter): Success → 200; InvalidCode →
+/// 401 <c>two_factor_required</c>/<c>invalid_code</c>; LockedOut → 401 <c>…</c>/<c>locked_out</c> +
+/// retryAfterSeconds; Unavailable → 503 <c>two_factor_unavailable</c>.
+/// Wire contract: <c>docs/api/2fa-step-up-protocol.md</c>. SP5 Admin Security S3 — D-S3-4.
 /// </summary>
 internal enum StepUpOutcome
 {
     Success,
     InvalidCode,
-    LockedOut
+    LockedOut,
+    Unavailable
 }
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommand.cs
@@ -1,0 +1,38 @@
+using Api.SharedKernel.Application.Interfaces;
+
+#pragma warning disable MA0048 // File name must match type name - Contains Command + Result + enum
+namespace Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
+
+/// <summary>
+/// Outcome of a step-up TOTP verification. The endpoint maps these to HTTP:
+/// Success → 200, InvalidCode → 401, LockedOut → 429. SP5 Admin Security S3 — D-S3-4.
+/// </summary>
+internal enum StepUpOutcome
+{
+    Success,
+    InvalidCode,
+    LockedOut
+}
+
+/// <summary>
+/// Refreshes the TOTP recency (<c>LastTotpVerifiedAt</c>) on the CURRENT session after the actor
+/// re-verifies their authenticator code. This is the step-up flow that clears a
+/// <c>step_up_required</c> block from <c>TwoFactorEnforcementBehavior</c> (T4) — it does NOT
+/// create a new session (unlike the login-time <c>/auth/2fa/verify</c>).
+///
+/// <para><see cref="ActorUserId"/> is the EffectiveActor of the session (the impersonating admin
+/// during an impersonation, else the user). <see cref="SessionId"/> is the session row whose
+/// recency is refreshed. Both are resolved by the endpoint from the validated session, keeping
+/// this handler free of HttpContext coupling.</para>
+///
+/// SP5 Admin Security S3 — D-S3-4.
+/// </summary>
+internal record StepUpTwoFactorCommand(
+    Guid SessionId,
+    Guid ActorUserId,
+    string Code) : ICommand<StepUpTwoFactorResult>;
+
+internal record StepUpTwoFactorResult(
+    StepUpOutcome Outcome,
+    DateTime? LastTotpVerifiedAt = null,
+    int? RetryAfterSeconds = null);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
@@ -1,0 +1,102 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
+
+/// <summary>
+/// Handles <see cref="StepUpTwoFactorCommand"/> (SP5 Admin Security S3 — T5).
+///
+/// Delegates verification to <see cref="ITotpService.VerifyCodeAsync"/> which already enforces
+/// rate-limit, lockout, replay-prevention, constant-time comparison, and emits the
+/// <c>TwoFactorVerify</c> audit — so this handler does NOT re-implement any of that. On success it
+/// refreshes <c>LastTotpVerifiedAt</c> on the session (clearing a step-up block) and emits a
+/// <c>TwoFactorStepUp</c> audit. A distinct lockout pre-check surfaces <c>LockedOut</c> so the
+/// endpoint can return 429 + retry-after (D-S3-4b).
+/// </summary>
+internal class StepUpTwoFactorCommandHandler : ICommandHandler<StepUpTwoFactorCommand, StepUpTwoFactorResult>
+{
+    // Mirrors TotpService.LockoutDurationMinutes (15min). The lockout key TTL is the authoritative
+    // wait; this fixed value is the client-facing retry-after hint for the 429 response.
+    private const int LockoutRetryAfterSeconds = 900;
+
+    private readonly ITotpService _totpService;
+    private readonly ISessionRepository _sessionRepository;
+    private readonly AuditService _auditService;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<StepUpTwoFactorCommandHandler> _logger;
+
+    public StepUpTwoFactorCommandHandler(
+        ITotpService totpService,
+        ISessionRepository sessionRepository,
+        AuditService auditService,
+        TimeProvider timeProvider,
+        ILogger<StepUpTwoFactorCommandHandler> logger)
+    {
+        _totpService = totpService ?? throw new ArgumentNullException(nameof(totpService));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _auditService = auditService ?? throw new ArgumentNullException(nameof(auditService));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<StepUpTwoFactorResult> Handle(StepUpTwoFactorCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // D-S3-4b: surface lockout distinctly (429). VerifyCodeAsync also re-checks lockout, so this
+        // pre-check is purely for the client-facing response — there is no security gap if the state
+        // changes between the read and the verify.
+        if (await _totpService.IsLockedOutAsync(command.ActorUserId, cancellationToken).ConfigureAwait(false))
+        {
+            await _auditService.LogAsync(
+                command.ActorUserId.ToString(),
+                "TwoFactorStepUpLockout",
+                "TwoFactor",
+                command.SessionId.ToString(),
+                "Blocked",
+                "Step-up blocked: account locked out after excessive failed attempts",
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            _logger.LogWarning(
+                "Step-up locked out for actor {ActorUserId} on session {SessionId}",
+                command.ActorUserId, command.SessionId);
+
+            return new StepUpTwoFactorResult(StepUpOutcome.LockedOut, RetryAfterSeconds: LockoutRetryAfterSeconds);
+        }
+
+        var verified = await _totpService.VerifyCodeAsync(command.ActorUserId, command.Code, cancellationToken).ConfigureAwait(false);
+        if (!verified)
+        {
+            // VerifyCodeAsync already audited TwoFactorVerify=Failed and tracked the attempt toward
+            // the lockout threshold. Nothing else to do here.
+            return new StepUpTwoFactorResult(StepUpOutcome.InvalidCode);
+        }
+
+        // Success — refresh the session's TOTP recency. ExecuteUpdate returns 0 if the session was
+        // revoked/expired between auth and step-up; treat that as a failed step-up (the next request
+        // would 401 on the invalid session anyway).
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var rowsAffected = await _sessionRepository
+            .UpdateLastTotpVerifiedAtAsync(command.SessionId, now, cancellationToken).ConfigureAwait(false);
+        if (rowsAffected == 0)
+        {
+            _logger.LogWarning(
+                "Step-up verified but session {SessionId} no longer exists for actor {ActorUserId}",
+                command.SessionId, command.ActorUserId);
+            return new StepUpTwoFactorResult(StepUpOutcome.InvalidCode);
+        }
+
+        await _auditService.LogAsync(
+            command.ActorUserId.ToString(),
+            "TwoFactorStepUp",
+            "TwoFactor",
+            command.SessionId.ToString(),
+            "Success",
+            "Step-up TOTP verification succeeded; session recency refreshed",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new StepUpTwoFactorResult(StepUpOutcome.Success, LastTotpVerifiedAt: now);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
@@ -45,10 +45,31 @@ internal class StepUpTwoFactorCommandHandler : ICommandHandler<StepUpTwoFactorCo
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // D-S3-4b: surface lockout distinctly (429). VerifyCodeAsync also re-checks lockout, so this
+        // D-S3-4b: surface lockout distinctly. VerifyCodeAsync also re-checks lockout, so this
         // pre-check is purely for the client-facing response — there is no security gap if the state
-        // changes between the read and the verify.
-        if (await _totpService.IsLockedOutAsync(command.ActorUserId, cancellationToken).ConfigureAwait(false))
+        // changes between the read and the verify. Both calls hit the Redis-backed TOTP store, so a
+        // backend failure here means 2FA is unavailable (Option B → 503), not an invalid code.
+        bool lockedOut;
+        bool verified;
+        try
+        {
+            lockedOut = await _totpService.IsLockedOutAsync(command.ActorUserId, cancellationToken).ConfigureAwait(false);
+            // Short-circuit when locked out: do not call VerifyCodeAsync (avoids consuming an attempt).
+            verified = !lockedOut
+                && await _totpService.VerifyCodeAsync(command.ActorUserId, command.Code, cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031, S2221 // infrastructure boundary: any TotpService/Redis failure ⇒ 2FA unavailable
+        catch (Exception ex)
+#pragma warning restore CA1031, S2221
+        {
+            _logger.LogError(
+                ex,
+                "Step-up 2FA unavailable for actor {ActorUserId} on session {SessionId}: TOTP backend error",
+                command.ActorUserId, command.SessionId);
+            return new StepUpTwoFactorResult(StepUpOutcome.Unavailable);
+        }
+
+        if (lockedOut)
         {
             await _auditService.LogAsync(
                 command.ActorUserId.ToString(),
@@ -66,7 +87,6 @@ internal class StepUpTwoFactorCommandHandler : ICommandHandler<StepUpTwoFactorCo
             return new StepUpTwoFactorResult(StepUpOutcome.LockedOut, RetryAfterSeconds: LockoutRetryAfterSeconds);
         }
 
-        var verified = await _totpService.VerifyCodeAsync(command.ActorUserId, command.Code, cancellationToken).ConfigureAwait(false);
         if (!verified)
         {
             // VerifyCodeAsync already audited TwoFactorVerify=Failed and tracked the attempt toward

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
+
+/// <summary>
+/// Validates <see cref="StepUpTwoFactorCommand"/>. Keeps format validation minimal — the
+/// authoritative code check (and constant-time comparison) is in <c>TotpService</c>; over-tight
+/// format rules here would leak timing/shape information and duplicate that logic.
+/// SP5 Admin Security S3 — T5.
+/// </summary>
+internal sealed class StepUpTwoFactorCommandValidator : AbstractValidator<StepUpTwoFactorCommand>
+{
+    public StepUpTwoFactorCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.ActorUserId).NotEmpty();
+        RuleFor(x => x.Code)
+            .NotEmpty()
+            .MaximumLength(10); // 6-digit TOTP; bounded to reject obviously malformed input
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfiguration.cs
@@ -1,0 +1,71 @@
+using Api.Services;
+
+namespace Api.BoundedContexts.Authentication.Application.Configuration;
+
+/// <summary>
+/// Compile-time documented configuration keys for the 2FA enforcement subsystem.
+/// SP5 Admin Security S3 — D-S3-1 cutover flag.
+/// </summary>
+internal static class TwoFactorConfigurationKeys
+{
+    /// <summary>
+    /// Boolean flag controlling whether <c>TwoFactorEnforcementBehavior</c> runs in strict
+    /// (throws <c>TwoFactorRequiredException</c>) or shadow (logs only) mode. Default
+    /// <c>false</c> at deploy — ops explicitly flips to <c>true</c> via admin toggle after
+    /// the pre-cutover sweep (D-S3-5) confirms zero admins lack 2FA. See
+    /// <c>audits/2026-05-26-s3-three-amigos-kickoff.md</c> §D-S3-1.
+    /// </summary>
+    public const string StrictMode = "TwoFactor:StrictMode";
+
+    /// <summary>Default for <see cref="StrictMode"/> — strict OFF on first deploy.</summary>
+    public const bool StrictModeDefault = false;
+}
+
+/// <summary>
+/// Typed accessor for the 2FA enforcement runtime configuration. Provides:
+/// <list type="bullet">
+/// <item>compile-time-safe binding to <see cref="TwoFactorConfigurationKeys.StrictMode"/></item>
+/// <item>mockable seam for unit-testing <c>TwoFactorEnforcementBehavior</c> (T4) without
+///   needing a full <c>IConfigurationService</c> setup</item>
+/// <item>fail-closed semantics (returns the default on any error — matches the existing
+///   <c>GetRegistrationModeQueryHandler</c> pattern)</item>
+/// </list>
+/// SP5 Admin Security S3 — D-S3-1.
+/// </summary>
+internal interface ITwoFactorEnforcementConfiguration
+{
+    /// <summary>
+    /// Reads the strict-mode flag from the dynamic configuration store. Returns
+    /// <see cref="TwoFactorConfigurationKeys.StrictModeDefault"/> when the flag is unset
+    /// or the underlying store is unreachable (fail-closed: shadow mode is the safe default
+    /// since it never blocks legitimate admin actions).
+    /// </summary>
+    Task<bool> GetStrictModeAsync(CancellationToken cancellationToken = default);
+}
+
+internal sealed class TwoFactorEnforcementConfiguration : ITwoFactorEnforcementConfiguration
+{
+    private readonly IConfigurationService _configurationService;
+
+    public TwoFactorEnforcementConfiguration(IConfigurationService configurationService)
+    {
+        _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
+    }
+
+    public async Task<bool> GetStrictModeAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var value = await _configurationService.GetValueAsync<bool?>(
+                TwoFactorConfigurationKeys.StrictMode,
+                TwoFactorConfigurationKeys.StrictModeDefault).ConfigureAwait(false);
+            return value ?? TwoFactorConfigurationKeys.StrictModeDefault;
+        }
+        catch
+        {
+            // Fail-closed: shadow mode on any read error. Strict mode is opt-in by ops, so
+            // an unreachable config store must NOT silently flip behavior to strict.
+            return TwoFactorConfigurationKeys.StrictModeDefault;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/SessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/SessionDto.cs
@@ -45,5 +45,11 @@ internal record SessionStatusDto(
     // Carries the subject + actor ids so the middleware can attribute the audit row.
     bool WasImpersonationAutoEnded = false,
     Guid? ImpersonationSubjectUserId = null,
-    Guid? ImpersonationActorUserId = null
+    Guid? ImpersonationActorUserId = null,
+    // SP5 S3 D-S3-3: TOTP recency, read by TwoFactorEnforcementBehavior strict path against
+    // per-command MaxAgeMinutes. Null on (a) password-only login pre-S3, (b) sessions whose
+    // step-up window has not been refreshed, (c) impersonate sessions where the actor had no
+    // verification at the time of impersonation start (rare — ImpersonationStart is itself
+    // [RequireTwoFactor(MaxAgeMinutes=5)] so a fresh value is expected to flow in).
+    DateTime? LastTotpVerifiedAt = null
 );

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetAdminsWithoutTwoFactorQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetAdminsWithoutTwoFactorQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries;
+
+/// <summary>
+/// Query for the strict-2FA cutover compliance sweep (SP5 Admin Security S3 — T6, D-S3-5).
+/// Returns every privileged account (Admin or SuperAdmin) that has NOT enrolled in 2FA, so ops can
+/// drive enrollment before flipping <c>TwoFactorStrictMode</c> in an environment.
+/// </summary>
+internal sealed record GetAdminsWithoutTwoFactorQuery() : IQuery<IReadOnlyList<UserDto>>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetAdminsWithoutTwoFactorQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetAdminsWithoutTwoFactorQueryHandler.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries;
+
+/// <summary>
+/// Handles <see cref="GetAdminsWithoutTwoFactorQuery"/> (SP5 Admin Security S3 — T6).
+/// </summary>
+internal class GetAdminsWithoutTwoFactorQueryHandler
+    : IQueryHandler<GetAdminsWithoutTwoFactorQuery, IReadOnlyList<UserDto>>
+{
+    private readonly IUserRepository _userRepository;
+
+    public GetAdminsWithoutTwoFactorQueryHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+    }
+
+    public async Task<IReadOnlyList<UserDto>> Handle(GetAdminsWithoutTwoFactorQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // GetAdminUsersAsync already scopes to Role in (admin, superadmin); we keep only the
+        // accounts that have NOT enrolled in 2FA — the ones ops must chase before the strict flip.
+        var admins = await _userRepository.GetAdminUsersAsync(cancellationToken).ConfigureAwait(false);
+        return admins
+            .Where(u => !u.IsTwoFactorEnabled)
+            .Select(MapToUserDto)
+            .ToList();
+    }
+
+    private static UserDto MapToUserDto(User user) => new(
+        Id: user.Id,
+        Email: user.Email.Value,
+        DisplayName: user.DisplayName,
+        Role: user.Role.Value,
+        Tier: user.Tier.Value,
+        CreatedAt: user.CreatedAt,
+        IsTwoFactorEnabled: user.IsTwoFactorEnabled,
+        TwoFactorEnabledAt: user.TwoFactorEnabledAt,
+        Level: user.Level,
+        ExperiencePoints: user.ExperiencePoints,
+        EmailVerified: user.EmailVerified,
+        EmailVerifiedAt: user.EmailVerifiedAt,
+        VerificationGracePeriodEndsAt: user.VerificationGracePeriodEndsAt,
+        OnboardingCompleted: user.OnboardingCompleted,
+        OnboardingSkipped: user.OnboardingSkipped);
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/ValidateSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/ValidateSessionQueryHandler.cs
@@ -123,7 +123,10 @@ internal class ValidateSessionQueryHandler : IQueryHandler<ValidateSessionQuery,
             Principal: principal,
             ExpiresAt: session.ExpiresAt,
             LastSeenAt: session.LastSeenAt,
-            SessionId: session.Id
+            SessionId: session.Id,
+            // SP5 S3 D-S3-3: surface TOTP recency so TwoFactorEnforcementBehavior can enforce
+            // per-command MaxAgeMinutes without re-querying the session row.
+            LastTotpVerifiedAt: session.LastTotpVerifiedAt
         );
     }
 

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/Session.cs
@@ -36,6 +36,15 @@ public sealed class Session : AggregateRoot<Guid>
     /// </summary>
     public DateTime? ImpersonatedUntil { get; private set; }
 
+    /// <summary>
+    /// UTC timestamp of the last successful TOTP verification on this session (login OR step-up).
+    /// Null when no TOTP verification has happened. Read by the strict
+    /// <c>TwoFactorEnforcementBehavior</c> against per-command <c>MaxAgeMinutes</c>. For impersonate
+    /// sessions, inherited from the actor at creation (S3 spike §5).
+    /// SP5 Admin Security S3 — D-S3-3.
+    /// </summary>
+    public DateTime? LastTotpVerifiedAt { get; private set; }
+
     /// <summary>True when this session is an active impersonation.</summary>
     public bool IsImpersonation => ImpersonatedByUserId is not null;
 
@@ -68,7 +77,8 @@ public sealed class Session : AggregateRoot<Guid>
         string? userAgent = null,
         TimeProvider? timeProvider = null,
         Guid? impersonatedByUserId = null,
-        DateTime? impersonatedUntil = null) : base(id)
+        DateTime? impersonatedUntil = null,
+        DateTime? lastTotpVerifiedAt = null) : base(id)
     {
         ArgumentNullException.ThrowIfNull(token);
         UserId = userId;
@@ -89,6 +99,12 @@ public sealed class Session : AggregateRoot<Guid>
         // For regular login both are null and the session behaves as before.
         ImpersonatedByUserId = impersonatedByUserId;
         ImpersonatedUntil = impersonatedUntil;
+
+        // SP5 Admin Security S3 — TOTP recency. Optional; for impersonate sessions this is
+        // INHERITED from the actor's session at creation (spike §5). For login sessions this
+        // is set by the login handler when verification succeeded; for password-only sessions
+        // it stays null and the strict behavior treats the session as needing step-up.
+        LastTotpVerifiedAt = lastTotpVerifiedAt;
     }
 
     /// <summary>
@@ -129,6 +145,31 @@ public sealed class Session : AggregateRoot<Guid>
     public void UpdateLastSeen(TimeProvider? timeProvider = null)
     {
         LastSeenAt = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>
+    /// Records a successful TOTP verification on this session — login OR step-up. Refreshes the
+    /// recency window read by <c>TwoFactorEnforcementBehavior</c>. SP5 Admin Security S3 — D-S3-4.
+    /// </summary>
+    public void UpdateTotpVerified(TimeProvider? timeProvider = null)
+    {
+        LastTotpVerifiedAt = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>
+    /// Returns true when the session has a TOTP verification within <paramref name="maxAgeMinutes"/>.
+    /// Used by the strict <c>TwoFactorEnforcementBehavior</c> path (D-S3-1/D-S3-7).
+    /// </summary>
+    public bool IsTotpRecent(int maxAgeMinutes, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        if (LastTotpVerifiedAt is null)
+        {
+            return false;
+        }
+
+        var age = timeProvider.GetUtcNow().UtcDateTime - LastTotpVerifiedAt.Value;
+        return age <= TimeSpan.FromMinutes(maxAgeMinutes);
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Authentication.Application.Configuration;
 using Api.BoundedContexts.Authentication.Application.Services;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
@@ -39,6 +40,11 @@ internal static class AuthenticationServiceExtensions
         // Used by StagingAccessMiddleware (active only when ASPNETCORE_ENVIRONMENT=Staging).
         services.AddMemoryCache();
         services.AddSingleton<IStagingAccessGuard, StagingAccessGuard>();
+
+        // SP5 Admin Security S3 — D-S3-1: typed wrapper around the "TwoFactor:StrictMode"
+        // dynamic config flag, consumed by TwoFactorEnforcementBehavior (T4) without per-test
+        // IConfigurationService setup. Scoped because IConfigurationService is scoped.
+        services.AddScoped<ITwoFactorEnforcementConfiguration, TwoFactorEnforcementConfiguration>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/ISessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/ISessionRepository.cs
@@ -45,6 +45,13 @@ public interface ISessionRepository
     Task UpdateLastSeenAsync(Guid sessionId, DateTime lastSeenAt, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// SP5 S3 — D-S3-4: records a successful TOTP step-up by setting <c>LastTotpVerifiedAt</c> on
+    /// the session via a single-column SQL UPDATE (no change-tracking). Returns the number of rows
+    /// affected — 0 when the session no longer exists (revoked/expired between auth and step-up).
+    /// </summary>
+    Task<int> UpdateLastTotpVerifiedAtAsync(Guid sessionId, DateTime lastTotpVerifiedAt, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Revokes all sessions for a user.
     /// </summary>
     Task RevokeAllUserSessionsAsync(Guid userId, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs
@@ -207,6 +207,10 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         var impersonatedUntilProp = typeof(Session).GetProperty("ImpersonatedUntil");
         impersonatedUntilProp?.SetValue(session, entity.ImpersonatedUntil);
 
+        // SP5 Admin Security S3 — hydrate TOTP recency.
+        var lastTotpVerifiedAtProp = typeof(Session).GetProperty("LastTotpVerifiedAt");
+        lastTotpVerifiedAtProp?.SetValue(session, entity.LastTotpVerifiedAt);
+
         return session;
     }
 
@@ -229,6 +233,8 @@ public class SessionRepository : RepositoryBase, ISessionRepository
             // SP5 Admin Security S2 — propagate dual-principal fields end-to-end.
             ImpersonatedByUserId = domainEntity.ImpersonatedByUserId,
             ImpersonatedUntil = domainEntity.ImpersonatedUntil,
+            // SP5 Admin Security S3 — propagate TOTP recency.
+            LastTotpVerifiedAt = domainEntity.LastTotpVerifiedAt,
             User = null! // Required navigation property, will be loaded by EF Core
         };
     }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs
@@ -94,6 +94,17 @@ public class SessionRepository : RepositoryBase, ISessionRepository
                 cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<int> UpdateLastTotpVerifiedAtAsync(Guid sessionId, DateTime lastTotpVerifiedAt, CancellationToken cancellationToken = default)
+    {
+        // Single-column SQL UPDATE — atomic, no change-tracking, returns rows affected so the
+        // caller can detect a vanished session. SP5 S3 — D-S3-4.
+        return await DbContext.UserSessions
+            .Where(s => s.Id == sessionId)
+            .ExecuteUpdateAsync(setters =>
+                setters.SetProperty(s => s.LastTotpVerifiedAt, lastTotpVerifiedAt),
+                cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task RevokeAllUserSessionsAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         var now = _timeProvider.GetUtcNow().UtcDateTime;

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/UserSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/UserSessionEntity.cs
@@ -37,6 +37,16 @@ public class UserSessionEntity
     /// </summary>
     public DateTime? ImpersonatedUntil { get; set; }
 
+    /// <summary>
+    /// UTC timestamp of the last successful TOTP verification on this session — login OR step-up.
+    /// Null when no TOTP verification has occurred (e.g. password-only login, or pre-S3 sessions
+    /// at flag-flip time). The <c>TwoFactorEnforcementBehavior</c> reads this to enforce
+    /// <c>[RequireTwoFactor(MaxAgeMinutes)]</c> recency. For impersonate sessions, this is INHERITED
+    /// from the actor's session at creation (S3 spike §5) — represents the actor's recency,
+    /// not the subject's. SP5 Admin Security S3 — D-S3-3.
+    /// </summary>
+    public DateTime? LastTotpVerifiedAt { get; set; }
+
     required public UserEntity User { get; set; }
 }
 

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserSessionEntityConfiguration.cs
@@ -28,6 +28,10 @@ internal class UserSessionEntityConfiguration : IEntityTypeConfiguration<UserSes
         builder.Property(e => e.ImpersonatedByUserId).HasColumnName("impersonated_by_user_id");
         builder.Property(e => e.ImpersonatedUntil).HasColumnName("impersonated_until");
 
+        // SP5 Admin Security S3 — D-S3-3: TOTP recency for the strict TwoFactorEnforcementBehavior.
+        // Nullable timestamptz; read-by-PK on session validation hot path, no index needed.
+        builder.Property(e => e.LastTotpVerifiedAt).HasColumnName("last_totp_verified_at");
+
         // Partial index supports GetActiveImpersonationsQuery (T6) without scanning the whole
         // sessions table. PostgreSQL filtered index applies WHERE clause at write time so the
         // index only contains the (typically small) set of active impersonations.

--- a/apps/api/src/Api/Infrastructure/Migrations/20260526124527_AddTwoFactorRecencyToUserSession.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260526124527_AddTwoFactorRecencyToUserSession.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526124527_AddTwoFactorRecencyToUserSession")]
+    partial class AddTwoFactorRecencyToUserSession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260526124527_AddTwoFactorRecencyToUserSession.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260526124527_AddTwoFactorRecencyToUserSession.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTwoFactorRecencyToUserSession : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_totp_verified_at",
+                table: "user_sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_totp_verified_at",
+                table: "user_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -98,6 +98,14 @@ internal class ApiExceptionHandlerMiddleware
             return;
         }
 
+        // SP5 S3 — D-S3-4 (Option B): TwoFactorUnavailableException maps to 503 (transient) so the FE
+        // shows a retryable error toast, not a step-up/enroll signal or a generic 500.
+        if (ex is TwoFactorUnavailableException twoFactorUnavailableEx)
+        {
+            await HandleTwoFactorUnavailableAsync(context, twoFactorUnavailableEx).ConfigureAwait(false);
+            return;
+        }
+
         // Determine status code and error type based on exception type
         var (statusCode, errorType, message) = MapExceptionToResponse(ex);
 
@@ -263,6 +271,38 @@ internal class ApiExceptionHandlerMiddleware
             subcode = twoFactorException.SubcodeWire,
             message = twoFactorException.Message,
             retryAfterSeconds = twoFactorException.RetryAfterSeconds,
+            correlationId = context.TraceIdentifier,
+            timestamp = DateTime.UtcNow
+        };
+
+        await context.Response.WriteAsJsonAsync(errorResponse).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles <see cref="TwoFactorUnavailableException"/> with HTTP 503 + structured body
+    /// (<c>error="two_factor_unavailable"</c>). Raised by the step-up endpoint when the TOTP store /
+    /// rate-limit backend is unreachable; the FE treats this as a transient error (retryable toast)
+    /// rather than a failed code or a step-up signal. SP5 Admin Security S3 — D-S3-4 (Option B).
+    /// </summary>
+    private async Task HandleTwoFactorUnavailableAsync(
+        HttpContext context,
+        TwoFactorUnavailableException exception)
+    {
+        var endpoint = GetRoutePattern(context) ?? context.Request.Path.ToString();
+
+        MeepleAiMetrics.RecordApiError(
+            exception: exception,
+            httpStatusCode: StatusCodes.Status503ServiceUnavailable,
+            endpoint: endpoint,
+            isUnhandled: false);
+
+        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        context.Response.ContentType = "application/json";
+
+        var errorResponse = new
+        {
+            error = "two_factor_unavailable",
+            message = exception.Message,
             correlationId = context.TraceIdentifier,
             timestamp = DateTime.UtcNow
         };

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -89,6 +89,15 @@ internal class ApiExceptionHandlerMiddleware
             return;
         }
 
+        // SP5 Admin Security S3 — D-S3-2: TwoFactorRequiredException maps to 401 + structured
+        // body (error + subcode + optional retryAfterSeconds) + WWW-Authenticate header so the
+        // FE can distinguish step-up-required from session-invalid 401 and open the right modal.
+        if (ex is TwoFactorRequiredException twoFactorEx)
+        {
+            await HandleTwoFactorRequiredAsync(context, twoFactorEx).ConfigureAwait(false);
+            return;
+        }
+
         // Determine status code and error type based on exception type
         var (statusCode, errorType, message) = MapExceptionToResponse(ex);
 
@@ -217,6 +226,43 @@ internal class ApiExceptionHandlerMiddleware
             message = glossaryCollisionException.Message,
             collidingEntryId = glossaryCollisionException.CollidingEntryId,
             collidingTermEn = glossaryCollisionException.CollidingTermEn,
+            correlationId = context.TraceIdentifier,
+            timestamp = DateTime.UtcNow
+        };
+
+        await context.Response.WriteAsJsonAsync(errorResponse).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Handles <see cref="TwoFactorRequiredException"/> with HTTP 401 + structured body
+    /// (<c>error="two_factor_required"</c>, <c>subcode</c>, optional <c>retryAfterSeconds</c>)
+    /// + <c>WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"</c> header. The FE consumes
+    /// the <c>subcode</c> to route to step-up modal / enroll prompt / locked-out toast.
+    /// SP5 Admin Security S3 — D-S3-2 + spec <c>docs/api/2fa-step-up-protocol.md</c>.
+    /// </summary>
+    private async Task HandleTwoFactorRequiredAsync(
+        HttpContext context,
+        TwoFactorRequiredException twoFactorException)
+    {
+        var endpoint = GetRoutePattern(context) ?? context.Request.Path.ToString();
+
+        MeepleAiMetrics.RecordApiError(
+            exception: twoFactorException,
+            httpStatusCode: StatusCodes.Status401Unauthorized,
+            endpoint: endpoint,
+            isUnhandled: false);   // handled by design (security gate, not a bug)
+
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        context.Response.ContentType = "application/json";
+        // RFC 7235 challenge header — distinguishes step-up requirement from password auth 401.
+        context.Response.Headers["WWW-Authenticate"] = "TOTP-StepUp realm=\"meepleai-admin\"";
+
+        var errorResponse = new
+        {
+            error = "two_factor_required",
+            subcode = twoFactorException.SubcodeWire,
+            message = twoFactorException.Message,
+            retryAfterSeconds = twoFactorException.RetryAfterSeconds,
             correlationId = context.TraceIdentifier,
             timestamp = DateTime.UtcNow
         };

--- a/apps/api/src/Api/Middleware/Exceptions/TwoFactorRequiredException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/TwoFactorRequiredException.cs
@@ -28,7 +28,14 @@ public enum TwoFactorRequiredSubcode
     /// retry-after toast; <see cref="TwoFactorRequiredException.RetryAfterSeconds"/>
     /// carries the wait. D-S3-4b.
     /// </summary>
-    LockedOut
+    LockedOut,
+
+    /// <summary>
+    /// A step-up verification attempt failed: the submitted TOTP/backup code was invalid, expired,
+    /// or already used. Distinct from <see cref="StepUpRequired"/> ("you must step up") — this means
+    /// "the step-up you attempted did not succeed". Emitted by the step-up endpoint only. D-S3-4.
+    /// </summary>
+    InvalidCode
 }
 
 /// <summary>
@@ -78,6 +85,7 @@ public sealed class TwoFactorRequiredException : Exception
         TwoFactorRequiredSubcode.StepUpRequired => "step_up_required",
         TwoFactorRequiredSubcode.EnrollRequired => "enroll_required",
         TwoFactorRequiredSubcode.LockedOut => "locked_out",
+        TwoFactorRequiredSubcode.InvalidCode => "invalid_code",
         _ => "step_up_required"   // defensive fallback; should never hit
     };
 }

--- a/apps/api/src/Api/Middleware/Exceptions/TwoFactorRequiredException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/TwoFactorRequiredException.cs
@@ -1,0 +1,83 @@
+namespace Api.Middleware.Exceptions;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Discriminator of the reason a 2FA-required command was rejected. The wire format
+/// (snake_case) is the contract documented in <c>docs/api/2fa-step-up-protocol.md</c>;
+/// the FE distinguishes between "open the step-up modal" vs "open the enroll prompt"
+/// vs "show locked-out toast" based on this value. SP5 Admin Security S3 — D-S3-2.
+/// </summary>
+public enum TwoFactorRequiredSubcode
+{
+    /// <summary>
+    /// The user has 2FA enabled but the most recent TOTP verification on their session is
+    /// stale (older than the per-command <c>MaxAgeMinutes</c>) or missing. The FE should
+    /// open the step-up modal and retry the original request on success.
+    /// </summary>
+    StepUpRequired,
+
+    /// <summary>
+    /// The user does NOT have 2FA enabled at all. Hard block per D-S3-5; the FE should
+    /// route to the 2FA enrollment flow.
+    /// </summary>
+    EnrollRequired,
+
+    /// <summary>
+    /// Step-up attempts have been throttled (5 fails in 5 min). The FE should show a
+    /// retry-after toast; <see cref="TwoFactorRequiredException.RetryAfterSeconds"/>
+    /// carries the wait. D-S3-4b.
+    /// </summary>
+    LockedOut
+}
+
+/// <summary>
+/// Thrown by <c>TwoFactorEnforcementBehavior</c> (and the step-up endpoint) when a
+/// <c>[RequireTwoFactor]</c>-decorated command is rejected. Mapped by
+/// <c>ApiExceptionHandlerMiddleware</c> to <c>401 Unauthorized</c> + structured body
+/// <c>{ error: "two_factor_required", subcode, retryAfterSeconds? }</c> + header
+/// <c>WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"</c>.
+///
+/// SP5 Admin Security S3 — D-S3-2.
+/// </summary>
+public sealed class TwoFactorRequiredException : Exception
+{
+    /// <summary>Reason discriminator surfaced to the client.</summary>
+    public required TwoFactorRequiredSubcode Subcode { get; init; }
+
+    /// <summary>
+    /// Seconds the client should wait before retrying. Non-null only when
+    /// <see cref="Subcode"/> is <see cref="TwoFactorRequiredSubcode.LockedOut"/>.
+    /// </summary>
+    public int? RetryAfterSeconds { get; init; }
+
+    public TwoFactorRequiredException()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public TwoFactorRequiredException(TwoFactorRequiredSubcode subcode, string message)
+        : base(message)
+    {
+        Subcode = subcode;
+    }
+
+    [SetsRequiredMembers]
+    public TwoFactorRequiredException(TwoFactorRequiredSubcode subcode, string message, int retryAfterSeconds)
+        : base(message)
+    {
+        Subcode = subcode;
+        RetryAfterSeconds = retryAfterSeconds;
+    }
+
+    /// <summary>
+    /// Wire-format string used in the JSON response body (snake_case per D-S3-2).
+    /// </summary>
+    public string SubcodeWire => Subcode switch
+    {
+        TwoFactorRequiredSubcode.StepUpRequired => "step_up_required",
+        TwoFactorRequiredSubcode.EnrollRequired => "enroll_required",
+        TwoFactorRequiredSubcode.LockedOut => "locked_out",
+        _ => "step_up_required"   // defensive fallback; should never hit
+    };
+}

--- a/apps/api/src/Api/Middleware/Exceptions/TwoFactorUnavailableException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/TwoFactorUnavailableException.cs
@@ -1,0 +1,26 @@
+namespace Api.Middleware.Exceptions;
+
+/// <summary>
+/// Thrown when a 2FA verification cannot complete because the underlying TOTP store / rate-limit
+/// backend (Redis or the encrypted-secret store) is unreachable. Mapped by
+/// <c>ApiExceptionHandlerMiddleware</c> to <c>503 Service Unavailable</c> + body
+/// <c>{ error: "two_factor_unavailable", message, correlationId, timestamp }</c>, so the FE can
+/// surface a transient-error toast (retryable) instead of treating it as a failed code or a
+/// step-up/enroll signal. SP5 Admin Security S3 — D-S3-4 (step-up failure mode).
+/// </summary>
+public sealed class TwoFactorUnavailableException : Exception
+{
+    public TwoFactorUnavailableException()
+    {
+    }
+
+    public TwoFactorUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public TwoFactorUnavailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/apps/api/src/Api/Models/TwoFactorDto.cs
+++ b/apps/api/src/Api/Models/TwoFactorDto.cs
@@ -21,6 +21,15 @@ internal class TwoFactorVerifyRequest
 }
 
 /// <summary>
+/// Request to step-up (re-verify) 2FA on the current session. SP5 Admin Security S3 — T5.
+/// The session is identified by the auth cookie (resolved server-side); only the code is sent.
+/// </summary>
+internal class TwoFactorStepUpRequest
+{
+    public string Code { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// Request to disable two-factor authentication
 /// </summary>
 internal class TwoFactorDisableRequest

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -892,6 +892,7 @@ v1Api.MapAdminAgentAnalyticsEndpoints(); // Issue #4653: Agents analytics for Ad
 v1Api.MapAdminAnalyticsEndpoints();      // Admin analytics: overview, chat, PDF, model performance, MAU
 v1Api.MapAdminOperationsEndpoints();   // Issue #3696: Operations - Service Control Panel
 v1Api.MapAdminImpersonationEndpoints(); // SP5 S2: consolidated impersonation API (start/end/revoke/active)
+v1Api.MapAdminTwoFactorComplianceEndpoints(); // SP5 S3 T6: admin 2FA compliance sweep (GET /admin/users/no-2fa)
 v1Api.MapAdminCategoriesEndpoints();   // Issue #1440: SharedGame categories CRUD
 v1Api.MapAdminInfrastructureEndpoints(); // AI Infrastructure Dashboard: service status, config, restart
 v1Api.MapDatabaseSyncEndpoints();     // Database sync admin panel

--- a/apps/api/src/Api/Routing/Admin/AdminTwoFactorComplianceEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminTwoFactorComplianceEndpoints.cs
@@ -1,0 +1,43 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing.Admin;
+
+/// <summary>
+/// Admin 2FA compliance endpoints for the SP5 Admin Security S3 strict-2FA cutover (T6, D-S3-5).
+///
+/// Provides the pre-flip sweep: list every privileged account (Admin/SuperAdmin) that has NOT
+/// enrolled in 2FA, so ops can drive enrollment to 100% before flipping <c>TwoFactorStrictMode</c>
+/// in an environment (otherwise the flip would lock those admins out — the mass-lockout risk
+/// neutralized by the default=OFF cutover strategy, D-S3-1).
+///
+/// Superadmin-gated and IMediator-only (CQRS — CLAUDE.md), mirroring the S2 impersonation endpoints.
+/// </summary>
+internal static class AdminTwoFactorComplianceEndpoints
+{
+    public static RouteGroupBuilder MapAdminTwoFactorComplianceEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/admin/users/no-2fa", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireSuperAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(new GetAdminsWithoutTwoFactorQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthorization("RequireSuperAdmin")
+        .WithName("GetAdminsWithoutTwoFactor")
+        .WithTags("Admin", "TwoFactor")
+        .WithSummary("List admin/superadmin accounts without 2FA enrolled (compliance sweep, superadmin only)")
+        .Produces<IReadOnlyList<UserDto>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden);
+
+        return group;
+    }
+}

--- a/apps/api/src/Api/Routing/TwoFactorEndpoints.cs
+++ b/apps/api/src/Api/Routing/TwoFactorEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Api.Extensions;
 using Api.Helpers;
 using Api.Middleware;
 using Api.Models;
@@ -10,6 +11,8 @@ using GenerateTotpSetupCommand = Api.BoundedContexts.Authentication.Application.
 using Verify2FACommand = Api.BoundedContexts.Authentication.Application.Commands.TwoFactor.Verify2FACommand;
 using AdminDisable2FACommand = Api.BoundedContexts.Authentication.Application.Commands.TwoFactor.AdminDisable2FACommand;
 using DddCreateSessionCommand = Api.BoundedContexts.Authentication.Application.Commands.CreateSessionCommand;
+using StepUpTwoFactorCommand = Api.BoundedContexts.Authentication.Application.Commands.TwoFactor.StepUpTwoFactorCommand;
+using StepUpOutcome = Api.BoundedContexts.Authentication.Application.Commands.TwoFactor.StepUpOutcome;
 
 namespace Api.Routing;
 
@@ -155,6 +158,56 @@ internal static class TwoFactorEndpoints
         .RequireRateLimiting("AuthVerify2FA") // C6: IP-based throttle on top of per-session-token limit
         .WithName("Verify2FA")
         .WithTags("Authentication");
+
+        // SP5 Admin Security S3 — T5: step-up re-verification on the CURRENT session. Clears a
+        // step_up_required block from TwoFactorEnforcementBehavior by refreshing LastTotpVerifiedAt.
+        // Does NOT create a new session. The acting admin (EffectiveActor) is verified — during an
+        // impersonation that is the admin, not the target. Wire contract: docs/api/2fa-step-up-protocol.md.
+        group.MapPost("/auth/2fa/step-up", async (
+            TwoFactorStepUpRequest request, HttpContext context, IMediator mediator, ILogger<Program> logger, CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetActiveSession();
+            if (!authenticated) return error!;
+
+            // EffectiveActor: the impersonating admin during an impersonation, else the user.
+            var actorId = session.Principal!.EffectiveActor.Id;
+            var sessionId = session.SessionId ?? Guid.Empty;
+            if (sessionId == Guid.Empty)
+            {
+                // A valid session without a SessionId should not happen post-S2; fail closed.
+                return Results.Unauthorized();
+            }
+
+            var result = await mediator.Send(
+                new StepUpTwoFactorCommand(sessionId, actorId, request.Code), ct).ConfigureAwait(false);
+
+            return result.Outcome switch
+            {
+                StepUpOutcome.Success => Results.Ok(new
+                {
+                    success = true,
+                    lastTotpVerifiedAt = result.LastTotpVerifiedAt
+                }),
+                StepUpOutcome.LockedOut => Results.Json(
+                    new
+                    {
+                        error = "two_factor_locked_out",
+                        message = "Too many failed attempts. Try again later.",
+                        retryAfterSeconds = result.RetryAfterSeconds
+                    },
+                    statusCode: StatusCodes.Status429TooManyRequests),
+                _ => Results.Json(
+                    new { error = "two_factor_failed", message = "Invalid or expired verification code." },
+                    statusCode: StatusCodes.Status401Unauthorized)
+            };
+        })
+        .RequireAuthorization()
+        .WithName("StepUp2FA")
+        .WithTags("Authentication")
+        .WithSummary("Step-up 2FA verification on the current session (SP5 S3)")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status429TooManyRequests);
     }
 
     private static void MapTwoFactorManagementEndpoints(RouteGroupBuilder group)

--- a/apps/api/src/Api/Routing/TwoFactorEndpoints.cs
+++ b/apps/api/src/Api/Routing/TwoFactorEndpoints.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Api.Extensions;
 using Api.Helpers;
 using Api.Middleware;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using Api.Services;
 using MediatR;
@@ -159,10 +160,13 @@ internal static class TwoFactorEndpoints
         .WithName("Verify2FA")
         .WithTags("Authentication");
 
-        // SP5 Admin Security S3 — T5: step-up re-verification on the CURRENT session. Clears a
-        // step_up_required block from TwoFactorEnforcementBehavior by refreshing LastTotpVerifiedAt.
-        // Does NOT create a new session. The acting admin (EffectiveActor) is verified — during an
-        // impersonation that is the admin, not the target. Wire contract: docs/api/2fa-step-up-protocol.md.
+        // SP5 Admin Security S3 — T5 + Option B: step-up re-verification on the CURRENT session.
+        // Clears a step_up_required block from TwoFactorEnforcementBehavior by refreshing
+        // LastTotpVerifiedAt. Does NOT create a new session. The acting admin (EffectiveActor) is
+        // verified — during an impersonation that is the admin, not the target. All error mapping
+        // delegates to ApiExceptionHandlerMiddleware via TwoFactorRequiredException /
+        // TwoFactorUnavailableException for one shared error vocabulary with the enforcement filter.
+        // Wire contract: docs/api/2fa-step-up-protocol.md.
         group.MapPost("/auth/2fa/step-up", async (
             TwoFactorStepUpRequest request, HttpContext context, IMediator mediator, ILogger<Program> logger, CancellationToken ct) =>
         {
@@ -188,17 +192,22 @@ internal static class TwoFactorEndpoints
                     success = true,
                     lastTotpVerifiedAt = result.LastTotpVerifiedAt
                 }),
-                StepUpOutcome.LockedOut => Results.Json(
-                    new
-                    {
-                        error = "two_factor_locked_out",
-                        message = "Too many failed attempts. Try again later.",
-                        retryAfterSeconds = result.RetryAfterSeconds
-                    },
-                    statusCode: StatusCodes.Status429TooManyRequests),
-                _ => Results.Json(
-                    new { error = "two_factor_failed", message = "Invalid or expired verification code." },
-                    statusCode: StatusCodes.Status401Unauthorized)
+                // The three non-success outcomes are mapped by the middleware to the shared 2FA
+                // error vocabulary (401 two_factor_required + subcode for InvalidCode/LockedOut;
+                // 503 two_factor_unavailable for store-down) so a client speaks the SAME wire format
+                // here as it does for an enforcement-blocked command.
+                StepUpOutcome.LockedOut => throw new TwoFactorRequiredException(
+                    TwoFactorRequiredSubcode.LockedOut,
+                    "Too many failed step-up attempts. Try again later.",
+                    retryAfterSeconds: result.RetryAfterSeconds ?? 900),
+                StepUpOutcome.Unavailable => throw new TwoFactorUnavailableException(
+                    "Two-factor service is temporarily unavailable. Please try again."),
+                StepUpOutcome.InvalidCode => throw new TwoFactorRequiredException(
+                    TwoFactorRequiredSubcode.InvalidCode,
+                    "Invalid or expired verification code."),
+                _ => throw new TwoFactorRequiredException(
+                    TwoFactorRequiredSubcode.InvalidCode,
+                    "Invalid or expired verification code.")
             };
         })
         .RequireAuthorization()
@@ -207,7 +216,7 @@ internal static class TwoFactorEndpoints
         .WithSummary("Step-up 2FA verification on the current session (SP5 S3)")
         .Produces(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
-        .Produces(StatusCodes.Status429TooManyRequests);
+        .Produces(StatusCodes.Status503ServiceUnavailable);
     }
 
     private static void MapTwoFactorManagementEndpoints(RouteGroupBuilder group)

--- a/apps/api/src/Api/Services/ITotpService.cs
+++ b/apps/api/src/Api/Services/ITotpService.cs
@@ -45,6 +45,14 @@ internal interface ITotpService
     Task<bool> VerifyBackupCodeAsync(Guid userId, string backupCode, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// SP5 S3 — D-S3-4b: read-only check of the TOTP lockout state (5 failed attempts within the
+    /// 15-min window). Does NOT consume the rate-limit token bucket — it only reads the failed
+    /// counter. Lets the step-up endpoint surface a distinct <c>locked_out</c> response while
+    /// <see cref="VerifyCodeAsync"/> remains the single source of truth that also re-checks lockout.
+    /// </summary>
+    Task<bool> IsLockedOutAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Disable two-factor authentication with password and code verification
     /// </summary>
     /// <param name="userId">User ID</param>

--- a/apps/api/src/Api/Services/TotpService.cs
+++ b/apps/api/src/Api/Services/TotpService.cs
@@ -320,6 +320,17 @@ internal class TotpService : ITotpService
         };
     }
 
+    /// <summary>
+    /// SP5 S3 — D-S3-4b: read-only lockout check (does not consume the rate-limit bucket).
+    /// Delegates to the same <see cref="IsAccountLockedOutAsync"/> used internally by
+    /// <see cref="VerifyCodeAsync"/>, so the step-up endpoint and the verify flow share one
+    /// source of truth for the lockout state.
+    /// </summary>
+    public virtual async Task<bool> IsLockedOutAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await IsAccountLockedOutAsync(userId, "totp").ConfigureAwait(false);
+    }
+
     // ==================== PRIVATE HELPER METHODS ====================
 
     private async Task<bool> ValidateTotpRateLimitAndLockoutAsync(Guid userId, CancellationToken cancellationToken)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Api.SharedKernel.Domain.ValueObjects;
 using Api.Tests.Constants;
 using FluentAssertions;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -29,6 +30,7 @@ public class ImpersonationStartCommandHandlerTests
 {
     private readonly Mock<IUserRepository> _mockUserRepository;
     private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private readonly FakeTimeProvider _timeProvider;
     private readonly ImpersonationStartCommandHandler _handler;
 
@@ -36,12 +38,14 @@ public class ImpersonationStartCommandHandlerTests
     {
         _mockUserRepository = new Mock<IUserRepository>();
         _mockMediator = new Mock<IMediator>();
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();   // default: HttpContext null → no inheritance
         _timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-26T12:00:00Z"));
 
         _handler = new ImpersonationStartCommandHandler(
             _mockUserRepository.Object,
             _mockMediator.Object,
             _timeProvider,
+            _mockHttpContextAccessor.Object,
             Mock.Of<ILogger<ImpersonationStartCommandHandler>>());
     }
 
@@ -167,6 +171,73 @@ public class ImpersonationStartCommandHandlerTests
 
         var act = () => _handler.Handle(command, CancellationToken.None);
         await act.Should().ThrowAsync<ConflictException>().WithMessage("*demo account*");
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_InheritsActorLastTotpVerifiedAtFromHttpContext()
+    {
+        // SP5 S3 spike §5: the impersonate session's LastTotpVerifiedAt must inherit the
+        // ACTOR's value (read from HttpContext SessionStatusDto), not the target's. The strict
+        // TwoFactorEnforcementBehavior thus gates impersonate commands against the admin's
+        // step-up recency.
+        var requesterId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        SetupUser(requesterId, "root@test.com", "superadmin");
+        SetupUser(targetId, "bob@test.com", "user");
+
+        // Arrange — actor session with a fresh TOTP verification 2min ago.
+        var actorVerifiedAt = _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-2);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items[nameof(SessionStatusDto)] = new SessionStatusDto(
+            IsValid: true,
+            Principal: null,                       // not needed for this inheritance path
+            ExpiresAt: null,
+            LastSeenAt: null,
+            LastTotpVerifiedAt: actorVerifiedAt);
+        _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        CreateSessionCommand? captured = null;
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<CreateSessionResponse>, CancellationToken>((cmd, _) => captured = (CreateSessionCommand)cmd)
+            .ReturnsAsync(new CreateSessionResponse(
+                User: null!, SessionToken: "tok", ExpiresAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(15), SessionId: Guid.NewGuid()));
+
+        var command = new ImpersonationStartCommand(targetId, requesterId, "Inherit actor TOTP recency");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.LastTotpVerifiedAt.Should().Be(actorVerifiedAt,
+            "the impersonate session inherits the actor's TOTP recency so the strict behavior gates against it");
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WhenNoHttpContext_LastTotpVerifiedAtIsNull()
+    {
+        // Defensive path: the endpoint is gated by RequireSuperAdmin so HttpContext is normally
+        // populated, but the handler must not crash if it isn't. Inheritance defaults to null.
+        var requesterId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        SetupUser(requesterId, "root@test.com", "superadmin");
+        SetupUser(targetId, "bob@test.com", "user");
+
+        // _mockHttpContextAccessor default returns null HttpContext.
+
+        CreateSessionCommand? captured = null;
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<CreateSessionResponse>, CancellationToken>((cmd, _) => captured = (CreateSessionCommand)cmd)
+            .ReturnsAsync(new CreateSessionResponse(
+                User: null!, SessionToken: "tok", ExpiresAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(15), SessionId: Guid.NewGuid()));
+
+        var command = new ImpersonationStartCommand(targetId, requesterId, "No HttpContext defensive case");
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        captured!.LastTotpVerifiedAt.Should().BeNull();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehaviorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehaviorTests.cs
@@ -1,0 +1,276 @@
+using Api.BoundedContexts.Authentication.Application.Attributes;
+using Api.BoundedContexts.Authentication.Application.Behaviors;
+using Api.BoundedContexts.Authentication.Application.Configuration;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Behaviors;
+
+/// <summary>
+/// Unit tests for the SP5 S3 T4 strict path of <see cref="TwoFactorEnforcementBehavior{TRequest,TResponse}"/>.
+/// Covers the unit-level slices of acceptance scenarios S3-1 (happy), S3-2 (stale → step-up),
+/// S3-3 (not enrolled → enroll), S3-7 (non-decorated regression), S3-8 (per-command MaxAge), plus
+/// shadow-mode passthrough and the no-session defensive case. The full request→pipeline acceptance
+/// runs in T8 integration tests.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class TwoFactorEnforcementBehaviorTests
+{
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor = new();
+    private readonly Mock<ITwoFactorEnforcementConfiguration> _config = new();
+    private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.Parse("2026-05-26T12:00:00Z"));
+    private readonly Mock<IServiceScopeFactory> _scopeFactory = new();
+
+    public TwoFactorEnforcementBehaviorTests()
+    {
+        // Fresh-scope audit emission resolves AuditService; returning null makes GetRequiredService
+        // throw, which the behavior swallows (forensic audit must never suppress the security gate).
+        // This lets the unit tests exercise the THROW path without a real AuditService/DbContext.
+        var scopeProvider = new Mock<IServiceProvider>();
+        scopeProvider.Setup(p => p.GetService(typeof(Api.Services.AuditService))).Returns(null!);
+        var scope = new Mock<IServiceScope>();
+        scope.Setup(s => s.ServiceProvider).Returns(scopeProvider.Object);
+        _scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+    }
+
+    // ── Test command types ─────────────────────────────────────────────────────────────────────
+    [RequireTwoFactor(Reason = "test 30min")]
+    private sealed record Decorated30MinCommand : IRequest<string>;
+
+    [RequireTwoFactor(MaxAgeMinutes = 5, Reason = "test 5min")]
+    private sealed record Decorated5MinCommand : IRequest<string>;
+
+    private sealed record PlainCommand : IRequest<string>;   // NOT decorated → S3-7
+
+    private TwoFactorEnforcementBehavior<TRequest, string> CreateBehavior<TRequest>()
+        where TRequest : IRequest<string>
+        => new(
+            _httpContextAccessor.Object,
+            _config.Object,
+            _timeProvider,
+            _scopeFactory.Object,
+            NullLogger<TwoFactorEnforcementBehavior<TRequest, string>>.Instance);
+
+    private void SetupSession(bool isTwoFactorEnabled, DateTime? lastTotpVerifiedAt, bool impersonating = false)
+    {
+        var subject = MakeUser("bob@user.test", isTwoFactorEnabled: false);   // target — never the gate
+        var actor = impersonating
+            ? MakeUser("alice@admin.test", isTwoFactorEnabled)
+            : null;
+        // When not impersonating, the subject IS the actor — so the subject carries the 2FA flag.
+        var effectiveSubject = impersonating ? subject : MakeUser("alice@admin.test", isTwoFactorEnabled);
+        var principal = new Principal(effectiveSubject, actor);
+
+        var sessionStatus = new SessionStatusDto(
+            IsValid: true,
+            Principal: principal,
+            ExpiresAt: _timeProvider.GetUtcNow().UtcDateTime.AddHours(1),
+            LastSeenAt: _timeProvider.GetUtcNow().UtcDateTime,
+            LastTotpVerifiedAt: lastTotpVerifiedAt);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items[nameof(SessionStatusDto)] = sessionStatus;
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+    }
+
+    private static UserDto MakeUser(string email, bool isTwoFactorEnabled)
+        => new(
+            Id: Guid.NewGuid(),
+            Email: email,
+            DisplayName: email.Split('@')[0],
+            Role: "superadmin",
+            Tier: "free",
+            CreatedAt: DateTime.UtcNow,
+            IsTwoFactorEnabled: isTwoFactorEnabled,
+            TwoFactorEnabledAt: isTwoFactorEnabled ? DateTime.UtcNow : null,
+            Level: 1,
+            ExperiencePoints: 0);
+
+    [Fact]
+    public async Task StrictMode_FreshTotp_AllowsCommand()
+    {
+        // S3-1: 2FA enabled + verified 5min ago (< 30min MaxAge) → proceeds.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: true, lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-5));
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue();
+        result.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task StrictMode_StaleTotp_ThrowsStepUpRequired()
+    {
+        // S3-2: verified 45min ago (> 30min MaxAge) → blocked with step_up_required.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: true, lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-45));
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var act = () => behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<TwoFactorRequiredException>();
+        ex.Which.Subcode.Should().Be(TwoFactorRequiredSubcode.StepUpRequired);
+        called.Should().BeFalse("the command handler must not run when 2FA is stale");
+    }
+
+    [Fact]
+    public async Task StrictMode_NotEnrolled_ThrowsEnrollRequired()
+    {
+        // S3-3: actor has no 2FA → hard block with enroll_required (even if LastTotpVerifiedAt set).
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: false, lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime);
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        RequestHandlerDelegate<string> next = (ct) => Task.FromResult("ok");
+
+        var act = () => behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<TwoFactorRequiredException>();
+        ex.Which.Subcode.Should().Be(TwoFactorRequiredSubcode.EnrollRequired);
+    }
+
+    [Fact]
+    public async Task StrictMode_NullLastTotp_ThrowsStepUpRequired()
+    {
+        // 2FA enrolled but never step-up'd on this session (LastTotpVerifiedAt null) → step_up_required.
+        // This is the post-cutover state of every pre-existing admin session (the mass-lockout case
+        // D-S3-1 mitigates with default=OFF + ops sweep).
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: true, lastTotpVerifiedAt: null);
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        RequestHandlerDelegate<string> next = (ct) => Task.FromResult("ok");
+
+        var act = () => behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<TwoFactorRequiredException>();
+        ex.Which.Subcode.Should().Be(TwoFactorRequiredSubcode.StepUpRequired);
+    }
+
+    [Fact]
+    public async Task StrictMode_NonDecoratedCommand_AlwaysProceeds()
+    {
+        // S3-7 regression guard: a command without [RequireTwoFactor] is never gated, even in
+        // strict mode with no 2FA and no recency.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: false, lastTotpVerifiedAt: null);
+        var behavior = CreateBehavior<PlainCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new PlainCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue("non-decorated commands must short-circuit before any 2FA check");
+        result.Should().Be("ok");
+        _config.Verify(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "the strict-mode flag should not even be read for non-decorated commands");
+    }
+
+    [Theory]
+    [InlineData(6, false)]   // 6min recency vs 5min MaxAge → blocked
+    public async Task StrictMode_PerCommandMaxAge_5MinCommand_BlocksAt6Min(int ageMinutes, bool expectAllowed)
+    {
+        // S3-8a: ImpersonationStart-style 5-min MaxAge rejects a 6-min-old verification...
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: true, lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-ageMinutes));
+        var behavior = CreateBehavior<Decorated5MinCommand>();
+
+        RequestHandlerDelegate<string> next = (ct) => Task.FromResult("ok");
+
+        var act = () => behavior.Handle(new Decorated5MinCommand(), next, CancellationToken.None);
+
+        expectAllowed.Should().BeFalse();
+        await act.Should().ThrowAsync<TwoFactorRequiredException>();
+    }
+
+    [Fact]
+    public async Task StrictMode_PerCommandMaxAge_30MinCommand_AllowsAt6Min()
+    {
+        // S3-8b: ...while the same 6-min-old verification satisfies a 30-min MaxAge command.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(isTwoFactorEnabled: true, lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-6));
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue();
+        result.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task ShadowMode_NotEnrolled_ProceedsWithoutThrowing()
+    {
+        // Strict OFF (default at deploy): the legacy shadow behavior logs + proceeds, never blocks.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        SetupSession(isTwoFactorEnabled: false, lastTotpVerifiedAt: null);
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue("shadow mode never blocks");
+        result.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task NoSession_ProceedsDefensively()
+    {
+        // No SessionStatusDto in HttpContext (internal/test caller) → don't block.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(new DefaultHttpContext());
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue();
+        result.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task StrictMode_Impersonation_GatesOnActorNotSubject()
+    {
+        // S3-6 (unit slice): during impersonation, the gate reads EffectiveActor (alice, the admin)
+        // — NOT Subject (bob, the target who has no 2FA). Inherited LastTotpVerifiedAt is fresh, so
+        // the command proceeds even though the subject has no 2FA.
+        _config.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        SetupSession(
+            isTwoFactorEnabled: true,   // applies to the ACTOR (alice) when impersonating
+            lastTotpVerifiedAt: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-3),
+            impersonating: true);
+        var behavior = CreateBehavior<Decorated30MinCommand>();
+
+        var called = false;
+        RequestHandlerDelegate<string> next = (ct) => { called = true; return Task.FromResult("ok"); };
+
+        var result = await behavior.Handle(new Decorated30MinCommand(), next, CancellationToken.None);
+
+        called.Should().BeTrue("gate reads the actor's 2FA (alice), not the subject's (bob)");
+        result.Should().Be("ok");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfigurationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfigurationTests.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.Authentication.Application.Configuration;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Configuration;
+
+/// <summary>
+/// Unit tests for the SP5 S3 T3 typed config-flag wrapper. Verifies fail-closed semantics
+/// and the contract that <c>StrictModeDefault</c> is FALSE (shadow mode) at deploy time —
+/// the cutover from shadow to strict is an explicit ops decision via admin toggle, not a
+/// code change. See <c>audits/2026-05-26-s3-three-amigos-kickoff.md</c> §D-S3-1.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class TwoFactorEnforcementConfigurationTests
+{
+    private readonly Mock<IConfigurationService> _mockConfigService;
+    private readonly TwoFactorEnforcementConfiguration _sut;
+
+    public TwoFactorEnforcementConfigurationTests()
+    {
+        _mockConfigService = new Mock<IConfigurationService>();
+        _sut = new TwoFactorEnforcementConfiguration(_mockConfigService.Object);
+    }
+
+    [Fact]
+    public void StrictModeDefault_IsFalse_AtDeployTime()
+    {
+        // Cutover contract: strict mode is OFF by default. Flipping it on is an explicit ops
+        // decision (admin toggle) — separates code merge from behavior change and prevents the
+        // mass-lockout scenario at deploy time when all existing sessions have LastTotpVerifiedAt
+        // = null. See D-S3-1.
+        TwoFactorConfigurationKeys.StrictModeDefault.Should().BeFalse(
+            "default must be shadow mode; ops flips strict via admin toggle post-sweep");
+    }
+
+    [Fact]
+    public void StrictModeKey_FollowsColonNamespaceConvention()
+    {
+        // Pattern consistent with Registration:PublicEnabled etc — the dynamic config store uses
+        // ":" as the namespace separator.
+        TwoFactorConfigurationKeys.StrictMode.Should().Be("TwoFactor:StrictMode");
+    }
+
+    [Fact]
+    public async Task GetStrictModeAsync_WhenConfigStoreReturnsTrue_ReturnsTrue()
+    {
+        _mockConfigService
+            .Setup(s => s.GetValueAsync<bool?>(TwoFactorConfigurationKeys.StrictMode, It.IsAny<bool?>(), It.IsAny<string?>()))
+            .ReturnsAsync(true);
+
+        var result = await _sut.GetStrictModeAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetStrictModeAsync_WhenConfigStoreReturnsNull_ReturnsDefaultFalse()
+    {
+        // Key absent from the DB — store returns null; provider applies the StrictModeDefault.
+        _mockConfigService
+            .Setup(s => s.GetValueAsync<bool?>(TwoFactorConfigurationKeys.StrictMode, It.IsAny<bool?>(), It.IsAny<string?>()))
+            .ReturnsAsync((bool?)null);
+
+        var result = await _sut.GetStrictModeAsync();
+
+        result.Should().BeFalse("default at deploy is shadow mode");
+    }
+
+    [Fact]
+    public async Task GetStrictModeAsync_WhenConfigStoreThrows_FailsClosedToShadow()
+    {
+        // Fail-closed: an unreachable config store must NOT silently flip behavior to strict.
+        // Strict mode is opt-in by ops via admin toggle; any read error => shadow.
+        _mockConfigService
+            .Setup(s => s.GetValueAsync<bool?>(It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<string?>()))
+            .ThrowsAsync(new InvalidOperationException("config store unreachable"));
+
+        var result = await _sut.GetStrictModeAsync();
+
+        result.Should().BeFalse("fail-closed: any error => shadow mode (the safe default)");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Validators/StepUpTwoFactorCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Validators/StepUpTwoFactorCommandValidatorTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Validators;
+
+/// <summary>
+/// Unit tests for <see cref="StepUpTwoFactorCommandValidator"/> (SP5 Admin Security S3 — T5).
+/// Format validation is intentionally minimal — the authoritative TOTP check (and constant-time
+/// comparison) lives in TotpService — so these only assert the not-empty guards on
+/// SessionId/ActorUserId/Code plus the Code length bound.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class StepUpTwoFactorCommandValidatorTests
+{
+    private readonly StepUpTwoFactorCommandValidator _validator = new();
+
+    private static StepUpTwoFactorCommand ValidCommand() =>
+        new(SessionId: Guid.NewGuid(), ActorUserId: Guid.NewGuid(), Code: "123456");
+
+    [Fact]
+    public void Should_Pass_When_Command_Is_Valid()
+    {
+        var result = _validator.TestValidate(ValidCommand());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Should_Fail_When_SessionId_Is_Empty()
+    {
+        var command = ValidCommand() with { SessionId = Guid.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Should_Fail_When_ActorUserId_Is_Empty()
+    {
+        var command = ValidCommand() with { ActorUserId = Guid.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.ActorUserId);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Code_Is_Empty()
+    {
+        var command = ValidCommand() with { Code = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Code_Exceeds_Max_Length()
+    {
+        var command = ValidCommand() with { Code = new string('1', 11) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Code);
+    }
+
+    [Fact]
+    public void Should_Pass_When_Code_At_Max_Length()
+    {
+        var command = ValidCommand() with { Code = new string('1', 10) };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.Code);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/TwoFactor/StepUpTwoFactorCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/TwoFactor/StepUpTwoFactorCommandHandlerTests.cs
@@ -165,4 +165,22 @@ public sealed class StepUpTwoFactorCommandHandlerTests
         var act = async () => await _handler.Handle(null!, CancellationToken.None);
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
+
+    [Fact]
+    public async Task Handle_TotpStoreThrows_ReturnsUnavailable()
+    {
+        // S3 Option B / D-S3-4: VerifyCodeAsync is Redis-backed; if the store is unreachable the
+        // step-up cannot complete. The handler surfaces Unavailable (→ endpoint 503), never a false
+        // InvalidCode and never an unhandled 500.
+        _totp.Setup(t => t.IsLockedOutAsync(ActorId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _totp.Setup(t => t.VerifyCodeAsync(ActorId, ValidCode, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("totp store unreachable"));
+
+        var result = await _handler.Handle(Command(), CancellationToken.None);
+
+        result.Outcome.Should().Be(StepUpOutcome.Unavailable);
+        result.LastTotpVerifiedAt.Should().BeNull();
+        _sessions.Verify(r => r.UpdateLastTotpVerifiedAtAsync(
+            It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/TwoFactor/StepUpTwoFactorCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/TwoFactor/StepUpTwoFactorCommandHandlerTests.cs
@@ -1,0 +1,168 @@
+using Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Commands.TwoFactor;
+
+/// <summary>
+/// Unit tests for <see cref="StepUpTwoFactorCommandHandler"/> (SP5 Admin Security S3 — T5).
+/// Covers the handler-level slices of acceptance scenarios S3-4 (step-up success / invalid code) and
+/// S3-5 (lockout → 429). The full HTTP request→pipeline acceptance (real audit_outbox row + re-POST
+/// of the previously-blocked sensitive command) runs in the T8 integration suite.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class StepUpTwoFactorCommandHandlerTests
+{
+    private readonly Mock<ITotpService> _totp = new();
+    private readonly Mock<ISessionRepository> _sessions = new();
+    private readonly Mock<AuditService> _audit;
+    private readonly FakeTimeProvider _time = new(DateTimeOffset.Parse("2026-05-26T12:00:00Z"));
+    private readonly StepUpTwoFactorCommandHandler _handler;
+
+    private static readonly Guid SessionId = Guid.NewGuid();
+    private static readonly Guid ActorId = Guid.NewGuid();
+    private const string ValidCode = "123456";
+
+    public StepUpTwoFactorCommandHandlerTests()
+    {
+        // AuditService has virtual methods — mock with a satisfied base ctor (InMemory ctx, unused
+        // because LogAsync is overridden by the mock and never hits the real DbContext body).
+        _audit = new Mock<AuditService>(
+            new MeepleAiDbContext(
+                new DbContextOptionsBuilder<MeepleAiDbContext>()
+                    .UseInMemoryDatabase($"stepup_audit_{Guid.NewGuid()}").Options,
+                Mock.Of<IMediator>(),
+                Mock.Of<Api.SharedKernel.Application.Services.IDomainEventCollector>()),
+            Mock.Of<ILogger<AuditService>>(),
+            null!);
+
+        // LogAsync returns a Task; without a setup Moq yields a null Task → NRE on await.
+        _audit
+            .Setup(a => a.LogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new StepUpTwoFactorCommandHandler(
+            _totp.Object,
+            _sessions.Object,
+            _audit.Object,
+            _time,
+            Mock.Of<ILogger<StepUpTwoFactorCommandHandler>>());
+    }
+
+    private StepUpTwoFactorCommand Command(string code = ValidCode) => new(SessionId, ActorId, code);
+
+    [Fact]
+    public async Task Handle_ValidCode_RefreshesRecencyAndAuditsSuccess()
+    {
+        // Arrange — S3-4 happy path.
+        _totp.Setup(t => t.IsLockedOutAsync(ActorId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _totp.Setup(t => t.VerifyCodeAsync(ActorId, ValidCode, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _sessions
+            .Setup(r => r.UpdateLastTotpVerifiedAtAsync(SessionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(StepUpOutcome.Success);
+        result.LastTotpVerifiedAt.Should().Be(_time.GetUtcNow().UtcDateTime);
+        result.RetryAfterSeconds.Should().BeNull();
+
+        _sessions.Verify(r => r.UpdateLastTotpVerifiedAtAsync(
+            SessionId, _time.GetUtcNow().UtcDateTime, It.IsAny<CancellationToken>()), Times.Once);
+        _audit.Verify(a => a.LogAsync(
+            ActorId.ToString(), "TwoFactorStepUp", "TwoFactor", SessionId.ToString(), "Success",
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCode_ReturnsInvalidCode_WithoutRefreshing()
+    {
+        // Arrange — S3-4 negative: VerifyCodeAsync already audited the failed attempt + advanced lockout.
+        _totp.Setup(t => t.IsLockedOutAsync(ActorId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _totp.Setup(t => t.VerifyCodeAsync(ActorId, ValidCode, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        // Act
+        var result = await _handler.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(StepUpOutcome.InvalidCode);
+        result.LastTotpVerifiedAt.Should().BeNull();
+
+        _sessions.Verify(r => r.UpdateLastTotpVerifiedAtAsync(
+            It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+        _audit.Verify(a => a.LogAsync(
+            It.IsAny<string>(), "TwoFactorStepUp", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_LockedOut_Returns429Semantics_WithoutVerifying()
+    {
+        // Arrange — S3-5: lockout pre-check short-circuits before any TOTP verification.
+        _totp.Setup(t => t.IsLockedOutAsync(ActorId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        // Act
+        var result = await _handler.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(StepUpOutcome.LockedOut);
+        result.RetryAfterSeconds.Should().Be(900);
+        result.LastTotpVerifiedAt.Should().BeNull();
+
+        _totp.Verify(t => t.VerifyCodeAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _sessions.Verify(r => r.UpdateLastTotpVerifiedAtAsync(
+            It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+        _audit.Verify(a => a.LogAsync(
+            ActorId.ToString(), "TwoFactorStepUpLockout", "TwoFactor", SessionId.ToString(), "Blocked",
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SessionVanishedAfterVerify_ReturnsInvalidCode_WithoutSuccessAudit()
+    {
+        // Arrange — verified, but the session was revoked/expired between auth and step-up
+        // (ExecuteUpdate affected 0 rows). Treated as a failed step-up.
+        _totp.Setup(t => t.IsLockedOutAsync(ActorId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _totp.Setup(t => t.VerifyCodeAsync(ActorId, ValidCode, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _sessions
+            .Setup(r => r.UpdateLastTotpVerifiedAtAsync(SessionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        // Act
+        var result = await _handler.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(StepUpOutcome.InvalidCode);
+        result.LastTotpVerifiedAt.Should().BeNull();
+        _audit.Verify(a => a.LogAsync(
+            It.IsAny<string>(), "TwoFactorStepUp", It.IsAny<string>(), It.IsAny<string>(), "Success",
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullCommand_ThrowsArgumentNullException()
+    {
+        var act = async () => await _handler.Handle(null!, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
@@ -1,0 +1,466 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.Authentication.Application.Configuration;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using OtpNet;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Integration.Administration;
+
+/// <summary>
+/// SP5 Admin Security S3 — acceptance scenarios (T8). Exercises the REAL HTTP pipeline
+/// (WebApplicationFactory + Testcontainers Postgres + login + cookies) for the 8 scenarios
+/// S3-1..S3-8 documented in <c>audits/2026-05-26-s3-three-amigos-kickoff.md</c>.
+///
+/// Critical lesson from S2: tests MUST exercise the real pipeline via
+/// <c>ValidateSessionQueryHandler</c> + <c>TwoFactorEnforcementBehavior</c>, NOT construct
+/// <c>SessionStatusDto</c> manually.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Authentication")]
+[Trait("Sprint", "SP5-S3")]
+public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _dbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    // Toggled per-test; the mocked ITwoFactorEnforcementConfiguration reads this field so a single
+    // factory instance can serve scenarios with strict ON or OFF (and the per-command MaxAge tests).
+    private bool _strictModeOn;
+
+    public S3AcceptanceScenariosTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _dbName = $"s3_accept_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_dbName);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    // Enable public registration so SeedAdminAsync can call /auth/register.
+                    services.RemoveAll(typeof(IConfigurationService));
+                    var configurationMock = new Mock<IConfigurationService>();
+                    configurationMock
+                        .Setup(c => c.GetValueAsync<bool?>("Registration:PublicEnabled", It.IsAny<bool?>(), It.IsAny<string?>()))
+                        .ReturnsAsync(true);
+                    services.AddSingleton<IConfigurationService>(configurationMock.Object);
+
+                    // Strict 2FA mode reads _strictModeOn on every call, so flipping it mid-test
+                    // takes effect on the next request without a factory rebuild.
+                    services.RemoveAll(typeof(ITwoFactorEnforcementConfiguration));
+                    var twoFactorConfigMock = new Mock<ITwoFactorEnforcementConfiguration>();
+                    twoFactorConfigMock.Setup(c => c.GetStrictModeAsync(It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(() => _strictModeOn);
+                    services.AddSingleton(twoFactorConfigMock.Object);
+
+                    // Redis counter simulation (pattern from TwoFactorSecurityPenetrationTests):
+                    // the default factory's Redis mock returns nothing for StringIncrementAsync, so
+                    // TotpService's lockout counter never trips. Wire a ConcurrentDictionary-backed
+                    // mock that actually counts — required by S3-5 to reach the 5-fail threshold.
+                    services.RemoveAll(typeof(IConnectionMultiplexer));
+                    var counters = new System.Collections.Concurrent.ConcurrentDictionary<string, long>();
+                    var redisMock = new Mock<IConnectionMultiplexer>();
+                    var dbMock = new Mock<IDatabase>();
+                    redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+                    dbMock.Setup(d => d.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+                        .ReturnsAsync((RedisKey key, long inc, CommandFlags _) =>
+                            counters.AddOrUpdate(key.ToString(), inc, (_, current) => current + inc));
+                    dbMock.Setup(d => d.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                        .ReturnsAsync((RedisKey key, CommandFlags _) =>
+                            counters.TryGetValue(key.ToString(), out var v) ? (RedisValue)v : RedisValue.Null);
+                    dbMock.Setup(d => d.KeyExpireAsync(It.IsAny<RedisKey>(), It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()))
+                        .ReturnsAsync(true);
+                    services.AddSingleton(redisMock.Object);
+                });
+            });
+
+        // Migrate the isolated database.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        try { await _fixture.DropIsolatedDatabaseAsync(_dbName); }
+        catch { /* ignore cleanup */ }
+    }
+
+    // ================== HELPERS ==================
+
+    /// <summary>
+    /// Registers a user via the public HTTP endpoint, then raises the role on the entity. Returns
+    /// the user id. The session created by registration is discarded (we log in fresh per test).
+    /// </summary>
+    private async Task<(Guid UserId, Guid SessionId)> SeedAdminAsync(string email, string password, string role = "admin")
+    {
+        var registerResponse = await _client.PostAsJsonAsync("/api/v1/auth/register",
+            new { Email = email, Password = password, DisplayName = email.Split('@')[0] });
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            $"the test fixture expects a clean registration; got {await registerResponse.Content.ReadAsStringAsync()}");
+
+        // WebApplicationFactory.CreateClient() does not auto-persist cookies across requests, so
+        // extract the session cookie from Set-Cookie and pin it on DefaultRequestHeaders for every
+        // subsequent call. Pattern lifted from AuthenticationEndpointsIntegrationTests.
+        var setCookie = registerResponse.Headers.GetValues("Set-Cookie")
+            .First(c => c.Contains("meepleai_session"))
+            .Split(';')[0];
+        _client.DefaultRequestHeaders.Remove("Cookie");
+        _client.DefaultRequestHeaders.Add("Cookie", setCookie);
+
+        // Promote: registration creates a 'user'; bump the row directly for the scenarios that need
+        // admin/superadmin role.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var user = await db.Users.SingleAsync(u => u.Email == email);
+        user.Role = role;
+        await db.SaveChangesAsync();
+
+        var session = await db.UserSessions
+            .Where(s => s.UserId == user.Id && s.RevokedAt == null)
+            .OrderByDescending(s => s.CreatedAt)
+            .FirstAsync();
+        return (user.Id, session.Id);
+    }
+
+    /// <summary>
+    /// Creates a UserEntity directly in the DB (no HTTP) — used to seed impersonation targets and
+    /// other "passive" users that don't need a session/cookie of their own.
+    /// </summary>
+    private async Task<Guid> SeedTargetUserAsync(string email, string role = "user")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var id = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = id,
+            Email = email,
+            DisplayName = email.Split('@')[0],
+            Role = role,
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow,
+            IsTwoFactorEnabled = false,
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// Seeds an admin with 2FA enabled, using the real TotpService so the encrypted secret in the DB
+    /// matches what production stores. Returns the plaintext secret so the test can later mint valid
+    /// codes via <see cref="GenerateTotpCode"/>.
+    /// </summary>
+    private async Task<(Guid UserId, Guid SessionId, string TotpSecret)> SeedAdminWith2FAAsync(
+        string email, string password, string role = "admin")
+    {
+        var (userId, sessionId) = await SeedAdminAsync(email, password, role);
+
+        using var scope = _factory.Services.CreateScope();
+        var totpService = scope.ServiceProvider.GetRequiredService<ITotpService>();
+        var setup = await totpService.GenerateSetupAsync(userId, email, CancellationToken.None);
+        var validCode = GenerateTotpCode(setup.Secret);
+        await totpService.EnableTwoFactorAsync(userId, validCode, CancellationToken.None);
+        return (userId, sessionId, setup.Secret);
+    }
+
+    private static string GenerateTotpCode(string base32Secret)
+        => new Totp(Base32Encoding.ToBytes(base32Secret)).ComputeTotp();
+
+    /// <summary>
+    /// Manipulates <c>LastTotpVerifiedAt</c> on a session row directly — the only way to model the
+    /// "fresh" vs "stale" inputs without waiting wall-clock time.
+    /// </summary>
+    private async Task SetLastTotpVerifiedAtAsync(Guid sessionId, DateTime? when)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var session = await db.UserSessions.FirstAsync(s => s.Id == sessionId);
+        session.LastTotpVerifiedAt = when;
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Re-pins the HttpClient's Cookie header from the response's Set-Cookie. Required when an
+    /// endpoint mints a new session token (e.g. impersonation start ⇒ new session row + new cookie).
+    /// </summary>
+    private void RefreshClientCookieFromResponse(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies)) return;
+        var sessionCookie = setCookies.FirstOrDefault(c => c.Contains("meepleai_session"));
+        if (sessionCookie is null) return;
+        _client.DefaultRequestHeaders.Remove("Cookie");
+        _client.DefaultRequestHeaders.Add("Cookie", sessionCookie.Split(';')[0]);
+    }
+
+    private static async Task<(string error, string? subcode, int? retryAfterSeconds)> ParseTwoFactorErrorAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        var error = root.GetProperty("error").GetString() ?? "";
+        var subcode = root.TryGetProperty("subcode", out var s) ? s.GetString() : null;
+        int? retry = root.TryGetProperty("retryAfterSeconds", out var r) && r.ValueKind != System.Text.Json.JsonValueKind.Null
+            ? r.GetInt32() : null;
+        return (error, subcode, retry);
+    }
+
+    // ================== SCENARIOS ==================
+
+    [Fact]
+    public async Task S3_1_FreshTotp_AllowsDecoratedCommand_HappyPath()
+    {
+        // Given a superadmin with 2FA enabled, LastTotpVerifiedAt=now (well under
+        // ImpersonationStart's MaxAge=5), and strict mode ON.
+        var (_, sessionId, _) = await SeedAdminWith2FAAsync(
+            $"s3-1-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        await SetLastTotpVerifiedAtAsync(sessionId, DateTime.UtcNow);
+        var targetId = await SeedTargetUserAsync($"s3-1-target-{Guid.NewGuid():N}@meepleai.test");
+        _strictModeOn = true;
+
+        // When the admin starts an impersonation (decorated, MaxAge=5min).
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-1 happy path", DurationMinutes = 15 });
+
+        // Then the enforcement filter lets it through — fresh recency satisfies the gate.
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"fresh TOTP must allow the decorated command; body: {await response.Content.ReadAsStringAsync()}");
+    }
+
+    [Fact]
+    public async Task S3_2_StaleTotp_BlockedWith_StepUpRequired()
+    {
+        // Given a superadmin with 2FA enabled but LastTotpVerifiedAt=now-1h (well past every
+        // command's MaxAge), and strict mode ON.
+        var (_, sessionId, _) = await SeedAdminWith2FAAsync(
+            $"s3-2-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        await SetLastTotpVerifiedAtAsync(sessionId, DateTime.UtcNow.AddHours(-1));
+        var targetId = await SeedTargetUserAsync($"s3-2-target-{Guid.NewGuid():N}@meepleai.test");
+        _strictModeOn = true;
+
+        // When the admin starts an impersonation.
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-2 stale", DurationMinutes = 15 });
+
+        // Then enforcement blocks → 401 + step_up_required + WWW-Authenticate.
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.GetValues("WWW-Authenticate").Should().ContainSingle()
+            .Which.Should().Be("TOTP-StepUp realm=\"meepleai-admin\"");
+
+        var (error, subcode, _) = await ParseTwoFactorErrorAsync(response);
+        error.Should().Be("two_factor_required");
+        subcode.Should().Be("step_up_required");
+    }
+
+    [Fact]
+    public async Task S3_4_StepUpAndRetry_UnblocksTheDecoratedCommand()
+    {
+        // Given a superadmin with stale 2FA recency, strict mode ON, and a target to impersonate.
+        var (_, sessionId, totpSecret) = await SeedAdminWith2FAAsync(
+            $"s3-4-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        await SetLastTotpVerifiedAtAsync(sessionId, DateTime.UtcNow.AddHours(-1));
+        var targetId = await SeedTargetUserAsync($"s3-4-target-{Guid.NewGuid():N}@meepleai.test");
+        _strictModeOn = true;
+
+        // 1) The original command is blocked: 401 step_up_required.
+        var blocked = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-4 first attempt", DurationMinutes = 15 });
+        blocked.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        (await ParseTwoFactorErrorAsync(blocked)).subcode.Should().Be("step_up_required");
+
+        // 2) Step-up with a fresh, valid TOTP code → 200 refreshes LastTotpVerifiedAt.
+        var validCode = GenerateTotpCode(totpSecret);
+        var stepUp = await _client.PostAsJsonAsync("/api/v1/auth/2fa/step-up", new { Code = validCode });
+        stepUp.StatusCode.Should().Be(HttpStatusCode.OK,
+            $"valid code should unblock; body: {await stepUp.Content.ReadAsStringAsync()}");
+
+        // Side-effect verified on the row, not on a hand-built DTO (S2 lesson).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var session = await db.UserSessions.AsNoTracking().FirstAsync(s => s.Id == sessionId);
+            session.LastTotpVerifiedAt.Should().NotBeNull("step-up writes session recency");
+            session.LastTotpVerifiedAt!.Value.Should().BeAfter(DateTime.UtcNow.AddMinutes(-1));
+        }
+
+        // 3) Retry the originally-blocked command → 201, now allowed.
+        var retry = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-4 retry", DurationMinutes = 15 });
+        retry.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"fresh recency should pass enforcement on the retry; body: {await retry.Content.ReadAsStringAsync()}");
+    }
+
+    [Fact]
+    public async Task S3_8_PerCommandMaxAge_FreshFor30ButStaleFor5()
+    {
+        // Given a superadmin with 2FA and LastTotpVerifiedAt=now-10min. ImpersonationStart has
+        // MaxAge=5 → stale for it. DeleteUser (default MaxAge=30) → fresh for it.
+        var (_, sessionId, _) = await SeedAdminWith2FAAsync(
+            $"s3-8-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        await SetLastTotpVerifiedAtAsync(sessionId, DateTime.UtcNow.AddMinutes(-10));
+        var targetId = await SeedTargetUserAsync($"s3-8-target-{Guid.NewGuid():N}@meepleai.test");
+        _strictModeOn = true;
+
+        // 10min is STALE for ImpersonationStart (MaxAge=5) → 401 step_up_required.
+        var stricterResponse = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-8 stricter", DurationMinutes = 15 });
+        stricterResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "MaxAge=5 fires before MaxAge=30 — tighter ceiling on privileged commands (D-S3-7)");
+        var (_, stricterSubcode, _) = await ParseTwoFactorErrorAsync(stricterResponse);
+        stricterSubcode.Should().Be("step_up_required");
+
+        // 10min is FRESH for DeleteUser (MaxAge=30) → 204 No Content (the route's success status).
+        var lenientResponse = await _client.DeleteAsync($"/api/v1/admin/users/{targetId}");
+        lenientResponse.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            $"MaxAge=30 still tolerates 10min recency; got {await lenientResponse.Content.ReadAsStringAsync()}");
+    }
+
+    [Fact]
+    public async Task S3_3_NotEnrolledAdmin_BlockedWith_EnrollRequired()
+    {
+        // Given a superadmin with NO 2FA enabled and strict mode ON.
+        var adminEmail = $"s3-3-admin-{Guid.NewGuid():N}@meepleai.test";
+        await SeedAdminAsync(adminEmail, "UnusualPwd123!", role: "superadmin");
+        var targetId = await SeedTargetUserAsync($"s3-3-target-{Guid.NewGuid():N}@meepleai.test");
+        _strictModeOn = true;
+
+        // When the admin tries to start an impersonation (decorated with [RequireTwoFactor]).
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = targetId, Reason = "S3-3 acceptance test", DurationMinutes = 15 });
+
+        // Then the enforcement filter blocks BEFORE the command runs.
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.GetValues("WWW-Authenticate").Should().ContainSingle()
+            .Which.Should().Be("TOTP-StepUp realm=\"meepleai-admin\"");
+
+        var (error, subcode, _) = await ParseTwoFactorErrorAsync(response);
+        error.Should().Be("two_factor_required");
+        subcode.Should().Be("enroll_required",
+            "the admin has IsTwoFactorEnabled=false → must enrol before strict can succeed (D-S3-5)");
+    }
+
+    [Fact]
+    public async Task S3_5_FiveFailedStepUps_LeadsToLockout()
+    {
+        // Given an admin with 2FA enrolled and a stale recency (so step-up is the only path).
+        var (_, sessionId, _) = await SeedAdminWith2FAAsync(
+            $"s3-5-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "admin");
+        await SetLastTotpVerifiedAtAsync(sessionId, DateTime.UtcNow.AddHours(-1));
+
+        // 5 failed step-up attempts (wrong code).
+        for (int i = 1; i <= 5; i++)
+        {
+            var fail = await _client.PostAsJsonAsync("/api/v1/auth/2fa/step-up", new { Code = "000000" });
+            fail.StatusCode.Should().Be(HttpStatusCode.Unauthorized, $"failed attempt #{i}");
+            var (_, failSubcode, _) = await ParseTwoFactorErrorAsync(fail);
+            failSubcode.Should().Be("invalid_code", $"attempt #{i} should be invalid_code, not locked yet");
+        }
+
+        // 6th attempt: the lockout pre-check returns LockedOut → 401 with subcode locked_out
+        // and retryAfterSeconds populated (D-S3-4b).
+        var locked = await _client.PostAsJsonAsync("/api/v1/auth/2fa/step-up", new { Code = "000000" });
+        locked.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var (error, subcode, retry) = await ParseTwoFactorErrorAsync(locked);
+        error.Should().Be("two_factor_required");
+        subcode.Should().Be("locked_out", "5 failures within the window must trigger the lockout pre-check");
+        retry.Should().Be(900, "retryAfterSeconds is a fixed 15-minute client hint");
+    }
+
+    [Fact]
+    public async Task S3_6_ImpersonationContext_ActorsRecencyApplies()
+    {
+        // Alice (superadmin with 2FA fresh) starts impersonating Bob — that requires a fresh
+        // ImpersonationStart MaxAge=5, so we set LastTotpVerifiedAt=now first.
+        var (aliceId, _, _) = await SeedAdminWith2FAAsync(
+            $"s3-6-alice-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        var bobId = await SeedTargetUserAsync($"s3-6-bob-{Guid.NewGuid():N}@meepleai.test");
+        var carolId = await SeedTargetUserAsync($"s3-6-carol-{Guid.NewGuid():N}@meepleai.test");
+
+        // Refresh alice's recency (SeedAdminWith2FAAsync leaves it at the register-time default = null).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var aliceSession = await db.UserSessions
+                .Where(s => s.UserId == aliceId && s.RevokedAt == null && s.ImpersonatedByUserId == null)
+                .OrderByDescending(s => s.CreatedAt)
+                .FirstAsync();
+            aliceSession.LastTotpVerifiedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        }
+        _strictModeOn = true;
+
+        var impStart = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = bobId, Reason = "S3-6 acceptance impersonation context", DurationMinutes = 15 });
+        impStart.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"impersonation start should succeed; body: {await impStart.Content.ReadAsStringAsync()}");
+        RefreshClientCookieFromResponse(impStart);
+
+        // The impersonate session inherits alice's recency (T1 spike). Move that recency back to
+        // -10min: STALE for ImpersonationStart (MaxAge=5) but FRESH for DeleteUser (MaxAge=30).
+        Guid impSessionId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var imp = await db.UserSessions
+                .Where(s => s.ImpersonatedByUserId == aliceId && s.RevokedAt == null)
+                .OrderByDescending(s => s.CreatedAt)
+                .FirstAsync();
+            imp.LastTotpVerifiedAt = DateTime.UtcNow.AddMinutes(-10);
+            await db.SaveChangesAsync();
+            impSessionId = imp.Id;
+        }
+
+        // From the impersonate session, delete Carol — must succeed: the gate uses the ACTOR's
+        // recency (alice's 10min, inherited at impersonation-start), and DeleteUser MaxAge=30 covers it.
+        var delete = await _client.DeleteAsync($"/api/v1/admin/users/{carolId}");
+        delete.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            $"actor's 10min recency satisfies DeleteUser MaxAge=30 from the impersonate session; got {await delete.Content.ReadAsStringAsync()}");
+        impSessionId.Should().NotBe(Guid.Empty);  // smoke the row exists; sanity for the SetLast above
+    }
+
+    [Fact]
+    public async Task S3_7_NonDecoratedCommand_PassesEvenInStrictMode_RegressionGuard()
+    {
+        // Given strict 2FA enforcement is ON and a user with NO 2FA enrolled.
+        var email = $"s3-7-{Guid.NewGuid():N}@meepleai.test";
+        await SeedAdminAsync(email, "UnusualPwd123!", role: "user");
+        _strictModeOn = true;
+
+        // When the user calls an endpoint backed by a query/command NOT decorated with
+        // [RequireTwoFactor] (here: GET /auth/me → GetCurrentUserQuery).
+        var response = await _client.GetAsync("/api/v1/auth/me");
+
+        // Then the regression guard in TwoFactorEnforcementBehavior short-circuits and the request
+        // succeeds — strict mode must NEVER touch non-decorated commands.
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "TwoFactorEnforcementBehavior.S3-7 regression guard: missing [RequireTwoFactor] = no gate");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Authentication/GetAdminsWithoutTwoFactorQueryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/GetAdminsWithoutTwoFactorQueryIntegrationTests.cs
@@ -1,0 +1,144 @@
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.Authentication;
+
+/// <summary>
+/// Integration tests for <see cref="GetAdminsWithoutTwoFactorQueryHandler"/> (SP5 Admin Security S3 — T6).
+/// Verifies the compliance-sweep predicate: only users with Role in (admin, superadmin) AND
+/// IsTwoFactorEnabled=false are returned; admins who already enrolled and non-admin users are excluded.
+/// Exercises the real repository (<see cref="UserRepository.GetAdminUsersAsync"/>) against Postgres,
+/// not a hand-built DTO (lesson S2 — acceptance must exercise the real pipeline).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Authentication")]
+public sealed class GetAdminsWithoutTwoFactorQueryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private ServiceProvider? _serviceProvider;
+    private MeepleAiDbContext? _dbContext;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public GetAdminsWithoutTwoFactorQueryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_admins_no_2fa_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        await ApplyMigrationsAsync(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_serviceProvider is not null) await _serviceProvider.DisposeAsync();
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOnlyAdminsAndSuperadminsWithoutTwoFactor()
+    {
+        using var scope = _serviceProvider!.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var adminNo2Fa = SeedUser(db, "admin-no2fa@meepleai.test", role: "admin", twoFactor: false);
+        var superadminNo2Fa = SeedUser(db, "root-no2fa@meepleai.test", role: "superadmin", twoFactor: false);
+        SeedUser(db, "admin-with2fa@meepleai.test", role: "admin", twoFactor: true);     // excluded: enrolled
+        SeedUser(db, "regular@meepleai.test", role: "user", twoFactor: false);            // excluded: not admin
+        await db.SaveChangesAsync(TestCancellationToken);
+
+        var handler = new GetAdminsWithoutTwoFactorQueryHandler(
+            new UserRepository(db, Mock.Of<IDomainEventCollector>()));
+
+        // Act
+        var result = await handler.Handle(new GetAdminsWithoutTwoFactorQuery(), TestCancellationToken);
+
+        // Assert — exactly the two non-enrolled privileged accounts.
+        result.Should().HaveCount(2);
+        result.Select(u => u.Id).Should().BeEquivalentTo(new[] { adminNo2Fa, superadminNo2Fa });
+        result.Should().OnlyContain(u => !u.IsTwoFactorEnabled);
+        result.Select(u => u.Email).Should().Contain("admin-no2fa@meepleai.test")
+            .And.NotContain("admin-with2fa@meepleai.test")
+            .And.NotContain("regular@meepleai.test");
+    }
+
+    [Fact]
+    public async Task Handle_AllAdminsEnrolled_ReturnsEmpty()
+    {
+        using var scope = _serviceProvider!.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        SeedUser(db, "admin-a@meepleai.test", role: "admin", twoFactor: true);
+        SeedUser(db, "root-b@meepleai.test", role: "superadmin", twoFactor: true);
+        SeedUser(db, "regular-c@meepleai.test", role: "user", twoFactor: false);
+        await db.SaveChangesAsync(TestCancellationToken);
+
+        var handler = new GetAdminsWithoutTwoFactorQueryHandler(
+            new UserRepository(db, Mock.Of<IDomainEventCollector>()));
+
+        var result = await handler.Handle(new GetAdminsWithoutTwoFactorQuery(), TestCancellationToken);
+
+        result.Should().BeEmpty();
+    }
+
+    private static Guid SeedUser(MeepleAiDbContext db, string email, string role, bool twoFactor)
+    {
+        var id = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = id,
+            Email = email,
+            DisplayName = email.Split('@')[0],
+            Role = role,
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow,
+            IsTwoFactorEnabled = twoFactor,
+            TwoFactorEnabledAt = twoFactor ? DateTime.UtcNow : null,
+            // The entity→domain mapping only restores 2FA state when both the flag AND an encrypted
+            // secret are present (UserRepository.MapToDomain) — mirroring Enable2FA, which always sets
+            // both. A secret is therefore required to model a genuinely 2FA-enrolled account.
+            TotpSecretEncrypted = twoFactor ? "encrypted-totp-secret-test" : null,
+        });
+        return id;
+    }
+
+    private static async Task ApplyMigrationsAsync(MeepleAiDbContext db)
+    {
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await db.Database.MigrateAsync(TestContext.Current.CancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestContext.Current.CancellationToken);
+            }
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
@@ -701,6 +701,32 @@ public class ApiExceptionHandlerMiddlewareTests
             "the FE shows a retry-after toast with the wait duration");
     }
 
+    [Fact]
+    public async Task InvokeAsync_TwoFactorUnavailableException_Returns503()
+    {
+        // SP5 S3 — D-S3-4 (Option B): when the TOTP store / rate-limit backend is unreachable, the
+        // step-up cannot complete; the middleware maps it to 503 (transient) rather than a generic
+        // 500, so the FE shows a retryable error toast instead of a failed-code / step-up signal.
+        var exception = new TwoFactorUnavailableException("Two-factor service is temporarily unavailable.");
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(503);
+
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("error").GetString().Should().Be("two_factor_unavailable");
+    }
+
     private static JsonDocument ParseErrorResponse(string responseBody)
     {
         return JsonDocument.Parse(responseBody);

--- a/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
@@ -616,6 +616,91 @@ public class ApiExceptionHandlerMiddlewareTests
         _httpContext.Response.StatusCode.Should().Be(expectedStatusCode);
     }
 
+    [Fact]
+    public async Task InvokeAsync_TwoFactorRequiredException_StepUp_Returns401WithSubcodeAndChallenge()
+    {
+        // SP5 S3 — D-S3-2: strict TwoFactorEnforcementBehavior throws when TOTP recency is
+        // missing/stale. The middleware maps to 401 + structured body + WWW-Authenticate header.
+        var exception = new TwoFactorRequiredException(
+            TwoFactorRequiredSubcode.StepUpRequired,
+            "TOTP verification required for this command.");
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(401);
+        _httpContext.Response.Headers["WWW-Authenticate"].ToString()
+            .Should().Be("TOTP-StepUp realm=\"meepleai-admin\"",
+                "RFC 7235 challenge header lets non-browser clients distinguish from session-invalid 401");
+
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("error").GetString().Should().Be("two_factor_required");
+        errorResponse.RootElement.GetProperty("subcode").GetString().Should().Be("step_up_required",
+            "FE routes on subcode: step_up_required opens the TOTP modal");
+        errorResponse.RootElement.GetProperty("message").GetString().Should().Contain("TOTP");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_TwoFactorRequiredException_EnrollRequired_Returns401WithEnrollSubcode()
+    {
+        var exception = new TwoFactorRequiredException(
+            TwoFactorRequiredSubcode.EnrollRequired,
+            "Two-factor authentication must be enabled for this action.");
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(401);
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("subcode").GetString().Should().Be("enroll_required",
+            "FE routes on subcode: enroll_required redirects to /settings/2fa/enroll");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_TwoFactorRequiredException_LockedOut_Returns401WithRetryAfter()
+    {
+        var exception = new TwoFactorRequiredException(
+            TwoFactorRequiredSubcode.LockedOut,
+            "Account locked due to excessive failed step-up attempts.",
+            retryAfterSeconds: 900);
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(401);
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("subcode").GetString().Should().Be("locked_out");
+        errorResponse.RootElement.GetProperty("retryAfterSeconds").GetInt32().Should().Be(900,
+            "the FE shows a retry-after toast with the wait duration");
+    }
+
     private static JsonDocument ParseErrorResponse(string responseBody)
     {
         return JsonDocument.Parse(responseBody);

--- a/audits/2026-05-26-s3-spike-cutover-readiness.md
+++ b/audits/2026-05-26-s3-spike-cutover-readiness.md
@@ -1,0 +1,286 @@
+# S3 Spike — Cutover Readiness + Existing 2FA Infrastructure Inventory
+
+**Date:** 2026-05-26
+**Branch:** `feature/sp5-admin-security-s3-strict-2fa`
+**Kickoff:** `audits/2026-05-26-s3-three-amigos-kickoff.md`
+**Plan:** `docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md`
+
+Output del Task 0 (read-only inventory + risk assessment) — informa T1-T9. Ha rivelato infrastruttura 2FA esistente molto più ricca del previsto: due decisioni del kickoff DRAFT vengono **semplificate** in conseguenza (vedi §6 "Amends al kickoff").
+
+---
+
+## §1 — Inventory dei 4 comandi decorati `[RequireTwoFactor]`
+
+Tutti i 4 comandi target di S3 sono già decorati `[RequireTwoFactor]` ma usano il DEFAULT `MaxAgeMinutes = 30`. Nessuno ha tuning esplicito.
+
+| Comando | File | `[RequireTwoFactor]` | `[AuditableAction]` | Audit name attuale |
+|---------|------|-----------------------|---------------------|--------------------|
+| `ChangeUserRoleCommand` | `BoundedContexts/Administration/Application/Commands/ChangeUserRoleCommand.cs:17` | default (30min) | Level 1 | `UserRoleChange` |
+| `DeleteUserCommand` | `BoundedContexts/Administration/Application/Commands/DeleteUserCommand.cs:20` | default (30min) | Level 2 | `UserDelete` |
+| `SuspendUserCommand` | `BoundedContexts/Administration/Application/Commands/SuspendUserCommand.cs:16` | default (30min) | Level 1 | `UserBlock` |
+| `ImpersonationStartCommand` | `BoundedContexts/Administration/Application/Commands/ImpersonationStartCommand.cs:44` | default (30min) **→ T1: 5min** | Level 2 | `ImpersonationStarted` |
+
+**Azione T1**: aggiorna `ImpersonationStartCommand` a `[RequireTwoFactor(MaxAgeMinutes = 5, Reason = "...")]` per D-S3-7.
+
+**Audit name S3 nuovi (per scenari S3-2/S3-4/S3-5)**:
+- `TwoFactorRequired` (block emesso quando strict path rifiuta)
+- `TwoFactorStepUp` (step-up esplicito, separato da `TwoFactorVerify` di login)
+- `TwoFactorStepUpLockout` (5° fail in 1min → lockout 15min, audit forensic)
+
+Il `TwoFactorVerify` audit row è già emesso da `TotpService.VerifyCodeAsync` (vedi §2) — coesiste con `TwoFactorStepUp` per distinguere login vs step-up.
+
+---
+
+## §2 — Sistema 2FA esistente (più maturo del previsto)
+
+### File mappati
+| Componente | Path | Funzione |
+|------------|------|----------|
+| `ITotpService` / `TotpService` | `apps/api/src/Api/Services/TotpService.cs` | Setup, Enable, Verify, Disable. RFC 6238 TOTP via `OtpNet`. |
+| `RequireTwoFactorAttribute` | `BoundedContexts/Authentication/Application/Attributes/` | Attribute MediatR (`MaxAgeMinutes`, `Reason`) |
+| `TwoFactorEnforcementBehavior` | `BoundedContexts/Authentication/Application/Behaviors/` | Pipeline behavior — shadow mode attuale, target del flip strict |
+| `TotpSecret` | `BoundedContexts/Authentication/Domain/ValueObjects/` | Value object encrypted secret |
+| `GenerateTotpSetupCommand` (+ Handler + Validator) | `Commands/TwoFactor/` | CQRS setup |
+| `Verify2FACommand`, `Enable2FACommand`, `Disable2FACommand`, `AdminDisable2FACommand` | `Commands/TwoFactor/` | CQRS verbs |
+| `Get2FAStatusQuery` | `Queries/` | Read status |
+| `TwoFactorEnabledEvent` / `TwoFactorDisabledEvent` (+ handlers) | `Domain/Events/`, `Application/EventHandlers/` | Domain events |
+| `UsedTotpCodeEntity` + cleanup task | `Infrastructure/Entities/Authentication/`, `BackgroundTasks/` | Replay-attack guard (60s window) |
+| `TwoFactorEndpoints.cs` | `Routing/` | REST API (vedi §3) |
+
+### `TotpService.VerifyCodeAsync(userId, code)` — overview funzionalità già implementate
+
+Letto in `apps/api/src/Api/Services/TotpService.cs:179-213`. **Riutilizzabile direttamente per lo step-up endpoint** — fornisce tutte le primitive necessarie:
+
+| Feature | Implementazione |
+|---------|-----------------|
+| Rate limit | Redis key `2fa:totp:{userId}`, 5 attempts / 5 min, via `_rateLimitService.CheckRateLimitAsync` |
+| Lockout | 15 min dopo 5 fail (Redis sliding window TTL) |
+| Replay-attack prevention | `UsedTotpCodes` table (SHA256 hash, 2 min expiry) — SEC-07 |
+| Audit row | `TwoFactorVerify` (Success/Failed) emesso via `_auditService.LogAsync` |
+| Security alerting | Alert critical a `_alertingService` su 10+ fail consecutivi |
+| Constant-time | 5ms minimum delay artificial — SEC-08 (Issue #2621) |
+| Metrics | `MeepleAiMetrics.Record2FAVerification("totp", success, userId, isReplayAttack)` |
+
+Il SignalR di S3-4b ("DB-backed rate-limit") era ridondante — vedi §6 amend del kickoff.
+
+### `IsTwoFactorEnabled = true` set in 2 punti
+
+1. `TotpService.EnableTwoFactorAsync` (riga 159) — dopo verifica TOTP del codice iniziale
+2. `User.cs:676` — metodo dominio (probabilmente `EnableTwoFactor()`)
+
+Nessun aggiornamento di un'analogo `LastTotpVerifiedAt` — è la nuova colonna che S3 deve aggiungere.
+
+---
+
+## §3 — Endpoint 2FA esistenti
+
+| Endpoint | Handler | Funzione | Riuso S3? |
+|----------|---------|----------|-----------|
+| `POST /auth/2fa/setup` | `GenerateTotpSetupCommand` | Generate secret + QR + backup codes | NO (è enroll-init) |
+| `POST /auth/2fa/enable` | `Enable2FACommand` | Verify code → enable 2FA | NO (è enroll-finalize) |
+| `POST /auth/2fa/verify` | `Verify2FACommand` | **Login-time verify → CREATES new session** | NO (login flow, NON step-up) |
+| `POST /auth/2fa/disable` | `Disable2FACommand` | Disable 2FA con password + code | NO |
+| `GET /users/me/2fa/status` | `Get2FAStatusQuery` | Lettura status | NO |
+| `POST /auth/admin/2fa/disable` | `AdminDisable2FACommand` | Admin override per locked-out users | NO |
+
+**Lo step-up endpoint (T5) è NEW** — opera su sessione ESISTENTE, NON crea nuova session, aggiorna `LastTotpVerifiedAt`. Path proposto: `POST /api/v1/auth/2fa/step-up { code }`.
+
+**Implementation hint**: il handler di `StepUpTwoFactorCommand` può semplicemente:
+1. Resolvere current session da `HttpContext.Items["SessionStatusDto"]`
+2. Determinare l'ACTOR (vedi §5 impersonate semantics): `session.IsImpersonation ? session.ImpersonatedByUserId : session.UserId`
+3. Chiamare `_totpService.VerifyCodeAsync(actorId, code, ct)` — riusa rate-limit, replay-guard, audit `TwoFactorVerify`, metrics
+4. Se `true`: aggiornare `session.LastTotpVerifiedAt = _timeProvider.GetUtcNow()` via `ISessionRepository`, emit audit `TwoFactorStepUp` (action specifico per scope step-up)
+5. Return `SessionStatusResponse` (riusa wire S2)
+
+Nessun rate-limit counter custom necessario — `TotpService.ValidateTotpRateLimitAndLockoutAsync` già copre il caso.
+
+---
+
+## §4 — Admin senza 2FA (pre-cutover sweep)
+
+### Query SQL proposta
+```sql
+SELECT id, email, role, created_at, is_two_factor_enabled
+FROM users
+WHERE role IN ('admin', 'superadmin')
+  AND is_two_factor_enabled = false
+  AND is_deleted = false
+ORDER BY created_at ASC;
+```
+
+### Endpoint `GET /admin/users/no-2fa` (T6)
+
+Wrapper CQRS via `GetAdminsWithoutTwoFactorQuery` + handler. Superadmin-only. Output = `IReadOnlyList<AdminWithoutTwoFactorDto>` (id, email, role, createdAt, lastLogin?).
+
+### Ops sequence pre-flip prod (D-S3-5)
+1. Chiamata `GET /admin/users/no-2fa` → conta + lista nominativa
+2. Email/Slack diretto agli admin: "abilita 2FA entro T per evitare lockout"
+3. Re-conta finché count == 0
+4. Flip `TwoFactorStrictMode = true` in staging, dogfooding 24h
+5. Flip in prod
+6. Monitor: `MeepleAiMetrics.Record2FAVerification` + audit `TwoFactorRequired` (block count) — picco atteso a 0 post-sweep; ogni `TwoFactorRequired` row post-flip = bug ops (admin nuovo senza 2FA) o tentativo malizioso (utente non-admin con [RequireTwoFactor] command — non dovrebbe esistere ma è un canary)
+
+---
+
+## §5 — Impersonate context semantics (interazione con S2)
+
+**Decisione architetturale chiave (NEW finding)**: durante impersonate, la TOTP recency deve essere quella dell'**actor** (admin), NON del subject (target).
+
+### Razionale
+- Bob (target) può non avere 2FA enabled affatto
+- Bob può non aver mai fatto un TOTP verify
+- L'azione "danger-zone" è di alice (l'admin), non di bob (l'identità "borrowed")
+- Industry pattern (Okta, Salesforce): step-up verifica le credenziali del REAL actor
+
+### Implementazione
+S2 ha creato `UserSessionEntity` con `ImpersonatedByUserId` (alice) e `UserId` (bob). L'impersonate session è una NUOVA row in `user_sessions`. Quando S3 aggiunge `last_totp_verified_at` come colonna sulla session:
+
+**Strategy**: l'impersonate session **eredita** il `LastTotpVerifiedAt` dell'actor al momento della creazione.
+
+```csharp
+// In ImpersonationStartCommandHandler (T1 modify)
+var actorSession = await _sessionRepository.GetCurrentActorSessionAsync(...);
+var newSession = new UserSessionEntity {
+    UserId = target.Id,
+    ImpersonatedByUserId = requester.Id,
+    ImpersonatedUntil = ...,
+    LastTotpVerifiedAt = actorSession?.LastTotpVerifiedAt,  // NEW — inherit
+    ...
+};
+```
+
+Poiché `ImpersonationStartCommand` stesso è `[RequireTwoFactor(MaxAgeMinutes = 5)]` (D-S3-7), alice DEVE aver appena fatto step-up — il valore ereditato è fresco per definizione (≤5min).
+
+### Step-up DURANTE impersonate
+Quando alice (impersonando bob) fa `POST /auth/2fa/step-up`:
+- Verifica TOTP code contro `requester.Id` (alice), non `session.UserId` (bob)
+- Aggiorna `session.LastTotpVerifiedAt = now` sulla CURRENT impersonate session (non sulla session originale di alice)
+- Audit `TwoFactorStepUp`: `user_id = bob` (subject), `impersonated_user_id = alice` (actor) — convenzione S2
+
+### Step-up impatta solo la CURRENT session
+Aggiornare `LastTotpVerifiedAt` sull'impersonate session NON aggiorna anche la session originale di alice (sono 2 row separate). Se alice termina l'impersonate, la sua session originale ha un `LastTotpVerifiedAt` separato. Acceptable — alice può fare un altro step-up se necessario sulla session normale.
+
+---
+
+## §6 — Amends al kickoff post-T0
+
+### D-S3-4b — semplificato (Redis rate-limit, no nuovo DB counter)
+
+**ORIGINALE**: "DB-backed counter via tabella `step_up_attempts`, lockout 15min" — proposta del kickoff DRAFT.
+
+**REVISED**: riusa direttamente `TotpService.VerifyCodeAsync` che ha GIÀ:
+- Rate-limit Redis 5/5min per `2fa:totp:{userId}` key
+- Lockout 15min via sliding window TTL
+- Replay-attack guard via `UsedTotpCodes`
+- Audit `TwoFactorVerify`
+- Security alerting a 10+ fail
+- Metrics
+
+**Conseguenze**:
+- T5 step (DB migration `step_up_attempts`) → RIMOSSO. No nuova tabella.
+- T5 handler diventa: ~30 LOC wrapper su `_totpService.VerifyCodeAsync` + `_sessionRepository.UpdateLastTotpVerifiedAtAsync`
+- File `TwoFactorStepUpRateLimiter.cs` → NON CREARE (era nel plan "File Structure")
+
+### D-S3-3 — confermato
+`last_totp_verified_at` nullable timestamptz su `user_sessions`. No nuovi indici.
+
+### Inheritance dell'`actor.LastTotpVerifiedAt` in `ImpersonationStartCommand` (NEW finding §5)
+
+**NEW step in T1**: `ImpersonationStartCommandHandler` (modificato in S2) deve ora anche **copiare l'attuale `LastTotpVerifiedAt` dell'actor** nella session impersonate appena creata. Questo è strettamente legato a S3 (la colonna `last_totp_verified_at` non esiste ancora pre-T1), quindi `T1` deve:
+1. Aggiungere migration (LastTotpVerifiedAt column)
+2. Modificare `UserSessionEntity` + `Session` domain + `SessionRepository` per hydrate
+3. **NEW**: Modificare `CreateSessionCommand` + handler per accettare `LastTotpVerifiedAt = null` (caller può passarlo per impersonation)
+4. **NEW**: Modificare `ImpersonationStartCommandHandler` per copiare il valore dall'actor session
+
+### Behavior strict path — actor-aware reading
+
+`TwoFactorEnforcementBehavior` strict path: NON leggere `session.Principal.Subject.LastTotpVerifiedAt` ma `session.LastTotpVerifiedAt` direttamente dal `UserSessionEntity` o (più semplice) **passare il `LastTotpVerifiedAt` nel SessionStatusDto** — la colonna è sulla session, è semantica "session attribute", non "user attribute".
+
+Aggiungi `LastTotpVerifiedAt: DateTime?` al `SessionStatusDto` (mirror del pattern S2 `SessionId`). Il behavior legge `sessionStatus.LastTotpVerifiedAt`.
+
+---
+
+## §7 — Risk matrix (Nygard) — failure modes documentati
+
+| # | Failure mode | Probabilità | Impatto | Mitigation |
+|---|-------------|-------------|---------|------------|
+| F1 | TOTP secret DB unavailable | Bassa | Step-up endpoint ritorna 503; strict path con `LastTotpVerifiedAt` esistente still works fino a expiry | Documentato. No mitigation aggiuntiva. |
+| F2 | Redis rate-limit unreachable | Media (Redis storia di flake) | `_rateLimitService.CheckRateLimitAsync` failure mode dipende dall'impl — verificare se fail-open o fail-closed | T5 verificare fail-open assunto; se fail-closed, aggiungere fallback locale |
+| F3 | Flag toggle race (admin flippa mid-request) | Bassa | Lettura non-cached → la request successiva legge il nuovo valore. Race minimo. | Documentato. Acceptable. |
+| F4 | Esistenti sessioni con `LastTotpVerifiedAt=null` post-deploy | **CERTA** (è l'effetto voluto post-sweep) | Tutti gli admin DEVONO step-up al primo comando `[RequireTwoFactor]` | Default=OFF deploy + ops sweep + dogfood staging |
+| F5 | Admin disabilita 2FA per se stesso → invoca command decorato | Bassa | `IsTwoFactorEnabled=false` → 401 `enroll_required` | By design. Re-enroll è il fix. |
+| F6 | TOTP code valido ma session expired tra verify e LastTotpVerifiedAt update | Estremamente bassa | Race: il code è single-use (UsedTotpCodes); se la session expire l'update non avviene → user dovrà re-step-up con un nuovo code | Documentato. Frequenza << 1/year. |
+| F7 | Step-up DURING impersonate quando l'impersonate session è già expired (S2 D-S2-4 auto-end) | Bassa | Middleware auto-end emette 401 prima che lo step-up reach l'handler | S2 semantica già copre. |
+
+---
+
+## §8 — FE 401 handler audit (T7 wire format spec)
+
+Trovati 8 handler 401 in `apps/web/src/lib/api/core/httpClient.ts` + `errors.ts` + `i18n/errors.ts`. Tutti gestiscono 401 genericamente (probabilmente redirect-to-login).
+
+**Migration richiesta nel FE** (OUT OF SCOPE S3, ma da documentare in `docs/api/2fa-step-up-protocol.md`):
+
+```ts
+// PRIMA (oggi):
+if (response.status === 401) {
+  router.push('/login');
+  return;
+}
+
+// DOPO (post-S3 deploy strict):
+if (response.status === 401) {
+  const body = await response.json();
+  if (body?.error === 'two_factor_required') {
+    switch (body.subcode) {
+      case 'step_up_required':
+        openTwoFactorStepUpModal({ retryUrl: request.url });
+        return;
+      case 'enroll_required':
+        router.push('/settings/2fa/enroll?reason=admin_action');
+        return;
+      case 'locked_out':
+        toast.error(`Locked out. Retry after ${body.retryAfterSeconds}s.`);
+        return;
+    }
+  }
+  router.push('/login');  // fallback per 401 generici
+}
+```
+
+**Compat path**: il default=OFF del config flag in deploy iniziale significa zero rilascio di 401 con `subcode` finché ops non flippano in staging. Il FE handler attuale (redirect-to-login) continua a funzionare senza modifiche **per tutti i casi shadow**. Quando il flag flippa in staging, i 401 con `subcode` partono — il FE dovrà avere il refactor pronto in quel momento. Tracking: plan FE separato post-merge S3.
+
+---
+
+## §9 — File da creare/modificare (revised after T0)
+
+Update vs il plan original:
+
+**Da rimuovere** (semplificazione D-S3-4b):
+- ❌ `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/RateLimit/TwoFactorStepUpRateLimiter.cs`
+- ❌ `apps/api/src/Api/Infrastructure/Entities/Authentication/TwoFactorStepUpAttemptEntity.cs`
+- ❌ Migration `step_up_attempts` table
+
+**Da aggiungere** (NEW finding §5):
+- ✅ Modify `CreateSessionCommand` — accept `LastTotpVerifiedAt? : DateTime?`
+- ✅ Modify `ImpersonationStartCommandHandler` — pass actor's `LastTotpVerifiedAt` to `CreateSessionCommand` (T1 extra step)
+- ✅ Modify `SessionStatusDto` — add `LastTotpVerifiedAt? : DateTime?` (mirror S2 `SessionId` pattern)
+
+Resto del plan invariato.
+
+---
+
+## §10 — Conclusioni T0
+
+✅ **Cutover readiness CONFIRMED**: infrastruttura 2FA matura, riusabile per step-up. Schema migration trivial (1 colonna nullable). Risk matrix accettabile con default=OFF deploy strategy.
+
+✅ **2 semplificazioni vs draft kickoff**:
+1. D-S3-4b → riusa Redis rate-limit di `TotpService` (no nuovo DB counter)
+2. Impersonate context → step inheritance + actor-aware behavior reading (chiarito)
+
+✅ **1 nuovo step in T1**: copia di `LastTotpVerifiedAt` dell'actor nella impersonate session creata.
+
+✅ **Pronto a procedere con T1** (migration + Session domain + extra step impersonate inheritance).
+
+---
+
+*Spike completata 2026-05-26. Amend del kickoff riflessi nel commit di T0. T1 può iniziare dopo signoff utente.*

--- a/audits/2026-05-26-s3-three-amigos-kickoff.md
+++ b/audits/2026-05-26-s3-three-amigos-kickoff.md
@@ -1,7 +1,8 @@
 # S3 Three-Amigos Kickoff — Strict 2FA Enforcement Cutover
 
 **Date:** 2026-05-26
-**Status:** decisions converged (post-critique revision)
+**Status:** decisions converged (post-critique revision) + **T0 spike amends** (2026-05-26b)
+**T0 spike:** [`audits/2026-05-26-s3-spike-cutover-readiness.md`](2026-05-26-s3-spike-cutover-readiness.md) — autoritativo per: (1) semplificazione D-S3-4b (riusa Redis rate-limit di `TotpService.VerifyCodeAsync`); (2) impersonate context (inherit actor's `LastTotpVerifiedAt` in T1); (3) actor-aware reading nel behavior (legge `sessionStatus.LastTotpVerifiedAt`)
 **Plan di riferimento:** `docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md`
 **Predecessor:** S2 (`audits/2026-05-25-s2-three-amigos-kickoff.md`) — MERGED in `main-dev` as PR #1555 / commit `7ca5b5151`.
 **Issue:** Q2 2026 Security Review #186 P1.1 — 2FA admin enforcement.

--- a/audits/2026-05-26-s3-three-amigos-kickoff.md
+++ b/audits/2026-05-26-s3-three-amigos-kickoff.md
@@ -1,0 +1,231 @@
+# S3 Three-Amigos Kickoff — Strict 2FA Enforcement Cutover
+
+**Date:** 2026-05-26
+**Status:** decisions converged (post-critique revision)
+**Plan di riferimento:** `docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md`
+**Predecessor:** S2 (`audits/2026-05-25-s2-three-amigos-kickoff.md`) — MERGED in `main-dev` as PR #1555 / commit `7ca5b5151`.
+**Issue:** Q2 2026 Security Review #186 P1.1 — 2FA admin enforcement.
+
+Facilitato come spec-panel three-amigos kickoff (Gregory facilitator; Fowler BE-proxy; Crispin+Adzic QE-proxy; Nygard Sec/Ops-proxy; Wiegers PM-proxy; Newman API-proxy; Hightower Ops-proxy; Cockburn UC-proxy). Output classico: domande risolte, scenari executable, ownership matrix, DoD. **Draft iniziale revisionato in critique-mode** (vedi sezione "Critique findings applicate") — 3 critical + 3 major fix incorporati prima della persistenza.
+
+---
+
+## Contesto da S2 (già live)
+
+- `TwoFactorEnforcementBehavior` esiste in shadow mode (`apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs`). Quando un comando decorato `[RequireTwoFactor]` viene eseguito:
+  - 2FA off su user → `LogWarning` + proceed
+  - 2FA on → `LogInformation` + proceed (NESSUN check di recency — `LastTotpVerifiedAt` non esiste ancora)
+- 4 comandi attualmente decorati:
+  - `ChangeUserRoleCommand` (default MaxAge 30min)
+  - `DeleteUserCommand` (default 30min)
+  - `SuspendUserCommand` (default 30min)
+  - `ImpersonationStartCommand` (S2; default 30min — review propone 5min, vedi D-S3-7)
+- `ExtractImpersonationActorId` in `AuditLoggingBehavior` (S2) wira l'actor durante impersonate — riusabile per attribution del `TwoFactorStepUp` audit.
+- Wire format S2 `SessionStatusResponse` con backward-compat `user` field — riusabile per la response del step-up endpoint.
+
+---
+
+## Decisioni convergenti (7)
+
+### D-S3-1 — Strategia di cutover (config-flag, default OFF)
+
+**Decisione:** `SystemConfiguration.TwoFactorStrictMode` (boolean, DB-persisted, admin toggle in `/admin/config`). **Default `false` al merge** — il behavior continua a girare in shadow finché ops non flip. Flippato prima in staging per validazione, poi in prod. Removal del flag = follow-up dopo 1 sprint di prod-stable.
+
+**Razionale (Nygard + Hightower):** alla deploy ogni sessione admin esistente ha `LastTotpVerifiedAt=null`. Se default=ON, strict immediato = mass-lockout di TUTTI gli admin contemporaneamente. Default=OFF separa "code merge" da "behavior change", consentendo ops di:
+1. Sweep pre-flip (D-S3-5) per garantire 100% admin con 2FA enrolled
+2. Flip in staging, dogfooding 24h
+3. Flip in prod con rollback istantaneo via admin toggle se emerge regression
+
+Flag-read non-cached (per-command pipeline): un toggle prende effetto sulla request successiva, no Redis cache warmup.
+
+### D-S3-2 — HTTP status code e wire format
+
+**Decisione:** `401 Unauthorized` + body `{ error: "two_factor_required", subcode: "step_up_required" | "enroll_required" | "locked_out" }` + header `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"`.
+
+**Razionale (Newman):** 401 conflate semanticamente con session-invalid ma riusa l'infrastruttura 401 esistente. Il `subcode` permette al FE di distinguere — su `step_up_required` apre la modale TOTP, NON redirect a `/login`. Il `WWW-Authenticate` header rispetta RFC 7235 e permette ai client API non-browser di disambiguare programmaticamente.
+
+**Wire format spec**: `docs/api/2fa-step-up-protocol.md` — handoff esplicito per il team FE (separato plan FE post-cutover).
+
+### D-S3-3 — Schema `LastTotpVerifiedAt`
+
+**Decisione:** colonna `last_totp_verified_at` (timestamptz nullable) su `user_sessions`. No index (read-by-PK è sufficiente — la sessione corrente è già caricata via token hash).
+
+**Razionale (Fowler):** TOTP recency è per-sessione (un device verificato non implica gli altri). Migration tipo S2 (additive, nullable). `SessionRepository.MapToDomain` + `MapToPersistence` aggiornati per hydrate del campo.
+
+### D-S3-4 — Step-up endpoint
+
+**Decisione:** `POST /api/v1/auth/2fa/step-up { code: "123456" }` → 200 con `SessionStatusResponse` (riusa wire S2, ora con `lastTotpVerifiedAt` rinfrescato) | 401 (codice errato) | 503 (TOTP store down).
+
+**Razionale (Newman):** endpoint dedicato auth-prefix, separato da `/auth/2fa/enroll` (esistente). Body minimale `{ code }`; la sessione corrente identifica subject+actor.
+
+### D-S3-4b — Rate-limit step-up (DB-backed)
+
+**Decisione:** 5 attempt/min per session via counter DB-backed (analogo al pattern `BggRateLimitMiddleware`). Dopo 5 fail consecutivi → lockout 15min (audit `TwoFactorStepUpLockout`).
+
+**Razionale (Nygard):** in-memory counter non funziona su API multi-istanza (3 pod = 15/min reale). DB counter è authoritative cross-instance.
+
+### D-S3-5 — Policy admin senza 2FA enrolled (hard block)
+
+**Decisione:** `enroll_required` 401, no mutation. Pre-req ops: sweep + email forzato a admin senza 2FA prima del flip in prod. **NEW endpoint admin** `GET /admin/users/no-2fa` per il sweep (superadmin-only, returns lista admin/superadmin con `IsTwoFactorEnabled=false`).
+
+**Razionale (Wiegers):** Hard block è coerente con il principio "no halfway secure". Il pre-cutover sweep è SMART (lista enumerable, target 0 admin senza 2FA prima del flip prod).
+
+### D-S3-6 — Audit attribution
+
+**Decisione:** ogni step-up emette audit `TwoFactorStepUp` (action="verify"), ogni rigetto strict emette `TwoFactorRequired` (action="block"). Entrambi best-effort (S1 default — non distruttivi). Durante impersonate, l'attribution segue la convenzione S2: `user_id` = subject, `impersonated_user_id` = actor (l'admin che esegue lo step-up).
+
+**Razionale (Adzic + Crispin):** lo step-up DURANTE impersonate è un'azione DELL'ADMIN REALE (alice impersonando bob fa step-up → è alice che verifica il suo TOTP, bob non c'entra). `ExtractImpersonationActorId` (S2) già wira correttamente.
+
+### D-S3-7 — Per-command MaxAge tuning
+
+**Decisione:** decorazione esplicita per comando:
+- `ImpersonationStartCommand` → `[RequireTwoFactor(MaxAgeMinutes = 5)]` (HIGH RISK — sessione completa target user)
+- `DeleteUserCommand`/`ChangeUserRoleCommand`/`SuspendUserCommand` → default 30min
+
+**Razionale (Wiegers):** la default uniforme 30min non riflette il risk profile. `ImpersonationStart` concede pieno accesso a un altro account — fresh challenge 5min è industry-standard (Salesforce, Okta).
+
+---
+
+## Critique findings applicate (3 critical + 3 major)
+
+| # | Critique | Expert | Applied to |
+|---|----------|--------|-----------|
+| C1 | Mass-lockout risk al cutover (default=ON) | Nygard + Hightower | D-S3-1 → default=OFF |
+| C2 | Per-command MaxAge tuning mancante | Wiegers | D-S3-7 (new) |
+| C3 | Distributed rate-limit (in-memory non basta) | Nygard | D-S3-4b (new) |
+| M1 | FE migration path su `subcode` non documentato | Newman | D-S3-2 + wire format spec |
+| M2 | Regression scenario per non-decorated commands | Crispin | S3-7 (new) |
+| M3 | Step-up failure modes (503 TOTP store down) | Nygard | D-S3-4 |
+
+---
+
+## Acceptance scenarios (8 — gate DoD)
+
+File target: `apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs`.
+
+### S3-1 — Happy path
+```
+Given admin "alice@admin.test" with 2FA enabled, LastTotpVerifiedAt = now - 5min
+  And TwoFactorStrictMode = true
+When alice POSTs /admin/users/bob/delete
+Then response 200, bob soft-deleted
+  And audit_outbox has "UserDelete" row (user_id=alice)
+```
+
+### S3-2 — Stale TOTP (default MaxAge 30min)
+```
+Given admin alice with 2FA enabled, LastTotpVerifiedAt = now - 45min
+  And TwoFactorStrictMode = true
+When alice POSTs /admin/users/bob/delete
+Then response 401 with body { error: "two_factor_required", subcode: "step_up_required" }
+  And header WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"
+  And bob is NOT deleted
+  And audit_outbox has "TwoFactorRequired" row (user_id=alice, resource="DeleteUser")
+```
+
+### S3-3 — Not enrolled
+```
+Given admin alice with IsTwoFactorEnabled=false
+  And TwoFactorStrictMode = true
+When alice POSTs /admin/users/bob/change-role
+Then response 401 { error: "two_factor_required", subcode: "enroll_required" }
+  And no mutation
+```
+
+### S3-4 — Step-up + retry
+```
+Given Scenario S3-2 state (401 step_up_required)
+When alice POSTs /auth/2fa/step-up { code: <valid TOTP> }
+Then response 200 with SessionStatusResponse (lastTotpVerifiedAt = now)
+  And audit_outbox has "TwoFactorStepUp" row (user_id=alice)
+When alice re-POSTs /admin/users/bob/delete
+Then response 200, bob deleted
+  And audit_outbox has "UserDelete" row
+```
+
+### S3-5 — Throttle + lockout
+```
+Given admin alice with 5 failed step-up attempts in last 60s
+When alice POSTs /auth/2fa/step-up { code: any }
+Then response 429 with body { error: "two_factor_required", subcode: "locked_out", retryAfterSeconds: 900 }
+  And audit_outbox has "TwoFactorStepUpLockout" row (user_id=alice, forensic detail)
+```
+
+### S3-6 — Impersonation context
+```
+Given superadmin alice is impersonating bob (S2 active session)
+  And alice's LastTotpVerifiedAt = now - 10min (STALE for ImpersonationStart per D-S3-7, but FRESH for DeleteUser default 30min)
+  And TwoFactorStrictMode = true
+When the impersonate-session executes DeleteUserCommand(carol)
+Then response 200, carol deleted
+  And audit_outbox: user_id=bob, impersonated_user_id=alice
+  // alice's 10min recency satisfies DeleteUser MaxAge=30min
+```
+
+### S3-7 — Non-decorated command (regression guard)
+```
+Given any user invoking CreateGameCommand (NOT [RequireTwoFactor])
+  And TwoFactorStrictMode = true
+  And user with 2FA disabled / no LastTotpVerifiedAt
+When user POSTs /games
+Then response 200 (created)
+  // Behavior MUST short-circuit on missing attribute; no false positives
+```
+
+### S3-8 — Per-command MaxAge differentiation
+```
+Given admin alice with LastTotpVerifiedAt = now - 6min
+  And TwoFactorStrictMode = true
+When alice POSTs /admin/impersonation/start (MaxAgeMinutes = 5 per D-S3-7)
+Then response 401 step_up_required (6min > 5min)
+When alice POSTs /admin/users/X/delete (MaxAgeMinutes = 30 default)
+Then response 200 (6min ≤ 30min)
+```
+
+---
+
+## Ownership Matrix
+
+| Area | Owner | Notes |
+|------|-------|-------|
+| Migration `last_totp_verified_at` + `UserSessionEntity` + Session domain | BE | Pattern S2 |
+| `TwoFactorEnforcementBehavior` strict path + flag read | BE | Throw `TwoFactorRequiredException` |
+| `TwoFactorRequiredException` + ExceptionFilter mapping → 401 + body + header | BE | New domain exception in SharedKernel.Domain.Exceptions |
+| `POST /auth/2fa/step-up` endpoint + rate-limit (DB counter) | BE | IMediator.Send only (CQRS) |
+| `GET /admin/users/no-2fa` ops sweep endpoint | BE | Superadmin filter |
+| `SystemConfiguration.TwoFactorStrictMode` flag | BE | Pattern `RegistrationMode` |
+| Wire format doc `docs/api/2fa-step-up-protocol.md` | BE + FE handoff | Specifica `subcode` + header + retry semantics |
+| 8 acceptance scenarios + unit tests | QE | Lezione S2: **pipeline reale obbligatoria** ([[feedback_acceptance_tests_must_exercise_real_pipeline]]) |
+| Pre-cutover sweep ops (email admin senza 2FA) | Ops | Usa `GET /admin/users/no-2fa` |
+| FE step-up modal + 401 handler refactor | FE | OUT OF SCOPE S3 — plan FE separato; wire ready in D-S3-2 |
+
+---
+
+## Definition of Done (10 criteri)
+
+| # | Criterio | Verifica |
+|---|----------|----------|
+| 1 | Migration `last_totp_verified_at` applica clean | `dotnet ef database update --dry-run` ok + Migration Safety Gate CI verde |
+| 2 | Strict behavior throw `TwoFactorRequiredException` dietro flag `TwoFactorStrictMode` | Scenari S3-1..3 PASS |
+| 3 | ExceptionFilter → 401 + body + header `WWW-Authenticate` | 1 unit test su filter mapping |
+| 4 | `POST /auth/2fa/step-up` con rate-limit DB-backed (5/min, lockout 15min) | Scenari S3-4 + S3-5 |
+| 5 | 4 comandi decorati + ImpersonationStart con MaxAge=5min | Scenario S3-8 |
+| 6 | Audit `TwoFactorRequired` + `TwoFactorStepUp` + `TwoFactorStepUpLockout` via outbox | Scenari S3-2/S3-4/S3-5 |
+| 7 | Admin endpoint `GET /admin/users/no-2fa` per ops sweep | Integration test + superadmin gate |
+| 8 | Acceptance tests via pipeline reale (no fixture diretto di `SessionStatusDto`) | `S3AcceptanceScenariosTests` traversa `ValidateSessionQueryHandler` + behavior |
+| 9 | Wire format `docs/api/2fa-step-up-protocol.md` published | PR include il doc |
+| 10 | Regression scenario S3-7 (non-decorated commands) | PASS — behavior short-circuit su attr null |
+
+---
+
+## Open follow-ups (non bloccanti per S3)
+
+- **FE step-up modal** + 401 `subcode` handler refactor (plan FE separato; wire format ready in D-S3-2)
+- **WebAuthn / passkeys** (#186 P1.2, epic separato)
+- **Recovery codes / backup factors** (Q2 §11 D5)
+- **Auto-enrollment forzato** (ops task; il blocker S3 è il SWEEP, l'enroll automatico è enhancement)
+- **Removal del flag `TwoFactorStrictMode`** dopo 1 sprint di prod-stable
+
+---
+
+*Questo documento è il riferimento autoritativo per la DoD di S3. Citarlo dai commit messages dei task e dal merge finale. Cita anche il three-amigos S2 per il pattern dual-principal e [[feedback_acceptance_tests_must_exercise_real_pipeline]] per il pattern di testing.*

--- a/audits/2026-05-26-s3-three-amigos-kickoff.md
+++ b/audits/2026-05-26-s3-three-amigos-kickoff.md
@@ -229,4 +229,29 @@ Then response 200 (6min ≤ 30min)
 
 ---
 
+## DoD verification log
+
+**Date:** 2026-05-26 (T9 sign-off)
+**Branch:** `feature/sp5-admin-security-s3-strict-2fa` @ `b5df523cf`
+**Predecessor:** S2 PR #1555 / `7ca5b5151` su `main-dev` (MERGED)
+
+Tutti i 10 criteri verificati su `b5df523cf` (working tree pulito, `dotnet build` exit 0).
+
+| # | Criterio | Stato | Evidenza |
+|---|----------|-------|----------|
+| 1 | Migration `last_totp_verified_at` applica clean | ✅ | `apps/api/src/Api/Infrastructure/Migrations/20260526124527_AddTwoFactorRecencyToUserSession.cs:14-18` — `AddColumn` timestamptz nullable, no index. Commit `6800273d9`. Schema exercise via Testcontainers in `GetActiveImpersonationsQueryIntegrationTests` (ApplyMigrationsAsync). |
+| 2 | Strict behavior throw `TwoFactorRequiredException` dietro flag `TwoFactorStrictMode` | ✅ | Flag wrapper: `TwoFactorEnforcementConfiguration.cs:18` (`"TwoFactor:StrictMode"`) + `:21` (`StrictModeDefault = false`) + `:55-68` (fail-closed read). Behavior strict path: `TwoFactorEnforcementBehavior.cs:102-137`. Commit `634712b34` (flag) + `64cdbccb3` (strict path). Unit: `TwoFactorEnforcementBehaviorStrictTests` 10/10 + flag tests 5/5. |
+| 3 | ExceptionFilter → 401 + body + header `WWW-Authenticate` | ✅ | `ApiExceptionHandlerMiddleware.cs:97` dispatcher → `:251` `HandleTwoFactorRequiredAsync` → `:266` setta `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"` + `:270` body `error = "two_factor_required"` + `subcode` (snake_case). 503 path `:287` `HandleTwoFactorUnavailableAsync` → `:304` body `error = "two_factor_unavailable"`. Commit `bd9cc5f96`. Unit: 3 mapping tests (StepUpRequired/EnrollRequired/LockedOut) + 1 503 test = **4/4** in `ApiExceptionHandlerMiddlewareTests`. |
+| 4 | `POST /api/v1/auth/2fa/step-up` con rate-limit DB-backed (5/min, lockout 15min) | ✅ | Endpoint: `TwoFactorEndpoints.cs:170-219` (Option B). Rate-limit/lockout: riusa Redis di `TotpService.VerifyCodeAsync`/`IsLockedOutAsync` (post-T0 spike — `TwoFactorStepUpAttemptEntity` CANCELED). Handler `StepUpTwoFactorCommandHandler.cs:52-95`. Commit `240f7c1b5` + Option B `399c98543`. Unit: handler `StepUpTwoFactorCommandHandlerTests` 12/12 (success/invalid/lockout/vanished-session/null/unavailable) — fresh test run via `dotnet test --filter "FullyQualifiedName~S3AcceptanceScenariosTests"` 2026-05-26 → S3-4 + S3-5 PASS in pipeline reale. |
+| 5 | 4 comandi decorati + ImpersonationStart con MaxAge=5min | ✅ | `DeleteUserCommand.cs:20` (`[RequireTwoFactor(Reason = "Irreversible…")]`, MaxAge default 30) + `ChangeUserRoleCommand.cs:17` (default 30) + `SuspendUserCommand.cs:16` (default 30) + `ImpersonationStartCommand.cs:47` (`[RequireTwoFactor(MaxAgeMinutes = 5, Reason = "Impersonate other user; HIGH RISK")]`). Differenziazione validata da S3-8 acceptance scenario. Commit `64cdbccb3`. |
+| 6 | Audit `TwoFactorRequired` + `TwoFactorStepUp` + `TwoFactorStepUpLockout` via outbox | ✅ | `TwoFactorRequired`: `TwoFactorEnforcementBehavior.cs:160-193` (fresh DI scope per atomicity con `[AtomicAudit]` rollback). `TwoFactorStepUp`: `StepUpTwoFactorCommandHandler.cs:111-118`. `TwoFactorStepUpLockout`: `StepUpTwoFactorCommandHandler.cs:74-81`. Best-effort (S1 default — non distruttivi). Attribution impersonate: `ExtractImpersonationActorId` (S2) wira `user_id=subject, impersonated_user_id=actor`. Acceptance S3-2/S3-4/S3-5 validano end-to-end. |
+| 7 | Admin endpoint `GET /admin/users/no-2fa` per ops sweep | ✅ | `AdminTwoFactorComplianceEndpoints.cs:22-39` — `RequireSuperAdminSession()` + `.RequireAuthorization("RequireSuperAdmin")`. Query handler `GetAdminsWithoutTwoFactorQuery` riusa `IUserRepository.GetAdminUsersAsync` (già scopato admin/superadmin) + filter `!IsTwoFactorEnabled`. Commit `215173bad`. Integration: `GetAdminsWithoutTwoFactorQueryIntegrationTests` 2/2 PASS (Testcontainers Postgres). |
+| 8 | Acceptance tests via pipeline reale (no fixture diretto di `SessionStatusDto`) | ✅ | `apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs` — 8/8 PASS, ~3m22s su Testcontainers Postgres + `WebApplicationFactory` + real HTTP + real `TotpService` + Redis-counter via `ConcurrentDictionary` (pattern da `TwoFactorSecurityPenetrationTests`). TOTP codes minted with `OtpNet` contro l'encrypted secret. Endpoints exercised: `POST /api/v1/admin/impersonation/start` (MaxAge=5), `DELETE /api/v1/admin/users/{id}` (default MaxAge=30), `POST /api/v1/auth/2fa/step-up`, `GET /api/v1/auth/me` (regression). [[feedback_acceptance_tests_must_exercise_real_pipeline]] applicato. Commit `b5df523cf`. |
+| 9 | Wire format `docs/api/2fa-step-up-protocol.md` published | ✅ | File presente (Option B as-built, post-spec-panel critique: Wiegers per-command MaxAge table, Newman/Nygard replay-guard + 5xx FE rule, Adzic curl example). Commit `249aee74a` (T7 draft) + Option B refactor `399c98543`. Cross-link a piano + audit (D-S3-2/4/4b/5). |
+| 10 | Regression scenario S3-7 (non-decorated commands) | ✅ | Short-circuit: `TwoFactorEnforcementBehavior.cs:72-76` (`if (attr is null) return await next()`). Acceptance scenario S3-7: `GET /api/v1/auth/me` in strict mode → 200 (no enforcement on commands missing `[RequireTwoFactor]`). PASS in T8 8/8 batch. |
+
+**Conclusion:** ✅ 10/10 criteri DoD soddisfatti. Branch ready per push + PR su `main-dev` (no `Closes #N` — pattern S2 deciso 2026-05-26, vedi `feedback_acceptance_tests_must_exercise_real_pipeline.md` per lesson applicata).
+
+---
+
 *Questo documento è il riferimento autoritativo per la DoD di S3. Citarlo dai commit messages dei task e dal merge finale. Cita anche il three-amigos S2 per il pattern dual-principal e [[feedback_acceptance_tests_must_exercise_real_pipeline]] per il pattern di testing.*

--- a/docs/api/2fa-step-up-protocol.md
+++ b/docs/api/2fa-step-up-protocol.md
@@ -1,0 +1,198 @@
+# 2FA Step-Up Protocol — Wire-Format Contract
+
+> **SP5 Admin Security S3** — handoff contract for the frontend. The backend ships behind the
+> `TwoFactorStrictMode` config flag (**default OFF at merge**); the FE work below is only exercised
+> once an environment flips the flag. Until then every endpoint here is reachable but the enforcement
+> 401 is never raised, so the current FE (which redirects to `/login` on any 401) keeps working.
+
+## 1. Purpose
+
+Strict 2FA enforcement gates four sensitive admin commands (`ChangeUserRole`, `DeleteUser`,
+`SuspendUser`, `ImpersonationStart`) on a **recent** TOTP verification, tracked per session via
+`LastTotpVerifiedAt`. Two HTTP surfaces make this work:
+
+| Flow | Trigger | Outcome |
+|------|---------|---------|
+| **A — Enforcement** | A `[RequireTwoFactor]` command is sent with stale/absent/disabled 2FA | `401` telling the FE *what* to do (`subcode`) |
+| **B — Step-up** | `POST /api/v1/auth/2fa/step-up` with a fresh TOTP code | `200` refreshes `LastTotpVerifiedAt`, unblocking Flow A |
+
+The FE loop: *call command → get Flow-A 401 → open the right UI → on `step_up_required`, POST step-up
+(Flow B) → on 200, retry the original command.*
+
+---
+
+## 2. Flow A — Enforcement rejection
+
+Raised by `TwoFactorEnforcementBehavior` and mapped by `ApiExceptionHandlerMiddleware`.
+
+**Status:** `401 Unauthorized`
+**Header:** `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"` — lets the FE distinguish a 2FA
+block from an ordinary session-expired 401 *without parsing the body*.
+
+**Body:**
+
+```json
+{
+  "error": "two_factor_required",
+  "subcode": "step_up_required",
+  "message": "Two-factor re-verification required for this action.",
+  "retryAfterSeconds": null,
+  "correlationId": "0HN...",
+  "timestamp": "2026-05-26T16:02:10.974Z"
+}
+```
+
+**Subcode → FE action:**
+
+| `subcode` | Meaning | FE action |
+|-----------|---------|-----------|
+| `step_up_required` | 2FA enabled, but last TOTP verification is stale/absent for this command's `MaxAgeMinutes` | Open the **step-up modal** → POST Flow B → retry original request |
+| `enroll_required` | The account has no 2FA at all (hard block, D-S3-5) | Route to the **2FA enrollment** flow |
+| `locked_out` | Too many failed step-up attempts | Show a **retry-after toast**; `retryAfterSeconds` carries the wait |
+
+`retryAfterSeconds` is non-null **only** for `locked_out`.
+
+**Staleness thresholds** — `step_up_required` fires when `now − LastTotpVerifiedAt` exceeds the
+command's `MaxAgeMinutes`:
+
+| Command | `MaxAgeMinutes` |
+|---------|-----------------|
+| `ImpersonationStart` | 5 (tighter — privileged escalation, D-S3-7) |
+| `ChangeUserRole`, `DeleteUser`, `SuspendUser` | 30 (default) |
+
+---
+
+## 3. Flow B — Step-up endpoint
+
+```
+POST /api/v1/auth/2fa/step-up
+```
+
+**Auth:** required — active session cookie (`RequireAuthorization`). The verified actor is the
+session's **EffectiveActor**: during an impersonation that is the *impersonating admin*, not the
+target user. The endpoint does **not** create a new session; it only refreshes the current one's
+`LastTotpVerifiedAt`.
+
+**Request body:**
+
+```json
+{ "code": "123456" }
+```
+
+`code` — the 6-digit TOTP from the authenticator app (or a backup code). Required, max 10 chars.
+
+> **Replay guard:** a TOTP code is single-use (used-code tracking inherited from `VerifyCodeAsync`).
+> The FE must submit the **current** code shown by the authenticator; re-submitting an
+> already-accepted code returns `401 two_factor_failed`. Do not auto-retry with the same code.
+
+**Responses:**
+
+| Status | Body | When |
+|--------|------|------|
+| `200 OK` | `{ "success": true, "lastTotpVerifiedAt": "2026-05-26T16:02:10.974Z" }` | Code valid → session recency refreshed (ISO-8601 UTC) |
+| `401 Unauthorized` | `{ "error": "two_factor_failed", "message": "Invalid or expired verification code." }` | Code invalid/expired, or the session vanished mid-request |
+| `429 Too Many Requests` | `{ "error": "two_factor_locked_out", "message": "Too many failed attempts. Try again later.", "retryAfterSeconds": 900 }` | Account is locked after repeated failures |
+
+**Example:**
+
+```bash
+curl -X POST https://api.meepleai.app/api/v1/auth/2fa/step-up \
+  -H "Content-Type: application/json" \
+  -b "session=<auth-cookie>" \
+  -d '{"code":"123456"}'
+
+# 200 → { "success": true, "lastTotpVerifiedAt": "2026-05-26T16:02:10.974Z" }
+# wrong/expired/reused code → 401 { "error": "two_factor_failed", "message": "Invalid or expired verification code." }
+# after 5 failures in 5 min → 429 { "error": "two_factor_locked_out", "retryAfterSeconds": 900 }
+```
+
+---
+
+## 4. Sequence (happy path)
+
+```
+FE                          API
+│  POST /admin/users/{id}/suspend
+├───────────────────────────────────►
+│  401 two_factor_required            │  TwoFactorEnforcementBehavior: stale TOTP
+│  subcode=step_up_required           │
+│◄───────────────────────────────────┤
+│  (open step-up modal, collect code) │
+│  POST /auth/2fa/step-up {code}      │
+├───────────────────────────────────►│  StepUpTwoFactorCommand → VerifyCodeAsync
+│  200 {success, lastTotpVerifiedAt}  │  refresh LastTotpVerifiedAt + audit TwoFactorStepUp
+│◄───────────────────────────────────┤
+│  POST /admin/users/{id}/suspend     │  (retry original)
+├───────────────────────────────────►│  recency now fresh → allowed
+│  200                                │
+│◄───────────────────────────────────┤
+```
+
+---
+
+## 5. Rate limiting & lockout
+
+Step-up verification **delegates to the existing `TotpService.VerifyCodeAsync`**, so it shares one
+source of truth with login-time `/auth/2fa/verify`:
+
+- **5 attempts / 5 minutes** (Redis token bucket), then **15-minute lockout**.
+- Constant-time comparison + replay-attack guard (used-code tracking) are inherited.
+- The step-up handler performs a read-only `IsLockedOutAsync` pre-check to return the distinct `429`
+  before consuming an attempt; `retryAfterSeconds` is a fixed client hint (900s) — the Redis key TTL
+  is the authoritative wait.
+
+---
+
+## 6. Audit events
+
+| Event | Emitted when | Attribution during impersonation |
+|-------|--------------|----------------------------------|
+| `TwoFactorRequired` | Flow A blocks a command | `user_id` = acting admin (EffectiveActor) |
+| `TwoFactorStepUp` | Flow B succeeds | `user_id` = EffectiveActor |
+| `TwoFactorStepUpLockout` | Flow B blocked by lockout | `user_id` = EffectiveActor |
+
+---
+
+## 7. Known gaps & future alignment
+
+> Documented honestly so the FE plans around the **current** behavior, not the original design intent.
+
+1. **Error-shape asymmetry between the two flows.** Flow A uses `error: "two_factor_required"` +
+   `subcode`; Flow B uses top-level `error: "two_factor_failed"` / `"two_factor_locked_out"` and
+   returns `429` (not `401`) for lockout. The FE must therefore handle two shapes. The original plan
+   (T7) envisaged Flow B reusing `two_factor_required` + `subcode`; the implementation diverged. See
+   §8 for the rationale and the open decision.
+2. **No `503` for TOTP-store-down.** The plan (D-S3-4) specified a `503 two_factor_unavailable` when
+   the secret store / Redis is unreachable. The current implementation lets that surface as a generic
+   `500`. Tracked as a follow-up. **FE rule:** treat any unexpected `5xx` as a generic, retryable
+   error (show an error toast) — **not** as a step-up or enroll signal; never loop the step-up modal
+   on a `5xx`.
+3. **Minimal 200 body.** Flow B returns `{ success, lastTotpVerifiedAt }`, not the full
+   `SessionStatusResponse` the plan mentioned. The FE only needs the timestamp to know the block is
+   cleared.
+
+## 8. Open decision (for review)
+
+Should Flow B be aligned to the enforcement vocabulary before the strict flip?
+
+- **Option A — keep as built:** distinct shapes are arguably honest (enforcement says *"you must
+  step up"*; step-up says *"your code was wrong"* — different semantics). Document both; FE handles two.
+- **Option B — unify:** Flow B returns `401 { error: "two_factor_required", subcode: "invalid_code" }`
+  and `429 { … subcode: "locked_out" }`, plus the `503`. One vocabulary, smaller FE surface, but a
+  code change to the already-merged-on-branch T5 endpoint.
+
+This document describes **Option A (as built)**. The decision is deferred to the T8 acceptance review.
+
+---
+
+## 9. Backward compatibility
+
+The FE currently redirects to `/login` on **any** 401. With `TwoFactorStrictMode=OFF` (merge default)
+Flow A never fires, so nothing changes. When an environment flips the flag *before* the FE step-up
+modal ships, blocked admins are bounced to login (a safe degrade, not a data risk) until the FE
+consumes the `WWW-Authenticate: TOTP-StepUp` header / `subcode`.
+
+---
+
+**References:** plan `docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md` ·
+decisions `audits/2026-05-26-s3-three-amigos-kickoff.md` (D-S3-2, D-S3-4, D-S3-4b, D-S3-5).

--- a/docs/api/2fa-step-up-protocol.md
+++ b/docs/api/2fa-step-up-protocol.md
@@ -9,7 +9,10 @@
 
 Strict 2FA enforcement gates four sensitive admin commands (`ChangeUserRole`, `DeleteUser`,
 `SuspendUser`, `ImpersonationStart`) on a **recent** TOTP verification, tracked per session via
-`LastTotpVerifiedAt`. Two HTTP surfaces make this work:
+`LastTotpVerifiedAt`. Two HTTP surfaces make this work, and they **share one error vocabulary** —
+the same `two_factor_required` + `subcode` body (with the same `WWW-Authenticate` header) is
+returned whether a command was blocked by the enforcement filter or the step-up attempt itself
+failed. The FE only has to learn one error shape.
 
 | Flow | Trigger | Outcome |
 |------|---------|---------|
@@ -44,11 +47,12 @@ block from an ordinary session-expired 401 *without parsing the body*.
 
 **Subcode → FE action:**
 
-| `subcode` | Meaning | FE action |
-|-----------|---------|-----------|
-| `step_up_required` | 2FA enabled, but last TOTP verification is stale/absent for this command's `MaxAgeMinutes` | Open the **step-up modal** → POST Flow B → retry original request |
-| `enroll_required` | The account has no 2FA at all (hard block, D-S3-5) | Route to the **2FA enrollment** flow |
-| `locked_out` | Too many failed step-up attempts | Show a **retry-after toast**; `retryAfterSeconds` carries the wait |
+| `subcode` | Emitted by | Meaning | FE action |
+|-----------|-----------|---------|-----------|
+| `step_up_required` | Flow A | 2FA enabled, but last TOTP verification is stale/absent for this command's `MaxAgeMinutes` | Open the **step-up modal** → POST Flow B → retry original request |
+| `enroll_required` | Flow A | The account has no 2FA at all (hard block, D-S3-5) | Route to the **2FA enrollment** flow |
+| `locked_out` | Flow A *or* Flow B | Too many failed step-up attempts | Show a **retry-after toast**; `retryAfterSeconds` carries the wait |
+| `invalid_code` | Flow B only | The submitted TOTP/backup code was invalid, expired, or already used | Show an inline "wrong code" error in the step-up modal; let the user retry with a fresh code |
 
 `retryAfterSeconds` is non-null **only** for `locked_out`.
 
@@ -83,15 +87,19 @@ target user. The endpoint does **not** create a new session; it only refreshes t
 
 > **Replay guard:** a TOTP code is single-use (used-code tracking inherited from `VerifyCodeAsync`).
 > The FE must submit the **current** code shown by the authenticator; re-submitting an
-> already-accepted code returns `401 two_factor_failed`. Do not auto-retry with the same code.
+> already-accepted code returns `401 two_factor_required` / `subcode: invalid_code`. Do not
+> auto-retry with the same code.
 
 **Responses:**
 
 | Status | Body | When |
 |--------|------|------|
 | `200 OK` | `{ "success": true, "lastTotpVerifiedAt": "2026-05-26T16:02:10.974Z" }` | Code valid → session recency refreshed (ISO-8601 UTC) |
-| `401 Unauthorized` | `{ "error": "two_factor_failed", "message": "Invalid or expired verification code." }` | Code invalid/expired, or the session vanished mid-request |
-| `429 Too Many Requests` | `{ "error": "two_factor_locked_out", "message": "Too many failed attempts. Try again later.", "retryAfterSeconds": 900 }` | Account is locked after repeated failures |
+| `401 Unauthorized` | `{ "error": "two_factor_required", "subcode": "invalid_code", "message": "Invalid or expired verification code.", "retryAfterSeconds": null, "correlationId": "…", "timestamp": "…" }` + header `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"` | Code invalid/expired/reused, or the session vanished mid-request |
+| `401 Unauthorized` | Same shape with `"subcode": "locked_out"` and `"retryAfterSeconds": 900` + same header | After 5 failed attempts in 5 min — 15-min lockout |
+| `503 Service Unavailable` | `{ "error": "two_factor_unavailable", "message": "Two-factor service is temporarily unavailable. Please try again.", "correlationId": "…", "timestamp": "…" }` | TOTP store / rate-limit backend (Redis or encrypted-secret store) is unreachable. Retryable. |
+
+> Both 401 shapes are identical to a Flow-A 401 — the FE's existing 2FA error handler covers them.
 
 **Example:**
 
@@ -102,8 +110,9 @@ curl -X POST https://api.meepleai.app/api/v1/auth/2fa/step-up \
   -d '{"code":"123456"}'
 
 # 200 → { "success": true, "lastTotpVerifiedAt": "2026-05-26T16:02:10.974Z" }
-# wrong/expired/reused code → 401 { "error": "two_factor_failed", "message": "Invalid or expired verification code." }
-# after 5 failures in 5 min → 429 { "error": "two_factor_locked_out", "retryAfterSeconds": 900 }
+# wrong / expired / reused code → 401 { "error": "two_factor_required", "subcode": "invalid_code", ... }
+# after 5 fails in 5 min       → 401 { ..., "subcode": "locked_out", "retryAfterSeconds": 900 }
+# TOTP store unreachable        → 503 { "error": "two_factor_unavailable", ... }
 ```
 
 ---
@@ -137,9 +146,9 @@ source of truth with login-time `/auth/2fa/verify`:
 
 - **5 attempts / 5 minutes** (Redis token bucket), then **15-minute lockout**.
 - Constant-time comparison + replay-attack guard (used-code tracking) are inherited.
-- The step-up handler performs a read-only `IsLockedOutAsync` pre-check to return the distinct `429`
-  before consuming an attempt; `retryAfterSeconds` is a fixed client hint (900s) — the Redis key TTL
-  is the authoritative wait.
+- The step-up handler performs a read-only `IsLockedOutAsync` pre-check to surface the distinct
+  `locked_out` subcode before consuming an attempt; `retryAfterSeconds: 900` is a fixed client hint
+  — the Redis key TTL is the authoritative wait.
 
 ---
 
@@ -153,39 +162,21 @@ source of truth with login-time `/auth/2fa/verify`:
 
 ---
 
-## 7. Known gaps & future alignment
+## 7. FE handling rules
 
-> Documented honestly so the FE plans around the **current** behavior, not the original design intent.
-
-1. **Error-shape asymmetry between the two flows.** Flow A uses `error: "two_factor_required"` +
-   `subcode`; Flow B uses top-level `error: "two_factor_failed"` / `"two_factor_locked_out"` and
-   returns `429` (not `401`) for lockout. The FE must therefore handle two shapes. The original plan
-   (T7) envisaged Flow B reusing `two_factor_required` + `subcode`; the implementation diverged. See
-   §8 for the rationale and the open decision.
-2. **No `503` for TOTP-store-down.** The plan (D-S3-4) specified a `503 two_factor_unavailable` when
-   the secret store / Redis is unreachable. The current implementation lets that surface as a generic
-   `500`. Tracked as a follow-up. **FE rule:** treat any unexpected `5xx` as a generic, retryable
-   error (show an error toast) — **not** as a step-up or enroll signal; never loop the step-up modal
-   on a `5xx`.
-3. **Minimal 200 body.** Flow B returns `{ success, lastTotpVerifiedAt }`, not the full
-   `SessionStatusResponse` the plan mentioned. The FE only needs the timestamp to know the block is
-   cleared.
-
-## 8. Open decision (for review)
-
-Should Flow B be aligned to the enforcement vocabulary before the strict flip?
-
-- **Option A — keep as built:** distinct shapes are arguably honest (enforcement says *"you must
-  step up"*; step-up says *"your code was wrong"* — different semantics). Document both; FE handles two.
-- **Option B — unify:** Flow B returns `401 { error: "two_factor_required", subcode: "invalid_code" }`
-  and `429 { … subcode: "locked_out" }`, plus the `503`. One vocabulary, smaller FE surface, but a
-  code change to the already-merged-on-branch T5 endpoint.
-
-This document describes **Option A (as built)**. The decision is deferred to the T8 acceptance review.
+1. **`2xx` vs `4xx` vs `5xx`:** treat any unexpected `5xx` other than `503 two_factor_unavailable`
+   as a generic, retryable error toast — **never** loop the step-up modal on a `5xx`. A `503
+   two_factor_unavailable` is also retryable, but specifically a 2FA-backend outage; the modal can
+   stay open with a "service temporarily unavailable, try again" message.
+2. **Minimal 200 body.** Flow B returns `{ success, lastTotpVerifiedAt }`, not the full
+   `SessionStatusResponse`. The FE only needs the timestamp to know the block is cleared and the
+   blocked original request can be retried.
+3. **`WWW-Authenticate` header presence** is sufficient to distinguish a 2FA-related 401 from any
+   ordinary session-expired 401 without parsing the body — useful for a global 401 interceptor.
 
 ---
 
-## 9. Backward compatibility
+## 8. Backward compatibility
 
 The FE currently redirects to `/login` on **any** 401. With `TwoFactorStrictMode=OFF` (merge default)
 Flow A never fires, so nothing changes. When an environment flips the flag *before* the FE step-up

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -107,15 +107,11 @@
 
 ## Task 2: `TwoFactorRequiredException` + ExceptionFilter
 
-- [ ] **Step 1: TDD — unit test su ExceptionFilter mapping**
-
-- [ ] **Step 2: Crea `TwoFactorRequiredException`** in `SharedKernel.Domain.Exceptions` con `Subcode` enum (`StepUpRequired`, `EnrollRequired`, `LockedOut`).
-
-- [ ] **Step 3: Estendi il global exception filter** per mappare → 401 + body `{ error, subcode }` + header `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"`.
-
-- [ ] **Step 4: Test PASS**
-
-- [ ] **Step 5: Commit**
+- [x] **Step 1: TDD — unit test su ExceptionFilter mapping** — 3 tests in `ApiExceptionHandlerMiddlewareTests` covering StepUpRequired/EnrollRequired/LockedOut subcodes
+- [x] **Step 2: Crea `TwoFactorRequiredException`** — placed in `apps/api/src/Api/Middleware/Exceptions/` (existing convention; NotFoundException/ForbiddenException already live there) with `TwoFactorRequiredSubcode` enum (`StepUpRequired`, `EnrollRequired`, `LockedOut`) + optional `RetryAfterSeconds` for LockedOut + `SubcodeWire` snake_case projection.
+- [x] **Step 3: Estendi il global exception filter** — `HandleTwoFactorRequiredAsync` in `ApiExceptionHandlerMiddleware`: 401 + body `{ error: "two_factor_required", subcode, message, retryAfterSeconds?, correlationId, timestamp }` + `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"` header per RFC 7235.
+- [x] **Step 4: Test PASS** — 38/38 unit tests verdi (3 nuovi + 35 esistenti)
+- [x] **Step 5: Commit**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -176,7 +176,7 @@
 
 - [x] ~~**Step 4: `TwoFactorStepUpRateLimiter`**~~ — **CANCELED post-T0**: riuso rate-limit/lockout di `VerifyCodeAsync`.
 
-- [x] **Step 5: Endpoint** — `POST /auth/2fa/step-up` (group prefix; path pubblico finale da confermare in T7 wire-doc), `IMediator.Send` only (CQRS), `EffectiveActor`-gated, mapping Success→200 / InvalidCode→401 / LockedOut→429.
+- [x] **Step 5: Endpoint** — public path **`POST /api/v1/auth/2fa/step-up`** (registrato `/auth/2fa/step-up` sul group `v1Api` con prefix `/api/v1`, `Program.cs:714`+`717` → `AuthenticationEndpoints.cs:58` → `TwoFactorEndpoints.cs`) — allineato al contratto D-S3-4. `IMediator.Send` only (CQRS), `EffectiveActor`-gated, mapping Success→200 / InvalidCode→401 / LockedOut→429.
 
 - [x] **Step 6: Test PASS** — 11/11.
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -223,15 +223,26 @@
 
 ## Task 8: 8 acceptance scenarios — gate DoD
 
-> Mirror S2 T8.
+> **DONE — 8/8 PASS** (`S3AcceptanceScenariosTests.cs`, Integration-GroupD, ~3m22s).
+> All scenarios exercise the REAL pipeline (Testcontainers Postgres + WebApplicationFactory + real
+> HTTP + real `TotpService` + Redis-counter simulation), never building `SessionStatusDto` by hand
+> (lesson S2). Endpoints exercised: `POST /admin/impersonation/start` (MaxAge=5),
+> `DELETE /admin/users/{id}` (default MaxAge=30), `POST /auth/2fa/step-up`,
+> `GET /auth/me` (regression). TOTP codes minted with `OtpNet` against the encrypted secret returned
+> by `TotpService.GenerateSetupAsync`.
 
-- [ ] **Step 1-8**: implementa S3-1, S3-2, S3-3, S3-4, S3-5, S3-6, S3-7, S3-8 in `S3AcceptanceScenariosTests.cs`.
+- [x] **S3-1 happy path** — fresh TOTP + strict ON → 201 on `/impersonation/start`.
+- [x] **S3-2 stale → step_up_required** — 1h-stale → 401 `two_factor_required`/`step_up_required` + `WWW-Authenticate` header.
+- [x] **S3-3 not enrolled → enroll_required** — superadmin without 2FA → 401 `enroll_required`.
+- [x] **S3-4 step-up + retry loop** — blocked → POST `/auth/2fa/step-up` with valid OtpNet-minted code → 200 refreshes `LastTotpVerifiedAt` (verified directly on the row) → retry → 201.
+- [x] **S3-5 5 fails → lockout** — Redis counter mocked with `ConcurrentDictionary` (pattern from `TwoFactorSecurityPenetrationTests`); 5×`invalid_code` then 6th → 401 `locked_out` + `retryAfterSeconds=900`.
+- [x] **S3-6 impersonation context** — alice → bob; impersonate session inherits alice's recency at start; setting that to -10min keeps `DeleteUser` (MaxAge=30) green ⇒ the gate reads the EffectiveActor's recency, not the subject's.
+- [x] **S3-7 non-decorated regression guard** — `GET /auth/me` in strict mode → 200 (no enforcement on commands missing `[RequireTwoFactor]`).
+- [x] **S3-8 per-command MaxAge** — same 10min recency: stricter `ImpersonationStart` MaxAge=5 → 401 `step_up_required`; lenient `DeleteUser` MaxAge=30 → 204.
 
-  **CRITICAL** (lezione S2): tutti gli scenari DEVONO esercitare la pipeline reale via `ValidateSessionQueryHandler` + `TwoFactorEnforcementBehavior`, NON costruire `SessionStatusDto` manualmente. Vedi [[feedback_acceptance_tests_must_exercise_real_pipeline]].
+- [x] **Step 9: Run all 8 — 8/8 PASS gate** — verified in iter 6 (3m22s).
 
-- [ ] **Step 9: Run all 8 — 8/8 PASS gate**
-
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -202,18 +202,19 @@
 
 ## Task 7: Wire format spec `docs/api/2fa-step-up-protocol.md`
 
-- [ ] **Step 1: Documenta endpoint contract**
+> **DONE** — documents the REAL implementation (Option A), not the contract this plan hypothesized
+> (Option B). The divergence (Flow B uses `two_factor_failed`/`two_factor_locked_out` 429 instead of
+> `two_factor_required`+subcode; no 503) is tracked in doc §7–8 as an open decision for T8.
+> spec-panel critique applied: Wiegers (per-command MaxAge table), Newman/Nygard (replay-guard +
+> 5xx FE rule), Adzic (curl example).
 
-  - Request: `POST /api/v1/auth/2fa/step-up { code: string }`
-  - Response 200: `SessionStatusResponse` (riusa shape S2) con `lastTotpVerifiedAt` rinfrescato
-  - Response 401: `{ error: "two_factor_required", subcode: "invalid_code" | "locked_out" }`
-  - Response 503: `{ error: "two_factor_unavailable" }`
+- [x] **Step 1: Endpoint contract** — request `{ code }`; 200 `{ success, lastTotpVerifiedAt }` (minimal, not full SessionStatusResponse); 401 `two_factor_failed`; 429 `two_factor_locked_out`. Divergence from the hypothesized contract noted in doc §8.
 
-- [ ] **Step 2: Documenta `subcode` semantics** — quando il FE deve mostrare modale step-up vs redirect-to-login vs enroll prompt.
+- [x] **Step 2: `subcode` semantics** — Flow A (enforcement) `step_up_required` / `enroll_required` / `locked_out` → FE-action table; `WWW-Authenticate: TOTP-StepUp` header distinguishes the 2FA-block 401 from a session-expired 401.
 
-- [ ] **Step 3: Cross-link** dal commit message e dalla PR description per FE handoff.
+- [x] **Step 3: Cross-link** — doc footer references the plan + audit (D-S3-2/4/4b/5); commit message links the doc.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -127,9 +127,9 @@
 
 ## Task 4: `TwoFactorEnforcementBehavior` strict path
 
-- [ ] **Step 1: TDD — unit test scenari S3-1, S3-2, S3-3, S3-7, S3-8** (con mock `ISystemConfiguration`)
+- [x] **Step 1: TDD — unit test scenari S3-1, S3-2, S3-3, S3-7, S3-8** — `TwoFactorEnforcementBehaviorTests` 10/10: fresh/stale/null TOTP, not-enrolled, non-decorated, per-command MaxAge (5 vs 30), shadow passthrough, no-session, impersonation actor-gate
 
-- [ ] **Step 2: Strict path implementation**
+- [x] **Step 2: Strict path implementation**
 
   Pseudo:
   ```csharp
@@ -154,11 +154,13 @@
   return await next();
   ```
 
-- [ ] **Step 3: Aggiorna `ImpersonationStartCommand`** con `[RequireTwoFactor(MaxAgeMinutes = 5)]` (D-S3-7).
+- [x] **Step 3: Aggiorna `ImpersonationStartCommand`** con `[RequireTwoFactor(MaxAgeMinutes = 5)]` (D-S3-7).
 
-- [ ] **Step 4: Test PASS** (5 scenari unit)
+- [x] **Step 4: Test PASS** — 101/101 unit (behavior + impersonation + validate-session regression)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
+
+> **Design note (investigated, T4):** AuditLoggingBehavior (pipeline-outer) wraps the 2FA behavior. For `[AtomicAudit]` commands (DeleteUser, ImpersonationStart) a 2FA throw rolls back the transaction → no command audit; for best-effort commands the catch emits an "Error" audit. To get a CONSISTENT forensic `TwoFactorRequired` row that survives the atomic rollback, the behavior emits it from a FRESH DI scope (independent DbContext) via `AuditService.LogAsync` (direct-write — consistent with the existing 2FA audit family in `TotpService`). The gate also reads `Principal.EffectiveActor` (not Subject) so impersonation enforces the acting admin's 2FA recency (inherited at impersonate-start, T1).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -75,34 +75,29 @@
 
 ## Task 1: Migration + `LastTotpVerifiedAt` + Session domain
 
-- [ ] **Step 1: Estendi `UserSessionEntity` con la colonna**
+- [x] **Step 1: Estendi `UserSessionEntity` con la colonna**
 
   ```csharp
   public DateTime? LastTotpVerifiedAt { get; set; }
   ```
 
-- [ ] **Step 2: `UserSessionEntityConfiguration` mapping**
+- [x] **Step 2: `UserSessionEntityConfiguration` mapping**
 
   ```csharp
   builder.Property(e => e.LastTotpVerifiedAt).HasColumnName("last_totp_verified_at");
   ```
 
-- [ ] **Step 3: `Session` domain entity**
+- [x] **Step 3: `Session` domain entity**
 
   Aggiungi proprietà + `UpdateTotpVerified(TimeProvider)` metodo; `IsTotpRecent(int maxAgeMinutes, TimeProvider)` query.
 
-- [ ] **Step 4: `SessionRepository.MapToPersistence` + `MapToDomain` hydrate**
+- [x] **Step 4: `SessionRepository.MapToPersistence` + `MapToDomain` hydrate** + spike §6 amends (CreateSessionCommand param, SessionStatusDto field, ValidateSessionQueryHandler populate, ImpersonationStartCommandHandler inheritance via HttpContext)
 
-- [ ] **Step 5: Genera migration EF**
+- [x] **Step 5: Genera migration EF** — `20260526124527_AddTwoFactorRecencyToUserSession` adds `last_totp_verified_at` nullable timestamptz, no index. Touches only `user_sessions`.
 
-  ```bash
-  cd apps/api/src/Api
-  dotnet ef migrations add AddTwoFactorRecencyToUserSession
-  ```
+- [x] **Step 6: Test schema migration (Testcontainers)** — coperto da `ValidateSessionQueryImpersonationTests` (5 unit) + tutta la suite Impersonation (2481/2481 PASS locale post-T1 changes); integration via `ApplyMigrationsAsync` in `GetActiveImpersonationsQueryIntegrationTests` exercises the new migration.
 
-- [ ] **Step 6: Test schema migration (Testcontainers)**
-
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
   ```bash
   git commit -m "feat(2fa): migration + LastTotpVerifiedAt on UserSession (SP5 S3 T1)"

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -166,23 +166,21 @@
 
 ## Task 5: Step-up endpoint + DB-backed rate-limit
 
-- [ ] **Step 1: TDD — scenari S3-4 + S3-5**
+> **DONE** — commit `240f7c1b5`. Steps 3-4 CANCELED post-T0 (riuso Redis rate-limit/lockout di `TotpService.VerifyCodeAsync`; nessuna nuova tabella né rate-limiter). Acceptance E2E completi S3-4/S3-5 (HTTP + audit_outbox + re-POST del comando bloccato) → T8.
 
-- [ ] **Step 2: `StepUpTwoFactorCommand` + handler**
+- [x] **Step 1: TDD — scenari S3-4 + S3-5** — coperti a livello handler unit: `StepUpTwoFactorCommandHandlerTests` (success / invalid / lockout / vanished-session / null) + `StepUpTwoFactorCommandValidatorTests` (not-empty + length). 11/11 PASS. Acceptance HTTP+audit_outbox → T8.
 
-  Verifica TOTP code (riusa la library 2FA esistente), update `session.LastTotpVerifiedAt`, emit audit `TwoFactorStepUp`.
+- [x] **Step 2: `StepUpTwoFactorCommand` + handler** — delega a `ITotpService.VerifyCodeAsync`; success refresh `LastTotpVerifiedAt` (via `ISessionRepository.UpdateLastTotpVerifiedAtAsync`, atomic ExecuteUpdate) + audit `TwoFactorStepUp`; lockout pre-check (`IsLockedOutAsync`) → 429 + retryAfterSeconds=900 + audit `TwoFactorStepUpLockout`.
 
-- [ ] **Step 3: `TwoFactorStepUpAttemptEntity` + migration**
+- [x] ~~**Step 3: `TwoFactorStepUpAttemptEntity` + migration**~~ — **CANCELED post-T0**: Redis bucket di `TotpService` è authoritative.
 
-  Tabella tracking attempts per rate-limit cross-instance (5/min, lockout 15min).
+- [x] ~~**Step 4: `TwoFactorStepUpRateLimiter`**~~ — **CANCELED post-T0**: riuso rate-limit/lockout di `VerifyCodeAsync`.
 
-- [ ] **Step 4: `TwoFactorStepUpRateLimiter`** — DB counter (pattern `BggRateLimitMiddleware`).
+- [x] **Step 5: Endpoint** — `POST /auth/2fa/step-up` (group prefix; path pubblico finale da confermare in T7 wire-doc), `IMediator.Send` only (CQRS), `EffectiveActor`-gated, mapping Success→200 / InvalidCode→401 / LockedOut→429.
 
-- [ ] **Step 5: Endpoint `POST /api/v1/auth/2fa/step-up`** — `IMediator.Send` only (CQRS).
+- [x] **Step 6: Test PASS** — 11/11.
 
-- [ ] **Step 6: Test PASS**
-
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit** — `240f7c1b5`.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -186,15 +186,17 @@
 
 ## Task 6: Admin sweep endpoint `GET /admin/users/no-2fa`
 
-- [ ] **Step 1: TDD — integration test (superadmin auth gate)**
+> **DONE** — public path `GET /api/v1/admin/users/no-2fa`, superadmin-gated, IMediator-only (CQRS).
 
-- [ ] **Step 2: `GetAdminsWithoutTwoFactorQuery` + handler** — filtra `IsTwoFactorEnabled=false AND Role IN ('admin','superadmin')`.
+- [x] **Step 1: TDD — integration test** — `GetAdminsWithoutTwoFactorQueryIntegrationTests` (2/2) exercises the real `UserRepository` against Postgres (Testcontainers), RED→GREEN. The test surfaced that the entity→domain mapping (`UserRepository.MapToDomain`) only restores `IsTwoFactorEnabled` when BOTH the flag AND an encrypted secret are present (mirroring `Enable2FA`); the fixture seeds a secret accordingly. HTTP gate E2E (403 for non-superadmin) deferred to T8 acceptance, mirroring S2 T6.
 
-- [ ] **Step 3: Endpoint in `AdminTwoFactorComplianceEndpoints.cs`** con `RequireSuperAdmin` gate.
+- [x] **Step 2: `GetAdminsWithoutTwoFactorQuery` + handler** — reuses `IUserRepository.GetAdminUsersAsync` (already scopes Role to admin/superadmin) + `!IsTwoFactorEnabled` filter; maps to `UserDto`.
 
-- [ ] **Step 4: Test PASS**
+- [x] **Step 3: Endpoint in `AdminTwoFactorComplianceEndpoints.cs`** — `RequireSuperAdminSession()` + `.RequireAuthorization("RequireSuperAdmin")`; registered in `Program.cs`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 4: Test PASS** — 2/2 integration.
+
+- [x] **Step 5: Commit**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -166,21 +166,23 @@
 
 ## Task 5: Step-up endpoint + DB-backed rate-limit
 
-> **DONE** — commit `240f7c1b5`. Steps 3-4 CANCELED post-T0 (riuso Redis rate-limit/lockout di `TotpService.VerifyCodeAsync`; nessuna nuova tabella né rate-limiter). Acceptance E2E completi S3-4/S3-5 (HTTP + audit_outbox + re-POST del comando bloccato) → T8.
+> **DONE** — commit `240f7c1b5` (T5 base) + Option B refactor (handler/endpoint/middleware/doc) in
+> successive commit. Steps 3-4 stay CANCELED post-T0 (Redis rate-limit/lockout of
+> `TotpService.VerifyCodeAsync` is authoritative). Acceptance E2E for S3-4/S3-5 → T8.
 
-- [x] **Step 1: TDD — scenari S3-4 + S3-5** — coperti a livello handler unit: `StepUpTwoFactorCommandHandlerTests` (success / invalid / lockout / vanished-session / null) + `StepUpTwoFactorCommandValidatorTests` (not-empty + length). 11/11 PASS. Acceptance HTTP+audit_outbox → T8.
+- [x] **Step 1: TDD — scenari S3-4 + S3-5** — handler-unit coverage: `StepUpTwoFactorCommandHandlerTests` (success / invalid / lockout / vanished-session / null / **unavailable**) + `StepUpTwoFactorCommandValidatorTests` (not-empty + length). **12/12 PASS**. Acceptance HTTP + audit_outbox → T8.
 
-- [x] **Step 2: `StepUpTwoFactorCommand` + handler** — delega a `ITotpService.VerifyCodeAsync`; success refresh `LastTotpVerifiedAt` (via `ISessionRepository.UpdateLastTotpVerifiedAtAsync`, atomic ExecuteUpdate) + audit `TwoFactorStepUp`; lockout pre-check (`IsLockedOutAsync`) → 429 + retryAfterSeconds=900 + audit `TwoFactorStepUpLockout`.
+- [x] **Step 2: `StepUpTwoFactorCommand` + handler** — delegates to `ITotpService.VerifyCodeAsync`; on success refreshes `LastTotpVerifiedAt` via `ISessionRepository.UpdateLastTotpVerifiedAtAsync` (atomic `ExecuteUpdate`) + audit `TwoFactorStepUp`; `IsLockedOutAsync` pre-check → outcome `LockedOut` + audit `TwoFactorStepUpLockout`; **try/catch around the TotpService calls → outcome `Unavailable`** (Option B, D-S3-4 store-down failure mode).
 
 - [x] ~~**Step 3: `TwoFactorStepUpAttemptEntity` + migration**~~ — **CANCELED post-T0**: Redis bucket di `TotpService` è authoritative.
 
-- [x] ~~**Step 4: `TwoFactorStepUpRateLimiter`**~~ — **CANCELED post-T0**: riuso rate-limit/lockout di `VerifyCodeAsync`.
+- [x] ~~**Step 4: `TwoFactorStepUpRateLimiter`**~~ — **CANCELED post-T0**: reuses rate-limit/lockout of `VerifyCodeAsync`.
 
-- [x] **Step 5: Endpoint** — public path **`POST /api/v1/auth/2fa/step-up`** (registrato `/auth/2fa/step-up` sul group `v1Api` con prefix `/api/v1`, `Program.cs:714`+`717` → `AuthenticationEndpoints.cs:58` → `TwoFactorEndpoints.cs`) — allineato al contratto D-S3-4. `IMediator.Send` only (CQRS), `EffectiveActor`-gated, mapping Success→200 / InvalidCode→401 / LockedOut→429.
+- [x] **Step 5: Endpoint** — public path **`POST /api/v1/auth/2fa/step-up`** (group prefix `/api/v1` from `Program.cs:714`+`717`). `IMediator.Send` only (CQRS), `EffectiveActor`-gated. **Option B mapping (uniform error vocabulary with the enforcement filter)**: Success → 200 `{ success, lastTotpVerifiedAt }`; InvalidCode → `throw TwoFactorRequiredException(InvalidCode)` → 401 `two_factor_required`/`invalid_code`; LockedOut → `throw TwoFactorRequiredException(LockedOut, 900)` → 401 `…`/`locked_out` + `retryAfterSeconds`; Unavailable → `throw TwoFactorUnavailableException` → 503 `two_factor_unavailable`. All wrapped by `ApiExceptionHandlerMiddleware` (DRY with Flow A).
 
-- [x] **Step 6: Test PASS** — 11/11.
+- [x] **Step 6: Test PASS** — 12/12 unit (handler + validator) + 4/4 middleware (`TwoFactorRequiredException` × 3 subcodes + `TwoFactorUnavailableException` → 503).
 
-- [x] **Step 7: Commit** — `240f7c1b5`.
+- [x] **Step 7: Commit** — `240f7c1b5` (T5 base) + follow-up Option B refactor commit.
 
 ---
 
@@ -202,17 +204,18 @@
 
 ## Task 7: Wire format spec `docs/api/2fa-step-up-protocol.md`
 
-> **DONE** — documents the REAL implementation (Option A), not the contract this plan hypothesized
-> (Option B). The divergence (Flow B uses `two_factor_failed`/`two_factor_locked_out` 429 instead of
-> `two_factor_required`+subcode; no 503) is tracked in doc §7–8 as an open decision for T8.
-> spec-panel critique applied: Wiegers (per-command MaxAge table), Newman/Nygard (replay-guard +
-> 5xx FE rule), Adzic (curl example).
+> **DONE — Option B as-built.** The initial draft (post-T5 commit `249aee74a`) described Option A
+> and tracked the schema asymmetry as an open decision for T8. The user chose **Option B**: the doc
+> was rewritten, and the implementation was aligned — Flow B now reuses the enforcement vocabulary
+> (`two_factor_required` + `subcode` for `invalid_code` / `locked_out`, plus `503
+> two_factor_unavailable` for store-down). spec-panel critique applied: Wiegers (per-command MaxAge
+> table), Newman/Nygard (replay-guard + 5xx FE rule), Adzic (curl example).
 
-- [x] **Step 1: Endpoint contract** — request `{ code }`; 200 `{ success, lastTotpVerifiedAt }` (minimal, not full SessionStatusResponse); 401 `two_factor_failed`; 429 `two_factor_locked_out`. Divergence from the hypothesized contract noted in doc §8.
+- [x] **Step 1: Endpoint contract** — request `{ code }`; 200 `{ success, lastTotpVerifiedAt }` (minimal, not full SessionStatusResponse); 401 `two_factor_required` + `subcode: invalid_code | locked_out` + `WWW-Authenticate: TOTP-StepUp` header; 503 `two_factor_unavailable` (Redis/store-down failure mode).
 
-- [x] **Step 2: `subcode` semantics** — Flow A (enforcement) `step_up_required` / `enroll_required` / `locked_out` → FE-action table; `WWW-Authenticate: TOTP-StepUp` header distinguishes the 2FA-block 401 from a session-expired 401.
+- [x] **Step 2: `subcode` semantics** — unified table across both flows: `step_up_required` / `enroll_required` (Flow A only), `locked_out` (Flow A or B), `invalid_code` (Flow B only) → FE-action mapping. One shared 2FA error vocabulary.
 
-- [x] **Step 3: Cross-link** — doc footer references the plan + audit (D-S3-2/4/4b/5); commit message links the doc.
+- [x] **Step 3: Cross-link** — doc footer references the plan + audit (D-S3-2/4/4b/5).
 
 - [x] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -233,6 +233,8 @@
 
 > Mirror S2 T9.
 
+> **Issue linking (deciso 2026-05-26):** nessuna issue dedicata — pattern S2 (PR #1555 `closingIssuesReferences: []`). La PR NON usa `Closes #N`; il body cita questo piano three-amigos + l'origine concettuale #186 (Q2 Security Review, voce P1.1 — CLOSED) come contesto, e menziona le correlate **#1533** (2FA BackupCodes wipe on role/suspend), **#1534**/**#1535** (audit tech-debt) per verifica d'interazione.
+
 - [ ] **Step 1**: per ognuno dei 10 criteri DoD, esegui verifica + annota evidenza
 - [ ] **Step 2**: compila DoD log in `audits/2026-05-26-s3-three-amigos-kickoff.md` (sezione "DoD verification log")
 - [ ] **Step 3**: commit DoD log

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -28,24 +28,28 @@
   - `apps/api/src/Api/Routing/Auth/TwoFactorStepUpEndpoints.cs`
   - `apps/api/src/Api/Routing/Admin/AdminTwoFactorComplianceEndpoints.cs`
   - `apps/api/src/Api/Middleware/TwoFactorRequiredExceptionFilter.cs` (or extend existing exception filter)
-  - `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/RateLimit/TwoFactorStepUpRateLimiter.cs`
-  - `apps/api/src/Api/Infrastructure/Entities/Authentication/TwoFactorStepUpAttemptEntity.cs` (for rate-limit counter)
-  - `apps/api/src/Api/Infrastructure/Migrations/{ts}_AddTwoFactorStrictMode.cs`
+  - ~~`TwoFactorStepUpRateLimiter.cs`~~ — **CANCELED post-T0**: riusa `TotpService.VerifyCodeAsync` (Redis rate-limit 5/5min + lockout 15min già implementati). Spike §6.
+  - ~~`TwoFactorStepUpAttemptEntity.cs`~~ — **CANCELED post-T0**: no nuova tabella; Redis è authoritative
+  - `apps/api/src/Api/Infrastructure/Migrations/{ts}_AddTwoFactorRecencyToUserSession.cs`
   - `docs/api/2fa-step-up-protocol.md` (wire format spec for FE handoff)
   - `tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs`
   - `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/StepUpTwoFactorCommandHandlerTests.cs`
   - `tests/Api.Tests/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehaviorStrictTests.cs`
 
 - **Modify:**
-  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs` (strict path + flag read)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs` (strict path + flag read; legge `sessionStatus.LastTotpVerifiedAt`)
   - `apps/api/src/Api/BoundedContexts/Authentication/Application/Attributes/RequireTwoFactorAttribute.cs` (doc update only — semantics unchanged)
   - `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommand.cs` (MaxAgeMinutes = 5)
+  - **NEW post-T0** `ImpersonationStartCommandHandler.cs` — inherit actor's `LastTotpVerifiedAt` nella session impersonate (spike §5)
   - `apps/api/src/Api/Infrastructure/Entities/Authentication/UserSessionEntity.cs` (LastTotpVerifiedAt)
   - `apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserSessionEntityConfiguration.cs`
   - `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/Session.cs` (LastTotpVerifiedAt + UpdateTotpVerified method)
-  - `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs` (hydrate)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs` (hydrate + UpdateLastTotpVerifiedAtAsync method)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/CreateSessionCommand.cs` — **NEW post-T0**: accept optional `LastTotpVerifiedAt` param (per impersonate inheritance)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/SessionDto.cs` — **NEW post-T0**: add `LastTotpVerifiedAt? : DateTime?` field (mirror S2 SessionId pattern)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/ValidateSessionQueryHandler.cs` — **NEW post-T0**: populate `LastTotpVerifiedAt` in SessionStatusDto
   - `apps/api/src/Api/BoundedContexts/SystemConfiguration/...` (TwoFactorStrictMode config key, default false)
-  - `apps/api/src/Api/Program.cs` (wire new endpoints + rate-limiter + exception filter)
+  - `apps/api/src/Api/Program.cs` (wire new endpoints + exception filter; NO rate-limiter — riuso `TotpService`)
 
 ---
 
@@ -55,17 +59,17 @@
 
 **Output:** `audits/2026-05-26-s3-spike-cutover-readiness.md`
 
-- [ ] **Step 1: Inventory dei 4 comandi decorati `[RequireTwoFactor]`** — confermare MaxAge attuale, identificare i call site, mappare l'audit emission attuale (action names) per gli scenari S3-1..S3-8.
+- [x] **Step 1: Inventory dei 4 comandi decorati `[RequireTwoFactor]`** — confermare MaxAge attuale, identificare i call site, mappare l'audit emission attuale (action names) per gli scenari S3-1..S3-8.
 
-- [ ] **Step 2: Inventario sistema 2FA enrollment esistente** — dove vive il TOTP secret? Quale endpoint setta `IsTwoFactorEnabled=true`? Come funziona oggi la verifica TOTP (interfaccia + library)? Identifica i punti dove inserire l'aggiornamento di `LastTotpVerifiedAt` (probabile: login + enroll-verify + step-up).
+- [x] **Step 2: Inventario sistema 2FA enrollment esistente** — dove vive il TOTP secret? Quale endpoint setta `IsTwoFactorEnabled=true`? Come funziona oggi la verifica TOTP (interfaccia + library)? Identifica i punti dove inserire l'aggiornamento di `LastTotpVerifiedAt` (probabile: login + enroll-verify + step-up).
 
-- [ ] **Step 3: Conta gli admin senza 2FA in dev/staging** — `SELECT count(*) FROM users WHERE (role='admin' OR role='superadmin') AND is_two_factor_enabled=false`. Output: numero da sweep prima del flip prod (D-S3-5).
+- [x] **Step 3: Conta gli admin senza 2FA in dev/staging** (SQL query proposed; live count differito a ops sweep via T6 endpoint) — `SELECT count(*) FROM users WHERE (role='admin' OR role='superadmin') AND is_two_factor_enabled=false`. Output: numero da sweep prima del flip prod (D-S3-5).
 
-- [ ] **Step 4: Identifica i 401 handler esistenti nel FE** — `apps/web/src/lib/api/*` — verifica che esista logica per distinguere `subcode` nel body. Output: gap document per il plan FE separato.
+- [x] **Step 4: Identifica i 401 handler esistenti nel FE** — 8 handler in `apps/web/src/lib/api/core/httpClient.ts` + `errors.ts` + `i18n/errors.ts`, tutti generic redirect-to-login. Migration spec documentata in spike §8. — `apps/web/src/lib/api/*` — verifica che esista logica per distinguere `subcode` nel body. Output: gap document per il plan FE separato.
 
-- [ ] **Step 5: Risk matrix (Nygard)** — failure modes documentati: (a) TOTP store unavailable, (b) rate-limit counter DB unreachable, (c) flag toggle race, (d) sessione esistente con `LastTotpVerifiedAt=null` al flip → tutte richiedono step-up (questo è l'effetto voluto post-sweep).
+- [x] **Step 5: Risk matrix (Nygard)** — 7 failure modes (F1-F7) documentati in spike §7 — failure modes documentati: (a) TOTP store unavailable, (b) rate-limit counter DB unreachable, (c) flag toggle race, (d) sessione esistente con `LastTotpVerifiedAt=null` al flip → tutte richiedono step-up (questo è l'effetto voluto post-sweep).
 
-- [ ] **Step 6: Commit spike doc + amend kickoff se servono refinement**
+- [x] **Step 6: Commit spike doc + amend kickoff se servono refinement** — spike `audits/2026-05-26-s3-spike-cutover-readiness.md` con 2 semplificazioni (D-S3-4b riusa Redis rate-limit di TotpService; impersonate inherit actor's LastTotpVerifiedAt). File Structure del plan aggiornato di conseguenza (vedi sotto).
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -117,15 +117,11 @@
 
 ## Task 3: `SystemConfiguration.TwoFactorStrictMode` flag (default false)
 
-- [ ] **Step 1: Aggiungi key** al SystemConfiguration BC (pattern `RegistrationMode`).
-
-- [ ] **Step 2: Admin toggle UI** — endpoint esistente `/api/v1/admin/config` deve esporre la nuova key per il toggle.
-
-- [ ] **Step 3: Read non-cached** — il behavior legge il flag a ogni request (no Redis cache su questo specifico flag — vedi D-S3-1).
-
-- [ ] **Step 4: Unit test su read/write del flag**
-
-- [ ] **Step 5: Commit**
+- [x] **Step 1: Aggiungi key** — `TwoFactorConfigurationKeys.StrictMode = "TwoFactor:StrictMode"` (compile-time constant) + `StrictModeDefault = false`. La key è dinamica (DB row creata al primo toggle via admin UI esistente); il constant la documenta in codice e la rende rifattorizzabile.
+- [x] **Step 2: Admin toggle UI** — l'endpoint esistente generico (`ConfigurationEndpoints` + `BulkUpdateConfigsCommand`) già consente CRUD su qualsiasi key. Nessun codice nuovo BE necessario; il FE renderizzerà il toggle nella sezione Security di `/admin/config`.
+- [x] **Step 3: Read non-cached** — `ITwoFactorEnforcementConfiguration.GetStrictModeAsync()` chiama `IConfigurationService.GetValueAsync<bool?>` direttamente ad ogni request. No Redis wrapper su questa specifica chiave (la latenza DB lookup PK è < 1ms).
+- [x] **Step 4: Unit test su read/write del flag** — 5/5 PASS: StrictModeDefault=false, colon-namespace convention, true path, null→default, throws→fail-closed
+- [x] **Step 5: Commit**
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
+++ b/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md
@@ -1,0 +1,286 @@
+# SP5 Admin Security S3 — Strict 2FA Enforcement Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flippare `TwoFactorEnforcementBehavior` da shadow → strict. Tracciare la recency del TOTP a livello sessione (`LastTotpVerifiedAt`), bloccare 4 comandi sensibili quando la verifica è stale/assente, fornire un endpoint `POST /auth/2fa/step-up`, gated da config-flag `TwoFactorStrictMode` con default=OFF al merge.
+
+**Architecture:** `UserSessionEntity.LastTotpVerifiedAt` (timestamptz nullable). `TwoFactorEnforcementBehavior` strict path throw `TwoFactorRequiredException` quando (2FA off) ∨ (LastTotpVerifiedAt null ∨ stale per `MaxAgeMinutes`). ExceptionFilter mappa a 401 + structured body + `WWW-Authenticate: TOTP-StepUp` header. Step-up endpoint con rate-limit DB-backed. Tutto behind `SystemConfiguration.TwoFactorStrictMode` flag (default false).
+
+**Predecessor:** S2 (PR #1555, commit `7ca5b5151` su `main-dev`). Riutilizzo: `Principal { Subject, Actor? }`, `ExtractImpersonationActorId` per audit attribution durante impersonate, `SessionStatusResponse` wire format con backward-compat.
+
+**Out of scope:**
+- ❌ FE step-up modal/banner (plan FE separato; wire format spec in D-S3-2)
+- ❌ WebAuthn / passkeys (#186 P1.2)
+- ❌ Recovery codes / backup factors (Q2 §11 D5)
+- ❌ Auto-enrollment forzato (ops task)
+- ❌ Removal del flag (follow-up dopo 1 sprint prod-stable)
+
+**Reference:** decisioni complete in `audits/2026-05-26-s3-three-amigos-kickoff.md` (D-S3-1..7 + 8 acceptance scenarios + DoD 10 criteri).
+
+---
+
+## File Structure
+
+- **Create:**
+  - `apps/api/src/Api/SharedKernel/Domain/Exceptions/TwoFactorRequiredException.cs`
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/StepUpTwoFactorCommand.cs` (+ Handler + Validator)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetAdminsWithoutTwoFactorQuery.cs` (+ Handler)
+  - `apps/api/src/Api/Routing/Auth/TwoFactorStepUpEndpoints.cs`
+  - `apps/api/src/Api/Routing/Admin/AdminTwoFactorComplianceEndpoints.cs`
+  - `apps/api/src/Api/Middleware/TwoFactorRequiredExceptionFilter.cs` (or extend existing exception filter)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/RateLimit/TwoFactorStepUpRateLimiter.cs`
+  - `apps/api/src/Api/Infrastructure/Entities/Authentication/TwoFactorStepUpAttemptEntity.cs` (for rate-limit counter)
+  - `apps/api/src/Api/Infrastructure/Migrations/{ts}_AddTwoFactorStrictMode.cs`
+  - `docs/api/2fa-step-up-protocol.md` (wire format spec for FE handoff)
+  - `tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs`
+  - `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/StepUpTwoFactorCommandHandlerTests.cs`
+  - `tests/Api.Tests/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehaviorStrictTests.cs`
+
+- **Modify:**
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Behaviors/TwoFactorEnforcementBehavior.cs` (strict path + flag read)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Application/Attributes/RequireTwoFactorAttribute.cs` (doc update only — semantics unchanged)
+  - `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationStartCommand.cs` (MaxAgeMinutes = 5)
+  - `apps/api/src/Api/Infrastructure/Entities/Authentication/UserSessionEntity.cs` (LastTotpVerifiedAt)
+  - `apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserSessionEntityConfiguration.cs`
+  - `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/Session.cs` (LastTotpVerifiedAt + UpdateTotpVerified method)
+  - `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/SessionRepository.cs` (hydrate)
+  - `apps/api/src/Api/BoundedContexts/SystemConfiguration/...` (TwoFactorStrictMode config key, default false)
+  - `apps/api/src/Api/Program.cs` (wire new endpoints + rate-limiter + exception filter)
+
+---
+
+## Task 0: Spike — Inventory + cutover risk assessment
+
+> **Tipo Task:** spike read-only + design doc. Nessun codice di prodotto; output = il risk + readiness blueprint per T1-T9.
+
+**Output:** `audits/2026-05-26-s3-spike-cutover-readiness.md`
+
+- [ ] **Step 1: Inventory dei 4 comandi decorati `[RequireTwoFactor]`** — confermare MaxAge attuale, identificare i call site, mappare l'audit emission attuale (action names) per gli scenari S3-1..S3-8.
+
+- [ ] **Step 2: Inventario sistema 2FA enrollment esistente** — dove vive il TOTP secret? Quale endpoint setta `IsTwoFactorEnabled=true`? Come funziona oggi la verifica TOTP (interfaccia + library)? Identifica i punti dove inserire l'aggiornamento di `LastTotpVerifiedAt` (probabile: login + enroll-verify + step-up).
+
+- [ ] **Step 3: Conta gli admin senza 2FA in dev/staging** — `SELECT count(*) FROM users WHERE (role='admin' OR role='superadmin') AND is_two_factor_enabled=false`. Output: numero da sweep prima del flip prod (D-S3-5).
+
+- [ ] **Step 4: Identifica i 401 handler esistenti nel FE** — `apps/web/src/lib/api/*` — verifica che esista logica per distinguere `subcode` nel body. Output: gap document per il plan FE separato.
+
+- [ ] **Step 5: Risk matrix (Nygard)** — failure modes documentati: (a) TOTP store unavailable, (b) rate-limit counter DB unreachable, (c) flag toggle race, (d) sessione esistente con `LastTotpVerifiedAt=null` al flip → tutte richiedono step-up (questo è l'effetto voluto post-sweep).
+
+- [ ] **Step 6: Commit spike doc + amend kickoff se servono refinement**
+
+---
+
+## Task 1: Migration + `LastTotpVerifiedAt` + Session domain
+
+- [ ] **Step 1: Estendi `UserSessionEntity` con la colonna**
+
+  ```csharp
+  public DateTime? LastTotpVerifiedAt { get; set; }
+  ```
+
+- [ ] **Step 2: `UserSessionEntityConfiguration` mapping**
+
+  ```csharp
+  builder.Property(e => e.LastTotpVerifiedAt).HasColumnName("last_totp_verified_at");
+  ```
+
+- [ ] **Step 3: `Session` domain entity**
+
+  Aggiungi proprietà + `UpdateTotpVerified(TimeProvider)` metodo; `IsTotpRecent(int maxAgeMinutes, TimeProvider)` query.
+
+- [ ] **Step 4: `SessionRepository.MapToPersistence` + `MapToDomain` hydrate**
+
+- [ ] **Step 5: Genera migration EF**
+
+  ```bash
+  cd apps/api/src/Api
+  dotnet ef migrations add AddTwoFactorRecencyToUserSession
+  ```
+
+- [ ] **Step 6: Test schema migration (Testcontainers)**
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git commit -m "feat(2fa): migration + LastTotpVerifiedAt on UserSession (SP5 S3 T1)"
+  ```
+
+---
+
+## Task 2: `TwoFactorRequiredException` + ExceptionFilter
+
+- [ ] **Step 1: TDD — unit test su ExceptionFilter mapping**
+
+- [ ] **Step 2: Crea `TwoFactorRequiredException`** in `SharedKernel.Domain.Exceptions` con `Subcode` enum (`StepUpRequired`, `EnrollRequired`, `LockedOut`).
+
+- [ ] **Step 3: Estendi il global exception filter** per mappare → 401 + body `{ error, subcode }` + header `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"`.
+
+- [ ] **Step 4: Test PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 3: `SystemConfiguration.TwoFactorStrictMode` flag (default false)
+
+- [ ] **Step 1: Aggiungi key** al SystemConfiguration BC (pattern `RegistrationMode`).
+
+- [ ] **Step 2: Admin toggle UI** — endpoint esistente `/api/v1/admin/config` deve esporre la nuova key per il toggle.
+
+- [ ] **Step 3: Read non-cached** — il behavior legge il flag a ogni request (no Redis cache su questo specifico flag — vedi D-S3-1).
+
+- [ ] **Step 4: Unit test su read/write del flag**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 4: `TwoFactorEnforcementBehavior` strict path
+
+- [ ] **Step 1: TDD — unit test scenari S3-1, S3-2, S3-3, S3-7, S3-8** (con mock `ISystemConfiguration`)
+
+- [ ] **Step 2: Strict path implementation**
+
+  Pseudo:
+  ```csharp
+  if (!_systemConfig.GetBool("TwoFactorStrictMode")) {
+      // Shadow path (esistente, log only)
+      LogShadow(...);
+      return await next();
+  }
+
+  if (!user.IsTwoFactorEnabled) {
+      throw new TwoFactorRequiredException(Subcode.EnrollRequired, ...);
+  }
+
+  var session = ExtractSession();
+  var maxAge = TimeSpan.FromMinutes(attr.MaxAgeMinutes);
+  if (session.LastTotpVerifiedAt is null
+      || _timeProvider.GetUtcNow() - session.LastTotpVerifiedAt > maxAge) {
+      // Emit best-effort audit "TwoFactorRequired" via _auditService
+      throw new TwoFactorRequiredException(Subcode.StepUpRequired, ...);
+  }
+
+  return await next();
+  ```
+
+- [ ] **Step 3: Aggiorna `ImpersonationStartCommand`** con `[RequireTwoFactor(MaxAgeMinutes = 5)]` (D-S3-7).
+
+- [ ] **Step 4: Test PASS** (5 scenari unit)
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 5: Step-up endpoint + DB-backed rate-limit
+
+- [ ] **Step 1: TDD — scenari S3-4 + S3-5**
+
+- [ ] **Step 2: `StepUpTwoFactorCommand` + handler**
+
+  Verifica TOTP code (riusa la library 2FA esistente), update `session.LastTotpVerifiedAt`, emit audit `TwoFactorStepUp`.
+
+- [ ] **Step 3: `TwoFactorStepUpAttemptEntity` + migration**
+
+  Tabella tracking attempts per rate-limit cross-instance (5/min, lockout 15min).
+
+- [ ] **Step 4: `TwoFactorStepUpRateLimiter`** — DB counter (pattern `BggRateLimitMiddleware`).
+
+- [ ] **Step 5: Endpoint `POST /api/v1/auth/2fa/step-up`** — `IMediator.Send` only (CQRS).
+
+- [ ] **Step 6: Test PASS**
+
+- [ ] **Step 7: Commit**
+
+---
+
+## Task 6: Admin sweep endpoint `GET /admin/users/no-2fa`
+
+- [ ] **Step 1: TDD — integration test (superadmin auth gate)**
+
+- [ ] **Step 2: `GetAdminsWithoutTwoFactorQuery` + handler** — filtra `IsTwoFactorEnabled=false AND Role IN ('admin','superadmin')`.
+
+- [ ] **Step 3: Endpoint in `AdminTwoFactorComplianceEndpoints.cs`** con `RequireSuperAdmin` gate.
+
+- [ ] **Step 4: Test PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Task 7: Wire format spec `docs/api/2fa-step-up-protocol.md`
+
+- [ ] **Step 1: Documenta endpoint contract**
+
+  - Request: `POST /api/v1/auth/2fa/step-up { code: string }`
+  - Response 200: `SessionStatusResponse` (riusa shape S2) con `lastTotpVerifiedAt` rinfrescato
+  - Response 401: `{ error: "two_factor_required", subcode: "invalid_code" | "locked_out" }`
+  - Response 503: `{ error: "two_factor_unavailable" }`
+
+- [ ] **Step 2: Documenta `subcode` semantics** — quando il FE deve mostrare modale step-up vs redirect-to-login vs enroll prompt.
+
+- [ ] **Step 3: Cross-link** dal commit message e dalla PR description per FE handoff.
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 8: 8 acceptance scenarios — gate DoD
+
+> Mirror S2 T8.
+
+- [ ] **Step 1-8**: implementa S3-1, S3-2, S3-3, S3-4, S3-5, S3-6, S3-7, S3-8 in `S3AcceptanceScenariosTests.cs`.
+
+  **CRITICAL** (lezione S2): tutti gli scenari DEVONO esercitare la pipeline reale via `ValidateSessionQueryHandler` + `TwoFactorEnforcementBehavior`, NON costruire `SessionStatusDto` manualmente. Vedi [[feedback_acceptance_tests_must_exercise_real_pipeline]].
+
+- [ ] **Step 9: Run all 8 — 8/8 PASS gate**
+
+- [ ] **Step 10: Commit**
+
+---
+
+## Task 9: DoD verification log
+
+> Mirror S2 T9.
+
+- [ ] **Step 1**: per ognuno dei 10 criteri DoD, esegui verifica + annota evidenza
+- [ ] **Step 2**: compila DoD log in `audits/2026-05-26-s3-three-amigos-kickoff.md` (sezione "DoD verification log")
+- [ ] **Step 3**: commit DoD log
+- [ ] **Step 4**: flip PR draft→ready, code review, merge in `main-dev`
+
+---
+
+## Self-Review
+
+**1. Atomicity:** lo step-up command è best-effort sull'audit (S1 default — verifying TOTP non è distruttivo; perdita audit recuperabile da telemetria). `TwoFactorRequiredException` throw BEFORE handler execution → nessuna mutazione → atomicità garantita by design (no partial state).
+
+**2. Cutover safety:** flag default=OFF al merge = zero-risk deploy. Il flip è una decisione ops cosciente in staging-then-prod. Sweep pre-flip (T6 endpoint) garantisce 100% admin enrolled.
+
+**3. Lezione S2 applicata:** DoD criterio #8 esplicito — pipeline reale via `ValidateSessionQueryHandler` + behavior. Acceptance scenarios non costruiscono `SessionStatusDto` manualmente.
+
+**4. Backward compat FE:** wire format `{ error, subcode, WWW-Authenticate }` documentato in T7. FE refactor è OUT OF SCOPE; il FE attuale che redirecta a /login su qualsiasi 401 continua a funzionare (degrade silente) finché ops non flip strict in prod.
+
+**5. Risks (Nygard):**
+- **Rate-limit counter DB scrittura**: ogni step-up tentato fa una INSERT. Volume admin atteso: <100/giorno → trascurabile.
+- **Flag read frequenza**: ogni request `[RequireTwoFactor]` legge il flag. Cache in-memory L1 con TTL 5s per evitare DB hot-path.
+- **TOTP store availability**: se la library 2FA fallisce, step-up restituisce 503 → admin non si sblocca. Mitigation: la verifica TOTP usa SOLO secret store (DB) + RFC 6238 math, no external dep.
+
+---
+
+## Execution Handoff
+
+**Branch:** `feature/sp5-admin-security-s3-strict-2fa` (from `main-dev` HEAD `7ca5b5151`)
+
+**Ordine esecuzione:** T0 (spike) → T1 (migration + Session) → T2 (exception + filter) → T3 (config flag) → T4 (behavior strict) → T5 (step-up endpoint + rate-limit) → T6 (sweep endpoint) → T7 (wire format doc) → T8 (8 acceptance scenarios) → T9 (DoD log + merge).
+
+**Effort stimato:** 4-6 giorni.
+
+**Predecessor dependency:** S2 (PR #1555) ✅ MERGED in `main-dev`.
+
+**Post-merge ops sequence:**
+1. Merge S3 in main-dev (flag default=OFF — zero impact)
+2. Deploy to staging
+3. Ops chiama `GET /admin/users/no-2fa` → sweep + email enrollment
+4. Ops flip `TwoFactorStrictMode=true` in staging admin config
+5. Dogfooding 24h in staging
+6. Repeat 3-4 in prod
+7. After 1 sprint prod-stable → follow-up issue per rimuovere il flag (hard-code true)


### PR DESCRIPTION
## Summary

SP5 Admin Security **S3** — flip `TwoFactorEnforcementBehavior` da shadow → strict.

Tracking della recency del TOTP a livello sessione (`LastTotpVerifiedAt`), 4 comandi sensibili bloccati quando la verifica è stale/assente, nuovo endpoint `POST /api/v1/auth/2fa/step-up`, sweep endpoint admin `GET /api/v1/admin/users/no-2fa`. Tutto gated da config-flag `TwoFactor:StrictMode` con **default OFF al merge → zero-impact deploy**.

> **Pattern S2 — no `Closes #N`.** Issue #186 (Q2 Security Review) è CLOSED e generica; il branch traccia il piano three-amigos S3 + audit, mirror di S2 PR #1555 (`closingIssuesReferences: []`). Decisione registrata 2026-05-26 in commit `6f3741436`.

## What changed (T0–T9)

| Task | Commit | Scope |
|------|--------|-------|
| T0 | `c45f2733a` | spike cutover readiness + 2FA infra inventory |
| T1 | `6800273d9` | `LastTotpVerifiedAt` schema + Session domain |
| T2 | `bd9cc5f96` | `TwoFactorRequiredException` + 401 filter mapping |
| T3 | `634712b34` | `TwoFactor:StrictMode` config flag wrapper |
| T4 | `64cdbccb3` | strict enforcement path in `TwoFactorEnforcementBehavior` |
| T5 | `240f7c1b5` | step-up re-verification endpoint + handler (12 unit) |
| T6 | `215173bad` | `GET /api/v1/admin/users/no-2fa` sweep endpoint (2 integration) |
| T7 | `249aee74a` → Option B refactor `399c98543` | wire-doc + uniform error vocabulary (`two_factor_required` + subcode + `WWW-Authenticate`) + `503 two_factor_unavailable` |
| T8 | `b5df523cf` | `S3AcceptanceScenariosTests.cs` 8/8 PASS via real HTTP pipeline |
| T9 | `dd3611bf5` | DoD verification log (this PR) |

Plus three docs-only commits: `6f3741436` (T9 issue-linking decision), `652fda74f` (T5 path confirmation), `21c9082e2` (T5 checkboxes).

## DoD verification — 10/10 ✅

Tutti i 10 criteri DoD verificati su `b5df523cf` (build verde, working tree pulito). Evidenza completa file:line + commit hash in [`audits/2026-05-26-s3-three-amigos-kickoff.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/sp5-admin-security-s3-strict-2fa/audits/2026-05-26-s3-three-amigos-kickoff.md#dod-verification-log) § DoD verification log.

## Acceptance tests — 8/8 PASS ✅ (fresh run)

Run su `dd3611bf5` 2026-05-26 (~9m 40s, exit 0):

```
Superato S3_1_FreshTotp_AllowsDecoratedCommand_HappyPath                       [1m 9s]
Superato S3_2_StaleTotp_BlockedWith_StepUpRequired                             [55s]
Superato S3_3_NotEnrolledAdmin_BlockedWith_EnrollRequired                      [58s]
Superato S3_4_StepUpAndRetry_UnblocksTheDecoratedCommand                       [1m 17s]
Superato S3_5_FiveFailedStepUps_LeadsToLockout                                 [1m 3s]
Superato S3_6_ImpersonationContext_ActorsRecencyApplies                        [1m 34s]
Superato S3_7_NonDecoratedCommand_PassesEvenInStrictMode_RegressionGuard       [57s]
Superato S3_8_PerCommandMaxAge_FreshFor30ButStaleFor5                          [1m 1s]
Totale test: 8 / Superati: 8 / Tempo totale: 9.6754 minuti
```

Tutti gli scenari esercitano la pipeline reale (Testcontainers Postgres + WebApplicationFactory + real HTTP + real `TotpService` + Redis-counter via `ConcurrentDictionary`). TOTP codes minted con `OtpNet` contro l'encrypted secret di `TotpService.GenerateSetupAsync`. Lezione S2 [`feedback_acceptance_tests_must_exercise_real_pipeline`] applicata.

## Post-merge ops sequence

Da [`docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/sp5-admin-security-s3-strict-2fa/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md#execution-handoff) § Execution Handoff:

1. Merge S3 in `main-dev` (flag default=OFF — zero impact)
2. Deploy to staging
3. Ops chiama `GET /api/v1/admin/users/no-2fa` → sweep + email enrollment fino a 0 admin senza 2FA
4. Ops flip `TwoFactor:StrictMode=true` in staging admin config (`/admin/config` → Security)
5. Dogfooding 24h in staging
6. Repeat 3-4 in prod
7. Dopo 1 sprint prod-stable → follow-up issue per rimuovere il flag (hard-code `true`)

## Related context

- **Plan:** [`docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/sp5-admin-security-s3-strict-2fa/docs/superpowers/plans/2026-05-26-sp5-admin-security-s3-strict-2fa.md) — autoritativo, checkbox aggiornati.
- **Audit:** [`audits/2026-05-26-s3-three-amigos-kickoff.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/sp5-admin-security-s3-strict-2fa/audits/2026-05-26-s3-three-amigos-kickoff.md) — D-S3-1..7 + 8 acceptance scenari + DoD verification log.
- **Wire-doc:** [`docs/api/2fa-step-up-protocol.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/feature/sp5-admin-security-s3-strict-2fa/docs/api/2fa-step-up-protocol.md) — Option B as-built, FE handoff contract.
- **Epic concettuale:** #186 (Q2 2026 Security Review — CLOSED, voce P1.1).
- **Predecessor S2:** #1555 — MERGED in `main-dev` come `7ca5b5151`.
- **Correlate (NOT closed by this PR — verifica d'interazione):**
  - #1533 — bug(auth): `UserRepository.UpdateAsync` wipes 2FA BackupCodes on role/suspend changes
  - #1534 — tech-debt(audit): dual `audit_logs` write paths (DomainEventHandlerBase vs S1 outbox)
  - #1535 — tech-debt(audit): move domain-event dispatch post-commit (durable event outbox)

## Design decisions (highlights — full rationale in audit)

- **D-S3-1 cutover strategy:** config-flag default OFF al merge → flip in staging-then-prod previene mass-lockout (Nygard + Hightower critique applicata).
- **D-S3-2 wire format:** `401` + `two_factor_required` body + subcode + `WWW-Authenticate: TOTP-StepUp realm="meepleai-admin"` (RFC 7235).
- **D-S3-4b rate-limit:** **NON nuova entità**; riuso Redis di `TotpService.VerifyCodeAsync` (5/5min + lockout 15min già implementati, spike T0).
- **D-S3-6 audit attribution:** durante impersonate, lo step-up è azione dell'admin REALE (alice). Behavior legge `Principal.EffectiveActor`, NOT `Subject` (gate sull'admin, non sul target).
- **D-S3-7 per-command MaxAge:** `ImpersonationStartCommand` → 5min (industry-standard fresh challenge), gli altri 3 → default 30min.
- **Option B error vocabulary (post-T7 spec-panel):** step-up usa `two_factor_required` + `invalid_code`/`locked_out` (uniforme con enforcement) invece di divergent `two_factor_failed`/`two_factor_locked_out 429`. `503 two_factor_unavailable` per TOTP store-down failure mode.

## Out of scope (follow-up)

- FE step-up modal + 401 `subcode` handler refactor (plan FE separato; wire format ready in D-S3-2)
- WebAuthn / passkeys (#186 P1.2, epic separato)
- Recovery codes / backup factors (Q2 §11 D5)
- Auto-enrollment forzato (ops task; il blocker S3 è il SWEEP)
- Removal del flag `TwoFactor:StrictMode` dopo 1 sprint prod-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)