### PR TITLE
feat(ci): plumb WATCHDOG_RUNNERS_PAT + simplify cancel to run-level (#1573)

### DIFF
--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -125,6 +125,10 @@ jobs:
           # The previous version conflated (b) and (c), with `|| true` swallowing
           # the 403 error and then the `[ -z "$ONLINE_RUNNERS" ]` check failing
           # because the variable contained the JSON error body, not empty.
+          # Primary guard: gh CLI exits non-zero on any HTTP 4xx/5xx (incl. the
+          # 403 from a missing administration scope). The grep is intentionally
+          # belt-and-suspenders for a hypothetical future CLI that exits 0 with
+          # an error body — RUNNERS_RC is the authoritative check.
           RUNNERS_RAW=$(gh api "repos/${REPO}/actions/runners" 2>&1) && RUNNERS_RC=0 || RUNNERS_RC=$?
           if [ "$RUNNERS_RC" -ne 0 ] || echo "$RUNNERS_RAW" | grep -q '"status": *"403"\|Resource not accessible'; then
             echo "⚠️ Cannot list runners (HTTP error or permission denied):"
@@ -132,10 +136,12 @@ jobs:
             echo ""
             echo "🛡️ FAIL-SAFE: forcing DRY_RUN=true. Stuck-job detection still runs"
             echo "   for visibility, but no actual cancellations will occur."
-            echo "   To enable cancellations, ensure the workflow has"
-            echo "   permissions.administration: read and the org allows it."
+            echo "   To enable cancellations, configure the WATCHDOG_RUNNERS_PAT secret"
+            echo "   (fine-grained PAT: Administration:Read + Actions:Read/write)."
+            echo "   See docs/for-developers/operations/watchdog-runners-pat-setup.md"
             DRY_RUN=true
-            ONLINE_RUNNERS="(unknown — runners API unreachable, fail-safe engaged)"
+            ONLINE_RUNNERS=""
+            RUNNERS_ONLINE_COUNT="unknown (fail-safe)"
           else
             ONLINE_RUNNERS=$(echo "$RUNNERS_RAW" | jq -r '.runners[] | select(.status == "online") | select(.labels | any(.name == "self-hosted")) | .name' || true)
             if [ -z "$ONLINE_RUNNERS" ]; then
@@ -143,6 +149,8 @@ jobs:
               echo "   (A queued job in this state is waiting legitimately; cancelling would not help.)"
               exit 0
             fi
+            # grep -c . counts non-empty lines (one runner name per line)
+            RUNNERS_ONLINE_COUNT=$(echo "$ONLINE_RUNNERS" | grep -c .)
             echo "✅ Self-hosted runners online:"
             echo "$ONLINE_RUNNERS" | sed 's/^/   - /'
           fi
@@ -204,14 +212,19 @@ jobs:
                     # this is fine: it's a single linear job chain, so there's
                     # no healthy parallel job to preserve. Cancel the run, then
                     # force-cancel as fallback for terminal-but-stuck states.
-                    if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
+                    # Capture stderr so a cancel failure (e.g. PAT missing
+                    # Actions:write, or token expired) surfaces the HTTP error
+                    # instead of a generic "already terminal?" guess. The
+                    # runners-endpoint fail-safe does NOT cover the cancel
+                    # endpoint, so this diagnostic is the only signal here.
+                    if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>/tmp/cancel_err; then
                       echo "   ✅ Cancelled run ${RUN_ID}"
                       CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}"
-                    elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>&1; then
+                    elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>/tmp/cancel_err; then
                       echo "   ✅ Force-cancelled run ${RUN_ID}"
                       CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}(force)"
                     else
-                      echo "   ⚠️ Run cancellation did not succeed (already terminal?)"
+                      echo "   ⚠️ Run cancellation did not succeed: $(head -2 /tmp/cancel_err 2>/dev/null | tr '\n' ' ')"
                     fi
                   fi
                 else
@@ -234,7 +247,7 @@ jobs:
             echo ""
             echo "- Threshold: ${THRESHOLD} min"
             echo "- Per page: ${PER_PAGE}"
-            echo "- Self-hosted runners online: $(echo "$ONLINE_RUNNERS" | wc -l)"
+            echo "- Self-hosted runners online: ${RUNNERS_ONLINE_COUNT}"
             echo "- Stuck jobs detected: ${STUCK_COUNT}"
             if [ -n "$CANCELLED_REFS" ]; then
               echo "- Cancelled:${CANCELLED_REFS}"

