### PR TITLE
fix(ci): add always() to snapshot+e2e if guards (#1602 final resolution)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -497,7 +497,15 @@ jobs:
     # change (e.g. DEPLOY_METHOD=k8s) would still SSH and silently fail (the
     # `|| true` on the BASELINE read swallows errors), wasting a self-hosted
     # runner slot. Aligns with the gating pattern on every other SSH step.
-    if: vars.DEPLOY_METHOD == 'ssh'
+    #
+    # Issue #1602: the explicit `if:` alone does NOT bypass GHA's implicit
+    # `success()` propagation along the entire `needs` chain. When upstream
+    # `pre-deploy-check` is skipped (workflow_dispatch + skip_tests=true),
+    # GHA propagates the skip down to this job even though `build.result` is
+    # `success`. Empirically validated by run 26492568604 (post-#1600). The
+    # `always() &&` prefix forces evaluation of the explicit condition
+    # regardless of the implicit success() check — see #1602 for full finding.
+    if: always() && vars.DEPLOY_METHOD == 'ssh'
     outputs:
       previous_baseline: ${{ steps.read-baseline.outputs.baseline }}
     steps:
@@ -1069,7 +1077,12 @@ jobs:
     name: Staging E2E Smoke Tests
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}  # Needs browser support (not self-hosted ARM64)
     needs: [validate]
-    if: needs.validate.result == 'success'
+    # Issue #1602: `always() &&` prefix required to bypass GHA's implicit
+    # success() propagation along the entire `needs` chain. Without it, this
+    # job is skipped under workflow_dispatch + skip_tests=true even when
+    # `validate` succeeds, because upstream `pre-deploy-check` is skipped.
+    # Validated by investigation run 26492568604 — see #1602 for full finding.
+    if: always() && needs.validate.result == 'success'
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -498,14 +498,19 @@ jobs:
     # `|| true` on the BASELINE read swallows errors), wasting a self-hosted
     # runner slot. Aligns with the gating pattern on every other SSH step.
     #
-    # Issue #1602: the explicit `if:` alone does NOT bypass GHA's implicit
-    # `success()` propagation along the entire `needs` chain. When upstream
-    # `pre-deploy-check` is skipped (workflow_dispatch + skip_tests=true),
-    # GHA propagates the skip down to this job even though `build.result` is
-    # `success`. Empirically validated by run 26492568604 (post-#1600). The
-    # `always() &&` prefix forces evaluation of the explicit condition
-    # regardless of the implicit success() check — see #1602 for full finding.
-    if: always() && vars.DEPLOY_METHOD == 'ssh'
+    # Issue #1602 (PR #1610 + post-review refinement): the explicit `if:`
+    # alone does NOT bypass GHA's implicit `success()` propagation along the
+    # entire `needs` chain. When upstream `pre-deploy-check` is skipped
+    # (workflow_dispatch + skip_tests=true), GHA propagates the skip down to
+    # this job even though `build.result` is `success` (validated by run
+    # 26492568604 post-#1600). We use `!cancelled() &&` rather than `always() &&`:
+    #   - `always()` would also run the job on workflow cancellation, leaking
+    #     SSH sessions and contradicting the cancel-in-progress: true rationale.
+    #   - `!cancelled()` respects cancellation while still suppressing the
+    #     implicit success() chain check.
+    # The explicit `needs.build.result == 'success'` re-adds the upstream
+    # success gate (otherwise a `build` failure would still trigger SSH).
+    if: ${{ !cancelled() && needs.build.result == 'success' && vars.DEPLOY_METHOD == 'ssh' }}
     outputs:
       previous_baseline: ${{ steps.read-baseline.outputs.baseline }}
     steps:
@@ -841,7 +846,11 @@ jobs:
     # validate runs only when deploy actually succeeded — snapshot-baseline
     # may be `skipped` (e.g. first deploy with no prior DEPLOYMENT.json) and
     # validate still proceeds, since the baseline read is informational only.
-    if: always() && needs.deploy.result == 'success'
+    #
+    # PR #1610 post-review refinement: switched from `always() &&` to
+    # `!cancelled() &&` for consistency with snapshot-baseline and
+    # e2e-staging, and to respect workflow cancellation (cancel-in-progress).
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1077,12 +1086,14 @@ jobs:
     name: Staging E2E Smoke Tests
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}  # Needs browser support (not self-hosted ARM64)
     needs: [validate]
-    # Issue #1602: `always() &&` prefix required to bypass GHA's implicit
-    # success() propagation along the entire `needs` chain. Without it, this
-    # job is skipped under workflow_dispatch + skip_tests=true even when
-    # `validate` succeeds, because upstream `pre-deploy-check` is skipped.
-    # Validated by investigation run 26492568604 — see #1602 for full finding.
-    if: always() && needs.validate.result == 'success'
+    # Issue #1602 (PR #1610 + post-review refinement): bypass GHA's implicit
+    # success() chain propagation. Without this, the job is skipped under
+    # workflow_dispatch + skip_tests=true even when `validate` succeeds,
+    # because upstream `pre-deploy-check` is skipped (validated by run
+    # 26492568604). We use `!cancelled() &&` instead of `always() &&` so the
+    # job still respects user/concurrency-group cancellation — `always()`
+    # would risk orphaning Playwright browser processes on cancel.
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Closes #1602 finally. Empirical investigation [`26492568604`](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26492568604) established that GHA applies an **implicit `success()` check over the entire upstream `needs` chain** even when a job declares a custom `if:`. When `pre-deploy-check` is skipped (via `skip_tests=true`), GHA propagates the skip downstream regardless of the explicit `if:` condition.

`always() &&` prefix bypasses the implicit success() check, forcing evaluation of the explicit condition.

## Empirical evidence

Test run from #1602 investigation (with PR #1600 changes):

| Job | `if` condition | Result |
|-----|----|----|
| `validate` | `always() && needs.deploy.result == 'success'` | ✅ SUCCESS |
| `snapshot-baseline` | `vars.DEPLOY_METHOD == 'ssh'` (no always()) | ❌ skipped |
| `e2e-staging` | `needs.validate.result == 'success'` (no always()) | ❌ skipped |

Only `validate` ran successfully — the only job with `always() &&` prefix.

## Changes

| Job | Before | After |
|-----|--------|-------|
| `snapshot-baseline.if` | `vars.DEPLOY_METHOD == 'ssh'` | `always() && vars.DEPLOY_METHOD == 'ssh'` |
| `e2e-staging.if` | `needs.validate.result == 'success'` | `always() && needs.validate.result == 'success'` |

## Behavior delta

| Scenario | Before | After |
|----------|--------|-------|
| `push` to main-staging (realistic) | All jobs run ✓ | All jobs run ✓ (unchanged) |
| `workflow_dispatch+skip_tests=true` | snapshot/e2e skipped | snapshot/e2e run ✓ |
| `workflow_dispatch+force_full_deploy=true` | All jobs run ✓ | All jobs run ✓ (unchanged) |

## Validation

```
$ python yaml.safe_load(...)
snapshot-baseline.if: always() && vars.DEPLOY_METHOD == 'ssh'
e2e-staging.if: always() && needs.validate.result == 'success'
always() prefix on both: True
```

Post-merge: another `workflow_dispatch+skip_tests=true` run will empirically confirm snapshot and e2e now run successfully under that trigger.

## Refs

- #1602 (will close after empirical post-merge validation)
- #1573 (architectural parent — all follow-up findings now resolved)
- #1600 (PR that partially resolved this via validate.if)
- Investigation run: https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26492568604

🤖 Generated with [Claude Code](https://claude.com/claude-code)