### PR TITLE
fix(ci): #1630 resample chi-square dice tests + right-size backend-fast timeout

### DIFF
--- a/.github/workflows/dev-fast.yml
+++ b/.github/workflows/dev-fast.yml
@@ -183,7 +183,14 @@ jobs:
     # 8min cap. The 12-min budget gives ~3min headroom. Per issue #1161 note,
     # this trigger justifies splitting build + test into separate jobs (option b);
     # tracked as follow-up.
-    timeout-minutes: 12
+    # Issue #1630: raised 12 → 18 minutes. The 12-min cap covers setup + Release
+    # build (~4min) + the full unit suite (~4-8min, 17k+ tests) in ONE job, and
+    # on a cache-miss / noisy-runner combo the three phases stacked past 12min
+    # (PR #1627 hit the cap on 2/3 attempts on a 3-line change). This is runner
+    # variance on a monolithic job, not a slow test — 18min right-sizes the
+    # budget. Splitting build+test (artifact hand-off, à la ci.yml) and xUnit
+    # parallelization remain the structural follow-ups.
+    timeout-minutes: 18
     needs: changes
     if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
     steps:

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollFairnessTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollFairnessTests.cs
@@ -9,17 +9,26 @@ namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
 /// NFR-5: Verifica la fairness del RNG crittografico usato da <see cref="DiceRoll.Create"/>.
 ///
 /// <para>
-/// Metodo: Chi-square goodness-of-fit test su 6 000 tiri di 1d6.
-/// Expected frequency per faccia = 6000 / 6 = 1000.
-/// Gradi di libertà (df) = 5, alpha = 0.05 → valore critico = 11.07.
+/// Metodo: Chi-square goodness-of-fit test sui tiri di un dado.
+/// Gradi di libertà (df) = facce − 1, α = 0.05 → valore critico tabulato.
 /// </para>
 ///
 /// <para>
 /// Il test è puramente unitario: non richiede DB né infrastruttura.
 /// <see cref="DiceRoll.Create"/> usa <c>System.Security.Cryptography.RandomNumberGenerator</c>
-/// (RNG crittografico) — nessun seed controllabile, quindi il test è statistico
-/// e probabilistico: la probabilità di falso positivo è &lt; 5 %.
-/// In pratica, per un dado equo, il chi-square osservato è tipicamente &lt; 5.
+/// (RNG crittografico) — nessun seed controllabile, quindi il test è statistico.
+/// </para>
+///
+/// <para>
+/// <b>Anti-flakiness (issue #1630):</b> un singolo chi-square con α = 0.05 fallisce
+/// per definizione il 5 % delle volte anche con un dado perfettamente equo. Con due
+/// asserzioni indipendenti la probabilità di un falso positivo per run è
+/// 1 − 0.95² ≈ 9.75 %, abbastanza da rompere la CI su PR non correlate. Per questo
+/// le asserzioni di distribuzione usano il <b>resampling</b> (vedi
+/// <see cref="AssertChiSquareFairness"/>): più campioni indipendenti, fail solo se
+/// <i>tutti</i> superano la soglia. Questo non indebolisce il test — un RNG realmente
+/// biased fallisce sistematicamente tutti i campioni — ma porta il falso positivo da
+/// α a α^attempts (≈ 0.0125 %).
 /// </para>
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
@@ -31,74 +40,26 @@ public sealed class DiceRollFairnessTests
     private static readonly Guid AnyParticipantId = Guid.Parse("bbbbbbbb-0000-4000-8000-bbbbbbbbbbbb");
 
     /// <summary>
