### PR TITLE
docs+test(2fa): SP5 S3 post-merge follow-up — F1/F3/F4 from PR #1597 code review

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/StepUpTwoFactorCommandHandler.cs
@@ -13,12 +13,15 @@ namespace Api.BoundedContexts.Authentication.Application.Commands.TwoFactor;
 /// <c>TwoFactorVerify</c> audit — so this handler does NOT re-implement any of that. On success it
 /// refreshes <c>LastTotpVerifiedAt</c> on the session (clearing a step-up block) and emits a
 /// <c>TwoFactorStepUp</c> audit. A distinct lockout pre-check surfaces <c>LockedOut</c> so the
-/// endpoint can return 429 + retry-after (D-S3-4b).
+/// endpoint can return <c>401 two_factor_required</c> with <c>subcode=locked_out</c> +
+/// <c>retryAfterSeconds</c> (D-S3-4b; unified with the enforcement vocabulary in Option B —
+/// see refactor commit <c>399c98543</c> and <c>docs/api/2fa-step-up-protocol.md</c>).
 /// </summary>
 internal class StepUpTwoFactorCommandHandler : ICommandHandler<StepUpTwoFactorCommand, StepUpTwoFactorResult>
 {
     // Mirrors TotpService.LockoutDurationMinutes (15min). The lockout key TTL is the authoritative
-    // wait; this fixed value is the client-facing retry-after hint for the 429 response.
+    // wait; this fixed value is the client-facing retry-after hint for the
+    // 401 + subcode=locked_out response (Option B; not 429 — see ApiExceptionHandlerMiddleware).
     private const int LockoutRetryAfterSeconds = 900;
 
     private readonly ITotpService _totpService;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Configuration/TwoFactorEnforcementConfiguration.cs
@@ -27,7 +27,8 @@ internal static class TwoFactorConfigurationKeys
 /// <item>compile-time-safe binding to <see cref="TwoFactorConfigurationKeys.StrictMode"/></item>
 /// <item>mockable seam for unit-testing <c>TwoFactorEnforcementBehavior</c> (T4) without
 ///   needing a full <c>IConfigurationService</c> setup</item>
-/// <item>fail-closed semantics (returns the default on any error — matches the existing
+/// <item>fail-safe semantics (returns the default — shadow — on any error, so a config-store
+///   outage NEVER silently flips behavior to strict; matches the existing
 ///   <c>GetRegistrationModeQueryHandler</c> pattern)</item>
 /// </list>
 /// SP5 Admin Security S3 — D-S3-1.
@@ -37,8 +38,8 @@ internal interface ITwoFactorEnforcementConfiguration
     /// <summary>
     /// Reads the strict-mode flag from the dynamic configuration store. Returns
     /// <see cref="TwoFactorConfigurationKeys.StrictModeDefault"/> when the flag is unset
-    /// or the underlying store is unreachable (fail-closed: shadow mode is the safe default
-    /// since it never blocks legitimate admin actions).
+    /// or the underlying store is unreachable (fail-safe: shadow mode is the safe default
+    /// since it never blocks legitimate admin actions, and strict is opt-in by ops).
     /// </summary>
     Task<bool> GetStrictModeAsync(CancellationToken cancellationToken = default);
 }
@@ -63,8 +64,10 @@ internal sealed class TwoFactorEnforcementConfiguration : ITwoFactorEnforcementC
         }
         catch
         {
-            // Fail-closed: shadow mode on any read error. Strict mode is opt-in by ops, so
-            // an unreachable config store must NOT silently flip behavior to strict.
+            // Fail-safe: shadow mode on any read error. Strict mode is opt-in by ops, so an
+            // unreachable config store must NOT silently flip behavior to strict (which would
+            // mass-lock-out admins). "fail-safe" not "fail-closed/fail-secure": the security
+            // gate stays open to legitimate operators when the policy store is unreachable.
             return TwoFactorConfigurationKeys.StrictModeDefault;
         }
     }

--- a/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
@@ -405,6 +405,8 @@ public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
         var carolId = await SeedTargetUserAsync($"s3-6-carol-{Guid.NewGuid():N}@meepleai.test");
 
         // Refresh alice's recency (SeedAdminWith2FAAsync leaves it at the register-time default = null).
+        // Capture the exact value so we can later assert the impersonate session inherited it.
+        var aliceFreshTime = DateTime.UtcNow;
         using (var scope = _factory.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
@@ -412,7 +414,7 @@ public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
                 .Where(s => s.UserId == aliceId && s.RevokedAt == null && s.ImpersonatedByUserId == null)
                 .OrderByDescending(s => s.CreatedAt)
                 .FirstAsync();
-            aliceSession.LastTotpVerifiedAt = DateTime.UtcNow;
+            aliceSession.LastTotpVerifiedAt = aliceFreshTime;
             await db.SaveChangesAsync();
         }
         _strictModeOn = true;
