### PR TITLE
feat(email): #1629 migrate to Resend transactional provider (FROM @meepleai.app)

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -90,6 +90,8 @@
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.13.1" />
     <PackageReference Include="QuestPDF" Version="2025.12.3" />
+    <!-- Issue #1629: Resend transactional email provider (replaces Gmail SMTP for FROM @meepleai.app) -->
+    <PackageReference Include="Resend" Version="0.1.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <!-- PERF-05: HybridCache for AI/RAG response caching with L1+L2 support -->
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.0.0" />

--- a/apps/api/src/Api/Extensions/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/AuthenticationServiceExtensions.cs
@@ -18,6 +18,9 @@ internal static class AuthenticationServiceExtensions
         services.AddDataProtectionServices(configuration, environment);
         services.AddAuthServices();
         services.AddSessionServices();
+        // Issue #1629: register IEmailSender BEFORE password-reset services so
+        // EmailService can resolve the configured transport (Resend or SMTP).
+        services.AddEmailSender(configuration);
         services.AddPasswordResetServices();
         services.AddRateLimitServices();
         services.AddAlertingServices(configuration);
@@ -141,6 +144,11 @@ internal static class AuthenticationServiceExtensions
     {
         // AUTH-04: Password reset services
         services.AddScoped<IPasswordResetService, PasswordResetService>();
+
+        // Issue #1629: IEmailSender transport (Resend or SMTP) is selected via
+        // EMAIL_PROVIDER env var; see EmailSenderServiceExtensions.AddEmailSender.
+        // EmailService remains the high-level facade that builds templates and
+        // delegates raw transmission to the configured IEmailSender.
         services.AddScoped<IEmailService, EmailService>();
 
         // ISSUE-4416: Push notification service

--- a/apps/api/src/Api/Extensions/EmailSenderServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/EmailSenderServiceExtensions.cs
@@ -1,0 +1,85 @@
+using Api.Services.Email;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Resend;
+
+namespace Api.Extensions;
+
+/// <summary>
+/// DI registration for the <see cref="IEmailSender"/> abstraction (Issue #1629).
+/// </summary>
+/// <remarks>
+/// The choice between Resend and SMTP is driven by the <c>EMAIL_PROVIDER</c> env var
+/// (also accepts <c>Email:Provider</c> in <c>appsettings</c>). When <c>resend</c> is
+/// selected but no API key is present, the resolver falls back to SMTP and registers a
+/// hosted service that logs a startup warning so the misconfiguration is visible.
+/// </remarks>
+internal static class EmailSenderServiceExtensions
+{
+    public static IServiceCollection AddEmailSender(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var provider = (configuration["EMAIL_PROVIDER"]
+            ?? configuration["Email:Provider"]
+            ?? "smtp").Trim();
+
+        var resendApiKey = configuration["RESEND_API_KEY"]
+            ?? configuration["Email:Resend:ApiKey"];
+
+        var providerIsResend = string.Equals(provider, "resend", StringComparison.OrdinalIgnoreCase);
+        var useResend = providerIsResend && !string.IsNullOrWhiteSpace(resendApiKey);
+
+        if (useResend)
+        {
+            services.AddHttpClient<ResendClient>();
+            services.Configure<ResendClientOptions>(o =>
+            {
+                o.ApiToken = resendApiKey!;
+            });
+            services.AddTransient<IResend, ResendClient>();
+            services.AddScoped<IEmailSender, ResendEmailSender>();
+        }
+        else
+        {
+            // SMTP fallback (also used when EMAIL_PROVIDER is unset or RESEND_API_KEY missing).
+            services.AddScoped<IEmailSender, SmtpEmailSender>();
+
+            if (providerIsResend)
+            {
+                services.AddHostedService<ResendMisconfigurationWarningService>();
+            }
+        }
+
+        return services;
+    }
+}
+
+/// <summary>
+/// Logs a single warning at startup when <c>EMAIL_PROVIDER=resend</c> was requested but
+/// no <c>RESEND_API_KEY</c> was configured. Keeps the failure mode loud so silent
+/// fallbacks to SMTP do not surprise operators.
+/// </summary>
+internal sealed class ResendMisconfigurationWarningService : IHostedService
+{
+    private readonly ILogger<ResendMisconfigurationWarningService> _logger;
+
+    public ResendMisconfigurationWarningService(ILogger<ResendMisconfigurationWarningService> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogWarning(
+            "EMAIL_PROVIDER=resend was requested but RESEND_API_KEY is not configured; falling back to SMTP transport.");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/apps/api/src/Api/Services/Email/EmailService.Auth.cs
+++ b/apps/api/src/Api/Services/Email/EmailService.Auth.cs
@@ -312,6 +312,9 @@ internal partial class EmailService
     }
 
     // ISSUE-124: Invitation system emails
+    // Issue #1629: refactored to route through IEmailSender (Resend/SMTP) and
+    // fixed redeem link from /accept-invite?token=… to /invites/{token} so it
+    // matches the actual Next.js route at apps/web/src/app/(public)/invites/[token].
     public async Task SendInvitationEmailAsync(
         string toEmail,
         string role,
@@ -321,26 +324,11 @@ internal partial class EmailService
     {
         try
         {
-            var inviteLink = $"{_frontendBaseUrl}/accept-invite?token={Uri.EscapeDataString(token)}";
+            var inviteLink = $"{_frontendBaseUrl}/invites/{Uri.EscapeDataString(token)}";
             var subject = "You've been invited to MeepleAI";
             var body = BuildInvitationEmailBody(role, inviteLink, invitedByName);
 
-            using var message = new MailMessage();
-            message.From = new MailAddress(_fromAddress, _fromName);
-            message.To.Add(new MailAddress(toEmail));
-            message.Subject = subject;
-            message.Body = body;
-            message.IsBodyHtml = true;
-
-            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
-            smtpClient.EnableSsl = _enableSsl;
-
-            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
-            {
-                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
-            }
-
-            await smtpClient.SendMailAsync(message, ct).ConfigureAwait(false);
+            await SendViaTransportAsync(toEmail, subject, body, ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Invitation email sent successfully to {Email} for role {Role}",
@@ -359,6 +347,8 @@ internal partial class EmailService
     }
 
     // ISSUE-124: Enhanced invitation email with custom message, platform intro, and expiry notice
+    // Issue #1629: same transport routing + link fix as the basic overload above.
+    // The enhanced flow points at /setup-account (account-provisioning UI), not /invites/[token].
     public async Task SendInvitationEmailAsync(
         string toEmail,
         string displayName,
@@ -375,22 +365,7 @@ internal partial class EmailService
             var subject = "Sei stato invitato su MeepleAI!";
             var body = BuildEnhancedInvitationEmailBody(displayName, role, setupLink, invitedByName, customMessage, expiresAt);
 
-            using var message = new MailMessage();
-            message.From = new MailAddress(_fromAddress, _fromName);
-            message.To.Add(new MailAddress(toEmail));
-            message.Subject = subject;
-            message.Body = body;
-            message.IsBodyHtml = true;
-
-            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
-            smtpClient.EnableSsl = _enableSsl;
-
-            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
-            {
-                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
-            }
-
-            await smtpClient.SendMailAsync(message, ct).ConfigureAwait(false);
+            await SendViaTransportAsync(toEmail, subject, body, ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Enhanced invitation email sent successfully to {Email} for role {Role}",

--- a/apps/api/src/Api/Services/Email/IEmailSender.cs
+++ b/apps/api/src/Api/Services/Email/IEmailSender.cs
@@ -1,0 +1,49 @@
+namespace Api.Services.Email;
+
+/// <summary>
+/// Abstraction over the raw email transport. Implementations: <see cref="SmtpEmailSender"/>
+/// (legacy Gmail/standard SMTP) and <see cref="ResendEmailSender"/> (transactional API).
+/// </summary>
+/// <remarks>
+/// Issue #1629: introduced to decouple <see cref="EmailService"/> from the underlying
+/// transport so we can switch providers via configuration (<c>EMAIL_PROVIDER</c>) without
+/// touching the template-building code paths.
+/// </remarks>
+internal interface IEmailSender
+{
+    /// <summary>
+    /// Sends a single email. Throws <see cref="InvalidOperationException"/> on transport
+    /// failure (callers decide whether to swallow or rethrow).
+    /// </summary>
+    Task SendAsync(EmailRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Identifier of the active transport (used for logging / diagnostics).
+    /// </summary>
+    string ProviderName { get; }
+}
+
+/// <summary>
+/// Provider-agnostic email payload. Built by <see cref="EmailService"/> and passed to
+/// the active <see cref="IEmailSender"/>.
+/// </summary>
+internal sealed class EmailRequest
+{
+    public required string FromEmail { get; init; }
+    public required string FromName { get; init; }
+    public required string ToEmail { get; init; }
+    public required string Subject { get; init; }
+    public required string HtmlBody { get; init; }
+
+    /// <summary>
+    /// Optional plain-text fallback. Falls back to a stripped version of <see cref="HtmlBody"/>
+    /// at transport time if null.
+    /// </summary>
+    public string? TextBody { get; init; }
+
+    /// <summary>
+    /// Optional Reply-To header. Useful when the FROM is a no-reply alias but replies
+    /// should be routed to a monitored mailbox.
+    /// </summary>
+    public string? ReplyTo { get; init; }
+}

--- a/apps/api/src/Api/Services/Email/ResendEmailSender.cs
+++ b/apps/api/src/Api/Services/Email/ResendEmailSender.cs
@@ -1,0 +1,81 @@
+using Api.Infrastructure.Security;
+using Microsoft.Extensions.Logging;
+using Resend;
+
+namespace Api.Services.Email;
+
+/// <summary>
+/// <see cref="IEmailSender"/> implementation backed by the Resend transactional API.
+/// </summary>
+/// <remarks>
+/// Issue #1629: introduced to replace Gmail SMTP for FROM @meepleai.app delivery.
+/// Resend requires the sender domain to be verified (SPF + DKIM + DMARC) — see
+/// docs/for-developers/operations/email-provider-setup.md.
+/// </remarks>
+internal sealed class ResendEmailSender : IEmailSender
+{
+    private readonly IResend _resend;
+    private readonly ILogger<ResendEmailSender> _logger;
+
+    public ResendEmailSender(IResend resend, ILogger<ResendEmailSender> logger)
+    {
+        _resend = resend ?? throw new ArgumentNullException(nameof(resend));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public string ProviderName => "resend";
+
+    public async Task SendAsync(EmailRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var message = new EmailMessage
+        {
+            From = $"{request.FromName} <{request.FromEmail}>",
+            Subject = request.Subject,
+            HtmlBody = request.HtmlBody
+        };
+        message.To.Add(request.ToEmail);
+
+        if (!string.IsNullOrWhiteSpace(request.TextBody))
+        {
+            message.TextBody = request.TextBody;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ReplyTo))
+        {
+            // Resend SDK exposes ReplyTo as nullable EmailAddressList — auto-initialized
+            // by the EmailMessage constructor but typed as nullable in the SDK surface.
+            message.ReplyTo!.Add(request.ReplyTo);
+        }
+
+        try
+        {
+            var response = await _resend.EmailSendAsync(message, cancellationToken).ConfigureAwait(false);
+
+            if (response is null || !response.Success)
+            {
+                _logger.LogError(
+                    "Resend EmailSendAsync returned non-success for {Email}",
+                    DataMasking.MaskEmail(request.ToEmail));
+                throw new InvalidOperationException(
+                    $"Resend API rejected the email submission for {DataMasking.MaskEmail(request.ToEmail)}.");
+            }
+
+            _logger.LogInformation(
+                "Resend accepted email {EmailId} to {Email}",
+                response.Content,
+                DataMasking.MaskEmail(request.ToEmail));
+        }
+        catch (ResendException ex)
+        {
+            _logger.LogError(
+                ex,
+                "Resend API error sending email to {Email}: {ErrorType}",
+                DataMasking.MaskEmail(request.ToEmail),
+                ex.ErrorType);
+            throw new InvalidOperationException(
+                $"Failed to send email via Resend: {ex.ErrorType}", ex);
+        }
+    }
+}

--- a/apps/api/src/Api/Services/Email/ResendEmailSender.cs
+++ b/apps/api/src/Api/Services/Email/ResendEmailSender.cs
@@ -1,4 +1,5 @@
 using Api.Infrastructure.Security;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Resend;
 
@@ -16,11 +17,20 @@ internal sealed class ResendEmailSender : IEmailSender
 {
     private readonly IResend _resend;
     private readonly ILogger<ResendEmailSender> _logger;
+    private readonly string? _fromEmailOverride;
 
-    public ResendEmailSender(IResend resend, ILogger<ResendEmailSender> logger)
+    public ResendEmailSender(IResend resend, IConfiguration configuration, ILogger<ResendEmailSender> logger)
     {
         _resend = resend ?? throw new ArgumentNullException(nameof(resend));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Resend can only send from a verified domain. The caller's FROM (EmailService
+        // _fromAddress) may be an environment-specific dev value (e.g. noreply@meepleai.dev
+        // used for Mailpit) that is NOT verified on Resend. So the Resend transport pins the
+        // FROM to RESEND_FROM_EMAIL, falling back to the caller value only if unset.
+        _fromEmailOverride = configuration["RESEND_FROM_EMAIL"]
+            ?? configuration["Email:Resend:FromEmail"];
     }
 
     public string ProviderName => "resend";
@@ -29,9 +39,13 @@ internal sealed class ResendEmailSender : IEmailSender
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        var fromEmail = !string.IsNullOrWhiteSpace(_fromEmailOverride)
+            ? _fromEmailOverride
+            : request.FromEmail;
+
         var message = new EmailMessage
         {
-            From = $"{request.FromName} <{request.FromEmail}>",
+            From = $"{request.FromName} <{fromEmail}>",
             Subject = request.Subject,
             HtmlBody = request.HtmlBody
         };

--- a/apps/api/src/Api/Services/Email/SmtpEmailSender.cs
+++ b/apps/api/src/Api/Services/Email/SmtpEmailSender.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Mail;
+using Api.Infrastructure.Security;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Services.Email;
+
+/// <summary>
+/// Legacy SMTP <see cref="IEmailSender"/> implementation using <see cref="SmtpClient"/>.
+/// Retained for development / fallback when Resend is not configured.
+/// </summary>
+/// <remarks>
+/// Issue #1629: extracted from the original <c>EmailService</c> so the transport choice
+/// (SMTP vs Resend) is a DI concern, not hard-coded inside template-building methods.
+/// </remarks>
+internal sealed class SmtpEmailSender : IEmailSender
+{
+    private readonly ILogger<SmtpEmailSender> _logger;
+    private readonly string _smtpHost;
+    private readonly int _smtpPort;
+    private readonly string? _smtpUsername;
+    private readonly string? _smtpPassword;
+    private readonly bool _enableSsl;
+
+    public SmtpEmailSender(IConfiguration configuration, ILogger<SmtpEmailSender> logger)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _smtpHost = configuration["Email:SmtpHost"] ?? configuration["SMTP_HOST"] ?? "localhost";
+        _smtpPort = int.Parse(
+            configuration["Email:SmtpPort"] ?? configuration["SMTP_PORT"] ?? "587",
+            System.Globalization.CultureInfo.InvariantCulture);
+        _smtpUsername = configuration["Email:SmtpUsername"] ?? configuration["SMTP_USER"];
+        _smtpPassword = configuration["Email:SmtpPassword"]
+            ?? configuration["SMTP_PASSWORD"]
+            ?? configuration["GMAIL_APP_PASSWORD"];
+        _enableSsl = bool.Parse(configuration["Email:EnableSsl"] ?? "true");
+    }
+
+    public string ProviderName => "smtp";
+
+    public async Task SendAsync(EmailRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            using var message = new MailMessage();
+            message.From = new MailAddress(request.FromEmail, request.FromName);
+            message.To.Add(new MailAddress(request.ToEmail));
+            message.Subject = request.Subject;
+            message.Body = request.HtmlBody;
+            message.IsBodyHtml = true;
+
+            if (!string.IsNullOrWhiteSpace(request.ReplyTo))
+            {
+                message.ReplyToList.Add(new MailAddress(request.ReplyTo));
+            }
+
+            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
+            smtpClient.EnableSsl = _enableSsl;
+
+            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
+            {
+                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
+            }
+
+            await smtpClient.SendMailAsync(message, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "SMTP accepted email to {Email}",
+                DataMasking.MaskEmail(request.ToEmail));
+        }
+#pragma warning disable CA1031 // wrap any transport error into InvalidOperationException
+        catch (Exception ex) when (ex is not OperationCanceledException)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(
+                ex,
+                "SMTP error sending email to {Email}",
+                DataMasking.MaskEmail(request.ToEmail));
+            throw new InvalidOperationException(
+                $"Failed to send email via SMTP to {DataMasking.MaskEmail(request.ToEmail)}.", ex);
+        }
+    }
+}

--- a/apps/api/src/Api/Services/EmailService.cs
+++ b/apps/api/src/Api/Services/EmailService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Net;
 using System.Net.Mail;
 using Api.Infrastructure.Security;
+using Api.Services.Email;
 using Microsoft.Extensions.Configuration;
 
 namespace Api.Services;
@@ -9,6 +10,7 @@ namespace Api.Services;
 internal partial class EmailService : IEmailService
 {
     private readonly ILogger<EmailService> _logger;
+    private readonly IEmailSender? _sender;
     private readonly string _fromAddress;
     private readonly string _fromName;
     private readonly string _smtpHost;
@@ -19,7 +21,25 @@ internal partial class EmailService : IEmailService
     private readonly string _resetUrlBase;
     private readonly string _frontendBaseUrl;
 
+    /// <summary>
+    /// Legacy ctor used by existing unit tests that mock EmailService directly without
+    /// providing an <see cref="IEmailSender"/>. The transport falls back to in-method
+    /// SmtpClient instantiation (original behaviour).
+    /// </summary>
     public EmailService(IConfiguration configuration, ILogger<EmailService> logger)
+        : this(configuration, logger, sender: null)
+    {
+    }
+
+    /// <summary>
+    /// Preferred ctor (resolved by DI). The <paramref name="sender"/> dependency centralises
+    /// the choice between SMTP and Resend (Issue #1629), so individual <c>SendXxxEmailAsync</c>
+    /// methods do not need to know about the transport.
+    /// </summary>
+    public EmailService(
+        IConfiguration configuration,
+        ILogger<EmailService> logger,
+        IEmailSender? sender)
     {
         // S1075: Default values extracted to const
 #pragma warning disable S1075 // URIs should not be hardcoded - Default/Fallback value
@@ -28,11 +48,15 @@ internal partial class EmailService : IEmailService
 #pragma warning restore S1075
 
         _logger = logger;
+        _sender = sender;
 
         // Load email configuration with fallback to SMTP_* env var names from email.secret
         // email.secret uses SMTP_HOST/SMTP_USER/SMTP_PASSWORD but EmailService originally
         // expected Email:SmtpHost/Email:SmtpUsername/Email:SmtpPassword — bridge the gap
-        _fromAddress = configuration["Email:FromAddress"] ?? configuration["SMTP_FROM_EMAIL"] ?? "noreply@meepleai.dev";
+        _fromAddress = configuration["Email:FromAddress"]
+            ?? configuration["RESEND_FROM_EMAIL"]
+            ?? configuration["SMTP_FROM_EMAIL"]
+            ?? "noreply@meepleai.app";
         _fromName = configuration["Email:FromName"] ?? "MeepleAI";
         _smtpHost = configuration["Email:SmtpHost"] ?? configuration["SMTP_HOST"] ?? "localhost";
         _smtpPort = int.Parse(configuration["Email:SmtpPort"] ?? configuration["SMTP_PORT"] ?? "587", CultureInfo.InvariantCulture);
@@ -40,7 +64,58 @@ internal partial class EmailService : IEmailService
         _smtpPassword = configuration["Email:SmtpPassword"] ?? configuration["SMTP_PASSWORD"] ?? configuration["GMAIL_APP_PASSWORD"];
         _enableSsl = bool.Parse(configuration["Email:EnableSsl"] ?? "true");
         _resetUrlBase = configuration["Email:ResetUrlBase"] ?? DefaultResetUrlBase;
-        _frontendBaseUrl = configuration["Frontend:BaseUrl"] ?? DefaultFrontendBaseUrl;
+        _frontendBaseUrl = configuration["Frontend:BaseUrl"]
+            ?? configuration["FRONTEND_BASE_URL"]
+            ?? DefaultFrontendBaseUrl;
+    }
+
+    /// <summary>
+    /// Routes the send through the registered <see cref="IEmailSender"/> when available
+    /// (production/staging) or falls back to a direct <see cref="SmtpClient"/> path
+    /// (legacy ctor / unit tests). Throws on transport failure — callers decide whether
+    /// to swallow the exception or propagate it (Issue #1629).
+    /// </summary>
+    private async Task SendViaTransportAsync(
+        string toEmail,
+        string subject,
+        string htmlBody,
+        CancellationToken cancellationToken)
+    {
+        if (_sender is not null)
+        {
+            await _sender.SendAsync(new EmailRequest
+            {
+                FromEmail = _fromAddress,
+                FromName = _fromName,
+                ToEmail = toEmail,
+                Subject = subject,
+                HtmlBody = htmlBody
+            }, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // Legacy direct-SMTP path used only when no IEmailSender is injected
+        // (kept for backward compatibility with existing unit tests).
+        using var message = new MailMessage
+        {
+            From = new MailAddress(_fromAddress, _fromName),
+            Subject = subject,
+            Body = htmlBody,
+            IsBodyHtml = true
+        };
+        message.To.Add(new MailAddress(toEmail));
+
+        using var smtpClient = new SmtpClient(_smtpHost, _smtpPort)
+        {
+            EnableSsl = _enableSsl
+        };
+
+        if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
+        {
+            smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
+        }
+
+        await smtpClient.SendMailAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
     // ISSUE-4417: Raw email sending for queue processor

--- a/apps/api/tests/Api.Tests/Services/Email/EmailServiceInvitationLinkTests.cs
+++ b/apps/api/tests/Api.Tests/Services/Email/EmailServiceInvitationLinkTests.cs
@@ -1,0 +1,126 @@
+using Api.Services;
+using Api.Services.Email;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services.Email;
+
+/// <summary>
+/// Issue #1629: covers the refactor of EmailService.SendInvitationEmailAsync to delegate
+/// raw transmission to IEmailSender (instead of constructing SmtpClient directly) AND the
+/// collateral bug fix on the redeem link path (/accept-invite → /invites/{token}).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class EmailServiceInvitationLinkTests
+{
+    private const string FrontendBaseUrl = "https://app.test.meepleai.example";
+
+    private readonly Mock<ILogger<EmailService>> _logger = new();
+    private readonly Mock<IEmailSender> _sender = new();
+    private readonly IConfiguration _configuration;
+
+    public EmailServiceInvitationLinkTests()
+    {
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Email:FromAddress"] = "noreply@meepleai.app",
+                ["Email:FromName"] = "MeepleAI",
+                ["Frontend:BaseUrl"] = FrontendBaseUrl,
+                ["Email:EnableSsl"] = "false",
+            })
+            .Build();
+    }
+
+    [Fact]
+    public async Task SendInvitationEmailAsync_DelegatesToInjectedSender()
+    {
+        // Arrange
+        EmailRequest? captured = null;
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailRequest, CancellationToken>((req, _) => captured = req)
+            .Returns(Task.CompletedTask);
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        await service.SendInvitationEmailAsync(
+            toEmail: "recipient@example.com",
+            role: "User",
+            token: "raw-token-value",
+            invitedByName: "Admin",
+            ct: CancellationToken.None);
+
+        // Assert
+        _sender.Verify(
+            s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "EmailService MUST delegate raw transport to IEmailSender when one is injected.");
+
+        captured.Should().NotBeNull();
+        captured!.ToEmail.Should().Be("recipient@example.com");
+        captured.FromEmail.Should().Be("noreply@meepleai.app");
+        captured.FromName.Should().Be("MeepleAI");
+        captured.Subject.Should().Contain("invited");
+    }
+
+    [Fact]
+    public async Task SendInvitationEmailAsync_RedeemLinkUsesInvitesPath()
+    {
+        // Arrange — Issue #1629 collateral fix: link path was /accept-invite (query string token)
+        // but the actual Next.js route is /invites/[token]. Without this fix the link in
+        // delivered emails returned 404.
+        EmailRequest? captured = null;
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailRequest, CancellationToken>((req, _) => captured = req)
+            .Returns(Task.CompletedTask);
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        await service.SendInvitationEmailAsync(
+            toEmail: "recipient@example.com",
+            role: "User",
+            token: "abc123",
+            invitedByName: "Admin",
+            ct: CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.HtmlBody.Should().Contain(
+            $"{FrontendBaseUrl}/invites/abc123",
+            "the redeem URL must point to the /invites/{token} path that exists in apps/web/src/app/(public)/invites/[token].");
+        captured.HtmlBody.Should().NotContain(
+            "/accept-invite?token=",
+            "the legacy /accept-invite?token= URL is a 404 — must be removed in this PR.");
+    }
+
+    [Fact]
+    public async Task SendInvitationEmailAsync_WrapsSenderFailureInInvalidOperationException()
+    {
+        // Arrange
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("transport down"));
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        var act = () => service.SendInvitationEmailAsync(
+            toEmail: "recipient@example.com",
+            role: "User",
+            token: "tok",
+            invitedByName: "Admin",
+            ct: CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Failed to send invitation email");
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/Email/ResendEmailSenderTests.cs
+++ b/apps/api/tests/Api.Tests/Services/Email/ResendEmailSenderTests.cs
@@ -1,0 +1,111 @@
+using Api.Services.Email;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Resend;
+using Xunit;
+
+namespace Api.Tests.Services.Email;
+
+/// <summary>
+/// Issue #1629: unit coverage for ResendEmailSender. The key behaviour validated here is
+/// the FROM override — Resend can only send from a verified domain, so the transport must
+/// pin FROM to RESEND_FROM_EMAIL regardless of the caller's address (which may be a dev-only
+/// value like noreply@meepleai.dev used for Mailpit). This bug was caught by the E2E test:
+/// without the override Resend rejected with "domain meepleai.dev is not verified".
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class ResendEmailSenderTests
+{
+    private readonly Mock<IResend> _resend = new();
+
+    private static IConfiguration Config(string? resendFrom)
+    {
+        var dict = new Dictionary<string, string?>();
+        if (resendFrom is not null)
+        {
+            dict["RESEND_FROM_EMAIL"] = resendFrom;
+        }
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    private static EmailRequest Request(string fromEmail = "noreply@meepleai.dev") => new()
+    {
+        FromEmail = fromEmail,
+        FromName = "MeepleAI",
+        ToEmail = "recipient@example.com",
+        Subject = "Hello",
+        HtmlBody = "<p>body</p>",
+    };
+
+    [Fact]
+    public async Task SendAsync_PinsFromToResendVerifiedDomain_NotCallerAddress()
+    {
+        // Arrange
+        EmailMessage? captured = null;
+        _resend
+            .Setup(r => r.EmailSendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(new ResendResponse<Guid>(Guid.NewGuid(), new ResendRateLimit()));
+
+        var sender = new ResendEmailSender(
+            _resend.Object,
+            Config(resendFrom: "noreply@meepleai.app"),
+            Mock.Of<ILogger<ResendEmailSender>>());
+
+        // Act — caller passes the dev .dev address; the transport must override it.
+        await sender.SendAsync(Request(fromEmail: "noreply@meepleai.dev"), CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.From.Email.Should().Be("noreply@meepleai.app",
+            "Resend transport must send from the verified domain, not the caller's dev address.");
+        captured.From.Email.Should().NotContain("meepleai.dev",
+            "the unverified .dev address must be overridden to avoid Resend ValidationError.");
+    }
+
+    [Fact]
+    public async Task SendAsync_FallsBackToCallerFrom_WhenResendFromUnset()
+    {
+        // Arrange
+        EmailMessage? captured = null;
+        _resend
+            .Setup(r => r.EmailSendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(new ResendResponse<Guid>(Guid.NewGuid(), new ResendRateLimit()));
+
+        var sender = new ResendEmailSender(
+            _resend.Object,
+            Config(resendFrom: null),
+            Mock.Of<ILogger<ResendEmailSender>>());
+
+        // Act
+        await sender.SendAsync(Request(fromEmail: "caller@example.com"), CancellationToken.None);
+
+        // Assert
+        captured!.From.Email.Should().Be("caller@example.com");
+    }
+
+    [Fact]
+    public async Task SendAsync_WrapsResendExceptionInInvalidOperationException()
+    {
+        // Arrange
+        _resend
+            .Setup(r => r.EmailSendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ResendException(System.Net.HttpStatusCode.UnprocessableEntity, ErrorType.ValidationError, "domain not verified"));
+
+        var sender = new ResendEmailSender(
+            _resend.Object,
+            Config(resendFrom: "noreply@meepleai.app"),
+            Mock.Of<ILogger<ResendEmailSender>>());
+
+        // Act
+        var act = () => sender.SendAsync(Request(), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Resend*");
+    }
+}

--- a/docs/for-developers/operations/email-provider-setup.md
+++ b/docs/for-developers/operations/email-provider-setup.md
@@ -1,0 +1,109 @@
+# Email Provider Setup (Resend)
+
+**Issue**: [#1629](https://github.com/meepleAi-app/meepleai-monorepo/issues/1629)
+**Status**: active since 2026-05-27
+
+MeepleAI sends transactional email (invitations, password reset, email verification,
+report delivery, share-request notifications) through a pluggable transport selected at
+startup via the `EMAIL_PROVIDER` environment variable.
+
+| Provider | When | Notes |
+|----------|------|-------|
+| `resend` | staging / prod (and dev once configured) | Transactional API, requires a Resend-verified sender domain. **Default.** |
+| `smtp` | dev / fallback | Legacy `SmtpClient`. ⚠️ Gmail SMTP silently drops transactional mail (accept-then-discard) — never rely on it for real delivery. |
+
+## Why we left Gmail SMTP
+
+Gmail SMTP accepted the submission (`SendMailAsync` returned no exception, logs said
+`Invitation email sent successfully`) but **the email never left Gmail** — it was not even
+in the sender's "Sent" folder. Gmail's abuse detection drops mail when the FROM equals the
+authenticated account, the recipient is external, and the body contains non-canonical links
+(e.g. `localhost`). There is no bounce, no log — a silent black hole. A dedicated
+transactional provider with a verified domain (SPF/DKIM/DMARC) is the correct fix.
+
+## Architecture
+
+```
+EmailService (template building)
+   └── IEmailSender (transport abstraction)        ← Issue #1629
+         ├── ResendEmailSender   (Resend HTTP API)
+         └── SmtpEmailSender     (System.Net.Mail SmtpClient, legacy/fallback)
+```
+
+- `IEmailSender` / `EmailRequest`: `apps/api/src/Api/Services/Email/IEmailSender.cs`
+- `ResendEmailSender`: `apps/api/src/Api/Services/Email/ResendEmailSender.cs`
+- `SmtpEmailSender`: `apps/api/src/Api/Services/Email/SmtpEmailSender.cs`
+- DI resolver: `apps/api/src/Api/Extensions/EmailSenderServiceExtensions.cs`
+
+`EmailService` builds the subject + HTML body, then delegates raw transmission to the
+injected `IEmailSender`. Adding a new provider = implement `IEmailSender` + wire it in the
+resolver; no template code changes.
+
+> **Incremental migration note**: as of #1629 only the invitation flow
+> (`SendInvitationEmailAsync`, both overloads) routes through `IEmailSender`. The remaining
+> `EmailService` methods (password reset, verification, reports, share-requests) still
+> instantiate `SmtpClient` directly and will be migrated in follow-up PRs. Track via the
+> "Out of scope" section of #1629.
+
+## One-time setup
+
+### 1. Resend account + API key
+
+1. Sign up at <https://resend.com/signup>.
+2. **API Keys → Create API Key** → name `meepleai-<env>` → permission **Full access**.
+3. Copy the `re_…` key into `infra/secrets/email.secret` as `RESEND_API_KEY`.
+
+### 2. Verify the sender domain
+
+1. **Domains → Add Domain** → `meepleai.app`.
+2. Resend shows **3 DNS records** (SPF, DKIM, DMARC). Add each to **Cloudflare DNS**:
+   - **DNS only** (grey cloud — NOT proxied). TXT auth records must not be proxied.
+   - Typical records:
+     - `TXT  send`            → `v=spf1 include:amazonses.com ~all` (SPF; exact value per Resend)
+     - `TXT  resend._domainkey` → DKIM public key (long value from Resend)
+     - `TXT  _dmarc`          → `v=DMARC1; p=none;` (DMARC; tighten to `p=quarantine` later)
+3. Wait 5–15 min for propagation, then click **Verify** in Resend. Status must be **Verified**.
+
+### 3. Configure the app
+
+In `infra/secrets/email.secret`:
+
+```ini
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxx
+RESEND_FROM_EMAIL=noreply@meepleai.app
+FRONTEND_BASE_URL=http://localhost:3000   # staging/prod: public app URL
+```
+
+Restart the API to pick up the new config:
+
+```powershell
+pwsh -c "docker restart meepleai-api"
+```
+
+## Verifying delivery
+
+1. Send a test invitation (admin session required):
+   ```bash
+   curl -X POST http://localhost:8080/api/v1/admin/users/invite \
+     -H "Content-Type: application/json" -b cookies.txt \
+     -d '{"email":"you@example.com","role":"User"}'
+   ```
+2. Check the **Resend dashboard → Emails**: the message should show `delivered` (not just
+   `sent`). Resend reports bounces/complaints explicitly — unlike Gmail SMTP.
+3. API log line: `Resend accepted email {EmailId} to {Email}` (from `ResendEmailSender`).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Startup warning `EMAIL_PROVIDER=resend … RESEND_API_KEY is not configured` | key missing | add `RESEND_API_KEY` to `email.secret`, restart |
+| Resend dashboard shows `bounced` | recipient invalid / domain not verified | verify domain status; check recipient |
+| Email `delivered` in Resend but not in inbox | recipient spam filter | check spam; tighten DMARC after warm-up |
+| `Resend API rejected the email submission` in logs | API key invalid or domain unverified | re-check key + domain verification |
+| Link in email is `/accept-invite?token=…` (404) | stale build pre-#1629 | rebuild; fixed to `/invites/{token}` |
+
+## Free tier limits
+
+Resend free tier: **3000 emails/month, 100/day**. Sufficient for staging + early access.
+Upgrade when onboarding scales past the daily cap.

--- a/infra/compose.dev.yml
+++ b/infra/compose.dev.yml
@@ -43,6 +43,10 @@ services:
       - ./secrets/smoldocling-service.secret
       - ./secrets/storage.secret
       - ./secrets/db-sync.secret
+      # Issue #1629: email provider config (EMAIL_PROVIDER, RESEND_API_KEY, …).
+      # Listed BEFORE api.env.dev so the dev Mailpit overrides (Email__SmtpHost=mailpit)
+      # still win for the SMTP path; only the Resend keys come from here.
+      - ./secrets/email.secret
       - ./env/api.env.dev
     ports: ["127.0.0.1:8080:8080"]
     environment:

--- a/infra/secrets/email.secret.example
+++ b/infra/secrets/email.secret.example
@@ -1,9 +1,42 @@
-# SMTP Email Server Credentials
+# Email Provider Credentials
 # OPTIONAL - Info logged if missing (email notifications disabled)
 # Copy this file to infra/secrets/email.secret and fill in values
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Provider selection (Issue #1629)
+# ─────────────────────────────────────────────────────────────────────────────
+# EMAIL_PROVIDER = resend | smtp
+#   resend → transactional delivery via Resend API (REQUIRES verified domain).
+#            Recommended for staging/prod. FROM must be on a Resend-verified domain.
+#   smtp   → legacy SMTP (Gmail etc.). Dev/fallback only. NOTE: Gmail silently drops
+#            transactional mail (accept-then-discard) — do NOT use for real delivery.
+# If EMAIL_PROVIDER=resend but RESEND_API_KEY is empty, the app falls back to SMTP
+# and logs a startup warning.
+EMAIL_PROVIDER=resend
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resend (https://resend.com) — used when EMAIL_PROVIDER=resend
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Create an API key at https://resend.com/api-keys (Full access).
+# 2. Add + verify the domain at https://resend.com/domains (meepleai.app).
+# 3. Add the SPF/DKIM/DMARC DNS records Resend shows you to Cloudflare DNS
+#    (DNS only — NOT proxied). See docs/for-developers/operations/email-provider-setup.md.
+RESEND_API_KEY=re_your_api_key_here
+# FROM address — MUST be on the Resend-verified domain.
+RESEND_FROM_EMAIL=noreply@meepleai.app
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SMTP — used when EMAIL_PROVIDER=smtp (legacy / dev fallback)
+# ─────────────────────────────────────────────────────────────────────────────
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=your_email@gmail.com
 SMTP_PASSWORD=your_app_password_here
 SMTP_FROM_EMAIL=noreply@meepleai.local
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared
+# ─────────────────────────────────────────────────────────────────────────────
+# Base URL used to build links inside emails (invitation redeem, password reset, …).
+# Dev: http://localhost:3000 | Staging/Prod: the public app URL.
+FRONTEND_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## Sommario

Migra l'email transactional da **Gmail SMTP** a **Resend** introducendo un'astrazione di transport pluggable (`IEmailSender`) selezionata via `EMAIL_PROVIDER`. Closes #1629.

Validato **end-to-end**: invito reale a `badsworm@alice.it` → Resend `accepted` (email id `8c600999…`) → **ricevuto in casella** (dominio `meepleai.app` verificato, SPF/DKIM/DMARC su Cloudflare).

## Contesto

Durante un test del sistema invitation è emerso che in **staging/prod** le email partono da `badsworm@gmail.com` via Gmail SMTP — branding sbagliato + deliverability scarsa per transactional. (In **dev** invece le email vanno correttamente a **Mailpit**, mail catcher; nessun problema lì.) Serve un provider dedicato con dominio verificato per gli ambienti che spediscono davvero.

## Modifiche

### Transport abstraction
- **`IEmailSender` + `EmailRequest`** (`Services/Email/`): disaccoppia `EmailService` (costruzione template) dal transport.
- **`ResendEmailSender`**: invio via Resend .NET SDK. **Pin del FROM** a `RESEND_FROM_EMAIL` (dominio verificato) — il transport sa qual è il sender accettato da Resend, indipendentemente dal valore passato dal chiamante.
- **`SmtpEmailSender`**: logica `SmtpClient` estratta (legacy/dev/fallback).
- **DI resolver** (`EmailSenderServiceExtensions`): `resend` quando `RESEND_API_KEY` è presente, altrimenti fallback SMTP + warning di startup.

### EmailService
- Nuovo ctor che inietta `IEmailSender`; `SendInvitationEmailAsync` (entrambi gli overload) instradati sul transport.
- **Bug fix collaterale**: link di redeem `/accept-invite?token=` → `/invites/{token}` (la route Next.js reale è `/invites/[token]`; il vecchio URL era un 404).
- FROM default `noreply@meepleai.dev` → `noreply@meepleai.app`; nuove chiavi config `FRONTEND_BASE_URL`, `RESEND_FROM_EMAIL`.

### Infra / config
- `compose.dev.yml`: aggiunto `./secrets/email.secret` agli `env_file` dell'API (prima di `api.env.dev`, così gli override Mailpit `Email__Smtp*` restano validi per il path SMTP). Staging/prod già caricano `email.secret`.
- `email.secret.example`: riscritto con sezione Resend + SMTP + provider switch.
- `docs/for-developers/operations/email-provider-setup.md`: runbook setup (account, dominio, DNS Cloudflare, troubleshooting).

## Test

- **Unit**: `ResendEmailSenderTests` (from-override, fallback, wrap `ResendException`), `EmailServiceInvitationLinkTests` (delega al sender, fix link, wrap errore). **25/25 email unit test verdi.**
- **E2E manuale**: invito reale consegnato via Resend (vedi sopra). Confermato che NON passa più da Mailpit quando `EMAIL_PROVIDER=resend`.

## Note / follow-up (fuori scope)

- Solo il flusso **invitation** è instradato su `IEmailSender`. Gli altri metodi `EmailService` (password reset, verification, reports, share-requests) restano su `SmtpClient` diretto — migrazione incrementale in PR successive.
- **Bug osservato (separato)**: la revoca invito (`DELETE /admin/users/invitations/{id}`) risponde `success:true` ma non persiste il cambio `Pending→Revoked` nel DB. Da investigare in issue dedicata (non tocca questo PR).
- Dev resta su `EMAIL_PROVIDER=smtp` (Mailpit); Resend si attiva in staging/prod via il rispettivo `email.secret`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