-    /// 6 000 tiri di 1d6: Chi-square &lt; 11.07 (α = 0.05, df = 5).
+    /// 6 000 tiri di 1d6: Chi-square &lt; 11.07 (α = 0.05, df = 5), con resampling.
     /// </summary>
     [Fact]
     public void RollDice_1d6_PassesChiSquareFairnessTest()
     {
-        const int rolls = 6_000;
-        const int sides = 6;
-        const double expectedPerFace = (double)rolls / sides; // 1000.0
-        const double criticalValue = 11.07;                   // α=0.05, df=5
-
-        var counts = new int[sides + 1]; // index 1..6
-
-        for (var i = 0; i < rolls; i++)
-        {
-            var diceRoll = DiceRoll.Create(AnySessionId, AnyParticipantId, "1d6");
-            var result = diceRoll.GetRolls()[0];
-            counts[result]++;
-        }
-
-        var chiSquare = 0.0;
-        for (var face = 1; face <= sides; face++)
-        {
-            var diff = counts[face] - expectedPerFace;
-            chiSquare += diff * diff / expectedPerFace;
-        }
-
-        chiSquare.Should().BeLessThan(criticalValue,
-            because: $"il RNG crittografico deve produrre una distribuzione uniforme su 1d6 " +
-                     $"(chi-square={chiSquare:F3}, critical={criticalValue}, df={sides - 1}). " +
-                     $"Conteggi per faccia: [{string.Join(", ", counts[1..])}]");
+        AssertChiSquareFairness(formula: "1d6", rolls: 6_000, sides: 6, criticalValue: 11.07);
     }
 
     /// <summary>
-    /// 2 000 tiri di 1d20: Chi-square &lt; 30.14 (α = 0.05, df = 19).
+    /// 2 000 tiri di 1d20: Chi-square &lt; 30.14 (α = 0.05, df = 19), con resampling.
     /// </summary>
     [Fact]
     public void RollDice_1d20_PassesChiSquareFairnessTest()
     {
-        const int rolls = 2_000;
-        const int sides = 20;
-        const double expectedPerFace = (double)rolls / sides; // 100.0
-        const double criticalValue = 30.14;                   // α=0.05, df=19
-
-        var counts = new int[sides + 1]; // index 1..20
-
-        for (var i = 0; i < rolls; i++)
-        {
-            var diceRoll = DiceRoll.Create(AnySessionId, AnyParticipantId, "1d20");
-            var result = diceRoll.GetRolls()[0];
-            counts[result]++;
-        }
-
-        var chiSquare = 0.0;
-        for (var face = 1; face <= sides; face++)
-        {
-            var diff = counts[face] - expectedPerFace;
-            chiSquare += diff * diff / expectedPerFace;
-        }
-
-        chiSquare.Should().BeLessThan(criticalValue,
-            because: $"il RNG crittografico deve produrre una distribuzione uniforme su 1d20 " +
-                     $"(chi-square={chiSquare:F3}, critical={criticalValue}, df={sides - 1}). " +
-                     $"Conteggi per faccia: [{string.Join(", ", counts[1..])}]");
+        AssertChiSquareFairness(formula: "1d20", rolls: 2_000, sides: 20, criticalValue: 30.14);
     }
 
     /// <summary>
     /// Verifica che i totali di 1 000 tiri di 2d6 ricadano nel range [2, 12].
-    /// Complementare al chi-square: nessun risultato fuori bounds.
+    /// Complementare al chi-square: invariante deterministica, mai flaky.
     /// </summary>
     [Fact]
     public void RollDice_2d6_TotalsAlwaysInRange()
@@ -114,5 +75,61 @@ public sealed class DiceRollFairnessTests
             foreach (var roll in individualRolls)
                 roll.Should().BeInRange(1, 6, because: "ogni dado deve essere tra 1 e 6");
         }
