### PR TITLE
feat(events): #1590 cross-entity event sourcing + GET /api/v1/activity (BE-3)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/ActivityItemDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/ActivityItemDto.cs
@@ -1,0 +1,31 @@
+namespace Api.BoundedContexts.Administration.Application.Queries.ActivityFeed;
+
+/// <summary>
+/// Represents a single activity item in the cross-entity feed.
+/// Returned by <see cref="GetActivityFeedQuery"/> (BE-3 #1590 Task 8).
+/// </summary>
+/// <param name="Id">Row id of the <c>domain_event_logs</c> entry.</param>
+/// <param name="EventId">Idempotency-safe event id (deduplicated per event source).</param>
+/// <param name="EventType">Stable event type alias (e.g. "agent.created", "session.finalized").</param>
+/// <param name="UserId">User that caused the event.</param>
+/// <param name="EntityType">
+/// Clean entity type name derived from EventType:
+/// "Agent" | "ChatSession" | "PdfDocument" | "Session" | "UserLibraryEntry".
+/// </param>
+/// <param name="EntityId">The aggregate / entity id extracted from the event payload or <c>AggregateId</c>.</param>
+/// <param name="Title">Human-readable title extracted from the event payload (e.g. agent name, game name).</param>
+/// <param name="Timestamp">When the event occurred (domain clock).</param>
+/// <param name="LoggedAt">When the row was persisted to <c>domain_event_logs</c>.</param>
+/// <param name="PayloadVersion">Schema version of the event payload (currently always 1).</param>
+internal sealed record ActivityItemDto(
+    Guid Id,
+    Guid EventId,
+    string EventType,
+    Guid UserId,
+    string EntityType,
+    Guid EntityId,
+    string? Title,
+    DateTime Timestamp,
+    DateTime LoggedAt,
+    int PayloadVersion
+);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQuery.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.ActivityFeed;
+
+/// <summary>
+/// Query that returns the cross-entity activity feed for a specific user.
+/// Reads from <c>domain_event_logs</c>, filtered by <see cref="UserId"/>,
+/// with a 90-day retention window, ordered by <c>LoggedAt DESC</c>.
+/// BE-3 #1590 Task 8.
+/// </summary>
+/// <param name="UserId">The user whose events are fetched (caller-scoped).</param>
+/// <param name="Limit">Maximum number of items to return. Validated: 1..100, default 20.</param>
+/// <param name="Since">Optional upper-bound cursor: only events logged before this timestamp.</param>
+internal sealed record GetActivityFeedQuery(
+    Guid UserId,
+    int Limit = 20,
+    DateTime? Since = null
+) : IQuery<GetActivityFeedResult>;
+
+/// <summary>Result envelope returned by <see cref="GetActivityFeedQuery"/>.</summary>
+/// <param name="Items">Activity items ordered by LoggedAt DESC.</param>
+/// <param name="Count">Count of items in this page (equals Items.Count).</param>
+internal sealed record GetActivityFeedResult(
+    List<ActivityItemDto> Items,
+    int Count
+);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQueryHandler.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.ActivityFeed;
+
+/// <summary>
+/// Handles <see cref="GetActivityFeedQuery"/>: reads cross-entity activity from
+/// <c>domain_event_logs</c> scoped to the requesting user (90-day retention,
+/// ordered by <c>LoggedAt DESC</c>, limited by <see cref="GetActivityFeedQuery.Limit"/>).
+///
+/// EventType → EntityType mapping (stable contract, not raw AggregateType):
+/// <list type="bullet">
+///   <item>agent.created → Agent</item>
+///   <item>chat.session.created → ChatSession</item>
+///   <item>kb.doc.indexed → PdfDocument</item>
+///   <item>session.created | session.finalized → Session</item>
+///   <item>library.entry.removed | library.session.recorded → UserLibraryEntry</item>
+///   <item>(default) → raw AggregateType or EventType</item>
+/// </list>
+///
+/// BE-3 #1590 Task 8.
+/// </summary>
+internal sealed class GetActivityFeedQueryHandler
+    : IQueryHandler<GetActivityFeedQuery, GetActivityFeedResult>
+{
+    private const int RetentionDays = 90;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetActivityFeedQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<GetActivityFeedResult> Handle(
+        GetActivityFeedQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var retentionCutoff = DateTime.UtcNow.AddDays(-RetentionDays);
+
+        var query = _db.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.UserId == request.UserId && e.LoggedAt >= retentionCutoff);
+
+        if (request.Since.HasValue)
+        {
+            query = query.Where(e => e.LoggedAt < request.Since.Value);
+        }
+
+        var rows = await query
+            .OrderByDescending(e => e.LoggedAt)
+            .Take(request.Limit)
+            .Select(e => new
+            {
+                e.Id,
+                e.EventId,
+                e.EventType,
+                e.UserId,
+                e.AggregateId,
+                e.AggregateType,
+                e.PayloadJson,
+                e.OccurredAt,
+                e.LoggedAt,
+                e.PayloadVersion,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows.Select(r =>
+        {
+            var entityType = MapEntityType(r.EventType, r.AggregateType);
+            var entityId = r.AggregateId ?? r.Id;
+            var title = ExtractTitle(r.EventType, r.PayloadJson);
+
+            return new ActivityItemDto(
+                Id: r.Id,
+                EventId: r.EventId,
+                EventType: r.EventType,
+                UserId: r.UserId!.Value,
+                EntityType: entityType,
+                EntityId: entityId,
+                Title: title,
+                Timestamp: r.OccurredAt,
+                LoggedAt: r.LoggedAt,
+                PayloadVersion: r.PayloadVersion
+            );
+        }).ToList();
+
+        return new GetActivityFeedResult(items, items.Count);
+    }
+
+    /// <summary>
+    /// Maps the stable <paramref name="eventType"/> alias to a clean entity type name.
+    /// Falls back to <paramref name="aggregateType"/> (raw domain type) when unknown.
+    /// </summary>
+    private static string MapEntityType(string eventType, string? aggregateType)
+    {
+        return eventType switch
+        {
+            "agent.created" => "Agent",
+            "chat.session.created" => "ChatSession",
+            "kb.doc.indexed" => "PdfDocument",
+            "session.created" or "session.finalized" => "Session",
+            "library.entry.removed" or "library.session.recorded" => "UserLibraryEntry",
+            _ => aggregateType ?? eventType,
+        };
+    }
+
+    /// <summary>
+    /// Best-effort title extraction from the camelCase JSON payload.
+    /// Returns null when the field is absent or the payload cannot be parsed.
+    /// </summary>
+    private static string? ExtractTitle(string eventType, string payloadJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(payloadJson);
+            var root = doc.RootElement;
+
+            switch (eventType)
+            {
+                case "agent.created":
+                    return TryGetString(root, "agentName");
+
+                case "chat.session.created":
+                    return TryGetString(root, "agentName") ?? TryGetString(root, "gameName");
+
+                case "kb.doc.indexed":
+                    return TryGetString(root, "fileName");
+
+                case "session.created":
+                case "session.finalized":
+                    return TryGetString(root, "gameName");
+
+                default:
+                    return null;
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetString(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop)
+            && prop.ValueKind == JsonValueKind.String)
+        {
+            var value = prop.GetString();
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/ActivityFeed/GetActivityFeedQueryValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.ActivityFeed;
+
+/// <summary>
+/// Validates <see cref="GetActivityFeedQuery"/> before it reaches the handler.
+/// Validation failures surface as HTTP 422 via <c>ApiExceptionHandlerMiddleware</c>.
+/// </summary>
+internal sealed class GetActivityFeedQueryValidator : AbstractValidator<GetActivityFeedQuery>
+{
+    public GetActivityFeedQueryValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId must not be empty.");
+
+        RuleFor(x => x.Limit)
+            .InclusiveBetween(1, 100)
+            .WithMessage("limit must be between 1 and 100.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -380,6 +380,23 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
 
         // Emit domain event for real-time updates (Issue #4218)
         AddDomainEvent(new PdfStateChangedEvent(Id, previousState, newState, UploadedByUserId));
+
+        // BE-3 #1590 B2: when entering Ready, also raise a dedicated KbDocIndexedEvent for the
+        // activity log. PdfStateChangedEvent stays for internal handlers (cache, metrics, UI
+        // real-time); KbDocIndexedEvent is the user-meaningful "doc indexed" milestone for the
+        // activity rail. gameName is null — resolved query-time by the activity endpoint via
+        // SharedGameRepository (pure domain method has no repository access).
+        if (newState == PdfProcessingState.Ready)
+        {
+            AddDomainEvent(new KbDocIndexedEvent(
+                aggregateId: Id,
+                userId: UploadedByUserId,
+                fileName: FileName.Value,
+                gameId: SharedGameId,
+                gameName: null,
+                pageCount: PageCount
+            ));
+        }
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs
@@ -1,0 +1,96 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
+
+/// <summary>
+/// Raised by <see cref="Api.BoundedContexts.DocumentProcessing.Domain.Entities.PdfDocument"/>
+/// when <c>TransitionTo(Ready)</c> succeeds — the PDF is now fully indexed and searchable via RAG.
+///
+/// Registered in <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/>
+/// with alias <c>"kb.doc.indexed"</c>. BE-3 #1590.
+///
+/// <para><b>Why NOT <c>PdfStateChangedEvent</c>?</b>
+/// <c>PdfStateChangedEvent</c> fires on EVERY state transition (internal: cache invalidation,
+/// metrics, UI real-time updates). Registering it in EventTypeRegistry would produce one log
+/// row per pipeline step = log explosion. <c>KbDocIndexedEvent</c> fires ONLY on the Ready
+/// terminal transition, representing the single user-meaningful "doc indexed" milestone for
+/// the activity rail. Decision B3 from #1590 spec panel.</para>
+///
+/// <para><b>gameName resolution strategy (design decision opt-a):</b>
+/// <c>PdfDocument.TransitionTo</c> is a pure domain method with no repository access.
+/// The event carries <c>GameName = null</c>. The Task 8 activity endpoint resolves the
+/// game name at query time via <c>SharedGameRepository.GetNamesByIds</c> using the
+/// persisted <c>GameId</c> value. <c>FileName</c> is the PRIMARY rail title because it
+/// is available on the aggregate and uniquely identifies the indexed document to the user.</para>
+///
+/// <para><b>Mapper conventions (DomainEventLogMapper):</b>
+/// <list type="bullet">
+///   <item><c>AggregateId</c> → <c>domain_event_logs.aggregate_id</c> (reflection lookup)</item>
+///   <item><c>UserId</c>      → <c>domain_event_logs.user_id</c> (reflection lookup)</item>
+///   <item>Class name minus "Event" suffix → <c>domain_event_logs.aggregate_type = "KbDocIndexed"</c></item>
+///   <item>Payload serialized with <c>JsonNamingPolicy.CamelCase</c> → keys: fileName, gameId, gameName, pageCount</item>
+/// </list></para>
+/// </summary>
+internal sealed class KbDocIndexedEvent : DomainEventBase
+{
+    /// <summary>
+    /// The <c>PdfDocument</c> id. Named <c>AggregateId</c> so
+    /// <see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/> reflection
+    /// populates <c>domain_event_logs.aggregate_id</c> without a custom mapper override.
+    /// </summary>
+    public Guid AggregateId { get; }
+
+    /// <summary>
+    /// The user who uploaded the document. Reflected to <c>domain_event_logs.user_id</c>.
+    /// Sourced from <c>PdfDocument.UploadedByUserId</c>.
+    /// </summary>
+    public Guid UserId { get; }
+
+    /// <summary>
+    /// The PDF file name (e.g. "catan-rulebook.pdf"). Primary rail title — available
+    /// directly on the aggregate, no repository access needed.
+    /// </summary>
+    public string FileName { get; }
+
+    /// <summary>
+    /// The shared game this document belongs to (<c>PdfDocument.SharedGameId</c>).
+    /// Null for private-game documents (<c>PdfDocument.PrivateGameId</c> is set instead).
+    /// </summary>
+    public Guid? GameId { get; }
+
+    /// <summary>
+    /// Always <c>null</c> at emit time. Resolved at query time by the Task 8 activity
+    /// endpoint via <c>SharedGameRepository.GetNamesByIds</c>. Included in the payload
+    /// schema so forward-compatible consumers can expect the field without a v2 migration.
+    /// </summary>
+    public string? GameName { get; }
+
+    /// <summary>
+    /// Total pages in the PDF, if the extraction pipeline populated it.
+    /// May be null if the processing worker did not set <c>PdfDocument.PageCount</c>
+    /// before emitting the Ready transition.
+    /// </summary>
+    public int? PageCount { get; }
+
+    /// <param name="aggregateId">The <c>PdfDocument</c> id.</param>
+    /// <param name="userId">The uploading user's id (<c>PdfDocument.UploadedByUserId</c>).</param>
+    /// <param name="fileName">The file name string (<c>PdfDocument.FileName.Value</c>).</param>
+    /// <param name="gameId">Shared game id, if any (<c>PdfDocument.SharedGameId</c>).</param>
+    /// <param name="gameName">Always null at emit — resolved query-time.</param>
+    /// <param name="pageCount">Page count if available (<c>PdfDocument.PageCount</c>).</param>
+    public KbDocIndexedEvent(
+        Guid aggregateId,
+        Guid userId,
+        string fileName,
+        Guid? gameId,
+        string? gameName,
+        int? pageCount)
+    {
+        AggregateId = aggregateId;
+        UserId = userId;
+        FileName = fileName;
+        GameId = gameId;
+        GameName = gameName;
+        PageCount = pageCount;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Infrastructure.Entities;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -13,21 +14,25 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 /// <summary>
 /// Handler for CreateChatSessionCommand.
 /// Issue #3483: Chat Session Persistence Service.
+/// BE-3 #1590: ISharedGameRepository injected to resolve gameName for ChatSessionCreatedEvent payload.
 /// </summary>
 internal sealed class CreateChatSessionCommandHandler : IRequestHandler<CreateChatSessionCommand, Guid>
 {
     private readonly IChatSessionRepository _sessionRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IRagAccessService _ragAccessService;
     private readonly ILogger<CreateChatSessionCommandHandler> _logger;
 
     public CreateChatSessionCommandHandler(
         IChatSessionRepository sessionRepository,
+        ISharedGameRepository sharedGameRepository,
         IUnitOfWork unitOfWork,
         IRagAccessService ragAccessService,
         ILogger<CreateChatSessionCommandHandler> logger)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _ragAccessService = ragAccessService ?? throw new ArgumentNullException(nameof(ragAccessService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -81,6 +86,18 @@ internal sealed class CreateChatSessionCommandHandler : IRequestHandler<CreateCh
             }
         }
 
+        // Resolve gameName for the ChatSessionCreatedEvent payload (BE-3 #1590 H2).
+        // The event must carry gameName so the activity rail can show a meaningful title
+        // without a secondary join at read time.
+        string? gameName = null;
+        if (request.GameId != Guid.Empty)
+        {
+            var names = await _sharedGameRepository
+                .GetNamesByIdsAsync(new[] { request.GameId }, cancellationToken)
+                .ConfigureAwait(false);
+            names.TryGetValue(request.GameId, out gameName);
+        }
+
         var sessionId = Guid.NewGuid();
 
         var session = new ChatSession(
@@ -93,7 +110,8 @@ internal sealed class CreateChatSessionCommandHandler : IRequestHandler<CreateCh
             agentConfigJson: request.AgentConfigJson,
             agentId: request.AgentId,
             agentType: request.AgentType,
-            agentName: request.AgentName);
+            agentName: request.AgentName,
+            gameName: gameName);
 
         await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs
@@ -108,7 +108,15 @@ internal sealed class CreateUserAgentCommandHandler
         // Activate so it shows up in the user's agent list immediately.
         if (!agent.IsActive) agent.Activate();
 
+        // BE-3 #1590 H1: emit agent.created ONLY from the user-facing flow.
+        // gameName is already resolved above (line that calls GetNamesByIdsAsync).
+        // Called BEFORE AddAsync so AgentDefinitionRepository.AddAsync.CollectDomainEvents()
+        // picks up this event alongside AgentDefinitionCreatedEvent in a single collection pass,
+        // ensuring the log row is written atomically with the agent row in SaveChangesAsync.
+        agent.RaiseUserCreatedEvent(request.UserId, gameName);
+
         await _repository.AddAsync(agent, cancellationToken).ConfigureAwait(false);
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Record usage so CanPerformAsync reflects the new count on next call (Redis atomic counter).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AgentCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AgentCreatedEventHandler.cs
@@ -22,13 +22,14 @@ internal sealed class AgentCreatedEventHandler : DomainEventHandlerBase<AgentCre
 
     protected override Dictionary<string, object?>? GetAuditMetadata(AgentCreatedEvent domainEvent)
     {
-        return new Dictionary<string, object?>
-(StringComparer.Ordinal)
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["Action"] = "AgentCreated",
-            ["AgentId"] = domainEvent.AgentId,
-            ["Type"] = domainEvent.Type,
-            ["Name"] = domainEvent.Name
+            ["AgentId"] = domainEvent.AggregateId,
+            ["Type"] = domainEvent.AgentType,
+            ["Name"] = domainEvent.AgentName,
+            ["GameId"] = domainEvent.GameId,
+            ["GameName"] = domainEvent.GameName,
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs
@@ -588,4 +588,23 @@ public sealed class AgentDefinition : AggregateRoot<Guid>
 
         AddDomainEvent(new AgentDefinitionUpdatedEvent(Id, "Restored from soft-delete"));
     }
+
+    /// <summary>
+    /// Raises <see cref="AgentCreatedEvent"/> for durable activity-log persistence.
+    /// Call ONLY from <c>CreateUserAgentCommandHandler</c> (user-facing flow).
+    /// NOT called from <c>CreateAgentDefinitionCommandHandler</c> (admin/AI-Lab) — see BE-3 #1590 decision H1.
+    /// </summary>
+    /// <param name="userId">The authenticated user who triggered the creation.</param>
+    /// <param name="gameName">Resolved game name; non-null when <see cref="GameId"/> is set.</param>
+    public void RaiseUserCreatedEvent(Guid userId, string? gameName)
+    {
+        AddDomainEvent(new AgentCreatedEvent(
+            aggregateId: Id,
+            userId: userId,
+            agentType: _typeValue,
+            isActive: _isActive,
+            gameId: _gameId,
+            gameName: gameName,
+            agentName: _name));
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ChatSession.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ChatSession.cs
@@ -42,6 +42,8 @@ internal sealed class ChatSession : AggregateRoot<Guid>
     /// <summary>
     /// Creates a new chat session.
     /// Issue #4913: Added AgentId/AgentType/AgentName for grouped history.
+    /// BE-3 #1590: gameName added so the ChatSessionCreatedEvent carries a complete
+    /// payload for the activity rail without a secondary join.
     /// </summary>
     public ChatSession(
         Guid id,
@@ -53,7 +55,8 @@ internal sealed class ChatSession : AggregateRoot<Guid>
         string? agentConfigJson = null,
         Guid? agentId = null,
         string? agentType = null,
-        string? agentName = null) : base(id)
+        string? agentName = null,
+        string? gameName = null) : base(id)
     {
         if (userId == Guid.Empty)
             throw new ArgumentException("UserId cannot be empty", nameof(userId));
@@ -73,7 +76,13 @@ internal sealed class ChatSession : AggregateRoot<Guid>
         LastMessageAt = CreatedAt;
         IsArchived = false;
 
-        AddDomainEvent(new ChatSessionCreatedEvent(id, userId, gameId));
+        AddDomainEvent(new ChatSessionCreatedEvent(
+            sessionId: id,
+            userId: userId,
+            gameId: gameId,
+            gameName: gameName,
+            agentId: agentId,
+            agentName: agentName));
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs
@@ -2,16 +2,73 @@ using Api.SharedKernel.Domain.Events;
 
 namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
 
+/// <summary>
+/// Domain event raised when a user creates a new agent via <c>CreateUserAgentCommand</c>
+/// (user-facing flow — quick-create / POST /agents/user).
+///
+/// NOT raised for the admin/AI-Lab path (<c>CreateAgentDefinitionCommand</c>).
+/// Decision H1 from BE-3 spec panel #1590.
+///
+/// Registered in <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/>
+/// with alias <c>"agent.created"</c>.
+///
+/// <para><b>Mapper conventions (DomainEventLogMapper):</b>
+/// <list type="bullet">
+///   <item><c>UserId</c> → <c>domain_event_logs.user_id</c> (reflection lookup)</item>
+///   <item><c>AggregateId</c> → <c>domain_event_logs.aggregate_id</c> (reflection lookup)</item>
+///   <item>Class name minus "Event" suffix → <c>domain_event_logs.aggregate_type = "AgentCreated"</c></item>
+///   <item>Payload serialized with <c>JsonNamingPolicy.CamelCase</c></item>
+/// </list></para>
+/// </summary>
 internal sealed class AgentCreatedEvent : DomainEventBase
 {
-    public Guid AgentId { get; }
-    public string Type { get; }
-    public string Name { get; }
+    /// <summary>
+    /// Logical FK to <c>agent_definitions.id</c>. Named <c>AggregateId</c> so
+    /// <see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/> reflection
+    /// populates <c>domain_event_logs.aggregate_id</c> without a custom mapper override.
+    /// </summary>
+    public Guid AggregateId { get; }
 
-    public AgentCreatedEvent(Guid agentId, string type, string name)
+    /// <summary>User who triggered the creation. Reflected to <c>domain_event_logs.user_id</c>.</summary>
+    public Guid UserId { get; }
+
+    /// <summary>Agent type value (e.g. "Tutor", "RAG").</summary>
+    public string AgentType { get; }
+
+    /// <summary>Whether the agent was immediately activated (always true for user flow).</summary>
+    public bool IsActive { get; }
+
+    /// <summary>Optional SharedGame the agent is linked to.</summary>
+    public Guid? GameId { get; }
+
+    /// <summary>Resolved game name at creation time. Null if no game linked.</summary>
+    public string? GameName { get; }
+
+    /// <summary>Resolved agent name (auto-derived or caller-supplied).</summary>
+    public string AgentName { get; }
+
+    /// <param name="aggregateId">The new agent definition id (<c>agent_definitions.id</c>).</param>
+    /// <param name="userId">The user who created the agent.</param>
+    /// <param name="agentType">Agent type value string.</param>
+    /// <param name="isActive">Whether the agent was activated on creation.</param>
+    /// <param name="gameId">Optional game the agent is linked to.</param>
+    /// <param name="gameName">Resolved game name (non-null when <paramref name="gameId"/> is set).</param>
+    /// <param name="agentName">Resolved agent name.</param>
+    public AgentCreatedEvent(
+        Guid aggregateId,
+        Guid userId,
+        string agentType,
+        bool isActive,
+        Guid? gameId,
+        string? gameName,
+        string agentName)
     {
-        AgentId = agentId;
-        Type = type;
-        Name = name;
+        AggregateId = aggregateId;
+        UserId = userId;
+        AgentType = agentType;
+        IsActive = isActive;
+        GameId = gameId;
+        GameName = gameName;
+        AgentName = agentName;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs
@@ -9,6 +9,15 @@ namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
 /// BE-3 #1590 H2: registered in <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/>
 /// with alias <c>"chat.session.created"</c> (matches real command name, not fictional CreateChatThreadCommand).
 ///
+/// <para><b>Payload fields (H2 spec):</b>
+/// <list type="bullet">
+///   <item><c>GameId</c> — game the session belongs to (always present)</item>
+///   <item><c>GameName</c> — display name resolved via ISharedGameRepository (null when game not found)</item>
+///   <item><c>AgentId</c> — custom agent definition id (null for system-agent or bare chat)</item>
+///   <item><c>AgentName</c> — display name copied from aggregate (null when no agent)</item>
+/// </list>
+/// Required so the Task 8 activity rail can show title-meaningful chat items without a join.</para>
+///
 /// <para><b>Mapper conventions (DomainEventLogMapper):</b>
 /// <list type="bullet">
 ///   <item><c>UserId</c> → <c>domain_event_logs.user_id</c> (reflection lookup)</item>
@@ -34,10 +43,38 @@ internal sealed class ChatSessionCreatedEvent : DomainEventBase
     /// <summary>The game associated with this chat session.</summary>
     public Guid GameId { get; }
 
-    public ChatSessionCreatedEvent(Guid sessionId, Guid userId, Guid gameId)
+    /// <summary>
+    /// Display name of the game, resolved at creation time via ISharedGameRepository.
+    /// Null when the game is not found in the catalog (edge case: deleted / pending import).
+    /// BE-3 #1590 H2: required for activity rail title rendering without a join.
+    /// </summary>
+    public string? GameName { get; }
+
+    /// <summary>
+    /// Id of the custom AgentDefinition used for this session.
+    /// Null when a system agent type (auto/tutor/arbitro/decisore) is used, or for bare chat.
+    /// </summary>
+    public Guid? AgentId { get; }
+
+    /// <summary>
+    /// Display name of the agent. Copied from ChatSession.AgentName at creation time.
+    /// Null when no agent is configured.
+    /// </summary>
+    public string? AgentName { get; }
+
+    public ChatSessionCreatedEvent(
+        Guid sessionId,
+        Guid userId,
+        Guid gameId,
+        string? gameName,
+        Guid? agentId,
+        string? agentName)
     {
         AggregateId = sessionId;
         UserId = userId;
         GameId = gameId;
+        GameName = gameName;
+        AgentId = agentId;
+        AgentName = agentName;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs
@@ -3,18 +3,40 @@ using Api.SharedKernel.Domain.Events;
 namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
 
 /// <summary>
-/// Domain event raised when a chat session is created.
+/// Domain event raised when a user creates a new chat session via <c>CreateChatSessionCommand</c>.
 /// Issue #3483: Chat Session Persistence Service.
+///
+/// BE-3 #1590 H2: registered in <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/>
+/// with alias <c>"chat.session.created"</c> (matches real command name, not fictional CreateChatThreadCommand).
+///
+/// <para><b>Mapper conventions (DomainEventLogMapper):</b>
+/// <list type="bullet">
+///   <item><c>UserId</c> → <c>domain_event_logs.user_id</c> (reflection lookup)</item>
+///   <item><c>AggregateId</c> → <c>domain_event_logs.aggregate_id</c> (reflection lookup, aliases SessionId)</item>
+///   <item>Class name minus "Event" suffix → <c>domain_event_logs.aggregate_type = "ChatSessionCreated"</c></item>
+///   <item>Payload serialized with <c>JsonNamingPolicy.CamelCase</c></item>
+/// </list></para>
 /// </summary>
 internal sealed class ChatSessionCreatedEvent : DomainEventBase
 {
-    public Guid SessionId { get; }
+    /// <summary>The new chat session's id. Named <c>AggregateId</c> so
+    /// <see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/> reflection
+    /// populates <c>domain_event_logs.aggregate_id</c> without a custom mapper override.
+    /// </summary>
+    public Guid AggregateId { get; }
+
+    /// <summary>Preserved for backward-compat with existing callers (aliases AggregateId).</summary>
+    public Guid SessionId => AggregateId;
+
+    /// <summary>User who triggered the creation. Reflected to <c>domain_event_logs.user_id</c>.</summary>
     public Guid UserId { get; }
+
+    /// <summary>The game associated with this chat session.</summary>
     public Guid GameId { get; }
 
     public ChatSessionCreatedEvent(Guid sessionId, Guid userId, Guid gameId)
     {
-        SessionId = sessionId;
+        AggregateId = sessionId;
         UserId = userId;
         GameId = gameId;
     }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/AgentType.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/ValueObjects/AgentType.cs
@@ -47,6 +47,12 @@ public sealed record AgentType
     /// </summary>
     public static AgentType Narrator => new("Narrator", "Storyteller for immersive game narrative and lore");
 
+    /// <summary>
+    /// Tutor agent: Learning-focused assistant for teaching game rules and onboarding.
+    /// BE-3 #1590 / Issue #659 Phase δ.1: quick-create default type.
+    /// </summary>
+    public static AgentType Tutor => new("Tutor", "Learning-focused assistant for teaching game rules and onboarding");
+
     public string Value { get; }
     public string Description { get; }
 
@@ -82,6 +88,7 @@ public sealed record AgentType
             "CONVERSATION" => ConversationAgent,
             "STRATEGIST" => Strategist,
             "NARRATOR" => Narrator,
+            "TUTOR" => Tutor,
             "DECISORE" => Strategist, // Backward-compatible alias
             _ => throw new ArgumentException($"Unknown AgentType: {value}", nameof(value))
         };

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
@@ -80,6 +80,11 @@ public sealed class AgentDefinitionRepository : RepositoryBase, IAgentDefinition
         // ADR-056: repository methods mutate the change-tracker only.
         // Callers are responsible for invoking IUnitOfWork.SaveChangesAsync(ct).
         await DbContext.Set<AgentDefinition>().AddAsync(agentDefinition, cancellationToken).ConfigureAwait(false);
+        // Collect domain events raised on the aggregate before or at AddAsync time so that
+        // MeepleAiDbContext.SaveChangesAsync can read them from _eventCollector.PeekEvents()
+        // and write domain_event_logs rows atomically with the agent row.
+        // BE-3 #1590: supports agent.created event raised via RaiseUserCreatedEvent().
+        CollectDomainEvents(agentDefinition);
     }
 
     public Task UpdateAsync(AgentDefinition agentDefinition, CancellationToken cancellationToken = default)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -6,6 +6,7 @@ using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Exceptions;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
@@ -81,6 +82,15 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
 
         var sessionType = Enum.Parse<SessionType>(request.SessionType);
 
+        // BE-3 #1590: resolve the game title ONCE (invariant across retries) — reused for both
+        // the domain event snapshot (session.created) and the GameNight link entity below.
+        var gameTitle = await _db.SharedGames
+            .AsNoTracking()
+            .Where(g => g.Id == request.GameId)
+            .Select(g => g.Title)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false) ?? "Unknown Game";
+
         // Create session with retry for unique code
         Session session;
         const int maxRetries = 3;
@@ -126,17 +136,25 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                 }
             }
 
+            // BE-3 #1590: emit session.created BEFORE AddAsync so the durable domain_event_logs
+            // row is collected (SessionRepository.AddAsync calls CollectDomainEvents) and committed
+            // atomically with the session + the session_events diary row in one SaveChangesAsync.
+            // Timestamp uses _timeProvider (same clock as the diary row) so the AC5.b cross-table
+            // proximity assertion holds even under a fake test clock.
+            session.AddDomainEvent(new SessionCreatedEvent
+            {
+                SessionId = session.Id,
+                UserId = request.UserId,
+                SessionCode = session.SessionCode,
+                GameId = request.GameId,
+                GameName = gameTitle,
+                PlayerCount = session.Participants.Count,
+                Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
+            });
+
             try
             {
                 await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
-
-                // Session Flow v2.1 — T4: Link session to the GameNight envelope.
-                var gameTitle = await _db.SharedGames
-                    .AsNoTracking()
-                    .Where(g => g.Id == request.GameId)
-                    .Select(g => g.Title)
-                    .FirstOrDefaultAsync(cancellationToken)
-                    .ConfigureAwait(false) ?? "Unknown Game";
 
                 // I2 fix: enforce max 5 sessions per GameNight (domain invariant bypass guard)
                 var existingSessionCount = await _db.GameNightSessions

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
@@ -81,6 +81,41 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
         // Update participant final ranks (need to access through persistence for now)
         // For now, this is a known limitation that will be addressed in refactoring
 
+        // BE-3 #1590: emit session.finalized domain event BEFORE UpdateAsync so it is collected
+        // (SessionRepository.UpdateAsync calls CollectDomainEvents — Task 5) and durably logged to
+        // domain_event_logs atomically with the session update + the session_events diary row below.
+        // This MediatR dispatch ALSO activates the previously-dormant KnowledgeBase
+        // SessionFinalizedEventHandler cascade cleanup (it was raised for SSE only until now).
+        var winnerIdForEvent = request.FinalRanks.FirstOrDefault(kvp => kvp.Value == 1).Key;
+        var winnerNameForEvent = winnerIdForEvent != Guid.Empty
+            ? session.Participants.FirstOrDefault(p => p.Id == winnerIdForEvent)?.DisplayName
+            : null;
+        var finalizedAtForEvent = session.FinalizedAt ?? _timeProvider.GetUtcNow().UtcDateTime;
+        var durationMinutesForEvent = Math.Max(0, (int)(finalizedAtForEvent - session.SessionDate).TotalMinutes);
+        string? gameNameForEvent = null;
+        if (session.GameId != Guid.Empty)
+        {
+            gameNameForEvent = await _db.SharedGames
+                .AsNoTracking()
+                .Where(g => g.Id == session.GameId)
+                .Select(g => g.Title)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        session.AddDomainEvent(new SessionFinalizedEvent
+        {
+            SessionId = session.Id,
+            UserId = session.UserId,
+            GameId = session.GameId,
+            GameName = gameNameForEvent,
+            PlayerCount = session.Participants.Count,
+            WinnerId = winnerIdForEvent != Guid.Empty ? winnerIdForEvent : null,
+            WinnerName = winnerNameForEvent,
+            FinalRanks = request.FinalRanks,
+            DurationMinutes = durationMinutesForEvent,
+            Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
+        });
+
         // Save session (adds tracked changes; SaveChangesAsync below flushes)
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -2,15 +2,44 @@ using System.ComponentModel.DataAnnotations;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.Interfaces;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
 
 /// <summary>
 /// Session aggregate root representing a collaborative game session.
 /// </summary>
-public class Session
+/// <remarks>
+/// Implements <see cref="IDomainEventSource"/> so that domain events (e.g.
+/// <c>session.created</c>, <c>session.finalized</c>) can be raised and collected
+/// by the <c>domain_event_logs</c> pipeline (BE-3 #1590).  This is a light,
+/// additive change — Session is NOT converted to a full AggregateRoot subclass;
+/// its existing factory, value-objects, and persistence mapping are unchanged.
+/// </remarks>
+public class Session : IDomainEventSource
 {
     private readonly List<Participant> _participants = [];
+
+    // ── Domain event plumbing (BE-3 #1590, C1) ──────────────────────────────
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    /// <summary>
+    /// Appends a domain event to the pending-events list.
+    /// Called by domain methods after state transitions (e.g. Create, Finalize).
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="domainEvent"/> is null.</exception>
+    public void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _domainEvents.Add(domainEvent);
+    }
+
+    /// <inheritdoc />
+    public void ClearDomainEvents() => _domainEvents.Clear();
+    // ── End domain event plumbing ────────────────────────────────────────────
 
     /// <summary>
     /// Session unique identifier.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs
@@ -1,11 +1,22 @@
-using MediatR;
+using Api.SharedKernel.Domain.Interfaces;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Events;
 
 /// <summary>
 /// Domain event raised when a new session is created.
+///
+/// <para>BE-3 #1590: now implements <see cref="IDomainEvent"/> so it is durably persisted to
+/// <c>domain_event_logs</c> (registered with alias <c>"session.created"</c>) and powers the
+/// cross-entity activity rail. Orthogonal to the <c>session_events</c> diary "session_created"
+/// row (#1590 C3 socratic resolution — same milestone, different consumers/durability).</para>
+///
+/// <para>Mapper conventions (<see cref="Api.Infrastructure.DomainEventLog.DomainEventLogMapper"/>):
+/// AggregateType derived "SessionCreated"; AggregateId/UserId read via reflection; payload
+/// camelCase. <see cref="GameName"/> is a snapshot taken at emit time (resilient to SharedGame
+/// soft-delete). <see cref="OccurredAt"/> and <see cref="AggregateId"/> are aliases over the
+/// existing <see cref="Timestamp"/>/<see cref="SessionId"/> so no duplicate state is stored.</para>
 /// </summary>
-public record SessionCreatedEvent : INotification
+public record SessionCreatedEvent : IDomainEvent
 {
     /// <summary>
     /// Session unique identifier.
@@ -28,7 +39,32 @@ public record SessionCreatedEvent : INotification
     public Guid? GameId { get; init; }
 
     /// <summary>
+    /// Game title snapshot at emit time (null if unresolved). BE-3 #1590 — rail display title.
+    /// </summary>
+    public string? GameName { get; init; }
+
+    /// <summary>
+    /// Number of participants in the session at creation. BE-3 #1590.
+    /// </summary>
+    public int PlayerCount { get; init; }
+
+    /// <summary>
     /// When the session was created.
     /// </summary>
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Unique identifier for this event instance (IDomainEvent — idempotency, AC1).
+    /// </summary>
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// IDomainEvent occurrence time — alias over <see cref="Timestamp"/>.
+    /// </summary>
+    public DateTime OccurredAt => Timestamp;
+
+    /// <summary>
+    /// Aggregate id read by the DomainEventLog mapper — alias over <see cref="SessionId"/>.
+    /// </summary>
+    public Guid AggregateId => SessionId;
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs
@@ -1,11 +1,23 @@
-using MediatR;
+using Api.SharedKernel.Domain.Interfaces;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Events;
 
 /// <summary>
 /// Domain event raised when a session is finalized.
+///
+/// <para>BE-3 #1590: now implements <see cref="IDomainEvent"/> so it is durably persisted to
+/// <c>domain_event_logs</c> (registered with alias <c>"session.finalized"</c>) for the cross-entity
+/// activity rail. Adding this event to the Session aggregate's collection ALSO activates the
+/// previously-dormant <c>KnowledgeBase.SessionFinalizedEventHandler</c> (cascade cleanup of
+/// AgentSessions) via the MediatR dispatch in <c>MeepleAiDbContext.SaveChangesAsync</c> — that
+/// handler was wired but never fired because no code raised the event into the MediatR pipeline.</para>
+///
+/// <para>Mapper conventions: AggregateType derived "SessionFinalized"; AggregateId/UserId read via
+/// reflection; payload camelCase. <see cref="GameName"/>/<see cref="WinnerName"/> are snapshots at
+/// emit time. <see cref="OccurredAt"/> and <see cref="AggregateId"/> alias the existing
+/// <see cref="Timestamp"/>/<see cref="SessionId"/> so no duplicate state is stored.</para>
 /// </summary>
-public record SessionFinalizedEvent : INotification
+public record SessionFinalizedEvent : IDomainEvent
 {
     /// <summary>
     /// Session unique identifier.
@@ -13,9 +25,34 @@ public record SessionFinalizedEvent : INotification
     public Guid SessionId { get; init; }
 
     /// <summary>
+    /// User who owns the session (mapper reads this for the UserId column). BE-3 #1590.
+    /// </summary>
+    public Guid UserId { get; init; }
+
+    /// <summary>
+    /// Game reference. BE-3 #1590.
+    /// </summary>
+    public Guid GameId { get; init; }
+
+    /// <summary>
+    /// Game title snapshot at emit time (null if unresolved). BE-3 #1590 — rail display title.
+    /// </summary>
+    public string? GameName { get; init; }
+
+    /// <summary>
+    /// Number of participants in the session. BE-3 #1590.
+    /// </summary>
+    public int PlayerCount { get; init; }
+
+    /// <summary>
     /// Winner participant ID (if applicable).
     /// </summary>
     public Guid? WinnerId { get; init; }
+
+    /// <summary>
+    /// Winner participant display name snapshot (if applicable). BE-3 #1590 — rail detail.
+    /// </summary>
+    public string? WinnerName { get; init; }
 
     /// <summary>
     /// Final ranks for all participants (ParticipantId -> Rank).
@@ -31,4 +68,19 @@ public record SessionFinalizedEvent : INotification
     /// When the session was finalized.
     /// </summary>
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Unique identifier for this event instance (IDomainEvent — idempotency, AC1).
+    /// </summary>
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// IDomainEvent occurrence time — alias over <see cref="Timestamp"/>.
+    /// </summary>
+    public DateTime OccurredAt => Timestamp;
+
+    /// <summary>
+    /// Aggregate id read by the DomainEventLog mapper — alias over <see cref="SessionId"/>.
+    /// </summary>
+    public Guid AggregateId => SessionId;
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -82,6 +82,10 @@ public class SessionRepository : RepositoryBase, ISessionRepository
             throw new InvalidOperationException($"Session code {session.SessionCode} already exists.");
         }
 
+        // BE-3 #1590 (C2): collect domain events (e.g. session.created) before persistence
+        // so they are dispatched atomically with the SaveChangesAsync call upstream.
+        CollectDomainEvents(session);
+
         var entity = SessionMapper.ToEntity(session);
         await DbContext.SessionTrackingSessions.AddAsync(entity, ct).ConfigureAwait(false);
     }
@@ -89,6 +93,10 @@ public class SessionRepository : RepositoryBase, ISessionRepository
     public async Task UpdateAsync(Session session, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(session);
+
+        // BE-3 #1590 (C2): collect domain events (e.g. session.finalized) before persistence
+        // so they are dispatched atomically with the SaveChangesAsync call upstream.
+        CollectDomainEvents(session);
 
         // Retrieve existing entity to preserve EF Core tracking
         var existing = await DbContext.SessionTrackingSessions

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -16,7 +16,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
 /// Repository implementation for the <see cref="MechanicAnalysis"/> aggregate (ADR-051 / M1.1).
 /// </summary>
 /// <remarks>
-/// Audit-via-repository pattern: before clearing domain events via <see cref="RepositoryBase.CollectDomainEvents"/>,
+/// Audit-via-repository pattern: before clearing domain events via <see cref="RepositoryBase.CollectDomainEvents(Api.SharedKernel.Domain.Interfaces.IAggregateRoot)"/>,
 /// the repository inspects the aggregate's pending events and synthesizes corresponding rows in
 /// <c>mechanic_status_audit</c> / <c>mechanic_suppression_audit</c> into the same <see cref="DbContext"/>.
 /// Because all inserts share the same <see cref="DbContext.SaveChangesAsync(CancellationToken)"/>

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.UserLibrary.Application.DTOs;
 using Api.BoundedContexts.UserLibrary.Domain.ValueObjects;
 using Api.Infrastructure;
@@ -13,8 +14,14 @@ namespace Api.BoundedContexts.UserLibrary.Application.Queries;
 /// Reads from TWO disjoint sources (spec §3.5 hardened):
 ///   (a) <c>UserLibraryEntries</c> rows — projects <c>added</c> and
 ///       <c>state-changed</c> from row timestamps (legacy MVP path).
+///       Titles are resolved via EF navigation properties (<c>SharedGame</c>
+///       / <c>PrivateGame</c>) at query time — no extra round-trip.
 ///   (b) <c>domain_event_logs</c> — projects <c>removed</c> and
 ///       <c>session-recorded</c> from durable event log rows (post-#661).
+///       Titles are resolved via a single bulk call to
+///       <see cref="ISharedGameRepository.GetNamesByIdsAsync"/> (D1 #1590).
+///       Soft-deleted or unknown games fall back to
+///       <c>"library.activity.deletedGame"</c> (D2 #1590).
 ///
 /// The two sources are disjoint (no overlapping kinds), so the merge is
 /// a straight ordered union. Pagination is cursor-based on
@@ -26,12 +33,18 @@ internal class GetLibraryActivityQueryHandler
     : IQueryHandler<GetLibraryActivityQuery, IReadOnlyList<LibraryActivityItemDto>>
 {
     private const int DefaultRetentionDays = 90;
+    private const string DeletedGameI18NKey = "library.activity.deletedGame";
 
     private readonly MeepleAiDbContext _dbContext;
+    private readonly ISharedGameRepository _sharedGameRepository;
 
-    public GetLibraryActivityQueryHandler(MeepleAiDbContext dbContext)
+    public GetLibraryActivityQueryHandler(
+        MeepleAiDbContext dbContext,
+        ISharedGameRepository sharedGameRepository)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
     }
 
     public async Task<IReadOnlyList<LibraryActivityItemDto>> Handle(
@@ -114,9 +127,28 @@ internal class GetLibraryActivityQueryHandler
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // D1 (#1590): resolve game titles for all log rows in ONE bulk call —
+        // no N+1. Parse gameIds first, then fetch names once.
+        var logGameIds = logRows
+            .Select(l => ExtractGameId(l.PayloadJson))
+            .Where(id => id != Guid.Empty)
+            .Distinct()
+            .ToList();
+
+        var gameNames = logGameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(logGameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : (IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>();
+
         foreach (var log in logRows)
         {
-            var (gameId, gameTitle) = ExtractGamePayload(log.PayloadJson, log.EventType);
+            var gameId = ExtractGameId(log.PayloadJson);
+            // D2 (#1590): soft-deleted or unknown game → i18n key so the FE
+            // can render "Gioco rimosso" / "Removed game" in the user's locale.
+            var gameTitle = gameId != Guid.Empty && gameNames.TryGetValue(gameId, out var name)
+                ? name
+                : DeletedGameI18NKey;
             var aggregateId = log.AggregateId ?? log.Id;
 
             switch (log.EventType)
@@ -153,36 +185,29 @@ internal class GetLibraryActivityQueryHandler
     }
 
     /// <summary>
-    /// Best-effort extraction of <c>GameId</c> + game title from a logged
-    /// event payload. The payload schema is the event class itself
-    /// (camelCase JSON). Until we add denormalized title columns we resolve
-    /// titles by joining the game catalogs — for the removed case the
-    /// library entry is gone, so we display the game id as a fallback.
+    /// Best-effort extraction of <c>GameId</c> from a logged event payload.
+    /// The payload schema is the event class itself (camelCase JSON).
+    /// Returns <see cref="Guid.Empty"/> when the property is absent or the
+    /// JSON is malformed.
     /// </summary>
-    private static (Guid gameId, string gameTitle) ExtractGamePayload(string payloadJson, string eventType)
+    private static Guid ExtractGameId(string payloadJson)
     {
         try
         {
             using var doc = JsonDocument.Parse(payloadJson);
             var root = doc.RootElement;
 
-            Guid gameId = Guid.Empty;
             if (root.TryGetProperty("gameId", out var gameIdEl) &&
                 gameIdEl.TryGetGuid(out var parsedGameId))
             {
-                gameId = parsedGameId;
+                return parsedGameId;
             }
 
-            // Future enhancement: persist a `gameTitle` snapshot in the event
-            // payload so the activity feed survives game-catalog deletions.
-            // For now, the i18n message reads "Game" when the title can't be
-            // resolved.
-            var gameTitle = gameId == Guid.Empty ? "Unknown" : "Game";
-            return (gameId, gameTitle);
+            return Guid.Empty;
         }
         catch (JsonException)
         {
-            return (Guid.Empty, "Unknown");
+            return Guid.Empty;
         }
     }
 }

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/DomainEventLogMapper.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/DomainEventLogMapper.cs
@@ -48,6 +48,7 @@ public static class DomainEventLogMapper
             AggregateId = aggregateId,
             AggregateType = aggregateType,
             PayloadJson = JsonSerializer.Serialize(domainEvent, domainEvent.GetType(), PayloadJsonOptions),
+            PayloadVersion = 1,
             OccurredAt = domainEvent.OccurredAt,
             LoggedAt = DateTime.UtcNow,
         };

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.UserLibrary.Domain.Events;
 using Api.SharedKernel.Domain.Interfaces;
@@ -43,6 +44,11 @@ public static class EventTypeRegistry
         // H2: chat.session.created matches the real command name (CreateChatSessionCommand).
         //     Alias uses "session" not "thread" — the BE has no CreateChatThreadCommand.
         [typeof(ChatSessionCreatedEvent)] = "chat.session.created",
+
+        // H3: kb.doc.indexed fires ONLY when PdfDocument.TransitionTo(Ready) succeeds.
+        //     PdfStateChangedEvent (fires on every transition) remains UNREGISTERED to avoid
+        //     log explosion (one row per pipeline step). Decision B3 from #1590 spec panel.
+        [typeof(KbDocIndexedEvent)] = "kb.doc.indexed",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.UserLibrary.Domain.Events;
 using Api.SharedKernel.Domain.Interfaces;
 
@@ -33,6 +34,11 @@ public static class EventTypeRegistry
         // Adding a type does NOT change the existing in-memory dispatch behavior.
         [typeof(GameRemovedFromLibraryEvent)] = "library.entry.removed",
         [typeof(GameSessionRecordedEvent)] = "library.session.recorded",
+
+        // BE-3 #1590 — cross-entity activity feed events (user-facing flows only).
+        // H1: agent.created is emitted SOLELY from CreateUserAgentCommand (user flow).
+        //     NOT from CreateAgentDefinitionCommand (admin/AI-Lab path).
+        [typeof(AgentCreatedEvent)] = "agent.created",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.UserLibrary.Domain.Events;
 using Api.SharedKernel.Domain.Interfaces;
 
@@ -49,6 +50,11 @@ public static class EventTypeRegistry
         //     PdfStateChangedEvent (fires on every transition) remains UNREGISTERED to avoid
         //     log explosion (one row per pipeline step). Decision B3 from #1590 spec panel.
         [typeof(KbDocIndexedEvent)] = "kb.doc.indexed",
+
+        // SessionTracking lifecycle. session.created is orthogonal to the session_events diary
+        // "session_created" row (#1590 C3 — different consumers). session.finalized is added in
+        // Task 7 (after SessionFinalizedEvent implements IDomainEvent).
+        [typeof(SessionCreatedEvent)] = "session.created",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -52,9 +52,11 @@ public static class EventTypeRegistry
         [typeof(KbDocIndexedEvent)] = "kb.doc.indexed",
 
         // SessionTracking lifecycle. session.created is orthogonal to the session_events diary
-        // "session_created" row (#1590 C3 — different consumers). session.finalized is added in
-        // Task 7 (after SessionFinalizedEvent implements IDomainEvent).
+        // "session_created" row (#1590 C3 — different consumers). session.finalized also (re)wires
+        // the previously-dormant KnowledgeBase SessionFinalizedEventHandler cascade cleanup (the
+        // event was raised for SSE only, never into the MediatR pipeline, until BE-3).
         [typeof(SessionCreatedEvent)] = "session.created",
+        [typeof(SessionFinalizedEvent)] = "session.finalized",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -39,6 +39,10 @@ public static class EventTypeRegistry
         // H1: agent.created is emitted SOLELY from CreateUserAgentCommand (user flow).
         //     NOT from CreateAgentDefinitionCommand (admin/AI-Lab path).
         [typeof(AgentCreatedEvent)] = "agent.created",
+
+        // H2: chat.session.created matches the real command name (CreateChatSessionCommand).
+        //     Alias uses "session" not "thread" — the BE has no CreateChatThreadCommand.
+        [typeof(ChatSessionCreatedEvent)] = "chat.session.created",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs
@@ -29,14 +29,31 @@ public class DomainEventLogEntity
     /// <summary>The user associated with the event, when applicable.</summary>
     public Guid? UserId { get; set; }
 
-    /// <summary>The aggregate root that raised the event.</summary>
-    public Guid? AggregateId { get; set; }
-
-    /// <summary>Short type label of the aggregate, e.g. "UserLibraryEntry".</summary>
+    /// <summary>
+    /// PascalCase aggregate name. Logical FK pointer to a specific aggregate table:
+    ///   - "Session"     → sessions_tracking.id
+    ///   - "Agent"       → agent_definitions.id
+    ///   - "ChatSession" → chat_sessions.id
+    ///   - "PdfDocument" → pdf_documents.id
+    ///   - "UserLibraryEntry" → user_library_entries.id (existing library.* events)
+    /// Not enforced at DB level — append-only audit log policy (AC9, #1590).
+    /// </summary>
     public string? AggregateType { get; set; }
+
+    /// <summary>
+    /// Logical FK to the aggregate root. See <see cref="AggregateType"/> for the mapping
+    /// from PascalCase aggregate name to physical table.
+    /// </summary>
+    public Guid? AggregateId { get; set; }
 
     /// <summary>JSON-serialized event payload.</summary>
     public string PayloadJson { get; set; } = default!;
+
+    /// <summary>
+    /// Schema version of the event payload, used for forward-compatible migrations.
+    /// v1 events: PayloadVersion = 1. New payload schemas (with breaking changes) increment this.
+    /// </summary>
+    public int PayloadVersion { get; set; } = 1;
 
     /// <summary>
     /// From <see cref="Api.SharedKernel.Domain.Interfaces.IDomainEvent.OccurredAt"/>.

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DomainEventLogEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DomainEventLogEntityConfiguration.cs
@@ -31,6 +31,9 @@ internal class DomainEventLogEntityConfiguration : IEntityTypeConfiguration<Doma
             .IsRequired();
         builder.Property(e => e.OccurredAt).IsRequired();
         builder.Property(e => e.LoggedAt).IsRequired();
+        builder.Property(e => e.PayloadVersion)
+            .IsRequired()
+            .HasDefaultValue(1);
 
         // Primary query path: activity feed reads `WHERE UserId = caller AND LoggedAt >= cutoff ORDER BY LoggedAt DESC`.
         builder.HasIndex(e => new { e.UserId, e.LoggedAt })

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -1,5 +1,6 @@
 using Api.Infrastructure.DomainEventLog;
 using Api.Infrastructure.Entities;
+using Api.Observability;
 using Api.Infrastructure.Entities.Administration;
 using Api.Infrastructure.Entities.Authentication;
 using Api.Infrastructure.Entities.DocumentProcessing;
@@ -449,6 +450,10 @@ public class MeepleAiDbContext : DbContext
                 if (logEntity is not null)
                 {
                     DomainEventLogs.Add(logEntity);
+                    // G1 (#1590 AC7): one counter tick per durable row added.
+                    MeepleAiMetrics.DomainEventsInserted.Add(
+                        1,
+                        new KeyValuePair<string, object?>("event_type", logEntity.EventType));
                 }
             }
         }
@@ -475,6 +480,18 @@ public class MeepleAiDbContext : DbContext
                 _logger?.LogError(ex,
                     "MediatR.Publish failed for domain event {EventType} (EventId={EventId}); log row already committed",
                     domainEvent.GetType().Name, domainEvent.EventId);
+
+                // G2 (#1590 AC7): expose the otherwise-silent handler crash.
+                // event_type uses the registry alias (CLR-type fallback) so it JOINS with the
+                // G1 inserted.total counter on the same label value. handler_name uses the CLR
+                // type name because MediatR.Publish dispatches to all handlers internally — the
+                // specific failing handler is not available in this scope (acceptable for v1;
+                // only SessionFinalizedEvent has >1 handler).
+                var eventAlias = EventTypeRegistry.TryResolve(domainEvent) ?? domainEvent.GetType().Name;
+                MeepleAiMetrics.DomainEventDispatchFailures.Add(
+                    1,
+                    new KeyValuePair<string, object?>("event_type", eventAlias),
+                    new KeyValuePair<string, object?>("handler_name", domainEvent.GetType().Name));
             }
 #pragma warning restore CA1031
         }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260527192206_AddPayloadVersionToDomainEventLogs.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260527192206_AddPayloadVersionToDomainEventLogs.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527192206_AddPayloadVersionToDomainEventLogs")]
+    partial class AddPayloadVersionToDomainEventLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260527192206_AddPayloadVersionToDomainEventLogs.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260527192206_AddPayloadVersionToDomainEventLogs.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPayloadVersionToDomainEventLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PayloadVersion",
+                table: "domain_event_logs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PayloadVersion",
+                table: "domain_event_logs");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs
@@ -1,0 +1,33 @@
+// BE-3 #1590 AC7: Domain event log persistence counters
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>
+    /// G1: Incremented once per domain_event_logs row successfully inserted.
+    /// Tag: event_type — the registered alias (e.g. "agent.created") from EventTypeRegistry.
+    /// </summary>
+    public static readonly Counter<long> DomainEventsInserted = Meter.CreateCounter<long>(
+        name: "meepleai.domain_event_log.inserted.total",
+        unit: "events",
+        description: "Total domain events persisted to domain_event_logs by event type (#1590 G1)");
+
+    /// <summary>
+    /// G2: Incremented when a MediatR notification handler throws after the
+    /// domain_event_log row is already durably committed (row is NOT rolled back).
+    /// Tags:
+    ///   event_type   — the registered alias (e.g. "agent.created"), with CLR-type fallback
+    ///                  for unregistered events. Matches G1's event_type so the two counters
+    ///                  JOIN on the same label value in dashboards/alerts.
+    ///   handler_name — MediatR dispatches to all handlers internally, so the individual
+    ///                  handler name is not available here; set to the event CLR type name
+    ///                  to keep the tag cardinality bounded (only SessionFinalizedEvent has &gt;1
+    ///                  handler — acceptable for v1 without a custom INotificationPublisher).
+    /// </summary>
+    public static readonly Counter<long> DomainEventDispatchFailures = Meter.CreateCounter<long>(
+        name: "meepleai.domain_event_log.dispatch_failures.total",
+        unit: "failures",
+        description: "Total handler dispatch failures after domain event persisted (#1590 G2)");
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -746,6 +746,7 @@ v1Api.MapModelEndpoints(); // Issue #3377: AI model configuration endpoints
 v1Api.MapLlmEndpoints(); // ISSUE-2391: Sprint 2 - LLM provider management
 v1Api.MapAiEndpoints();
 v1Api.MapAgentsEndpoints(); // Issue #641 (Wave B.2 hotfix): user-facing agent listing
+v1Api.MapActivityFeedEndpoints(); // BE-3 #1590 Task 8: cross-entity activity feed from domain_event_logs
 v1Api.MapAgentTypologiesEndpoints(); // Issue #649: user-facing typology dropdown
 v1Api.MapRulebookAnalysisEndpoints(); // ISSUE-2402: Rulebook analysis service
 

--- a/apps/api/src/Api/Routing/ActivityFeedEndpoints.cs
+++ b/apps/api/src/Api/Routing/ActivityFeedEndpoints.cs
@@ -1,0 +1,64 @@
+using Api.BoundedContexts.Administration.Application.Queries.ActivityFeed;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// User-facing cross-entity activity feed endpoint.
+/// Reads from <c>domain_event_logs</c> scoped to the authenticated caller.
+/// BE-3 #1590 Task 8 — <c>GET /api/v1/activity</c>.
+/// </summary>
+internal static class ActivityFeedEndpoints
+{
+    public static RouteGroupBuilder MapActivityFeedEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetActivityFeedEndpoint(group);
+        return group;
+    }
+
+    private static void MapGetActivityFeedEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/activity", async (
+            [FromQuery] int? limit,
+            [FromQuery] DateTime? since,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var userId = session!.Principal!.Subject!.Id;
+
+            var query = new GetActivityFeedQuery(
+                UserId: userId,
+                Limit: limit ?? 20,
+                Since: since
+            );
+
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return Results.Ok(new
+            {
+                success = true,
+                items = result.Items,
+                count = result.Count,
+            });
+        })
+        .RequireAuthenticatedUser()
+        .Produces(200)
+        .Produces(401)
+        .Produces(422)
+        .WithTags("Activity")
+        .WithSummary("Get cross-entity activity feed")
+        .WithDescription(
+            "Returns the caller's cross-entity activity feed from domain_event_logs. " +
+            "Events are scoped to the authenticated user, filtered to the last 90 days, " +
+            "ordered by loggedAt DESC. " +
+            "?limit (1-100, default 20), ?since (cursor: only events before this timestamp). " +
+            "BE-3 #1590.")
+        .WithOpenApi();
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Domain/Interfaces/IDomainEventSource.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Interfaces/IDomainEventSource.cs
@@ -1,0 +1,26 @@
+namespace Api.SharedKernel.Domain.Interfaces;
+
+/// <summary>
+/// Lightweight alternative to <see cref="IAggregateRoot"/> for domain objects that need to raise
+/// domain events but cannot (or should not) inherit from the <c>AggregateRoot&lt;TId&gt;</c> base class.
+/// <para>
+/// Extends <see cref="IAggregateRoot"/> so that any implementation satisfies the existing
+/// <c>IDomainEventCollector.CollectEventsFrom</c> and <c>RepositoryBase.CollectDomainEvents</c>
+/// overloads without requiring changes to the collection infrastructure.
+/// </para>
+/// <para>
+/// BE-3 #1590: introduced to let <c>Session</c> (SessionTracking BC) participate in the
+/// <c>domain_event_logs</c> pipeline without a full <c>AggregateRoot&lt;TId&gt;</c> conversion.
+/// </para>
+/// </summary>
+public interface IDomainEventSource : IAggregateRoot
+{
+    /// <summary>
+    /// Appends a domain event to the pending-events list.
+    /// Called by domain methods immediately after a state transition (e.g.
+    /// <c>Session.Create</c>, <c>Session.Finalize</c>).
+    /// </summary>
+    /// <param name="domainEvent">The event to enqueue. Must not be <see langword="null"/>.</param>
+    /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="domainEvent"/> is null.</exception>
+    void AddDomainEvent(IDomainEvent domainEvent);
+}

--- a/apps/api/src/Api/SharedKernel/Infrastructure/RepositoryBase.cs
+++ b/apps/api/src/Api/SharedKernel/Infrastructure/RepositoryBase.cs
@@ -38,4 +38,23 @@ public abstract class RepositoryBase
             aggregate.ClearDomainEvents();
         }
     }
+
+    /// <summary>
+    /// Collects domain events from a domain object that implements
+    /// <see cref="IDomainEventSource"/> but is not a full <see cref="IAggregateRoot"/>
+    /// subclass (e.g. <c>Session</c> in SessionTracking BC — BE-3 #1590).
+    /// Because <see cref="IDomainEventSource"/> extends <see cref="IAggregateRoot"/> the
+    /// existing <see cref="IDomainEventCollector.CollectEventsFrom"/> overload is reused
+    /// without any modification to the collector.
+    /// </summary>
+    protected void CollectDomainEvents(IDomainEventSource source)
+    {
+        if (source == null) return;
+
+        if (source.DomainEvents.Count > 0)
+        {
+            EventCollector.CollectEventsFrom(source);
+            source.ClearDomainEvents();
+        }
+    }
 }

--- a/apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs
+++ b/apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+/// <summary>
+/// AC8 (BE-3 #1590 C3.1) — drift-prevention guard ensuring the two orthogonal
+/// event-log tables remain decoupled at the handler level.
+///
+/// Architecture invariant:
+///   session_events    → owned exclusively by SessionTracking BC
+///   domain_event_logs → owned exclusively by the durable event log pipeline
+///
+/// The two tables are intentionally disjoint (spec §3.5 hardened).
+/// <see cref="GetSessionDiaryQueryHandler"/> reads session_events only;
+/// <see cref="GetLibraryActivityQueryHandler"/> reads domain_event_logs only.
+///
+/// NOTE on boundary style: both handlers share <c>MeepleAiDbContext</c>, so the
+/// boundary is by-convention (each handler accesses only its own DbSet).
+/// This test enforces that neither handler has been coupled to the OTHER table
+/// via a dedicated repository interface (<c>ISessionEventRepository</c> or a
+/// hypothetical <c>IDomainEventLogRepository</c>). It also documents the intent
+/// so a future refactor introducing explicit repository types does not silently
+/// cross the boundary.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Architecture")]
+public sealed class EventLogBoundaryTests
+{
+    // -----------------------------------------------------------------------
+    // AC8 — GetSessionDiaryQueryHandler must NOT cross into domain_event_logs
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// The session-diary handler reads only <c>session_events</c>. It must never
+    /// be given a repository or service whose name contains "DomainEventLog".
+    /// </summary>
+    [Fact]
+    public void GetSessionDiaryQueryHandler_does_NOT_depend_on_domain_event_log_infrastructure()
+    {
+        var paramTypeNames = CtorParamTypeNames(typeof(GetSessionDiaryQueryHandler));
+
+        paramTypeNames.Should().NotContain(
+            n => n.Contains("DomainEventLog", StringComparison.Ordinal),
+            "session diary reads session_events only — introducing a DomainEventLog dependency would cross the orthogonal table boundary (BE-3 #1590 AC8 / C3.1)");
+    }
+
+    // -----------------------------------------------------------------------
+    // AC8 — GetLibraryActivityQueryHandler must NOT cross into session_events
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// The library-activity handler reads only <c>domain_event_logs</c> and
+    /// <c>user_library_entries</c>. It must never be given a repository or
+    /// service whose name contains "SessionEvent".
+    /// </summary>
+    [Fact]
+    public void GetLibraryActivityQueryHandler_does_NOT_depend_on_session_events_infrastructure()
+    {
+        var paramTypeNames = CtorParamTypeNames(typeof(GetLibraryActivityQueryHandler));
+
+        paramTypeNames.Should().NotContain(
+            n => n.Contains("SessionEvent", StringComparison.Ordinal),
+            "library activity reads domain_event_logs only — introducing a SessionEvent dependency would cross the orthogonal table boundary (BE-3 #1590 AC8 / C3.1)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns the simple type name of every parameter in the first public
+    /// instance constructor of <paramref name="handlerType"/>. Uses reflection
+    /// so the assertions survive parameter reordering without maintenance.
+    /// </summary>
+    private static string[] CtorParamTypeNames(Type handlerType)
+    {
+        var ctor = handlerType
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .First();
+
+        return ctor
+            .GetParameters()
+            .Select(p => p.ParameterType.Name)
+            .ToArray();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/CreateChatSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ChatSession/CreateChatSessionCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -16,11 +17,13 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.ChatSessi
 /// <summary>
 /// Tests for CreateChatSessionCommandHandler.
 /// Issue #3483: Chat Session Persistence Service.
+/// BE-3 #1590: ISharedGameRepository added to resolve gameName for ChatSessionCreatedEvent.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 public class CreateChatSessionCommandHandlerTests
 {
     private readonly Mock<IChatSessionRepository> _mockRepository;
+    private readonly Mock<ISharedGameRepository> _mockSharedGameRepository;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly Mock<ILogger<CreateChatSessionCommandHandler>> _mockLogger;
     private readonly CreateChatSessionCommandHandler _handler;
@@ -28,10 +31,18 @@ public class CreateChatSessionCommandHandlerTests
     public CreateChatSessionCommandHandlerTests()
     {
         _mockRepository = new Mock<IChatSessionRepository>();
+        _mockSharedGameRepository = new Mock<ISharedGameRepository>();
         _mockUnitOfWork = new Mock<IUnitOfWork>();
         _mockLogger = new Mock<ILogger<CreateChatSessionCommandHandler>>();
+
+        // Default: return empty names dict (no game name resolution needed for most tests)
+        _mockSharedGameRepository
+            .Setup(r => r.GetNamesByIdsAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>());
+
         _handler = new CreateChatSessionCommandHandler(
             _mockRepository.Object,
+            _mockSharedGameRepository.Object,
             _mockUnitOfWork.Object,
             CreatePermissiveRagAccessServiceMock(),
             _mockLogger.Object);
@@ -178,6 +189,21 @@ public class CreateChatSessionCommandHandlerTests
         Action act = () =>
             new CreateChatSessionCommandHandler(
                 null!,
+                _mockSharedGameRepository.Object,
+                _mockUnitOfWork.Object,
+                CreatePermissiveRagAccessServiceMock(),
+                _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullSharedGameRepository_ThrowsArgumentNullException()
+    {
+        // Act & Assert — BE-3 #1590: ISharedGameRepository is required
+        Action act = () =>
+            new CreateChatSessionCommandHandler(
+                _mockRepository.Object,
+                null!,
                 _mockUnitOfWork.Object,
                 CreatePermissiveRagAccessServiceMock(),
                 _mockLogger.Object);
@@ -191,6 +217,7 @@ public class CreateChatSessionCommandHandlerTests
         Action act = () =>
             new CreateChatSessionCommandHandler(
                 _mockRepository.Object,
+                _mockSharedGameRepository.Object,
                 null!,
                 CreatePermissiveRagAccessServiceMock(),
                 _mockLogger.Object);
@@ -204,6 +231,7 @@ public class CreateChatSessionCommandHandlerTests
         Action act = () =>
             new CreateChatSessionCommandHandler(
                 _mockRepository.Object,
+                _mockSharedGameRepository.Object,
                 _mockUnitOfWork.Object,
                 CreatePermissiveRagAccessServiceMock(),
                 null!);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Events/KnowledgeBaseDomainEventsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Events/KnowledgeBaseDomainEventsTests.cs
@@ -12,20 +12,35 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Domain.Events;
 public sealed class KnowledgeBaseDomainEventsTests
 {
     #region AgentCreatedEvent Tests
+    // BE-3 #1590: AgentCreatedEvent extended with UserId, GameId, GameName, IsActive, AggregateId.
+    // Constructor signature: (aggregateId, userId, agentType, isActive, gameId, gameName, agentName).
 
     [Fact]
     public void AgentCreatedEvent_SetsProperties()
     {
         // Arrange
         var agentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
 
         // Act
-        var evt = new AgentCreatedEvent(agentId, "RulesAgent", "Catan Rules Helper");
+        var evt = new AgentCreatedEvent(
+            aggregateId: agentId,
+            userId: userId,
+            agentType: "RulesAgent",
+            isActive: true,
+            gameId: gameId,
+            gameName: "Catan",
+            agentName: "Catan Rules Helper");
 
         // Assert
-        evt.AgentId.Should().Be(agentId);
-        evt.Type.Should().Be("RulesAgent");
-        evt.Name.Should().Be("Catan Rules Helper");
+        evt.AggregateId.Should().Be(agentId);
+        evt.UserId.Should().Be(userId);
+        evt.AgentType.Should().Be("RulesAgent");
+        evt.IsActive.Should().BeTrue();
+        evt.GameId.Should().Be(gameId);
+        evt.GameName.Should().Be("Catan");
+        evt.AgentName.Should().Be("Catan Rules Helper");
     }
 
     [Fact]
@@ -34,16 +49,17 @@ public sealed class KnowledgeBaseDomainEventsTests
         // Arrange
         var agentId1 = Guid.NewGuid();
         var agentId2 = Guid.NewGuid();
+        var userId = Guid.NewGuid();
 
         // Act
-        var evt1 = new AgentCreatedEvent(agentId1, "RulesAgent", "Rules Helper");
-        var evt2 = new AgentCreatedEvent(agentId2, "StrategyAgent", "Strategy Guide");
+        var evt1 = new AgentCreatedEvent(agentId1, userId, "RulesAgent", true, null, null, "Rules Helper");
+        var evt2 = new AgentCreatedEvent(agentId2, userId, "StrategyAgent", true, null, null, "Strategy Guide");
 
         // Assert
-        evt1.Type.Should().Be("RulesAgent");
-        evt1.Name.Should().Be("Rules Helper");
-        evt2.Type.Should().Be("StrategyAgent");
-        evt2.Name.Should().Be("Strategy Guide");
+        evt1.AgentType.Should().Be("RulesAgent");
+        evt1.AgentName.Should().Be("Rules Helper");
+        evt2.AgentType.Should().Be("StrategyAgent");
+        evt2.AgentName.Should().Be("Strategy Guide");
     }
 
     [Fact]
@@ -51,12 +67,13 @@ public sealed class KnowledgeBaseDomainEventsTests
     {
         // Arrange
         var agentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
 
         // Act
-        var evt = new AgentCreatedEvent(agentId, "TestAgent", "");
+        var evt = new AgentCreatedEvent(agentId, userId, "TestAgent", false, null, null, "");
 
         // Assert
-        evt.Name.Should().BeEmpty();
+        evt.AgentName.Should().BeEmpty();
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionDomainEventTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionDomainEventTests.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.SharedKernel.Domain.Events;
+using Api.SharedKernel.Domain.Interfaces;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Unit tests verifying that <see cref="Session"/> implements <see cref="IDomainEventSource"/>
+/// correctly (BE-3 #1590, C1 — light IDomainEventSource plumbing, no events emitted yet).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionDomainEventTests
+{
+    // A minimal concrete event used only for testing the list plumbing.
+    // Extends DomainEventBase — the established pattern in this codebase.
+    private sealed class TestSessionEvent : DomainEventBase { }
+
+    [Fact]
+    public void Session_implements_IDomainEventSource()
+    {
+        typeof(Session).Should().Implement<IDomainEventSource>(
+            because: "BE-3 #1590 requires Session to participate in the domain_event_logs pipeline");
+    }
+
+    [Fact]
+    public void AddDomainEvent_adds_event_to_DomainEvents()
+    {
+        var session = CreateValidSession();
+        var evt = new TestSessionEvent();
+
+        session.AddDomainEvent(evt);
+
+        session.DomainEvents.Should().Contain(evt,
+            because: "AddDomainEvent must enqueue the event for later collection");
+    }
+
+    [Fact]
+    public void ClearDomainEvents_empties_list()
+    {
+        var session = CreateValidSession();
+        session.AddDomainEvent(new TestSessionEvent());
+        session.AddDomainEvent(new TestSessionEvent());
+
+        session.ClearDomainEvents();
+
+        session.DomainEvents.Should().BeEmpty(
+            because: "ClearDomainEvents is called by the repository after the collector drains events");
+    }
+
+    [Fact]
+    public void AddDomainEvent_null_throws_ArgumentNullException()
+    {
+        var session = CreateValidSession();
+
+        var act = () => session.AddDomainEvent(null!);
+
+        act.Should().Throw<ArgumentNullException>(
+            because: "passing null must be rejected to prevent silent event-loss in the pipeline");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static Session CreateValidSession() =>
+        Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.UserLibrary.Application.Queries;
 using Api.BoundedContexts.UserLibrary.Domain.ValueObjects;
 using Api.Infrastructure;
@@ -17,7 +18,7 @@ namespace Api.Tests.BoundedContexts.UserLibrary.Application.Queries;
 /// <summary>
 /// Unit tests for <see cref="GetLibraryActivityQueryHandler"/> issue #661 PR-B.
 /// Covers AC-5 (full integration of log + row sources), AC-6 (retention filter),
-/// AC-12 (merge/order correctness).
+/// AC-12 (merge/order correctness), D1/D2 (#1590 bulk join + soft-delete i18n key).
 ///
 /// Uses EF Core InMemory; the production EF query is straightforward LINQ that
 /// translates to the same in-memory result, so the assertions hold across
@@ -28,6 +29,7 @@ namespace Api.Tests.BoundedContexts.UserLibrary.Application.Queries;
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "UserLibrary")]
 [Trait("Issue", "661")]
+[Trait("Issue", "1590")]
 public sealed class GetLibraryActivityQueryHandlerTests
 {
     private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
@@ -43,6 +45,21 @@ public sealed class GetLibraryActivityQueryHandlerTests
             options,
             Mock.Of<IMediator>(),
             Mock.Of<IDomainEventCollector>());
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="ISharedGameRepository"/> that returns the given
+    /// name map from <c>GetNamesByIdsAsync</c>.
+    /// </summary>
+    private static ISharedGameRepository CreateSharedGameRepo(
+        IReadOnlyDictionary<Guid, string>? nameMap = null)
+    {
+        var mock = new Mock<ISharedGameRepository>();
+        mock.Setup(r => r.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(nameMap ?? new Dictionary<Guid, string>());
+        return mock.Object;
     }
 
     // -----------------------------------------------------------------------
@@ -70,12 +87,14 @@ public sealed class GetLibraryActivityQueryHandlerTests
         });
         await db.SaveChangesAsync();
 
-        var handler = new GetLibraryActivityQueryHandler(db);
+        var repo = CreateSharedGameRepo(new Dictionary<Guid, string> { [gameId] = "Catan" });
+        var handler = new GetLibraryActivityQueryHandler(db, repo);
         var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
 
         result.Should().ContainSingle();
         result[0].Type.Should().Be("removed");
         result[0].GameId.Should().Be(gameId);
+        result[0].GameTitle.Should().Be("Catan");
     }
 
     // -----------------------------------------------------------------------
@@ -103,12 +122,14 @@ public sealed class GetLibraryActivityQueryHandlerTests
         });
         await db.SaveChangesAsync();
 
-        var handler = new GetLibraryActivityQueryHandler(db);
+        var repo = CreateSharedGameRepo(new Dictionary<Guid, string> { [gameId] = "Pandemic" });
+        var handler = new GetLibraryActivityQueryHandler(db, repo);
         var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
 
         result.Should().ContainSingle();
         result[0].Type.Should().Be("session-recorded");
         result[0].GameId.Should().Be(gameId);
+        result[0].GameTitle.Should().Be("Pandemic");
     }
 
     // -----------------------------------------------------------------------
@@ -136,7 +157,7 @@ public sealed class GetLibraryActivityQueryHandlerTests
         });
         await db.SaveChangesAsync();
 
-        var handler = new GetLibraryActivityQueryHandler(db);
+        var handler = new GetLibraryActivityQueryHandler(db, CreateSharedGameRepo());
         var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
 
         result.Should().BeEmpty();
@@ -166,7 +187,7 @@ public sealed class GetLibraryActivityQueryHandlerTests
         });
         await db.SaveChangesAsync();
 
-        var handler = new GetLibraryActivityQueryHandler(db);
+        var handler = new GetLibraryActivityQueryHandler(db, CreateSharedGameRepo());
         var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
 
         result.Should().BeEmpty();
@@ -212,12 +233,109 @@ public sealed class GetLibraryActivityQueryHandlerTests
 
         await db.SaveChangesAsync();
 
-        var handler = new GetLibraryActivityQueryHandler(db);
+        var repo = CreateSharedGameRepo(new Dictionary<Guid, string> { [gameId] = "Ticket to Ride" });
+        var handler = new GetLibraryActivityQueryHandler(db, repo);
         var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
 
         // Both events present, ordered DESC by timestamp (session-recorded first).
         result.Should().HaveCount(2);
         result[0].Type.Should().Be("session-recorded");
+        result[0].GameTitle.Should().Be("Ticket to Ride");
         result[1].Type.Should().Be("added");
+    }
+
+    // -----------------------------------------------------------------------
+    // D2 (#1590) — soft-deleted game → i18n key instead of real title
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_SoftDeletedGame_ReturnsI18nKey()
+    {
+        await using var db = CreateInMemoryContext();
+
+        var gameId = Guid.NewGuid();
+        var payload = JsonSerializer.Serialize(new { gameId, userId = UserId });
+
+        db.DomainEventLogs.Add(new DomainEventLogEntity
+        {
+            Id = Guid.NewGuid(),
+            EventId = Guid.NewGuid(),
+            EventType = "library.entry.removed",
+            UserId = UserId,
+            AggregateId = Guid.NewGuid(),
+            PayloadJson = payload,
+            OccurredAt = DateTime.UtcNow.AddMinutes(-10),
+            LoggedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        // Simulate soft-deleted game: GetNamesByIdsAsync returns empty dict (game absent).
+        var repo = CreateSharedGameRepo(new Dictionary<Guid, string>());
+        var handler = new GetLibraryActivityQueryHandler(db, repo);
+        var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].GameTitle.Should().Be("library.activity.deletedGame");
+    }
+
+    // -----------------------------------------------------------------------
+    // D1 (#1590) — bulk join resolves title without N+1
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_MultipleLogEvents_ResolvesAllTitlesInOneBulkCall()
+    {
+        await using var db = CreateInMemoryContext();
+        var now = DateTime.UtcNow;
+
+        var gameId1 = Guid.NewGuid();
+        var gameId2 = Guid.NewGuid();
+
+        db.DomainEventLogs.AddRange(
+            new DomainEventLogEntity
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                EventType = "library.entry.removed",
+                UserId = UserId,
+                AggregateId = Guid.NewGuid(),
+                PayloadJson = JsonSerializer.Serialize(new { gameId = gameId1, userId = UserId }),
+                OccurredAt = now.AddMinutes(-5),
+                LoggedAt = now,
+            },
+            new DomainEventLogEntity
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                EventType = "library.session.recorded",
+                UserId = UserId,
+                AggregateId = Guid.NewGuid(),
+                PayloadJson = JsonSerializer.Serialize(new { gameId = gameId2, userId = UserId }),
+                OccurredAt = now.AddMinutes(-2),
+                LoggedAt = now,
+            });
+        await db.SaveChangesAsync();
+
+        var mockRepo = new Mock<ISharedGameRepository>();
+        mockRepo.Setup(r => r.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>
+            {
+                [gameId1] = "7 Wonders",
+                [gameId2] = "Wingspan",
+            });
+
+        var handler = new GetLibraryActivityQueryHandler(db, mockRepo.Object);
+        var result = await handler.Handle(new GetLibraryActivityQuery(UserId), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(e => e.GameTitle == "7 Wonders");
+        result.Should().Contain(e => e.GameTitle == "Wingspan");
+
+        // Verify bulk join: only ONE call regardless of event count.
+        mockRepo.Verify(r => r.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/activity</c> — cross-entity activity feed.
+/// BE-3 #1590 Task 8: verifies the endpoint reads <c>domain_event_logs</c> scoped
+/// to the calling user, applies 90-day retention and limit, maps EventType to clean
+/// entityType names, and enforces authentication + validation.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Administration")]
+public sealed class ActivityFeedEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+
+    public ActivityFeedEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"activity_feed_endpoint_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_webFactory is not null)
+        {
+            await _webFactory.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_testDbName))
+        {
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+        }
+    }
+
+    // ── Test 1 ──────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetActivity_returns_cross_entity_items_for_caller()
+    {
+        // Arrange — create user + seed game + POST quick-create agent (emits agent.created)
+        using var setupScope = _webFactory.Services.CreateScope();
+        var db = setupScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "TestGame-Activity-T1");
+
+        var client = _webFactory.CreateClient();
+
+        // Quick-create agent → emits agent.created event
+        var createAgentRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/quick-create",
+            token,
+            new { gameId });
+
+        var createResponse = await client.SendAsync(createAgentRequest);
+        // quick-create succeeds for the standard test user (same precedent as
+        // AgentCreatedIntegrationTests, Task 2) → agent.created lands in domain_event_logs.
+        createResponse.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        // Act — GET /api/v1/activity?limit=20
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/activity?limit=20",
+            token);
+        var response = await client.SendAsync(getRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ActivityFeedResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        body.Should().NotBeNull();
+        body!.Success.Should().BeTrue();
+        body.Items.Should().NotBeNull();
+        body.Count.Should().Be(body.Items.Count);
+
+        // Happy-path: the agent.created event MUST surface with the full mapped shape.
+        var agentItems = body.Items
+            .Where(i => string.Equals(i.EventType, "agent.created", StringComparison.Ordinal))
+            .ToList();
+
+        agentItems.Should().ContainSingle("quick-create emits exactly one agent.created event");
+        var item = agentItems[0];
+        item.EventType.Should().Be("agent.created");
+        item.EntityType.Should().Be("Agent"); // mapped from eventType, not raw AggregateType
+        item.EntityId.Should().NotBe(Guid.Empty);
+        item.Title.Should().NotBeNullOrEmpty(); // AgentName snapshot in payload
+        item.PayloadVersion.Should().Be(1);
+    }
+
+    // ── Test 2 ──────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetActivity_unauthenticated_returns_401()
+    {
+        // Act — no cookie header
+        var client = _webFactory.CreateClient();
+        var response = await client.GetAsync("/api/v1/activity");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Test 3 ──────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetActivity_invalid_limit_returns_422()
+    {
+        // Arrange
+        using var scope = _webFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var client = _webFactory.CreateClient();
+
+        // Act — limit=999 exceeds max (100)
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/activity?limit=999",
+            token);
+        var response = await client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity); // 422
+    }
+
+    // ── Test 4 ──────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetActivity_only_caller_events_not_other_users()
+    {
+        // Arrange — two independent users
+        using var scope = _webFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (userAId, tokenA) = await TestSessionHelper.CreateUserSessionAsync(db);
+        var (userBId, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "TestGame-Activity-T4");
+
+        var client = _webFactory.CreateClient();
+
+        // User A creates an agent (seeds an event attributed to userA)
+        var createReqA = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/quick-create",
+            tokenA,
+            new { gameId });
+        await client.SendAsync(createReqA);
+
+        // Act — User B queries the activity feed
+        var getReqB = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/activity?limit=50",
+            tokenB);
+        var response = await client.SendAsync(getReqB);
+
+        // Assert — B's feed must not contain A's events
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ActivityFeedResponse>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        body.Should().NotBeNull();
+
+        // None of the items in B's feed should have userId == userA
+        body!.Items.Should().NotContain(
+            i => i.UserId == userAId,
+            "User B should not see events belonging to User A");
+    }
+
+    // ── Response shape contracts ─────────────────────────────────────────────────
+
+    private sealed record ActivityFeedResponse(
+        bool Success,
+        List<ActivityItemResponse> Items,
+        int Count);
+
+    private sealed record ActivityItemResponse(
+        Guid Id,
+        Guid EventId,
+        string EventType,
+        Guid UserId,
+        string EntityType,
+        Guid EntityId,
+        string? Title,
+        DateTime Timestamp,
+        DateTime LoggedAt,
+        int PayloadVersion);
+}

