### PR TITLE
fix(web): follow-up minors navbar sp4 (#1638)

### DIFF
--- a/apps/web/e2e/mobile-card-browser.spec.ts
+++ b/apps/web/e2e/mobile-card-browser.spec.ts
@@ -3,17 +3,14 @@
  * Feature: mobile-ux-card-browser
  *
  * Test Coverage:
- * - MobileTabBar visibility and navigation (mobile only, md:hidden)
  * - 2-column card grid on mobile viewport
  * - MeepleCardBrowser overlay (open, carousel, ESC close)
  * - DomainHub page (/hub) with 8 domain tiles
  * - Responsive behavior across mobile breakpoints
  *
- * Architecture Notes (post mobile-ux overhaul):
- * - MobileTabBar replaces the old MobileBottomBar (data-testid: "mobile-tab-bar")
- * - HandDrawer is now desktop-only (not tested on mobile viewports)
- * - ContextualBottomNav is hidden on mobile (hidden md:flex)
- * - SmartFAB deleted (replaced by morphing center tab in MobileTabBar)
+ * Note: global bottom-bar navigation is covered by bottom-nav.spec.ts
+ * (MobileBottomBar, data-testid "mobile-bottom-bar"). This file focuses on the
+ * card browser + DomainHub.
  */
 
 import { test, expect } from '@playwright/test';
@@ -21,90 +18,6 @@ import { test, expect } from '@playwright/test';
 // iPhone 13 / 14 viewport
 test.use({
   viewport: { width: 390, height: 844 },
-});
-
-test.describe('Mobile Card Browser - MobileTabBar', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/hub');
-    await page.waitForLoadState('networkidle');
-  });
-
-  test('tab bar is visible on mobile viewport', async ({ page }) => {
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    await expect(tabBar).toBeVisible();
-  });
-
-  test('tab bar renders core tabs (Dashboard, Discover)', async ({ page }) => {
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    await expect(tabBar).toBeVisible();
-
-    // Dashboard and Discover are always visible (not auth-gated)
-    await expect(page.getByTestId('mobile-tab-dashboard')).toBeVisible();
-    await expect(page.getByTestId('mobile-tab-discover')).toBeVisible();
-  });
-
-  test('tab bar is hidden on desktop viewport', async ({ page }) => {
-    await page.setViewportSize({ width: 1024, height: 768 });
-    await page.goto('/hub');
-    await page.waitForLoadState('networkidle');
-
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    await expect(tabBar).toBeHidden();
-  });
-
-  test('tab bar touch targets meet minimum 44x44px', async ({ page }) => {
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    await expect(tabBar).toBeVisible();
-
-    // MobileTabBar uses links and optionally a button for the morphed center tab
-    const targets = tabBar.locator('a, button[data-testid^="mobile-tab-"]');
-    const count = await targets.count();
-    expect(count).toBeGreaterThanOrEqual(2);
-
-    for (let i = 0; i < count; i++) {
-      const box = await targets.nth(i).boundingBox();
-      expect(box).not.toBeNull();
-      expect(box!.width).toBeGreaterThanOrEqual(44);
-      expect(box!.height).toBeGreaterThanOrEqual(44);
-    }
-  });
-
-  test('Dashboard tab navigates to /dashboard', async ({ page }) => {
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
-
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    const isVisible = await tabBar.isVisible().catch(() => false);
-    if (!isVisible) test.skip(true, 'Tab bar not visible in this environment');
-
-    await page.getByTestId('mobile-tab-dashboard').click();
-    await page.waitForURL(/\/dashboard/, { timeout: 5000 });
-    expect(page.url()).toContain('/dashboard');
-  });
-
-  test('Discover tab navigates to /games', async ({ page }) => {
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    const isVisible = await tabBar.isVisible().catch(() => false);
-    if (!isVisible) test.skip(true, 'Tab bar not visible in this environment');
-
-    await page.getByTestId('mobile-tab-discover').click();
-    await page.waitForURL(/\/library/, { timeout: 5000 });
-    expect(page.url()).toContain('/library');
-  });
-
-  test('Library tab navigates to /library (authenticated)', async ({ page }) => {
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    const isVisible = await tabBar.isVisible().catch(() => false);
-    if (!isVisible) test.skip(true, 'Tab bar not visible in this environment');
-
-    const libraryTab = page.getByTestId('mobile-tab-library');
-    const tabVisible = await libraryTab.isVisible().catch(() => false);
-    if (!tabVisible) test.skip(true, 'Library tab only visible when authenticated');
-
-    await libraryTab.click();
-    await page.waitForURL(/\/library/, { timeout: 5000 });
-    expect(page.url()).toContain('/library');
-  });
 });
 
 test.describe('Mobile Card Browser - DomainHub', () => {
@@ -313,16 +226,6 @@ test.describe('Mobile Card Browser - Responsive Breakpoints', () => {
   ];
 
   for (const viewport of mobileViewports) {
-    test(`tab bar visible on ${viewport.name} (${viewport.width}px)`, async ({ page }) => {
-      await page.setViewportSize({ width: viewport.width, height: viewport.height });
-      await page.goto('/hub');
-      await page.waitForLoadState('networkidle');
-
-      // MobileTabBar is md:hidden — only visible below 768px
-      const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-      await expect(tabBar).toBeVisible();
-    });
-
     test(`domain hub grid renders on ${viewport.name}`, async ({ page }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await page.goto('/hub');
@@ -333,14 +236,4 @@ test.describe('Mobile Card Browser - Responsive Breakpoints', () => {
       await expect(grid).toBeVisible({ timeout: 5000 });
     });
   }
-
-  test('tab bar is hidden at tablet breakpoint (768px)', async ({ page }) => {
-    await page.setViewportSize({ width: 768, height: 1024 });
-    await page.goto('/hub');
-    await page.waitForLoadState('networkidle');
-
-    // MobileTabBar uses md:hidden — hidden at 768px and above
-    const tabBar = page.locator('[data-testid="mobile-tab-bar"]');
-    await expect(tabBar).toBeHidden();
-  });
 });

--- a/apps/web/src/components/layout/AppNav/MobileBottomBar.tsx
+++ b/apps/web/src/components/layout/AppNav/MobileBottomBar.tsx
@@ -7,12 +7,10 @@ import { BOTTOM_TAB_LABEL_OVERRIDES } from '@/config/navigation';
 import { useNavigationItems } from '@/hooks/useNavigationItems';
 import { cn } from '@/lib/utils';
 
-/** Immersive routes where the global bottom bar is replaced by an in-session layout. */
-const IMMERSIVE_ROUTE_PATTERNS = [/^\/sessions\/live(\/|$)/, /^\/library\/[^/]+\/play(\/|$)/];
+import { isImmersiveRoute } from './immersive-routes';
 
-export function isImmersiveRoute(pathname: string): boolean {
-  return IMMERSIVE_ROUTE_PATTERNS.some(pattern => pattern.test(pathname));
-}
+// Re-exported for the existing MobileBottomBar test + the AppNav barrel.
+export { isImmersiveRoute };
 
 interface MobileBottomBarProps {
   className?: string;

--- a/apps/web/src/components/layout/AppNav/immersive-routes.ts
+++ b/apps/web/src/components/layout/AppNav/immersive-routes.ts
@@ -1,0 +1,10 @@
+/**
+ * Immersive routes where the global navbar chrome is replaced by an in-session
+ * layout. Shared by {@link MobileBottomBar} (to hide itself) and `DesktopShell`
+ * (to drop the bottom-bar padding) so the two stay in sync.
+ */
+const IMMERSIVE_ROUTE_PATTERNS = [/^\/sessions\/live(\/|$)/, /^\/library\/[^/]+\/play(\/|$)/];
+
+export function isImmersiveRoute(pathname: string): boolean {
+  return IMMERSIVE_ROUTE_PATTERNS.some(pattern => pattern.test(pathname));
+}

--- a/apps/web/src/components/layout/UserShell/DesktopShell.tsx
+++ b/apps/web/src/components/layout/UserShell/DesktopShell.tsx
@@ -2,11 +2,15 @@
 
 import { useState, type ReactNode } from 'react';
 
+import { usePathname } from 'next/navigation';
+
 import { ChatSlideOverPanel } from '@/components/chat/panel/ChatSlideOverPanel';
 import { AppTopBar } from '@/components/layout/AppNav/AppTopBar';
+import { isImmersiveRoute } from '@/components/layout/AppNav/immersive-routes';
 import { MobileBottomBar } from '@/components/layout/AppNav/MobileBottomBar';
 import { MobileTopBar } from '@/components/layout/AppNav/MobileTopBar';
 import { SideDrawer } from '@/components/layout/SideDrawer/SideDrawer';
+import { cn } from '@/lib/utils';
 
 import { SessionBanner } from './SessionBanner';
 
@@ -19,9 +23,14 @@ interface DesktopShellProps {
  * Desktop/tablet: {@link AppTopBar}. Mobile: {@link MobileTopBar} (☰ → drawer) +
  * {@link MobileBottomBar}. The hamburger drawer holds the secondary destinations
  * ("tutto il resto"); the bottom bar holds the 5 primary tabs.
+ *
+ * The bottom-bar clearance padding is dropped on immersive routes, where the
+ * bottom bar hides itself (kept in sync via {@link isImmersiveRoute}).
  */
 export function DesktopShell({ children }: DesktopShellProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const pathname = usePathname();
+  const immersive = isImmersiveRoute(pathname);
 
   return (
     <div className="min-h-dvh flex flex-col bg-[var(--bg)]">
@@ -30,7 +39,10 @@ export function DesktopShell({ children }: DesktopShellProps) {
 
       <SessionBanner />
 
-      <main id="main-content" className="flex-1 overflow-y-auto overflow-x-clip pb-16 md:pb-0">
+      <main
+        id="main-content"
+        className={cn('flex-1 overflow-y-auto overflow-x-clip', !immersive && 'pb-16 md:pb-0')}
+      >
         {children}
       </main>
 

--- a/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/DesktopShell.test.tsx
@@ -25,6 +25,10 @@ vi.mock('@/components/layout/UserShell/SessionBanner', () => ({
   SessionBanner: () => null,
 }));
 
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+}));
+
 import { DesktopShell } from '../DesktopShell';
 
 describe('DesktopShell', () => {
@@ -55,5 +59,14 @@ describe('DesktopShell', () => {
       </DesktopShell>
     );
     expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('applies bottom-bar clearance padding on non-immersive routes', () => {
+    render(
+      <DesktopShell>
+        <div>child</div>
+      </DesktopShell>
+    );
+    expect(screen.getByRole('main').className).toContain('pb-16');
   });
 });


### PR DESCRIPTION
## Follow-up minors dalla code review della PR #1638 (navbar sp4)

1. **Bottom-bar padding condizionale** — `DesktopShell` applicava `pb-16` su `<main>` anche sulle rotte immersive dove `MobileBottomBar` si nasconde (ghost padding 64px). Ora applicato solo se `!isImmersiveRoute(pathname)`. `isImmersiveRoute` estratto in `AppNav/immersive-routes.ts`, condiviso da `MobileBottomBar` + `DesktopShell`.
2. **e2e stale** — rimossi i test su `mobile-tab-bar` in `mobile-card-browser.spec.ts` (componente `MobileTabBar` e route `/hub` index inesistenti). Copertura bottom bar in `bottom-nav.spec.ts`.

## Test
- typecheck ✅ · eslint ✅ · vitest AppNav + DesktopShell 20/20 ✅
- nuovo test: `DesktopShell` applica `pb-16` su rotte non immersive

🤖 Generated with [Claude Code](https://claude.com/claude-code)