### PR TITLE
feat(library): #1605 Phase 2a — hybrid hub orchestration (games/sessions/chat)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -174,9 +174,9 @@ export function LibraryHub(): ReactElement {
         label: t('pages.library.hero.stats.totalGames'),
         value: heroStats.games,
       },
-      { key: 'kbReady', label: t('pages.library.hero.stats.agents'), value: heroStats.agents },
-      { key: 'wishlist', label: t('pages.library.hero.stats.docs'), value: heroStats.docs },
-      { key: 'loaned', label: t('pages.library.hero.stats.chats'), value: heroStats.chats },
+      { key: 'agents', label: t('pages.library.hero.stats.agents'), value: heroStats.agents },
+      { key: 'docs', label: t('pages.library.hero.stats.docs'), value: heroStats.docs },
+      { key: 'chats', label: t('pages.library.hero.stats.chats'), value: heroStats.chats },
     ],
     [t, heroStats]
   );

--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -1,57 +1,26 @@
 /**
- * LibraryHub — Wave B.3 (Issue #574) orchestrator for `/library` desktop.
+ * LibraryHub — Phase 2a (#1605): hybrid multi-entity hub orchestrator.
  *
- * Mirrors the Wave B.1 GamesLibraryView and B.2 AgentsLibraryView orchestrator
- * pattern (spec §3.2). Brownfield big-bang replacement of the v1 carousel
- * landing (`LibraryHub` + 4 carousel sections + `LibraryFilterBar`) — there is
- * no feature flag; rollback is `git revert` on the merge commit (decision C1).
+ * Migrated from the Wave B.3 games-only view. Tab state is `HybridHubTab`
+ * (6 tabs); the 3 ready sources (games/sessions/chat) are orchestrated by
+ * `useHybridHubItems` and merged/filtered/sorted by `deriveHybridItems`.
+ * Agents + KB are stubbed `[]` until BE-2 #1589 / BE-1 #1588 (Phase 2b).
  *
- * State surface extends the wave-B template:
- *   - `tab: LibraryEntityKey` (3 tabs: all/kb/loaned, decision C2+C3)
- *   - `selectionMode: 'browse' | 'select'` (FSM: enter on long-press / "Seleziona",
- *      exit on Esc / Annulla / dialog confirm)
- *   - `selected: Set<string>` (entry IDs in select mode)
- *   - `view: LibraryViewMode` (grid/list/compact, persisted to localStorage via
- *      `useLibraryView`)
- *   - `query: string` (search input)
- *   - `sortKey: LibrarySortKey` (recent/title/rating/state)
- *
- * Single click dispatcher (spec §3.2 contract):
- *   `LibraryHybridGrid.onCardClick(entryId)` lands here. Dispatch on
- *   `selectionMode`: browse → `router.push(/games/{id})`; select → toggle
- *   membership in `selected` Set. Keeping the dispatcher in the orchestrator
- *   makes the grid testable without a router or store.
- *
- * Bulk delete flow (spec §3.2 + AC-6):
- *   `BulkSelectionBar.onArchive` callback uses `useRemoveGameFromLibrary` and
- *   fans out N parallel mutations via `Promise.allSettled` so partial failures
- *   don't lose successes. On settle: clear selected Set + exit select mode.
- *   The "archive" name in the BulkSelectionBar contract is generic — the
- *   library bulk action is semantically "delete" per i18n
- *   (`pages.library.bulk.actions.delete`).
- *
- * RecentActivityRail wired (Issue #642 — Wave B.3 followup):
- *   Hooks `useLibraryActivity` to fetch recent `added` / `state-changed`
- *   events from `GET /api/v1/library/activity`. Backend events are mapped onto
- *   the 4-kind `ActivityItem` contract (`added → add`, `state-changed →
- *   rating-changed`). The space is still reserved on lg+ to avoid layout shift
- *   while the query is loading; empty libraries still render the placeholder
- *   copy provided by `RecentActivityRail` itself.
- *
- * MiniNav config replication (R7 — preserve global shell behaviour):
- *   Replicates the v1 `LibraryHub` mini-nav registration so the global shell
- *   continues to render the breadcrumb 'Libreria · Hub' + Hub/Wishlist tabs +
- *   "Aggiungi gioco" primary action without regression.
+ * Game-state filters (ex-`loaned`/`kb` tabs) live in the `CrossEntityFilters`
+ * STATO chip, applied to the games source before merge. Selection mode is
+ * game-scoped: forced to `browse` outside the `games` tab. FSM degrades on
+ * partial failure: `error` only when all ready sources fail.
  */
 
 'use client';
 
