### PR TITLE
fix(2fa): persist TotpService entity changes (NoTracking default bypass) — BLOCKER

### DIFF
--- a/apps/api/src/Api/Services/TotpService.cs
+++ b/apps/api/src/Api/Services/TotpService.cs
@@ -81,9 +81,17 @@ internal class TotpService : ITotpService
         // Generate backup codes
         var backupCodes = GenerateBackupCodes();
 
-        // Store encrypted secret (not enabled yet - requires verification)
+        // Store encrypted secret (not enabled yet - requires verification).
+        // BUG-FIX (#1608 dogfood): the DbContext default is NoTracking (PERF-06 in
+        // InfrastructureServiceExtensions.cs), so FindAsync above returns a DETACHED entity
+        // whose property mutations are invisible to the change tracker. Without an explicit
+        // Update(), SaveChangesAsync is a silent no-op — the secret never reaches the DB and
+        // the subsequent enable2FA call sees TotpSecretEncrypted=NULL ("No secret configured").
+        // Integration tests (Api.Tests) didn't catch this because the test fixture re-registers
+        // the DbContext without NoTracking, leaving TrackAll as the default.
         user.TotpSecretEncrypted = encryptedSecret;
         user.IsTwoFactorEnabled = false; // Not enabled until verified
+        _dbContext.Users.Update(user);
         await _dbContext.SaveChangesAsync().ConfigureAwait(false);
 
         // Delete existing backup codes if re-enrolling
@@ -155,9 +163,11 @@ internal class TotpService : ITotpService
             return false;
         }
 
-        // Enable 2FA
+        // Enable 2FA. See BUG-FIX comment in GenerateSetupAsync — Update() is required because
+        // the DbContext default is NoTracking (PERF-06).
         user.IsTwoFactorEnabled = true;
         user.TwoFactorEnabledAt = _timeProvider.GetUtcNow().UtcDateTime;
+        _dbContext.Users.Update(user);
         await _dbContext.SaveChangesAsync().ConfigureAwait(false);
 
         await _auditService.LogAsync(userId.ToString(), "TwoFactorEnable", "TwoFactor", userId.ToString(), "Success",
@@ -276,10 +286,14 @@ internal class TotpService : ITotpService
             throw new UnauthorizedAccessException("Invalid verification code");
         }
 
-        // Disable 2FA and clear all data
+        // Disable 2FA and clear all data. See BUG-FIX comment in GenerateSetupAsync — Update()
+        // is required because the DbContext default is NoTracking (PERF-06). UserBackupCodes
+        // changes via Add/RemoveRange are tracked automatically (they touch the change-tracker
+        // through the DbSet API), so only the user mutation needs the explicit Update().
         user.IsTwoFactorEnabled = false;
         user.TotpSecretEncrypted = null;
         user.TwoFactorEnabledAt = null;
+        _dbContext.Users.Update(user);
 
         // Delete all backup codes (used and unused)
         var allBackupCodes = await _dbContext.UserBackupCodes


### PR DESCRIPTION
## Summary

🔴 **BLOCKER for SP5 S3 strict 2FA cutover.**

Discovered during post-deploy staging dogfood (2026-05-27, after #1622): 2FA setup wizard returned 200 with a valid \`{secret, qrCodeUrl, backupCodes}\` response, but \`TotpSecretEncrypted\` was **never persisted to the DB**. The subsequent \`enable2FA\` call then hit the NULL check and returned "No secret configured for user" (surfaced to FE as the misleading "Invalid verification code").

## Root cause

\`MeepleAiDbContext\` is registered with \`UseQueryTrackingBehavior(NoTracking)\` by default (PERF-06 in [\`InfrastructureServiceExtensions.cs:162\`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs#L162)).

\`TotpService\` uses \`_dbContext.Users.FindAsync(userId)\` which inherits the default tracking behavior — the returned entity is **DETACHED**. Subsequent property mutations (\`user.TotpSecretEncrypted = ...\`, \`user.IsTwoFactorEnabled = ...\`) are invisible to the change tracker. \`SaveChangesAsync\` silently no-ops: 0 rows affected, no exception, success log fires, 200 response. Nothing was persisted.

## Why tests didn't catch it

\`IntegrationWebApplicationFactory\` ([\`apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs:146-158\`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs#L146-L158)) re-registers \`MeepleAiDbContext\` **without** \`UseQueryTrackingBehavior\`, so the test DbContext falls back to EF Core's default (\`TrackAll\`). All \`TotpService\` writes are tracked correctly under test, while being silently broken in production.

This prod-vs-test config divergence has masked a fully broken \`TotpService\` write path for an unknown duration. The bug pre-existed; the staging cutover post-#1608 is what made it visible end-to-end via UI.

## Fix

3 surgical \`_dbContext.Users.Update(user);\` calls before \`SaveChangesAsync\` in the writer methods of \`apps/api/src/Api/Services/TotpService.cs\`:

| Method | Line | Persists |
|--------|------|----------|
| \`GenerateSetupAsync\` | +87 | \`TotpSecretEncrypted\` + \`IsTwoFactorEnabled=false\` |
| \`EnableTwoFactorAsync\` | +161 | \`IsTwoFactorEnabled=true\` + \`TwoFactorEnabledAt\` |
| \`DisableTwoFactorAsync\` | +294 | clears \`TotpSecretEncrypted\` + flags |

Reader methods (\`VerifyCodeAsync\`, \`VerifyBackupCodeAsync\`, \`GetTwoFactorStatusAsync\`) are intentionally left as-is — \`NoTracking\` is correct for read-only paths and the performance optimization (PERF-06) was made for a reason.

\`Update()\` is **idempotent when an entity is already tracked**, so the fix is also safe for the test fixture (TrackAll default) and any future scenario where someone overrides the per-query tracking behavior.

## Validation

- ✅ Build: 0 errors / 0 warnings (\`dotnet build apps/api/src/Api\`)
- ✅ \`S3AcceptanceScenariosTests\`: 9/9 PASS, 3m29s (the only existing integration tests that exercise the full 2FA setup→enable flow via real HTTP pipeline)
- ✅ Manual diagnostic via session-injection on staging confirmed the bug pre-fix (200 response + DB \`has_secret=false\`)

## Follow-up issue to file

**Align \`IntegrationWebApplicationFactory\` with the production \`UseQueryTrackingBehavior(NoTracking)\` setting + refactor impacted tests.** This bug is the canonical reason: prod-test config divergence silently masked a fully broken write path for unknown duration. Pattern likely affects other services with \`FindAsync\` + property mutations — full audit recommended.

## Related

- Companion FE hotfix: [#1626](https://github.com/meepleAi-app/meepleai-monorepo/pull/1626) (QR rendering via \`qrcode.react\` + CSP \`manifest-src\`)
- Parent: [PR #1622](https://github.com/meepleAi-app/meepleai-monorepo/pull/1622) — Settings tab consolidation (#1608)
- Once merged + deployed to staging: re-trigger SP5 S3 enrollment for the 2 superadmin → \`GET /admin/users/no-2fa\` should return \`[]\` → flip \`TwoFactor:StrictMode=true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)