@@ -422,6 +424,24 @@ public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
         impStart.StatusCode.Should().Be(HttpStatusCode.Created,
             $"impersonation start should succeed; body: {await impStart.Content.ReadAsStringAsync()}");
         RefreshClientCookieFromResponse(impStart);
+
+        // F3 pre-overwrite assertion: the impersonate session MUST inherit alice's recency from
+        // the REAL HTTP pipeline (ValidateSessionQueryHandler → HttpContext.Items[SessionStatusDto]
+        // → ImpersonationStartCommandHandler.ExtractCallerLastTotpVerifiedAt → impersonate row).
+        // Without this, the overwrite below would mask a regression where the propagation silently
+        // returns null. Companion regression-only test: Regression_ImpersonationInheritsActorRecency_ViaRealPipeline.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var impAfterStart = await db.UserSessions
+                .Where(s => s.ImpersonatedByUserId == aliceId && s.RevokedAt == null)
+                .OrderByDescending(s => s.CreatedAt)
+                .FirstAsync();
+            impAfterStart.LastTotpVerifiedAt.Should().BeCloseTo(aliceFreshTime, TimeSpan.FromSeconds(5),
+                "ExtractCallerLastTotpVerifiedAt must propagate the actor's LastTotpVerifiedAt from "
+                + "the live SessionStatusDto in HttpContext.Items — fixture-only injection would mask "
+                + "a regression in the real ValidateSession pipeline (S2 lesson)");
+        }
 
         // The impersonate session inherits alice's recency (T1 spike). Move that recency back to
         // -10min: STALE for ImpersonationStart (MaxAge=5) but FRESH for DeleteUser (MaxAge=30).
@@ -462,5 +482,63 @@ public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
         // succeeds — strict mode must NEVER touch non-decorated commands.
         response.StatusCode.Should().Be(HttpStatusCode.OK,
             "TwoFactorEnforcementBehavior.S3-7 regression guard: missing [RequireTwoFactor] = no gate");
+    }
+
+    /// <summary>
+    /// F3 follow-up regression test (post-merge of PR #1597): isolates the propagation of the
+    /// actor's <c>LastTotpVerifiedAt</c> through the REAL HTTP pipeline
+    /// (<c>SessionAuthenticationMiddleware</c> → <c>ValidateSessionQueryHandler</c> →
+    /// <c>HttpContext.Items[SessionStatusDto]</c> →
+    /// <c>ImpersonationStartCommandHandler.ExtractCallerLastTotpVerifiedAt</c> → impersonate row).
+    ///
+    /// S3_6 exercises this propagation but then immediately overwrites the inherited value, so a
+    /// regression where <c>ExtractCallerLastTotpVerifiedAt</c> silently returns <c>null</c> would
+    /// still PASS S3_6's DeleteUser assertion. This test asserts ONLY the propagation, with no
+    /// overwrite. Aligns with the S2 lesson <c>feedback_acceptance_tests_must_exercise_real_pipeline</c>
+    /// — the unit test <c>Handle_HappyPath_InheritsActorLastTotpVerifiedAtFromHttpContext</c>
+    /// constructs <c>SessionStatusDto</c> manually and would not catch a regression in the
+    /// <c>ValidateSession</c> hydration step.
+    /// </summary>
+    [Fact]
+    public async Task Regression_ImpersonationInheritsActorRecency_ViaRealPipeline()
+    {
+        var aliceFreshTime = DateTime.UtcNow;
+        var (aliceId, _, _) = await SeedAdminWith2FAAsync(
+            $"f3-alice-{Guid.NewGuid():N}@meepleai.test", "UnusualPwd123!", role: "superadmin");
+        var bobId = await SeedTargetUserAsync($"f3-bob-{Guid.NewGuid():N}@meepleai.test");
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var aliceSession = await db.UserSessions
+                .Where(s => s.UserId == aliceId && s.RevokedAt == null && s.ImpersonatedByUserId == null)
+                .OrderByDescending(s => s.CreatedAt)
+                .FirstAsync();
+            aliceSession.LastTotpVerifiedAt = aliceFreshTime;
+            await db.SaveChangesAsync();
+        }
+        _strictModeOn = true;
+
+        var impStart = await _client.PostAsJsonAsync("/api/v1/admin/impersonation/start",
+            new { TargetUserId = bobId, Reason = "F3 regression: real-pipeline recency inheritance", DurationMinutes = 15 });
+        impStart.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"impersonation start should succeed; body: {await impStart.Content.ReadAsStringAsync()}");
+
+        // Assert the impersonate session row carries alice's recency (no mutation between start and read).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var imp = await db.UserSessions
+                .Where(s => s.ImpersonatedByUserId == aliceId && s.RevokedAt == null)
+                .OrderByDescending(s => s.CreatedAt)
+                .FirstAsync();
+
+            imp.LastTotpVerifiedAt.Should().BeCloseTo(aliceFreshTime, TimeSpan.FromSeconds(5),
+                "ImpersonationStartCommandHandler.ExtractCallerLastTotpVerifiedAt must read alice's "
+                + "LastTotpVerifiedAt from HttpContext.Items[SessionStatusDto] (populated by the real "
+                + "ValidateSessionQueryHandler) and write it into the new impersonate session row. "
+                + "A null value here indicates ValidateSession is failing to hydrate "
+                + "LastTotpVerifiedAt into SessionStatusDto exposed to the command handler.");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1597 (`0cc7e7bad` MERGED 2026-05-26) addressing 3 findings raised by the code review subagent (all score 75 — below the ≥80 cutoff, so not blocking the merge, but actionable).

