### PR TITLE
docs(ops): fill watchdog PAT ownership/expiry table (#1573)

### DIFF
--- a/docs/for-developers/operations/watchdog-runners-pat-setup.md
+++ b/docs/for-developers/operations/watchdog-runners-pat-setup.md
@@ -90,9 +90,10 @@ gh run view <run-id> --repo meepleAi-app/meepleai-monorepo --log \
 
   | Field | Value |
   |-------|-------|
-  | Token owner | _(fill in)_ |
-  | Created | _(fill in)_ |
-  | Expires | _(fill in — 90 days from creation)_ |
+  | Token owner | `meepleAi-app` (GitHub account authenticated for the repo at setup) |
+  | Created | 2026-05-27 (secret `WATCHDOG_RUNNERS_PAT` set 09:30 UTC) |
+  | Expires | 2026-08-25 (assumes the 90-day expiry from this guide — update if a different expiry was chosen at token creation) |
+  | Validated | 2026-05-27 — watchdog run `26503048359` listed runner `meepleai-staging`, no fail-safe |
 
 - **Future hardening**: migrate to a **GitHub App** installation token
   (org-owned, auto-refreshing, not tied to a personal account). Tracked as a


### PR DESCRIPTION
## Summary

Compila la tabella di tracciabilità del PAT `WATCHDOG_RUNNERS_PAT` in `docs/for-developers/operations/watchdog-runners-pat-setup.md` dopo setup + validation.

| Field | Value |
|-------|-------|
| Token owner | `meepleAi-app` (account autenticato al setup) |
| Created | 2026-05-27 (secret set 09:30 UTC) |
| Expires | 2026-08-25 (assunzione 90gg — da aggiornare se scadenza diversa) |
| Validated | run `26503048359` — runner `meepleai-staging` listato, no fail-safe |

Doc-only change (+4/-3). La riga **Expires** è l'ancora per il reminder di rotation; la riga **Validated** documenta la conferma empirica.

## Refs
- #1573 (watchdog cancel-capability — chiuso)
- Validation run: https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26503048359

🤖 Generated with [Claude Code](https://claude.com/claude-code)