### PR TITLE
fix(2fa): render QR via qrcode.react + explicit manifest-src CSP (#1608 follow-up)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -604,6 +604,12 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https:",
               "font-src 'self' data:",
+              // PWA manifest declared in app/layout.tsx (rel="manifest" -> /manifest.json).
+              // Explicit manifest-src avoids falling back to default-src and reduces console
+              // noise when an upstream gateway (e.g. Cloudflare Access) intercepts the static
+              // /manifest.json request and serves a cross-origin login page. Root cause of the
+              // gateway-intercept must be fixed via infra (allowlist /manifest.json + /sw.js).
+              "manifest-src 'self'",
               `connect-src 'self' ${apiBaseUrl}`,
               "frame-ancestors 'none'",
               "base-uri 'self'",

--- a/apps/web/src/components/features/settings/__tests__/TwoFactorSetupModal.test.tsx
+++ b/apps/web/src/components/features/settings/__tests__/TwoFactorSetupModal.test.tsx
@@ -26,7 +26,12 @@ beforeEach(() => {
 describe('TwoFactorSetupModal', () => {
   it('renders QR with data-testid="2fa-qr-code" at step 1 (setup)', () => {
     wrap(<TwoFactorSetupModal open setupData={SETUP} onClose={() => {}} onEnabled={() => {}} />);
-    expect(screen.getByTestId('2fa-qr-code')).toBeInTheDocument();
+    const qrWrapper = screen.getByTestId('2fa-qr-code');
+    expect(qrWrapper).toBeInTheDocument();
+    // Regression guard: BE returns an otpauth:// URI, NOT a PNG. The wrapper must contain a
+    // client-rendered <svg> from qrcode.react (not an <img> trying to fetch otpauth://).
+    expect(qrWrapper.querySelector('svg')).not.toBeNull();
+    expect(qrWrapper.querySelector('img')).toBeNull();
   });
 
   it('moves to verify step when Continue clicked', () => {

--- a/apps/web/src/components/features/settings/two-factor/TwoFactorWizardBody.tsx
+++ b/apps/web/src/components/features/settings/two-factor/TwoFactorWizardBody.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, Loader2 } from 'lucide-react';
-import Image from 'next/image';
+import { QRCodeSVG } from 'qrcode.react';
 
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
@@ -75,14 +75,21 @@ export function TwoFactorWizardBody({ setupData, onEnabled, resetKey }: Props): 
           <p className="text-sm text-muted-foreground">
             Scan this QR code with your authenticator app (Google Authenticator, Authy, ecc.)
           </p>
-          <div className="bg-card p-4 rounded-lg mx-auto w-fit border border-border">
-            <Image
-              data-testid="2fa-qr-code"
-              src={setupData.qrCodeUrl}
-              alt="2FA QR Code"
-              width={192}
-              height={192}
-              unoptimized
+          {/*
+           * BE returns an otpauth:// URI (RFC 6238) — NOT a PNG. We render the QR
+           * client-side via qrcode.react (same pattern as TwoFactorSetup.tsx +
+           * InviteModal). Wrap with data-testid on the div so e2e selectors stay
+           * stable regardless of the underlying SVG markup the lib emits.
+           */}
+          <div
+            data-testid="2fa-qr-code"
+            className="bg-card p-4 rounded-lg mx-auto w-fit border border-border"
+          >
+            <QRCodeSVG
+              value={setupData.qrCodeUrl}
+              size={192}
+              level="M"
+              aria-label="2FA QR code — scan with your authenticator app"
             />
           </div>
           <div>


### PR DESCRIPTION
## Summary

Two issues found during the post-merge staging dogfood of [#1608](https://github.com/meepleAi-app/meepleai-monorepo/issues/1608) (PR #1622, deployed 2026-05-27):

### Issue 1 — QR code invisible in the 2FA setup wizard

**Root cause**: \`TwoFactorWizardBody\` passed the BE \`qrCodeUrl\` directly to Next.js \`<Image>\`. But the BE returns an \`otpauth://totp/...\` URI (RFC 6238 — the standard format for authenticator apps), NOT a PNG/JPEG. \`<Image>\` attempted to fetch the \`otpauth:\` scheme and rendered nothing.

This bug pre-existed in the now-deleted \`SecuritySettingsPage\` but was masked by #1608 (the page was unreachable, so the flow was never exercised end-to-end via UI).

**Fix**: replace \`<Image>\` with \`<QRCodeSVG>\` from \`qrcode.react\` (already a project dependency, used by \`TwoFactorSetup.tsx\`, \`InviteModal.tsx\`, \`QrInviteSheet.tsx\`). Test-id moved onto the wrapper \`<div>\` to stay stable regardless of the underlying SVG markup.

**Regression guard** added to \`TwoFactorSetupModal.test.tsx\`:
\`\`\`ts
expect(qrWrapper.querySelector('svg')).not.toBeNull();
expect(qrWrapper.querySelector('img')).toBeNull();
\`\`\`

### Issue 2 — CSP violation on /manifest.json

Console error during enrollment: \`Loading a manifest from 'https://meepleai-staging.cloudflareaccess.com/...' violates default-src 'self'\`. The PWA \`/manifest.json\` (declared in \`app/layout.tsx:63\`) is intercepted by Cloudflare Access (zero-trust gateway) which 302s to its cross-origin login page — the CSP \`default-src 'self'\` then rejects the redirect target.

**Fix**: add explicit \`manifest-src 'self'\` to the CSP (best practice: declare per-asset-type src so default-src doesn't have to absorb everything).

**Note**: this is a DEFENSIVE improvement only. The real fix is **infra-side** — Cloudflare Access must be configured to allowlist \`/manifest.json\` and \`/sw.js\` (PWA precache assets) for the static-asset path. Tracked separately.

## Validation

- 4/4 TwoFactor* unit tests pass (incl. new regression guard)
- 2/2 TwoFactorBottomSheet tests pass (shared WizardBody is DRY)
- Typecheck clean
- zod \`.url()\` accepts \`otpauth://\` (sanity-checked via node REPL)

## Related

- Parent: [PR #1622](https://github.com/meepleAi-app/meepleai-monorepo/pull/1622) — Settings tab consolidation
- Closes (partial): the QR rendering aspect of the post-deploy enrollment blocker. The "Invalid verification code" error reported separately is caused by a deeper BE bug (TotpService secret not persisting due to \`QueryTrackingBehavior.NoTracking\` default) — fixed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)