### PR TITLE
release: main-dev → main-staging 2026-05-27 (watchdog hotfix + #1602 final fix)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -497,7 +497,20 @@ jobs:
     # change (e.g. DEPLOY_METHOD=k8s) would still SSH and silently fail (the
     # `|| true` on the BASELINE read swallows errors), wasting a self-hosted
     # runner slot. Aligns with the gating pattern on every other SSH step.
-    if: vars.DEPLOY_METHOD == 'ssh'
+    #
+    # Issue #1602 (PR #1610 + post-review refinement): the explicit `if:`
+    # alone does NOT bypass GHA's implicit `success()` propagation along the
+    # entire `needs` chain. When upstream `pre-deploy-check` is skipped
+    # (workflow_dispatch + skip_tests=true), GHA propagates the skip down to
+    # this job even though `build.result` is `success` (validated by run
+    # 26492568604 post-#1600). We use `!cancelled() &&` rather than `always() &&`:
+    #   - `always()` would also run the job on workflow cancellation, leaking
+    #     SSH sessions and contradicting the cancel-in-progress: true rationale.
+    #   - `!cancelled()` respects cancellation while still suppressing the
+    #     implicit success() chain check.
+    # The explicit `needs.build.result == 'success'` re-adds the upstream
+    # success gate (otherwise a `build` failure would still trigger SSH).
+    if: ${{ !cancelled() && needs.build.result == 'success' && vars.DEPLOY_METHOD == 'ssh' }}
     outputs:
       previous_baseline: ${{ steps.read-baseline.outputs.baseline }}
     steps:
@@ -833,7 +846,11 @@ jobs:
     # validate runs only when deploy actually succeeded — snapshot-baseline
     # may be `skipped` (e.g. first deploy with no prior DEPLOYMENT.json) and
     # validate still proceeds, since the baseline read is informational only.
-    if: always() && needs.deploy.result == 'success'
+    #
+    # PR #1610 post-review refinement: switched from `always() &&` to
+    # `!cancelled() &&` for consistency with snapshot-baseline and
+    # e2e-staging, and to respect workflow cancellation (cancel-in-progress).
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1069,7 +1086,14 @@ jobs:
     name: Staging E2E Smoke Tests
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}  # Needs browser support (not self-hosted ARM64)
     needs: [validate]
