### PR TITLE
hotfix(ci): revert invalid 'administration' permission on watchdog (#1573)

### DIFF
--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -49,12 +49,18 @@ on:
 
 permissions:
   contents: read
-  actions: write       # required for run/job cancel
-  administration: read # required for /repos/{owner}/{repo}/actions/runners listing
-                       # (without this, GITHUB_TOKEN gets HTTP 403 on the runners
-                       # endpoint and the safety guard cannot determine if a
-                       # self-hosted runner is online — runtime falls back to
-                       # dry-run mode in that case to fail safe.)
+  actions: write  # required for run/job cancel
+  # NOTE on runners endpoint access:
+  # /repos/{owner}/{repo}/actions/runners requires the `administration` scope,
+  # which is NOT a valid GITHUB_TOKEN permission for GitHub Actions workflows
+  # (it's only available on PATs / GitHub Apps). Adding `administration: read`
+  # here causes the workflow parser to fail with HTTP 422 (see hotfix that
+  # reverted the attempt). The runtime gracefully degrades via the fail-safe
+  # block in the step below: on HTTP 403, DRY_RUN is forced true so detection
+  # still runs for visibility but no cancellations occur. To get full cancel
+  # capability, configure a repository secret WATCHDOG_RUNNERS_PAT with a
+  # fine-grained PAT scoped `Administration: Read` on this repo, then plumb
+  # it into GH_TOKEN below (out of scope for this initial watchdog).
 
 concurrency:
   # Only one watchdog at a time. cancel-in-progress: true so a manual


### PR DESCRIPTION
## Summary

**Hotfix urgente** per il bug introdotto da PR #1607 nel watchdog `monitor-runner-queue.yml`.

## Bug

PR #1607 ha aggiunto `administration: read` al `permissions:` block per cercare di dare al `GITHUB_TOKEN` lo scope necessario per listare i self-hosted runner. Però **`administration` NON è una permission valida per workflow GitHub Actions** — è disponibile solo su PAT e GitHub Apps. Il parser del workflow lo rifiuta con:

```
HTTP 422: failed to parse workflow:
(Line: 53, Col: 3): Unexpected value 'administration'
```

Il run scheduled dopo il merge di PR #1607 ([`26493685619`](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26493685619), 0 jobs, conclusion failure) lo conferma.

## Fix

Rimosso `administration: read` dalle permissions. Aggiornato il commento per documentare:
1. Perché la permission non può essere usata
2. Che il fail-safe block introdotto in PR #1607 funziona comunque (force `DRY_RUN=true` su HTTP 403)
3. Workaround per il futuro: configurare un PAT secret `WATCHDOG_RUNNERS_PAT` con scope `Administration: Read` e usarlo come `GH_TOKEN` (out of scope per questo hotfix)

## Behavior post-merge

Il watchdog girerà in **fail-safe mode permanente** finché non viene configurato un PAT:
- Detection logic gira normalmente
- Logging di stuck job per visibility
- **Nessuna cancellazione effettiva** (DRY_RUN forzato a true via fail-safe path)

Questo è il comportamento corretto per fail-safe-by-default: meglio loggare e non agire che agire senza poter verificare la precondizione.

## Validation

```
$ python yaml.safe_load(...)
YAML OK: Monitor Runner Queue (self-hosted job watchdog)
Permissions: {'contents': 'read', 'actions': 'write'}
administration absent: True
```

## Refs

- #1573 (parent)
- PR #1607 (introduced the bug)
- PR #1601 (original watchdog)
- Failed run: https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26493685619

🤖 Generated with [Claude Code](https://claude.com/claude-code)