+    }
+
+    /// <summary>
+    /// Esegue un chi-square goodness-of-fit con <b>resampling</b> per eliminare la
+    /// flakiness intrinseca (issue #1630). Effettua fino a <paramref name="maxAttempts"/>
+    /// campioni indipendenti (ogni <see cref="DiceRoll.Create"/> istanzia un nuovo RNG
+    /// crittografico, quindi i campioni non sono correlati) e passa appena uno di essi
+    /// rientra sotto la soglia. Fallisce solo se <i>tutti</i> i campioni la superano:
+    /// per un dado equo P(tutti falliscono) ≈ α^maxAttempts, mentre un RNG realmente
+    /// biased supera la soglia in modo sistematico e viene comunque catturato.
+    /// </summary>
+    private static void AssertChiSquareFairness(string formula, int rolls, int sides, double criticalValue, int maxAttempts = 3)
+    {
+        var observed = new List<double>(maxAttempts);
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            var counts = new int[sides + 1]; // index 1..sides
+            for (var i = 0; i < rolls; i++)
+            {
+                var diceRoll = DiceRoll.Create(AnySessionId, AnyParticipantId, formula);
+                counts[diceRoll.GetRolls()[0]]++;
+            }
+
+            var chiSquare = ComputeChiSquare(counts, sides, expectedPerFace: (double)rolls / sides);
+            observed.Add(chiSquare);
+
+            if (chiSquare < criticalValue)
+                return; // un solo campione equo è sufficiente: distribuzione uniforme confermata
+        }
+
+        // Nessuno dei campioni indipendenti è rientrato sotto la soglia ⇒ bias sistematico,
+        // non sfortuna statistica. Falliamo riportando tutti i valori per diagnostica.
+        var best = observed.Min();
+        best.Should().BeLessThan(criticalValue,
+            because: $"il RNG crittografico deve produrre una distribuzione uniforme su {formula} " +
+                     $"(df={sides - 1}, α=0.05, critical={criticalValue}); su {maxAttempts} campioni " +
+                     $"di resampling indipendenti nessuno è rientrato sotto la soglia " +
+                     $"(chi-square=[{string.Join(", ", observed.Select(v => v.ToString("F3")))}]). " +
+                     $"Per un dado equo P(tutti falliscono) ≈ α^{maxAttempts} = {Math.Pow(0.05, maxAttempts):P4}, " +
+                     $"quindi indica un bias reale del RNG, non rumore statistico (issue #1630).");
+    }
+
+    /// <summary>
+    /// Chi-square goodness-of-fit: Σ (osservato − atteso)² / atteso, sulle facce 1..<paramref name="sides"/>.
+    /// </summary>
+    private static double ComputeChiSquare(int[] countsByFace, int sides, double expectedPerFace)
+    {
+        var chiSquare = 0.0;
+        for (var face = 1; face <= sides; face++)
+        {
+            var diff = countsByFace[face] - expectedPerFace;
+            chiSquare += diff * diff / expectedPerFace;
+        }
+
+        return chiSquare;
     }
 }


### PR DESCRIPTION
## Scommario

L'issue #1630 mescola **due failure distinti** del job `Backend Fast (build + unit)` di `dev-fast.yml`. Entrambi risolti alla root cause.

### A — Flakiness (chi-square)
- I test `RollDice_1d6/1d20_PassesChiSquareFairnessTest` usano α=0.05 → ogni test fallisce ~5% delle volte **anche con RNG perfettamente equo** (~9.75% combinato sui due). Reale occorrenza: PR #1627 (toccava solo `TotpService`), `attempt 1` fallito sul chi-square.
- **Fix**: resampling — fino a 3 campioni indipendenti (ogni `DiceRoll.Create` istanzia un nuovo RNG crittografico), il test passa appena uno sta sotto la soglia, fallisce solo se **tutti** la superano. Falso positivo: ~α³ = 0.0125%. La sensibilità è preservata: un RNG realmente biased supera la soglia in modo sistematico e fallisce tutti i campioni.

### B — Timeout 12m
- `backend-fast` fa `setup` + build Release (~4m) + suite unit completa (~4-8m, 17k+ test) sotto **un solo budget di 12m**. Su cache-miss/noisy-runner le tre fasi si sommano oltre i 12m (PR #1627: timeout su 2/3 tentativi per una modifica di 3 righe).
- **Evidenza** che NON è un test lento: i fairness test girano in **~100ms**. È varianza runner su un job monolitico.
- **Fix**: right-size `timeout-minutes` 12 → 18. Split build+test (artifact hand-off, come `ci.yml`) e parallelizzazione xUnit restano follow-up strutturali tracciati.

## Deviazione consapevole dall'issue
L'issue suggeriva (medium-term) "trait Slow + nightly job". Ho preferito il **resampling**: risolve la root cause della flakiness senza un nightly da mantenere (che resterebbe esso stesso flaky) e mantiene il valore di guardia su ogni PR. I fairness test sono velocissimi (~100ms), quindi non c'è motivo di spostarli fuori dal path PR.

## Verifica
- Build Release: 0 errori.
- `DiceRollFairnessTests`: 3/3 superati su 4 esecuzioni, ~96-109ms.

Closes #1630