--- a/.github/workflows/monitor-runner-queue.yml
+++ b/.github/workflows/monitor-runner-queue.yml
@@ -57,10 +57,13 @@ permissions:
   # here causes the workflow parser to fail with HTTP 422 (see hotfix that
   # reverted the attempt). The runtime gracefully degrades via the fail-safe
   # block in the step below: on HTTP 403, DRY_RUN is forced true so detection
-  # still runs for visibility but no cancellations occur. To get full cancel
-  # capability, configure a repository secret WATCHDOG_RUNNERS_PAT with a
-  # fine-grained PAT scoped `Administration: Read` on this repo, then plumb
-  # it into GH_TOKEN below (out of scope for this initial watchdog).
+  # still runs for visibility but no cancellations occur.
+  #
+  # FULL CANCEL CAPABILITY: configure the repository secret WATCHDOG_RUNNERS_PAT
+  # (a fine-grained PAT scoped to THIS repo with `Administration: Read` +
+  # `Actions: Read and write`). The GH_TOKEN env below falls back to it when
+  # present. When absent, the workflow keeps running in fail-safe (DRY_RUN).
+  # See docs/for-developers/operations/watchdog-runners-pat-setup.md.
 
 concurrency:
   # Only one watchdog at a time. cancel-in-progress: true so a manual
@@ -77,7 +80,11 @@ jobs:
     steps:
       - name: Identify and cancel stuck jobs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer the fine-grained PAT (Administration:Read + Actions:RW) so
+          # the runners endpoint returns 200 and cancellations are authorized.
+          # Falls back to GITHUB_TOKEN when the secret is absent → the step's
+          # fail-safe forces DRY_RUN on the resulting 403. See header note.
+          GH_TOKEN: ${{ secrets.WATCHDOG_RUNNERS_PAT || secrets.GITHUB_TOKEN }}
           THRESHOLD: ${{ inputs.threshold_minutes || '10' }}
           # Explicit boolean coercion to string: avoids accidental shell
           # comparison against a non-string truthy value from the boolean input.
@@ -189,23 +196,22 @@ jobs:
                   STUCK_COUNT=$((STUCK_COUNT + 1))
 
                   if [ "$DRY_RUN" = "true" ]; then
-                    echo "   🧪 DRY_RUN: would cancel job ${JOB_ID} (fall back to run ${RUN_ID})"
+                    echo "   🧪 DRY_RUN: would cancel run ${RUN_ID} (stuck job ${JOB_ID})"
                   else
-                    # Prefer job-level cancel to minimize blast radius on
-                    # multi-job runs (e.g. a run with one healthy ubuntu-latest
-                    # job + one stuck self-hosted job). Fall back to run-level
-                    # cancel if the job endpoint fails, then force-cancel.
-                    if gh api -X POST "repos/${REPO}/actions/jobs/${JOB_ID}/cancel" >/dev/null 2>&1; then
-                      echo "   ✅ Cancelled job ${JOB_ID} (run ${RUN_ID})"
-                      CANCELLED_REFS="${CANCELLED_REFS} job:${JOB_ID}"
-                    elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
-                      echo "   ✅ Cancelled run ${RUN_ID} (job-level cancel unavailable; whole run cancelled)"
+                    # GitHub's REST API has NO job-level cancel endpoint
+                    # (POST /actions/jobs/{id}/cancel returns 404 — verified).
+                    # The unit of cancellation is the RUN. For deploy-staging
+                    # this is fine: it's a single linear job chain, so there's
+                    # no healthy parallel job to preserve. Cancel the run, then
+                    # force-cancel as fallback for terminal-but-stuck states.
+                    if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1; then
+                      echo "   ✅ Cancelled run ${RUN_ID}"
                       CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}"
                     elif gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null 2>&1; then
                       echo "   ✅ Force-cancelled run ${RUN_ID}"
                       CANCELLED_REFS="${CANCELLED_REFS} run:${RUN_ID}(force)"
                     else
-                      echo "   ⚠️ Neither job nor run cancellation succeeded (already terminal?)"
+                      echo "   ⚠️ Run cancellation did not succeed (already terminal?)"
                     fi
                   fi
                 else

