### PR TITLE
feat(ci): #1578 AI services GHCR build & push pipeline

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -698,8 +698,14 @@ jobs:
     # completed in 13m38s. Margin is tight on cold-cache builds; bump to 40
     # if NuGet restore consistently exceeds 8 min.
     timeout-minutes: 30
-    needs: [build, snapshot-baseline]
-    if: always() && needs.build.result == 'success' && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
+    needs: [detect-changes, build, build-ai, snapshot-baseline]
+    # Issue #1578 — skip-propagation handling. An AI-only deploy has `build`
+    # (api/web) skipped, so `build` may be 'success' OR 'skipped'. build-ai may
+    # be 'success' (built) or 'skipped' (no AI change); a build-ai FAILURE
+    # (success||skipped false) blocks the deploy on purpose — don't deploy when
+    # an image we asked to build failed. snapshot-baseline may be skipped on
+    # AI-only deploys (it gates on `build`).
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped') && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
     environment:
       name: staging
       url: https://meepleai.app

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -517,6 +517,90 @@ jobs:
           echo "  API built: ${{ needs.detect-changes.outputs.deploy_api }}"
           echo "  Web built: ${{ needs.detect-changes.outputs.deploy_web }}"
 
+  # Build and push AI service images (only changed ones). Issue #1578.
+  # Separate from `build` so the slow torch QEMU builds run in parallel
+  # (matrix), with per-service timeout, and a single failure does not block
+  # the other services. ALWAYS ubuntu-latest (cloud) — never the VPS.
+  build-ai:
+    name: Build AI Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: [pre-deploy-check, detect-changes]
+    if: always() && (needs.pre-deploy-check.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true)) && needs.detect-changes.outputs.ai_any == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [embedding, reranker, orchestration]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          sparse-checkout: |
+            apps/${{ matrix.service }}-service/
+          sparse-checkout-cone-mode: true
+
+      - name: Generate Version
+        id: version
+        run: |
+          VERSION="staging-$(date +'%Y%m%d')-${GITHUB_SHA::7}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 ${{ matrix.service }} version: $VERSION"
+
+      - name: Free disk space for build
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        run: |
+          docker builder prune -f 2>/dev/null || true
+          docker image prune -a -f --filter 'until=24h' 2>/dev/null || true
+          echo "📊 Disk free: $(df -h / | tail -1 | awk '{print $4}')"
+
+      - name: Setup Docker Buildx
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Setup QEMU for ARM64
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4
+        with:
+          platforms: arm64
+
+      - name: Login to GitHub Container Registry
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Metadata
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service }}-service
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=staging-latest
+
+      # Python torch Dockerfiles are NOT cross-compile-ready (no $BUILDPLATFORM),
+      # so the arm64 build runs under QEMU emulation. Acceptable: gated by
+      # change-detection (rare) and runs on the cloud runner (never the VPS).
+      - name: Build and Push ${{ matrix.service }}
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: ./apps/${{ matrix.service }}-service
+          file: ./apps/${{ matrix.service }}-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha,scope=ai-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=ai-${{ matrix.service }}
+
+      - name: Build Summary
+        run: echo "🤖 ${{ matrix.service }}-service — changed=${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}"
+
   # Snapshot previous performance baseline before deploy overwrites DEPLOYMENT.json
   snapshot-baseline:
     name: Snapshot Performance Baseline

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1327,9 +1327,30 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Bound GHCR storage for the AI packages. Issue #1578.
+  ghcr-retention:
+    name: GHCR Retention (AI)
+    needs: [deploy]
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [embedding, reranker, orchestration]
+    steps:
+      - name: Delete old container versions (keep last 5)
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
+        with:
+          package-name: ${{ github.event.repository.name }}/${{ matrix.service }}-service
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: '^staging-latest$'
+
   notify-end:
     if: always()
-    needs: [detect-changes, pre-deploy-check, build, snapshot-baseline, deploy, validate, e2e-staging]
+    needs: [detect-changes, pre-deploy-check, build, build-ai, snapshot-baseline, deploy, validate, e2e-staging, ghcr-retention]
     uses: ./.github/workflows/notify-slack.yml
     with:
       event: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'completed' }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -136,6 +136,8 @@ jobs:
       infra: ${{ steps.changes.outputs.infra }}
       deploy_api: ${{ steps.decision.outputs.deploy_api }}
       deploy_web: ${{ steps.decision.outputs.deploy_web }}
+      ai_changed: ${{ steps.decision.outputs.ai_changed }}
+      ai_any: ${{ steps.decision.outputs.ai_any }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -178,6 +180,12 @@ jobs:
             infra:
               - 'infra/**'
               - '.github/workflows/deploy-staging.yml'
+            embedding:
+              - 'apps/embedding-service/**'
+            reranker:
+              - 'apps/reranker-service/**'
+            orchestration:
+              - 'apps/orchestration-service/**'
 
       - name: Determine what to deploy
         id: decision
@@ -208,6 +216,29 @@ jobs:
             echo "deploy_web=$WEB" >> $GITHUB_OUTPUT
             echo "📦 Selective deploy: api=$API, web=$WEB"
           fi
+
+          # Issue #1578 — AI service change detection. Same force-full triggers
+          # as api/web (workflow_dispatch / force / infra / initial push).
+          EMB="${{ steps.changes.outputs.embedding }}"
+          RRK="${{ steps.changes.outputs.reranker }}"
+          ORC="${{ steps.changes.outputs.orchestration }}"
+          if [ "$EVENT" = "workflow_dispatch" ] \
+            || [ "$FORCE" = "true" ] \
+            || [ "$INFRA" = "true" ] \
+            || [ "$BEFORE" = "$ZEROS" ] \
+            || [ -z "$BEFORE" ]; then
+            EMB=true; RRK=true; ORC=true
+          fi
+          # paths-filter outputs are empty when the changes step is skipped
+          # (workflow_dispatch). Normalize empties to false.
+          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"
+          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC}" >> $GITHUB_OUTPUT
+          if [ "$EMB" = "true" ] || [ "$RRK" = "true" ] || [ "$ORC" = "true" ]; then
+            echo "ai_any=true" >> $GITHUB_OUTPUT
+          else
+            echo "ai_any=false" >> $GITHUB_OUTPUT
+          fi
+          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC"
 
   # Lightweight pre-deploy validation (full CI already ran on main-dev PR)
   # Rationale: Code reaching main-staging has already passed the full ci.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -878,6 +878,40 @@ jobs:
             export API_IMAGE="${{ env.API_IMAGE }}:staging-latest"
             export WEB_IMAGE="${{ env.WEB_IMAGE }}:staging-latest"
 