--- a/apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+/// <summary>
+/// Integration test: CreateUserAgentCommand emits <c>agent.created</c> to
+/// <c>domain_event_logs</c> atomically with the agent row.
+/// BE-3 #1590 — H1: user-facing flow only (quick-create / POST /agents/user).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AgentCreatedIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+    private HttpClient _client = null!;
+
+    public AgentCreatedIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"agent_created_events_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+        _client = _webFactory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_webFactory is not null)
+            await _webFactory.DisposeAsync();
+        if (!string.IsNullOrEmpty(_testDbName))
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    /// <summary>
+    /// POST /api/v1/agents/quick-create → CreateUserAgentCommand → domain_event_logs row
+    /// with EventType="agent.created", AggregateType="AgentCreated", PayloadVersion=1,
+    /// payload containing camelCase gameId and gameName.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAgent_ViaQuickCreate_LogsAgentCreatedEvent_InDomainEventLogs()
+    {
+        // Arrange
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Agent");
+
+        var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/quick-create",
+            sessionToken,
+            new { gameId });
+
+        // Act
+        var response = await _client.SendAsync(createRequest);
+
+        // Assert — HTTP success first
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        // Re-fetch from a fresh scope to read post-commit state (avoids first-level-cache hits)
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "agent.created" && e.UserId == userId)
+            .OrderByDescending(e => e.LoggedAt)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull(
+            "CreateUserAgentCommand must emit agent.created to domain_event_logs — BE-3 #1590");
+
+        // EventType alias registered in EventTypeRegistry
+        logRow!.EventType.Should().Be("agent.created");
+
+        // UserId — populated by DomainEventLogMapper reflection on event.UserId property
+        logRow.UserId.Should().Be(userId);
+
+        // AggregateType — mapper derives from class name by stripping "Event" suffix:
+        // AgentCreatedEvent → "AgentCreated"
+        logRow.AggregateType.Should().Be("AgentCreated");
+
+        // AggregateId — mapper reads event.AggregateId property (the agent id)
+        logRow.AggregateId.Should().NotBeNull();
+        logRow.AggregateId.Should().NotBe(Guid.Empty);
+
+        // PayloadVersion — v1 schema (BE-3 #1590)
+        logRow.PayloadVersion.Should().Be(1);
+
+        // PayloadJson — DomainEventLogMapper uses JsonNamingPolicy.CamelCase
+        logRow.PayloadJson.Should().Contain("\"gameId\"")
+            .And.Contain(gameId.ToString());
+        logRow.PayloadJson.Should().Contain("\"gameName\"")
+            .And.Contain("Catan-BE3-Agent");
+    }
+
+    /// <summary>
+    /// POST /api/v1/agents/user → CreateUserAgentCommand directly → domain_event_logs row.
+    /// Verifies the same handler path is covered regardless of the calling route.
+    /// </summary>
+    [Fact]
+    public async Task CreateUserAgent_ViaUserRoute_LogsAgentCreatedEvent_InDomainEventLogs()
+    {
+        // Arrange
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Wingspan-BE3-Agent");
+
+        var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/user",
+            sessionToken,
+            new { gameId, agentType = "Tutor" });
+
+        // Act
+        var response = await _client.SendAsync(createRequest);
+
+        // Assert — HTTP success
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "agent.created" && e.UserId == userId)
+            .OrderByDescending(e => e.LoggedAt)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull(
+            "POST /agents/user must also emit agent.created — BE-3 #1590 H1");
+        logRow!.EventType.Should().Be("agent.created");
+        logRow.PayloadJson.Should().Contain("\"gameName\"").And.Contain("Wingspan-BE3-Agent");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+/// <summary>
+/// Integration test: CreateChatSessionCommand emits <c>chat.session.created</c> to
+/// <c>domain_event_logs</c> atomically with the session row.
+/// BE-3 #1590 — H2: alias "chat.session.created" matches real command name (not fictional CreateChatThreadCommand).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class ChatSessionCreatedIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+    private HttpClient _client = null!;
+
+    public ChatSessionCreatedIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"chat_session_created_events_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+        _client = _webFactory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_webFactory is not null)
+            await _webFactory.DisposeAsync();
+        if (!string.IsNullOrEmpty(_testDbName))
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    /// <summary>
+    /// POST /api/v1/chat/sessions → CreateChatSessionCommand → domain_event_logs row
+    /// with EventType="chat.session.created", AggregateType="ChatSessionCreated",
+    /// PayloadVersion=1, payload containing camelCase gameId.
+    ///
+    /// Uses Admin session to satisfy RAG access check (Rule 1: Admin → always allowed),
+    /// which sidesteps the need for a UserLibraryEntry or IsRagPublic flag.
+    /// </summary>
+    [Fact]
+    public async Task CreateChatSession_LogsChatSessionCreatedEvent_InDomainEventLogs()
+    {
+        // Arrange — Admin session bypasses RAG access check (RagAccessService Rule 1)
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Chat");
+
+        var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/chat/sessions",
+            sessionToken,
+            new { gameId });
+
+        // Act
+        var response = await _client.SendAsync(createRequest);
+
+        // Assert — HTTP success
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        // Re-fetch from a fresh scope to read post-commit state (avoids first-level-cache hits)
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "chat.session.created" && e.UserId == userId)
+            .OrderByDescending(e => e.LoggedAt)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull(
+            "CreateChatSessionCommand must emit chat.session.created to domain_event_logs — BE-3 #1590 H2");
+
+        // EventType alias registered in EventTypeRegistry
+        logRow!.EventType.Should().Be("chat.session.created");
+
+        // UserId — populated by DomainEventLogMapper reflection on event.UserId property
+        logRow.UserId.Should().Be(userId);
+
+        // AggregateType — mapper derives from class name by stripping "Event" suffix:
+        // ChatSessionCreatedEvent → "ChatSessionCreated"
+        logRow.AggregateType.Should().Be("ChatSessionCreated");
+
+        // AggregateId — mapper reads event.AggregateId property (= the new chat session id)
+        logRow.AggregateId.Should().NotBeNull();
+        logRow.AggregateId.Should().NotBe(Guid.Empty);
+
+        // PayloadVersion — v1 schema (BE-3 #1590)
+        logRow.PayloadVersion.Should().Be(1);
+
+        // PayloadJson — DomainEventLogMapper uses JsonNamingPolicy.CamelCase
+        logRow.PayloadJson.Should().Contain("\"gameId\"")
+            .And.Contain(gameId.ToString());
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs
@@ -113,5 +113,11 @@ public sealed class ChatSessionCreatedIntegrationTests : IAsyncLifetime
         // PayloadJson — DomainEventLogMapper uses JsonNamingPolicy.CamelCase
         logRow.PayloadJson.Should().Contain("\"gameId\"")
             .And.Contain(gameId.ToString());