**Branch:** `feature/sp5-s3-followup-findings` ← `main-dev` HEAD `8d43ff95e`.

**No `Closes #N`** — same pattern as PR #1597 and S2 PR #1555 (`closingIssuesReferences: []`).

## What changed (3 commits)

| Finding | Commit | Type | Scope |
|---------|--------|------|-------|
| F1 | `d7fb470e5` | docs | `StepUpTwoFactorCommandHandler.cs:8-21` — stale "429" handler XML doc + retry-after constant comment → 401 + subcode=locked_out (Option B post-`399c98543`) |
| F4 | `94dbfd25f` | docs | `TwoFactorEnforcementConfiguration.cs:30, 40-41, 66-69` — "fail-closed" → "fail-safe" (3 sites) for terminological correctness (security gate stays open on store failure, NEVER auto-flips to strict) |
| F3 | `285632566` | test | `S3AcceptanceScenariosTests.cs` — (a) pre-overwrite assertion in `S3_6` against `aliceFreshTime` (BeCloseTo 5s); (b) new `Regression_ImpersonationInheritsActorRecency_ViaRealPipeline` test exercising ONLY the real-pipeline propagation (no overwrite, no downstream command) |

## Why this PR exists

The PR #1597 code review surfaced these 3 findings via 5 parallel review agents:

- **F1 / F4** — doc/comment-only mismatches with the as-built behavior. The wire-protocol spec [`docs/api/2fa-step-up-protocol.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/8d43ff95e/docs/api/2fa-step-up-protocol.md) was already correct; only the in-handler/in-config comments were stale (F1) or terminologically inverted (F4). The risk is misreading by a future maintainer relying on the doc comment as the contract instead of the wire-doc.

- **F3** — test-coverage gap: the unit test `Handle_HappyPath_InheritsActorLastTotpVerifiedAtFromHttpContext` constructs `SessionStatusDto` manually (bypassing the live middleware + `ValidateSessionQueryHandler` hydration), and `S3_6` exercises the real pipeline but immediately overwrites the inherited value before asserting. A regression where `ExtractCallerLastTotpVerifiedAt` silently returns `null` would pass both. Same risk pattern as the S2 lesson [`feedback_acceptance_tests_must_exercise_real_pipeline`].

## Verification

```
S3AcceptanceScenariosTests fresh run (Integration-GroupD, 3m29s):
  S3_1..S3_8                                                  8/8 ✅
  Regression_ImpersonationInheritsActorRecency_ViaRealPipeline  ✅  (new)
  Totale test: 9 / Superati: 9
```

The new regression test PASSes against the existing (correct) propagation code — it only adds coverage, no behavior change. F1/F4 are comments-only edits (build verde, 0 errors).

## Related

- **Parent PR:** #1597 (SP5 S3 strict 2FA cutover, merged 2026-05-26 as `0cc7e7bad`)
- **Audit:** [`audits/2026-05-26-s3-three-amigos-kickoff.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/8d43ff95e/audits/2026-05-26-s3-three-amigos-kickoff.md) § DoD verification log
- **Wire-doc:** [`docs/api/2fa-step-up-protocol.md`](https://github.com/meepleAi-app/meepleai-monorepo/blob/8d43ff95e/docs/api/2fa-step-up-protocol.md) — confirmed 401 + subcode=locked_out is the canonical contract; F1 aligns the handler comments to this
- **Code review findings list:** [PR #1597 comment](https://github.com/meepleAi-app/meepleai-monorepo/pull/1597#issuecomment-4548499792)
- **S2 lesson:** `feedback_acceptance_tests_must_exercise_real_pipeline` (project memory)

## Out of scope

- F2 (forensic-audit best-effort cancellation) — score 35; intentional documented best-effort design trade-off, not addressed.
- Any new behavior, new endpoints, new flags, or test-helper refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)