### PR TITLE
fix(ci): #1578 free old AI images BEFORE pull (disk-safe order)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -929,6 +929,32 @@ jobs:
               echo "📦 Web image updated"
             fi
 
+            # Issue #1578 follow-up — free-old-AI before pull (disk-safe order).
+            # The original "pull then recreate then prune" order leaves OLD AI
+            # images on disk during the new pull (transient peak ~old+new). On
+            # a VPS at 14 GB free this hit the AI_PULL_GATE_GB=15 fail-safe and
+            # blocked the deploy (run 26563212569). Re-ordering to:
+            #   stop+rm container → rmi old image → pull new → compose recreate
+            # frees ~5.3 GB (embedding) + ~2.1 GB (reranker) BEFORE the pull, so
+            # the transient peak does not need the full old+new headroom.
+            # Trade-off: ~30-60s extra AI downtime per service during the pull,
+            # acceptable on staging.
+            free_old_ai() {
+              local cont="$1"
+              local old_img
+              old_img=$(docker inspect "$cont" --format '{{.Image}}' 2>/dev/null || true)
+              docker rm -f "$cont" 2>/dev/null && echo "  - stopped + removed $cont" || true
+              if [ -n "$old_img" ]; then
+                docker rmi "$old_img" 2>/dev/null && echo "  - rmi $old_img" || echo "  - rmi $old_img skipped (in use elsewhere)"
+              fi
+            }
+            if [ "$EMB_CHANGED" = "true" ] || [ "$RRK_CHANGED" = "true" ]; then
+              echo "🗑️ Freeing old AI images before pull (disk-safe ordering)..."
+              [ "$EMB_CHANGED" = "true" ] && free_old_ai meepleai-embedding
+              [ "$RRK_CHANGED" = "true" ] && free_old_ai meepleai-reranker
+              echo "💽 Disk after free-old: $(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}') GB free"
+            fi
+
             # Issue #1578 — AI services. embedding/reranker are in the
             # ai-essential profile → pull + recreate. orchestration is
             # publish-only → pull ONLY (cached for a future activation).


### PR DESCRIPTION
## Summary

Follow-up to #1643. Staging deploy run [26563212569](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/26563212569) hit the `AI_PULL_GATE_GB=15` fail-safe at **14 GB free** and aborted. Root cause was NOT my code — the gate worked exactly as designed. The underlying issue is that the VPS legitimately runs a heavy stack (api+web+postgres+redis+embedding+reranker+monitoring) which keeps disk near 80% used, leaving little headroom for the "old+new" transient of the original pull-then-recreate order.

This PR re-orders the AI deploy to be **disk-safe** without weakening the gate.

## Change

In `Deploy via SSH`, between the api/web pull and the AI pull, add a helper `free_old_ai()` that for each changed AI service:
1. `docker inspect` to find the current image ID
2. `docker rm -f <container>` (stop + remove the running container)
3. `docker rmi <old_image>` (frees ~5.3 GB embedding + ~2.1 GB reranker)

Then the existing `docker pull` uses the just-freed space, and `compose up --force-recreate` creates fresh containers from the new images.

## Trade-off

- **~30-60s extra AI downtime** per service during the pull (was previously "online during pull, ~10s recreate gap"). Acceptable on staging where embedding/reranker only serve the api's RAG features.
- Gate stays at 15 GB — **no safety relaxation**.

## Validation

- Local YAML parse + actionlint (incl. shellcheck) clean.
- Real validation = next staging deploy after this merges + releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)