+
+        // BE-3 #1590 H2 payload-completeness: gameName must be present so the
+        // activity rail can render a meaningful title without a secondary join.
+        logRow.PayloadJson.Should().Contain("\"gameName\"")
+            .And.Contain("Catan-BE3-Chat",
+                because: "CreateChatSessionCommandHandler resolves gameName via ISharedGameRepository");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs
@@ -1,0 +1,163 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+/// <summary>
+/// Integration test: <c>TransitionTo(Ready)</c> on <c>PdfDocument</c> emits exactly ONE
+/// <c>kb.doc.indexed</c> row in <c>domain_event_logs</c> — NOT one per transition.
+///
+/// BE-3 #1590 — design decision B2: only the Ready terminal transition raises the
+/// user-meaningful "doc indexed" event. <c>PdfStateChangedEvent</c> (internal, unregistered)
+/// continues to fire on every transition for cache/metrics handlers; only
+/// <c>KbDocIndexedEvent</c> (registered alias "kb.doc.indexed") reaches the log table.
+///
+/// Design decision (gameName resolution): <c>PdfDocument.TransitionTo</c> is a pure domain
+/// method with no repository access. The event carries <c>GameName = null</c>; the Task 8
+/// activity endpoint resolves the name via <c>SharedGameRepository.GetNamesByIds</c>.
+/// <c>FileName</c> is the primary rail title.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class KbDocIndexedIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+
+    public KbDocIndexedIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"kb_doc_indexed_events_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_webFactory is not null)
+            await _webFactory.DisposeAsync();
+        if (!string.IsNullOrEmpty(_testDbName))
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    /// <summary>
+    /// Verifies that exactly ONE <c>kb.doc.indexed</c> row is written when a
+    /// <c>PdfDocument</c> transitions through the full pipeline to <c>Ready</c>,
+    /// even though <c>PdfStateChangedEvent</c> fires on every intermediate step.
+    ///
+    /// Pipeline path: Pending → Uploading → Extracting → Chunking → Embedding → Indexing → Ready.
+    /// We call <c>UpdateAsync</c> + <c>SaveChangesAsync</c> only ONCE (after the Ready
+    /// transition) to reflect the real production flow where the processing worker
+    /// transitions the aggregate and persists at the terminal state.
+    /// </summary>
+    [Fact]
+    public async Task TransitionToReady_LogsKbDocIndexedEvent_ExactlyOnce_NotPerTransition()
+    {
+        // Arrange: seed user + shared game via TestSessionHelper
+        using var arrangeScope = _webFactory.Services.CreateScope();
+        var dbContext = arrangeScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Kb");
+
+        // Build PdfDocument domain object (constructor → Pending state, 0 domain events)
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocument(
+            id: pdfId,
+            gameId: gameId,                             // mirrors into SharedGameId in ctor
+            fileName: new FileName($"test-{pdfId:N}.pdf"),
+            filePath: $"/uploads/test-{pdfId:N}.pdf",
+            fileSize: new FileSize(1024),
+            uploadedByUserId: userId
+        );
+
+        // Persist the new aggregate (collects constructor domain events; SaveChanges writes them).
+        var repo = arrangeScope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();
+        var unitOfWork = arrangeScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        await repo.AddAsync(pdf);
+        await unitOfWork.SaveChangesAsync();
+
+        // Act: drive the full pipeline to Ready in a NEW scope (mimics processing worker DI scope).
+        // Only one UpdateAsync+SaveChanges after the terminal Ready transition.
+        using var actScope = _webFactory.Services.CreateScope();
+        var actDb = actScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var actRepo = actScope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();
+        var actUow = actScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        // Re-load the domain object (must re-fetch since DomainEvents live on the in-memory instance)
+        var domainPdf = await actRepo.GetByIdAsync(pdfId);
+        domainPdf.Should().NotBeNull("the PDF was just persisted in the Arrange scope");
+
+        // Full pipeline: Pending → Uploading → Extracting → Chunking → Embedding → Indexing → Ready
+        // (ValidateStateTransition enforces forward-only; each step emits PdfStateChangedEvent)
+        domainPdf!.TransitionTo(PdfProcessingState.Uploading);
+        domainPdf.TransitionTo(PdfProcessingState.Extracting);
+        domainPdf.TransitionTo(PdfProcessingState.Chunking);
+        domainPdf.TransitionTo(PdfProcessingState.Embedding);
+        domainPdf.TransitionTo(PdfProcessingState.Indexing);
+        domainPdf.TransitionTo(PdfProcessingState.Ready);   // ← ONLY this raises KbDocIndexedEvent
+
+        // Persist: CollectEventsFrom(domainPdf) → MeepleAiDbContext.SaveChangesAsync
+        // writes aggregate + domain_event_log rows atomically.
+        await actRepo.UpdateAsync(domainPdf);
+        await actUow.SaveChangesAsync();
+
+        // Assert: fresh scope to avoid first-level-cache hits
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var rows = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "kb.doc.indexed" && e.AggregateId == pdfId)
+            .ToListAsync();
+
+        // Exactly ONE row — not 6 (one per transition) or 0 (event not emitted)
+        rows.Should().HaveCount(1,
+            "kb.doc.indexed fires only on the Ready transition (B2 decision, #1590)");
+
+        var row = rows[0];
+
+        // AggregateType — DomainEventLogMapper strips "Event": KbDocIndexedEvent → "KbDocIndexed"
+        row.AggregateType.Should().Be("KbDocIndexed");
+
+        // UserId — reflected from event.UserId property
+        row.UserId.Should().Be(userId);
+
+        // PayloadVersion — v1 schema (BE-3 #1590)
+        row.PayloadVersion.Should().Be(1);
+
+        // PayloadJson — DomainEventLogMapper uses JsonNamingPolicy.CamelCase
+        // FileName is the PRIMARY title (domain method has no repo access → gameName=null)
+        row.PayloadJson.Should().Contain("\"fileName\"",
+            "fileName is the primary kb.doc.indexed rail title");
+        row.PayloadJson.Should().Contain("\"gameId\"",
+            "gameId must be serialized camelCase for the activity endpoint join");
+        row.PayloadJson.Should().Contain(gameId.ToString(),
+            "gameId value must match the seeded shared game");
+
+        // Confirm PdfStateChangedEvent rows are NOT in kb.doc.indexed
+        // (PdfStateChangedEvent is unregistered → only dispatched via MediatR in-memory)
+        rows.Should().HaveCount(1,
+            "PdfStateChangedEvent (internal, unregistered) must not produce kb.doc.indexed rows");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
@@ -141,4 +141,55 @@ public sealed class SessionLifecycleIntegrationTests : IAsyncLifetime
         delta.TotalMilliseconds.Should().BeLessThan(100,
             "session_events and domain_event_logs are written in the same transaction (AC5.b)");
     }