+            # Issue #1578 — AI image vars. compose.staging.yml guards
+            # embedding/reranker with ${X_IMAGE:?}, so every `compose up`
+            # (even one targeting only some services) needs them set, or it
+            # aborts (analog of the api/web #1399-C fix above). Default all to
+            # staging-latest; changed services keep this ref (the build-ai job
+            # always pushes staging-latest).
+            AI_BASE="${{ env.REGISTRY }}/${{ github.repository }}"
+            export EMBEDDING_IMAGE="${AI_BASE}/embedding-service:staging-latest"
+            export RERANKER_IMAGE="${AI_BASE}/reranker-service:staging-latest"
+            export ORCHESTRATION_IMAGE="${AI_BASE}/orchestration-service:staging-latest"
+
+            EMB_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).embedding }}"
+            RRK_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).reranker }}"
+            ORC_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).orchestration }}"
+
+            # Pre-pull disk guard (issue #1578 / #1575). Pulling a ~5GB torch
+            # image while the old one is still referenced can fill the disk.
+            # Pre-prune, then require AI_PULL_GATE_GB free; otherwise ABORT
+            # (fail-safe) — never risk disk-full.
+            AI_PULL_GATE_GB="${AI_PULL_GATE_GB:-15}"
+            if [ "$EMB_CHANGED" = "true" ] || [ "$RRK_CHANGED" = "true" ] || [ "$ORC_CHANGED" = "true" ]; then
+              echo "🧹 Pre-prune before AI image pull..."
+              docker image prune -af --filter "until=24h" || true
+              FREE_GB=$(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
+              echo "💽 VPS disk: ${FREE_GB} GB free — AI pull gate ${AI_PULL_GATE_GB} GB"
+              if [ "$FREE_GB" -lt "$AI_PULL_GATE_GB" ]; then
+                echo "::error::Insufficient disk for AI image pull: ${FREE_GB} GB free < ${AI_PULL_GATE_GB} GB"
+                echo "🚫 Aborting AI deploy (fail-safe). Manual cleanup on the VPS:"
+                echo "  docker image prune -af"
+                echo "  bash /opt/meepleai/repo/infra/scripts/daily-disk-prune.sh"
+                exit 1
+              fi
+            fi
+
             SERVICES=""
 
             # Pull and tag only changed images
@@ -893,6 +927,24 @@ jobs:
               export WEB_IMAGE="${{ needs.build.outputs.web_image }}"
               SERVICES="$SERVICES web"
               echo "📦 Web image updated"
+            fi
+
+            # Issue #1578 — AI services. embedding/reranker are in the
+            # ai-essential profile → pull + recreate. orchestration is
+            # publish-only → pull ONLY (cached for a future activation).
+            if [ "$EMB_CHANGED" = "true" ]; then
+              docker pull "$EMBEDDING_IMAGE"
+              SERVICES="$SERVICES embedding-service"
+              echo "📦 embedding-service image updated"
+            fi
+            if [ "$RRK_CHANGED" = "true" ]; then
+              docker pull "$RERANKER_IMAGE"
+              SERVICES="$SERVICES reranker-service"
+              echo "📦 reranker-service image updated"
+            fi
+            if [ "$ORC_CHANGED" = "true" ]; then
+              docker pull "$ORCHESTRATION_IMAGE" || echo "⚠️ orchestration pull failed (non-blocking; not active in staging)"
+              echo "📦 orchestration-service image cached (not started in staging)"
             fi
 
             if [ -z "$SERVICES" ]; then
@@ -937,12 +989,34 @@ jobs:
             assert any(c['name']=='redis' and c['status']=='Healthy' for c in d['checks']), 'redis unhealthy'
             " || exit 1
 
+            # Issue #1578 — AI container health (only for recreated services).
+            # Container names per compose: embedding-service→meepleai-embedding,
+            # reranker-service→meepleai-reranker.
+            ai_health() {
+              cname="$1"
+              echo "⏳ Waiting for ${cname} health..."
+              for attempt in $(seq 1 40); do
+                st=$(docker inspect --format '{{.State.Health.Status}}' "$cname" 2>/dev/null || echo "missing")
+                if [ "$st" = "healthy" ]; then echo "✅ ${cname} healthy after ~$((attempt*5))s"; return 0; fi
+                sleep 5
+              done
+              echo "::error::${cname} did not become healthy"
+              docker logs "$cname" --tail 30 2>/dev/null || true
+              return 1
+            }
+            case " $SERVICES " in *" embedding-service "*) ai_health meepleai-embedding || exit 1 ;; esac
+            case " $SERVICES " in *" reranker-service "*) ai_health meepleai-reranker || exit 1 ;; esac
+
             # Record deployment version
             cat > /opt/meepleai/repo/infra/DEPLOYMENT.json << VEREOF
             {
               "version": "${{ needs.build.outputs.version }}",
               "api_image": "${{ needs.build.outputs.api_image }}",
               "web_image": "${{ needs.build.outputs.web_image }}",
+              "embedding_image": "${EMBEDDING_IMAGE}",
+              "reranker_image": "${RERANKER_IMAGE}",
+              "orchestration_image": "${ORCHESTRATION_IMAGE}",
+              "ai_changed": "embedding=${EMB_CHANGED},reranker=${RRK_CHANGED},orchestration=${ORC_CHANGED}",
               "environment": "staging",
               "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
               "deployed_by": "${{ github.actor }}",

--- a/docs/for-developers/specs/2026-05-28-ai-services-ghcr-pipeline-design.md
+++ b/docs/for-developers/specs/2026-05-28-ai-services-ghcr-pipeline-design.md
@@ -1,0 +1,292 @@
+# AI Services GHCR Build & Push Pipeline Design
+
+**Date**: 2026-05-28
+**Status**: Approved (brainstorming) — pending implementation plan
+**Author**: /sc:spec-panel + brainstorming session
+**Issue**: [#1578](https://github.com/meepleAi-app/meepleai-monorepo/issues/1578) — infra(ai-services): 2-month drift, local build, no GHCR push pipeline
+**Related**: [[2026-05-25-ci-arm64-crosscompile-design]] (api/web ARM64 build), [[2026-05-25-ci-build-once-test-many]]
+
+## Problem
+
+In `infra/docker-compose.yml`, the AI services use a local-only `build:` directive with **no** `image: ghcr.io/...`:
+
+```yaml
+embedding-service:
+  build:
+    context: ../apps/embedding-service
+    dockerfile: ./Dockerfile
+  # no image: → built locally as meepleai_embedding-service:latest, never refreshed
+```
+
+Unlike `api`/`web` — which `deploy-staging.yml` builds and pushes to GHCR on every merge to `main-staging` — the AI services are **never rebuilt by automation**. `docker compose up` reuses the local image as long as it exists. Result: ~50-day drift between repo code and the images running on the staging VPS (discovered during the 2026-05-26 manual recovery deploy, #1575).
+
+**Concrete impact:**
+- `orchestration-service`: fix #1073 (OPENROUTER_API_KEY guard, 2026-05-12) is in repo but not in the running staging image.
+- `embedding-service` / `reranker-service`: every dependency bump (pytest #776, Hadolint #781) and security fix of the last 2 months is absent from staging.
+
+## Goal
+
+Build + push `embedding`, `reranker`, and `orchestration` images to GHCR with **per-service change detection**, **pulled (never built) on the ARM64 staging VPS**, under **strict disk safety**.
+
+**Constraints** (drove the design decisions below):
+
+- **Disk safety is a hard requirement.** The staging VPS (Hetzner CAX21, ARM64, ~75 GB disk) hit disk-full on 2026-05-26 (#1575). Current AI images ≈ 7.4 GB (embedding ~5.26 GB + reranker ~2.1 GB). The real risk is the **transient** during deploy: pulling a new image while the old one is still referenced (~10.5 GB for embedding alone) before pruning.
+- **ARM64 only.** The VPS is ARM64; images must be `linux/arm64`.
+- **Python torch Dockerfiles are NOT cross-compile-ready.** All 5 AI Dockerfiles use plain `FROM python:3.11-slim AS builder` (no `$BUILDPLATFORM` pinning, unlike the api/web Onda B rework). `embedding` (`torch==2.8.0`) and `reranker` (`torch`) also **pre-download their ML model at build time** by executing torch under the build stage. Building `linux/arm64` on an x64 runner therefore requires **QEMU emulation** for those torch steps.
+- **Zero added runner cost.** No paid GitHub-hosted ARM64 runners.
+- **Dev local-build behavior must not regress.** `make dev` must keep building the AI services locally.
+- **Never build torch on the VPS.** Rebuilding embedding/reranker on the CAX21 (8 GB RAM) drives it into swap thrashing and disk-full (prior incident; see memory `vps-torch-rebuild-diskfull`). Staging must **pull**, never build.
+
+## Key Decisions (brainstorming outcomes)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Scope** | embedding + reranker + orchestration | The 3 services with cited real impact. smoldocling + unstructured are disabled in staging (`pdf-cloud-extractors` profile) → out of scope. |
+| **ARM64 build** | QEMU on `ubuntu-latest` + per-service change detection | Zero cost, reuses existing build pattern. Slow torch builds are acceptable because they run only when that service's code/requirements change (rare, ~monthly) and on a cloud runner (never the VPS). |
+| **orchestration** | Publish-only (build+push, **not** activated in staging) | Avoids adding a running container to the 8 GB VPS. Image is fresh and ready for a future `--profile tutor-agents` activation (separate decision). |
+| **Disk safety** | Aggressive prune + dedicated pull gate (15 GB) + GHCR retention (keep 5) | Protects the VPS disk against the old+new transient; bounds registry storage growth over time. |
+| **Architecture** | Matrix `build-ai` job inside `deploy-staging.yml` | Isolates slow torch builds (parallel, per-service timeout, `fail-fast: false`) without duplicating the SSH/deploy/disk-gate logic. |
+| **build-ai timeout** | 120 min | Prudent headroom for a not-yet-measured torch+model build under QEMU; lower once real timings are known. |
+| **Disk gate behavior** | Abort fail-safe | If free disk stays below the gate after pre-prune, the AI deploy stops with a clear error rather than risking disk-full. |
+
+## Design
+
+All changes live in `deploy-staging.yml` + the two compose files. New job graph (additions in **bold**):
+
+```
+gate → detect-changes → pre-deploy-check
+pre-deploy-check + detect-changes → build (api/web)        [existing]
+pre-deploy-check + detect-changes → build-ai (matrix)      ◄── NEW
+build + build-ai → snapshot-baseline
+build + build-ai + snapshot-baseline → deploy              ◄── extended
+deploy → validate → e2e-staging
+... → notify-end
+deploy → ghcr-retention                                    ◄── NEW
+```
+
+### Unit 1 — `detect-changes` extension
+
+**Responsibility**: decide which AI services changed and need rebuild.
+
+**Change**: add 3 path filters + two outputs.
+
+```yaml
+filters: |
+  api:    [ 'apps/api/**' ]
+  web:    [ 'apps/web/**' ]
+  infra:  [ 'infra/**', '.github/workflows/deploy-staging.yml' ]
+  embedding:     [ 'apps/embedding-service/**' ]
+  reranker:      [ 'apps/reranker-service/**' ]
+  orchestration: [ 'apps/orchestration-service/**' ]
+```
+
+The decision step emits:
+- `ai_changed` — a JSON map, e.g. `{"embedding":true,"reranker":false,"orchestration":true}`.
+- `ai_any` — `"true"` if any of the three changed (gates the whole `build-ai` job).
+
+Same force-full logic as today: on `workflow_dispatch`, `force_full_deploy=true`, an `infra` change, or initial push (`before=zeros`), all three are forced `true`.
+
+**Interface**: downstream jobs read `needs.detect-changes.outputs.ai_changed` / `.ai_any`.
+
+### Unit 2 — `build-ai` matrix job (NEW)
+
+**Responsibility**: build + push the ARM64 image of each changed AI service to GHCR.
+
+```yaml
+build-ai:
+  name: Build AI Images
+  runs-on: ubuntu-latest
+  timeout-minutes: 120
+  needs: [pre-deploy-check, detect-changes]
+  if: always()
+     && (needs.pre-deploy-check.result == 'success'
+         || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true))
+     && needs.detect-changes.outputs.ai_any == 'true'
+  strategy:
+    fail-fast: false
+    matrix:
+      service: [embedding, reranker, orchestration]
+  steps:
+    - Checkout (sparse: apps/${{ matrix.service }}-service/)
+    - Free disk space            # reuse existing step (buildx + image prune)
+    - Setup Buildx
+    - Setup QEMU (platforms: arm64)
+    - Login GHCR
+    - Extract metadata (docker/metadata-action)   # if service changed
+    - Build & Push                                 # if service changed
+```
+
+**Per-service skip**: the metadata + build/push steps carry
+`if: fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service]`.
+An unchanged service still spins up the leg (checkout + setup) but does no build/push — a fast no-op. (Matrix legs cannot be skipped wholesale; gating the heavy steps is the idiomatic approach.)
+
+**Tags** (via `docker/metadata-action`, same scheme as api/web):
+- `ghcr.io/<repo>/<service>-service:staging-YYYYMMDD-SHA` (immutable)
+- `ghcr.io/<repo>/<service>-service:staging-latest` (moving)
+
+**Build** (`docker/build-push-action`):
+- `context: ./apps/<service>-service`, `file: ./apps/<service>-service/Dockerfile`
+- `platforms: linux/arm64`, `push: true`
+- `cache-from/to: type=gha,scope=ai-<service>` (GHA cache isolated per service)
+
+**No job-output aggregation.** Matrix jobs don't aggregate outputs cleanly, and we don't need them: the deploy step pulls the deterministic `:staging-latest` tag for each changed service (build-ai always pushes `staging-latest`). Same pattern as the api/web `staging-latest` default.
+
+**Cloud-runner disk**: each matrix leg runs on its own VM and builds a **single** image (~5 GB) → comfortably within ubuntu-latest's free space after the free-disk step. The matrix parallelism also helps here.
+
+### Unit 3 — Compose changes
+
+**Principle**: dev builds locally as today; staging pulls from GHCR and never builds torch on the VPS.
+
+**`infra/docker-compose.yml`** (base) — add `image:` while keeping `build:`, mirroring api/web:
+
+```yaml
+embedding-service:
+  build: { context: ../apps/embedding-service, dockerfile: ./Dockerfile }
+  image: ${EMBEDDING_IMAGE:-meepleai-embedding}       # NEW
+reranker-service:
+  build: { ... }
+  image: ${RERANKER_IMAGE:-meepleai-reranker}         # NEW
+orchestration-service:
+  build: { ... }
+  image: ${ORCHESTRATION_IMAGE:-meepleai-orchestrator} # NEW
+```
+
+In **dev** the env vars are unset → compose builds locally under the default name → **dev behavior unchanged**.
+
+**`infra/compose.staging.yml`** (override) — this is where disk/staleness safety lives:
+
+```yaml
+embedding-service:
+  image: ${EMBEDDING_IMAGE:?EMBEDDING_IMAGE required for staging — set to GHCR tag}
+  pull_policy: always          # forces PULL — never build torch on the VPS
+reranker-service:
+  image: ${RERANKER_IMAGE:?RERANKER_IMAGE required for staging — set to GHCR tag}
+  pull_policy: always
+orchestration-service:
+  image: ${ORCHESTRATION_IMAGE:-ghcr.io/<repo>/orchestration-service:staging-latest}
+  pull_policy: always
+```
+
+- **embedding + reranker**: hard-required `:?` (no stale-local fallback, like api/web) + `pull_policy: always` → the VPS pulls from GHCR, never builds. This is the safeguard against the torch-rebuild disk-full failure mode.
+- **orchestration**: soft default (`:-…:staging-latest`), **not** in the `ai-essential` profile → not started by the deploy command. If `--profile tutor-agents` is ever passed, it pulls from GHCR instead of building locally.
+
+### Unit 4 — `deploy` job extension + disk safety
+
+**Responsibility**: pull + recreate changed staging-active AI services, pull-only orchestration, all under disk guards.
+
+`needs` extended to `[build, build-ai, snapshot-baseline]`. SSH-script sequence (new steps in **bold**):
+
+1. *(existing)* sync repo, kill stale `:8080`, load secrets.
+2. **Export staging-latest defaults for ALL AI image vars** (analog of the #1399-C api/web fix): because `compose.staging.yml` uses `${EMBEDDING_IMAGE:?}` / `${RERANKER_IMAGE:?}`, any `docker compose up` evaluates the whole file — an unchanged AI service's var must still be set or the command aborts. Default each to `…:staging-latest`; changed services override below.
+3. **Pre-pull disk guard**: if any AI service changed, require `free-disk ≥ AI_PULL_GATE_GB` (repo var, default `15`). First run `docker image prune -af --filter "until=24h"`; if still below threshold → **abort** with a clear cleanup message (fail-safe). api/web-only deploys are unaffected.
+4. *(existing)* for changed api/web: pull + export var + add to `$SERVICES`.
+5. **For changed embedding/reranker**: `docker pull <svc>:staging-latest`, export `EMBEDDING_IMAGE`/`RERANKER_IMAGE`, add to `$SERVICES`.
+6. **For changed orchestration**: `docker pull` only (cached for future activation; **not** added to `$SERVICES`).
+7. *(existing)* `docker compose -f docker-compose.yml -f compose.staging.yml --profile ai-essential --profile monitoring-essential up -d --no-deps --force-recreate $SERVICES`.
+8. *(existing)* API health check.
+9. **AI health check**: for each recreated AI service, wait for `docker inspect --format '{{.State.Health.Status}}'` = `healthy` (embedding start-period ~60 s, reranker ~120 s).
+10. **Post-prune**: `docker rmi` the previous AI tags by name (keep `staging-latest` + the current versioned tag); `docker image prune -f` removes the now-unreferenced old images.
+11. *(existing, extended)* write `DEPLOYMENT.json` with new `embedding_image` / `reranker_image` / `orchestration_image` fields; final prune.
+
+**Pull→recreate→rmi ordering** guarantees no steady-state accumulation of two versions: after `--force-recreate`, the old image becomes unreferenced and is pruned.
+
+### Unit 5 — `ghcr-retention` job (NEW)
+
+**Responsibility**: bound registry storage growth.
+
+```yaml
+ghcr-retention:
+  needs: [deploy]
+  if: ${{ !cancelled() && needs.deploy.result == 'success' }}
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      service: [embedding, reranker, orchestration]   # same short tokens as build-ai
+  steps:
+    - uses: actions/delete-package-versions@<pinned-sha>
+      with:
+        package-name: meepleai-monorepo/${{ matrix.service }}-service
+        package-type: container
+        min-versions-to-keep: 5
+        ignore-versions: '^staging-latest$'   # never delete the moving tag
+```
+
+Keeps the last 5 versions per package, protects `staging-latest`. Affects registry storage only — VPS disk is already covered by Unit 4.
+
+**Naming convention** (consistent across all units): the short token `<svc>` ∈ {`embedding`, `reranker`, `orchestration`} is the single source of truth. From it: app dir = `apps/<svc>-service/`, GHCR image/package = `ghcr.io/<repo>/<svc>-service`, deploy env var = `<SVC>_IMAGE`, `ai_changed` key = `<svc>`.
+
+## GHA skip-propagation handling (correctness note)
+
+GitHub Actions propagates an implicit `success()` over the entire `needs` chain, and a skipped upstream job propagates `skipped` downstream (documented in this very workflow's #1602 comments; see memory `gha-if-cancelled-vs-always`). Two cases must be handled so an **AI-only** deploy (no api/web change → `build` is `skipped`) still proceeds:
+
+- **`snapshot-baseline`**: `needs: [build, build-ai]`, `if: !cancelled() && (needs.build.result == 'success' || needs.build-ai.result == 'success') && vars.DEPLOY_METHOD == 'ssh'`.
+- **`deploy`**: `if: !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped') && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')`. The SSH script already `exit 0`s when `$SERVICES` is empty, so a both-skipped run is a harmless no-op.
+
+`!cancelled()` (not `always()`) is used throughout, consistent with the existing jobs, so cancellation still aborts cleanly.
+
+## Data Flow
+
+```
+push main-staging / workflow_dispatch
+  └─ detect-changes → ai_changed={embedding,reranker,orchestration}, ai_any
+       └─ build-ai (matrix, ubuntu-latest, QEMU arm64)
+            embedding ─┐  (build only if changed)
+            reranker  ─┤→ push ghcr.io/<repo>/<svc>-service:{staging-DATE-SHA, staging-latest}
+            orchestr. ─┘
+       └─ deploy (self-hosted VPS, ARM64)
+            pre-pull disk guard (≥15GB or abort)
+            pull staging-latest for changed svc
+            embedding/reranker → compose up --force-recreate (profile ai-essential)
+            orchestration      → pull only (not started)
+            post-prune old AI tags
+  └─ ghcr-retention (keep last 5 per package)
+```
+
+## Error Handling / Failure Modes
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Torch build exceeds 120 min under QEMU | `build-ai` leg times out | Re-run; raise `timeout-minutes` once real timings known. `fail-fast: false` isolates the affected service. |
+| Insufficient VPS disk for pull | Pre-pull guard after pre-prune | **Abort** deploy with cleanup instructions (fail-safe). api/web deploy still proceeds if it needs no AI space. |
+| Unchanged AI service var unset → compose abort | `docker compose up` errors on `${X_IMAGE:?}` | Prevented by step 2 (export `:staging-latest` defaults for all AI vars). |
+| New AI image unhealthy after recreate | AI health check (`docker inspect` health) fails | Deploy job fails; previous image still pullable via its versioned tag for manual rollback. |
+| QEMU torch step pulls wrong-arch wheel | Build fails on `pip install` | torch ships manylinux aarch64 wheels; buildx `--platform arm64` selects them. Non-issue, documented. |
+| GHCR retention deletes an in-use tag | n/a — `staging-latest` is `ignore-versions`-protected; VPS keeps local copies regardless | Re-push via a forced `build-ai` run. |
+| AI-only deploy skipped because `build` skipped | `deploy` never runs | Prevented by the skip-propagation `if:` (see correctness note). |
+
+## Testing Strategy
+
+No local ARM64 Docker build environment exists in this dev setup. Validation layers:
+
+| Layer | How |
+|---|---|
+| Workflow syntax | `Validate Workflows` job (actionlint) already in CI covers the new YAML |
+| Compose resolution | `docker compose -f docker-compose.yml -f compose.staging.yml config` → `${X_IMAGE}` resolve, no errors |
+| Dev not regressed | `make dev` still builds AI services locally (env vars absent) |
+| Real build+push | `workflow_dispatch` with `force_full_deploy` → matrix builds all 3; verify tags on GHCR (`gh api .../packages`) |
+| Pull + health on VPS | Post-deploy `docker inspect` health of embedding/reranker = healthy; existing smoke tests |
+| Disk | Pre-pull guard logs + `df -h` before/after; confirm old AI tags removed |
+
+**Rollback**: the workflow changes are additive; reverting the deploy-staging.yml + compose commits restores the prior (local-build) behavior. Versioned GHCR tags remain pullable for manual image rollback on the VPS.
+
+## Scope
+
+- **In**: `.github/workflows/deploy-staging.yml` (detect-changes, build-ai, deploy, ghcr-retention, snapshot-baseline gating); `infra/docker-compose.yml` + `infra/compose.staging.yml` (image vars for embedding/reranker/orchestration).
+- **Out**:
+  - `smoldocling-service`, `unstructured-service` (disabled in staging via `pdf-cloud-extractors`) → remain local-build, separate follow-up.
+  - Runtime activation of orchestration in staging (`--profile tutor-agents`) → separate decision; this spec only publishes its image.
+  - Native cross-compile rework of the Python Dockerfiles (`$BUILDPLATFORM`) → future optimization if QEMU proves too slow.
+  - Building AI images on `main-dev` CI → only on the staging deploy, consistent with api/web.
+
+## Expected Impact
+
+- Closes the ~50-day staging drift for embedding + reranker; publishes a fresh orchestration image (incl. fix #1073) ready for activation.
+- Build cost incurred only when a service's code/requirements change (per-service change detection) — typically ≤ monthly per service.
+- VPS disk protected by a dedicated pre-pull gate + pull→recreate→prune ordering; registry storage bounded by retention.
+- Zero added runner cost; reversible.
+
+## Open Questions
+
+None blocking. Two empirical unknowns, both surfaced on the first real deploy:
+1. Actual QEMU torch build wall-clock (sets whether 120 min can be lowered, or whether native ARM runners become worth their cost).
+2. Whether the 15 GB `AI_PULL_GATE_GB` default is comfortable when embedding **and** reranker change in the same deploy (worst-case transient). Tunable via repo variable.

--- a/docs/superpowers/plans/2026-05-28-ai-services-ghcr-pipeline.md
+++ b/docs/superpowers/plans/2026-05-28-ai-services-ghcr-pipeline.md
@@ -1,0 +1,967 @@
+# AI Services GHCR Build & Push Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build + push `embedding`, `reranker`, and `orchestration` Docker images to GHCR on the staging deploy, with per-service change detection, so the ARM64 staging VPS pulls fresh images (never builds torch) under strict disk safety — closing the ~50-day drift (#1578).
+
+**Architecture:** Add a matrix `build-ai` job to `deploy-staging.yml` (QEMU arm64, one leg per service, gated by per-service change detection). The `deploy` job pulls + recreates the changed staging-active services (embedding, reranker) and pull-only-caches orchestration, behind a dedicated pre-pull disk gate. The two compose files get `image:` vars so dev still builds locally while staging pulls from GHCR. A `ghcr-retention` job bounds registry storage.
+
+**Tech Stack:** GitHub Actions, `docker/build-push-action` + buildx + QEMU, GHCR, docker compose v2.
+
+**Spec:** `docs/for-developers/specs/2026-05-28-ai-services-ghcr-pipeline-design.md`
+
+**Naming convention (single source of truth):** short token `<svc>` ∈ {`embedding`, `reranker`, `orchestration`}. From it: app dir `apps/<svc>-service/`, GHCR image `ghcr.io/<repo>/<svc>-service`, compose service name `<svc>-service`, container name `meepleai-embedding`/`meepleai-reranker`/`meepleai-orchestrator`, deploy env var `<SVC>_IMAGE`, `ai_changed` JSON key `<svc>`.
+
+**Validation note:** No local ARM64/torch build is attempted (slow under QEMU; that's the CI's job). Local validation = `docker compose config` (compose resolution) + `python -c yaml.safe_load` (workflow YAML parse, since `actionlint` is not installed locally — the `Validate Workflows` CI job runs actionlint on push). The authoritative end-to-end test is a `workflow_dispatch` run (Task 9).
+
+---
+
+## File Structure
+
+- **Modify** `infra/docker-compose.yml` — add `image: ${<SVC>_IMAGE:-meepleai-<name>}` to the 3 AI services (keep `build:`). Dev behavior unchanged.
+- **Modify** `infra/compose.staging.yml` — add `image:` + `pull_policy: always` to the 3 AI services (embedding/reranker hard-required `:?`; orchestration soft default).
+- **Modify** `.github/workflows/deploy-staging.yml` — extend `detect-changes`; add `build-ai` matrix job; extend `deploy` (needs/if + SSH script); add `ghcr-retention` job.
+
+Each task leaves both files in a valid, committable state.
+
+---
+
+## Task 1: Pre-flight + baselines
+
+**Files:** none
+
+- [ ] **Step 1: Confirm branch + tools**
+
+```bash
+cd "D:/Repositories/meepleai-monorepo-main"
+git branch --show-current        # → feature/issue-1578-ai-services-ghcr-pipeline
+docker compose version           # → v2.x present
+python -c "import yaml; print('pyyaml ok')"
+```
+Expected: branch correct, docker compose + pyyaml present. (The spec commit `e07818a84` is already on this branch.)
+
+- [ ] **Step 2: Baseline — current compose resolves (dev)**
+
+```bash
+docker compose -f infra/docker-compose.yml --profile ai config >/dev/null && echo "BASE compose OK"
+```
+Expected: `BASE compose OK` (no error). Record that today the AI services have no `image:` key (compose assigns a default project image name).
+
+- [ ] **Step 3: Baseline — workflow YAML parses**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); print('YAML valid')"
+```
+Expected: `YAML valid`.
+
+---
+
+## Task 2: Compose base — `image:` vars for AI services
+
+**Files:**
+- Modify: `infra/docker-compose.yml`
+
+- [ ] **Step 1: Add `image:` to `embedding-service`**
+
+Find (the `embedding-service` block, ~line 180):
+```yaml
+  embedding-service:
+    build:
+      context: ../apps/embedding-service
+      dockerfile: ./Dockerfile
+    container_name: meepleai-embedding
+```
+Replace with (insert the `image:` line after the `build:` block):
+```yaml
+  embedding-service:
+    build:
+      context: ../apps/embedding-service
+      dockerfile: ./Dockerfile
+    # Issue #1578: staging pulls this from GHCR (compose.staging.yml sets
+    # EMBEDDING_IMAGE + pull_policy: always). Dev leaves the var unset → builds
+    # locally as meepleai-embedding (mirrors api/web).
+    image: ${EMBEDDING_IMAGE:-meepleai-embedding}
+    container_name: meepleai-embedding
+```
+
+- [ ] **Step 2: Add `image:` to `reranker-service`**
+
+Find (~line 261):
+```yaml
+  reranker-service:
+    build:
+      context: ../apps/reranker-service
+      dockerfile: ./Dockerfile
+    container_name: meepleai-reranker
+```
+Replace with:
+```yaml
+  reranker-service:
+    build:
+      context: ../apps/reranker-service
+      dockerfile: ./Dockerfile
+    # Issue #1578: see embedding-service note above.
+    image: ${RERANKER_IMAGE:-meepleai-reranker}
+    container_name: meepleai-reranker
+```
+
+- [ ] **Step 3: Add `image:` to `orchestration-service`**
+
+Find (~line 287):
+```yaml
+  orchestration-service:
+    build:
+      context: ../apps/orchestration-service
+      dockerfile: ./Dockerfile
+    container_name: meepleai-orchestrator
+```
+Replace with:
+```yaml
+  orchestration-service:
+    build:
+      context: ../apps/orchestration-service
+      dockerfile: ./Dockerfile
+    # Issue #1578: publish-only. Image built+pushed to GHCR but not activated
+    # in staging (stays out of the ai-essential deploy profile).
+    image: ${ORCHESTRATION_IMAGE:-meepleai-orchestrator}
+    container_name: meepleai-orchestrator
+```
+
+- [ ] **Step 4: Validate dev resolution (vars unset → local names)**
+
+```bash
+cd "D:/Repositories/meepleai-monorepo-main"
+docker compose -f infra/docker-compose.yml --profile ai config | grep -E "image: (meepleai-embedding|meepleai-reranker|meepleai-orchestrator)$"
+```
+Expected: 3 lines, each showing the local default image name (proves dev still builds locally — the `:-default` branch is taken).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/docker-compose.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 add image: vars to AI services in base compose
+
+Mirror the api/web pattern: keep build: but add image: ${<SVC>_IMAGE:-local}
+so staging can inject GHCR tags while dev keeps building locally (vars unset).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Compose staging — `image:` + `pull_policy: always`
+
+**Files:**
+- Modify: `infra/compose.staging.yml`
+
+- [ ] **Step 1: Add image + pull_policy to `embedding-service`**
+
+Find (~line 153):
+```yaml
+  embedding-service:
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+```
+Replace with:
+```yaml
+  embedding-service:
+    # Issue #1578: hard-required GHCR image (no stale-local fallback) + force
+    # pull. pull_policy: always guarantees the VPS PULLS the arm64 image built
+    # in CI and NEVER builds torch locally (avoids the disk-full/swap incident).
+    image: ${EMBEDDING_IMAGE:?EMBEDDING_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+```
+
+- [ ] **Step 2: Add image + pull_policy to `reranker-service`**
+
+Find (~line 165):
+```yaml
+  reranker-service:
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+```
+Replace with:
+```yaml
+  reranker-service:
+    # Issue #1578: see embedding-service note above.
+    image: ${RERANKER_IMAGE:?RERANKER_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+```
+
+- [ ] **Step 3: Add image + pull_policy to `orchestration-service`**
+
+Find (~line 205):
+```yaml
+  orchestration-service:
+    restart: always
+    env_file:
+      - ./secrets/database.secret
+      - ./secrets/redis.secret
+      - ./secrets/openrouter.secret
+```
+Replace with:
+```yaml
+  orchestration-service:
+    # Issue #1578: publish-only. Soft default (not :?) — orchestration is not in
+    # the ai-essential deploy profile, so it is not started in staging. If a
+    # future --profile tutor-agents activates it, it pulls from GHCR (not build).
+    image: ${ORCHESTRATION_IMAGE:-ghcr.io/meepleai-app/meepleai-monorepo/orchestration-service:staging-latest}
+    pull_policy: always
+    restart: always
+    env_file:
+      - ./secrets/database.secret
+      - ./secrets/redis.secret
+      - ./secrets/openrouter.secret
+```
+
+- [ ] **Step 4: Validate staging resolution (vars set → GHCR; unset → error)**
+
+```bash
+cd "D:/Repositories/meepleai-monorepo-main"
+# (a) With vars set → resolves to GHCR refs, pull_policy present
+EMBEDDING_IMAGE=ghcr.io/meepleai-app/meepleai-monorepo/embedding-service:staging-latest \
+RERANKER_IMAGE=ghcr.io/meepleai-app/meepleai-monorepo/reranker-service:staging-latest \
+API_IMAGE=x WEB_IMAGE=y \
+docker compose -f infra/docker-compose.yml -f infra/compose.staging.yml --profile ai-essential config \
+  | grep -E "ghcr.io/.*(embedding|reranker)-service:staging-latest" && echo "STAGING resolves OK"
+
+# (b) Without EMBEDDING_IMAGE → the :? guard must fail
+API_IMAGE=x WEB_IMAGE=y RERANKER_IMAGE=z \
+docker compose -f infra/docker-compose.yml -f infra/compose.staging.yml --profile ai-essential config >/dev/null 2>&1 \
+  && echo "❌ guard did NOT fire" || echo "✅ EMBEDDING_IMAGE :? guard fires as expected"
+```
+Expected: (a) prints the GHCR refs + `STAGING resolves OK`; (b) prints `✅ … guard fires`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/compose.staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 staging AI services pull from GHCR (pull_policy: always)
+
+embedding/reranker hard-required (:?) + pull_policy: always so the ARM64 VPS
+pulls CI-built images and never builds torch locally. orchestration soft
+default (publish-only, not in ai-essential profile).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `detect-changes` — per-service filters + outputs
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+- [ ] **Step 1: Add outputs**
+
+Find (~line 133):
+```yaml
+    outputs:
+      api: ${{ steps.changes.outputs.api }}
+      web: ${{ steps.changes.outputs.web }}
+      infra: ${{ steps.changes.outputs.infra }}
+      deploy_api: ${{ steps.decision.outputs.deploy_api }}
+      deploy_web: ${{ steps.decision.outputs.deploy_web }}
+```
+Replace with:
+```yaml
+    outputs:
+      api: ${{ steps.changes.outputs.api }}
+      web: ${{ steps.changes.outputs.web }}
+      infra: ${{ steps.changes.outputs.infra }}
+      deploy_api: ${{ steps.decision.outputs.deploy_api }}
+      deploy_web: ${{ steps.decision.outputs.deploy_web }}
+      ai_changed: ${{ steps.decision.outputs.ai_changed }}
+      ai_any: ${{ steps.decision.outputs.ai_any }}
+```
+
+- [ ] **Step 2: Add path filters**
+
+Find (~line 173):
+```yaml
+          filters: |
+            api:
+              - 'apps/api/**'
+            web:
+              - 'apps/web/**'
+            infra:
+              - 'infra/**'
+              - '.github/workflows/deploy-staging.yml'
+```
+Replace with:
+```yaml
+          filters: |
+            api:
+              - 'apps/api/**'
+            web:
+              - 'apps/web/**'
+            infra:
+              - 'infra/**'
+              - '.github/workflows/deploy-staging.yml'
+            embedding:
+              - 'apps/embedding-service/**'
+            reranker:
+              - 'apps/reranker-service/**'
+            orchestration:
+              - 'apps/orchestration-service/**'
+```
+
+- [ ] **Step 3: Extend the decision step to emit `ai_changed` + `ai_any`**
+
+Find the end of the decision step (~line 206-210):
+```yaml
+          else
+            echo "deploy_api=$API" >> $GITHUB_OUTPUT
+            echo "deploy_web=$WEB" >> $GITHUB_OUTPUT
+            echo "📦 Selective deploy: api=$API, web=$WEB"
+          fi
+```
+Replace with:
+```yaml
+          else
+            echo "deploy_api=$API" >> $GITHUB_OUTPUT
+            echo "deploy_web=$WEB" >> $GITHUB_OUTPUT
+            echo "📦 Selective deploy: api=$API, web=$WEB"
+          fi
+
+          # Issue #1578 — AI service change detection. Same force-full triggers
+          # as api/web (workflow_dispatch / force / infra / initial push).
+          EMB="${{ steps.changes.outputs.embedding }}"
+          RRK="${{ steps.changes.outputs.reranker }}"
+          ORC="${{ steps.changes.outputs.orchestration }}"
+          if [ "$EVENT" = "workflow_dispatch" ] \
+            || [ "$FORCE" = "true" ] \
+            || [ "$INFRA" = "true" ] \
+            || [ "$BEFORE" = "$ZEROS" ] \
+            || [ -z "$BEFORE" ]; then
+            EMB=true; RRK=true; ORC=true
+          fi
+          # paths-filter outputs are empty when the changes step is skipped
+          # (workflow_dispatch). Normalize empties to false.
+          EMB="${EMB:-false}"; RRK="${RRK:-false}"; ORC="${ORC:-false}"
+          echo "ai_changed={\"embedding\":$EMB,\"reranker\":$RRK,\"orchestration\":$ORC}" >> $GITHUB_OUTPUT
+          if [ "$EMB" = "true" ] || [ "$RRK" = "true" ] || [ "$ORC" = "true" ]; then
+            echo "ai_any=true" >> $GITHUB_OUTPUT
+          else
+            echo "ai_any=false" >> $GITHUB_OUTPUT
+          fi
+          echo "🤖 AI changed: embedding=$EMB reranker=$RRK orchestration=$ORC"
+```
+
+- [ ] **Step 4: Validate YAML**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); print('YAML valid')"
+```
+Expected: `YAML valid`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 detect-changes per-AI-service filters + ai_changed output
+
+Adds embedding/reranker/orchestration path filters and emits ai_changed
+(JSON map) + ai_any. Same force-full logic as api/web.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `build-ai` matrix job
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+- [ ] **Step 1: Insert the `build-ai` job after the `build` job**
+
+Find the end of the `build` job — the `Build Summary` step (~line 483-487):
+```yaml
+      - name: Build Summary
+        run: |
+          echo "📦 Build summary:"
+          echo "  API built: ${{ needs.detect-changes.outputs.deploy_api }}"
+          echo "  Web built: ${{ needs.detect-changes.outputs.deploy_web }}"
+```
+Insert immediately AFTER it (before the `snapshot-baseline:` job) this new job:
+```yaml
+
+  # Build and push AI service images (only changed ones). Issue #1578.
+  # Separate from `build` so the slow torch QEMU builds run in parallel
+  # (matrix), with per-service timeout, and a single failure does not block
+  # the other services. ALWAYS ubuntu-latest (cloud) — never the VPS.
+  build-ai:
+    name: Build AI Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: [pre-deploy-check, detect-changes]
+    if: always() && (needs.pre-deploy-check.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true)) && needs.detect-changes.outputs.ai_any == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [embedding, reranker, orchestration]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          sparse-checkout: |
+            apps/${{ matrix.service }}-service/
+          sparse-checkout-cone-mode: true
+
+      - name: Generate Version
+        id: version
+        run: |
+          VERSION="staging-$(date +'%Y%m%d')-${GITHUB_SHA::7}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 ${{ matrix.service }} version: $VERSION"
+
+      - name: Free disk space for build
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        run: |
+          docker builder prune -f 2>/dev/null || true
+          docker image prune -a -f --filter 'until=24h' 2>/dev/null || true
+          echo "📊 Disk free: $(df -h / | tail -1 | awk '{print $4}')"
+
+      - name: Setup Docker Buildx
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Setup QEMU for ARM64
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4
+        with:
+          platforms: arm64
+
+      - name: Login to GitHub Container Registry
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Metadata
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service }}-service
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=staging-latest
+
+      # Python torch Dockerfiles are NOT cross-compile-ready (no $BUILDPLATFORM),
+      # so the arm64 build runs under QEMU emulation. Acceptable: gated by
+      # change-detection (rare) and runs on the cloud runner (never the VPS).
+      - name: Build and Push ${{ matrix.service }}
+        if: ${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: ./apps/${{ matrix.service }}-service
+          file: ./apps/${{ matrix.service }}-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
+          cache-from: type=gha,scope=ai-${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=ai-${{ matrix.service }}
+
+      - name: Build Summary
+        run: echo "🤖 ${{ matrix.service }}-service — changed=${{ fromJSON(needs.detect-changes.outputs.ai_changed)[matrix.service] }}"
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); assert 'build-ai' in d['jobs']; print('build-ai present, YAML valid')"
+```
+Expected: `build-ai present, YAML valid`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 build-ai matrix job (QEMU arm64, change-gated)
+
+Parallel per-service build+push of embedding/reranker/orchestration to GHCR.
+fail-fast:false, timeout 120m (torch under QEMU), each leg builds only if its
+service changed. Tags: staging-DATE-SHA + staging-latest.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `deploy` job gating (needs + if)
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+- [ ] **Step 1: Extend deploy `needs` and `if`**
+
+Find (~line 586-587):
+```yaml
+    needs: [build, snapshot-baseline]
+    if: always() && needs.build.result == 'success' && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
+```
+Replace with:
+```yaml
+    needs: [detect-changes, build, build-ai, snapshot-baseline]
+    # Issue #1578 — skip-propagation handling. An AI-only deploy has `build`
+    # (api/web) skipped, so `build` may be 'success' OR 'skipped'. build-ai may
+    # be 'success' (built) or 'skipped' (no AI change); a build-ai FAILURE
+    # (success||skipped false) blocks the deploy on purpose — don't deploy when
+    # an image we asked to build failed. snapshot-baseline may be skipped on
+    # AI-only deploys (it gates on `build`).
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped') && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); n=d['jobs']['deploy']['needs']; assert 'detect-changes' in n and 'build-ai' in n, n; print('deploy needs OK:', n)"
+```
+Expected: `deploy needs OK: ['detect-changes', 'build', 'build-ai', 'snapshot-baseline']`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 gate deploy on build-ai (skip-propagation safe)
+
+deploy now needs detect-changes + build-ai. if: accepts build/build-ai/
+snapshot-baseline = success||skipped so AI-only deploys proceed; a build-ai
+failure still blocks (don't deploy a failed image build).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `deploy` SSH script — AI vars, disk guard, pull/recreate, health
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml` (the `Deploy via SSH` step's `script:`)
+
+- [ ] **Step 1: Insert AI image vars + pre-pull disk guard**
+
+Find (~line 757-760, inside the SSH `script:`):
+```bash
+            export API_IMAGE="${{ env.API_IMAGE }}:staging-latest"
+            export WEB_IMAGE="${{ env.WEB_IMAGE }}:staging-latest"
+
+            SERVICES=""
+```
+Replace with:
+```bash
+            export API_IMAGE="${{ env.API_IMAGE }}:staging-latest"
+            export WEB_IMAGE="${{ env.WEB_IMAGE }}:staging-latest"
+
+            # Issue #1578 — AI image vars. compose.staging.yml guards
+            # embedding/reranker with ${X_IMAGE:?}, so every `compose up`
+            # (even one targeting only some services) needs them set, or it
+            # aborts (analog of the api/web #1399-C fix above). Default all to
+            # staging-latest; changed services keep this ref (the build-ai job
+            # always pushes staging-latest).
+            AI_BASE="${{ env.REGISTRY }}/${{ github.repository }}"
+            export EMBEDDING_IMAGE="${AI_BASE}/embedding-service:staging-latest"
+            export RERANKER_IMAGE="${AI_BASE}/reranker-service:staging-latest"
+            export ORCHESTRATION_IMAGE="${AI_BASE}/orchestration-service:staging-latest"
+
+            EMB_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).embedding }}"
+            RRK_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).reranker }}"
+            ORC_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).orchestration }}"
+
+            # Pre-pull disk guard (issue #1578 / #1575). Pulling a ~5GB torch
+            # image while the old one is still referenced can fill the disk.
+            # Pre-prune, then require AI_PULL_GATE_GB free; otherwise ABORT
+            # (fail-safe) — never risk disk-full.
+            AI_PULL_GATE_GB="${AI_PULL_GATE_GB:-15}"
+            if [ "$EMB_CHANGED" = "true" ] || [ "$RRK_CHANGED" = "true" ] || [ "$ORC_CHANGED" = "true" ]; then
+              echo "🧹 Pre-prune before AI image pull..."
+              docker image prune -af --filter "until=24h" || true
+              FREE_GB=$(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
+              echo "💽 VPS disk: ${FREE_GB} GB free — AI pull gate ${AI_PULL_GATE_GB} GB"
+              if [ "$FREE_GB" -lt "$AI_PULL_GATE_GB" ]; then
+                echo "::error::Insufficient disk for AI image pull: ${FREE_GB} GB free < ${AI_PULL_GATE_GB} GB"
+                echo "🚫 Aborting AI deploy (fail-safe). Manual cleanup on the VPS:"
+                echo "  docker image prune -af"
+                echo "  bash /opt/meepleai/repo/infra/scripts/daily-disk-prune.sh"
+                exit 1
+              fi
+            fi
+
+            SERVICES=""
+```
+
+- [ ] **Step 2: Insert AI pull/recreate blocks (before the empty-SERVICES check)**
+
+Find (~line 770-780):
+```bash
+            if [ "${{ needs.build.outputs.web_built }}" = "true" ]; then
+              docker pull ${{ needs.build.outputs.web_image }}
+              export WEB_IMAGE="${{ needs.build.outputs.web_image }}"
+              SERVICES="$SERVICES web"
+              echo "📦 Web image updated"
+            fi
+
+            if [ -z "$SERVICES" ]; then
+              echo "⏭️ No services to deploy"
+              exit 0
+            fi
+```
+Replace with:
+```bash
+            if [ "${{ needs.build.outputs.web_built }}" = "true" ]; then
+              docker pull ${{ needs.build.outputs.web_image }}
+              export WEB_IMAGE="${{ needs.build.outputs.web_image }}"
+              SERVICES="$SERVICES web"
+              echo "📦 Web image updated"
+            fi
+
+            # Issue #1578 — AI services. embedding/reranker are in the
+            # ai-essential profile → pull + recreate. orchestration is
+            # publish-only → pull ONLY (cached for a future activation).
+            if [ "$EMB_CHANGED" = "true" ]; then
+              docker pull "$EMBEDDING_IMAGE"
+              SERVICES="$SERVICES embedding-service"
+              echo "📦 embedding-service image updated"
+            fi
+            if [ "$RRK_CHANGED" = "true" ]; then
+              docker pull "$RERANKER_IMAGE"
+              SERVICES="$SERVICES reranker-service"
+              echo "📦 reranker-service image updated"
+            fi
+            if [ "$ORC_CHANGED" = "true" ]; then
+              docker pull "$ORCHESTRATION_IMAGE" || echo "⚠️ orchestration pull failed (non-blocking; not active in staging)"
+              echo "📦 orchestration-service image cached (not started in staging)"
+            fi
+
+            if [ -z "$SERVICES" ]; then
+              echo "⏭️ No services to deploy"
+              exit 0
+            fi
+```
+
+- [ ] **Step 3: Insert AI health check after the API health check**
+
+Find (~line 810-817), the end of the API health block:
+```bash
+            docker exec meepleai-api curl -sf http://localhost:8080/health | python3 -c "
+            import sys,json
+            d=json.load(sys.stdin)
+            healthy = [c['name'] for c in d['checks'] if c['status']=='Healthy']
+            print(f'Healthy services: {len(healthy)}')
+            assert any(c['name']=='postgres' and c['status']=='Healthy' for c in d['checks']), 'postgres unhealthy'
+            assert any(c['name']=='redis' and c['status']=='Healthy' for c in d['checks']), 'redis unhealthy'
+            " || exit 1
+```
+Insert immediately AFTER it:
+```bash
+
+            # Issue #1578 — AI container health (only for recreated services).
+            # Container names per compose: embedding-service→meepleai-embedding,
+            # reranker-service→meepleai-reranker.
+            ai_health() {
+              cname="$1"
+              echo "⏳ Waiting for ${cname} health..."
+              for attempt in $(seq 1 40); do
+                st=$(docker inspect --format '{{.State.Health.Status}}' "$cname" 2>/dev/null || echo "missing")
+                if [ "$st" = "healthy" ]; then echo "✅ ${cname} healthy after ~$((attempt*5))s"; return 0; fi
+                sleep 5
+              done
+              echo "::error::${cname} did not become healthy"
+              docker logs "$cname" --tail 30 2>/dev/null || true
+              return 1
+            }
+            case " $SERVICES " in *" embedding-service "*) ai_health meepleai-embedding || exit 1 ;; esac
+            case " $SERVICES " in *" reranker-service "*) ai_health meepleai-reranker || exit 1 ;; esac
+```
+
+- [ ] **Step 4: Add AI image fields to DEPLOYMENT.json**
+
+Find (~line 820-831):
+```bash
+            cat > /opt/meepleai/repo/infra/DEPLOYMENT.json << VEREOF
+            {
+              "version": "${{ needs.build.outputs.version }}",
+              "api_image": "${{ needs.build.outputs.api_image }}",
+              "web_image": "${{ needs.build.outputs.web_image }}",
+              "environment": "staging",
+              "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+              "deployed_by": "${{ github.actor }}",
+              "commit": "${{ env.DEPLOY_SHA }}",
+              "workflow_run": "${{ github.run_id }}"
+            }
+            VEREOF
+```
+Replace with:
+```bash
+            cat > /opt/meepleai/repo/infra/DEPLOYMENT.json << VEREOF
+            {
+              "version": "${{ needs.build.outputs.version }}",
+              "api_image": "${{ needs.build.outputs.api_image }}",
+              "web_image": "${{ needs.build.outputs.web_image }}",
+              "embedding_image": "${EMBEDDING_IMAGE}",
+              "reranker_image": "${RERANKER_IMAGE}",
+              "orchestration_image": "${ORCHESTRATION_IMAGE}",
+              "ai_changed": "embedding=${EMB_CHANGED},reranker=${RRK_CHANGED},orchestration=${ORC_CHANGED}",
+              "environment": "staging",
+              "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+              "deployed_by": "${{ github.actor }}",
+              "commit": "${{ env.DEPLOY_SHA }}",
+              "workflow_run": "${{ github.run_id }}"
+            }
+            VEREOF
+```
+(The final `docker image prune -f` at the end of the step already removes the now-dangling old AI image layers after `--force-recreate` re-points `staging-latest` — no extra rmi needed.)
+
+- [ ] **Step 5: Validate YAML**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); print('YAML valid')"
+```
+Expected: `YAML valid`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 deploy AI images with disk-safe pull/recreate
+
+SSH script: export AI image vars (#1399-C analog), pre-pull disk gate
+(AI_PULL_GATE_GB=15, abort fail-safe), pull+recreate embedding/reranker,
+pull-only orchestration, AI container health checks, DEPLOYMENT.json fields.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `ghcr-retention` job
+
+**Files:**
+- Modify: `.github/workflows/deploy-staging.yml`
+
+- [ ] **Step 1: Resolve the action SHA to pin (repo policy: SHA-pinned actions)**
+
+```bash
+gh api repos/actions/delete-package-versions/tags --jq '.[] | "\(.name) \(.commit.sha)"' | head -5
+```
+Expected: a list of `vX.Y.Z <sha>` lines. Pick the latest `v5.*` and use its `<sha>` in Step 2 (replace `PIN_SHA_HERE`).
+
+- [ ] **Step 2: Insert the `ghcr-retention` job before `notify-end`**
+
+Find (~line 1135) the start of `notify-end`:
+```yaml
+  notify-end:
+    if: always()
+    needs: [detect-changes, pre-deploy-check, build, snapshot-baseline, deploy, validate, e2e-staging]
+```
+Insert BEFORE it this new job (and add `build-ai` + `ghcr-retention` to notify-end's needs in the same edit):
+```yaml
+  # Bound GHCR storage for the AI packages. Issue #1578.
+  ghcr-retention:
+    name: GHCR Retention (AI)
+    needs: [deploy]
+    if: ${{ !cancelled() && needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [embedding, reranker, orchestration]
+    steps:
+      - name: Delete old container versions (keep last 5)
+        uses: actions/delete-package-versions@PIN_SHA_HERE  # v5 — resolved in Step 1
+        with:
+          package-name: ${{ github.event.repository.name }}/${{ matrix.service }}-service
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: '^staging-latest$'
+
+  notify-end:
+    if: always()
+    needs: [detect-changes, pre-deploy-check, build, build-ai, snapshot-baseline, deploy, validate, e2e-staging, ghcr-retention]
+```
+
+- [ ] **Step 3: Validate YAML**
+
+```bash
+PYTHONIOENCODING=utf-8 python -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); assert 'ghcr-retention' in d['jobs']; assert 'build-ai' in d['jobs']['notify-end']['needs']; print('retention + notify-end OK')"
+```
+Expected: `retention + notify-end OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy-staging.yml
+git commit -m "$(cat <<'EOF'
+feat(ci): #1578 GHCR retention for AI packages (keep last 5)
+
+Matrix job deletes old container versions per AI package after a successful
+deploy, protecting staging-latest. Wires build-ai + ghcr-retention into
+notify-end needs.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Push, PR, and `workflow_dispatch` validation (integration test)
+
+**Files:** none
+
+- [ ] **Step 1: Final local gates**
+
+```bash
+cd "D:/Repositories/meepleai-monorepo-main"
+PYTHONIOENCODING=utf-8 python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-staging.yml', encoding='utf-8')); print('workflow YAML valid')"
+docker compose -f infra/docker-compose.yml --profile ai config >/dev/null && echo "dev compose OK"
+EMBEDDING_IMAGE=ghcr.io/meepleai-app/meepleai-monorepo/embedding-service:staging-latest \
+RERANKER_IMAGE=ghcr.io/meepleai-app/meepleai-monorepo/reranker-service:staging-latest \
+API_IMAGE=x WEB_IMAGE=y \
+docker compose -f infra/docker-compose.yml -f infra/compose.staging.yml --profile ai-essential config >/dev/null && echo "staging compose OK"
+```
+Expected: `workflow YAML valid`, `dev compose OK`, `staging compose OK`.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin feature/issue-1578-ai-services-ghcr-pipeline
+```
+
+- [ ] **Step 3: Open PR to main-dev**
+
+```bash
+gh pr create --base main-dev \
+  --title "feat(ci): #1578 AI services GHCR build & push pipeline" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Closes the ~50-day AI-service image drift on staging (#1578). embedding,
+reranker, and orchestration are now built + pushed to GHCR by the staging
+deploy with per-service change detection; the ARM64 VPS pulls (never builds)
+them, under a dedicated disk-safety gate. orchestration is publish-only.
+
+- `detect-changes`: per-service path filters + `ai_changed`/`ai_any`.
+- `build-ai`: matrix job (QEMU arm64, change-gated, fail-fast:false, 120m).
+- compose: `image:` vars (dev builds local, staging pulls via `pull_policy: always`).
+- `deploy`: pre-pull disk gate (abort fail-safe), pull+recreate embedding/
+  reranker, pull-only orchestration, AI health checks.
+- `ghcr-retention`: keep last 5 per package.
+
+## Validation
+
+- Local: workflow YAML parse + `docker compose config` (dev + staging) green.
+- `Validate Workflows` CI (actionlint) on this PR.
+- Post-merge: a `workflow_dispatch` run with `force_full_deploy` exercises the
+  full matrix build + pull + health (see PR checklist).
+
+## Out of scope
+
+smoldocling/unstructured (disabled in staging), orchestration runtime
+activation, native Dockerfile cross-compile.
+
+Spec: `docs/for-developers/specs/2026-05-28-ai-services-ghcr-pipeline-design.md`
+Plan: `docs/superpowers/plans/2026-05-28-ai-services-ghcr-pipeline.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Confirm `Validate Workflows` (actionlint) passes on the PR**
+
+```bash
+gh pr checks --watch | grep -i "Validate Workflows"
+```
+Expected: `Validate Workflows` = pass. If actionlint flags a GHA-expression issue (e.g. `fromJSON(...)[matrix.service]`), fix it and re-push before merge.
+
+- [ ] **Step 5: Decide the integration test with the user**
+
+The real build+push+pull only runs on a staging deploy. Present options (do NOT auto-trigger):
+1. After merge to main-dev, run `gh workflow run deploy-staging.yml --ref feature/issue-1578-ai-services-ghcr-pipeline -f force_full_deploy=true -f skip_tests=true` to exercise the matrix build + GHCR push + VPS pull + AI health from the branch.
+2. Verify GHCR tags: `gh api /orgs/meepleai-app/packages/container/meepleai-monorepo%2Fembedding-service/versions --jq '.[0].metadata.container.tags'`.
+3. On the VPS, confirm `docker inspect meepleai-embedding meepleai-reranker --format '{{.Config.Image}}'` shows the GHCR ref + `df -h /` headroom held.
+
+Report build wall-clock (QEMU torch timing) so the 120m timeout and 15GB gate can be tuned.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Unit 1 (detect-changes) → Task 4 ✅
+- Unit 2 (build-ai matrix) → Task 5 ✅
+- Unit 3 (compose base + staging) → Tasks 2, 3 ✅
+- Unit 4 (deploy + disk safety) → Tasks 6, 7 ✅
+- Unit 5 (ghcr-retention) → Task 8 ✅
+- GHA skip-propagation note → Task 6 if-condition ✅
+- Testing strategy (compose config, YAML parse, workflow_dispatch) → Tasks 1-3, 9 ✅
+- Disk fail-safe (abort) → Task 7 Step 1 ✅
+- orchestration publish-only (pull, not recreated) → Task 7 Step 2 ✅
+
+**2. Placeholder scan:** `PIN_SHA_HERE` in Task 8 is resolved by Task 8 Step 1's `gh` command (concrete instruction, not a vague TODO). All YAML/code blocks are shown in full. No "TBD"/"add error handling"/"similar to".
+
+**3. Type/name consistency:**
+- Short tokens `embedding`/`reranker`/`orchestration` used in: filters (T4), `ai_changed` keys (T4), build-ai matrix (T5), SSH `*_CHANGED` flags (T7), retention matrix (T8). ✅
+- Compose service names `embedding-service`/`reranker-service` used in `$SERVICES` + health `case` (T7) and match docker-compose.yml. ✅
+- Container names `meepleai-embedding`/`meepleai-reranker` in health checks match compose `container_name`. ✅
+- Env vars `EMBEDDING_IMAGE`/`RERANKER_IMAGE`/`ORCHESTRATION_IMAGE` consistent across compose (T2, T3) and SSH export (T7). ✅
+- GHCR image path `ghcr.io/<repo>/<svc>-service` consistent in build-ai metadata (T5), SSH `AI_BASE` (T7), retention package-name (T8). ✅

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -151,6 +151,11 @@ services:
   # ===========================================================================
 
   embedding-service:
+    # Issue #1578: hard-required GHCR image (no stale-local fallback) + force
+    # pull. pull_policy: always guarantees the VPS PULLS the arm64 image built
+    # in CI and NEVER builds torch locally (avoids the disk-full/swap incident).
+    image: ${EMBEDDING_IMAGE:?EMBEDDING_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
     restart: always
     deploy:
       resources:
@@ -163,6 +168,9 @@ services:
     # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   reranker-service:
+    # Issue #1578: see embedding-service note above.
+    image: ${RERANKER_IMAGE:?RERANKER_IMAGE env var required for staging — set to GHCR tag}
+    pull_policy: always
     restart: always
     deploy:
       resources:
@@ -203,6 +211,11 @@ services:
     # Traefik labels removed (post CF Tunnel cutover). Internal service exposed only on docker network.
 
   orchestration-service:
+    # Issue #1578: publish-only. Soft default (not :?) — orchestration is not in
+    # the ai-essential deploy profile, so it is not started in staging. If a
+    # future --profile tutor-agents activates it, it pulls from GHCR (not build).
+    image: ${ORCHESTRATION_IMAGE:-ghcr.io/meepleai-app/meepleai-monorepo/orchestration-service:staging-latest}
+    pull_policy: always
     restart: always
     env_file:
       - ./secrets/database.secret

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -181,6 +181,10 @@ services:
     build:
       context: ../apps/embedding-service
       dockerfile: ./Dockerfile
+    # Issue #1578: staging pulls this from GHCR (compose.staging.yml sets
+    # EMBEDDING_IMAGE + pull_policy: always). Dev leaves the var unset → builds
+    # locally as meepleai-embedding (mirrors api/web).
+    image: ${EMBEDDING_IMAGE:-meepleai-embedding}
     container_name: meepleai-embedding
     restart: unless-stopped
     profiles: [ai, ai-essential]
@@ -262,6 +266,8 @@ services:
     build:
       context: ../apps/reranker-service
       dockerfile: ./Dockerfile
+    # Issue #1578: see embedding-service note above.
+    image: ${RERANKER_IMAGE:-meepleai-reranker}
     container_name: meepleai-reranker
     restart: unless-stopped
     profiles: [ai, ai-essential]
@@ -288,6 +294,9 @@ services:
     build:
       context: ../apps/orchestration-service
       dockerfile: ./Dockerfile
+    # Issue #1578: publish-only. Image built+pushed to GHCR but not activated
+    # in staging (stays out of the ai-essential deploy profile).
+    image: ${ORCHESTRATION_IMAGE:-meepleai-orchestrator}
     container_name: meepleai-orchestrator
     restart: unless-stopped
     profiles: [ai, tutor-agents]


### PR DESCRIPTION
## Summary

Closes the ~50-day AI-service image drift on staging (#1578). embedding, reranker, and orchestration are now built + pushed to GHCR by the staging deploy with per-service change detection; the ARM64 VPS pulls (never builds) them, under a dedicated disk-safety gate. orchestration is publish-only.

- `detect-changes`: per-service path filters + `ai_changed`/`ai_any`.
- `build-ai`: matrix job (QEMU arm64, change-gated, fail-fast:false, 120m).
- compose: `image:` vars (dev builds local, staging pulls via `pull_policy: always`).
- `deploy`: pre-pull disk gate (abort fail-safe), pull+recreate embedding/reranker, pull-only orchestration, AI health checks.
- `ghcr-retention`: keep last 5 per package.

## Validation

- Local: workflow YAML parse + `docker compose config` (dev + staging) green.
- `actionlint` (via Docker) validated all new GHA expressions (fromJSON/matrix/needs); the only flagged expression error (`github.workflow_id`, line 124) is pre-existing in `notify-start`, unrelated to this PR.
- `Validate Workflows` CI (SHA-pinning gate) — all new actions pinned.
- Post-merge: a `workflow_dispatch` run with `force_full_deploy` exercises the full matrix build + GHCR push + VPS pull + AI health.

## Out of scope

smoldocling/unstructured (disabled in staging), orchestration runtime activation, native Dockerfile cross-compile.

Spec: `docs/for-developers/specs/2026-05-28-ai-services-ghcr-pipeline-design.md`
Plan: `docs/superpowers/plans/2026-05-28-ai-services-ghcr-pipeline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)