### PR TITLE
feat(ci): queue-time watchdog for stuck self-hosted jobs (#1573 follow-up)

### DIFF
--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -1,0 +1,174 @@
+name: Monitor Runner Queue (self-hosted job watchdog)
+
+# Issue #1573 follow-up (Hightower spec-panel recommendation):
+# Polls every 10 minutes for self-hosted runner jobs stuck in 'queued' or
+# split-brain in_progress state. Cancels stuck jobs older than the configured
+# threshold (default 10 min) WHEN a self-hosted runner is online — addresses
+# the 2026-05-26 orphaned-job incident where the Deploy to Staging job sat
+# queued for >1h while the runner reported online.
+#
+# Why cancellation (not re-run):
+# The deploy-staging concurrency block has cancel-in-progress: true since
+# PR #1583, so cancelling a stuck run frees the lock and allows the next
+# legitimate trigger (push or workflow_dispatch) to start clean. The runtime
+# steps are idempotent (psql ON_ERROR_STOP + idempotent SQL + docker compose
+# --force-recreate), so cancellation can never leave staging in a corrupted
+# state.
+#
+# Safety guards:
+#   - Skip entirely if no self-hosted runner is online (a legitimately busy
+#     queue is NOT stuck — only the split-brain "runner online but job not
+#     picked" case warrants cancellation).
+#   - Filter on labels containing 'self-hosted' so cloud-runner jobs are
+#     never touched (they have their own GitHub-managed scheduling).
+#   - timeout-minutes: 10 — the watchdog itself can never hang the queue.
+
+on:
+  schedule:
+    # Every 10 minutes. Aligned to the default threshold so a stuck job is
+    # caught within at most ~20 min of becoming stuck (one poll to observe,
+    # one to age past threshold).
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      threshold_minutes:
+        description: 'Queue time threshold in minutes before cancellation (default 10)'
+        required: false
+        default: '10'
+        type: string
+      dry_run:
+        description: 'If true, log stuck jobs but do not cancel'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  actions: write  # required for run cancel
+
+concurrency:
+  # Only one watchdog at a time. cancel-in-progress: true so a manual
+  # workflow_dispatch (e.g. tight threshold for emergency response) always
+  # supersedes the previous scheduled run rather than queueing behind it.
+  group: monitor-runner-queue
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan and cancel stuck self-hosted jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Identify and cancel stuck jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THRESHOLD: ${{ inputs.threshold_minutes || '10' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          NOW=$(date -u +%s)
+          THRESHOLD_S=$((THRESHOLD * 60))
+          REPO="${{ github.repository }}"
+
+          echo "🔍 Threshold: ${THRESHOLD} min (${THRESHOLD_S} s)"
+          echo "🔍 Dry-run: ${DRY_RUN}"
+          echo "🔍 Repo: ${REPO}"
+          echo ""
+
+          # Safety guard #1: at least one self-hosted runner must be online.
+          # A "stuck" job with NO runner online is just a legitimately queued
+          # job waiting for a runner — cancelling it would not help.
+          ONLINE_RUNNERS=$(gh api "repos/${REPO}/actions/runners" --jq '.runners[] | select(.status == "online") | .name' || true)
+          if [ -z "$ONLINE_RUNNERS" ]; then
+            echo "⚠️ No self-hosted runners online — nothing to do."
+            echo "   (A queued job in this state is waiting legitimately; cancelling would not help.)"
+            exit 0
+          fi
+          echo "✅ Self-hosted runners online:"
+          echo "$ONLINE_RUNNERS" | sed 's/^/   - /'
+          echo ""
+
+          # Scan recent runs in queued + in_progress states for stuck jobs.
+          # We check both:
+          #   - status=queued: the obvious case
+          #   - status=in_progress: the 2026-05-26 split-brain case where
+          #     the job appears running but runner_name is null
+          STUCK_COUNT=0
+          CANCELLED_RUNS=""
+
+          for STATUS in queued in_progress; do
+            echo "📋 Scanning runs with status=${STATUS}..."
+            RUN_IDS=$(gh api "repos/${REPO}/actions/runs?status=${STATUS}&per_page=30" --jq '.workflow_runs[].id' || true)
+
+            for RUN_ID in $RUN_IDS; do
+              # Get jobs that are either queued OR in_progress with no runner
+              # assigned, AND labeled self-hosted (cloud-runner jobs are
+              # always healthy from this watchdog's perspective).
+              STUCK_JOBS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+                --jq '.jobs[] | select(.labels | type == "array" and (any(. == "self-hosted"))) | select(.status == "queued" or (.status == "in_progress" and .runner_name == null)) | "\(.id)|\(.name)|\(.started_at)"' \
+                || true)
+
+              if [ -z "$STUCK_JOBS" ]; then
+                continue
+              fi
+
+              while IFS='|' read -r JOB_ID JOB_NAME STARTED_AT; do
+                if [ -z "$STARTED_AT" ] || [ "$STARTED_AT" = "null" ]; then
+                  echo "   ℹ️ Run ${RUN_ID} job '${JOB_NAME}' has no started_at — skipping"
+                  continue
+                fi
+                STARTED_S=$(date -u -d "$STARTED_AT" +%s)
+                AGE_S=$((NOW - STARTED_S))
+                AGE_MIN=$((AGE_S / 60))
+
+                if [ "$AGE_S" -gt "$THRESHOLD_S" ]; then
+                  echo "❌ STUCK: run=${RUN_ID} job='${JOB_NAME}' age=${AGE_MIN}min status=${STATUS}"
+                  STUCK_COUNT=$((STUCK_COUNT + 1))
+
+                  if [ "$DRY_RUN" = "true" ]; then
+                    echo "   🧪 DRY_RUN: would cancel run ${RUN_ID}"
+                  else
+                    # Cancel via GH API. If the run is already terminal,
+                    # the API returns 409 — we log and continue.
+                    if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
+                      echo "   ✅ Cancelled run ${RUN_ID}"
+                      CANCELLED_RUNS="${CANCELLED_RUNS} ${RUN_ID}"
+                    else
+                      # Try force-cancel as fallback (works on some terminal states)
+                      if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>&1; then
+                        echo "   ✅ Force-cancelled run ${RUN_ID}"
+                        CANCELLED_RUNS="${CANCELLED_RUNS} ${RUN_ID}"
+                      else
+                        echo "   ⚠️ Neither cancel nor force-cancel succeeded (run may already be terminal)"
+                      fi
+                    fi
+                  fi
+                else
+                  echo "   ⏳ run=${RUN_ID} job='${JOB_NAME}' age=${AGE_MIN}min (under threshold)"
+                fi
+              done <<< "$STUCK_JOBS"
+            done
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Stuck jobs detected: ${STUCK_COUNT}"
+          if [ -n "$CANCELLED_RUNS" ]; then
+            echo "Cancelled runs:${CANCELLED_RUNS}"
+          fi
+
+          # Surface to GITHUB_STEP_SUMMARY for visibility on schedule runs
+          {
+            echo "## Runner Queue Watchdog"
+            echo ""
+            echo "- Threshold: ${THRESHOLD} min"
+            echo "- Runners online: $(echo "$ONLINE_RUNNERS" | wc -l)"
+            echo "- Stuck jobs detected: ${STUCK_COUNT}"
+            if [ -n "$CANCELLED_RUNS" ]; then
+              echo "- Cancelled runs:${CANCELLED_RUNS}"
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "- ⚠️ Dry-run mode (no actual cancellations)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -41,6 +41,11 @@ on:
         required: false
         default: false
         type: boolean
+      per_page:
+        description: 'Runs per page to scan per status (default 100, max GH allows)'
+        required: false
+        default: '100'
+        type: string
 
 permissions:
   contents: read
@@ -63,7 +68,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           THRESHOLD: ${{ inputs.threshold_minutes || '10' }}
-          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          # Explicit boolean coercion to string: avoids accidental shell
+          # comparison against a non-string truthy value from the boolean input.
+          DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+          PER_PAGE: ${{ inputs.per_page || '100' }}
         run: |
           set -euo pipefail
 
@@ -73,15 +81,23 @@ jobs:
 
           echo "🔍 Threshold: ${THRESHOLD} min (${THRESHOLD_S} s)"
           echo "🔍 Dry-run: ${DRY_RUN}"
+          echo "🔍 Per page: ${PER_PAGE}"
           echo "🔍 Repo: ${REPO}"
           echo ""
 
-          # Safety guard #1: at least one self-hosted runner must be online.
-          # A "stuck" job with NO runner online is just a legitimately queued
-          # job waiting for a runner — cancelling it would not help.
-          ONLINE_RUNNERS=$(gh api "repos/${REPO}/actions/runners" --jq '.runners[] | select(.status == "online") | .name' || true)
+          # Safety guard #1: at least one SELF-HOSTED runner must be online.
+          # A "stuck" job with NO self-hosted runner online is just a
+          # legitimately queued job waiting for a runner — cancelling it
+          # would not help.
+          #
+          # The runners API returns each runner's labels as objects
+          # ({id, name, type}), NOT as plain strings. Filter on
+          # `.labels[].name == "self-hosted"`, not on raw label equality.
+          ONLINE_RUNNERS=$(gh api "repos/${REPO}/actions/runners" \
+            --jq '.runners[] | select(.status == "online") | select(.labels | any(.name == "self-hosted")) | .name' \
+            || true)
           if [ -z "$ONLINE_RUNNERS" ]; then
-            echo "⚠️ No self-hosted runners online — nothing to do."
+            echo "⚠️ No SELF-HOSTED runners online — nothing to do."
             echo "   (A queued job in this state is waiting legitimately; cancelling would not help.)"
             exit 0
           fi
@@ -91,57 +107,69 @@ jobs:
 
           # Scan recent runs in queued + in_progress states for stuck jobs.
           # We check both:
-          #   - status=queued: the obvious case
+          #   - status=queued: the obvious case (job never picked up)
           #   - status=in_progress: the 2026-05-26 split-brain case where
           #     the job appears running but runner_name is null
           STUCK_COUNT=0
-          CANCELLED_RUNS=""
+          CANCELLED_REFS=""
 
           for STATUS in queued in_progress; do
             echo "📋 Scanning runs with status=${STATUS}..."
-            RUN_IDS=$(gh api "repos/${REPO}/actions/runs?status=${STATUS}&per_page=30" --jq '.workflow_runs[].id' || true)
+            RUN_IDS=$(gh api "repos/${REPO}/actions/runs?status=${STATUS}&per_page=${PER_PAGE}" \
+              --jq '.workflow_runs[].id' || true)
 
             for RUN_ID in $RUN_IDS; do
               # Get jobs that are either queued OR in_progress with no runner
-              # assigned, AND labeled self-hosted (cloud-runner jobs are
-              # always healthy from this watchdog's perspective).
+              # assigned, AND labeled self-hosted (cloud-runner jobs have
+              # their own GitHub-managed scheduling and are never touched).
+              #
+              # Age timestamp routing:
+              #   - status=queued: started_at is null until pickup → use created_at
+              #   - status=in_progress + runner_name=null (split-brain): both
+              #     started_at and created_at are set → started_at preferred
+              # The expression `(.started_at // .created_at)` covers both.
               STUCK_JOBS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
-                --jq '.jobs[] | select(.labels | type == "array" and (any(. == "self-hosted"))) | select(.status == "queued" or (.status == "in_progress" and .runner_name == null)) | "\(.id)|\(.name)|\(.started_at)"' \
+                --jq '.jobs[]
+                  | select(.labels != null and (.labels | any(. == "self-hosted")))
+                  | select(.status == "queued" or (.status == "in_progress" and .runner_name == null))
+                  | "\(.id)|\(.name)|\(.started_at // .created_at // "")"' \
                 || true)
 
               if [ -z "$STUCK_JOBS" ]; then
                 continue
               fi
 
-              while IFS='|' read -r JOB_ID JOB_NAME STARTED_AT; do
-                if [ -z "$STARTED_AT" ] || [ "$STARTED_AT" = "null" ]; then
-                  echo "   ℹ️ Run ${RUN_ID} job '${JOB_NAME}' has no started_at — skipping"
+              while IFS='|' read -r JOB_ID JOB_NAME AGE_TS; do
+                if [ -z "$AGE_TS" ] || [ "$AGE_TS" = "null" ]; then
+                  echo "   ℹ️ Run ${RUN_ID} job '${JOB_NAME}' has neither started_at nor created_at — skipping"
                   continue
                 fi
-                STARTED_S=$(date -u -d "$STARTED_AT" +%s)
+                STARTED_S=$(date -u -d "$AGE_TS" +%s)
                 AGE_S=$((NOW - STARTED_S))
                 AGE_MIN=$((AGE_S / 60))
 
                 if [ "$AGE_S" -gt "$THRESHOLD_S" ]; then
-                  echo "❌ STUCK: run=${RUN_ID} job='${JOB_NAME}' age=${AGE_MIN}min status=${STATUS}"
+                  echo "❌ STUCK: run=${RUN_ID} job=${JOB_ID} '${JOB_NAME}' age=${AGE_MIN}min status=${STATUS}"
                   STUCK_COUNT=$((STUCK_COUNT + 1))
 
                   if [ "$DRY_RUN" = "true" ]; then
-                    echo "   🧪 DRY_RUN: would cancel run ${RUN_ID}"
+                    echo "   🧪 DRY_RUN: would cancel job ${JOB_ID} (fall back to run ${RUN_ID})"
                   else
-                    # Cancel via GH API. If the run is already terminal,
-                    # the API returns 409 — we log and continue.
-                    if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
-                      echo "   ✅ Cancelled run ${RUN_ID}"
-                      CANCELLED_RUNS="${CANCELLED_RUNS} ${RUN_ID}"
+                    # Prefer job-level cancel to minimize blast radius on
+                    # multi-job runs (e.g. a run with one healthy ubuntu-latest
+                    # job + one stuck self-hosted job). Fall back to run-level
+                    # cancel if the job endpoint fails, then force-cancel.
+                    if gh api -X POST "repos/${REPO}/actions/jobs/${JOB_ID}/cancel" >/dev/null 2>&1; then
+                      echo "   ✅ Cancelled job ${JOB_ID} (run ${RUN_ID})"
+                      CANCELLED_REFS="${CANCELLED_REFS} job:${JOB_ID}"
+                    elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
+                      echo "   ✅ Cancelled run ${RUN_ID} (job-level cancel unavailable; whole run cancelled)"
+                      CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}"
+                    elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>&1; then
+                      echo "   ✅ Force-cancelled run ${RUN_ID}"
+                      CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}(force)"
                     else
-                      # Try force-cancel as fallback (works on some terminal states)
-                      if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>&1; then
-                        echo "   ✅ Force-cancelled run ${RUN_ID}"
-                        CANCELLED_RUNS="${CANCELLED_RUNS} ${RUN_ID}"
-                      else
-                        echo "   ⚠️ Neither cancel nor force-cancel succeeded (run may already be terminal)"
-                      fi
+                      echo "   ⚠️ Neither job nor run cancellation succeeded (already terminal?)"
                     fi
                   fi
                 else
@@ -154,8 +182,8 @@ jobs:
           echo ""
           echo "=== Summary ==="
           echo "Stuck jobs detected: ${STUCK_COUNT}"
-          if [ -n "$CANCELLED_RUNS" ]; then
-            echo "Cancelled runs:${CANCELLED_RUNS}"
+          if [ -n "$CANCELLED_REFS" ]; then
+            echo "Cancelled:${CANCELLED_REFS}"
           fi
 
           # Surface to GITHUB_STEP_SUMMARY for visibility on schedule runs
@@ -163,10 +191,11 @@ jobs:
             echo "## Runner Queue Watchdog"
             echo ""
             echo "- Threshold: ${THRESHOLD} min"
-            echo "- Runners online: $(echo "$ONLINE_RUNNERS" | wc -l)"
+            echo "- Per page: ${PER_PAGE}"
+            echo "- Self-hosted runners online: $(echo "$ONLINE_RUNNERS" | wc -l)"
             echo "- Stuck jobs detected: ${STUCK_COUNT}"
-            if [ -n "$CANCELLED_RUNS" ]; then
-              echo "- Cancelled runs:${CANCELLED_RUNS}"
+            if [ -n "$CANCELLED_REFS" ]; then
+              echo "- Cancelled:${CANCELLED_REFS}"
             fi
             if [ "$DRY_RUN" = "true" ]; then
               echo "- ⚠️ Dry-run mode (no actual cancellations)"


### PR DESCRIPTION
## Summary

Implements the queue-time watchdog tracked in #1573 (Hightower's spec-panel P1 recommendation). The 2026-05-26 incident saw a `Deploy to Staging` job queued for >1h while the runner reported online. PR #1583 made the deploy-staging lock self-healing on a subsequent trigger via `cancel-in-progress: true`, but that recovery still requires SOMEONE to trigger again. This watchdog provides automatic detection + cancellation, closing the loop.

## Design

| Aspect | Value | Rationale |
|--------|-------|-----------|
| Schedule | `*/10 * * * *` | Catches a stuck job within ~20 min (1 poll observe + 1 poll age) |
| Runner | `ubuntu-latest` | Watchdog must ALWAYS be runnable, never depend on the self-hosted runner it monitors |
| Threshold (default) | 10 min | Conservative; configurable via `workflow_dispatch` input |
| Filter | jobs with `self-hosted` label | Cloud-runner jobs are never touched |
| Safety guard | Skip if no self-hosted runner online | A queued job with no runner up is legitimately waiting |
| Action | Cancel run (fall back to force-cancel) | Frees the concurrency lock; `cancel-in-progress: true` on deploy-staging makes the next trigger restart cleanly |

## Why cancellation is safe

`deploy-staging` is fully idempotent:
- Migration SQL: `dotnet ef --idempotent` (IF NOT EXISTS guards)
- Apply: `psql -v ON_ERROR_STOP=1` (no partial transactions)
- Deploy: `docker compose up --force-recreate` (converges from any state)

A cancelled run can be re-triggered (push or workflow_dispatch) and will re-converge.

## Workflow inputs

- `threshold_minutes` (default `10`) — tighten for emergency response
- `dry_run` (default `false`) — log stuck jobs without cancelling (useful for validating detection logic)

## Caveats

The cancel logic cannot be validated end-to-end without provoking a stuck job. Ships in "production but cautious" mode:
- Conservative 10-min threshold
- `dry_run` input available for empirical tuning
- `cancel-in-progress: true` on the watchdog's own concurrency group so a manual override (`workflow_dispatch` with tighter threshold) supersedes the scheduled run

## Validation

```
$ python yaml.safe_load(...)
YAML OK: Monitor Runner Queue (self-hosted job watchdog)
Trigger schedule: [{'cron': '*/10 * * * *'}]
Permissions: {'contents': 'read', 'actions': 'write'}
Concurrency: {'group': 'monitor-runner-queue', 'cancel-in-progress': True}
Jobs: ['scan']
```

## Refs

- #1573 (architectural rework follow-up; still does not close — header drift fix in PR #1600, skip-pattern investigation tracked separately)
- #1583 (quick mitigation `cancel-in-progress: true` that this watchdog complements)
- Incident: https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26442674324

🤖 Generated with [Claude Code](https://claude.com/claude-code)