+
+    [Fact]
+    public async Task SessionFinalized_persists_to_domain_event_logs()
+    {
+        // Arrange — create + persist a session, then finalize it
+        using var scope = _webFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var sessionRepository = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "Catan-BE3-Finalize");
+
+        var session = Session.Create(userId, gameId, SessionType.Generic);
+        await sessionRepository.AddAsync(session, CancellationToken.None);
+        await unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+        // Act — finalize + emit session.finalized (mirrors FinalizeSessionCommandHandler: domain
+        // event added BEFORE UpdateAsync which collects it).
+        session.Finalize();
+        var emitTimestamp = DateTime.UtcNow;
+        session.AddDomainEvent(new SessionFinalizedEvent
+        {
+            SessionId = session.Id,
+            UserId = userId,
+            GameId = gameId,
+            GameName = "Catan-BE3-Finalize",
+            PlayerCount = session.Participants.Count,
+            WinnerId = null,
+            WinnerName = null,
+            DurationMinutes = 42,
+            Timestamp = emitTimestamp,
+        });
+        await sessionRepository.UpdateAsync(session, CancellationToken.None);
+        await unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "session.finalized" && e.AggregateId == session.Id)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull("session.finalized must be durably logged to domain_event_logs");
+        logRow!.AggregateType.Should().Be("SessionFinalized");
+        logRow.UserId.Should().Be(userId);
+        logRow.PayloadVersion.Should().Be(1);
+        logRow.PayloadJson.Should().Contain("\"gameId\"").And.Contain(gameId.ToString());
+        logRow.PayloadJson.Should().Contain("\"durationMinutes\"").And.Contain("42");
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
@@ -1,0 +1,144 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+/// <summary>
+/// Integration test: the SessionTracking <c>session.created</c> domain event is durably persisted
+/// to <c>domain_event_logs</c> via the real pipeline (SessionRepository.AddAsync collection wired
+/// in Task 5 → MeepleAiDbContext.SaveChangesAsync mapping → registry alias), AND lands atomically
+/// (same SaveChangesAsync transaction) with the <c>session_events</c> diary "session_created" row.
+///
+/// <para>BE-3 #1590 AC5.b / C3.3: proves the two orthogonal tables (session_events diary vs
+/// domain_event_logs activity log) both receive a row in one transaction, timestamps &lt;100ms apart.
+/// The test exercises the real persistence components (SessionRepository, DbContext, mapper,
+/// registry); it mirrors the emit + diary-write the CreateSessionCommandHandler performs, without
+/// the handler's orthogonal KB-readiness / GameNight / quota pre-checks (covered by the handler's
+/// own test suite).</para>
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionLifecycleIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+
+    public SessionLifecycleIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"session_lifecycle_events_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_webFactory is not null)
+        {
+            await _webFactory.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_testDbName))
+        {
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+        }
+    }
+
+    [Fact]
+    public async Task SessionCreated_persists_to_domain_event_logs_AND_session_events_atomically()
+    {
+        // Arrange
+        using var scope = _webFactory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var sessionRepository = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "Catan-BE3-Session");
+
+        var session = Session.Create(userId, gameId, SessionType.Generic);
+        var emitTimestamp = DateTime.UtcNow;
+
+        // Emit session.created (mirrors CreateSessionCommandHandler: domain event added BEFORE
+        // AddAsync, which collects it; Timestamp = the same clock as the diary row for AC5.b).
+        session.AddDomainEvent(new SessionCreatedEvent
+        {
+            SessionId = session.Id,
+            UserId = userId,
+            SessionCode = session.SessionCode,
+            GameId = gameId,
+            GameName = "Catan-BE3-Session",
+            PlayerCount = session.Participants.Count,
+            Timestamp = emitTimestamp,
+        });
+
+        await sessionRepository.AddAsync(session, CancellationToken.None);
+
+        // session_events diary "session_created" row written in the SAME SaveChangesAsync — this is
+        // exactly what the handler does (CreateSessionCommandHandler writes both before one save).
+        db.SessionEvents.Add(new SessionEventEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionId = session.Id,
+            EventType = "session_created",
+            Timestamp = emitTimestamp,
+            CreatedBy = userId,
+            Source = "system",
+            IsDeleted = false,
+        });
+
+        // Act — single atomic save: session aggregate + domain_event_logs row + session_events row.
+        await unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+        // Assert
+        using var verifyScope = _webFactory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // 1. domain_event_logs row (activity rail source)
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "session.created" && e.AggregateId == session.Id)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull("session.created must be durably logged to domain_event_logs");
+        logRow!.AggregateType.Should().Be("SessionCreated");
+        logRow.UserId.Should().Be(userId);
+        logRow.PayloadVersion.Should().Be(1);
+        logRow.PayloadJson.Should().Contain("\"gameId\"").And.Contain(gameId.ToString());
+        logRow.PayloadJson.Should().Contain("\"gameName\"").And.Contain("Catan-BE3-Session");
+
+        // 2. session_events diary row (in-session timeline UI source — orthogonal table, C3)
+        var diaryRow = await verifyDb.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == session.Id && e.EventType == "session_created")
+            .FirstOrDefaultAsync();
+
+        diaryRow.Should().NotBeNull("session_events must keep its diary session_created row");
+
+        // 3. AC5.b: the two writes are in the same transaction → timestamps within 100ms.
+        var delta = (diaryRow!.Timestamp - logRow.OccurredAt).Duration();
+        delta.TotalMilliseconds.Should().BeLessThan(100,
+            "session_events and domain_event_logs are written in the same transaction (AC5.b)");
+    }
+}