--- a/docs/for-developers/operations/watchdog-runners-pat-setup.md
+++ b/docs/for-developers/operations/watchdog-runners-pat-setup.md
@@ -1,0 +1,108 @@
+# Watchdog Runners PAT Setup
+
+**Workflow**: `.github/workflows/monitor-runner-queue.yml` (queue-time watchdog, issue #1573)
+
+The watchdog detects self-hosted runner jobs stuck in queue and cancels the
+containing run. To **list self-hosted runners** (`GET /repos/{owner}/{repo}/actions/runners`)
+and **cancel runs** it needs a token with scopes that the default
+`GITHUB_TOKEN` cannot carry (`administration` is not a valid workflow
+permission — see the header comment in the workflow).
+
+Until the PAT is configured, the watchdog runs in **fail-safe mode**:
+detection + logging only, **no cancellations** (forced `DRY_RUN=true` on the
+HTTP 403 from the runners endpoint). Configuring the PAT below upgrades it to
+full cancel capability.
+
+---
+
+## 1. Create the fine-grained PAT
+
+> Use a **fine-grained** PAT, NOT a classic token. Classic tokens grant the
+> entire `repo` scope (too broad); fine-grained tokens scope to a single repo
+> with minimal permissions.
+
+1. GitHub → your avatar → **Settings** → **Developer settings** →
+   **Personal access tokens** → **Fine-grained tokens** → **Generate new token**
+2. **Token name**: `meepleai-watchdog-runners` (or similar — identifiable)
+3. **Resource owner**: `meepleAi-app` (the org that owns the repo)
+4. **Expiration**: **90 days** (see Rotation below — do not pick "No expiration")
+5. **Repository access** → **Only select repositories** → `meepleai-monorepo`
+6. **Permissions** → **Repository permissions**, set exactly these (leave all others "No access"):
+
+   | Permission | Access | Why |
+   |------------|--------|-----|
+   | **Administration** | **Read-only** | `GET /actions/runners` (list self-hosted runners) |
+   | **Actions** | **Read and write** | list runs/jobs + `POST /actions/runs/{id}/cancel` |
+   | Metadata | Read-only | auto-selected (mandatory) |
+
+7. **Generate token** → copy the `github_pat_…` value (shown once).
+
+## 2. Add the token as a repository secret
+
+Either via UI or CLI.
+
+**UI**: repo → **Settings** → **Secrets and variables** → **Actions** →
+**New repository secret** → Name `WATCHDOG_RUNNERS_PAT`, Value = the token.
+
+**CLI** (run it yourself — do NOT paste the token into a shared session):
+
+```bash
+# You will be prompted to paste the token value (it is not echoed)
+gh secret set WATCHDOG_RUNNERS_PAT --repo meepleAi-app/meepleai-monorepo
+```
+
+The workflow picks it up automatically via
+`GH_TOKEN: ${{ secrets.WATCHDOG_RUNNERS_PAT || secrets.GITHUB_TOKEN }}` — no
+workflow edit needed.
+
+## 3. Validate
+
+Trigger a dry-run dispatch and confirm the runners list resolves (no 403):
+
+```bash
+gh workflow run monitor-runner-queue.yml \
+  --repo meepleAi-app/meepleai-monorepo \
+  --ref main-dev \
+  --field dry_run=true
+
+# wait, then inspect the latest run's log:
+gh run list --repo meepleAi-app/meepleai-monorepo \
+  --workflow monitor-runner-queue.yml --limit 1
+gh run view <run-id> --repo meepleAi-app/meepleai-monorepo --log \
+  | grep -E "runners online|Cannot list|FAIL-SAFE"
+```
+
+**Acceptance criteria** (issue #1573 follow-up):
+- [ ] `gh secret list` shows `WATCHDOG_RUNNERS_PAT`
+- [ ] Watchdog log shows `✅ Self-hosted runners online:` with real runner names (NOT the `{"message":"Resource not accessible..."}` JSON error)
+- [ ] No `🛡️ FAIL-SAFE` line in the log
+- [ ] With a real stuck job (or a forced test), `DRY_RUN=false` run cancels it
+
+## 4. Rotation & ownership (operational)
+
+- **Expiry**: the token expires in 90 days. When it expires the watchdog
+  silently reverts to fail-safe (no cancellations) — it does NOT break the
+  workflow, but it stops protecting against stuck deploys. Set a calendar
+  reminder to regenerate + update the secret before expiry.
+- **Ownership**: a fine-grained PAT is tied to the personal account that
+  created it. If that person rotates credentials or leaves, the watchdog loses
+  cancel capability. Record the owner here:
+
+  | Field | Value |
+  |-------|-------|
+  | Token owner | _(fill in)_ |
+  | Created | _(fill in)_ |
+  | Expires | _(fill in — 90 days from creation)_ |
+
+- **Future hardening**: migrate to a **GitHub App** installation token
+  (org-owned, auto-refreshing, not tied to a personal account). Tracked as a
+  potential follow-up; the PAT is the MVP.
+
+## Security notes
+
+- Scope is least-privilege: single repo, `Administration: Read` +
+  `Actions: Read and write`, nothing else.
+- The token is never logged: GH masks secret values, and the workflow only
+  echoes runner *names*, never the token.
+- If the token is ever leaked, revoke it immediately in Developer settings and
+  regenerate — the fail-safe ensures the watchdog degrades safely meanwhile.

--- a/docs/for-developers/operations/watchdog-runners-pat-setup.md
+++ b/docs/for-developers/operations/watchdog-runners-pat-setup.md
@@ -32,7 +32,7 @@ full cancel capability.
    | Permission | Access | Why |
    |------------|--------|-----|
    | **Administration** | **Read-only** | `GET /actions/runners` (list self-hosted runners) |
-   | **Actions** | **Read and write** | list runs/jobs + `POST /actions/runs/{id}/cancel` |
+   | **Actions** | **Read and write** | list runs/jobs + `POST /actions/runs/{id}/cancel` (and `/force-cancel`, same scope) |
    | Metadata | Read-only | auto-selected (mandatory) |
 
 7. **Generate token** → copy the `github_pat_…` value (shown once).


### PR DESCRIPTION
## Summary

Enables **real cancellations** for the queue-time watchdog (`monitor-runner-queue.yml`) by plumbing a fine-grained PAT, and removes dead code discovered while implementing it.

## Two changes

### 1. PAT plumbing (the requested feature)

```yaml
GH_TOKEN: ${{ secrets.WATCHDOG_RUNNERS_PAT || secrets.GITHUB_TOKEN }}
```

- **PAT present** → `Administration: Read` + `Actions: Read and write` → runners endpoint returns 200, cancellations authorized.
- **PAT absent** → falls back to `GITHUB_TOKEN` → existing fail-safe forces `DRY_RUN` on the 403. Backward-compatible, fully opt-in via the secret.

Setup doc: [`docs/for-developers/operations/watchdog-runners-pat-setup.md`](docs/for-developers/operations/watchdog-runners-pat-setup.md) — least-privilege scopes, 90-day rotation, ownership tracking, GitHub App as future hardening.

### 2. Cancel logic simplification (bug found)

Verified empirically that `POST /actions/jobs/{id}/cancel` returns **HTTP 404** — GitHub's REST API has **no job-level cancel endpoint**; cancellation unit is the *run*.

```
$ gh api -X POST repos/meepleAi-app/meepleai-monorepo/actions/jobs/77924242324/cancel
{ "message": "Not Found", "status": "404" }
```

The "prefer job-level cancel" path (added in PR #1601 per an earlier code-review suggestion) was dead code that always 404'd → fell back to run cancel. Removed it. Now: run-cancel → force-cancel fallback. Correct for deploy-staging (single linear job chain, no healthy parallel job to preserve).

## ⚠️ Action required by a human (cannot be automated)

Creating the PAT requires GitHub UI access with your credentials. After this PR merges:

1. Create fine-grained PAT (single repo, `Administration: Read` + `Actions: Read and write`, 90-day expiry) — steps in the setup doc
2. `gh secret set WATCHDOG_RUNNERS_PAT --repo meepleAi-app/meepleai-monorepo`
3. Validate: `gh workflow run monitor-runner-queue.yml --field dry_run=true` → log should show `✅ Self-hosted runners online:` with real names (no `🛡️ FAIL-SAFE`)

Until then, the watchdog continues in fail-safe mode (no behavior change).

## Validation

```
$ python yaml.safe_load(...)
YAML OK: Monitor Runner Queue (self-hosted job watchdog)
GH_TOKEN env: ${{ secrets.WATCHDOG_RUNNERS_PAT || secrets.GITHUB_TOKEN }}
PAT fallback present: True
job-cancel dead code removed: True
run-cancel present: True
```

Diff: +130 / -16 (2 files: workflow + new setup doc).

## Refs

- #1573 (watchdog cancel-capability follow-up)
- PR #1601 (original watchdog), PR #1607/#1609 (permission + fail-safe), PR #1610 (always→!cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)