### PR TITLE
fix(e2e): #1612 update games smoke + a11y after /games → /library redirect

### DIFF
--- a/apps/web/e2e/a11y/games-library.spec.ts
+++ b/apps/web/e2e/a11y/games-library.spec.ts
@@ -1,29 +1,29 @@
 /**
  * Accessibility tests — /games?tab=library (Wave B.1, Issue #633).
  *
- * Combines:
- *   - axe-core WCAG 2.1 AA scan su default state (results grid populato)
- *   - axe-core WCAG 2.1 AA scan su filtered-empty state (per coprire
- *     CTA + empty-state markup, sezioni che non sono presenti su default)
- *   - prefers-reduced-motion contract: AC-8 spec §5 — verifica che la
- *     route `/games?tab=library` rispetti l'override globale CSS
- *     (`globals.css:388-396` riduce `transition-duration` a 0.01ms !important
- *     sotto `@media (prefers-reduced-motion: reduce)`). Le card hover
- *     transitions su MeepleCard GridCard (default 350ms) devono collassare
- *     a sub-millisecondo durations.
+ * STATUS (2026-05-27, #1612): SKIPPED post-#1567.
  *
- * Comprehensive unit-level coverage degli ARIA tablist contracts su
- * GamesFiltersInline lives in
- * `src/components/v2/games/__tests__/GamesFiltersInline.test.tsx`.
- * This e2e suite verifies the contract holds against the real prod build.
+ * PR #1567 (Issue #1521) replaced `/games/page.tsx` with `redirect('/library')` and
+ * removed `GamesLibraryView` — the orchestrator that hosted `data-slot="games-library-view"`,
+ * `[data-slot="games-results-grid-link"]`, and `[data-slot="games-empty-state"]` consumed
+ * by the assertions below. The 5 `features/games/` mockup components are now shelf-ready
+ * (46 unit tests still green) but orphaned: no page composes them.
  *
- * Auth bypass: `(authenticated)` route renders senza session perché
- * `(authenticated)/layout.tsx` non gate-keepa server-side e
- * `PLAYWRIGHT_AUTH_BYPASS=true` è settato dal webServer di playwright.config.ts.
+ * Follow-up #1566 will wire those components into `LibraryHub` (`/library`). Once that
+ * lands, this suite should be rewritten to scan `/library` (not `/games?tab=library`)
+ * and unskipped. Until then every test here would hit the redirect and fail the
+ * `waitForSelector('[data-slot="games-library-view"]', { timeout: 30_000 })` gate.
  *
- * Visual-test fixture: i test passano contro Next.js prod build con
- * `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` in modo che useLibrary venga
- * short-circuitato dal fixture deterministico (5 entries).
+ * Historical context preserved:
+ *   - axe-core WCAG 2.1 AA scan on default state (results grid populated)
+ *   - axe-core WCAG 2.1 AA scan on filtered-empty state (CTA + empty-state markup)
+ *   - prefers-reduced-motion contract (AC-8 §5): card hover transitions collapse to <=50ms
+ *
+ * Comprehensive unit-level coverage of ARIA tablist contracts on GamesFiltersInline
+ * lives in `src/components/v2/games/__tests__/GamesFiltersInline.test.tsx`.
+ *
+ * @see https://github.com/meepleAi-app/meepleai-monorepo/issues/1566
+ * @see https://github.com/meepleAi-app/meepleai-monorepo/issues/1612
  */
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect, type Page } from '@playwright/test';
@@ -41,7 +41,7 @@ async function gotoLibraryReady(page: Page, search = '?tab=library'): Promise<vo
   await page.waitForSelector('[data-slot="games-library-view"]', { timeout: 30_000 });
 }
 