--- a/apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Api.Infrastructure;
+using Api.Observability;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Observability.Metrics;
+
+/// <summary>
+/// Integration tests for domain event log Prometheus counters (BE-3 #1590 AC7).
+/// G1: meepleai.domain_event_log.inserted.total{event_type} — incremented once per
+///     domain_event_logs row inserted.
+/// G2: meepleai.domain_event_log.dispatch_failures.total{event_type,handler_name} —
+///     incremented when a MediatR handler throws after the row is durably persisted.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1590")]
+public sealed class DomainEventLogMetricsTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _webFactory = null!;
+    private HttpClient _client = null!;
+
+    public DomainEventLogMetricsTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"domain_event_metrics_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _webFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await dbContext.Database.MigrateAsync();
+        _client = _webFactory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_webFactory is not null)
+            await _webFactory.DisposeAsync();
+        if (!string.IsNullOrEmpty(_testDbName))
+            await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    /// <summary>
+    /// G1: Posting quick-create (which emits agent.created) must increment
+    /// meepleai.domain_event_log.inserted.total with tag event_type="agent.created".
+    /// </summary>
+    [Fact]
+    public async Task InsertedCounter_G1_IncrementsWithEventTypeTag_WhenAgentCreatedEmitted()
+    {
+        // Arrange
+        using var scope = _webFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-Metrics-G1");
+
+        var measurements = new List<(long Value, KeyValuePair<string, object?>[] Tags)>();
+
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (string.Equals(instrument.Meter.Name, MeepleAiMetrics.MeterName, StringComparison.Ordinal) &&
+                    string.Equals(instrument.Name, "meepleai.domain_event_log.inserted.total", StringComparison.Ordinal))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((inst, value, tags, state) =>
+            measurements.Add((value, tags.ToArray())));
+        listener.Start();
+
+        var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/quick-create",
+            sessionToken,
+            new { gameId });
+
+        // Act
+        var response = await _client.SendAsync(createRequest);
+
+        // Assert — HTTP success first
+        response.StatusCode.Should().BeOneOf(
+            new[] { HttpStatusCode.OK, HttpStatusCode.Created },
+            "quick-create must succeed to generate the domain event log row");
+
+        // Give any async metric emission a moment to land
+        await Task.Delay(100);
+
+        // G1: at least one measurement with event_type="agent.created"
+        measurements.Should().Contain(
+            m => m.Tags.Any(t =>
+                string.Equals(t.Key, "event_type", StringComparison.Ordinal) &&
+                string.Equals(t.Value as string, "agent.created", StringComparison.Ordinal)),
+            "meepleai.domain_event_log.inserted.total must fire with event_type=agent.created (#1590 G1)");
+
+        // Each measurement must carry value=1 (one row at a time)
+        measurements
+            .Where(m => m.Tags.Any(t => string.Equals(t.Value as string, "agent.created", StringComparison.Ordinal)))
+            .Should().AllSatisfy(m => m.Value.Should().Be(1));
+    }
+
+    /// <summary>
+    /// Smoke test: Verifies the two counter instruments are properly initialized
+    /// and carry the expected names/units without spinning up Testcontainers.
+    /// </summary>
+    [Fact]
+    public void Counters_G1_G2_AreInitialized_WithCorrectNamesAndUnits()
+    {
+        MeepleAiMetrics.DomainEventsInserted.Should().NotBeNull(
+            "G1 counter must be registered at startup (#1590)");
+        MeepleAiMetrics.DomainEventDispatchFailures.Should().NotBeNull(
+            "G2 counter must be registered at startup (#1590)");
+
+        MeepleAiMetrics.DomainEventsInserted.Name
+            .Should().Be("meepleai.domain_event_log.inserted.total");
+        MeepleAiMetrics.DomainEventDispatchFailures.Name
+            .Should().Be("meepleai.domain_event_log.dispatch_failures.total");
+
+        MeepleAiMetrics.DomainEventsInserted.Unit.Should().Be("events");
+        MeepleAiMetrics.DomainEventDispatchFailures.Unit.Should().Be("failures");
+    }
+}

