### PR TITLE
fix(ci): #1587 add job timeout to remaining self-hosted perf jobs

### DIFF
--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -81,6 +81,11 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    # Issue #1587: explicit timeout so this self-hosted job (checkout +
+    # paths-filter) can never tie up the single runner in a stuck teardown.
+    # Completes the "timeout on every perf job" coverage started in #1594
+    # (which pinned lighthouse-* and added their timeouts).
+    timeout-minutes: 10
     outputs:
       web: ${{ steps.filter.outputs.web || 'true' }}
       api: ${{ steps.filter.outputs.api || 'true' }}
@@ -603,6 +608,8 @@ jobs:
   notify-failure:
     name: Notify on Failure
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
+    # Issue #1587: explicit timeout — completes the "every perf job" coverage.
+    timeout-minutes: 10
     needs: [k6-tests, lighthouse-ci]
     if: failure() && github.event_name == 'schedule'
     permissions:


### PR DESCRIPTION
## Contesto

Il grosso di #1587 è **già stato risolto** dalla PR #1594 (`70ef9c0e5`, già su `main-dev`):
- trigger disaccoppiato dal release path → `branches: [main]` (niente più Performance Tests sulle PR di release verso `main-staging`);
- `lighthouse-build` / `lighthouse-ci` spostati su `ubuntu-latest` con `timeout-minutes: 30`.

Questo ha già rimosso la contesa sul runner self-hosted che affamava `deploy-staging` nell'incidente del 2026-05-26.

## Cosa fa questa PR

Chiude il **gap residuo** dell'opzione 3 dell'issue ("add timeout-minutes to *every* perf job"). Due job giravano ancora sul singolo runner self-hosted (`vars.RUNNER`) **senza timeout a livello job**:

| Job | Prima | Dopo |
|-----|-------|------|
| `changes` (Detect Changes) | nessun timeout | `timeout-minutes: 10` |
| `notify-failure` (Notify on Failure) | nessun timeout | `timeout-minutes: 10` |

Un teardown bloccato — l'esatta failure mode dell'incidente (token job scaduto durante l'upload log → worker che cicla a vuoto → runner mai rilasciato) — poteva ancora pinnare il runner tramite questi job. Sono job leggeri, ma il cap è difesa in profondità a costo nullo.

Dopo questa PR **tutti e 5 i job** hanno un timeout a livello job: `changes` (10), `k6-tests` (45), `lighthouse-build` (30), `lighthouse-ci` (30), `notify-failure` (10).

L'opzione 4 ("deploy precedence") resta non necessaria: il disaccoppiamento del trigger (#1594) impedisce a Performance Tests di girare in contemporanea col deploy di release.

## Verifica
- `test-performance.yml`: YAML valido (`yaml.safe_load`).
- Diff: +7 righe (2 `timeout-minutes` + commenti di rationale).

Closes #1587