-test.describe('Games library — accessibility @a11y', () => {
+test.describe.skip('Games library — accessibility @a11y (skipped: #1566 follow-up)', () => {
   test('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
     await gotoLibraryReady(page);
     // Default state expects results grid populato — wait for first card.

--- a/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
@@ -2,15 +2,26 @@ import { test, expect } from '@playwright/test';
 
 import { smokeLogin, applySessionToPage } from './_helpers/auth';
 
-test.describe('SMOKE — /games?tab=library real backend round-trip', () => {
-  test('frontend /games?tab=library renders without kind="error"', async ({ page, request }) => {
+test.describe('SMOKE — /games redirect to /library (real backend round-trip)', () => {
+  test('GET /games?tab=library redirects to /library and renders LibraryHub without error', async ({
+    page,
+    request,
+  }) => {
     const { cookieHeader } = await smokeLogin(request);
     await applySessionToPage(page, cookieHeader);
+    // `/games` was a multi-tab hub (Wave B.1 #633). PR #1567 (Issue #1521) replaced its
+    // page.tsx with `redirect('/library')` and removed GamesLibraryView (which carried
+    // the legacy `data-slot="games-library-view"`). The `?tab=library` query is dropped
+    // by the redirect. We assert both that the redirect lands on `/library` AND that
+    // LibraryHub renders without entering its error FSM — same pattern as
+    // library.smoke.spec.ts:26 ("library-hub-v2" selector + [data-state="error"]).
+    //
+    // Follow-up #1566 will wire the shelf-ready features/games components into
+    // LibraryHub; until then the canonical surface is library-hub-v2.
     await page.goto('/games?tab=library', { waitUntil: 'domcontentloaded' });
-    await page.waitForSelector('[data-slot="games-library-view"]', { timeout: 30_000 });
-    const errorState = await page
-      .locator('[data-slot="games-empty-state"][data-kind="error"]')
-      .count();
+    expect(new URL(page.url()).pathname).toBe('/library');
+    await page.waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 });
+    const errorState = await page.locator('[data-state="error"]').count();
     expect(errorState).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes the P0 smoke failure **#1612** (nightly run [#26496359896](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26496359896), 2026-05-27).

**Root cause (single test, single missing selector):**
PR #1567 (Issue #1521, merged 2026-05-26 07:44Z) replaced `apps/web/src/app/(authenticated)/games/page.tsx` with `redirect('/library')` and removed `GamesLibraryView` — the orchestrator that exposed `data-slot="games-library-view"`. The 2 E2E specs targeting that selector were **not updated in the same PR**, so the first nightly post-merge (2026-05-27 07:07Z) hit a 30s timeout × 3 retries on `games.smoke.spec.ts:10`.

## Diagnosis (Phase 1 systematic-debugging)

| Step | Outcome |
|---|---|
| Container stack + DB fixtures + API probes (login, library, shared-games, kb-documents, chat-threads) | All 200 ✅ |
| 23 of 24 smoke tests | Pass / skipped ✅ |
| Single failing test | `games.smoke.spec.ts:6` → `waitForSelector('[data-slot="games-library-view"]')` timeout 30000ms × 3 |
| `grep -r 'games-library-view' apps/web/src` | 0 hits (selector removed from prod code by #1567) |
| `apps/web/src/app/(authenticated)/games/page.tsx` | Now `export default function GamesLegacyRedirect(): never { redirect('/library'); }` |
| Sibling test `library.smoke.spec.ts:26` (same nightly run) | ✅ passes via `[data-slot="library-hub-v2"]` + `[data-state="error"]` |

## Changes

### `apps/web/e2e/smoke-real-backend/games.smoke.spec.ts`
- Convert from "render `games-library-view`" → **redirect verification + LibraryHub rendering**:
  - `expect(new URL(page.url()).pathname).toBe('/library')` — asserts the Next.js App Router `redirect('/library')` actually lands
  - `waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 })` — same canonical selector as the passing `library.smoke.spec.ts:30`
  - `locator('[data-state="error"]').count() === 0` — same error FSM check
- Keeps `/games` smoke coverage: catches regressions if the redirect itself ever breaks (infinite loop, server error, accidental removal).

### `apps/web/e2e/a11y/games-library.spec.ts`
- `test.describe.skip` with explicit pointer to follow-up **#1566**.
- The 3 axe + reduced-motion tests scan selectors (`games-results-grid-link`, `games-empty-state[data-kind=...]`) belonging to the `features/games/*` components that are now **shelf-ready / orphaned** (no page consumes them). #1566 will wire them into `LibraryHub`; until then any goto to `/games?tab=library` hits the redirect and times out.
- File preserved (not deleted) because:
  - Historical context (Wave B.1 #633) is documented
  - When #1566 lands, the suite needs minimal edits (route + skip removal)

## Validation

- ✅ `pnpm typecheck` — clean
- ✅ `pnpm exec eslint <both files>` — clean
- ✅ Pattern parity with passing `library.smoke.spec.ts:26` in the same failing run
- ⏳ The nightly schedule will validate end-to-end on next cron tick (03:00 UTC); the workflow also supports `workflow_dispatch` for an immediate re-run if the reviewer wants.

## What this does NOT touch

- Backend code, fixtures, container stack — all green in the failing run, no fix needed.
- `features/games/*` shelf-ready components — they remain shelf-ready; #1566 is the proper home for re-integration.
- `library-hub-v2` rendering path — already verified by `library.smoke.spec.ts:26` in the same nightly run.

## Refs

- Closes #1612
- Refs #1521 (the redirect decision)
- Refs #1567 (the merge that introduced the stale-selector regression)
- Refs #1566 (the follow-up that will re-enable the a11y suite once `LibraryHub` consumes `Games*` components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)