-    if: needs.validate.result == 'success'
+    # Issue #1602 (PR #1610 + post-review refinement): bypass GHA's implicit
+    # success() chain propagation. Without this, the job is skipped under
+    # workflow_dispatch + skip_tests=true even when `validate` succeeds,
+    # because upstream `pre-deploy-check` is skipped (validated by run
+    # 26492568604). We use `!cancelled() &&` instead of `always() &&` so the
+    # job still respects user/concurrency-group cancellation — `always()`
+    # would risk orphaning Playwright browser processes on cancel.
+    if: ${{ !cancelled() && needs.validate.result == 'success' }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -49,12 +49,18 @@ on:
 
 permissions:
   contents: read
-  actions: write       # required for run/job cancel
-  administration: read # required for /repos/{owner}/{repo}/actions/runners listing
-                       # (without this, GITHUB_TOKEN gets HTTP 403 on the runners
-                       # endpoint and the safety guard cannot determine if a
-                       # self-hosted runner is online — runtime falls back to
-                       # dry-run mode in that case to fail safe.)
+  actions: write  # required for run/job cancel
+  # NOTE on runners endpoint access:
+  # /repos/{owner}/{repo}/actions/runners requires the `administration` scope,
+  # which is NOT a valid GITHUB_TOKEN permission for GitHub Actions workflows
+  # (it's only available on PATs / GitHub Apps). Adding `administration: read`
+  # here causes the workflow parser to fail with HTTP 422 (see hotfix that
+  # reverted the attempt). The runtime gracefully degrades via the fail-safe
+  # block in the step below: on HTTP 403, DRY_RUN is forced true so detection
+  # still runs for visibility but no cancellations occur. To get full cancel
+  # capability, configure a repository secret WATCHDOG_RUNNERS_PAT with a
+  # fine-grained PAT scoped `Administration: Read` on this repo, then plumb
+  # it into GH_TOKEN below (out of scope for this initial watchdog).
 
 concurrency:
   # Only one watchdog at a time. cancel-in-progress: true so a manual

--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -49,7 +49,12 @@ on:
 
 permissions:
   contents: read
-  actions: write  # required for run cancel
+  actions: write       # required for run/job cancel
+  administration: read # required for /repos/{owner}/{repo}/actions/runners listing
+                       # (without this, GITHUB_TOKEN gets HTTP 403 on the runners
+                       # endpoint and the safety guard cannot determine if a
+                       # self-hosted runner is online — runtime falls back to
+                       # dry-run mode in that case to fail safe.)
 
 concurrency:
   # Only one watchdog at a time. cancel-in-progress: true so a manual
@@ -93,16 +98,41 @@ jobs:
           # The runners API returns each runner's labels as objects
           # ({id, name, type}), NOT as plain strings. Filter on
           # `.labels[].name == "self-hosted"`, not on raw label equality.
-          ONLINE_RUNNERS=$(gh api "repos/${REPO}/actions/runners" \
-            --jq '.runners[] | select(.status == "online") | select(.labels | any(.name == "self-hosted")) | .name' \
-            || true)
-          if [ -z "$ONLINE_RUNNERS" ]; then
-            echo "⚠️ No SELF-HOSTED runners online — nothing to do."
-            echo "   (A queued job in this state is waiting legitimately; cancelling would not help.)"
-            exit 0
+          #
+          # Error handling rationale (post-2026-05-27 run 26492366133):
+          # The /actions/runners endpoint requires the `administration:read`
+          # GITHUB_TOKEN scope (declared in `permissions:` above). If the org
+          # has restricted that scope (e.g. fine-grained PAT-only access), the
+          # API returns HTTP 403. We MUST distinguish three states:
+          #   (a) API succeeded, runners online → proceed
+          #   (b) API succeeded, no runners online → exit cleanly (no work)
+          #   (c) API failed (403/network/etc) → fail-SAFE: force DRY_RUN so
+          #       we still log stuck-job detection for visibility but never
+          #       cancel anything we couldn't verify the precondition for
+          # The previous version conflated (b) and (c), with `|| true` swallowing
+          # the 403 error and then the `[ -z "$ONLINE_RUNNERS" ]` check failing
+          # because the variable contained the JSON error body, not empty.
+          RUNNERS_RAW=$(gh api "repos/${REPO}/actions/runners" 2>&1) && RUNNERS_RC=0 || RUNNERS_RC=$?
+          if [ "$RUNNERS_RC" -ne 0 ] || echo "$RUNNERS_RAW" | grep -q '"status": *"403"\|Resource not accessible'; then
+            echo "⚠️ Cannot list runners (HTTP error or permission denied):"
+            echo "$RUNNERS_RAW" | head -3 | sed 's/^/   /'
+            echo ""
+            echo "🛡️ FAIL-SAFE: forcing DRY_RUN=true. Stuck-job detection still runs"
+            echo "   for visibility, but no actual cancellations will occur."
+            echo "   To enable cancellations, ensure the workflow has"
+            echo "   permissions.administration: read and the org allows it."
+            DRY_RUN=true
+            ONLINE_RUNNERS="(unknown — runners API unreachable, fail-safe engaged)"
+          else
+            ONLINE_RUNNERS=$(echo "$RUNNERS_RAW" | jq -r '.runners[] | select(.status == "online") | select(.labels | any(.name == "self-hosted")) | .name' || true)
+            if [ -z "$ONLINE_RUNNERS" ]; then
+              echo "⚠️ No SELF-HOSTED runners online — nothing to do."
+              echo "   (A queued job in this state is waiting legitimately; cancelling would not help.)"
+              exit 0
+            fi
+            echo "✅ Self-hosted runners online:"
+            echo "$ONLINE_RUNNERS" | sed 's/^/   - /'
           fi
-          echo "✅ Self-hosted runners online:"
-          echo "$ONLINE_RUNNERS" | sed 's/^/   - /'
           echo ""
 
           # Scan recent runs in queued + in_progress states for stuck jobs.


### PR DESCRIPTION
## Summary

Release per propagare a `main-staging` gli hotfix watchdog (#1607 + #1609) e — al merge di PR #1610 prima di questa — il fix finale per #1602.

## Commits da propagare

Al momento della creazione (auto-update al merge di #1610):

| SHA | PR | Type | Scope |
|-----|----|------|-------|
| `f5e1ce83b` | #1609 | hotfix(ci) | revert invalid `administration:read` permission on watchdog |
| `30cef7d66` | #1607 | fix(ci) | watchdog permission attempt + fail-safe on runners API 403 |

Se PR #1610 (always() su snapshot+e2e per #1602) è mergiata prima del merge di questa release:
| `<hash>` | #1610 | fix(ci) | add `always() &&` to snapshot+e2e if guards (#1602 final) |

## Impatto su staging al merge

Il merge triggera `deploy-staging.yml` (push trigger). Effetti:

1. **Watchdog `monitor-runner-queue.yml` su main-staging**: era stato propagato nella release PR #1604 ma con il bug della permission invalida. Questa release lo aggiorna alla versione fail-safe corretta.
2. **Se #1610 incluso**: snapshot-baseline e e2e-staging useranno il pattern `always() &&` post-deploy. Sotto push trigger non c'è alcuna differenza visibile (tutti i job upstream sono success). La differenza emerge solo sotto `workflow_dispatch+skip_tests=true` che è l'emergency escape hatch.

**Migration**: nessuna nuova migration EF Core in questa release (solo CI fixes).

## Pre-validation

- PR #1607 + #1609: validati su main-dev via manual workflow_dispatch ([`26493794497`](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26493794497) — fail-safe mode confermato funzionante)
- PR #1610: verifica empirica da fare post-merge via altro workflow_dispatch+skip_tests=true

## Post-merge checklist

- [ ] Monitor `deploy-staging` triggerato dal merge
- [ ] Confermare deploy SUCCESS (nessuna migration nuova, dovrebbe essere veloce)
- [ ] Empirical validation: `workflow_dispatch+skip_tests=true` su main-staging → snapshot-baseline e e2e-staging dovrebbero ora girare (post-#1610)
- [ ] Chiudere #1602 dopo validation empirica

## Refs

- #1573 (closed) — atomicity rework
- #1602 — skip pattern under workflow_dispatch+skip_tests=true (will close post-validation)
- PR #1607 (watchdog permission attempt)
- PR #1609 (revert invalid permission, fail-safe path)
- PR #1610 (always() final fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)