### PR TITLE
fix(auth): #1633 persist invitation revoke/accept under NoTracking default

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/InvitationTokenRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/InvitationTokenRepository.cs
@@ -59,6 +59,12 @@ internal sealed class InvitationTokenRepository : RepositoryBase, IInvitationTok
         existingEntity.AcceptedAt = entity.AcceptedAt;
         existingEntity.AcceptedByUserId = entity.AcceptedByUserId;
         existingEntity.RevokedAt = entity.RevokedAt;
+
+        // Issue #1633: the DbContext default is QueryTrackingBehavior.NoTracking
+        // (PERF-06, InfrastructureServiceExtensions.cs:162), so the entity returned by
+        // FindAsync is NOT tracked and the field mutations above would be silently lost
+        // by SaveChanges. Mark it modified explicitly (mirrors the #1627 TotpService fix).
+        DbContext.InvitationTokens.Update(existingEntity);
     }
 
     public async Task DeleteAsync(InvitationToken entity, CancellationToken cancellationToken = default)

--- a/apps/api/tests/Api.Tests/Integration/Authentication/InvitationFlowIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/InvitationFlowIntegrationTests.cs
@@ -350,6 +350,66 @@ public sealed class InvitationFlowIntegrationTests : IAsyncLifetime
         _output("Revoked token correctly returns 'invalid'");
     }
 
+    /// <summary>
+    /// Issue #1633 — regression test for the NoTracking-default persistence bug.
+    /// The production DbContext sets QueryTrackingBehavior.NoTracking by default (PERF-06,
+    /// InfrastructureServiceExtensions.cs:162) but the integration fixture does NOT, so the
+    /// existing ValidateToken_RevokedInvitation test passes despite the prod bug (it reuses the
+    /// already-tracked entity from AddAsync). This test replicates the real request flow:
+    /// empty change tracker + NoTracking default → InvitationTokenRepository.UpdateAsync must
+    /// still persist the status change. Pre-fix: FAILS (status stays Pending because the
+    /// FindAsync-loaded entity is untracked and SaveChanges no-ops). Post-fix: PASSES.
+    /// </summary>
+    [Fact]
+    public async Task Revoke_WithNoTrackingDefault_PersistsRevokedStatus()
+    {
+        // Arrange
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var unitOfWork = _serviceProvider!.GetRequiredService<IUnitOfWork>();
+
+        var email = $"revoke-notracking-{Guid.NewGuid():N}@test.meepleai.dev";
+        var tokenHash = Convert.ToBase64String(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes("nt-" + Guid.NewGuid().ToString("N"))));
+        var invitation = Api.BoundedContexts.Authentication.Domain.Entities.InvitationToken.Create(
+            email, "User", tokenHash, AdminUserId);
+
+        await invitationRepo.AddAsync(invitation, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+        var invitationId = invitation.Id;
+
+        // Simulate a fresh HTTP request: empty tracker + production NoTracking default.
+        _dbContext!.ChangeTracker.Clear();
+        var originalBehavior = _dbContext.ChangeTracker.QueryTrackingBehavior;
+        _dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+
+        try
+        {
+            // Act — mirror RevokeInvitationCommandHandler exactly.
+            var loaded = await invitationRepo.GetByIdAsync(invitationId, TestCancellationToken);
+            loaded.Should().NotBeNull();
+            loaded!.Revoke();
+            await invitationRepo.UpdateAsync(loaded, TestCancellationToken);
+            await unitOfWork.SaveChangesAsync(TestCancellationToken);
+        }
+        finally
+        {
+            _dbContext.ChangeTracker.QueryTrackingBehavior = originalBehavior;
+        }
+
+        // Assert — read back from DB with a clean tracker; the change MUST be persisted.
+        _dbContext.ChangeTracker.Clear();
+        var fromDb = await _dbContext.InvitationTokens
+            .AsNoTracking()
+            .FirstAsync(t => t.Id == invitationId, TestCancellationToken);
+
+        fromDb.Status.Should().Be("Revoked",
+            "revoke must persist under the production NoTracking default (#1633)");
+        fromDb.RevokedAt.Should().NotBeNull("RevokedAt must be set when the revoke persists");
+
+        _output("Revoke persisted correctly under NoTracking default");
+    }
+
     #endregion
 
     #region Duplicate Email Conflict


### PR DESCRIPTION
## Sommario

Fixa il bug per cui la **revoca invito** (`DELETE /api/v1/admin/users/invitations/{id}`) rispondeva `success:true` ma non persisteva il cambio `Pending → Revoked` nel DB. Closes #1633.

Stesso pattern del fix #1627 (TotpService): il DbContext default è `QueryTrackingBehavior.NoTracking` (PERF-06), quindi l'entità caricata da `FindAsync` non è tracciata e le mutazioni si perdono in `SaveChanges`.

## Root cause (debugging sistematico)

`InvitationTokenRepository.UpdateAsync` modificava `existingEntity.Status/RevokedAt/AcceptedAt` affidandosi al change tracking, ma **mancava `Update()` esplicito**. Con NoTracking → no-op silenzioso. Il command ritornava `true` (nessuna eccezione) → falso successo.

Impatta sia **Revoke** che **Accept** (`MarkAccepted`), che condividono `UpdateAsync`.

## Fix

```csharp
// InvitationTokenRepository.UpdateAsync — dopo le mutazioni
DbContext.InvitationTokens.Update(existingEntity); // #1633
```

## Test

Aggiunto `Revoke_WithNoTrackingDefault_PersistsRevokedStatus`: replica il flusso prod (change tracker vuoto + `QueryTrackingBehavior.NoTracking`) che la fixture di integrazione **non** imposta di default — per questo il test esistente `ValidateToken_RevokedInvitation` passava nonostante il bug.

- **Pre-fix**: FAIL (`status` resta `Pending`) — confermato durante il debugging
- **Post-fix**: PASS
- **No-regression**: 13/13 `InvitationFlowIntegrationTests` verdi

## Note

Questa è una delle occorrenze residue del pattern NoTracking che **#1628** (AsTracking refactor + fixture alignment) dovrà coprire sistematicamente. Allineare la fixture al NoTracking default catturerebbe questa classe di bug a monte.

Refs: #1627 (stesso pattern), #1628 (refactor sistemico), PERF-06 (`InfrastructureServiceExtensions.cs:162`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)