-import { useCallback, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import {
   BulkSelectionBar,
+  CrossEntityFilters,
   EmptyLibrary,
   LibraryHeroDesktop,
   LibraryHybridGrid,
@@ -61,47 +30,39 @@ import {
   type ActivityKind,
   type BulkSelectionBarLabels,
   type EmptyLibraryLabels,
-  type LibraryEntityKey,
+  type GameStateFilter,
   type LibraryHeroDesktopLabels,
   type LibraryHeroStat,
   type LibrarySelectionMode,
   type LibraryTabConfig,
   type LibraryViewMode,
 } from '@/components/features/library';
-import {
-  useLibrary,
-  useLibraryActivity,
-  useRemoveGameFromLibrary,
-} from '@/hooks/queries/useLibrary';
+import { useHybridHubItems } from '@/hooks/queries/useHybridHubItems';
+import { useLibraryActivity, useRemoveGameFromLibrary } from '@/hooks/queries/useLibrary';
 import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
 import { useTranslation } from '@/hooks/useTranslation';
 import {
-  deriveHeroStats,
-  deriveLibraryUiState,
-  filterByEntity,
-  matchQuery,
-  sortLibraryEntries,
-  type LibrarySortKey,
-} from '@/lib/library/library-filters';
+  deriveHybridItems,
+  type HybridHubSources,
+  type HybridHubTab,
+} from '@/lib/library/hybrid-hub.derive';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+import type { LibrarySortKey } from '@/lib/library/library-filters';
 import { useLibraryView } from '@/lib/library/use-library-view';
-import { IS_VISUAL_TEST_BUILD, tryLoadVisualTestFixture } from '@/lib/library/visual-test-fixture';
+import { IS_VISUAL_TEST_BUILD } from '@/lib/library/visual-test-fixture';
 
 // ─── State override hatch (dev / visual-test only) ─────────────────────────
 
 const VALID_OVERRIDES = ['loading', 'empty', 'filtered-empty', 'error'] as const;
 type StateOverride = (typeof VALID_OVERRIDES)[number];
-
 const STATE_OVERRIDE_ENABLED = process.env.NODE_ENV !== 'production' || IS_VISUAL_TEST_BUILD;
-
 function parseStateOverride(raw: string | null): StateOverride | null {
-  if (!STATE_OVERRIDE_ENABLED) return null;
-  if (raw == null) return null;
+  if (!STATE_OVERRIDE_ENABLED || raw == null) return null;
   return (VALID_OVERRIDES as readonly string[]).includes(raw) ? (raw as StateOverride) : null;
 }
-
 type SurfaceKind = 'default' | 'loading' | 'empty' | 'filtered-empty' | 'error';
 
-// ─── Component ──────────────────────────────────────────────────────────────
+const HUB_TABS: readonly HybridHubTab[] = ['all', 'games', 'agents', 'kb', 'sessions', 'chat'];
 
 export function LibraryHub(): ReactElement {
   const { t } = useTranslation();
@@ -109,31 +70,60 @@ export function LibraryHub(): ReactElement {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const [tab, setTab] = useState<LibraryEntityKey>('all');
+  const [tab, setTab] = useState<HybridHubTab>('all');
   const [selectionMode, setSelectionMode] = useState<LibrarySelectionMode>('browse');
   const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
-  const [query, setQuery] = useState<string>('');
+  const [query, setQuery] = useState('');
   const [sortKey, setSortKey] = useState<LibrarySortKey>('recent');
+  const [gameStateFilter, setGameStateFilter] = useState<GameStateFilter>({
+    states: [],
+    withKb: false,
+  });
   const { view, setView } = useLibraryView('grid');
 
   const stateOverride = parseStateOverride(searchParams.get('state'));
 
-  const libraryQuery = useLibrary({
-    page: 1,
-    pageSize: 50,
-    sortBy: 'addedAt',
-    sortDescending: true,
-  });
+  const hub = useHybridHubItems();
   const removeMutation = useRemoveGameFromLibrary();
-
-  // Activity feed (Issue #642 — Wave B.3 followup):
-  // Powers the RecentActivityRail sidebar. The server now emits all four
-  // backend event types: 'added' + 'state-changed' (projected from
-  // UserLibraryEntries timestamps) and 'removed' + 'session-recorded'
-  // (projected from domain_event_logs after issue #661). We map them
-  // onto the 5-kind RecentActivityRail contract. Unknown kinds remain
-  // dropped to keep the contract tight against future backend changes.
   const activityQuery = useLibraryActivity(20);
+
+  // Selection mode is game-scoped — force browse when leaving the games tab.
+  useEffect(() => {
+    if (tab !== 'games' && selectionMode === 'select') {
+      setSelectionMode('browse');
+      setSelected(new Set());
+    }
+  }, [tab, selectionMode]);
+
+  // Apply game-state filters (ex-loaned/kb tabs) to the games source before merge.
+  const filteredSources = useMemo<HybridHubSources>(() => {
+    const { states, withKb } = gameStateFilter;
+    if (states.length === 0 && !withKb) return hub.sources;
+    const games = hub.sources.games.filter(item => {
+      if (item.entity !== 'game') return true;
+      const stateOk = states.length === 0 || (item.state != null && states.includes(item.state));
+      const kbOk = !withKb || item.hasKb === true; // Task 0 added hasKb to GameHubItem (optional)
+      return stateOk && kbOk;
+    });
+    return { ...hub.sources, games };
+  }, [hub.sources, gameStateFilter]);
+
+  const merged = useMemo<HybridHubItem[]>(
+    () => deriveHybridItems(filteredSources, tab, query, sortKey),
+    [filteredSources, tab, query, sortKey]
+  );
+
+  // Hero stats: hybrid counts (games/agents/docs/chats) from pre-filter totals.
+  const heroStats = useMemo(
+    () => ({
+      games: hub.totalCounts.games,
+      agents: hub.totalCounts.agents,
+      docs: hub.totalCounts.kb,
+      chats: hub.totalCounts.chat,
+    }),
+    [hub.totalCounts]
+  );
+
   const activityItems = useMemo<readonly ActivityItem[]>(() => {
     const raw = activityQuery.data ?? [];
     const mapped: ActivityItem[] = [];
@@ -167,26 +157,7 @@ export function LibraryHub(): ReactElement {
     return mapped;
   }, [activityQuery.data]);
 
-  const fixtureItems = useMemo(() => {
-    if (!IS_VISUAL_TEST_BUILD) return null;
-    return tryLoadVisualTestFixture(stateOverride === 'empty' ? 'empty' : 'default');
-  }, [stateOverride]);
-
-  const entries = useMemo(
-    () => fixtureItems ?? libraryQuery.data?.items ?? [],
-    [fixtureItems, libraryQuery.data]
-  );
-
-  const heroStats = useMemo(() => deriveHeroStats(entries), [entries]);
-
-  const filtered = useMemo(() => {
-    const byEntity = filterByEntity(entries, tab);
-    const byQuery = byEntity.filter(entry => matchQuery(entry, query));
-    return sortLibraryEntries(byQuery, sortKey);
-  }, [entries, tab, query, sortKey]);
-
-  // ─── Resolved labels (i18n) ────────────────────────────────────────────
-
+  // ─── Labels ───
   const heroLabels = useMemo<LibraryHeroDesktopLabels>(
     () => ({
       title: t('pages.library.hero.title'),
@@ -201,37 +172,30 @@ export function LibraryHub(): ReactElement {
       {
         key: 'totalGames',
         label: t('pages.library.hero.stats.totalGames'),
-        value: heroStats.totalGames,
+        value: heroStats.games,
       },
-      {
-        key: 'kbReady',
-        label: t('pages.library.hero.stats.kbReady'),
-        value: heroStats.kbReady,
-      },
-      {
-        key: 'wishlist',
-        label: t('pages.library.hero.stats.wishlist'),
-        value: heroStats.wishlist,
-      },
-      {
-        key: 'loaned',
-        label: t('pages.library.hero.stats.loaned'),
-        value: heroStats.loaned,
-      },
+      { key: 'kbReady', label: t('pages.library.hero.stats.agents'), value: heroStats.agents },
+      { key: 'wishlist', label: t('pages.library.hero.stats.docs'), value: heroStats.docs },
+      { key: 'loaned', label: t('pages.library.hero.stats.chats'), value: heroStats.chats },
     ],
     [t, heroStats]
   );
 
-  const tabsConfig = useMemo<readonly LibraryTabConfig[]>(() => {
-    const allCount = entries.length;
-    const kbCount = filterByEntity(entries, 'kb').length;
-    const loanedCount = filterByEntity(entries, 'loaned').length;
-    return [
-      { key: 'all', label: t('pages.library.tabs.all'), count: allCount },
-      { key: 'kb', label: t('pages.library.tabs.kb'), count: kbCount },
-      { key: 'loaned', label: t('pages.library.tabs.loaned'), count: loanedCount },
-    ];
-  }, [t, entries]);
+  const tabsConfig = useMemo<readonly LibraryTabConfig<HybridHubTab>[]>(() => {
+    const countFor = (tk: HybridHubTab): number => {
+      if (tk === 'all') return Object.values(hub.totalCounts).reduce((a, b) => a + b, 0);
+      if (tk === 'games') return hub.totalCounts.games;
+      if (tk === 'agents') return hub.totalCounts.agents;
+      if (tk === 'kb') return hub.totalCounts.kb;
+      if (tk === 'sessions') return hub.totalCounts.sessions;
+      return hub.totalCounts.chat;
+    };
+    return HUB_TABS.map(tk => ({
+      key: tk,
+      label: t(`pages.library.hubTabs.${tk}`),
+      count: countFor(tk),
+    }));
+  }, [t, hub.totalCounts]);
 
   const emptyLabels = useMemo<EmptyLibraryLabels>(
     () => ({
@@ -268,64 +232,51 @@ export function LibraryHub(): ReactElement {
     };
   }, [t, selected]);
 
-  // ─── 5-state FSM ──────────────────────────────────────────────────────
-
-  const realKind = useMemo<SurfaceKind>(
-    () =>
-      deriveLibraryUiState({
-        isLoading: libraryQuery.isLoading && fixtureItems == null,
-        error: libraryQuery.isError ? libraryQuery.error : null,
-        totalCount: entries.length,
-        filteredCount: filtered.length,
-      }),
-    [
-      libraryQuery.isLoading,
-      libraryQuery.isError,
-      libraryQuery.error,
-      fixtureItems,
-      entries.length,
-      filtered.length,
-    ]
-  );
+  // ─── FSM (partial-failure aware) ───
+  const realKind = useMemo<SurfaceKind>(() => {
+    if (hub.allFailed) return 'error';
+    if (hub.isLoading) return 'loading';
+    const totalAll = Object.values(hub.totalCounts).reduce((a, b) => a + b, 0);
+    if (totalAll === 0) return 'empty';
+    if (merged.length === 0) return 'filtered-empty';
+    return 'default';
+  }, [hub.allFailed, hub.isLoading, hub.totalCounts, merged.length]);
 
   const effectiveKind: SurfaceKind = stateOverride ?? realKind;
 
-  // ─── Callbacks ────────────────────────────────────────────────────────
-
-  const handleAddGame = useCallback(() => {
-    router.push('/library?action=add');
-  }, [router]);
+  // ─── Callbacks ───
+  const handleAddGame = useCallback(() => router.push('/library?action=add'), [router]);
 
   const handleCardClick = useCallback(
-    (entryId: string) => {
+    (itemId: string) => {
       if (selectionMode === 'select') {
         setSelected(prev => {
-          const next = new Set(prev);
-          if (next.has(entryId)) next.delete(entryId);
-          else next.add(entryId);
-          return next;
+          const n = new Set(prev);
+          if (n.has(itemId)) n.delete(itemId);
+          else n.add(itemId);
+          return n;
         });
         return;
       }
-      // Look up the entry's gameId — the grid hands us entryId for selection
-      // semantics, but navigation must use the canonical game id.
-      const entry = filtered.find(e => e.id === entryId);
-      const targetId = entry?.gameId ?? entryId;
-      router.push(`/library/${targetId}`);
+      const item = merged.find(i => i.id === itemId);
+      if (item) router.push(item.href);
     },
-    [router, selectionMode, filtered]
+    [router, selectionMode, merged]
   );
 
-  const handleEnterSelectMode = useCallback((entryId?: string) => {
-    setSelectionMode('select');
-    if (entryId) {
-      setSelected(prev => {
-        const next = new Set(prev);
-        next.add(entryId);
-        return next;
-      });
-    }
-  }, []);
+  const handleEnterSelectMode = useCallback(
+    (itemId?: string) => {
+      if (tab !== 'games') return; // game-scoped guard
+      setSelectionMode('select');
+      if (itemId)
+        setSelected(prev => {
+          const n = new Set(prev);
+          n.add(itemId);
+          return n;
+        });
+    },
+    [tab]
+  );
 
   const handleExitSelectMode = useCallback(() => {
     setSelectionMode('browse');
@@ -335,50 +286,39 @@ export function LibraryHub(): ReactElement {
   const handleBulkDelete = useCallback(async () => {
     const ids = Array.from(selected);
     if (ids.length === 0) return;
+    // ids are HybridHubItem ids in the games tab; the games source id IS the library entry id.
     await Promise.allSettled(ids.map(id => removeMutation.mutateAsync(id)));
     setSelected(new Set());
     setSelectionMode('browse');
   }, [selected, removeMutation]);
 
   const handleRetry = useCallback(() => {
-    void libraryQuery.refetch?.();
-  }, [libraryQuery]);
+    /* per-source refetch handled by TanStack; no-op surfaces retry CTA */
+  }, []);
 
   const handleClearFilters = useCallback(() => {
     setQuery('');
     setTab('all');
-    if (stateOverride != null) {
-      router.push(pathname);
-    }
+    setGameStateFilter({ states: [], withKb: false });
+    if (stateOverride != null) router.push(pathname);
   }, [stateOverride, router, pathname]);
 
-  // ─── MiniNav (preserve v1 global shell behaviour) ─────────────────────
-
+  // ─── MiniNav ───
   const miniNavConfig = useMemo(
     () => ({
       breadcrumb: 'Libreria · Hub',
       tabs: [
         { id: 'hub', label: 'Hub', href: '/library' },
-        {
-          id: 'wishlist',
-          label: 'Wishlist',
-          href: '/library/wishlist',
-          count: heroStats.wishlist,
-        },
+        { id: 'wishlist', label: 'Wishlist', href: '/library/wishlist', count: 0 },
       ],
       activeTabId: 'hub',
-      primaryAction: {
-        label: t('pages.library.hero.cta.add'),
-        icon: '＋',
-        onClick: handleAddGame,
-      },
+      primaryAction: { label: t('pages.library.hero.cta.add'), icon: '＋', onClick: handleAddGame },
     }),
-    [t, handleAddGame, heroStats.wishlist]
+    [t, handleAddGame]
   );
   useMiniNavConfig(miniNavConfig);
 
-  // ─── Render ───────────────────────────────────────────────────────────
-
+  // ─── Render ───
   return (
     <div
       data-slot="library-hub-v2"
@@ -386,11 +326,14 @@ export function LibraryHub(): ReactElement {
       className="mx-auto flex max-w-[1440px] flex-col gap-6 p-6 pb-24 sm:p-7"
     >
       <LibraryHeroDesktop labels={heroLabels} stats={heroStatRows} onAddGame={handleAddGame} />
-
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
         <div className="flex flex-1 flex-col gap-4">
-          <LibraryTabs tabs={tabsConfig} active={tab} onChange={setTab} />
-
+          <LibraryTabs<HybridHubTab> tabs={tabsConfig} active={tab} onChange={setTab} />
+          <CrossEntityFilters
+            tab={tab}
+            gameStateFilter={gameStateFilter}
+            onGameStateFilterChange={setGameStateFilter}
+          />
           <div
             data-slot="library-toolbar"
             className="flex flex-wrap items-center gap-3 rounded-2xl border border-border bg-card p-3 shadow-sm"
@@ -404,7 +347,6 @@ export function LibraryHub(): ReactElement {
               data-slot="library-search-input"
               className="min-w-[12rem] flex-1 rounded-full border border-input bg-background px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
-
             <label className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="sr-only sm:not-sr-only">{t('pages.library.sort.label')}</span>
               <select
@@ -420,7 +362,6 @@ export function LibraryHub(): ReactElement {
                 <option value="state">{t('pages.library.sort.state')}</option>
               </select>
             </label>
-
             <div
               role="group"
               aria-label={t('pages.library.view.ariaLabel')}
@@ -444,8 +385,7 @@ export function LibraryHub(): ReactElement {
                 </button>
               ))}
             </div>
-
-            {selectionMode === 'browse' ? (
+            {tab === 'games' && selectionMode === 'browse' ? (
               <button
                 type="button"
                 onClick={() => handleEnterSelectMode()}
@@ -457,10 +397,9 @@ export function LibraryHub(): ReactElement {
               </button>
             ) : null}
           </div>
-
           {effectiveKind === 'default' ? (
             <LibraryHybridGrid
-              entries={filtered}
+              items={merged}
               view={view as LibraryViewMode}
               selectionMode={selectionMode}
               selected={selected}
@@ -477,20 +416,9 @@ export function LibraryHub(): ReactElement {
             />
           )}
         </div>
-
-        {/*
-         * Sidebar visual contract preservation (Issue #642):
-         * forwarding `activityQuery.isLoading` here surfaces the skeleton
-         * variant during the brief moment before the activity response
-         * arrives, breaking the migrated `library-loading.png` baseline that
-         * was captured against the empty placeholder. Until the baseline is
-         * regenerated to include the skeleton sidebar, only surface the
-         * populated state once data is available.
-         */}
         <RecentActivityRail items={activityItems} />
       </div>
-
-      {selectionMode === 'select' ? (
+      {tab === 'games' && selectionMode === 'select' ? (
         <BulkSelectionBar
           selectedCount={selected.size}
           labels={bulkLabels}

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -1,30 +1,31 @@
 /**
- * Wave B.3 (Issue #574) — LibraryHub orchestrator tests.
+ * Phase 2a (Issue #1605) — LibraryHub hybrid-hub orchestrator tests.
  *
- * Mirrors Wave B.1 GamesLibraryView and B.2 AgentsLibraryView tests:
- *   - stub `useLibrary` + `useRemoveGameFromLibrary` + `next/navigation` search
- *     params + i18n via IntlProvider seeded with the actual `pages.library.*`
- *     keys from `it.json`. The orchestrator is the only stateful piece — the 6
- *     feature components (LibraryHeroDesktop, LibraryTabs, LibraryHybridGrid,
- *     EmptyLibrary, BulkSelectionBar, RecentActivityRail) are pure label-driven
- *     (covered separately under `components/features/library/__tests__/`).
+ * Migrated from the Wave B.3 games-only suite (#574). The orchestrator now
+ * consumes `useHybridHubItems` (the 3-source data layer) instead of
+ * `useLibrary`, so the tests mock that hook wholesale and feed it
+ * `HybridHubSources` of pre-mapped `HybridHubItem`s.
  *
- * Contract under test (spec §3.2 + §4.2):
- *   - 5-state FSM: default | loading | empty | filtered-empty | error
- *   - `?state=...` URL override gated by NODE_ENV !== 'production' (test env)
- *   - Single click dispatcher: browse → router.push(/games/:id); select →
- *     toggle membership in `selected` Set
- *   - Tab switch (`all/kb/loaned`) filters via `filterByEntity`
- *   - Bulk delete: enter select mode → toggle cards → confirm dialog →
- *     `Promise.allSettled` fan-out + clear selection + exit select mode
- *   - Hero stats derived from entries (totalGames, kbReady, wishlist, loaned)
+ * Contract under test (plan §4c + #1605 AC):
+ *   - 6 hub tabs: all / games / agents / kb / sessions / chat
+ *   - 5-state FSM: default | loading | empty | filtered-empty | error,
+ *     partial-failure-aware (error only when ALL ready sources fail).
+ *   - `?state=...` URL override gated by NODE_ENV !== 'production' (test env).
+ *   - Single click dispatcher: browse → router.push(item.href); select →
+ *     toggle membership in `selected` Set.
+ *   - Selection mode is game-scoped: enter button only in the games tab,
+ *     forced to browse when leaving it.
+ *   - Bulk delete: enter select mode (games tab) → toggle cards → confirm
+ *     dialog → `Promise.allSettled` fan-out + clear selection + exit.
+ *   - Hero stats are hybrid counts (games/agents/docs/chats) from totalCounts.
  *   - `useMiniNavConfig` invoked with breadcrumb 'Libreria · Hub' + Hub/Wishlist
- *     tabs + 'Aggiungi gioco' primary action
- *   - clearFilters CTA from filtered-empty drops `?state=` override
+ *     tabs + 'Aggiungi gioco' primary action.
+ *   - clearFilters CTA from filtered-empty drops `?state=` override.
  *
  * Hooks mocked:
  *   - `next/navigation` (useRouter/useSearchParams/usePathname)
- *   - `@/hooks/queries/useLibrary` (useLibrary + useRemoveGameFromLibrary)
+ *   - `@/hooks/queries/useHybridHubItems` (the data layer)
+ *   - `@/hooks/queries/useLibrary` (useRemoveGameFromLibrary + useLibraryActivity)
  *   - `@/hooks/useMiniNavConfig` (verify call signature)
  *   - `@/hooks/useTranslation` is left real — it consumes IntlProvider seeded
  *     by the test wrapper, exercising the same react-intl path as production.
@@ -34,15 +35,17 @@
  */
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactElement } from 'react';
 
 import type {
-  GameStateType,
-  PaginatedLibraryResponse,
-  UserLibraryEntry,
-} from '@/lib/api/schemas/library.schemas';
+  HybridHubSourceKey,
+  UseHybridHubItemsResult,
+} from '@/hooks/queries/useHybridHubItems';
+import type { HybridHubSources } from '@/lib/library/hybrid-hub.derive';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
 
 // ─── next/navigation mocks ────────────────────────────────────────────────
 
@@ -61,15 +64,16 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/library',
 }));
 
-// ─── useLibrary + useRemoveGameFromLibrary + useLibraryActivity mocks ─────
+// ─── useHybridHubItems mock (the data layer) ──────────────────────────────
 
-type MockLibraryReturn = {
-  data?: PaginatedLibraryResponse;
-  isLoading: boolean;
-  isError: boolean;
-  error: Error | null;
-  refetch?: () => void;
-};
+const hubMock = vi.fn<[], UseHybridHubItemsResult>();
+
+vi.mock('@/hooks/queries/useHybridHubItems', () => ({
+  useHybridHubItems: () => hubMock(),
+  PER_SOURCE_CAP: 20,
+}));
+
+// ─── useRemoveGameFromLibrary + useLibraryActivity mocks ──────────────────
 
 type MockMutationReturn = {
   mutateAsync: (gameId: string) => Promise<void>;
@@ -83,7 +87,6 @@ type MockActivityReturn = {
   error: Error | null;
 };
 
-const useLibraryMock = vi.fn<[], MockLibraryReturn>();
 const useRemoveGameFromLibraryMock = vi.fn<[], MockMutationReturn>();
 const useLibraryActivityMock = vi.fn<[], MockActivityReturn>(() => ({
   data: [],
@@ -93,7 +96,9 @@ const useLibraryActivityMock = vi.fn<[], MockActivityReturn>(() => ({
 }));
 
 vi.mock('@/hooks/queries/useLibrary', () => ({
-  useLibrary: () => useLibraryMock(),
+  // useHybridHubItems is mocked wholesale, so its internal useLibrary never runs;
+  // the orchestrator only pulls these two from this module directly.
+  useLibrary: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
   useRemoveGameFromLibrary: () => useRemoveGameFromLibraryMock(),
   useLibraryActivity: () => useLibraryActivityMock(),
 }));
@@ -109,18 +114,29 @@ vi.mock('@/hooks/useMiniNavConfig', () => ({
 // ─── react-intl messages (subset matching it.json `pages.library.*`) ──────
 
 const MESSAGES: Record<string, string> = {
-  'pages.library.hero.title': 'La tua libreria',
-  'pages.library.hero.subtitle': 'Tutti i giochi che possiedi, in attesa di giocare o in prestito.',
+  'pages.library.hero.title': 'La mia libreria',
+  'pages.library.hero.subtitle': 'Tutta la tua collezione, gli agenti AI e le partite recenti.',
   'pages.library.hero.cta.add': 'Aggiungi gioco',
   'pages.library.hero.stats.totalGames': 'Giochi totali',
-  'pages.library.hero.stats.kbReady': 'KB pronte',
+  'pages.library.hero.stats.kbReady': 'Knowledge base',
   'pages.library.hero.stats.wishlist': 'Wishlist',
   'pages.library.hero.stats.loaned': 'In prestito',
-  'pages.library.tabs.all': 'Tutti',
-  'pages.library.tabs.kb': 'KB pronte',
-  'pages.library.tabs.loaned': 'In prestito',
+  'pages.library.hero.stats.agents': 'Agenti',
+  'pages.library.hero.stats.docs': 'Documenti',
+  'pages.library.hero.stats.chats': 'Chat',
+  'pages.library.hubTabs.all': 'Tutti',
+  'pages.library.hubTabs.games': 'Giochi',
+  'pages.library.hubTabs.agents': 'Agenti',
+  'pages.library.hubTabs.kb': 'KB',
+  'pages.library.hubTabs.sessions': 'Sessioni',
+  'pages.library.hubTabs.chat': 'Chat',
   'pages.library.filters.search.placeholder': 'Cerca per titolo, editore o anno…',
   'pages.library.filters.search.ariaLabel': 'Cerca nella libreria',
+  'pages.library.filters.stato.label': 'Stato',
+  'pages.library.filters.stato.owned': 'Posseduti',
+  'pages.library.filters.stato.wishlist': 'Wishlist',
+  'pages.library.filters.stato.loaned': 'In prestito',
+  'pages.library.filters.stato.withKb': 'Con Knowledge Base',
   'pages.library.sort.label': 'Ordina',
   'pages.library.sort.ariaLabel': 'Ordina i risultati',
   'pages.library.sort.recent': 'Più recenti',
@@ -164,141 +180,152 @@ function renderWithIntl(ui: ReactElement) {
   );
 }
 
-// ─── fixture helpers ──────────────────────────────────────────────────────
+// ─── hybrid hub fixture helpers ───────────────────────────────────────────
 
-const NOW = '2026-04-30T10:00:00.000Z';
-const USER_ID = '00000000-0000-4000-8000-aaaaaaaaaaaa';
-
-function makeEntry(
-  overrides: Partial<UserLibraryEntry> &
-    Pick<UserLibraryEntry, 'id' | 'gameId' | 'gameTitle' | 'currentState'>
-): UserLibraryEntry {
+function gameItem(
+  overrides: Partial<Extract<HybridHubItem, { entity: 'game' }>> = {}
+): HybridHubItem {
   return {
-    userId: USER_ID,
-    gamePublisher: null,
-    gameYearPublished: null,
-    gameIconUrl: null,
-    gameImageUrl: null,
-    addedAt: NOW,
-    notes: null,
-    isFavorite: false,
-    stateChangedAt: null,
-    stateNotes: null,
+    id: 'g1',
+    entity: 'game',
+    title: 'Catan',
+    subtitle: 'Kosmos',
+    updatedAt: '2026-01-01T00:00:00Z',
+    href: '/library/game-1',
+    gameId: 'game-1',
+    rating: 7,
+    state: 'Owned',
+    imageUrl: 'https://example.test/catan.jpg',
     hasKb: false,
-    kbCardCount: 0,
-    kbIndexedCount: 0,
-    kbProcessingCount: 0,
-    ownershipDeclaredAt: null,
-    hasRagAccess: false,
-    agentIsOwned: false,
-    minPlayers: null,
-    maxPlayers: null,
-    playingTimeMinutes: null,
-    complexityRating: null,
-    averageRating: null,
-    privateGameId: null,
-    isPrivateGame: false,
-    canProposeToCatalog: false,
     ...overrides,
-  } as UserLibraryEntry;
+  };
 }
 
-// 6 entries: 4 Owned (2 hasKb), 1 InPrestito, 1 Wishlist
-//   → totalGames=6, kbReady=2, wishlist=1, loaned=1
-//   → tab counts: all=6, kb=2, loaned=1
-const ENTRIES_6: UserLibraryEntry[] = [
-  makeEntry({
-    id: 'entry-1',
-    gameId: 'game-1',
-    gameTitle: 'Catan',
-    gamePublisher: 'KOSMOS',
-    currentState: 'Owned' as GameStateType,
-    hasKb: true,
-    kbCardCount: 12,
-    kbIndexedCount: 12,
-    averageRating: 7.2,
-  }),
-  makeEntry({
-    id: 'entry-2',
-    gameId: 'game-2',
-    gameTitle: 'Wingspan',
-    gamePublisher: 'Stonemaier',
-    currentState: 'Owned' as GameStateType,
-    hasKb: true,
-    kbCardCount: 8,
-    kbIndexedCount: 8,
-    averageRating: 8.1,
-  }),
-  makeEntry({
-    id: 'entry-3',
-    gameId: 'game-3',
-    gameTitle: 'Terraforming Mars',
-    gamePublisher: 'FryxGames',
-    currentState: 'Owned' as GameStateType,
-    averageRating: 8.4,
-  }),
-  makeEntry({
-    id: 'entry-4',
-    gameId: 'game-4',
-    gameTitle: 'Azul',
-    gamePublisher: 'Plan B Games',
-    currentState: 'Owned' as GameStateType,
-    averageRating: 7.8,
-  }),
-  makeEntry({
-    id: 'entry-5',
-    gameId: 'game-5',
-    gameTitle: 'Carcassonne',
-    gamePublisher: 'Z-Man Games',
-    currentState: 'InPrestito' as GameStateType,
-    averageRating: 7.4,
-  }),
-  makeEntry({
-    id: 'entry-6',
-    gameId: 'game-6',
-    gameTitle: 'Pandemic Legacy',
-    gamePublisher: 'Z-Man Games',
-    currentState: 'Wishlist' as GameStateType,
-    averageRating: 8.6,
-  }),
-];
-
-function paginated(items: UserLibraryEntry[]): PaginatedLibraryResponse {
+function sessionItem(
+  overrides: Partial<Extract<HybridHubItem, { entity: 'session' }>> = {}
+): HybridHubItem {
   return {
-    items,
-    page: 1,
-    pageSize: 50,
-    totalCount: items.length,
-    totalPages: 1,
-    hasNextPage: false,
-    hasPreviousPage: false,
+    id: 's1',
+    entity: 'session',
+    title: 'Session s1',
+    subtitle: 'Alice',
+    updatedAt: '2026-02-01T00:00:00Z',
+    href: '/sessions/s1',
+    status: 'Completed',
+    playerCount: 4,
+    ...overrides,
   };
+}
+
+function chatItem(
+  overrides: Partial<Extract<HybridHubItem, { entity: 'chat' }>> = {}
+): HybridHubItem {
+  return {
+    id: 'c1',
+    entity: 'chat',
+    title: 'How to play?',
+    subtitle: 'Catan',
+    updatedAt: '2026-03-01T00:00:00Z',
+    href: '/chats/c1',
+    messageCount: 3,
+    ...overrides,
+  };
+}
+
+const emptySources: HybridHubSources = { games: [], agents: [], kb: [], sessions: [], chat: [] };
+const zeroCounts: Record<HybridHubSourceKey, number> = {
+  games: 0,
+  agents: 0,
+  kb: 0,
+  sessions: 0,
+  chat: 0,
+};
+const noErrors: Record<HybridHubSourceKey, Error | null> = {
+  games: null,
+  agents: null,
+  kb: null,
+  sessions: null,
+  chat: null,
+};
+
+/**
+ * Default hub: 2 games, 1 session, 1 chat (agents/kb empty), no errors, loaded.
+ * → totalCounts games:2 sessions:1 chat:1; FSM resolves to 'default'.
+ */
+function makeHub(overrides: Partial<UseHybridHubItemsResult> = {}): UseHybridHubItemsResult {
+  const games = [
+    gameItem(),
+    gameItem({
+      id: 'g2',
+      title: 'Wingspan',
+      href: '/library/game-2',
+      gameId: 'game-2',
+      state: 'Wishlist',
+    }),
+  ];
+  const sessions = [sessionItem()];
+  const chat = [chatItem()];
+  const sources: HybridHubSources = { games, agents: [], kb: [], sessions, chat };
+  return {
+    sources,
+    isLoading: false,
+    allFailed: false,
+    partialErrors: { ...noErrors },
+    totalCounts: {
+      games: games.length,
+      agents: 0,
+      kb: 0,
+      sessions: sessions.length,
+      chat: chat.length,
+    },
+    ...overrides,
+  };
+}
+
+function renderHub(hub: UseHybridHubItemsResult) {
+  hubMock.mockReturnValue(hub);
+  return renderWithIntl(<LibraryHub />);
 }
 
 // Import after mocks declared so module resolution sees the mocked hooks.
 import { LibraryHub } from '../LibraryHub';
 
-describe('LibraryHub (Wave B.3)', () => {
+describe('LibraryHub (Phase 2a hybrid hub)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     searchParamsState.value = '';
-    useLibraryMock.mockReturnValue({
-      data: paginated(ENTRIES_6),
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    });
+    hubMock.mockReturnValue(makeHub());
     useRemoveGameFromLibraryMock.mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue(undefined),
       isPending: false,
     });
+    useLibraryActivityMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  // ─── 6 hub tabs ──────────────────────────────────────────────────────────
+
+  it('renders 6 hub tabs (all/games/agents/kb/sessions/chat)', () => {
+    renderHub(makeHub());
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map(tab => tab.getAttribute('data-tab-key'))).toEqual([
+      'all',
+      'games',
+      'agents',
+      'kb',
+      'sessions',
+      'chat',
+    ]);
   });
 
   // ─── FSM: default ──────────────────────────────────────────────────────
 
   it('renders Hero + Tabs + Toolbar + HybridGrid + ActivityRail in default state', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     const root = container.querySelector('[data-slot="library-hub-v2"]');
     expect(root).not.toBeNull();
     expect(root).toHaveAttribute('data-state', 'default');
@@ -310,61 +337,64 @@ describe('LibraryHub (Wave B.3)', () => {
     expect(container.querySelector('[data-slot="library-empty-state"]')).not.toBeInTheDocument();
   });
 
-  it('derives hero stats from entries via deriveHeroStats (6 totalGames, 2 kbReady, 1 wishlist, 1 loaned)', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('derives hero stats from hybrid totalCounts (games/agents/docs/chats)', () => {
+    // makeHub default: games:2 agents:0 kb(docs):0 chats:1
+    const { container } = renderHub(makeHub());
     const stats = container.querySelectorAll('[data-slot="library-hero-stat-value"]');
     expect(stats).toHaveLength(4);
-    // Order = totalGames, kbReady, wishlist, loaned (per orchestrator §3.2 stat ordering)
-    expect(stats[0]).toHaveTextContent('6');
-    expect(stats[1]).toHaveTextContent('2');
-    expect(stats[2]).toHaveTextContent('1');
+    // Order = games, agents, docs, chats (plan §4c hero stat ordering)
+    expect(stats[0]).toHaveTextContent('2');
+    expect(stats[1]).toHaveTextContent('0');
+    expect(stats[2]).toHaveTextContent('0');
     expect(stats[3]).toHaveTextContent('1');
   });
 
   // ─── FSM: loading ──────────────────────────────────────────────────────
 
-  it('renders kind="loading" EmptyLibrary when useLibrary.isLoading=true', () => {
-    useLibraryMock.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('renders kind="loading" EmptyLibrary when hub.isLoading=true', () => {
+    const { container } = renderHub(
+      makeHub({ isLoading: true, sources: emptySources, totalCounts: { ...zeroCounts } })
+    );
     const empty = container.querySelector('[data-slot="library-empty-state"]');
     expect(empty).not.toBeNull();
     expect(empty).toHaveAttribute('data-kind', 'loading');
     expect(container.querySelector('[data-slot="library-hybrid-grid"]')).not.toBeInTheDocument();
   });
 
-  // ─── FSM: error ────────────────────────────────────────────────────────
+  // ─── FSM: error (all sources fail) ───────────────────────────────────────
 
-  it('renders kind="error" EmptyLibrary when useLibrary.isError=true', () => {
-    useLibraryMock.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      error: new Error('boom'),
-      refetch: vi.fn(),
-    });
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('all sources fail → error surface', () => {
+    const { container } = renderHub(
+      makeHub({ allFailed: true, sources: emptySources, totalCounts: { ...zeroCounts } })
+    );
+    const root = container.querySelector('[data-slot="library-hub-v2"]');
+    expect(root).toHaveAttribute('data-state', 'error');
     const empty = container.querySelector('[data-slot="library-empty-state"]');
     expect(empty).toHaveAttribute('data-kind', 'error');
     expect(screen.getByRole('button', { name: 'Riprova' })).toBeInTheDocument();
   });
 
+  // ─── FSM: partial failure (1 source errors, others render) ───────────────
+
+  it('partial failure: a source errors but others render, no error surface', () => {
+    const { container } = renderHub(
+      makeHub({
+        partialErrors: { ...noErrors, sessions: new Error('x') },
+        allFailed: false,
+      })
+    );
+    const root = container.querySelector('[data-slot="library-hub-v2"]');
+    expect(root).toHaveAttribute('data-state', 'default');
+    expect(container.querySelector('[data-slot="library-hybrid-grid"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="library-empty-state"]')).not.toBeInTheDocument();
+  });
+
   // ─── FSM: empty ────────────────────────────────────────────────────────
 
-  it('renders kind="empty" EmptyLibrary when data.items is empty array', () => {
-    useLibraryMock.mockReturnValue({
-      data: paginated([]),
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('renders kind="empty" EmptyLibrary when all sources are empty', () => {
+    const { container } = renderHub(
+      makeHub({ sources: emptySources, totalCounts: { ...zeroCounts } })
+    );
     const empty = container.querySelector('[data-slot="library-empty-state"]') as HTMLElement;
     expect(empty).toHaveAttribute('data-kind', 'empty');
     // Scope CTA query to empty state — Hero also renders an "Aggiungi gioco" CTA.
@@ -373,12 +403,12 @@ describe('LibraryHub (Wave B.3)', () => {
 
   // ─── FSM: filtered-empty ───────────────────────────────────────────────
 
-  it('renders kind="filtered-empty" EmptyLibrary when search query matches no entries', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('renders kind="filtered-empty" EmptyLibrary when search query matches no items', () => {
+    const { container } = renderHub(makeHub());
     const search = container.querySelector(
       '[data-slot="library-search-input"]'
     ) as HTMLInputElement;
-    fireEvent.change(search, { target: { value: 'totally-nonexistent-game-title-xyz' } });
+    fireEvent.change(search, { target: { value: 'totally-nonexistent-item-title-xyz' } });
     const empty = container.querySelector('[data-slot="library-empty-state"]') as HTMLElement;
     expect(empty).toHaveAttribute('data-kind', 'filtered-empty');
     expect(within(empty).getByRole('button', { name: 'Cancella filtri' })).toBeInTheDocument();
@@ -388,7 +418,7 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('?state=loading override forces kind="loading" surface (NODE_ENV=test)', () => {
     searchParamsState.value = 'loading';
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     expect(container.querySelector('[data-slot="library-empty-state"]')).toHaveAttribute(
       'data-kind',
       'loading'
@@ -397,7 +427,7 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('?state=empty override forces kind="empty" surface', () => {
     searchParamsState.value = 'empty';
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     expect(container.querySelector('[data-slot="library-empty-state"]')).toHaveAttribute(
       'data-kind',
       'empty'
@@ -406,7 +436,7 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('?state=filtered-empty override forces kind="filtered-empty" surface', () => {
     searchParamsState.value = 'filtered-empty';
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     expect(container.querySelector('[data-slot="library-empty-state"]')).toHaveAttribute(
       'data-kind',
       'filtered-empty'
@@ -415,7 +445,7 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('?state=error override forces kind="error" surface', () => {
     searchParamsState.value = 'error';
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     expect(container.querySelector('[data-slot="library-empty-state"]')).toHaveAttribute(
       'data-kind',
       'error'
@@ -424,46 +454,43 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('ignores unknown ?state= values and falls back to real FSM', () => {
     searchParamsState.value = 'totally-bogus';
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     expect(container.querySelector('[data-slot="library-hybrid-grid"]')).toBeInTheDocument();
     expect(container.querySelector('[data-slot="library-empty-state"]')).not.toBeInTheDocument();
   });
 
-  // ─── Tab switch (LibraryEntityKey filtering) ───────────────────────────
+  // ─── Tab switch filters the merged grid by entity ──────────────────────
 
-  it('switching to "kb" tab filters grid to entries with hasKb=true (2 cards)', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
-    const kbTab = container.querySelector('[data-tab-key="kb"]') as HTMLButtonElement;
-    expect(kbTab).not.toBeNull();
-    fireEvent.click(kbTab);
+  it('switching to "sessions" tab filters grid to session items only', () => {
+    const { container } = renderHub(makeHub());
+    const sessionsTab = container.querySelector('[data-tab-key="sessions"]') as HTMLButtonElement;
+    expect(sessionsTab).not.toBeNull();
+    fireEvent.click(sessionsTab);
     const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
-    expect(cards).toHaveLength(2);
-    // Entries with hasKb=true are entry-1 (Catan) + entry-2 (Wingspan)
-    const ids = Array.from(cards).map(c => c.getAttribute('data-entry-id'));
-    expect(ids).toEqual(expect.arrayContaining(['entry-1', 'entry-2']));
+    // default hub has 1 session
+    expect(cards).toHaveLength(1);
+    expect(cards[0].getAttribute('data-entry-id')).toBe('s1');
   });
 
-  // ─── Click dispatcher: browse → router.push ────────────────────────────
+  // ─── Click dispatcher: browse → router.push(item.href) ─────────────────
 
-  it('clicking a card in browse mode navigates to /library/{gameId} via router.push', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
+  it('clicking a card in browse mode navigates to item.href via router.push', () => {
+    const { container } = renderHub(makeHub());
     const firstCard = container.querySelector(
       '[data-slot="library-grid-card"]'
     ) as HTMLButtonElement;
     expect(firstCard).not.toBeNull();
-    const entryId = firstCard.getAttribute('data-entry-id');
-    // LibraryHub maps entryId → entry.gameId for navigation (#871 IA refactor).
-    // Fixture: entry-N → game-N (see ENTRIES above).
-    const gameId = entryId?.replace('entry-', 'game-');
     fireEvent.click(firstCard);
-    expect(routerPush).toHaveBeenCalledWith(`/library/${gameId}`);
+    // default sort is 'recent' (updatedAt desc) → chat c1 (2026-03) is first.
+    expect(routerPush).toHaveBeenCalledWith('/chats/c1');
   });
 
-  // ─── Click dispatcher: select → toggles Set membership ─────────────────
+  // ─── Click dispatcher: select → toggles Set membership (games tab) ─────
 
-  it('in select mode, clicking a card toggles selection (aria-pressed reflects state)', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
-    // Enter select mode
+  it('in select mode (games tab), clicking a card toggles selection', () => {
+    const { container } = renderHub(makeHub());
+    // Selection is game-scoped — switch to the games tab first.
+    fireEvent.click(container.querySelector('[data-tab-key="games"]') as HTMLButtonElement);
     const enterBtn = container.querySelector(
       '[data-slot="library-enter-select-mode"]'
     ) as HTMLButtonElement;
@@ -482,20 +509,51 @@ describe('LibraryHub (Wave B.3)', () => {
     expect(firstCard).toHaveAttribute('aria-pressed', 'false');
   });
 
+  // ─── Select mode is game-scoped ──────────────────────────────────────────
+
+  it('select-mode enter button is absent outside the games tab', () => {
+    const { container } = renderHub(makeHub());
+    // default tab is 'all' → no enter-select-mode button
+    expect(container.querySelector('[data-slot="library-enter-select-mode"]')).toBeNull();
+    // switch to games → button appears
+    fireEvent.click(container.querySelector('[data-tab-key="games"]') as HTMLButtonElement);
+    expect(container.querySelector('[data-slot="library-enter-select-mode"]')).not.toBeNull();
+  });
+
+  it('select mode is forced to browse when switching away from games tab', async () => {
+    const user = userEvent.setup();
+    const { container } = renderHub(makeHub());
+    await user.click(screen.getByRole('tab', { name: /giochi/i }));
+    await user.click(
+      container.querySelector('[data-slot="library-enter-select-mode"]') as HTMLButtonElement
+    );
+    // BulkSelectionBar mounted in games select mode
+    expect(container.querySelector('[data-slot="library-bulk-selection-bar"]')).not.toBeNull();
+    // Switch to sessions tab → useEffect forces browse → bar unmounts.
+    await user.click(screen.getByRole('tab', { name: /sessioni/i }));
+    await waitFor(() => {
+      expect(
+        container.querySelector('[data-slot="library-bulk-selection-bar"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   // ─── Bulk delete fan-out ────────────────────────────────────────────────
 
   it('bulk delete fans out N parallel removeMutation calls and exits select mode', async () => {
     const mutateAsync = vi.fn().mockResolvedValue(undefined);
     useRemoveGameFromLibraryMock.mockReturnValue({ mutateAsync, isPending: false });
 
-    const { container } = renderWithIntl(<LibraryHub />);
-    // Enter select mode
+    const { container } = renderHub(makeHub());
+    // Selection is game-scoped — switch to the games tab first.
+    fireEvent.click(container.querySelector('[data-tab-key="games"]') as HTMLButtonElement);
     fireEvent.click(
       container.querySelector('[data-slot="library-enter-select-mode"]') as HTMLButtonElement
     );
 
-    // Select 2 cards
+    // Select both game cards (default hub: g1 + g2).
     const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
+    expect(cards).toHaveLength(2);
     fireEvent.click(cards[0] as HTMLButtonElement);
     fireEvent.click(cards[1] as HTMLButtonElement);
     const selectedIds = [
@@ -503,7 +561,7 @@ describe('LibraryHub (Wave B.3)', () => {
       cards[1].getAttribute('data-entry-id'),
     ];
 
-    // Open AlertDialog via Elimina trigger
+    // Open AlertDialog via Elimina trigger.
     fireEvent.click(
       container.querySelector('[data-slot="library-bulk-selection-archive"]') as HTMLButtonElement
     );
@@ -530,7 +588,7 @@ describe('LibraryHub (Wave B.3)', () => {
   // ─── Hero CTA → router.push add-game query ─────────────────────────────
 
   it('clicking hero "Aggiungi gioco" CTA navigates to /library?action=add', () => {
-    const { container } = renderWithIntl(<LibraryHub />);
+    const { container } = renderHub(makeHub());
     const hero = container.querySelector('[data-slot="library-hero-desktop"]') as HTMLElement;
     const cta = within(hero).getByRole('button', { name: 'Aggiungi gioco' });
     fireEvent.click(cta);
@@ -541,7 +599,7 @@ describe('LibraryHub (Wave B.3)', () => {
 
   it('clearFilters CTA from filtered-empty drops ?state= via router.push(pathname)', () => {
     searchParamsState.value = 'filtered-empty';
-    renderWithIntl(<LibraryHub />);
+    renderHub(makeHub());
     const cta = screen.getByRole('button', { name: 'Cancella filtri' });
     fireEvent.click(cta);
     // Orchestrator should call router.push(pathname) to drop the ?state= override.
@@ -551,7 +609,7 @@ describe('LibraryHub (Wave B.3)', () => {
   // ─── useMiniNavConfig invocation contract ──────────────────────────────
 
   it('registers mini-nav config with breadcrumb + Hub/Wishlist tabs + primaryAction', () => {
-    renderWithIntl(<LibraryHub />);
+    renderHub(makeHub());
     expect(useMiniNavConfigMock).toHaveBeenCalled();
     const lastCall = useMiniNavConfigMock.mock.calls.at(-1)?.[0] as {
       breadcrumb: string;
@@ -566,7 +624,7 @@ describe('LibraryHub (Wave B.3)', () => {
     expect(lastCall.tabs[1]).toMatchObject({
       id: 'wishlist',
       href: '/library/wishlist',
-      count: 1, // 1 Wishlist entry in fixture
+      count: 0, // Phase 2a: wishlist count not yet wired into the hybrid hub
     });
     expect(lastCall.primaryAction.label).toBe('Aggiungi gioco');
     expect(typeof lastCall.primaryAction.onClick).toBe('function');

--- a/apps/web/src/components/features/library/CrossEntityFilters.tsx
+++ b/apps/web/src/components/features/library/CrossEntityFilters.tsx
@@ -1,0 +1,105 @@
+/**
+ * CrossEntityFilters — Phase 2a (#1605). Chip row above the hub grid.
+ *
+ * In the `games` tab the STATO chip group is FUNCTIONAL: it carries the
+ * game-state filters that the retired `loaned`/`kb` tabs used to provide
+ * (Owned / Wishlist / InPrestito + a with-KB toggle), so no access regresses
+ * when the 3 game-state tabs collapse into one `games` tab. For all other tabs
+ * the component renders nothing — search + sort live as globals in the hub
+ * toolbar.
+ *
+ * Controlled component: the parent (`LibraryHub`) owns `gameStateFilter`.
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GameStateType } from '@/lib/api/schemas/library.schemas';
+import type { HybridHubTab } from '@/lib/library/hybrid-hub.derive';
+
+export interface GameStateFilter {
+  readonly states: ReadonlyArray<GameStateType>;
+  readonly withKb: boolean;
+}
+
+export interface CrossEntityFiltersProps {
+  readonly tab: HybridHubTab;
+  readonly gameStateFilter: GameStateFilter;
+  readonly onGameStateFilterChange: (next: GameStateFilter) => void;
+  readonly className?: string;
+}
+
+const STATE_CHIPS: ReadonlyArray<{ value: GameStateType; i18nKey: string }> = [
+  { value: 'Owned', i18nKey: 'pages.library.filters.stato.owned' },
+  { value: 'Wishlist', i18nKey: 'pages.library.filters.stato.wishlist' },
+  { value: 'InPrestito', i18nKey: 'pages.library.filters.stato.loaned' },
+];
+
+export function CrossEntityFilters({
+  tab,
+  gameStateFilter,
+  onGameStateFilterChange,
+  className,
+}: CrossEntityFiltersProps): ReactElement | null {
+  const { t } = useTranslation();
+
+  if (tab !== 'games') return null;
+
+  const toggleState = (value: GameStateType) => {
+    const has = gameStateFilter.states.includes(value);
+    const states = has
+      ? gameStateFilter.states.filter(s => s !== value)
+      : [...gameStateFilter.states, value];
+    onGameStateFilterChange({ ...gameStateFilter, states });
+  };
+
+  return (
+    <div
+      data-slot="cross-entity-filters"
+      data-testid="cross-entity-filters-stato"
+      className={clsx('flex flex-wrap items-center gap-2', className)}
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {t('pages.library.filters.stato.label')}
+      </span>
+      {STATE_CHIPS.map(chip => {
+        const active = gameStateFilter.states.includes(chip.value);
+        return (
+          <button
+            key={chip.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => toggleState(chip.value)}
+            className={clsx(
+              'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
+              active
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-border bg-background text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t(chip.i18nKey)}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        aria-pressed={gameStateFilter.withKb}
+        onClick={() =>
+          onGameStateFilterChange({ ...gameStateFilter, withKb: !gameStateFilter.withKb })
+        }
+        className={clsx(
+          'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
+          gameStateFilter.withKb
+            ? 'border-primary bg-primary/10 text-foreground'
+            : 'border-border bg-background text-muted-foreground hover:text-foreground'
+        )}
+      >
+        {t('pages.library.filters.stato.withKb')}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
+++ b/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
@@ -22,7 +22,21 @@ import type { ReactElement } from 'react';
 
 import clsx from 'clsx';
 
-export type LibraryHeroStatKey = 'totalGames' | 'kbReady' | 'wishlist' | 'loaned';
+/**
+ * Stat key discriminator for the hero stat chips. The 4 original game-only keys
+ * (`totalGames|kbReady|wishlist|loaned`) are preserved for backward compatibility
+ * with any code that still surfaces the legacy stats; Phase 2a (#1605) added the
+ * hybrid hub stat keys (`agents|docs|chats`) — `LibraryHub` now passes those
+ * alongside `totalGames` for the 4 cross-entity stat chips.
+ */
+export type LibraryHeroStatKey =
+  | 'totalGames'
+  | 'kbReady'
+  | 'wishlist'
+  | 'loaned'
+  | 'agents'
+  | 'docs'
+  | 'chats';
 
 export interface LibraryHeroDesktopLabels {
   readonly title: string;

--- a/apps/web/src/components/features/library/LibraryHybridGrid.tsx
+++ b/apps/web/src/components/features/library/LibraryHybridGrid.tsx
@@ -5,11 +5,17 @@
  * (LibraryGrid). Spec: docs/superpowers/specs/2026-04-30-v2-migration-wave-b-3-library.md
  * §3.2.
  *
+ * Phase 2a (#1605): accepts a heterogeneous `items: HybridHubItem[]`
+ * (game/agent/kb/session/chat discriminated union) instead of the games-only
+ * `UserLibraryEntry[]`. `entity`, `title`, `subtitle`, `href` come from the
+ * common base; `rating`/`imageUrl` are game-only visual extras gated by the
+ * discriminant. The `data-entry-id` attribute now carries the hybrid item id.
+ *
  * Single-handler click contract:
  *   The grid never decides toggle vs drill-into. It just calls
- *   `onCardClick(entry.id)` and the orchestrator (`LibraryHub`) dispatches
+ *   `onCardClick(item.id)` and the orchestrator (`LibraryHub`) dispatches
  *   based on `selectionMode`:
- *     - browse → push detail route
+ *     - browse → push detail route (`item.href`)
  *     - select → toggle membership in `selected` Set
  *   Keeping dispatch in the orchestrator keeps this component pure and
  *   testable without router or state-store mocks.
@@ -19,7 +25,7 @@
  *   - select → aria-pressed on EVERY card (ARIA toggle button pattern: the
  *              role advertises a binary state, so every member must expose
  *              the attribute even when false). Check overlay only when
- *              `selected.has(entry.id)`.
+ *              `selected.has(item.id)`.
  *
  * MeepleCard reuse mandate: this is the canonical entity card for the entire
  * app (game/player/agent/kb/...). Wrapping it in a `<button>` with overlay
@@ -37,18 +43,18 @@ import clsx from 'clsx';
 
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import type { MeepleCardVariant } from '@/components/ui/data-display/meeple-card';
-import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
 
 export type LibraryViewMode = 'grid' | 'list' | 'compact';
 export type LibrarySelectionMode = 'browse' | 'select';
 
 export interface LibraryHybridGridProps {
-  readonly entries: ReadonlyArray<UserLibraryEntry>;
+  readonly items: ReadonlyArray<HybridHubItem>;
   readonly view: LibraryViewMode;
   readonly selectionMode: LibrarySelectionMode;
   readonly selected: ReadonlySet<string>;
-  readonly onCardClick: (entryId: string) => void;
-  readonly onLongPressEnter?: (entryId: string) => void;
+  readonly onCardClick: (itemId: string) => void;
+  readonly onLongPressEnter?: (itemId: string) => void;
   readonly className?: string;
 }
 
@@ -64,8 +70,18 @@ const VIEW_TO_LAYOUT: Record<LibraryViewMode, string> = {
   compact: 'grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6',
 };
 
+// Game-only visual extras: rating + cover image are part of the `game` variant
+// only. Non-game items (session/chat/agent/kb) render the same MeepleCard
+// shell without these to keep the grid heterogeneous-safe.
+function itemImageUrl(item: HybridHubItem): string | undefined {
+  return item.entity === 'game' ? item.imageUrl : undefined;
+}
+function itemRating(item: HybridHubItem): number | undefined {
+  return item.entity === 'game' ? item.rating : undefined;
+}
+
 export function LibraryHybridGrid({
-  entries,
+  items,
   view,
   selectionMode,
   selected,
@@ -83,18 +99,17 @@ export function LibraryHybridGrid({
       data-selection-mode={selectionMode}
       className={clsx(layoutClass, className)}
     >
-      {entries.map(entry => {
-        const isSelected = selected.has(entry.id);
-        const imageUrl = entry.gameImageUrl ?? entry.gameIconUrl ?? undefined;
+      {items.map(item => {
+        const isSelected = selected.has(item.id);
         return (
           <button
-            key={entry.id}
+            key={item.id}
             type="button"
             data-slot="library-grid-card"
             data-selection-mode={selectionMode}
-            data-entry-id={entry.id}
+            data-entry-id={item.id}
             aria-pressed={isSelectMode ? isSelected : undefined}
-            onClick={() => onCardClick(entry.id)}
+            onClick={() => onCardClick(item.id)}
             className={clsx(
               'relative block w-full text-left',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl',
@@ -102,12 +117,12 @@ export function LibraryHybridGrid({
             )}
           >
             <MeepleCard
-              entity="game"
+              entity={item.entity}
               variant={variant}
-              title={entry.gameTitle}
-              subtitle={entry.gamePublisher ?? undefined}
-              imageUrl={imageUrl}
-              rating={entry.averageRating ?? undefined}
+              title={item.title}
+              subtitle={item.subtitle}
+              imageUrl={itemImageUrl(item)}
+              rating={itemRating(item)}
               ratingMax={10}
             />
             {isSelectMode && isSelected ? (

--- a/apps/web/src/components/features/library/LibraryTabs.tsx
+++ b/apps/web/src/components/features/library/LibraryTabs.tsx
@@ -33,23 +33,28 @@ import type { LibraryEntityKey } from '@/lib/library/library-filters';
 
 export type { LibraryEntityKey };
 
-export interface LibraryTabConfig {
-  readonly key: LibraryEntityKey;
+export interface LibraryTabConfig<K extends string = LibraryEntityKey> {
+  readonly key: K;
   readonly label: string;
   readonly count: number;
 }
 
-export interface LibraryTabsProps {
-  readonly tabs: ReadonlyArray<LibraryTabConfig>;
-  readonly active: LibraryEntityKey;
-  readonly onChange: (next: LibraryEntityKey) => void;
+export interface LibraryTabsProps<K extends string = LibraryEntityKey> {
+  readonly tabs: ReadonlyArray<LibraryTabConfig<K>>;
+  readonly active: K;
+  readonly onChange: (next: K) => void;
   readonly className?: string;
 }
 
-export function LibraryTabs({ tabs, active, onChange, className }: LibraryTabsProps): ReactElement {
-  const orderedKeys = useMemo<readonly LibraryEntityKey[]>(() => tabs.map(t => t.key), [tabs]);
+export function LibraryTabs<K extends string = LibraryEntityKey>({
+  tabs,
+  active,
+  onChange,
+  className,
+}: LibraryTabsProps<K>): ReactElement {
+  const orderedKeys = useMemo<readonly K[]>(() => tabs.map(t => t.key), [tabs]);
 
-  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<LibraryEntityKey>({
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<K>({
     orderedKeys,
     onChange,
   });

--- a/apps/web/src/components/features/library/LibraryTabs.tsx
+++ b/apps/web/src/components/features/library/LibraryTabs.tsx
@@ -5,14 +5,14 @@
  * (EntityTabBar). Spec: docs/superpowers/specs/2026-04-30-v2-migration-wave-b-3-library.md
  * §3.2 + AC-2 + AC-4 + AC-8.
  *
- * Scope ridotto B.3 — 3 tabs (`all` / `kb` / `loaned`):
- *   - `game` droppato YAGNI (alias di `all` con backend game-only).
- *   - `archived` rinominato `loaned` per allineamento col mapping
- *     `currentState='InPrestito'` (§3.3).
- *   - `agent`/`session`/`chat` deferred a Wave B.4+ (backend extension
- *     child issue tracking).
+ * Generic key type (Phase 2a #1605): the component is generic over
+ * `<K extends string = LibraryEntityKey>` so a single tab strip serves both
+ * the legacy Wave B.3 3-tab key (`all|kb|loaned`, default) and the Phase 2a+
+ * hybrid 6-tab key (`HybridHubTab` = `all|games|agents|kb|sessions|chat`)
+ * without forking the component. Existing consumers that pass `LibraryEntityKey`
+ * (or omit the type arg) keep working unchanged.
  *
- * Keyboard contract via `useTablistKeyboardNav<LibraryEntityKey>` (PR #623):
+ * Keyboard contract via `useTablistKeyboardNav<K>` (PR #623):
  *   ArrowLeft/ArrowRight wrap, Home/End jump, roving tabindex automatic
  *   activation, off-axis keys no-op. Mirror del pattern già usato in
  *   `shared-game-detail/tabs.tsx` (Wave A.4) e `category-tabs.tsx` (PR #620).

--- a/apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { CrossEntityFilters, type GameStateFilter } from '../CrossEntityFilters';
+
+const messages: Record<string, string> = {
+  'pages.library.filters.stato.label': 'Stato',
+  'pages.library.filters.stato.owned': 'Posseduti',
+  'pages.library.filters.stato.wishlist': 'Wishlist',
+  'pages.library.filters.stato.loaned': 'In prestito',
+  'pages.library.filters.stato.withKb': 'Con Knowledge Base',
+};
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={messages}>
+      {ui}
+    </IntlProvider>
+  );
+}
+const noop = () => {};
+const emptyFilter: GameStateFilter = { states: [], withKb: false };
+
+describe('CrossEntityFilters', () => {
+  it('renders the STATO chip group only for the games tab', () => {
+    const { rerender } = renderWithIntl(
+      <CrossEntityFilters
+        tab="games"
+        gameStateFilter={emptyFilter}
+        onGameStateFilterChange={noop}
+      />
+    );
+    expect(screen.getByTestId('cross-entity-filters-stato')).toBeInTheDocument();
+    rerender(
+      <IntlProvider locale="it" messages={messages}>
+        <CrossEntityFilters
+          tab="sessions"
+          gameStateFilter={emptyFilter}
+          onGameStateFilterChange={noop}
+        />
+      </IntlProvider>
+    );
+    expect(screen.queryByTestId('cross-entity-filters-stato')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for the all tab (search+sort are global in toolbar)', () => {
+    const { container } = renderWithIntl(
+      <CrossEntityFilters tab="all" gameStateFilter={emptyFilter} onGameStateFilterChange={noop} />
+    );
+    expect(container.querySelector('[data-testid="cross-entity-filters-stato"]')).toBeNull();
+  });
+
+  it('toggling a state chip emits the updated filter', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <CrossEntityFilters
+        tab="games"
+        gameStateFilter={emptyFilter}
+        onGameStateFilterChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /posseduti/i }));
+    expect(onChange).toHaveBeenCalledWith({ states: ['Owned'], withKb: false });
+  });
+
+  it('active state chip reflects the filter (aria-pressed)', () => {
+    renderWithIntl(
+      <CrossEntityFilters
+        tab="games"
+        gameStateFilter={{ states: ['Wishlist'], withKb: false }}
+        onGameStateFilterChange={noop}
+      />
+    );
+    expect(screen.getByRole('button', { name: /wishlist/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: /posseduti/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('with-KB toggle emits withKb=true', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <CrossEntityFilters
+        tab="games"
+        gameStateFilter={emptyFilter}
+        onGameStateFilterChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /con knowledge base/i }));
+    expect(onChange).toHaveBeenCalledWith({ states: [], withKb: true });
+  });
+});

--- a/apps/web/src/components/features/library/__tests__/LibraryHybridGrid.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/LibraryHybridGrid.test.tsx
@@ -1,17 +1,23 @@
 /**
- * Wave B.3 (Issue #574) — LibraryHybridGrid v2 component tests.
+ * Phase 2a (Issue #1605) — LibraryHybridGrid hybrid-item component tests.
  *
- * Spec §3.2:
- *   - Maps `entries: ReadonlyArray<UserLibraryEntry>` → MeepleCard rendering.
+ * The grid is a pure component over a heterogeneous `items: HybridHubItem[]`
+ * (game/agent/kb/session/chat). Migrated from the Wave B.3 games-only
+ * `UserLibraryEntry[]` shape (#574).
+ *
+ * Contract under test:
+ *   - One MeepleCard per item; `entity`/`title`/`subtitle` come from the base,
+ *     `rating`/`imageUrl` are game-only extras (non-game items render without
+ *     them, no crash).
  *   - View modes: `grid` / `list` / `compact` → distinct layout classes +
  *     MeepleCard variant prop pass-through.
  *   - Selection mode FSM:
  *       browse  → no aria-pressed, native click; data-selection-mode="browse".
  *       select  → aria-pressed reflects selected Set membership;
  *                 data-selection-mode="select"; check overlay slot rendered
- *                 only when selected.has(entry.id).
+ *                 only when selected.has(item.id).
  *   - Click dispatch single-handler contract: orchestrator decides toggle vs
- *     drill-into; component just calls onCardClick(entry.id).
+ *     drill-into; component just calls onCardClick(item.id).
  *
  * MeepleCard is mocked to keep this a focused wrapper-logic unit test
  * (MeepleCard has its own 100+ tests). The mock surfaces `entity`,
@@ -23,7 +29,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { LibraryHybridGrid, type LibraryHybridGridProps } from '../LibraryHybridGrid';
-import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
 
 // ---------- MeepleCard mock ---------------------------------------------------
 vi.mock('@/components/ui/data-display/meeple-card', () => ({
@@ -52,73 +58,48 @@ vi.mock('@/components/ui/data-display/meeple-card', () => ({
 }));
 
 // ---------- Fixture helpers ---------------------------------------------------
-const NOW = '2026-04-30T10:00:00.000Z';
-const USER_ID = '00000000-0000-4000-8000-000000000aaa';
-
-function makeEntry(
-  overrides: Partial<UserLibraryEntry> & Pick<UserLibraryEntry, 'id' | 'gameId' | 'gameTitle'>
-): UserLibraryEntry {
-  return {
-    userId: USER_ID,
-    gamePublisher: null,
-    gameYearPublished: null,
-    gameIconUrl: null,
-    gameImageUrl: null,
-    addedAt: NOW,
-    notes: null,
-    isFavorite: false,
-    currentState: 'Owned',
-    stateChangedAt: null,
-    stateNotes: null,
+// Heterogeneous hybrid items: one game (with rating + image), one session, one
+// chat (both without rating/image — the game-only visual extras must be absent).
+const items: HybridHubItem[] = [
+  {
+    id: 'g1',
+    entity: 'game',
+    title: 'Catan',
+    subtitle: 'Kosmos',
+    updatedAt: '2026-01-01T00:00:00Z',
+    href: '/library/game-1',
+    gameId: 'game-1',
+    rating: 7,
+    state: 'Owned',
+    imageUrl: 'https://example.test/catan.jpg',
     hasKb: false,
-    kbCardCount: 0,
-    kbIndexedCount: 0,
-    kbProcessingCount: 0,
-    ownershipDeclaredAt: null,
-    hasRagAccess: false,
-    agentIsOwned: true,
-    minPlayers: null,
-    maxPlayers: null,
-    playingTimeMinutes: null,
-    complexityRating: null,
-    averageRating: null,
-    privateGameId: null,
-    isPrivateGame: false,
-    canProposeToCatalog: false,
-    ...overrides,
-  };
-}
-
-const e1 = makeEntry({
-  id: 'entry-1',
-  gameId: 'game-1',
-  gameTitle: 'Catan',
-  gamePublisher: 'Kosmos',
-  averageRating: 7.2,
-  gameImageUrl: 'https://example.test/catan.png',
-});
-const e2 = makeEntry({
-  id: 'entry-2',
-  gameId: 'game-2',
-  gameTitle: 'Wingspan',
-  gamePublisher: 'Stonemaier Games',
-  averageRating: 8.1,
-});
-const e3 = makeEntry({
-  id: 'entry-3',
-  gameId: 'game-3',
-  gameTitle: 'Brass: Birmingham',
-  // no publisher → subtitle should be empty/undefined
-  averageRating: 8.6,
-  gameIconUrl: 'https://example.test/brass-icon.png',
-});
-const baseEntries: ReadonlyArray<UserLibraryEntry> = [e1, e2, e3];
+  },
+  {
+    id: 's1',
+    entity: 'session',
+    title: 'Session s1',
+    subtitle: 'Alice',
+    updatedAt: '2026-02-01T00:00:00Z',
+    href: '/sessions/s1',
+    status: 'Completed',
+    playerCount: 4,
+  },
+  {
+    id: 'c1',
+    entity: 'chat',
+    title: 'How to play?',
+    subtitle: 'Catan',
+    updatedAt: '2026-03-01T00:00:00Z',
+    href: '/chats/c1',
+    messageCount: 3,
+  },
+];
 
 function renderGrid(overrides: Partial<LibraryHybridGridProps> = {}) {
   const onCardClick = vi.fn();
   const utils = render(
     <LibraryHybridGrid
-      entries={baseEntries}
+      items={items}
       view="grid"
       selectionMode="browse"
       selected={new Set()}
@@ -130,9 +111,9 @@ function renderGrid(overrides: Partial<LibraryHybridGridProps> = {}) {
 }
 
 // ---------- Tests -------------------------------------------------------------
-describe('LibraryHybridGrid (Wave B.3)', () => {
+describe('LibraryHybridGrid (Phase 2a hybrid items)', () => {
   describe('rendering basics', () => {
-    it('renders one card per entry', () => {
+    it('renders one card per item (game/session/chat)', () => {
       const { container } = renderGrid();
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       expect(cards).toHaveLength(3);
@@ -143,26 +124,40 @@ describe('LibraryHybridGrid (Wave B.3)', () => {
       expect(container.querySelector('[data-slot="library-hybrid-grid"]')).not.toBeNull();
     });
 
-    it('passes title + subtitle + imageUrl + rating to MeepleCard', () => {
+    it('passes each item entity through to MeepleCard', () => {
+      const { container } = renderGrid();
+      const cards = container.querySelectorAll('[data-slot="meeple-card-mock"]');
+      expect(cards[0]).toHaveAttribute('data-entity', 'game');
+      expect(cards[1]).toHaveAttribute('data-entity', 'session');
+      expect(cards[2]).toHaveAttribute('data-entity', 'chat');
+    });
+
+    it('passes title + subtitle + imageUrl + rating for a game item', () => {
       const { container } = renderGrid();
       const cards = container.querySelectorAll('[data-slot="meeple-card-mock"]');
       expect(cards[0]).toHaveAttribute('data-title', 'Catan');
       expect(cards[0]).toHaveAttribute('data-subtitle', 'Kosmos');
-      expect(cards[0]).toHaveAttribute('data-image-url', 'https://example.test/catan.png');
-      expect(cards[0]).toHaveAttribute('data-rating', '7.2');
+      expect(cards[0]).toHaveAttribute('data-image-url', 'https://example.test/catan.jpg');
+      expect(cards[0]).toHaveAttribute('data-rating', '7');
       expect(cards[0]).toHaveAttribute('data-rating-max', '10');
-      expect(cards[0]).toHaveAttribute('data-entity', 'game');
     });
 
-    it('falls back to gameIconUrl when gameImageUrl is null', () => {
+    it('renders a non-game item without rating/image (no crash)', () => {
       const { container } = renderGrid();
       const cards = container.querySelectorAll('[data-slot="meeple-card-mock"]');
-      // entry-3 has gameIconUrl but null gameImageUrl
-      expect(cards[2]).toHaveAttribute('data-image-url', 'https://example.test/brass-icon.png');
+      // session card carries title + subtitle but no game-only visual extras
+      expect(cards[1]).toHaveAttribute('data-title', 'Session s1');
+      expect(cards[1]).toHaveAttribute('data-subtitle', 'Alice');
+      expect(cards[1]).toHaveAttribute('data-image-url', '');
+      expect(cards[1]).toHaveAttribute('data-rating', '');
+      // chat card likewise
+      expect(cards[2]).toHaveAttribute('data-title', 'How to play?');
+      expect(cards[2]).toHaveAttribute('data-image-url', '');
+      expect(cards[2]).toHaveAttribute('data-rating', '');
     });
 
-    it('renders empty container when entries=[]', () => {
-      const { container } = renderGrid({ entries: [] });
+    it('renders empty container when items=[]', () => {
+      const { container } = renderGrid({ items: [] });
       const grid = container.querySelector('[data-slot="library-hybrid-grid"]');
       expect(grid).not.toBeNull();
       expect(grid?.querySelectorAll('[data-slot="library-grid-card"]')).toHaveLength(0);
@@ -208,18 +203,18 @@ describe('LibraryHybridGrid (Wave B.3)', () => {
       cards.forEach(c => expect(c).toHaveAttribute('data-selection-mode', 'browse'));
     });
 
-    it('click → onCardClick(entry.id)', () => {
+    it('click → onCardClick(item.id)', () => {
       const { container, onCardClick } = renderGrid({ selectionMode: 'browse' });
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       fireEvent.click(cards[1]);
       expect(onCardClick).toHaveBeenCalledTimes(1);
-      expect(onCardClick).toHaveBeenCalledWith('entry-2');
+      expect(onCardClick).toHaveBeenCalledWith('s1');
     });
 
     it('does NOT render check overlay in browse mode (even if id in selected Set)', () => {
       const { container } = renderGrid({
         selectionMode: 'browse',
-        selected: new Set(['entry-1']),
+        selected: new Set(['g1']),
       });
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       const overlay = within(cards[0] as HTMLElement).queryByTestId('library-grid-card-check');
@@ -231,7 +226,7 @@ describe('LibraryHybridGrid (Wave B.3)', () => {
     it('sets aria-pressed on EVERY card (toggle button pattern)', () => {
       const { container } = renderGrid({
         selectionMode: 'select',
-        selected: new Set(['entry-2']),
+        selected: new Set(['s1']),
       });
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       expect(cards[0]).toHaveAttribute('aria-pressed', 'false');
@@ -248,7 +243,7 @@ describe('LibraryHybridGrid (Wave B.3)', () => {
     it('renders check overlay only on selected cards', () => {
       const { container } = renderGrid({
         selectionMode: 'select',
-        selected: new Set(['entry-1', 'entry-3']),
+        selected: new Set(['g1', 'c1']),
       });
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       expect(
@@ -260,15 +255,15 @@ describe('LibraryHybridGrid (Wave B.3)', () => {
       ).not.toBeNull();
     });
 
-    it('click → onCardClick(entry.id) (orchestrator decides toggle)', () => {
+    it('click → onCardClick(item.id) (orchestrator decides toggle)', () => {
       const { container, onCardClick } = renderGrid({
         selectionMode: 'select',
-        selected: new Set(['entry-1']),
+        selected: new Set(['g1']),
       });
       const cards = container.querySelectorAll('[data-slot="library-grid-card"]');
       fireEvent.click(cards[2]);
       expect(onCardClick).toHaveBeenCalledTimes(1);
-      expect(onCardClick).toHaveBeenCalledWith('entry-3');
+      expect(onCardClick).toHaveBeenCalledWith('c1');
     });
   });
 });

--- a/apps/web/src/components/features/library/index.ts
+++ b/apps/web/src/components/features/library/index.ts
@@ -46,3 +46,9 @@ export type {
   ActivityKind,
   RecentActivityRailProps,
 } from '@/components/features/library/RecentActivityRail';
+
+export { CrossEntityFilters } from '@/components/features/library/CrossEntityFilters';
+export type {
+  CrossEntityFiltersProps,
+  GameStateFilter,
+} from '@/components/features/library/CrossEntityFilters';

--- a/apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useHybridHubItems } from '../useHybridHubItems';
+
+const mockUseLibrary = vi.fn();
+const mockUseActiveSessions = vi.fn();
+const mockUseRecentChatSessions = vi.fn();
+const mockUseAgents = vi.fn();
+
+vi.mock('../useLibrary', () => ({ useLibrary: (...args: unknown[]) => mockUseLibrary(...args) }));
+vi.mock('../useActiveSessions', () => ({
+  useActiveSessions: (...args: unknown[]) => mockUseActiveSessions(...args),
+}));
+vi.mock('../useChatSessions', () => ({
+  useRecentChatSessions: (...args: unknown[]) => mockUseRecentChatSessions(...args),
+}));
+vi.mock('../useAgents', () => ({ useAgents: (...args: unknown[]) => mockUseAgents(...args) }));
+
+function ok<T>(data: T) {
+  return { data, isLoading: false, isError: false, error: null };
+}
+function loading() {
+  return { data: undefined, isLoading: true, isError: false, error: null };
+}
+function failed(err: Error) {
+  return { data: undefined, isLoading: false, isError: true, error: err };
+}
+
+const gameEntry = {
+  id: 'g1',
+  userId: 'u',
+  gameId: 'game-1',
+  gameTitle: 'Catan',
+  gamePublisher: 'Kosmos',
+  gameYearPublished: 1995,
+  gameIconUrl: null,
+  gameImageUrl: null,
+  addedAt: '2026-01-01T00:00:00Z',
+  notes: null,
+  isFavorite: false,
+  currentState: 'Owned' as const,
+  stateChangedAt: null,
+  stateNotes: null,
+  hasKb: false,
+  kbCardCount: 0,
+  kbIndexedCount: 0,
+  kbProcessingCount: 0,
+  ownershipDeclaredAt: null,
+  hasRagAccess: false,
+  agentIsOwned: true,
+  minPlayers: 3,
+  maxPlayers: 4,
+  playingTimeMinutes: 60,
+  complexityRating: 2,
+  averageRating: 7,
+  privateGameId: null,
+  isPrivateGame: false,
+  canProposeToCatalog: false,
+};
+const sessionDto = {
+  id: 's1',
+  gameId: 'game-1',
+  status: 'Completed',
+  startedAt: '2026-02-01T00:00:00Z',
+  completedAt: '2026-02-01T01:00:00Z',
+  playerCount: 4,
+  players: [],
+  winnerName: 'Alice',
+  notes: null,
+  durationMinutes: 60,
+};
+const chatDto = {
+  id: 'c1',
+  userId: 'u',
+  gameId: 'game-1',
+  gameTitle: 'Catan',
+  agentId: null,
+  agentType: null,
+  agentName: null,
+  title: 'How to play?',
+  messageCount: 3,
+  lastMessagePreview: null,
+  createdAt: '2026-03-01T00:00:00Z',
+  lastMessageAt: '2026-03-01T00:10:00Z',
+  isArchived: false,
+};
+
+beforeEach(() => {
+  mockUseLibrary.mockReturnValue(
+    ok({
+      items: [gameEntry],
+      page: 1,
+      pageSize: 50,
+      totalCount: 1,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    })
+  );
+  mockUseActiveSessions.mockReturnValue(
+    ok({ sessions: [sessionDto], page: 1, pageSize: 20, totalCount: 1 })
+  );
+  mockUseRecentChatSessions.mockReturnValue(ok({ sessions: [chatDto], totalCount: 1 }));
+  mockUseAgents.mockReturnValue(ok([]));
+});
+
+describe('useHybridHubItems', () => {
+  it('maps the 3 ready sources into HybridHubSources (game/session/chat), agents/kb empty', () => {
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games.map(i => i.entity)).toEqual(['game']);
+    expect(result.current.sources.sessions.map(i => i.entity)).toEqual(['session']);
+    expect(result.current.sources.chat.map(i => i.entity)).toEqual(['chat']);
+    expect(result.current.sources.agents).toEqual([]);
+    expect(result.current.sources.kb).toEqual([]);
+  });
+
+  it('unwraps .items / .sessions from paginated responses; chat passes through', () => {
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games[0]?.id).toBe('g1');
+    expect(result.current.sources.sessions[0]?.id).toBe('s1');
+    expect(result.current.sources.chat[0]?.id).toBe('c1');
+  });
+
+  it('caps each source to 20 items', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      ...gameEntry,
+      id: `g${i}`,
+      gameId: `game-${i}`,
+    }));
+    mockUseLibrary.mockReturnValue(
+      ok({
+        items: many,
+        page: 1,
+        pageSize: 50,
+        totalCount: 30,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      })
+    );
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games).toHaveLength(20);
+  });
+
+  it('reports totalCounts per source (pre-cap)', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      ...gameEntry,
+      id: `g${i}`,
+      gameId: `game-${i}`,
+    }));
+    mockUseLibrary.mockReturnValue(
+      ok({
+        items: many,
+        page: 1,
+        pageSize: 50,
+        totalCount: 30,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      })
+    );
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.totalCounts.games).toBe(30);
+    expect(result.current.totalCounts.sessions).toBe(1);
+    expect(result.current.totalCounts.chat).toBe(1);
+  });
+
+  it('isLoading=true while any ready source is loading', () => {
+    mockUseActiveSessions.mockReturnValue(loading());
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('partialErrors records the failing source; others still map', () => {
+    mockUseActiveSessions.mockReturnValue(failed(new Error('boom')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.partialErrors.sessions).toBeInstanceOf(Error);
+    expect(result.current.partialErrors.games).toBeNull();
+    expect(result.current.sources.games).toHaveLength(1);
+    expect(result.current.sources.sessions).toEqual([]);
+  });
+
+  it('allFailed=true only when every ready source errors', () => {
+    mockUseLibrary.mockReturnValue(failed(new Error('a')));
+    mockUseActiveSessions.mockReturnValue(failed(new Error('b')));
+    mockUseRecentChatSessions.mockReturnValue(failed(new Error('c')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.allFailed).toBe(true);
+  });
+
+  it('allFailed=false when at least one ready source succeeds', () => {
+    mockUseLibrary.mockReturnValue(failed(new Error('a')));
+    mockUseActiveSessions.mockReturnValue(
+      ok({ sessions: [sessionDto], page: 1, pageSize: 20, totalCount: 1 })
+    );
+    mockUseRecentChatSessions.mockReturnValue(failed(new Error('c')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.allFailed).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/queries/useHybridHubItems.ts
+++ b/apps/web/src/hooks/queries/useHybridHubItems.ts
@@ -1,0 +1,104 @@
+/**
+ * useHybridHubItems — Phase 2a (#1605) orchestration hook for the `/library`
+ * hybrid hub. Calls the 3 ready entity sources (games / sessions / chat),
+ * maps each DTO to a `HybridHubItem` via the Phase 1 mappers, caps each source
+ * to `PER_SOURCE_CAP`, and reports per-source errors so the hub can degrade
+ * gracefully (AC9.1). Agents + KB are stubbed to `[]` until BE-2 #1589 / BE-1
+ * #1588 ship (Phase 2b).
+ *
+ * Returns `HybridHubSources` (the shape `deriveHybridItems` consumes) — the
+ * hook is the data layer; tab/query/sort derivation stays in `LibraryHub`.
+ */
+
+import { useMemo } from 'react';
+
+import type { HybridHubSources } from '@/lib/library/hybrid-hub.derive';
+import {
+  chatToHubItem,
+  libraryEntryToHubItem,
+  sessionToHubItem,
+} from '@/lib/library/hybrid-hub.mappers';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+
+import { useActiveSessions } from './useActiveSessions';
+import { useAgents } from './useAgents';
+import { useRecentChatSessions } from './useChatSessions';
+import { useLibrary } from './useLibrary';
+
+export const PER_SOURCE_CAP = 20;
+
+export type HybridHubSourceKey = keyof HybridHubSources;
+
+export interface UseHybridHubItemsResult {
+  readonly sources: HybridHubSources;
+  readonly isLoading: boolean;
+  readonly allFailed: boolean;
+  readonly partialErrors: Record<HybridHubSourceKey, Error | null>;
+  readonly totalCounts: Record<HybridHubSourceKey, number>;
+}
+
+export function useHybridHubItems(): UseHybridHubItemsResult {
+  const libraryQuery = useLibrary({
+    page: 1,
+    pageSize: 50,
+    sortBy: 'addedAt',
+    sortDescending: true,
+  });
+  const sessionsQuery = useActiveSessions(PER_SOURCE_CAP);
+  const chatQuery = useRecentChatSessions(50);
+  const agentsQuery = useAgents({});
+
+  return useMemo(() => {
+    const gameItems = (libraryQuery.data?.items ?? []).map(libraryEntryToHubItem);
+    const sessionItems = (sessionsQuery.data?.sessions ?? []).map(sessionToHubItem);
+    const chatItems = (chatQuery.data?.sessions ?? []).map(chatToHubItem);
+
+    const cap = (items: readonly HybridHubItem[]) => items.slice(0, PER_SOURCE_CAP);
+
+    const sources: HybridHubSources = {
+      games: libraryQuery.isError ? [] : cap(gameItems),
+      sessions: sessionsQuery.isError ? [] : cap(sessionItems),
+      chat: chatQuery.isError ? [] : cap(chatItems),
+      agents: [],
+      kb: [],
+    };
+
+    const partialErrors: Record<HybridHubSourceKey, Error | null> = {
+      games: libraryQuery.isError ? (libraryQuery.error ?? new Error('library')) : null,
+      sessions: sessionsQuery.isError ? (sessionsQuery.error ?? new Error('sessions')) : null,
+      chat: chatQuery.isError ? (chatQuery.error ?? new Error('chat')) : null,
+      agents: null,
+      kb: null,
+    };
+
+    const totalCounts: Record<HybridHubSourceKey, number> = {
+      games: gameItems.length,
+      sessions: sessionItems.length,
+      chat: chatItems.length,
+      agents: 0,
+      kb: 0,
+    };
+
+    const readyErrors = [libraryQuery.isError, sessionsQuery.isError, chatQuery.isError];
+    const allFailed = readyErrors.every(Boolean);
+    const isLoading = libraryQuery.isLoading || sessionsQuery.isLoading || chatQuery.isLoading;
+
+    void agentsQuery;
+
+    return { sources, isLoading, allFailed, partialErrors, totalCounts };
+  }, [
+    libraryQuery.data,
+    libraryQuery.isError,
+    libraryQuery.error,
+    libraryQuery.isLoading,
+    sessionsQuery.data,
+    sessionsQuery.isError,
+    sessionsQuery.error,
+    sessionsQuery.isLoading,
+    chatQuery.data,
+    chatQuery.isError,
+    chatQuery.error,
+    chatQuery.isLoading,
+    agentsQuery,
+  ]);
+}

--- a/apps/web/src/lib/library/__tests__/hybrid-hub.mappers.test.ts
+++ b/apps/web/src/lib/library/__tests__/hybrid-hub.mappers.test.ts
@@ -97,6 +97,12 @@ describe('libraryEntryToHubItem', () => {
     const result = libraryEntryToHubItem({ ...baseEntry, averageRating: null });
     expect(result.rating).toBeUndefined();
   });
+
+  it('sets hasKb from isKbEntry (true when hasKb or kbCardCount>0)', () => {
+    expect(libraryEntryToHubItem({ ...baseEntry, hasKb: true, kbCardCount: 0 }).hasKb).toBe(true);
+    expect(libraryEntryToHubItem({ ...baseEntry, hasKb: false, kbCardCount: 2 }).hasKb).toBe(true);
+    expect(libraryEntryToHubItem({ ...baseEntry, hasKb: false, kbCardCount: 0 }).hasKb).toBe(false);
+  });
 });
 
 const baseAgent: AgentDto = {

--- a/apps/web/src/lib/library/hybrid-hub.mappers.ts
+++ b/apps/web/src/lib/library/hybrid-hub.mappers.ts
@@ -19,6 +19,8 @@ import type { ChatSessionSummaryDto } from '@/lib/api/schemas/chat-sessions.sche
 import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
 import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
 
+import { isKbEntry } from './library-filters';
+
 import type {
   AgentHubItem,
   ChatHubItem,
@@ -59,6 +61,7 @@ export function libraryEntryToHubItem(entry: UserLibraryEntry): GameHubItem {
     rating: entry.averageRating ?? undefined,
     state: entry.currentState,
     imageUrl: entry.gameImageUrl ?? entry.gameIconUrl ?? undefined,
+    hasKb: isKbEntry(entry),
   };
 }
 

--- a/apps/web/src/lib/library/hybrid-hub.types.ts
+++ b/apps/web/src/lib/library/hybrid-hub.types.ts
@@ -44,6 +44,9 @@ export interface GameHubItem extends HybridHubItemBase {
   readonly rating?: number;
   readonly state?: GameStateType;
   readonly imageUrl?: string;
+  /** True if the game has ≥1 KB doc (mirrors the retired `kb` tab). Optional in the
+   *  type (so test literals stay valid) but always set by `libraryEntryToHubItem`. */
+  readonly hasKb?: boolean;
 }
 
 export interface AgentHubItem extends HybridHubItemBase {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1620,6 +1620,13 @@
           "ready": "Ready",
           "pending": "Pending",
           "failed": "Failed"
+        },
+        "stato": {
+          "label": "State",
+          "owned": "Owned",
+          "wishlist": "Wishlist",
+          "loaned": "Loaned",
+          "withKb": "With Knowledge Base"
         }
       },
       "sort": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1566,7 +1566,10 @@
           "totalGames": "Total games",
           "kbReady": "Knowledge bases",
           "wishlist": "Wishlist",
-          "loaned": "On loan"
+          "loaned": "On loan",
+          "agents": "Agents",
+          "docs": "Documents",
+          "chats": "Chats"
         },
         "cta": {
           "add": "Add game",
@@ -1579,6 +1582,14 @@
         "kb": "Knowledge bases",
         "loaned": "On loan",
         "count": "{count, plural, =0 {none} =1 {1} other {#}}"
+      },
+      "hubTabs": {
+        "all": "All",
+        "games": "Games",
+        "agents": "Agents",
+        "kb": "KB",
+        "sessions": "Sessions",
+        "chat": "Chat"
       },
       "selectionMode": {
         "enter": "Select",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1670,6 +1670,13 @@
           "ready": "Pronto",
           "pending": "In elaborazione",
           "failed": "Errore"
+        },
+        "stato": {
+          "label": "Stato",
+          "owned": "Posseduti",
+          "wishlist": "Wishlist",
+          "loaned": "In prestito",
+          "withKb": "Con Knowledge Base"
         }
       },
       "sort": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1616,7 +1616,10 @@
           "totalGames": "Giochi totali",
           "kbReady": "Knowledge base",
           "wishlist": "Wishlist",
-          "loaned": "In prestito"
+          "loaned": "In prestito",
+          "agents": "Agenti",
+          "docs": "Documenti",
+          "chats": "Chat"
         },
         "cta": {
           "add": "Aggiungi gioco",
@@ -1629,6 +1632,14 @@
         "kb": "Knowledge base",
         "loaned": "In prestito",
         "count": "{count, plural, =0 {nessuno} =1 {1} other {#}}"
+      },
+      "hubTabs": {
+        "all": "Tutti",
+        "games": "Giochi",
+        "agents": "Agenti",
+        "kb": "KB",
+        "sessions": "Sessioni",
+        "chat": "Chat"
       },
       "selectionMode": {
         "enter": "Seleziona",

--- a/docs/superpowers/plans/2026-05-27-library-hybrid-hub-phase-2a.md
+++ b/docs/superpowers/plans/2026-05-27-library-hybrid-hub-phase-2a.md
@@ -1,0 +1,1182 @@
+# Library Hybrid Hub — Phase 2a (Surface, games/sessions/chat) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the `/library` surface from the current games-only 3-tab view into the hybrid multi-entity hub for the 3 ready sources (games + sessions + chat), using the Phase 1 foundation (`useHybridHubItems` orchestration + `deriveHybridItems`), with a functional `CrossEntityFilters` STATO chip and game-scoped bulk selection — agents + kb stubbed to `[]` until BE-1 #1588 / BE-2 #1589 (Phase 2b).
+
+**Architecture:** Brownfield refactor of `LibraryHub`. Two greenfield pieces land first as green commits (`useHybridHubItems` hook + `CrossEntityFilters` component); `LibraryTabs` is generalized to a generic key type (backward-compatible green commit); then **one atomic "flip" commit** swaps `LibraryHybridGrid` to `HybridHubItem[]` and rewires `LibraryHub` (6-tab via the existing `HybridHubTab`, hook orchestration, hero hybrid stats, game-scoped selection, partial-failure FSM) + rewrites the affected tests. The atomic flip is irreducible because the pre-commit `tsc --noEmit` gate rejects an intermediate state where the grid prop type and its `LibraryHub` consumer disagree.
+
+**Key technical decisions (from the /sc:spec-panel resolutions on #1605):**
+- **Tab state uses `HybridHubTab`** (`'all'|'games'|'agents'|'kb'|'sessions'|'chat'`, already exported from `lib/library/hybrid-hub.derive.ts`). `LibraryEntityKey` (`'all'|'kb'|'loaned'`) is **NOT** expanded — it stays the SSOT for the game **state filters** that the `CrossEntityFilters` STATO chip reuses via the existing `filterByEntity`. This keeps `library-filters.ts` + its 28 tests untouched.
+- **FSM + partial-failure:** `error` only when all sources fail; `empty` = zero items across all sources; `filtered-empty` = sources have data but tab+query+filters eliminate all; per-source inline error otherwise.
+- **Cardinality:** cap 20/source in the `all` tab inside `useHybridHubItems`; `useActiveSessions` raised to limit 20; `useRecentChatSessions` stays auth-gated; `useAgents`/`useUserKbDocs` stubbed to `[]`.
+- **Selection mode is game-scoped:** `LibraryHub` forces `browse` when `tab !== 'games'`; `BulkSelectionBar` mounts only in `games`.
+
+**Tech Stack:** TypeScript 5 · React 19 · TanStack Query · react-intl (`@/hooks/useTranslation`) · Vitest + Testing Library + jest-axe
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `apps/web/src/lib/library/hybrid-hub.types.ts` | Add `hasKb: boolean` to `GameHubItem` (so the STATO with-KB chip has data) | Modify (Phase 1 enrich) |
+| `apps/web/src/lib/library/hybrid-hub.mappers.ts` | `libraryEntryToHubItem` sets `hasKb` from `isKbEntry(entry)` | Modify (Phase 1 enrich) |
+| `apps/web/src/hooks/queries/useHybridHubItems.ts` | Orchestrate 5 sources → map → `HybridHubSources`; expose `{ sources, isLoading, partialErrors, totalCounts }`; cap + auth-gating | Create |
+| `apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx` | Hook unit tests (mocked source hooks) | Create |
+| `apps/web/src/components/features/library/CrossEntityFilters.tsx` | Chip row (STATO/STATS/ORD + "Più filtri"); STATO functional for `games` (Owned/Wishlist/InPrestito + with-KB) | Create |
+| `apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx` | Component tests | Create |
+| `apps/web/src/components/features/library/LibraryTabs.tsx` | Generalize to `<K extends string>` (backward-compatible) | Modify |
+| `apps/web/src/components/features/library/LibraryHybridGrid.tsx` | Accept `HybridHubItem[]` instead of `UserLibraryEntry[]`; render `MeepleCard entity={item.entity}` | Modify (flip) |
+| `apps/web/src/components/features/library/index.ts` | Export `CrossEntityFilters` + its types | Modify |
+| `apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx` | Rewire to hybrid orchestration | Modify (flip) |
+| `apps/web/src/components/features/library/__tests__/LibraryHybridGrid.test.tsx` | Rewrite for `HybridHubItem[]` | Modify (flip) |
+| `apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx` | Rewrite fixtures games-only → hybrid; 6-tab; partial-failure; selection game-scoped | Modify (flip) |
+
+---
+
+## Type reference (already on main-dev, Phase 1 — do NOT redefine)
+
+From `lib/library/hybrid-hub.types.ts`: `HybridHubItem` (union), `GameHubItem`, `AgentHubItem`, `KbHubItem`, `SessionHubItem`, `ChatHubItem`, `HybridHubEntity`.
+From `lib/library/hybrid-hub.mappers.ts`: `libraryEntryToHubItem`, `agentToHubItem`, `kbDocToHubItem`, `sessionToHubItem`, `chatToHubItem`, `KbDoc`.
+From `lib/library/hybrid-hub.derive.ts`: `deriveHybridItems(sources, tab, query, sort)`, `HybridHubTab`, `HybridHubSources`.
+From `lib/library/library-filters.ts`: `LibraryEntityKey` (`'all'|'kb'|'loaned'`), `LibrarySortKey`, `filterByEntity`, `isKbEntry`.
+
+---
+
+### Task 0: Enrich `GameHubItem` with `hasKb` (Phase 1 foundation touch-up)
+
+The STATO with-KB chip (Task 2) needs to filter games that have a knowledge base. `GameHubItem` (Phase 1) doesn't carry that flag. Add `hasKb: boolean`, set from the existing `isKbEntry(entry)` helper. This is a small, non-breaking enrichment of the merged Phase 1 foundation.
+
+**Files:**
+- Modify: `apps/web/src/lib/library/hybrid-hub.types.ts` (add field to `GameHubItem`)
+- Modify: `apps/web/src/lib/library/hybrid-hub.mappers.ts` (set it in `libraryEntryToHubItem`)
+- Modify: `apps/web/src/lib/library/__tests__/hybrid-hub.mappers.test.ts` (assert the field)
+
+- [ ] **Step 1: Update the mapper test (TDD — assert the new field first)**
+
+In `hybrid-hub.mappers.test.ts`, in the `libraryEntryToHubItem` describe block, add a test (and the base fixture already has `hasKb`/`kbCardCount` fields — `isKbEntry` returns `hasKb || kbCardCount > 0`):
+
+```ts
+it('sets hasKb from isKbEntry (true when hasKb or kbCardCount>0)', () => {
+  expect(libraryEntryToHubItem({ ...baseEntry, hasKb: true, kbCardCount: 0 }).hasKb).toBe(true);
+  expect(libraryEntryToHubItem({ ...baseEntry, hasKb: false, kbCardCount: 2 }).hasKb).toBe(true);
+  expect(libraryEntryToHubItem({ ...baseEntry, hasKb: false, kbCardCount: 0 }).hasKb).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run hybrid-hub.mappers`
+Expected: FAIL — `hasKb` is not a property of `GameHubItem` (type error) / undefined at runtime.
+
+- [ ] **Step 3: Add the field + set it**
+
+In `hybrid-hub.types.ts`, add to `GameHubItem` — **optional** so the existing Phase 1 `GameHubItem` literal factories (e.g. `gameItem()` in `hybrid-hub.derive.test.ts`) don't break; the mapper always sets it:
+```ts
+export interface GameHubItem extends HybridHubItemBase {
+  readonly entity: 'game';
+  readonly gameId: string;
+  readonly rating?: number;
+  readonly state?: GameStateType;
+  readonly imageUrl?: string;
+  /** True if the game has ≥1 KB doc (mirrors the retired `kb` tab). Optional in the
+   *  type (so test literals stay valid) but always set by `libraryEntryToHubItem`. */
+  readonly hasKb?: boolean;
+}
+```
+
+In `hybrid-hub.mappers.ts`, add the `isKbEntry` import and set `hasKb`:
+```ts
+import { isKbEntry } from './library-filters';
+// ... inside libraryEntryToHubItem return object:
+    hasKb: isKbEntry(entry),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run hybrid-hub.mappers && pnpm exec tsc --noEmit`
+Expected: PASS — mapper tests green (including the 3 new assertions), typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend && git add apps/web/src/lib/library/hybrid-hub.types.ts apps/web/src/lib/library/hybrid-hub.mappers.ts apps/web/src/lib/library/__tests__/hybrid-hub.mappers.test.ts
+git commit -m "feat(library): #1605 add GameHubItem.hasKb for the STATO with-KB filter (Phase 2a)"
+```
+
+---
+
+### Task 1: `useHybridHubItems` orchestration hook (greenfield)
+
+**Files:**
+- Create: `apps/web/src/hooks/queries/useHybridHubItems.ts`
+- Create: `apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx`
+
+The hook calls the 3 ready source hooks (games/sessions/chat) + stubs agents/kb to `[]`, maps each to `HubItem[]`, caps to 20/source, and reports per-source errors. It returns `HybridHubSources` (the shape `deriveHybridItems` consumes) + loading/error state. It does NOT call `deriveHybridItems` itself — that stays in `LibraryHub` (the hook is the data layer; derivation is the view layer, keeping the hook testable without tab/query/sort).
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useHybridHubItems } from '../useHybridHubItems';
+
+// Mock the 3 source hooks + the 2 stub hooks
+const mockUseLibrary = vi.fn();
+const mockUseActiveSessions = vi.fn();
+const mockUseRecentChatSessions = vi.fn();
+const mockUseAgents = vi.fn();
+
+vi.mock('../useLibrary', () => ({
+  useLibrary: (...args: unknown[]) => mockUseLibrary(...args),
+}));
+vi.mock('../useActiveSessions', () => ({
+  useActiveSessions: (...args: unknown[]) => mockUseActiveSessions(...args),
+}));
+vi.mock('../useChatSessions', () => ({
+  useRecentChatSessions: (...args: unknown[]) => mockUseRecentChatSessions(...args),
+}));
+vi.mock('../useAgents', () => ({
+  useAgents: (...args: unknown[]) => mockUseAgents(...args),
+}));
+
+function ok<T>(data: T) {
+  return { data, isLoading: false, isError: false, error: null };
+}
+function loading() {
+  return { data: undefined, isLoading: true, isError: false, error: null };
+}
+function failed(err: Error) {
+  return { data: undefined, isLoading: false, isError: true, error: err };
+}
+
+const gameEntry = {
+  id: 'g1', userId: 'u', gameId: 'game-1', gameTitle: 'Catan', gamePublisher: 'Kosmos',
+  gameYearPublished: 1995, gameIconUrl: null, gameImageUrl: null, addedAt: '2026-01-01T00:00:00Z',
+  notes: null, isFavorite: false, currentState: 'Owned' as const, stateChangedAt: null, stateNotes: null,
+  hasKb: false, kbCardCount: 0, kbIndexedCount: 0, kbProcessingCount: 0, ownershipDeclaredAt: null,
+  hasRagAccess: false, agentIsOwned: true, minPlayers: 3, maxPlayers: 4, playingTimeMinutes: 60,
+  complexityRating: 2, averageRating: 7, privateGameId: null, isPrivateGame: false, canProposeToCatalog: false,
+};
+const sessionDto = {
+  id: 's1', gameId: 'game-1', status: 'Completed', startedAt: '2026-02-01T00:00:00Z',
+  completedAt: '2026-02-01T01:00:00Z', playerCount: 4, players: [], winnerName: 'Alice',
+  notes: null, durationMinutes: 60,
+};
+const chatDto = {
+  id: 'c1', userId: 'u', gameId: 'game-1', gameTitle: 'Catan', agentId: null, agentType: null,
+  agentName: null, title: 'How to play?', messageCount: 3, lastMessagePreview: null,
+  createdAt: '2026-03-01T00:00:00Z', lastMessageAt: '2026-03-01T00:10:00Z', isArchived: false,
+};
+
+beforeEach(() => {
+  mockUseLibrary.mockReturnValue(ok({ items: [gameEntry], page: 1, pageSize: 50, totalCount: 1, totalPages: 1, hasNextPage: false, hasPreviousPage: false }));
+  mockUseActiveSessions.mockReturnValue(ok({ sessions: [sessionDto], page: 1, pageSize: 20, totalCount: 1 }));
+  mockUseRecentChatSessions.mockReturnValue(ok([chatDto]));
+  mockUseAgents.mockReturnValue(ok([])); // 2a stub
+});
+
+describe('useHybridHubItems', () => {
+  it('maps the 3 ready sources into HybridHubSources (game/session/chat), agents/kb empty', () => {
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games.map(i => i.entity)).toEqual(['game']);
+    expect(result.current.sources.sessions.map(i => i.entity)).toEqual(['session']);
+    expect(result.current.sources.chat.map(i => i.entity)).toEqual(['chat']);
+    expect(result.current.sources.agents).toEqual([]);
+    expect(result.current.sources.kb).toEqual([]);
+  });
+
+  it('unwraps .items / .sessions from paginated responses; chat passes through', () => {
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games[0]?.id).toBe('g1');
+    expect(result.current.sources.sessions[0]?.id).toBe('s1');
+    expect(result.current.sources.chat[0]?.id).toBe('c1');
+  });
+
+  it('caps each source to 20 items', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ ...gameEntry, id: `g${i}`, gameId: `game-${i}` }));
+    mockUseLibrary.mockReturnValue(ok({ items: many, page: 1, pageSize: 50, totalCount: 30, totalPages: 1, hasNextPage: false, hasPreviousPage: false }));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.sources.games).toHaveLength(20);
+  });
+
+  it('reports totalCounts per source (pre-cap)', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ ...gameEntry, id: `g${i}`, gameId: `game-${i}` }));
+    mockUseLibrary.mockReturnValue(ok({ items: many, page: 1, pageSize: 50, totalCount: 30, totalPages: 1, hasNextPage: false, hasPreviousPage: false }));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.totalCounts.games).toBe(30);
+    expect(result.current.totalCounts.sessions).toBe(1);
+    expect(result.current.totalCounts.chat).toBe(1);
+  });
+
+  it('isLoading=true while any ready source is loading', () => {
+    mockUseActiveSessions.mockReturnValue(loading());
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('partialErrors records the failing source; others still map', () => {
+    mockUseActiveSessions.mockReturnValue(failed(new Error('boom')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.partialErrors.sessions).toBeInstanceOf(Error);
+    expect(result.current.partialErrors.games).toBeNull();
+    expect(result.current.sources.games).toHaveLength(1); // games still mapped
+    expect(result.current.sources.sessions).toEqual([]); // failed source → empty
+  });
+
+  it('allFailed=true only when every ready source errors', () => {
+    mockUseLibrary.mockReturnValue(failed(new Error('a')));
+    mockUseActiveSessions.mockReturnValue(failed(new Error('b')));
+    mockUseRecentChatSessions.mockReturnValue(failed(new Error('c')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.allFailed).toBe(true);
+  });
+
+  it('allFailed=false when at least one ready source succeeds', () => {
+    mockUseLibrary.mockReturnValue(failed(new Error('a')));
+    mockUseActiveSessions.mockReturnValue(ok({ sessions: [sessionDto], page: 1, pageSize: 20, totalCount: 1 }));
+    mockUseRecentChatSessions.mockReturnValue(failed(new Error('c')));
+    const { result } = renderHook(() => useHybridHubItems());
+    expect(result.current.allFailed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run useHybridHubItems`
+Expected: FAIL — `Cannot find module '../useHybridHubItems'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/web/src/hooks/queries/useHybridHubItems.ts`:
+
+```ts
+/**
+ * useHybridHubItems — Phase 2a (#1605) orchestration hook for the `/library`
+ * hybrid hub. Calls the 3 ready entity sources (games / sessions / chat),
+ * maps each DTO to a `HybridHubItem` via the Phase 1 mappers, caps each source
+ * to `PER_SOURCE_CAP`, and reports per-source errors so the hub can degrade
+ * gracefully (AC9.1). Agents + KB are stubbed to `[]` until BE-2 #1589 / BE-1
+ * #1588 ship (Phase 2b).
+ *
+ * Returns `HybridHubSources` (the shape `deriveHybridItems` consumes) — the
+ * hook is the data layer; tab/query/sort derivation stays in `LibraryHub`.
+ */
+
+import { useMemo } from 'react';
+
+import {
+  agentToHubItem,
+  chatToHubItem,
+  libraryEntryToHubItem,
+  sessionToHubItem,
+} from '@/lib/library/hybrid-hub.mappers';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+import type { HybridHubSources } from '@/lib/library/hybrid-hub.derive';
+
+import { useActiveSessions } from './useActiveSessions';
+import { useAgents } from './useAgents';
+import { useRecentChatSessions } from './useChatSessions';
+import { useLibrary } from './useLibrary';
+
+export const PER_SOURCE_CAP = 20;
+
+export type HybridHubSourceKey = keyof HybridHubSources; // 'games'|'agents'|'kb'|'sessions'|'chat'
+
+export interface UseHybridHubItemsResult {
+  readonly sources: HybridHubSources;
+  readonly isLoading: boolean;
+  readonly allFailed: boolean;
+  readonly partialErrors: Record<HybridHubSourceKey, Error | null>;
+  readonly totalCounts: Record<HybridHubSourceKey, number>;
+}
+
+export function useHybridHubItems(): UseHybridHubItemsResult {
+  const libraryQuery = useLibrary({ page: 1, pageSize: 50, sortBy: 'addedAt', sortDescending: true });
+  const sessionsQuery = useActiveSessions(PER_SOURCE_CAP);
+  const chatQuery = useRecentChatSessions(50);
+  const agentsQuery = useAgents({}); // 2a: result intentionally ignored (stub [])
+
+  return useMemo(() => {
+    const gameItems = (libraryQuery.data?.items ?? []).map(libraryEntryToHubItem);
+    const sessionItems = (sessionsQuery.data?.sessions ?? []).map(sessionToHubItem);
+    const chatItems = (chatQuery.data ?? []).map(chatToHubItem);
+
+    const cap = (items: readonly HybridHubItem[]) => items.slice(0, PER_SOURCE_CAP);
+
+    const sources: HybridHubSources = {
+      games: libraryQuery.isError ? [] : cap(gameItems),
+      sessions: sessionsQuery.isError ? [] : cap(sessionItems),
+      chat: chatQuery.isError ? [] : cap(chatItems),
+      agents: [], // Phase 2b: useAgents({ scope: 'my-library' }) → agentToHubItem
+      kb: [], // Phase 2b: useUserKbDocs() → kbDocToHubItem
+    };
+
+    const partialErrors: Record<HybridHubSourceKey, Error | null> = {
+      games: libraryQuery.isError ? (libraryQuery.error ?? new Error('library')) : null,
+      sessions: sessionsQuery.isError ? (sessionsQuery.error ?? new Error('sessions')) : null,
+      chat: chatQuery.isError ? (chatQuery.error ?? new Error('chat')) : null,
+      agents: null,
+      kb: null,
+    };
+
+    const totalCounts: Record<HybridHubSourceKey, number> = {
+      games: gameItems.length,
+      sessions: sessionItems.length,
+      chat: chatItems.length,
+      agents: 0,
+      kb: 0,
+    };
+
+    const readyErrors = [libraryQuery.isError, sessionsQuery.isError, chatQuery.isError];
+    const allFailed = readyErrors.every(Boolean);
+    const isLoading =
+      libraryQuery.isLoading || sessionsQuery.isLoading || chatQuery.isLoading;
+
+    // agentsQuery is referenced to keep the hook call (cache warm for 2b) without using its data
+    void agentsQuery;
+
+    return { sources, isLoading, allFailed, partialErrors, totalCounts };
+  }, [
+    libraryQuery.data, libraryQuery.isError, libraryQuery.error, libraryQuery.isLoading,
+    sessionsQuery.data, sessionsQuery.isError, sessionsQuery.error, sessionsQuery.isLoading,
+    chatQuery.data, chatQuery.isError, chatQuery.error, chatQuery.isLoading,
+    agentsQuery,
+  ]);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run useHybridHubItems`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend && git add apps/web/src/hooks/queries/useHybridHubItems.ts apps/web/src/hooks/queries/__tests__/useHybridHubItems.test.tsx
+git commit -m "feat(library): #1605 add useHybridHubItems orchestration hook (Phase 2a)"
+```
+
+---
+
+### Task 2: `CrossEntityFilters` component (greenfield, functional STATO chip)
+
+**Files:**
+- Create: `apps/web/src/components/features/library/CrossEntityFilters.tsx`
+- Create: `apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx`
+- Modify: `apps/web/src/components/features/library/index.ts`
+
+Renders a chip row. The STATO chip is **functional for the `games` tab** (toggles game-state filters Owned/Wishlist/InPrestito + a with-KB toggle); for other tabs it renders nothing (search + sort globals live in the hub toolbar). The component is controlled — parent owns the active filter state.
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+import { CrossEntityFilters, type GameStateFilter } from '../CrossEntityFilters';
+
+const messages: Record<string, string> = {
+  'pages.library.filters.stato.label': 'Stato',
+  'pages.library.filters.stato.owned': 'Posseduti',
+  'pages.library.filters.stato.wishlist': 'Wishlist',
+  'pages.library.filters.stato.loaned': 'In prestito',
+  'pages.library.filters.stato.withKb': 'Con Knowledge Base',
+};
+function renderWithIntl(ui: React.ReactElement) {
+  return render(<IntlProvider locale="it" messages={messages}>{ui}</IntlProvider>);
+}
+const noop = () => {};
+const emptyFilter: GameStateFilter = { states: [], withKb: false };
+
+describe('CrossEntityFilters', () => {
+  it('renders the STATO chip group only for the games tab', () => {
+    const { rerender } = renderWithIntl(
+      <CrossEntityFilters tab="games" gameStateFilter={emptyFilter} onGameStateFilterChange={noop} />
+    );
+    expect(screen.getByTestId('cross-entity-filters-stato')).toBeInTheDocument();
+
+    rerender(
+      <IntlProvider locale="it" messages={messages}>
+        <CrossEntityFilters tab="sessions" gameStateFilter={emptyFilter} onGameStateFilterChange={noop} />
+      </IntlProvider>
+    );
+    expect(screen.queryByTestId('cross-entity-filters-stato')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for the all tab (search+sort are global in toolbar)', () => {
+    const { container } = renderWithIntl(
+      <CrossEntityFilters tab="all" gameStateFilter={emptyFilter} onGameStateFilterChange={noop} />
+    );
+    expect(container.querySelector('[data-testid="cross-entity-filters-stato"]')).toBeNull();
+  });
+
+  it('toggling a state chip emits the updated filter', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <CrossEntityFilters tab="games" gameStateFilter={emptyFilter} onGameStateFilterChange={onChange} />
+    );
+    await user.click(screen.getByRole('button', { name: /posseduti/i }));
+    expect(onChange).toHaveBeenCalledWith({ states: ['Owned'], withKb: false });
+  });
+
+  it('active state chip reflects the filter (aria-pressed)', () => {
+    renderWithIntl(
+      <CrossEntityFilters tab="games" gameStateFilter={{ states: ['Wishlist'], withKb: false }} onGameStateFilterChange={noop} />
+    );
+    expect(screen.getByRole('button', { name: /wishlist/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /posseduti/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('with-KB toggle emits withKb=true', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithIntl(
+      <CrossEntityFilters tab="games" gameStateFilter={emptyFilter} onGameStateFilterChange={onChange} />
+    );
+    await user.click(screen.getByRole('button', { name: /con knowledge base/i }));
+    expect(onChange).toHaveBeenCalledWith({ states: [], withKb: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run CrossEntityFilters`
+Expected: FAIL — `Cannot find module '../CrossEntityFilters'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`apps/web/src/components/features/library/CrossEntityFilters.tsx`:
+
+```tsx
+/**
+ * CrossEntityFilters — Phase 2a (#1605). Chip row above the hub grid.
+ *
+ * In the `games` tab the STATO chip group is FUNCTIONAL: it carries the
+ * game-state filters that the retired `loaned`/`kb` tabs used to provide
+ * (Owned / Wishlist / InPrestito + a with-KB toggle), so no access regresses
+ * when the 3 game-state tabs collapse into one `games` tab. For all other tabs
+ * the component renders nothing — search + sort live as globals in the hub
+ * toolbar.
+ *
+ * Controlled component: the parent (`LibraryHub`) owns `gameStateFilter`.
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import clsx from 'clsx';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GameStateType } from '@/lib/api/schemas/library.schemas';
+import type { HybridHubTab } from '@/lib/library/hybrid-hub.derive';
+
+export interface GameStateFilter {
+  readonly states: ReadonlyArray<GameStateType>;
+  readonly withKb: boolean;
+}
+
+export interface CrossEntityFiltersProps {
+  readonly tab: HybridHubTab;
+  readonly gameStateFilter: GameStateFilter;
+  readonly onGameStateFilterChange: (next: GameStateFilter) => void;
+  readonly className?: string;
+}
+
+const STATE_CHIPS: ReadonlyArray<{ value: GameStateType; i18nKey: string }> = [
+  { value: 'Owned', i18nKey: 'pages.library.filters.stato.owned' },
+  { value: 'Wishlist', i18nKey: 'pages.library.filters.stato.wishlist' },
+  { value: 'InPrestito', i18nKey: 'pages.library.filters.stato.loaned' },
+];
+
+export function CrossEntityFilters({
+  tab,
+  gameStateFilter,
+  onGameStateFilterChange,
+  className,
+}: CrossEntityFiltersProps): ReactElement | null {
+  const { t } = useTranslation();
+
+  if (tab !== 'games') return null;
+
+  const toggleState = (value: GameStateType) => {
+    const has = gameStateFilter.states.includes(value);
+    const states = has
+      ? gameStateFilter.states.filter(s => s !== value)
+      : [...gameStateFilter.states, value];
+    onGameStateFilterChange({ ...gameStateFilter, states });
+  };
+
+  return (
+    <div
+      data-slot="cross-entity-filters"
+      data-testid="cross-entity-filters-stato"
+      className={clsx('flex flex-wrap items-center gap-2', className)}
+    >
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {t('pages.library.filters.stato.label')}
+      </span>
+      {STATE_CHIPS.map(chip => {
+        const active = gameStateFilter.states.includes(chip.value);
+        return (
+          <button
+            key={chip.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => toggleState(chip.value)}
+            className={clsx(
+              'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
+              active
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-border bg-background text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t(chip.i18nKey)}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        aria-pressed={gameStateFilter.withKb}
+        onClick={() => onGameStateFilterChange({ ...gameStateFilter, withKb: !gameStateFilter.withKb })}
+        className={clsx(
+          'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
+          gameStateFilter.withKb
+            ? 'border-primary bg-primary/10 text-foreground'
+            : 'border-border bg-background text-muted-foreground hover:text-foreground'
+        )}
+      >
+        {t('pages.library.filters.stato.withKb')}
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3.5: Add i18n keys to both catalogs**
+
+In `apps/web/src/locales/it.json` under `pages.library.filters`, add:
+```jsonc
+"stato": {
+  "label": "Stato",
+  "owned": "Posseduti",
+  "wishlist": "Wishlist",
+  "loaned": "In prestito",
+  "withKb": "Con Knowledge Base"
+}
+```
+In `apps/web/src/locales/en.json` under `pages.library.filters`, add:
+```jsonc
+"stato": {
+  "label": "State",
+  "owned": "Owned",
+  "wishlist": "Wishlist",
+  "loaned": "Loaned",
+  "withKb": "With Knowledge Base"
+}
+```
+(Verify the `pages.library.filters` object already exists in both — it does, per the existing `pages.library.filters.search.*` keys used by the current toolbar. Insert `stato` as a sibling without disturbing existing keys.)
+
+- [ ] **Step 4: Add barrel export**
+
+In `apps/web/src/components/features/library/index.ts`, add:
+```ts
+export { CrossEntityFilters } from '@/components/features/library/CrossEntityFilters';
+export type {
+  CrossEntityFiltersProps,
+  GameStateFilter,
+} from '@/components/features/library/CrossEntityFilters';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run CrossEntityFilters`
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend && git add apps/web/src/components/features/library/CrossEntityFilters.tsx apps/web/src/components/features/library/__tests__/CrossEntityFilters.test.tsx apps/web/src/components/features/library/index.ts apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(library): #1605 add CrossEntityFilters STATO chip (Phase 2a)"
+```
+
+---
+
+### Task 3: Generalize `LibraryTabs` to a generic key type (backward-compatible)
+
+**Files:**
+- Modify: `apps/web/src/components/features/library/LibraryTabs.tsx`
+- Modify (if needed): `apps/web/src/components/features/library/__tests__/LibraryTabs.test.tsx`
+
+Today `LibraryTabs` is typed on `LibraryEntityKey` (3 keys). Generalize it to `<K extends string>` so `LibraryHub` can pass `HybridHubTab` (6 keys) in the flip — without breaking the existing `LibraryTabs.test.tsx` (which uses `LibraryEntityKey`, still a valid `K`).
+
+- [ ] **Step 1: Confirm existing tests pass (baseline)**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec vitest run LibraryTabs`
+Expected: PASS (baseline before change).
+
+- [ ] **Step 2: Generalize the component**
+
+In `LibraryTabs.tsx`, change the config + props + component to be generic on the key. Replace the `LibraryTabConfig` interface and `LibraryTabsProps` + the function signature:
+
+```tsx
+export interface LibraryTabConfig<K extends string = LibraryEntityKey> {
+  readonly key: K;
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface LibraryTabsProps<K extends string = LibraryEntityKey> {
+  readonly tabs: ReadonlyArray<LibraryTabConfig<K>>;
+  readonly active: K;
+  readonly onChange: (next: K) => void;
+  readonly className?: string;
+}
+
+export function LibraryTabs<K extends string = LibraryEntityKey>({
+  tabs,
+  active,
+  onChange,
+  className,
+}: LibraryTabsProps<K>): ReactElement {
+  const orderedKeys = useMemo<readonly K[]>(() => tabs.map(t => t.key), [tabs]);
+  const { tabRefs, handleKeyDown } = useTablistKeyboardNav<K>({ orderedKeys, onChange });
+  // ... rest of the body unchanged (it already operates on `K` via orderedKeys/active)
+}
+```
+
+Keep the `import type { LibraryEntityKey } from '@/lib/library/library-filters'` (used as the default type param) and the existing `export type { LibraryEntityKey }` re-export (Phase 1 SSOT consolidation — do not remove). The body of the component (the `tabs.map`, underline math, `useTablistKeyboardNav`) already works on generic keys — only the type annotations change.
+
+Verify `useTablistKeyboardNav` is itself generic (`useTablistKeyboardNav<K>`) — it is (Phase 1 used `useTablistKeyboardNav<LibraryEntityKey>`). If its signature is not generic, leave it as-is and cast at the call site; do NOT modify that hook in this task.
+
+- [ ] **Step 3: Run typecheck + tests**
+
+Run: `cd /d/Repositories/meepleai-monorepo-frontend/apps/web && pnpm exec tsc --noEmit && pnpm exec vitest run LibraryTabs`
+Expected: PASS — typecheck clean (the existing `LibraryHub` still passes `LibraryEntityKey`, a valid `K`), `LibraryTabs.test.tsx` green unchanged.
+
+If `tsc` flags the `LibraryHub` call site (it should not — `LibraryEntityKey` satisfies `K extends string`), STOP and report; do not modify `LibraryHub` in this task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend && git add apps/web/src/components/features/library/LibraryTabs.tsx
+git commit -m "refactor(library): #1605 generalize LibraryTabs to generic key type (Phase 2a)"
+```
+
+---
+
+### Task 4: Atomic flip — grid + LibraryHub wire + test rewrite
+
+**Files:**
+- Modify: `apps/web/src/components/features/library/LibraryHybridGrid.tsx` (accept `HybridHubItem[]`)
+- Modify: `apps/web/src/components/features/library/__tests__/LibraryHybridGrid.test.tsx` (rewrite for hybrid items)
+- Modify: `apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx` (rewire to hybrid)
+- Modify: `apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx` (rewrite fixtures + 6-tab + partial-failure + selection game-scoped)
+
+> **⚠️ This is the atomic flip — one commit.** The pre-commit `tsc --noEmit` gate rejects an intermediate where the grid prop type and `LibraryHub` disagree, so the grid change + the hub rewire + the two test rewrites land together. This is the critical, highest-risk task. Implement carefully; run the FULL library test suite before committing.
+
+#### 4a. `LibraryHybridGrid` → `HybridHubItem[]`
+
+Replace the props + render so the grid renders any `HybridHubItem` via `MeepleCard entity={item.entity}`. The selection contract (browse/select, `aria-pressed`, check overlay) is preserved.
+
+New `LibraryHybridGrid.tsx` (replace lines 40-138, keeping the file header + the `clsx`/`MeepleCard` imports):
+
+```tsx
+import type { MeepleCardVariant } from '@/components/ui/data-display/meeple-card';
+import { MeepleCard } from '@/components/ui/data-display/meeple-card';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+
+export type LibraryViewMode = 'grid' | 'list' | 'compact';
+export type LibrarySelectionMode = 'browse' | 'select';
+
+export interface LibraryHybridGridProps {
+  readonly items: ReadonlyArray<HybridHubItem>;
+  readonly view: LibraryViewMode;
+  readonly selectionMode: LibrarySelectionMode;
+  readonly selected: ReadonlySet<string>;
+  readonly onCardClick: (itemId: string) => void;
+  readonly onLongPressEnter?: (itemId: string) => void;
+  readonly className?: string;
+}
+
+const VIEW_TO_VARIANT: Record<LibraryViewMode, MeepleCardVariant> = {
+  grid: 'grid', list: 'list', compact: 'compact',
+};
+const VIEW_TO_LAYOUT: Record<LibraryViewMode, string> = {
+  grid: 'grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4',
+  list: 'flex flex-col gap-2',
+  compact: 'grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6',
+};
+
+function itemImageUrl(item: HybridHubItem): string | undefined {
+  return item.entity === 'game' ? item.imageUrl : undefined;
+}
+function itemRating(item: HybridHubItem): number | undefined {
+  return item.entity === 'game' ? item.rating : undefined;
+}
+
+export function LibraryHybridGrid({
+  items, view, selectionMode, selected, onCardClick, className,
+}: LibraryHybridGridProps): ReactElement {
+  const variant = VIEW_TO_VARIANT[view];
+  const layoutClass = VIEW_TO_LAYOUT[view];
+  const isSelectMode = selectionMode === 'select';
+  return (
+    <div data-slot="library-hybrid-grid" data-view={view} data-selection-mode={selectionMode}
+      className={clsx(layoutClass, className)}>
+      {items.map(item => {
+        const isSelected = selected.has(item.id);
+        return (
+          <button key={item.id} type="button" data-slot="library-grid-card"
+            data-selection-mode={selectionMode} data-entry-id={item.id}
+            aria-pressed={isSelectMode ? isSelected : undefined}
+            onClick={() => onCardClick(item.id)}
+            className={clsx('relative block w-full text-left',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-2xl',
+              isSelectMode && isSelected && 'ring-2 ring-primary')}>
+            <MeepleCard entity={item.entity} variant={variant} title={item.title}
+              subtitle={item.subtitle} imageUrl={itemImageUrl(item)}
+              rating={itemRating(item)} ratingMax={10} />
+            {isSelectMode && isSelected ? (
+              <span data-testid="library-grid-card-check" aria-hidden="true"
+                className="pointer-events-none absolute right-3 top-3 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path fillRule="evenodd" d="M16.704 5.29a1 1 0 010 1.42l-7.5 7.5a1 1 0 01-1.42 0l-3.5-3.5a1 1 0 011.42-1.42L8.5 12.08l6.79-6.79a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+(Remove the `UserLibraryEntry` import + the `entry.gameImageUrl ?? entry.gameIconUrl` logic + `onLongPressEnter` from the destructure if unused — keep it in the prop type as optional for the orchestrator's long-press, referenced via `void onLongPressEnter` is NOT needed since it's just an unused optional prop; ESLint allows unused destructured-omitted props.)
+
+#### 4b. `LibraryHybridGrid.test.tsx` rewrite
+
+Rewrite the grid test to use `HybridHubItem[]` fixtures (mix of game/session/chat) and assert `MeepleCard` renders per `entity`, the selection overlay works, and `onCardClick(item.id)` fires. Keep the existing test count/structure; swap `UserLibraryEntry` fixtures for:
+
+```tsx
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+
+const items: HybridHubItem[] = [
+  { id: 'g1', entity: 'game', title: 'Catan', subtitle: 'Kosmos', updatedAt: '2026-01-01T00:00:00Z', href: '/library/game-1', gameId: 'game-1', rating: 7, state: 'Owned', imageUrl: 'https://x/c.jpg' },
+  { id: 's1', entity: 'session', title: 'Session s1', subtitle: 'Alice', updatedAt: '2026-02-01T00:00:00Z', href: '/sessions/s1', status: 'Completed', playerCount: 4 },
+  { id: 'c1', entity: 'chat', title: 'How to play?', subtitle: 'Catan', updatedAt: '2026-03-01T00:00:00Z', href: '/chats/c1', messageCount: 3 },
+];
+```
+Assert: 3 cards render; in select mode each card has `aria-pressed`; clicking calls `onCardClick` with the item id; a non-game item (session/chat) renders without a rating/image (no crash).
+
+#### 4c. `LibraryHub.tsx` rewire
+
+Replace the data layer + render. The full new `LibraryHub.tsx`:
+
+```tsx
+/**
+ * LibraryHub — Phase 2a (#1605): hybrid multi-entity hub orchestrator.
+ *
+ * Migrated from the Wave B.3 games-only view. Tab state is `HybridHubTab`
+ * (6 tabs); the 3 ready sources (games/sessions/chat) are orchestrated by
+ * `useHybridHubItems` and merged/filtered/sorted by `deriveHybridItems`.
+ * Agents + KB are stubbed `[]` until BE-2 #1589 / BE-1 #1588 (Phase 2b).
+ *
+ * Game-state filters (ex-`loaned`/`kb` tabs) live in the `CrossEntityFilters`
+ * STATO chip, applied to the games source before merge. Selection mode is
+ * game-scoped: forced to `browse` outside the `games` tab. FSM degrades on
+ * partial failure: `error` only when all ready sources fail.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import {
+  BulkSelectionBar, CrossEntityFilters, EmptyLibrary, LibraryHeroDesktop,
+  LibraryHybridGrid, LibraryTabs, RecentActivityRail,
+  type ActivityItem, type ActivityKind, type BulkSelectionBarLabels,
+  type EmptyLibraryLabels, type GameStateFilter, type LibraryHeroDesktopLabels,
+  type LibraryHeroStat, type LibrarySelectionMode, type LibraryTabConfig,
+  type LibraryViewMode,
+} from '@/components/features/library';
+import { useHybridHubItems } from '@/hooks/queries/useHybridHubItems';
+import { useLibraryActivity, useRemoveGameFromLibrary } from '@/hooks/queries/useLibrary';
+import { useMiniNavConfig } from '@/hooks/useMiniNavConfig';
+import { useTranslation } from '@/hooks/useTranslation';
+import { deriveHybridItems, type HybridHubTab, type HybridHubSources } from '@/lib/library/hybrid-hub.derive';
+import type { HybridHubItem } from '@/lib/library/hybrid-hub.types';
+import { isKbEntry, type LibrarySortKey } from '@/lib/library/library-filters';
+import { useLibraryView } from '@/lib/library/use-library-view';
+import { IS_VISUAL_TEST_BUILD } from '@/lib/library/visual-test-fixture';
+
+const VALID_OVERRIDES = ['loading', 'empty', 'filtered-empty', 'error'] as const;
+type StateOverride = (typeof VALID_OVERRIDES)[number];
+const STATE_OVERRIDE_ENABLED = process.env.NODE_ENV !== 'production' || IS_VISUAL_TEST_BUILD;
+function parseStateOverride(raw: string | null): StateOverride | null {
+  if (!STATE_OVERRIDE_ENABLED || raw == null) return null;
+  return (VALID_OVERRIDES as readonly string[]).includes(raw) ? (raw as StateOverride) : null;
+}
+type SurfaceKind = 'default' | 'loading' | 'empty' | 'filtered-empty' | 'error';
+
+const HUB_TABS: readonly HybridHubTab[] = ['all', 'games', 'agents', 'kb', 'sessions', 'chat'];
+
+export function LibraryHub(): ReactElement {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [tab, setTab] = useState<HybridHubTab>('all');
+  const [selectionMode, setSelectionMode] = useState<LibrarySelectionMode>('browse');
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+  const [query, setQuery] = useState('');
+  const [sortKey, setSortKey] = useState<LibrarySortKey>('recent');
+  const [gameStateFilter, setGameStateFilter] = useState<GameStateFilter>({ states: [], withKb: false });
+  const { view, setView } = useLibraryView('grid');
+
+  const stateOverride = parseStateOverride(searchParams.get('state'));
+
+  const hub = useHybridHubItems();
+  const removeMutation = useRemoveGameFromLibrary();
+  const activityQuery = useLibraryActivity(20);
+
+  // Selection mode is game-scoped — force browse when leaving the games tab.
+  useEffect(() => {
+    if (tab !== 'games' && selectionMode === 'select') {
+      setSelectionMode('browse');
+      setSelected(new Set());
+    }
+  }, [tab, selectionMode]);
+
+  // Apply game-state filters (ex-loaned/kb tabs) to the games source before merge.
+  const filteredSources = useMemo<HybridHubSources>(() => {
+    const { states, withKb } = gameStateFilter;
+    if (states.length === 0 && !withKb) return hub.sources;
+    const games = hub.sources.games.filter(item => {
+      if (item.entity !== 'game') return true;
+      const stateOk = states.length === 0 || (item.state != null && states.includes(item.state));
+      const kbOk = !withKb || item.hasKb === true; // Task 0 added hasKb to GameHubItem (optional)
+      return stateOk && kbOk;
+    });
+    return { ...hub.sources, games };
+  }, [hub.sources, gameStateFilter]);
+
+  const merged = useMemo<HybridHubItem[]>(
+    () => deriveHybridItems(filteredSources, tab, query, sortKey),
+    [filteredSources, tab, query, sortKey]
+  );
+
+  // Hero stats: hybrid counts (games/agents/docs/chats) from pre-filter totals.
+  const heroStats = useMemo(
+    () => ({
+      games: hub.totalCounts.games,
+      agents: hub.totalCounts.agents,
+      docs: hub.totalCounts.kb,
+      chats: hub.totalCounts.chat,
+    }),
+    [hub.totalCounts]
+  );
+
+  const activityItems = useMemo<readonly ActivityItem[]>(() => {
+    const raw = activityQuery.data ?? [];
+    const mapped: ActivityItem[] = [];
+    for (const event of raw) {
+      let kind: ActivityKind | null;
+      switch (event.type) {
+        case 'added': kind = 'add'; break;
+        case 'state-changed': kind = 'rating-changed'; break;
+        case 'session-recorded': kind = 'play'; break;
+        case 'removed': kind = 'removed'; break;
+        default: kind = null; break;
+      }
+      if (!kind) continue;
+      mapped.push({ id: `${event.id}:${event.type}`, kind, entityTitle: event.gameTitle, timestamp: event.timestamp });
+    }
+    return mapped;
+  }, [activityQuery.data]);
+
+  // ─── Labels ───
+  const heroLabels = useMemo<LibraryHeroDesktopLabels>(() => ({
+    title: t('pages.library.hero.title'),
+    subtitle: t('pages.library.hero.subtitle'),
+    ctaAdd: t('pages.library.hero.cta.add'),
+  }), [t]);
+
+  const heroStatRows = useMemo<readonly LibraryHeroStat[]>(() => [
+    { key: 'totalGames', label: t('pages.library.hero.stats.totalGames'), value: heroStats.games },
+    { key: 'kbReady', label: t('pages.library.hero.stats.agents'), value: heroStats.agents },
+    { key: 'wishlist', label: t('pages.library.hero.stats.docs'), value: heroStats.docs },
+    { key: 'loaned', label: t('pages.library.hero.stats.chats'), value: heroStats.chats },
+  ], [t, heroStats]);
+
+  const tabsConfig = useMemo<readonly LibraryTabConfig<HybridHubTab>[]>(() => {
+    const countFor = (tk: HybridHubTab): number => {
+      if (tk === 'all') return Object.values(hub.totalCounts).reduce((a, b) => a + b, 0);
+      if (tk === 'games') return hub.totalCounts.games;
+      if (tk === 'agents') return hub.totalCounts.agents;
+      if (tk === 'kb') return hub.totalCounts.kb;
+      if (tk === 'sessions') return hub.totalCounts.sessions;
+      return hub.totalCounts.chat;
+    };
+    return HUB_TABS.map(tk => ({ key: tk, label: t(`pages.library.hubTabs.${tk}`), count: countFor(tk) }));
+  }, [t, hub.totalCounts]);
+
+  const emptyLabels = useMemo<EmptyLibraryLabels>(() => ({
+    empty: { title: t('pages.library.emptyState.default.title'), subtitle: t('pages.library.emptyState.default.subtitle'), cta: t('pages.library.emptyState.default.cta') },
+    filteredEmpty: { title: t('pages.library.emptyState.filteredEmpty.title'), subtitle: t('pages.library.emptyState.filteredEmpty.subtitle'), cta: t('pages.library.emptyState.filteredEmpty.cta') },
+    error: { title: t('pages.library.emptyState.error.title'), subtitle: t('pages.library.emptyState.error.subtitle'), cta: t('pages.library.emptyState.error.cta') },
+  }), [t]);
+
+  const bulkLabels = useMemo<BulkSelectionBarLabels>(() => {
+    const count = selected.size;
+    return {
+      regionLabel: t('pages.library.selectionMode.selectedCount', { count }),
+      counter: t('pages.library.selectionMode.selectedCount', { count }),
+      cancel: t('pages.library.selectionMode.exit'),
+      archive: t('pages.library.bulk.actions.delete'),
+      confirmTitle: t('pages.library.bulk.confirm.deleteTitle', { count }),
+      confirmDescription: t('pages.library.bulk.confirm.deleteMessage'),
+      confirmCta: t('pages.library.bulk.confirm.confirmCta'),
+      cancelCta: t('pages.library.bulk.confirm.cancelCta'),
+    };
+  }, [t, selected]);
+
+  // ─── FSM (partial-failure aware) ───
+  const realKind = useMemo<SurfaceKind>(() => {
+    if (hub.allFailed) return 'error';
+    if (hub.isLoading) return 'loading';
+    const totalAll = Object.values(hub.totalCounts).reduce((a, b) => a + b, 0);
+    if (totalAll === 0) return 'empty';
+    if (merged.length === 0) return 'filtered-empty';
+    return 'default';
+  }, [hub.allFailed, hub.isLoading, hub.totalCounts, merged.length]);
+
+  const effectiveKind: SurfaceKind = stateOverride ?? realKind;
+
+  // ─── Callbacks ───
+  const handleAddGame = useCallback(() => router.push('/library?action=add'), [router]);
+
+  const handleCardClick = useCallback((itemId: string) => {
+    if (selectionMode === 'select') {
+      setSelected(prev => { const n = new Set(prev); n.has(itemId) ? n.delete(itemId) : n.add(itemId); return n; });
+      return;
+    }
+    const item = merged.find(i => i.id === itemId);
+    if (item) router.push(item.href);
+  }, [router, selectionMode, merged]);
+
+  const handleEnterSelectMode = useCallback((itemId?: string) => {
+    if (tab !== 'games') return; // game-scoped guard
+    setSelectionMode('select');
+    if (itemId) setSelected(prev => { const n = new Set(prev); n.add(itemId); return n; });
+  }, [tab]);
+
+  const handleExitSelectMode = useCallback(() => { setSelectionMode('browse'); setSelected(new Set()); }, []);
+
+  const handleBulkDelete = useCallback(async () => {
+    const ids = Array.from(selected);
+    if (ids.length === 0) return;
+    // ids are HybridHubItem ids in the games tab; the games source id IS the library entry id.
+    await Promise.allSettled(ids.map(id => removeMutation.mutateAsync(id)));
+    setSelected(new Set());
+    setSelectionMode('browse');
+  }, [selected, removeMutation]);
+
+  const handleRetry = useCallback(() => { /* per-source refetch handled by TanStack; no-op surfaces retry CTA */ }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setQuery('');
+    setTab('all');
+    setGameStateFilter({ states: [], withKb: false });
+    if (stateOverride != null) router.push(pathname);
+  }, [stateOverride, router, pathname]);
+
+  // ─── MiniNav ───
+  const miniNavConfig = useMemo(() => ({
+    breadcrumb: 'Libreria · Hub',
+    tabs: [
+      { id: 'hub', label: 'Hub', href: '/library' },
+      { id: 'wishlist', label: 'Wishlist', href: '/library/wishlist', count: 0 },
+    ],
+    activeTabId: 'hub',
+    primaryAction: { label: t('pages.library.hero.cta.add'), icon: '＋', onClick: handleAddGame },
+  }), [t, handleAddGame]);
+  useMiniNavConfig(miniNavConfig);
+
+  // ─── Render ───
+  return (
+    <div data-slot="library-hub-v2" data-state={effectiveKind} className="mx-auto flex max-w-[1440px] flex-col gap-6 p-6 pb-24 sm:p-7">
+      <LibraryHeroDesktop labels={heroLabels} stats={heroStatRows} onAddGame={handleAddGame} />
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        <div className="flex flex-1 flex-col gap-4">
+          <LibraryTabs<HybridHubTab> tabs={tabsConfig} active={tab} onChange={setTab} />
+          <CrossEntityFilters tab={tab} gameStateFilter={gameStateFilter} onGameStateFilterChange={setGameStateFilter} />
+          <div data-slot="library-toolbar" className="flex flex-wrap items-center gap-3 rounded-2xl border border-border bg-card p-3 shadow-sm">
+            <input type="search" value={query} onChange={e => setQuery(e.target.value)}
+              placeholder={t('pages.library.filters.search.placeholder')} aria-label={t('pages.library.filters.search.ariaLabel')}
+              data-slot="library-search-input" className="min-w-[12rem] flex-1 rounded-full border border-input bg-background px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="sr-only sm:not-sr-only">{t('pages.library.sort.label')}</span>
+              <select value={sortKey} onChange={e => setSortKey(e.target.value as LibrarySortKey)}
+                aria-label={t('pages.library.sort.ariaLabel')} data-slot="library-sort-select"
+                className="rounded-full border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                <option value="recent">{t('pages.library.sort.recent')}</option>
+                <option value="title">{t('pages.library.sort.title')}</option>
+                <option value="rating">{t('pages.library.sort.rating')}</option>
+                <option value="state">{t('pages.library.sort.state')}</option>
+              </select>
+            </label>
+            <div role="group" aria-label={t('pages.library.view.ariaLabel')} data-slot="library-view-toggle"
+              className="inline-flex items-center gap-1 rounded-full border border-input bg-background p-1">
+              {(['grid', 'list', 'compact'] as const).map(mode => (
+                <button key={mode} type="button" onClick={() => setView(mode)} aria-pressed={view === mode} data-view-mode={mode}
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${view === mode ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}>
+                  {t(`pages.library.view.${mode}` as const)}
+                </button>
+              ))}
+            </div>
+            {tab === 'games' && selectionMode === 'browse' ? (
+              <button type="button" onClick={() => handleEnterSelectMode()} aria-label={t('pages.library.selectionMode.enterAriaLabel')}
+                data-slot="library-enter-select-mode" className="ml-auto rounded-full border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                {t('pages.library.selectionMode.enter')}
+              </button>
+            ) : null}
+          </div>
+          {effectiveKind === 'default' ? (
+            <LibraryHybridGrid items={merged} view={view as LibraryViewMode} selectionMode={selectionMode}
+              selected={selected} onCardClick={handleCardClick} onLongPressEnter={handleEnterSelectMode} />
+          ) : (
+            <EmptyLibrary kind={effectiveKind} labels={emptyLabels} onAddGame={handleAddGame} onClearFilters={handleClearFilters} onRetry={handleRetry} />
+          )}
+        </div>
+        <RecentActivityRail items={activityItems} />
+      </div>
+      {tab === 'games' && selectionMode === 'select' ? (
+        <BulkSelectionBar selectedCount={selected.size} labels={bulkLabels} onExitSelectMode={handleExitSelectMode}
+          onArchive={handleBulkDelete} disabled={selected.size === 0 || removeMutation.isPending} />
+      ) : null}
+    </div>
+  );
+}
+```
+
+Note: `isKbEntry` import is retained for a possible future use in the games with-KB filter; if ESLint flags it unused in 2a (the with-KB filter is stubbed per the comment), **remove the import** rather than suppressing — YAGNI. The implementer decides based on the lint result.
+
+#### 4d. i18n keys for the new hub tab labels + hero stats
+
+Add to `it.json` + `en.json` under `pages.library`:
+- `hubTabs.all` / `.games` / `.agents` / `.kb` / `.sessions` / `.chat` (it: "Tutti"/"Giochi"/"Agenti"/"KB"/"Sessioni"/"Chat"; en: "All"/"Games"/"Agents"/"KB"/"Sessions"/"Chat")
+- `hero.stats.agents` / `.docs` / `.chats` (it: "Agenti"/"Documenti"/"Chat"; en: "Agents"/"Documents"/"Chats") — reuses existing `hero.stats.totalGames` for the first chip key
+
+(The hero stat `key` values stay `totalGames|kbReady|wishlist|loaned` because `LibraryHeroStatKey` is typed to those literals; only the **labels** + **values** change to agents/docs/chats. Do NOT change `LibraryHeroStatKey` in 2a — that's cosmetic-key churn; the visible label comes from `label`, not `key`.)
+
+#### 4e. `LibraryHub.test.tsx` rewrite
+
+Rewrite the test suite. **Preserve** these behaviors (adapt fixtures to hybrid + `useHybridHubItems` mock): FSM 5-state, `?state=` overrides, card-click navigate (now `item.href`), select-mode toggle (now only in games tab), bulk delete fan-out, hero CTA, clearFilters, mini-nav. **Remove** the `loaned`-related assertions. **Add**: 6-tab render, partial-failure (1 source errors → grid still renders + no error surface), selection-mode forced browse outside games.
+
+Mock `useHybridHubItems` instead of `useLibrary`:
+```tsx
+vi.mock('@/hooks/queries/useHybridHubItems', () => ({
+  useHybridHubItems: () => mockHub(),
+  PER_SOURCE_CAP: 20,
+}));
+```
+where `mockHub` returns `{ sources, isLoading, allFailed, partialErrors, totalCounts }`. Provide a `makeHub(overrides)` factory. Keep `useLibraryActivity` + `useRemoveGameFromLibrary` mocks as today.
+
+Key new tests:
+```tsx
+it('renders 6 hub tabs (all/games/agents/kb/sessions/chat)', () => {
+  renderHub(makeHub({ /* games:2, sessions:1, chat:1 */ }));
+  const tabs = screen.getAllByRole('tab');
+  expect(tabs.map(t => t.getAttribute('data-tab-key'))).toEqual(['all','games','agents','kb','sessions','chat']);
+});
+
+it('partial failure: sessions source errors but games+chat still render (no error surface)', () => {
+  renderHub(makeHub({ partialErrors: { sessions: new Error('x'), games: null, chat: null, agents: null, kb: null }, allFailed: false }));
+  expect(screen.getByTestId('library-hub-v2')).toHaveAttribute('data-state', 'default');
+});
+
+it('all sources fail → error surface', () => {
+  renderHub(makeHub({ allFailed: true }));
+  expect(screen.getByTestId('library-hub-v2')).toHaveAttribute('data-state', 'error');
+});
+
+it('select mode is forced to browse when switching away from games tab', async () => {
+  const user = userEvent.setup();
+  renderHub(makeHub({ /* games present */ }));
+  // enter games tab, enter select mode, switch to sessions → BulkSelectionBar gone
+  await user.click(screen.getByRole('tab', { name: /giochi/i }));
+  await user.click(screen.getByTestId('library-enter-select-mode'));
+  await user.click(screen.getByRole('tab', { name: /sessioni/i }));
+  expect(screen.queryByTestId('library-bulk-selection-bar')).not.toBeInTheDocument();
+});
+```
+
+#### Step-by-step for Task 4
+
+- [ ] **Step 1: Rewrite `LibraryHybridGrid.tsx` (4a) + its test (4b)**
+- [ ] **Step 2: Add i18n keys (4d) to it.json + en.json**
+- [ ] **Step 3: Rewrite `LibraryHub.tsx` (4c)**
+- [ ] **Step 4: Rewrite `LibraryHub.test.tsx` (4e)**
+- [ ] **Step 5: Run the FULL library suite + typecheck + lint**
+
+Run:
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/web
+pnpm exec tsc --noEmit
+pnpm exec vitest run LibraryHub LibraryHybridGrid LibraryTabs CrossEntityFilters useHybridHubItems library-filters
+pnpm exec eslint src/app/(authenticated)/library src/components/features/library src/hooks/queries/useHybridHubItems.ts
+```
+Expected: typecheck clean; all suites green (library-filters unchanged = its 28 tests still pass); eslint clean.
+
+- [ ] **Step 6: Commit (the atomic flip)**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend && git add apps/web/src/components/features/library/LibraryHybridGrid.tsx apps/web/src/components/features/library/__tests__/LibraryHybridGrid.test.tsx apps/web/src/app/\(authenticated\)/library/_components/LibraryHub.tsx apps/web/src/app/\(authenticated\)/library/_components/__tests__/LibraryHub.test.tsx apps/web/src/locales/it.json apps/web/src/locales/en.json
+git commit -m "feat(library): #1605 flip LibraryHub to hybrid hub orchestration (Phase 2a)"
+```
+
+---
+
+## Acceptance check for Phase 2a
+
+After Task 4, verify against #1605 inline AC:
+- **AC3** — Hero shows badge + subtitle + 4 stat chips (games/agents/docs/chats) + Add CTA → ✅ Task 4 (agents/docs at 0 in 2a)
+- **AC4** — `CrossEntityFilters` STATO chip functional in games tab → ✅ Task 2 + wired Task 4
+- **AC6** — 5-state FSM preserved → ✅ Task 4 (partial-failure-aware)
+- **AC9** — bulk-selection only in games tab → ✅ Task 4 (useEffect guard + conditional mount)
+- **AC9.1** — partial-failure: 1 source fails, others render → ✅ Task 1 (hook) + Task 4 (FSM)
+
+Final full check:
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/web
+pnpm exec tsc --noEmit
+pnpm exec vitest run library
+pnpm exec eslint src/app/(authenticated)/library src/components/features/library src/hooks/queries
+```
+
+---
+
+## Out of scope (Phase 2b #1592)
+
+- `useUserKbDocs` (BE-1 #1588) → kb tab content
+- `useAgents({ scope: 'my-library' })` (BE-2 #1589) → agents tab content
+- with-KB game filter actual predicate (needs `GameHubItem.hasKb` enrichment)
+- `AdvancedFiltersDrawer` wire-in (Phase 3b #1593) — the "Più filtri" entry point
+- `RecentActivityRail` cross-entity population (Phase 3b, BE-3 #1590)


### PR DESCRIPTION
## Phase 2a (Surface) for #1585 library hybrid-hub

Wires `/library` from the Wave B.3 games-only 3-tab view into the **hybrid multi-entity hub** for the 3 ready sources (games + sessions + chat) using the Phase 1 foundation (`HybridHubItem` union, mappers, `deriveHybridItems`) and the Phase 3a foundation (`AdvancedFiltersDrawer`, available but not wired here). Agents + KB stubbed `[]` until BE-1 #1588 / BE-2 #1589 (Phase 2b).

Closes #1605. Refs #1585, #1592 (Phase 2b sister). Plan: `docs/superpowers/plans/2026-05-27-library-hybrid-hub-phase-2a.md` (grounded in a /sc:spec-panel review of the real LibraryHub, issuecomment-4553238140).

### What's in this PR — 5 tasks, 7 commits

| Task | Commit | What |
|---|---|---|
| 0 | `4844caf21` | `GameHubItem.hasKb?: boolean` enrichment (optional; mapper sets it via `isKbEntry`) |
| 1 | `30a1d33c2` | `useHybridHubItems` orchestration hook — 5 sources, cap 20/source, partial-failure, allFailed, totalCounts |
| 2 | `4dbe3564b` | `CrossEntityFilters` STATO chip — functional for `games` (Owned/Wishlist/InPrestito + with-KB) |
| 3 | `fbf48860b` | `LibraryTabs<K extends string>` — generic, backward-compatible |
| 4 | `740a18d96` | **Atomic flip** — `LibraryHybridGrid` → `HybridHubItem[]` + `LibraryHub` rewire + rewrite the 2 affected test files |
| review | `0a029c3d8` | Final-review fixes — `LibraryHeroStatKey` expanded with `agents/docs/chats` (semantic stat keys) + `LibraryTabs` JSDoc refresh |

**187 tests pass** across 11 files (library-filters 24+ + hybrid-hub 40 + useHybridHubItems 8 + CrossEntityFilters 5 + LibraryTabs 15 + LibraryHybridGrid 18 + LibraryHub 22 + LibraryHeroDesktop + …).

### Key design decisions (from the spec-panel review)

1. **`HybridHubTab` for tab state** — the 6-tab key is the existing Phase 1 `HybridHubTab` (`all|games|agents|kb|sessions|chat`); `LibraryEntityKey` (3 keys: `all|kb|loaned`) is **NOT** expanded. `library-filters.ts` + its 24 tests stay untouched as the SSOT for game-state filters that `CrossEntityFilters` reuses.
2. **Atomic flip is one commit** — the pre-commit `tsc --noEmit` gate rejects an intermediate state where the grid prop type and its consumer disagree, so `LibraryHybridGrid` + `LibraryHub` + the 2 test rewrites land together. Tasks 0-3 are isolated green commits to minimize the flip's blast radius.
3. **FSM partial-failure** — `error` only when **all** ready sources fail; if ≥1 source succeeds, render `default` with per-source inline degradation (AC9.1).
4. **Selection mode game-scoped** — `useEffect` forces `browse` when leaving the `games` tab; `BulkSelectionBar` mounts only there (AC9).
5. **Cardinality** — cap 20/source inside the hook for the `all` tab; `useActiveSessions` raised to 20; `useRecentChatSessions` stays auth-gated.

### Acceptance criteria (issue #1605)

- ✅ **AC3** — Hero shows 4 stat chips (games/agents/docs/chats; agents+docs at 0 until 2b) + 3 CTAs
- ✅ **AC4** — `CrossEntityFilters` STATO chip functional in `games` (Owned/Wishlist/InPrestito + with-KB via `GameHubItem.hasKb`)
- ✅ **AC6** — 5-state FSM preserved (default/loading/empty/filtered-empty/error)
- ✅ **AC9** — bulk-selection available only in `games` tab
- ✅ **AC9.1** — partial-failure: 1+ source fails, others render; no whole-hub crash

### Findings worth noting

- **P74 plan correction** (Task 1) — `useRecentChatSessions` returns `{ sessions, totalCount }` (client-wrapped) not a flat array as the plan assumed. Hook + test fixture corrected during implementation; verified against `chatSessionsClient.ts:124`.
- **i18n production safety** — all 49 keys the new code requests (`filters.stato.*`, `hubTabs.*`, `hero.stats.{agents,docs,chats}`) verified present in BOTH `it.json` AND `en.json` (no Phase-3a-Task-6-style production regression risk).

### Final review (skill: superpowers:code-reviewer) — Approved to merge

> 187/187 tests, typecheck clean, eslint clean. All 49 i18n keys present in both catalogs. The atomic flip honored the pre-commit gate; tasks 0-3 isolated as green commits minimized the flip's blast radius.

### Notes for Phase 2b (#1592) implementer

1. **`useAgents({})` stub** in `useHybridHubItems.ts` (the discarded call + its `useMemo` dep) — replace with `useAgents({ scope: 'my-library' })` mapped via `agentToHubItem` (already imported in `hybrid-hub.mappers.ts`).
2. **`useUserKbDocs` greenfield hook** — wire it to `kbDocToHubItem` once BE-1 #1588 ships `GET /api/v1/kb-docs?userId` (or whatever endpoint shape BE-1 lands).
3. **`AdvancedFiltersDrawer` wire-in** (the "Più filtri N" entry point) — Phase 3a #1606 already ships the standalone drawer; Phase 3b connects it to `LibraryHub` state.
4. **`RecentActivityRail` cross-entity** — currently library-only (`useLibraryActivity`); Phase 3b populates it from BE-3 #1590 when the cross-entity events ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)