--- a/docs/superpowers/plans/2026-05-27-event-sourcing-cross-entity-be3.md
+++ b/docs/superpowers/plans/2026-05-27-event-sourcing-cross-entity-be3.md
@@ -1,0 +1,2045 @@
+# BE-3 #1590 — Event Sourcing Cross-Entity (Agent / Chat / KB / Session) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `EventTypeRegistry` with 5 new domain events (`agent.created`, `chat.session.created`, `kb.doc.indexed`, `session.created`, `session.finalized`) so that the durable activity log (`domain_event_logs` table) can power a cross-entity activity feed via a new endpoint `GET /api/v1/activity`. Forward-only — no backfill. Unblocks Phase 3b #1593 rail.
+
+**Architecture:** Each new event is a domain event raised via the existing `IDomainEventSource` pipeline (`MeepleAiDbContext.SaveChangesAsync` intercepts events from aggregates, maps them via `DomainEventLogMapper`, inserts log rows atomically with aggregate state). The `Session` aggregate gets a minimal `IDomainEventSource` implementation (not full AggregateRoot conversion) so it can participate. The legacy `/library/activity` endpoint is preserved (mapping layer enriches `gameTitle` via bulk lookup). A new `GET /api/v1/activity` endpoint exposes the generalized cross-entity feed. Two new Prometheus counters expose insert/dispatch-failure rates.
+
+**Tech Stack:** .NET 9 · MediatR · EF Core 9 (Postgres) · FluentValidation · xUnit + FluentAssertions + Moq · Testcontainers Postgres · System.Diagnostics.Metrics + OpenTelemetry · Meziantou.Analyzer
+
+**Spec source:** Issue #1590 body (refined 2026-05-27 via /sc:spec-panel discussion + socratic; 20 locked decisions A1-H2 + C3.1-C3.4).
+
+**⚠️ Branch policy:** parent = `main-dev`. PR target = `main-dev`. Commit messages end with `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`. Headers ≤80 chars.
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs` | Add `PayloadVersion` int property (default 1) | Modify |
+| `apps/api/src/Api/Infrastructure/EntityConfigurations/DomainEventLogEntityConfiguration.cs` | Add EF config for `PayloadVersion`, XML doc on `AggregateId`/`AggregateType` declaring logical FKs (AC9) | Modify |
+| `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDDHHMMSS_AddPayloadVersionToDomainEventLogs.cs` | EF migration: add `PayloadVersion INT NOT NULL DEFAULT 1` column | Create |
+| `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs` | Register 5 new event types | Modify |
+| `apps/api/src/Api/Infrastructure/DomainEventLog/DomainEventLogMapper.cs` | Map `PayloadVersion` from event to entity (default 1 v1) | Modify |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs` | New domain event for agent.created | Create |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs` | Add `AddDomainEvent(AgentCreatedEvent)` after agent saved | Modify |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs` | Verify `AggregateRoot<Guid>` base (already has `AddDomainEvent`); add `RaiseAgentCreatedEvent(userId, gameName?)` method | Modify |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs` | New domain event for chat.session.created | Create |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs` | Add domain event emission | Modify |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs` | New domain event for kb.doc.indexed | Create |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs` | `TransitionTo(Ready)` adds `KbDocIndexedEvent` after existing `PdfStateChangedEvent` | Modify |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs` | Light refactor: implement `IDomainEventSource` (private list + `AddDomainEvent`/`PeekEvents`/`ClearEvents`) — NO full AggregateRoot conversion | Modify |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs` | New domain event for session.created | Create |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs` | New domain event for session.finalized | Create |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs` | Add `session.AddDomainEvent(SessionCreatedEvent)` before SaveChangesAsync | Modify |
+| `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs` | Add `session.AddDomainEvent(SessionFinalizedEvent)` before SaveChangesAsync | Modify |
+| `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQuery.cs` | New cross-entity query (returns generalized `ActivityItemDto`) | Create |
+| `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryHandler.cs` | Reads `domain_event_logs` for `userId=caller`, maps to DTO | Create |
+| `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryValidator.cs` | Validates limit (1-100) + since (parseable ISO-8601) | Create |
+| `apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/ActivityItemDto.cs` | Generalized response DTO | Create |
+| `apps/api/src/Api/Routing/ActivityEndpoints.cs` | `GET /api/v1/activity` endpoint registration | Create |
+| `apps/api/src/Api/Routing/RouteRegistry.cs` | Wire `ActivityEndpoints.Map(...)` | Modify |
+| `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs` | Replace placeholder `"Game"` with `SharedGameRepository.GetNamesByIds` bulk join (D1) + soft-delete handling (D2) | Modify |
+| `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs` | New partial: `DomainEventsInserted` + `DomainEventDispatchFailures` counters (G1, G2) | Create |
+| `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs:lines 449-470` | Increment `DomainEventsInserted` after `DomainEventLogs.Add`; increment `DomainEventDispatchFailures` in the catch-around-mediator-publish block | Modify |
+| `apps/api/tests/Api.Tests/Infrastructure/DomainEventLog/EventTypeRegistryTests.cs` | Add assertion: all 5 new entries resolve to loaded IDomainEvent types | Modify |
+| `apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs` | End-to-end: CreateUserAgent → log row + endpoint surface (AC5) | Create |
+| `apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs` | End-to-end (AC5) | Create |
+| `apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs` | End-to-end (AC5) | Create |
+| `apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs` | End-to-end + cross-table assertion (AC5.b — both `session_events` and `domain_event_logs`, timestamps <100ms) | Create |
+| `apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs` | Endpoint integration (AC2, AC3 forward-only/empty-state, AC4 legacy backward-compat) | Create |
+| `apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs` | Asserts counters increment correctly | Create |
+| `apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs` | AC8: assert `GetSessionDiaryQueryHandler` has NO dependency on `IDomainEventLogRepository` and vice versa | Create |
+
+---
+
+## Verified reference facts (from BE exploration — do not re-discover)
+
+- **`DomainEventLogEntity`** (`apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs:15-52`): Fields `Id` (Guid PK), `EventId` (Guid unique), `EventType` (string ≤128), `UserId` (Guid?), `AggregateId` (Guid?), `AggregateType` (string? ≤64), `PayloadJson` (jsonb), `OccurredAt` (DateTime), `LoggedAt` (DateTime). **NO** `PayloadVersion` yet — Task 1 adds it.
+- **`EventTypeRegistry`** (`apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs:30-36`): `public static class` with `Dictionary<Type, string> _aliasByType`. Today 2 entries: `[typeof(GameRemovedFromLibraryEvent)] = "library.entry.removed"`, `[typeof(GameSessionRecordedEvent)] = "library.session.recorded"`.
+- **`MeepleAiDbContext.SaveChangesAsync`** (`apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs:434-483`): Snapshot via `IDomainEventCollector.PeekEvents()` → `DomainEventLogMapper.Map()` → `DomainEventLogs.Add(...)` → `base.SaveChangesAsync` (atomic) → MediatR `Publish` (handler failures log ERROR but DO NOT rollback).
+- **`DomainEventLogMapper`** (verified): translates `IDomainEvent` → `DomainEventLogEntity`. Reads `EventTypeRegistry.AliasByType[event.GetType()]` for `EventType`. Reads `event.EventId`/`OccurredAt`/`UserId` via reflection or direct property access. For new events, all expose `Guid EventId` (random) + `DateTime OccurredAt` (UtcNow) + `Guid UserId` properties.
+- **`AggregateRoot<TId>`** base (verified via `UserLibraryEntry` usage `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Entities/UserLibraryEntry.cs:194-196`): exposes `protected void AddDomainEvent(IDomainEvent)`. `IDomainEventCollector.PeekEvents()` collects from all tracked `IDomainEventSource` instances.
+- **`Session` aggregate** (`apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`): currently does NOT inherit `AggregateRoot` and does NOT implement `IDomainEventSource`. Task 7 adds it.
+- **`AgentDefinition` aggregate** (`apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs`): DOES inherit `AggregateRoot<Guid>`. `AddDomainEvent` available.
+- **`PdfDocument` aggregate** (`apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs:382`): DOES inherit `AggregateRoot`. Already emits `PdfStateChangedEvent` in `TransitionTo`. Task 6 appends `KbDocIndexedEvent` when newState==Ready.
+- **`CreateUserAgentCommandHandler`** (verified): saves at line 112 via `_unitOfWork.SaveChangesAsync(ct)`. The `agent` instance is mutable here — call `agent.AddDomainEvent(...)` BEFORE save.
+- **`CreateChatSessionCommandHandler`** (verified): saves at line 99. `ChatSession` is NOT an `AggregateRoot` today — for chat, the cleanest fix is the **inline-after-save** pattern: emit via the `IDomainEventCollector` directly post-handler? **No — defer this Task 5 decision: extend `ChatSession` to implement `IDomainEventSource` (same light pattern as Session in Task 7), then `chatSession.AddDomainEvent(...)` before save.**
+- **`SharedGameRepository.GetNamesByIds`** (used in BE-1 #1588): `Task<IReadOnlyDictionary<Guid, string>> GetNamesByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct)`. Returns Title for non-soft-deleted SharedGames.
+- **`IUnitOfWork.SaveChangesAsync`** delegates to `MeepleAiDbContext.SaveChangesAsync` (verified).
+- **`MeepleAiMetrics` pattern** (`apps/api/src/Api/Observability/MeepleAiMetrics.cs:33`): `internal static partial class` with shared `Meter Meter = new("MeepleAI.Api", "1.0.0")`. Partial files in `apps/api/src/Api/Observability/Metrics/`. Counter naming: `meepleai.<domain>.<name>.total`. Counter increment with `TagList` for labels.
+- **`TestSessionHelper.SeedSharedGameAsync`** (verified BE-2 Task 4) — pass `title` string. Returns `Guid`.
+- **`TestSessionHelper.CreateUserSessionAsync`** (verified) — returns `(Guid UserId, string RawToken)`.
+- **`TestSessionHelper.CreateAuthenticatedRequest`** (verified) — `(HttpMethod, requestUri, sessionToken)`.
+- **`ApiExceptionHandlerMiddleware`** maps FluentValidation `ValidationException` → 422 (verified BE-1 #1588).
+- **`SessionEntity` in DbContext** (`session_tracking_sessions` table) is read/written via `_db.Sessions.Add(...)` and saved via `SaveChangesAsync` (verified). The `Session` domain entity maps to `SessionEntity`.
+
+---
+
+## ⚠️ Brownfield risks
+- **R1**: `Session` light refactor (Task 7) MUST NOT change any existing behavior — `Session` is not an `AggregateRoot`, just gains `IDomainEventSource` implementation. Existing tests that construct `Session` directly MUST continue to compile (additive interface).
+- **R2**: `PayloadVersion` column migration (Task 1) — verify the column default `1` propagates to existing rows (no `NOT NULL DEFAULT 1` constraint = failed migration on filled tables). Use `defaultValue: 1`.
+- **R3**: Naming `chat.session.created` — `CreateChatSessionCommandHandler` saves a `ChatSession` (not `ChatThread`). The "thread" terminology in the original issue body was an aliasing error; the FE consumer (#1593) does not require the literal word "thread" — only an event tied to chat creation. The alias `chat.session.created` is semantically and code-name-aligned.
+- **R4**: `useActivityFeed` FE collision is **NOT in this plan** — tracked in #1593 (E1). Implementer should not touch the FE.
+
+---
+
+## Task 1: Add `PayloadVersion` column + EF migration
+
+**Goal**: Add the `PayloadVersion` column to `domain_event_logs` (A2, Hohpe non-negotiable).
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/DomainEventLogEntityConfiguration.cs`
+- Create: `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDDHHMMSS_AddPayloadVersionToDomainEventLogs.cs` (auto-generated)
+
+- [ ] **Step 1: Add the `PayloadVersion` property to the entity**
+
+In `DomainEventLog.cs`, after the `PayloadJson` property, add:
+
+```csharp
+/// <summary>
+/// Schema version of the event payload, used for forward-compatible migrations.
+/// v1 events: PayloadVersion = 1. New payload schemas (with breaking changes) increment this.
+/// </summary>
+public int PayloadVersion { get; set; } = 1;
+```
+
+- [ ] **Step 2: Update the EF Configuration**
+
+In `DomainEventLogEntityConfiguration.cs`, inside the `Configure` method, after the existing `Property` definitions, add:
+
+```csharp
+builder.Property(e => e.PayloadVersion)
+    .IsRequired()
+    .HasDefaultValue(1);
+```
+
+Also add XML doc to the entity class (in the SAME file, for AC9) — modify the existing `AggregateType` and `AggregateId` property XML docs:
+
+In `DomainEventLog.cs`, update the doc comments on `AggregateType` and `AggregateId`:
+
+```csharp
+/// <summary>
+/// PascalCase aggregate name. Logical FK pointer to a specific aggregate table:
+///   - "Session"     → sessions_tracking.id
+///   - "Agent"       → agent_definitions.id
+///   - "ChatSession" → chat_sessions.id
+///   - "PdfDocument" → pdf_documents.id
+///   - "UserLibraryEntry" → user_library_entries.id (existing library.* events)
+/// Not enforced at DB level — append-only audit log policy (AC9, #1590).
+/// </summary>
+public string? AggregateType { get; set; }
+
+/// <summary>
+/// Logical FK to the aggregate root. See <see cref="AggregateType"/> for the mapping
+/// from PascalCase aggregate name to physical table.
+/// </summary>
+public Guid? AggregateId { get; set; }
+```
+
+- [ ] **Step 3: Generate the migration**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api/src/Api
+dotnet ef migrations add AddPayloadVersionToDomainEventLogs --no-build
+```
+
+Expected: a new file `apps/api/src/Api/Infrastructure/Migrations/YYYYMMDDHHMMSS_AddPayloadVersionToDomainEventLogs.cs` containing an `Up()` that adds the `PayloadVersion` column with `defaultValue: 1` and `nullable: false`, and a `Down()` that drops the column.
+
+If `dotnet ef` blocks (slow EF tooling on Windows), the migration body should be:
+
+```csharp
+public partial class AddPayloadVersionToDomainEventLogs : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "PayloadVersion",
+            table: "domain_event_logs",
+            type: "integer",
+            nullable: false,
+            defaultValue: 1);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "PayloadVersion",
+            table: "domain_event_logs");
+    }
+}
+```
+
+- [ ] **Step 4: Update the `DomainEventLogMapper`**
+
+In `apps/api/src/Api/Infrastructure/DomainEventLog/DomainEventLogMapper.cs`, find the line that constructs the `DomainEventLogEntity`. Add `PayloadVersion = 1` to the initializer (all v1 events default to 1; future events with breaking payload changes set it explicitly):
+
+```csharp
+return new DomainEventLogEntity
+{
+    Id = Guid.NewGuid(),
+    EventId = domainEvent.EventId,
+    EventType = alias,
+    UserId = ExtractUserId(domainEvent),
+    AggregateId = ExtractAggregateId(domainEvent),
+    AggregateType = aggregateType,
+    OccurredAt = domainEvent.OccurredAt,
+    LoggedAt = DateTime.UtcNow,
+    PayloadJson = JsonSerializer.Serialize(domainEvent, SerializerOptions),
+    PayloadVersion = 1, // BE-3 #1590 (A2): all v1 events default to 1
+};
+```
+
+- [ ] **Step 5: Build the project**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet build src/Api/Api.csproj --nologo -v q
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend
+git add apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs apps/api/src/Api/Infrastructure/EntityConfigurations/DomainEventLogEntityConfiguration.cs apps/api/src/Api/Infrastructure/DomainEventLog/DomainEventLogMapper.cs apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(events): #1590 add PayloadVersion column to domain_event_logs (BE-3)"
+```
+
+---
+
+## Task 2: `AgentCreatedEvent` end-to-end (event + registry + emit + integration test)
+
+**Goal**: Implement `agent.created` event emission from `CreateUserAgentCommandHandler` + integration test (H1, AC5).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing integration test FIRST**
+
+Create `apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.DomainEventLog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AgentCreatedIntegrationTests : IClassFixture<IntegrationWebApplicationFactory<Program>>, IAsyncLifetime
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public AgentCreatedIntegrationTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateUserAgent_LogsAgentCreatedEvent_InDomainEventLogs()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Agent");
+
+        var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/agents/quick-create",
+            sessionToken,
+            new { gameId });
+
+        // Act
+        var response = await _client.SendAsync(createRequest);
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        // Re-fetch the dbContext from a fresh scope to read post-commit state
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "agent.created" && e.UserId == userId)
+            .OrderByDescending(e => e.LoggedAt)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull("CreateUserAgentCommand must emit agent.created to domain_event_logs");
+        logRow!.EventType.Should().Be("agent.created");
+        logRow.UserId.Should().Be(userId);
+        logRow.AggregateType.Should().Be("Agent");
+        logRow.AggregateId.Should().NotBe(Guid.Empty);
+        logRow.PayloadVersion.Should().Be(1);
+        logRow.PayloadJson.Should().Contain("\"GameId\"").And.Contain(gameId.ToString());
+        logRow.PayloadJson.Should().Contain("\"GameName\"").And.Contain("Catan-BE3-Agent");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AgentCreatedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL — no `agent.created` row inserted (event not yet defined or emitted).
+
+- [ ] **Step 3: Create the domain event**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs`:
+
+```csharp
+using Api.SharedKernel.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
+
+/// <summary>
+/// Raised by <see cref="AgentDefinition"/> aggregate when a user creates a new agent via
+/// <c>CreateUserAgentCommand</c> (user-facing flow). NOT raised for admin/AI-Lab path
+/// (<c>CreateAgentDefinitionCommand</c>) — see #1590 decision H1.
+/// Registered in <c>EventTypeRegistry</c> with alias <c>"agent.created"</c>.
+/// </summary>
+internal sealed record AgentCreatedEvent(
+    Guid AgentId,
+    Guid UserId,
+    string AgentType,
+    bool IsActive,
+    Guid? GameId,
+    string? GameName,
+    string AgentName,
+    DateTime OccurredAt
+) : IDomainEvent, INotification
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+}
+```
+
+- [ ] **Step 4: Register in `EventTypeRegistry`**
+
+In `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`, add the new entry to `_aliasByType`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+// ... existing usings
+
+private static readonly Dictionary<Type, string> _aliasByType = new()
+{
+    [typeof(GameRemovedFromLibraryEvent)] = "library.entry.removed",
+    [typeof(GameSessionRecordedEvent)] = "library.session.recorded",
+    [typeof(AgentCreatedEvent)] = "agent.created", // BE-3 #1590
+};
+```
+
+- [ ] **Step 5: Emit the event from the command handler**
+
+In `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs`, find the line where the agent has been saved (around line 112, after `_unitOfWork.SaveChangesAsync(ct)`).
+
+Move the event emission to BEFORE `SaveChangesAsync` (so it's atomic with the save). The handler currently has:
+
+```csharp
+// existing code (approximate location):
+_agentRepository.Add(agent);
+await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+Modify to:
+
+```csharp
+// BE-3 #1590: emit agent.created BEFORE save so the log row is atomic with the aggregate
+agent.AddDomainEvent(new AgentCreatedEvent(
+    AgentId: agent.Id,
+    UserId: request.UserId,
+    AgentType: agent.Type.Value,
+    IsActive: agent.IsActive,
+    GameId: agent.GameId,
+    GameName: gameName, // already resolved earlier in handler from request.GameId
+    AgentName: agent.Name,
+    OccurredAt: DateTime.UtcNow
+));
+
+_agentRepository.Add(agent);
+await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+Notes:
+- `agent.AddDomainEvent(...)` is inherited from `AggregateRoot<Guid>` (already the base class of `AgentDefinition`).
+- `gameName` should already be available in the handler context (it's used to populate `AgentDto.GameName`). If it isn't, fetch it via `_sharedGameRepository.GetNamesByIdsAsync(new[] { agent.GameId.Value }, ct)` before constructing the event.
+
+- [ ] **Step 6: Run the integration test to verify it passes**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AgentCreatedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS. Testcontainers spin-up time ~30-60s.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentCreatedEvent.cs apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateUserAgentCommandHandler.cs apps/api/tests/Api.Tests/Integration/Events/AgentCreatedIntegrationTests.cs
+git commit -m "feat(events): #1590 emit agent.created event from CreateUserAgent (BE-3)"
+```
+
+---
+
+## Task 3: `ChatSessionCreatedEvent` end-to-end
+
+**Goal**: Implement `chat.session.created` event emission (H2, AC5).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ChatSession.cs` (add `IDomainEventSource` light implementation)
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class ChatSessionCreatedIntegrationTests : IClassFixture<IntegrationWebApplicationFactory<Program>>, IAsyncLifetime
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public ChatSessionCreatedIntegrationTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateChatSession_LogsChatSessionCreatedEvent()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Chat");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/chat/sessions",
+            sessionToken,
+            new { gameId });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "chat.session.created" && e.UserId == userId)
+            .OrderByDescending(e => e.LoggedAt)
+            .FirstOrDefaultAsync();
+
+        logRow.Should().NotBeNull();
+        logRow!.AggregateType.Should().Be("ChatSession");
+        logRow.PayloadVersion.Should().Be(1);
+        logRow.PayloadJson.Should().Contain("\"GameId\"").And.Contain(gameId.ToString());
+        logRow.PayloadJson.Should().Contain("\"GameName\"").And.Contain("Catan-BE3-Chat");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ChatSessionCreatedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the domain event**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs`:
+
+```csharp
+using Api.SharedKernel.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
+
+/// <summary>
+/// Raised when a user creates a new chat session via <c>CreateChatSessionCommand</c>.
+/// Registered in <c>EventTypeRegistry</c> with alias <c>"chat.session.created"</c>.
+/// Renamed from <c>chat.thread.created</c> (#1590 decision H2 — match the real BE command name
+/// <c>CreateChatSessionCommand</c>, not the fictional <c>CreateChatThreadCommand</c>).
+/// </summary>
+internal sealed record ChatSessionCreatedEvent(
+    Guid ChatSessionId,
+    Guid UserId,
+    Guid? GameId,
+    string? GameName,
+    Guid? AgentId,
+    string? AgentName,
+    DateTime OccurredAt
+) : IDomainEvent, INotification
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+}
+```
+
+- [ ] **Step 4: Add `IDomainEventSource` to `ChatSession`**
+
+`ChatSession` is currently not an `AggregateRoot`. Light refactor (see #1590 decision C1 — same pattern as Session in Task 7).
+
+In `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ChatSession.cs`, change the class declaration:
+
+```csharp
+// BEFORE: public sealed class ChatSession
+// AFTER:
+public sealed class ChatSession : IDomainEventSource
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+
+    // ... existing members unchanged ...
+}
+```
+
+Add `using Api.SharedKernel.Domain.Events;` at the top if missing.
+
+Verify the `IDomainEventSource` interface signature in `apps/api/src/Api/SharedKernel/Domain/Events/IDomainEventSource.cs` and match it exactly (if it has slightly different method names, adapt).
+
+- [ ] **Step 5: Emit the event from the command handler**
+
+In `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs`, locate the line creating the `ChatSession` instance (around line 95 — the line that does `new ChatSession(...)`). Just before `_unitOfWork.SaveChangesAsync(...)` (around line 99), add:
+
+```csharp
+// BE-3 #1590: emit chat.session.created BEFORE save (atomic with aggregate persistence)
+chatSession.AddDomainEvent(new ChatSessionCreatedEvent(
+    ChatSessionId: chatSession.Id,
+    UserId: request.UserId,
+    GameId: chatSession.GameId,
+    GameName: gameName, // resolved earlier in handler if available; else null
+    AgentId: chatSession.AgentId,
+    AgentName: agentName, // resolved earlier in handler if available; else null
+    OccurredAt: DateTime.UtcNow
+));
+
+await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+If `gameName` / `agentName` are not already resolved in the handler, fetch them via:
+```csharp
+var gameName = chatSession.GameId.HasValue
+    ? (await _sharedGameRepository.GetNamesByIdsAsync(new[] { chatSession.GameId.Value }, ct))
+        .GetValueOrDefault(chatSession.GameId.Value)
+    : null;
+var agentName = chatSession.AgentId.HasValue
+    ? (await _agentRepository.GetByIdAsync(chatSession.AgentId.Value, ct))?.Name
+    : null;
+```
+
+- [ ] **Step 6: Register in `EventTypeRegistry`**
+
+In `EventTypeRegistry.cs`, add:
+
+```csharp
+[typeof(ChatSessionCreatedEvent)] = "chat.session.created", // BE-3 #1590
+```
+
+- [ ] **Step 7: Verify `IDomainEventCollector` picks up `ChatSession` events**
+
+The collector iterates EF Change Tracker for entities implementing `IDomainEventSource`. Since `ChatSession` is tracked by EF (`_db.ChatSessions.Add(chatSession)` is called in the handler), its `DomainEvents` will be collected automatically.
+
+If the existing collector uses a different mechanism (e.g. only collects from `AggregateRoot` subclasses), you'll need to verify by reading `apps/api/src/Api/SharedKernel/Domain/Events/IDomainEventCollector.cs` and its implementation. If it filters by `AggregateRoot<>` specifically, change to `IDomainEventSource` (or add `ChatSession` to the collector's tracked set).
+
+- [ ] **Step 8: Run the integration test**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ChatSessionCreatedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ChatSessionCreatedEvent.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ChatSession.cs apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateChatSessionCommandHandler.cs apps/api/tests/Api.Tests/Integration/Events/ChatSessionCreatedIntegrationTests.cs
+git commit -m "feat(events): #1590 emit chat.session.created from CreateChatSession (BE-3)"
+```
+
+---
+
+## Task 4: `KbDocIndexedEvent` end-to-end
+
+**Goal**: Emit `kb.doc.indexed` when `PdfDocument.TransitionTo(Ready)` (B1-B3, AC5).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs:382` (the `TransitionTo` method)
+- Create: `apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class KbDocIndexedIntegrationTests : IClassFixture<IntegrationWebApplicationFactory<Program>>
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+
+    public KbDocIndexedIntegrationTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task TransitionToReady_LogsKbDocIndexedEvent_NotEveryStateChange()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Kb");
+
+        var pdf = PdfDocument.Create(
+            sharedGameId: gameId,
+            uploadedByUserId: userId,
+            fileName: $"test-{Guid.NewGuid():N}.pdf",
+            fileSizeBytes: 1024,
+            blobStorageUrl: "test://blob"
+        );
+        dbContext.PdfDocuments.Add(pdf);
+        await unitOfWork.SaveChangesAsync();
+
+        // Act: transition through pipeline states up to Ready
+        pdf.TransitionTo(PdfProcessingState.Processing);
+        pdf.TransitionTo(PdfProcessingState.Indexing);
+        pdf.TransitionTo(PdfProcessingState.Ready);
+        await unitOfWork.SaveChangesAsync();
+
+        // Assert: only ONE kb.doc.indexed row should exist (NOT 3 — one per transition)
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var rows = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "kb.doc.indexed" && e.AggregateId == pdf.Id)
+            .ToListAsync();
+
+        rows.Should().HaveCount(1, "kb.doc.indexed must fire only on Ready transition");
+        rows[0].AggregateType.Should().Be("PdfDocument");
+        rows[0].UserId.Should().Be(userId);
+        rows[0].PayloadJson.Should().Contain("\"FileName\"");
+        rows[0].PayloadJson.Should().Contain("\"GameId\"").And.Contain(gameId.ToString());
+
+        // Also verify: PdfStateChangedEvent did NOT create rows (not in registry)
+        var stateChangedRows = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "pdf.state.changed")
+            .ToListAsync();
+        stateChangedRows.Should().BeEmpty("PdfStateChangedEvent is NOT registered (B3)");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~KbDocIndexedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the domain event**
+
+Create `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs`:
+
+```csharp
+using Api.SharedKernel.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
+
+/// <summary>
+/// Raised by <see cref="PdfDocument"/> aggregate when <c>TransitionTo(Ready)</c> succeeds
+/// (i.e., the PDF processing pipeline reaches the Ready state — the doc is now searchable).
+/// Distinct from <see cref="PdfStateChangedEvent"/> (which fires on EVERY state transition
+/// and is NOT registered in <c>EventTypeRegistry</c> — would cause log explosion, see B3 #1590).
+/// Registered in <c>EventTypeRegistry</c> with alias <c>"kb.doc.indexed"</c>.
+/// </summary>
+internal sealed record KbDocIndexedEvent(
+    Guid PdfDocumentId,
+    Guid UserId,
+    string FileName,
+    Guid? GameId,
+    string? GameName,
+    int? PageCount,
+    DateTime OccurredAt
+) : IDomainEvent, INotification
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+}
+```
+
+- [ ] **Step 4: Modify `PdfDocument.TransitionTo` to emit on Ready**
+
+In `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs`, find the `TransitionTo` method (around line 360-390). After the existing `AddDomainEvent(new PdfStateChangedEvent(...))` line (~line 382), add:
+
+```csharp
+// BE-3 #1590 (B2): when entering Ready, also raise a dedicated KbDocIndexedEvent
+// for the activity log. PdfStateChangedEvent stays for internal handlers (cache, metrics);
+// KbDocIndexedEvent is the user-meaningful milestone shown in the activity rail.
+if (newState == PdfProcessingState.Ready)
+{
+    AddDomainEvent(new KbDocIndexedEvent(
+        PdfDocumentId: Id,
+        UserId: UploadedByUserId,
+        FileName: FileName,
+        GameId: SharedGameId,
+        GameName: null, // payload-time game name resolution happens via consumer; can also be enriched here if SharedGameRepository is injected
+        PageCount: PageCount,
+        OccurredAt: DateTime.UtcNow
+    ));
+}
+```
+
+Note: `PdfDocument` aggregate doesn't have access to `SharedGameRepository`. Two options:
+- (a) Emit `GameName: null` from the aggregate; query-time enrichment (D1 hybrid strategy) supplies the name in the endpoint mapping.
+- (b) Resolve `GameName` in a domain event handler post-emit, by enriching the payload before persistence.
+
+**Choose (a)** — keeps aggregate purity. The endpoint mapping (Task 8) resolves `gameName` via `SharedGameRepository.GetNamesByIds` join when the payload's `GameName` is null.
+
+- [ ] **Step 5: Register in `EventTypeRegistry`**
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+// ...
+[typeof(KbDocIndexedEvent)] = "kb.doc.indexed", // BE-3 #1590
+```
+
+- [ ] **Step 6: Run the integration test**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~KbDocIndexedIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/KbDocIndexedEvent.cs apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs apps/api/tests/Api.Tests/Integration/Events/KbDocIndexedIntegrationTests.cs
+git commit -m "feat(events): #1590 emit kb.doc.indexed on PdfDocument Ready (BE-3)"
+```
+
+---
+
+## Task 5: `Session` light refactor — implement `IDomainEventSource`
+
+**Goal**: Add `IDomainEventSource` to `Session` (no behavior change, just plumbing for Tasks 6-7).
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionDomainEventTests.cs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionDomainEventTests.cs`:
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.SharedKernel.Domain.Events;
+using FluentAssertions;
+using MediatR;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionDomainEventTests
+{
+    private sealed record TestEvent(DateTime OccurredAt) : IDomainEvent, INotification
+    {
+        public Guid EventId { get; } = Guid.NewGuid();
+    }
+
+    [Fact]
+    public void Session_implements_IDomainEventSource()
+    {
+        var sut = typeof(Session);
+        sut.Should().Implement<IDomainEventSource>();
+    }
+
+    [Fact]
+    public void AddDomainEvent_adds_event_to_DomainEvents()
+    {
+        var session = CreateValidSession();
+        var evt = new TestEvent(DateTime.UtcNow);
+
+        session.AddDomainEvent(evt);
+
+        session.DomainEvents.Should().Contain(evt);
+    }
+
+    [Fact]
+    public void ClearDomainEvents_empties_list()
+    {
+        var session = CreateValidSession();
+        session.AddDomainEvent(new TestEvent(DateTime.UtcNow));
+
+        session.ClearDomainEvents();
+
+        session.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddDomainEvent_null_throws()
+    {
+        var session = CreateValidSession();
+        Action act = () => session.AddDomainEvent(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static Session CreateValidSession()
+    {
+        // Build a valid Session using its actual factory/constructor.
+        // Adapt to match the real Session.Create(...) signature in the codebase.
+        return Session.Create(
+            gameId: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid()
+            // ...other required parameters per the actual factory
+        );
+    }
+}
+```
+
+Adapt `CreateValidSession()` to match the real `Session` factory/constructor signature (read the actual `Session.cs` to find the entry point — typically `Session.Create(...)` or `new Session(...)`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionDomainEventTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL — `Session` does not implement `IDomainEventSource`.
+
+- [ ] **Step 3: Add `IDomainEventSource` to `Session`**
+
+In `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs`, modify the class declaration:
+
+```csharp
+// BEFORE:
+// public sealed class Session
+// AFTER:
+public sealed class Session : IDomainEventSource
+```
+
+Add the implementation (after the existing private fields, before the existing public properties):
+
+```csharp
+private readonly List<IDomainEvent> _domainEvents = new();
+
+/// <summary>
+/// BE-3 #1590 (C1): light IDomainEventSource implementation so Session can participate
+/// in the DomainEventLog pipeline. NOT a full AggregateRoot conversion — Session keeps
+/// its existing factory/methods/constructor unchanged.
+/// </summary>
+public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+public void AddDomainEvent(IDomainEvent domainEvent)
+{
+    ArgumentNullException.ThrowIfNull(domainEvent);
+    _domainEvents.Add(domainEvent);
+}
+
+public void ClearDomainEvents() => _domainEvents.Clear();
+```
+
+Add the `using Api.SharedKernel.Domain.Events;` import at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionDomainEventTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Verify `IDomainEventCollector` picks up `Session` events**
+
+Read `apps/api/src/Api/SharedKernel/Domain/Events/IDomainEventCollector.cs` (and its implementation). Confirm it scans EF Change Tracker for entities implementing `IDomainEventSource`. If it only scans `AggregateRoot<>`, modify the scan to use `IDomainEventSource` interface (same fix needed for ChatSession in Task 3).
+
+If you need to fix the collector, do it here (Task 5) — Tasks 6/7 depend on it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionDomainEventTests.cs apps/api/src/Api/SharedKernel/Domain/Events/
+git commit -m "feat(events): #1590 add IDomainEventSource to Session (light, BE-3)"
+```
+
+---
+
+## Task 6: `SessionCreatedEvent` end-to-end + cross-table integration test (AC5.b)
+
+**Goal**: Emit `session.created` from `CreateSessionCommandHandler`. Add the cross-table assertion (C3.3, AC5.b).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs` (includes cross-table assertion)
+
+- [ ] **Step 1: Write the failing integration test with cross-table assertion**
+
+Create `apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionLifecycleIntegrationTests : IClassFixture<IntegrationWebApplicationFactory<Program>>
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public SessionLifecycleIntegrationTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateSession_writes_to_BOTH_session_events_AND_domain_event_logs()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Session");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            "/api/v1/sessions",
+            sessionToken,
+            new { gameId, playerCount = 4 });
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert: BOTH tables must contain a row
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // Find the newly-created session (latest for this user)
+        var session = await verifyDb.Sessions
+            .AsNoTracking()
+            .Where(s => s.CreatedByUserId == userId)
+            .OrderByDescending(s => s.CreatedAt)
+            .FirstAsync();
+
+        // 1. session_events diary row
+        var diaryRow = await verifyDb.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == session.Id && e.EventType == "session_created")
+            .FirstOrDefaultAsync();
+        diaryRow.Should().NotBeNull("session_events must have session_created diary row");
+
+        // 2. domain_event_logs row
+        var logRow = await verifyDb.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.EventType == "session.created" && e.AggregateId == session.Id)
+            .FirstOrDefaultAsync();
+        logRow.Should().NotBeNull("domain_event_logs must have session.created row");
+        logRow!.AggregateType.Should().Be("Session");
+        logRow.UserId.Should().Be(userId);
+
+        // 3. AC5.b: timestamps differ by < 100ms (same-transaction guarantee)
+        var diaryTs = diaryRow!.Timestamp;
+        var logTs = logRow.OccurredAt;
+        var delta = (diaryTs - logTs).Duration();
+        delta.TotalMilliseconds.Should().BeLessThan(100,
+            "session_events and domain_event_logs must be written in the same transaction (AC5.b)");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionLifecycleIntegrationTests.CreateSession" --logger "console;verbosity=minimal"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the domain event**
+
+Create `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs`:
+
+```csharp
+using Api.SharedKernel.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Events;
+
+/// <summary>
+/// Raised when <c>CreateSessionCommand</c> succeeds — Session aggregate created and persisted.
+/// Registered in <c>EventTypeRegistry</c> with alias <c>"session.created"</c>.
+/// Orthogonal to <c>session_events</c> diary table (which has a "session_created" diary row);
+/// see #1590 C3 socratic resolution.
+/// </summary>
+internal sealed record SessionCreatedEvent(
+    Guid SessionId,
+    Guid UserId,
+    Guid GameId,
+    string? GameName,
+    int PlayerCount,
+    DateTime OccurredAt
+) : IDomainEvent, INotification
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+}
+```
+
+- [ ] **Step 4: Emit from `CreateSessionCommandHandler`**
+
+In `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs`, just before the `await _unitOfWork.SaveChangesAsync(cancellationToken)` at line 239:
+
+```csharp
+// BE-3 #1590: emit session.created domain event (orthogonal to session_events diary row)
+session.AddDomainEvent(new SessionCreatedEvent(
+    SessionId: session.Id,
+    UserId: request.UserId,
+    GameId: session.GameId,
+    GameName: gameName, // resolved earlier in handler if available; else fetch from SharedGameRepository
+    PlayerCount: session.PlayerCount, // adapt to actual property name on Session
+    OccurredAt: DateTime.UtcNow
+));
+
+await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+If `gameName` is not already in scope, resolve it via:
+```csharp
+var gameNames = await _sharedGameRepository
+    .GetNamesByIdsAsync(new[] { session.GameId }, cancellationToken)
+    .ConfigureAwait(false);
+var gameName = gameNames.GetValueOrDefault(session.GameId);
+```
+
+- [ ] **Step 5: Register in `EventTypeRegistry`**
+
+```csharp
+using Api.BoundedContexts.SessionTracking.Domain.Events;
+// ...
+[typeof(SessionCreatedEvent)] = "session.created", // BE-3 #1590
+```
+
+- [ ] **Step 6: Run the integration test**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionLifecycleIntegrationTests.CreateSession" --logger "console;verbosity=minimal"
+```
+Expected: PASS (incl. the <100ms timestamp delta).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionCreatedEvent.cs apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
+git commit -m "feat(events): #1590 emit session.created + AC5.b cross-table test (BE-3)"
+```
+
+---
+
+## Task 7: `SessionFinalizedEvent` end-to-end
+
+**Goal**: Emit `session.finalized` from `FinalizeSessionCommandHandler` (mirror of Task 6).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs`
+- Modify: `apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs` (add new test)
+
+- [ ] **Step 1: Write the failing test (add to existing class)**
+
+Append this test to `SessionLifecycleIntegrationTests.cs`:
+
+```csharp
+[Fact]
+public async Task FinalizeSession_writes_session_finalized_to_domain_event_logs()
+{
+    // Arrange — create a session first
+    using var scope = _factory.Services.CreateScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+    var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Final");
+
+    var createRequest = TestSessionHelper.CreateAuthenticatedRequest(
+        HttpMethod.Post,
+        "/api/v1/sessions",
+        sessionToken,
+        new { gameId, playerCount = 3 });
+    var createResp = await _client.SendAsync(createRequest);
+    createResp.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.Created);
+
+    using var lookupScope = _factory.Services.CreateScope();
+    var lookupDb = lookupScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var session = await lookupDb.Sessions.AsNoTracking()
+        .Where(s => s.CreatedByUserId == userId)
+        .OrderByDescending(s => s.CreatedAt)
+        .FirstAsync();
+
+    // Act — finalize
+    var finalizeRequest = TestSessionHelper.CreateAuthenticatedRequest(
+        HttpMethod.Post,
+        $"/api/v1/sessions/{session.Id}/finalize",
+        sessionToken,
+        new { /* finalize payload matching FinalizeSessionCommand */ });
+    var finalizeResp = await _client.SendAsync(finalizeRequest);
+
+    // Assert
+    finalizeResp.StatusCode.Should().BeOneOf(HttpStatusCode.OK, HttpStatusCode.NoContent);
+
+    using var verifyScope = _factory.Services.CreateScope();
+    var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var logRow = await verifyDb.DomainEventLogs
+        .AsNoTracking()
+        .Where(e => e.EventType == "session.finalized" && e.AggregateId == session.Id)
+        .FirstOrDefaultAsync();
+    logRow.Should().NotBeNull();
+    logRow!.AggregateType.Should().Be("Session");
+    logRow.UserId.Should().Be(userId);
+    logRow.PayloadJson.Should().Contain("\"PlayerCount\"").And.Contain("\"DurationMinutes\"");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionLifecycleIntegrationTests.FinalizeSession" --logger "console;verbosity=minimal"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the domain event**
+
+Create `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs`:
+
+```csharp
+using Api.SharedKernel.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Events;
+
+/// <summary>
+/// Raised when <c>FinalizeSessionCommand</c> succeeds — Session aggregate marked as finalized.
+/// Registered in <c>EventTypeRegistry</c> with alias <c>"session.finalized"</c>.
+/// </summary>
+internal sealed record SessionFinalizedEvent(
+    Guid SessionId,
+    Guid UserId,
+    Guid GameId,
+    string? GameName,
+    int PlayerCount,
+    string? WinnerName,
+    int DurationMinutes,
+    DateTime OccurredAt
+) : IDomainEvent, INotification
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+}
+```
+
+- [ ] **Step 4: Emit from `FinalizeSessionCommandHandler`**
+
+In `apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs`, just before `await _unitOfWork.SaveChangesAsync(cancellationToken)` at line 136:
+
+```csharp
+session.AddDomainEvent(new SessionFinalizedEvent(
+    SessionId: session.Id,
+    UserId: request.UserId,
+    GameId: session.GameId,
+    GameName: gameName,
+    PlayerCount: session.PlayerCount,
+    WinnerName: winnerName, // resolve from request.WinnerId if applicable
+    DurationMinutes: (int)(session.EndedAt!.Value - session.StartedAt).TotalMinutes,
+    OccurredAt: DateTime.UtcNow
+));
+
+await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+```
+
+Adapt property names (`StartedAt`, `EndedAt`, `WinnerId`, `PlayerCount`) to the actual `Session` aggregate's API.
+
+- [ ] **Step 5: Register in `EventTypeRegistry`**
+
+```csharp
+[typeof(SessionFinalizedEvent)] = "session.finalized", // BE-3 #1590
+```
+
+- [ ] **Step 6: Run the integration test**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~SessionLifecycleIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Events/SessionFinalizedEvent.cs apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs apps/api/tests/Api.Tests/Integration/Events/SessionLifecycleIntegrationTests.cs
+git commit -m "feat(events): #1590 emit session.finalized from Finalize (BE-3)"
+```
+
+---
+
+## Task 8: `GET /api/v1/activity` endpoint end-to-end
+
+**Goal**: Expose generalized cross-entity activity feed (AC2, AC3).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/ActivityItemDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryHandler.cs`
+- Create: `apps/api/src/Api/Routing/ActivityEndpoints.cs`
+- Modify: `apps/api/src/Api/Routing/RouteRegistry.cs` (wire `ActivityEndpoints.Map(...)`)
+- Create: `apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing endpoint integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.Events;
+
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Administration")]
+public sealed class ActivityFeedEndpointIntegrationTests : IClassFixture<IntegrationWebApplicationFactory<Program>>
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public ActivityFeedEndpointIntegrationTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetActivity_returns_cross_entity_items_for_user()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Activity");
+
+        // Create an agent → emits agent.created
+        var agentRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, "/api/v1/agents/quick-create", sessionToken, new { gameId });
+        await _client.SendAsync(agentRequest);
+
+        // Act
+        var feedRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/activity?limit=20", sessionToken);
+        var response = await _client.SendAsync(feedRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ActivityFeedResponse>();
+        body.Should().NotBeNull();
+        body!.Items.Should().Contain(i => i.EventType == "agent.created" && i.UserId == userId);
+        var agentItem = body.Items.First(i => i.EventType == "agent.created");
+        agentItem.EntityType.Should().Be("Agent");
+        agentItem.EntityId.Should().NotBe(Guid.Empty);
+        agentItem.PayloadVersion.Should().Be(1);
+        agentItem.Title.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetActivity_unauthenticated_returns_401()
+    {
+        var response = await _client.GetAsync("/api/v1/activity?limit=20");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetActivity_invalid_limit_returns_422()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var req = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/activity?limit=999", sessionToken);
+        var response = await _client.SendAsync(req);
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task GetActivity_only_returns_caller_events_not_other_users()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (alice, aliceToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var (bob, bobToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Multi");
+
+        // Bob creates an agent
+        await _client.SendAsync(TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, "/api/v1/agents/quick-create", bobToken, new { gameId }));
+
+        // Alice queries her feed
+        var req = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/activity?limit=20", aliceToken);
+        var resp = await _client.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<ActivityFeedResponse>();
+        body!.Items.Should().NotContain(i => i.UserId == bob, "Bob's events MUST NOT appear in Alice's feed");
+    }
+}
+
+internal sealed record ActivityFeedResponse(List<ActivityItem> Items, int Count);
+
+internal sealed record ActivityItem(
+    Guid Id,
+    Guid EventId,
+    string EventType,
+    Guid UserId,
+    string EntityType,
+    Guid EntityId,
+    string? Title,
+    DateTime Timestamp,
+    DateTime LoggedAt,
+    int PayloadVersion);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ActivityFeedEndpointIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL — endpoint not registered (404).
+
+- [ ] **Step 3: Create the DTO**
+
+Create `apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/ActivityItemDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Administration.Application.DTOs;
+
+/// <summary>
+/// Generalized activity feed item returned by GET /api/v1/activity.
+/// BE-3 #1590 — cross-entity DTO mapping AggregateType/Id (DB) to entityType/entityId (FE).
+/// </summary>
+internal sealed record ActivityItemDto(
+    Guid Id,
+    Guid EventId,
+    string EventType,
+    Guid UserId,
+    string EntityType,    // = DB AggregateType
+    Guid EntityId,        // = DB AggregateId
+    string? Title,        // entity-friendly display name, derived from PayloadJson where available
+    DateTime Timestamp,   // = DB OccurredAt
+    DateTime LoggedAt,    // = DB LoggedAt
+    int PayloadVersion
+);
+```
+
+- [ ] **Step 4: Create the query**
+
+Create `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+internal sealed record GetActivityFeedQuery(
+    Guid UserId,
+    int Limit = 20,
+    DateTime? Since = null
+) : IQuery<GetActivityFeedResult>;
+
+internal sealed record GetActivityFeedResult(List<ActivityItemDto> Items, int Count);
+```
+
+- [ ] **Step 5: Create the validator**
+
+Create `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryValidator.cs`:
+
+```csharp
+using FluentValidation;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+internal sealed class GetActivityFeedQueryValidator : AbstractValidator<GetActivityFeedQuery>
+{
+    public GetActivityFeedQueryValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.Limit).InclusiveBetween(1, 100);
+    }
+}
+```
+
+- [ ] **Step 6: Create the handler**
+
+Create `apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActivityFeedQueryHandler.cs`:
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+internal sealed class GetActivityFeedQueryHandler : IQueryHandler<GetActivityFeedQuery, GetActivityFeedResult>
+{
+    private static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(90);
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetActivityFeedQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<GetActivityFeedResult> Handle(GetActivityFeedQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var retentionCutoff = DateTime.UtcNow - RetentionWindow;
+        var query = _db.DomainEventLogs
+            .AsNoTracking()
+            .Where(e => e.UserId == request.UserId)
+            .Where(e => e.LoggedAt >= retentionCutoff);
+
+        if (request.Since.HasValue)
+        {
+            query = query.Where(e => e.LoggedAt >= request.Since.Value);
+        }
+
+        var rows = await query
+            .OrderByDescending(e => e.LoggedAt)
+            .Take(request.Limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var items = rows.Select(r => new ActivityItemDto(
+            Id: r.Id,
+            EventId: r.EventId,
+            EventType: r.EventType,
+            UserId: r.UserId ?? Guid.Empty,
+            EntityType: r.AggregateType ?? string.Empty,
+            EntityId: r.AggregateId ?? Guid.Empty,
+            Title: ExtractTitleFromPayload(r.PayloadJson, r.AggregateType),
+            Timestamp: r.OccurredAt,
+            LoggedAt: r.LoggedAt,
+            PayloadVersion: r.PayloadVersion
+        )).ToList();
+
+        return new GetActivityFeedResult(items, items.Count);
+    }
+
+    private static string? ExtractTitleFromPayload(string payloadJson, string? aggregateType)
+    {
+        if (string.IsNullOrWhiteSpace(payloadJson)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(payloadJson);
+            // Title priority by aggregate type:
+            //   Agent → AgentName | ChatSession → AgentName/GameName | PdfDocument → FileName | Session → GameName
+            //   library.* (legacy via GameRemovedFromLibraryEvent etc.) → null (no name in payload)
+            return aggregateType switch
+            {
+                "Agent" => GetString(doc, "AgentName"),
+                "ChatSession" => GetString(doc, "AgentName") ?? GetString(doc, "GameName"),
+                "PdfDocument" => GetString(doc, "FileName"),
+                "Session" => GetString(doc, "GameName"),
+                _ => null,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? GetString(JsonDocument doc, string propertyName)
+    {
+        if (!doc.RootElement.TryGetProperty(propertyName, out var prop)) return null;
+        if (prop.ValueKind != JsonValueKind.String) return null;
+        var value = prop.GetString();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}
+```
+
+- [ ] **Step 7: Create the endpoint**
+
+Create `apps/api/src/Api/Routing/ActivityEndpoints.cs`:
+
+```csharp
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.Infrastructure.Sessions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+internal static class ActivityEndpoints
+{
+    public static void Map(IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1");
+        group.MapGet("/activity", async (
+            [FromQuery] int? limit,
+            [FromQuery] DateTime? since,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            var userId = session!.Principal!.Subject!.Id;
+            var query = new GetActivityFeedQuery(
+                UserId: userId,
+                Limit: limit ?? 20,
+                Since: since
+            );
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return Results.Ok(new
+            {
+                success = true,
+                items = result.Items,
+                count = result.Count
+            });
+        })
+        .RequireAuthenticatedUser()
+        .Produces(200)
+        .Produces(401)
+        .Produces(422)
+        .WithTags("Activity")
+        .WithSummary("Cross-entity activity feed (BE-3 #1590)")
+        .WithDescription("Returns the caller's recent durable domain events from domain_event_logs, " +
+                         "ordered by LoggedAt DESC, capped at 100. 90-day retention. " +
+                         "Forward-only — events before BE-3 deploy do not appear.")
+        .WithOpenApi();
+    }
+}
+```
+
+- [ ] **Step 8: Wire into `RouteRegistry`**
+
+In `apps/api/src/Api/Routing/RouteRegistry.cs`, add (near other endpoint group registrations):
+
+```csharp
+ActivityEndpoints.Map(routes); // BE-3 #1590
+```
+
+- [ ] **Step 9: Run the integration tests**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ActivityFeedEndpointIntegrationTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS — all 4 tests (cross-entity, 401, 422, isolation).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Administration/ apps/api/src/Api/Routing/ActivityEndpoints.cs apps/api/src/Api/Routing/RouteRegistry.cs apps/api/tests/Api.Tests/Integration/Events/ActivityFeedEndpointIntegrationTests.cs
+git commit -m "feat(activity): #1590 add GET /api/v1/activity cross-entity feed (BE-3)"
+```
+
+---
+
+## Task 9: Legacy `/library/activity` — replace placeholder `"Game"` with bulk join
+
+**Goal**: D1 + D2 + AC4 — `GetLibraryActivityQueryHandler` returns real `gameTitle` instead of placeholder; handles soft-deleted SharedGame.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs:162-182`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandlerTests.cs` (update assertions)
+
+- [ ] **Step 1: Update the existing handler test for real gameTitle**
+
+In `apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandlerTests.cs`, find the test that seeds a `library.entry.removed` row and asserts on `GameTitle`. Change the assertion:
+
+```csharp
+// BEFORE: result[0].GameTitle.Should().Be("Game");
+// AFTER:
+result[0].GameTitle.Should().Be("Catan"); // BE-3 #1590: handler now joins SharedGameRepository
+```
+
+You'll need to also seed a `SharedGame` with the matching `GameId` and `Title = "Catan"` so the join can resolve it.
+
+If the test class has a shared `IBlobStorageService`/`ISharedGameRepository` mock, add the `GetNamesByIdsAsync` mock setup:
+
+```csharp
+_mockSharedGameRepository
+    .Setup(r => r.GetNamesByIdsAsync(
+        It.IsAny<IReadOnlyCollection<Guid>>(),
+        It.IsAny<CancellationToken>()))
+    .ReturnsAsync(new Dictionary<Guid, string> { { GameId, "Catan" } });
+```
+
+Add a new test for soft-deleted SharedGame (D2):
+
+```csharp
+[Fact]
+public async Task Handle_softDeletedGame_returnsI18nKey()
+{
+    // Arrange: seed library.entry.removed row but GameNames dictionary does not contain the id (soft-deleted)
+    _mockSharedGameRepository
+        .Setup(r => r.GetNamesByIdsAsync(
+            It.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(GameId)),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new Dictionary<Guid, string>()); // empty = soft-deleted
+
+    // ... seed log row as before ...
+
+    var result = await _sut.Handle(new GetLibraryActivityQuery(UserId, 20), CancellationToken.None);
+
+    result[0].GameTitle.Should().Be("library.activity.deletedGame");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetLibraryActivityQueryHandlerTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL — handler still returns `"Game"`.
+
+- [ ] **Step 3: Refactor the handler**
+
+In `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs`, locate the section that currently produces `gameTitle = "Game"` placeholder (around lines 162-182). Replace the entire mapping section with:
+
+```csharp
+// BE-3 #1590 (D1): bulk-join SharedGameRepository.GetNamesByIds for real gameTitle.
+// Replaces the legacy placeholder "Game" at line 180 (// Future enhancement).
+// Soft-deleted games (not in the dictionary) → return i18n key "library.activity.deletedGame".
+var gameIds = mergedItems
+    .Where(i => i.GameId != Guid.Empty)
+    .Select(i => i.GameId)
+    .Distinct()
+    .ToList();
+
+var gameNames = gameIds.Count > 0
+    ? await _sharedGameRepository.GetNamesByIdsAsync(gameIds, cancellationToken).ConfigureAwait(false)
+    : new Dictionary<Guid, string>();
+
+return mergedItems
+    .Select(i => new LibraryActivityItemDto(
+        Id: i.Id,
+        Type: i.Type,
+        Timestamp: i.Timestamp,
+        GameId: i.GameId,
+        GameTitle: gameNames.TryGetValue(i.GameId, out var title)
+            ? title
+            : "library.activity.deletedGame", // i18n key — FE renders "Gioco rimosso"
+        Message: i.Message
+    ))
+    .ToList()
+    .AsReadOnly();
+```
+
+The handler must now have `_sharedGameRepository` injected — add it to the constructor if not present. Mirror the BE-1 #1588 pattern (`ListUserKbDocsQueryHandler` injection).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetLibraryActivityQueryHandlerTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandler.cs apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Queries/GetLibraryActivityQueryHandlerTests.cs
+git commit -m "fix(activity): #1590 resolve real gameTitle via bulk join (BE-3 D1/D2)"
+```
+
+---
+
+## Task 10: Observability — counters G1 + G2
+
+**Goal**: AC7 — two Prometheus counters wired into `MeepleAiDbContext.SaveChangesAsync`.
+
+**Files:**
+- Create: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs`
+- Modify: `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs:449-470`
+- Create: `apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs`
+
+- [ ] **Step 1: Write the failing metrics test**
+
+Create `apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+using Api.Infrastructure;
+using Api.Observability;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Observability.Metrics;
+
+[Trait("Category", TestCategories.Integration)]
+public sealed class DomainEventLogMetricsTests : IClassFixture<IntegrationWebApplicationFactory<Program>>
+{
+    private readonly IntegrationWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+
+    public DomainEventLogMetricsTests(IntegrationWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task DomainEventInserted_counter_increments_on_event_emission()
+    {
+        // Arrange: subscribe to the Meter via MeterListener
+        var measurements = new List<(long Value, IReadOnlyList<KeyValuePair<string, object?>> Tags)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "MeepleAI.Api" &&
+                    instrument.Name == "meepleai.domain_event_log.inserted.total")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((inst, value, tags, state) =>
+            measurements.Add((value, tags.ToArray())));
+        listener.Start();
+
+        // Act
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, title: "Catan-BE3-Metric");
+
+        var req = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, "/api/v1/agents/quick-create", sessionToken, new { gameId });
+        await _client.SendAsync(req);
+
+        // Assert: at least one increment for agent.created
+        measurements
+            .Should().Contain(m =>
+                m.Tags.Any(t => t.Key == "event_type" && (string?)t.Value == "agent.created"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~DomainEventLogMetricsTests" --logger "console;verbosity=minimal"
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Create the metrics partial**
+
+Create `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>
+/// Domain event log persistence metrics (BE-3 #1590 AC7).
+/// G1: inserted counter — every successful log row insert.
+/// G2: dispatch failures counter — when an INotificationHandler throws after the log row
+///     is durable (the row is NOT rolled back; we only observe the silent handler crash).
+/// </summary>
+internal static partial class MeepleAiMetrics
+{
+    public static readonly Counter<long> DomainEventsInserted = Meter.CreateCounter<long>(
+        name: "meepleai.domain_event_log.inserted.total",
+        unit: "events",
+        description: "Total domain events persisted to domain_event_logs by event type (#1590 G1)");
+
+    public static readonly Counter<long> DomainEventDispatchFailures = Meter.CreateCounter<long>(
+        name: "meepleai.domain_event_log.dispatch_failures.total",
+        unit: "failures",
+        description: "Total handler dispatch failures after domain event was persisted (#1590 G2)");
+}
+```
+
+- [ ] **Step 4: Wire into `MeepleAiDbContext.SaveChangesAsync`**
+
+In `apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs`, find lines 449-470 (the loop that adds log entities and the try/catch around `_mediator.Publish`).
+
+After `DomainEventLogs.Add(logEntity)` (line ~451), add:
+
+```csharp
+// BE-3 #1590 G1: counter increment per inserted row
+MeepleAiMetrics.DomainEventsInserted.Add(1,
+    new KeyValuePair<string, object?>("event_type", logEntity.EventType));
+```
+
+In the catch block around `_mediator.Publish` (line ~468), add:
+
+```csharp
+catch (Exception ex)
+{
+    // existing ERROR log...
+    _logger.LogError(ex, ...);
+
+    // BE-3 #1590 G2: counter increment per handler dispatch failure
+    MeepleAiMetrics.DomainEventDispatchFailures.Add(1,
+        new KeyValuePair<string, object?>("event_type", domainEvent.GetType().Name), // or the alias if available
+        new KeyValuePair<string, object?>("handler_name", "unknown")); // refine if handler identity is accessible
+}
+```
+
+If the dispatch loop iterates per handler (Mediatr publishes to all handlers), and you can capture the handler type name from the exception/context, use that for the `handler_name` tag.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~DomainEventLogMetricsTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventLog.cs apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs apps/api/tests/Api.Tests/Observability/Metrics/DomainEventLogMetricsTests.cs
+git commit -m "feat(observability): #1590 add domain event log counters G1+G2 (BE-3)"
+```
+
+---
+
+## Task 11: Architectural test (AC8) + final XML doc sweep (AC9 verify)
+
+**Goal**: C3.1 + C3.4 — protect the orthogonal-tables boundary; ensure all XML docs are in place.
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs`
+- Modify (verify only — Task 1 should have done this): `apps/api/src/Api/Infrastructure/Entities/DomainEventLog/DomainEventLog.cs`
+
+- [ ] **Step 1: Write the architectural test**
+
+Create `apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs`:
+
+```csharp
+using System.Reflection;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.UserLibrary.Application.Queries;
+using Api.Infrastructure.Repositories;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Architecture;
+
+[Trait("Category", TestCategories.Architecture)]
+public sealed class EventLogBoundaryTests
+{
+    /// <summary>
+    /// AC8 (#1590 C3.1): the session-diary handler must NOT depend on the durable
+    /// domain event log infrastructure. The two tables are orthogonal by design.
+    /// </summary>
+    [Fact]
+    public void GetSessionDiaryQueryHandler_does_NOT_depend_on_IDomainEventLogRepository()
+    {
+        var ctorParams = GetCtorParameterTypes<GetSessionDiaryQueryHandler>();
+        ctorParams.Should().NotContain(t => t.Name == "IDomainEventLogRepository",
+            "GetSessionDiaryQueryHandler must not read from domain_event_logs (BE-3 #1590 AC8)");
+    }
+
+    /// <summary>
+    /// AC8 (#1590 C3.1): the library-activity handler must NOT depend on the
+    /// session-diary infrastructure. Drift prevention.
+    /// </summary>
+    [Fact]
+    public void GetLibraryActivityQueryHandler_does_NOT_depend_on_ISessionEventRepository()
+    {
+        var ctorParams = GetCtorParameterTypes<GetLibraryActivityQueryHandler>();
+        ctorParams.Should().NotContain(t => t.Name == "ISessionEventRepository",
+            "GetLibraryActivityQueryHandler must not read from session_events (BE-3 #1590 AC8)");
+    }
+
+    private static Type[] GetCtorParameterTypes<T>()
+    {
+        var ctor = typeof(T).GetConstructors(BindingFlags.Public | BindingFlags.Instance).First();
+        return ctor.GetParameters().Select(p => p.ParameterType).ToArray();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (both handlers should already be clean)**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~EventLogBoundaryTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS — both handlers should already be clean (Task 9 modified `GetLibraryActivityQueryHandler` to inject `_sharedGameRepository`, NOT `ISessionEventRepository`).
+
+If the test FAILS, it means one of the handlers accidentally took a dependency on the other side — fix the handler (the test enforces the architectural rule).
+
+- [ ] **Step 3: Verify XML docs are in place (AC9 sanity check)**
+
+Confirm `DomainEventLog.cs` (modified in Task 1) has the XML docs for `AggregateType` and `AggregateId` that declare the logical-FK mapping. If they're not there, add them now (per Task 1 Step 2).
+
+- [ ] **Step 4: Final full-suite test run**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~Events|FullyQualifiedName~EventTypeRegistry|FullyQualifiedName~DomainEventLog|FullyQualifiedName~Activity" --logger "console;verbosity=minimal"
+```
+Expected: ALL PASS. This is the BE-3 final test gate.
+
+- [ ] **Step 5: Verify `EventTypeRegistryTests` still passes**
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~EventTypeRegistryTests" --logger "console;verbosity=minimal"
+```
+Expected: PASS — the existing test that asserts all registry entries resolve to real `IDomainEvent` types will validate the 5 new entries automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Architecture/EventLogBoundaryTests.cs
+git commit -m "test(events): #1590 add architectural boundary tests AC8 (BE-3)"
+```
+
+---
+
+## Final acceptance check
+
+After all 11 tasks complete, run:
+
+```bash
+cd /d/Repositories/meepleai-monorepo-frontend/apps/api && dotnet test tests/Api.Tests/Api.Tests.csproj --filter "Category=Integration|Category=Architecture|FullyQualifiedName~EventTypeRegistry|FullyQualifiedName~DomainEventLog" --logger "console;verbosity=minimal"
+```
+
+Expected: ALL PASS.
+
+| AC | Verified by |
+|---|---|
+| AC1 (5 events land + idempotence + PayloadVersion) | Tasks 2/3/4/6/7 integration tests |
+| AC2 (GET /api/v1/activity generalized) | Task 8 integration tests |
+| AC3 (forward-only, no backfill) | No-op in BE-3 (no backfill code written); cold-start UX is FE in #1593 |
+| AC4 (GET /library/activity backward-compat + real gameTitle) | Task 9 unit + Task 8 multi-entity feed integration |
+| AC5 (≥2 BC integration tests + existing 2 library) | Tasks 2 (Agent) + 3 (Chat) + 4 (KbDoc) + 6 (Session) + EXISTING tests for library.* not removed |
+| AC5.b (cross-table SessionTracking <100ms) | Task 6 integration test |
+| AC6 (index exists) | Verified in BE exploration (`ix_domain_event_logs_user_loggedat`) — Task 1 confirms by reading EF config |
+| AC7 (counters G1 + G2) | Task 10 |
+| AC8 (architectural test) | Task 11 |
+| AC9 (XML doc on AggregateType/Id) | Task 1 (initial doc) + Task 11 (verification) |
+
+---
+
+## Out of scope (follow-ups / cross-cuts)
+
+- **E1 FE rename `useActivityFeed` → `useDashboardActivityFeed`**: tracked in #1593 pre-req. NOT BE-3.
+- **F1 unify `added` double-path**: keep two sources. Cleanup follow-up if ever needed.
+- **`PayloadVersion` v2 / breaking payload migrations**: when any event needs a breaking payload change, increment `PayloadVersion` for new emissions; the handler can branch on version (`if payloadVersion >= 2 then DTO_v2 else DTO_v1`). Defer until first real migration is needed.
+- **Backfill SessionTracking historical sessions into `domain_event_logs`**: explicitly rejected (AC3 + cold-start UX via FE in #1593).
+- **`ActivityTimelineService` runtime fan-out**: explicitly rejected in favor of durable log (issue body §"Endpoint generalization").


### PR DESCRIPTION
Extends `EventTypeRegistry` with 5 cross-entity events for the activity rail (BE-3 #1590, library hybrid-hub Phase 3 dependency). Forward-only — no backfill.

## Changes (11 tasks, TDD)

- **Task 1**: Add `PayloadVersion INT` column to `domain_event_logs` (migration, default 1; AC9 logical-FK XML docs on AggregateType/Id).
- **Tasks 2-7**: Emit 5 domain events — `agent.created` (user flow only, H1), `chat.session.created` (gameName/agent snapshot, H2), `kb.doc.indexed` (Ready-only dedicated event, B3), `session.created`, `session.finalized`. Each extends `DomainEventBase`/`IDomainEvent`, exposes `AggregateId`+`UserId` for the mapper, registered with a stable alias.
- **Task 5**: `Session` + `ChatSession` implement `IDomainEventSource` (additive, no aggregate behavior change); `SessionRepository.AddAsync`/`UpdateAsync` + `AgentDefinitionRepository.AddAsync` now collect domain events.
- **Task 2 bonus**: `AgentType.Tutor` added — fixes the pre-existing `quick-create` 400 baseline (was rejecting the hardcoded "Tutor" type; this is the `QuickCreateAgent_WithValidGame_ReturnsTutorResult` failure seen in #1589).
- **Task 8**: `GET /api/v1/activity` — caller-scoped cross-entity feed from `domain_event_logs` (90-day retention, limit 1-100, `?since` cursor, ordered `LoggedAt DESC`, eventType→clean entityType mapping).
- **Task 9**: `/library/activity` bulk-join refactor — real `gameTitle` via `SharedGameRepository.GetNamesByIds` (D1, no N+1) + `"library.activity.deletedGame"` i18n key for soft-deleted games (D2). Backward-compat DTO shape preserved (AC4).
- **Task 10**: Prometheus counters `meepleai.domain_event_log.inserted.total{event_type}` (G1) + `dispatch_failures.total{event_type, handler_name}` (G2), consistent alias tag.
- **Task 11**: AC8 architectural boundary tests (`session_events` and `domain_event_logs` read paths stay disjoint).
- `SessionFinalizedEvent` activation wires the previously-dormant KnowledgeBase cascade cleanup (ends AgentSessions on finalize).

## Acceptance criteria

AC1-AC9 + AC5.b all met. Cross-table SessionTracking test proves `session_events` + `domain_event_logs` land in one transaction (<100ms). 20 panel decisions (A1-H2 + C3.1-C3.4 from /sc:spec-panel discussion + socratic).

## Test plan

- [x] 343/343 BE-3 suite tests pass (5 event integration tests across 4 BCs + activity endpoint + legacy refactor + metrics + arch boundary + EventTypeRegistry).
- [x] Build 0 errors. Full CI on this PR.

## Notes (follow-ups, not blockers)

- `kb.doc.indexed` rail Title = filename (gameName null at emit by design — `PdfDocument.TransitionTo` has no repo access; opt-a from panel).
- `SessionFinalizedEvent` is instantiated twice in `FinalizeSessionCommandHandler` (durable-log + SSE); the KB cascade handler is idempotent so no correctness bug, but the dual-dispatch is structural debt worth a follow-up.
- G2 `handler_name` is best-effort (event CLR type) — MediatR.Publish is opaque; per-handler granularity would need a custom INotificationPublisher.

Closes #1590. Unblocks Phase 3b rail #1593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)