### PR TITLE
fix(2fa): surface backup codes from setup response when enable omits them

### DIFF
--- a/apps/web/src/components/features/settings/__tests__/TwoFactorSetupModal.test.tsx
+++ b/apps/web/src/components/features/settings/__tests__/TwoFactorSetupModal.test.tsx
@@ -10,8 +10,13 @@ vi.mock('@/lib/api', () => ({
 
 const SETUP = {
   secret: 'JBSWY3DPEHPK3PXP',
-  qrCodeUrl: 'data:image/png;base64,AAAA',
-  backupCodes: [],
+  // BE returns an otpauth:// URI (TotpService.GenerateQrCodeUrl), not a PNG.
+  // The wizard renders it via <QRCodeSVG>; the value is opaque to the test.
+  qrCodeUrl: 'otpauth://totp/MeepleAI:test%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=MeepleAI',
+  // Backup codes are the SETUP endpoint's plaintext payload (TotpSetupResponse.BackupCodes).
+  // They are the canonical source surfaced in the 'codes' step — the enable endpoint
+  // does NOT re-emit them (see TwoFactorWizardBody onSuccess for rationale).
+  backupCodes: ['SETUP-AAAA-1111', 'SETUP-BBBB-2222', 'SETUP-CCCC-3333'],
 };
 
 function wrap(ui: React.ReactNode) {
@@ -40,10 +45,12 @@ describe('TwoFactorSetupModal', () => {
     expect(screen.getByText(/enter the code/i)).toBeInTheDocument();
   });
 
-  it('calls enable2FA + moves to codes step on success', async () => {
+  it('calls enable2FA + moves to codes step on success (BE-emitted codes wins)', async () => {
+    // Forward-compatibility path: when the BE eventually populates `backupCodes` on
+    // enable, the wizard surfaces those (more authoritative than the setup snapshot).
     vi.mocked(api.auth.enable2FA).mockResolvedValue({
       success: true,
-      backupCodes: ['AAAA-1111', 'BBBB-2222'],
+      backupCodes: ['ENABLE-AAAA-1111', 'ENABLE-BBBB-2222'],
       errorMessage: null,
     });
     wrap(<TwoFactorSetupModal open setupData={SETUP} onClose={() => {}} onEnabled={() => {}} />);
@@ -53,6 +60,32 @@ describe('TwoFactorSetupModal', () => {
     fireEvent.paste(inputs[0], { clipboardData: { getData: () => '123456' } });
     await waitFor(() => expect(api.auth.enable2FA).toHaveBeenCalledWith('123456'));
     await waitFor(() => expect(screen.getByText(/recovery codes|save/i)).toBeInTheDocument());
+    // Codes surfaced are the enable-response ones, not the setup snapshot.
+    expect(screen.getByText('ENABLE-AAAA-1111')).toBeInTheDocument();
+    expect(screen.queryByText('SETUP-AAAA-1111')).not.toBeInTheDocument();
+  });
+
+  it('falls back to setupData.backupCodes when enable2FA omits codes (current BE behavior)', async () => {
+    // Regression guard for the 2026-05-28 hotfix: Enable2FACommandHandler returns
+    // `Success: true` without populating `BackupCodes` (the persisted codes are PBKDF2
+    // hashed at setup time, so the BE can't re-emit them on enable). Without this
+    // fallback the wizard would land on the 'codes' step with an empty list — exactly
+    // the bug Aaron hit during the SP5 S3 enrollment dogfood.
+    vi.mocked(api.auth.enable2FA).mockResolvedValue({
+      success: true,
+      backupCodes: null,
+      errorMessage: null,
+    });
+    wrap(<TwoFactorSetupModal open setupData={SETUP} onClose={() => {}} onEnabled={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.paste(inputs[0], { clipboardData: { getData: () => '123456' } });
+    await waitFor(() => expect(api.auth.enable2FA).toHaveBeenCalledWith('123456'));
+    await waitFor(() => expect(screen.getByText(/recovery codes|save/i)).toBeInTheDocument());
+    // All three setupData codes must surface.
+    expect(screen.getByText('SETUP-AAAA-1111')).toBeInTheDocument();
+    expect(screen.getByText('SETUP-BBBB-2222')).toBeInTheDocument();
+    expect(screen.getByText('SETUP-CCCC-3333')).toBeInTheDocument();
   });
 
   it('shows OTP error when enable2FA returns success:false (I4)', async () => {

--- a/apps/web/src/components/features/settings/two-factor/TwoFactorWizardBody.tsx
+++ b/apps/web/src/components/features/settings/two-factor/TwoFactorWizardBody.tsx
@@ -50,7 +50,17 @@ export function TwoFactorWizardBody({ setupData, onEnabled, resetKey }: Props): 
     onSuccess: result => {
       if (result.success) {
         setOtpError(null);
-        setIssuedCodes(result.backupCodes ?? []);
+        // Backup codes are returned in PLAINTEXT by the SETUP endpoint
+        // (TotpSetupResponse.BackupCodes) and surface here via `setupData.backupCodes`.
+        // The enable endpoint does NOT re-emit them — `Enable2FACommandHandler`
+        // returns `Success: true` only, and the persisted backup codes are PBKDF2
+        // hashed (one-way), so they cannot be reconstructed post-hash.
+        // Prefer `result.backupCodes` if the BE ever populates it; otherwise fall
+        // back to the trusted source already in the wizard's local state.
+        const codesFromEnable = result.backupCodes ?? [];
+        setIssuedCodes(
+          codesFromEnable.length > 0 ? codesFromEnable : [...(setupData.backupCodes ?? [])]
+        );
         setStep('codes');
         void queryClient.invalidateQueries({ queryKey: ['2fa-status'] });
       } else {


### PR DESCRIPTION
## What

When the user completes 2FA enrollment, the wizard's "codes" step now surfaces the backup codes from the **setup endpoint's plaintext payload** (`setupData.backupCodes`) when the enable response does not carry them. Forward-compat path is preserved: if the BE ever populates `Enable2FAResult.BackupCodes`, those win.

## Why

Discovered during the SP5 S3 staging enrollment dogfood (2026-05-28). The "codes" step rendered with an empty `BackupCodesView` — the user completing 2FA never saw their recovery codes. **Hard lockout risk** if the authenticator is ever lost.

## Root cause

[`Enable2FACommandHandler.cs:38`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TwoFactor/Enable2FACommandHandler.cs#L38) returns `Enable2FAResult(Success: true)` without populating `BackupCodes`. The persisted codes are PBKDF2 hashed (one-way) at setup time, so the BE genuinely **cannot** re-emit them on enable. The wizard's `onSuccess` read `result.backupCodes` (`null`) and dropped it through `?? []`.

The SETUP endpoint already returns the codes in plaintext via [`TotpSetupResponse.BackupCodes`](https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/apps/api/src/Api/Services/TotpService.cs#L128-L133) (commented "Only shown once during setup"). They reach the wizard via `setupData.backupCodes` but were never surfaced.

## Fix

One-line behavioral change in `TwoFactorWizardBody.onSuccess`:
```diff
- setIssuedCodes(result.backupCodes ?? []);
+ const codesFromEnable = result.backupCodes ?? [];
+ setIssuedCodes(codesFromEnable.length > 0
+   ? codesFromEnable
+   : [...(setupData.backupCodes ?? [])]);
```
With an inline comment documenting why (BE handler asymmetry + PBKDF2 one-way).

## Tests

- Updated `SETUP` fixture: `qrCodeUrl` is now an actual `otpauth://` URI (matches BE), `backupCodes` populated with 3 distinct `SETUP-*` values.
- Existing "codes step on success" test asserts the **enable-emitted codes win** when both are present (forward-compat).
- **New regression test** "falls back to setupData.backupCodes when enable2FA omits codes" — exactly the scenario hit in the dogfood.
- 5/5 PASS locally in 369ms.

## Scope NOT covered

A BE-side enhancement (have Enable2FA re-emit the plaintext codes) is intentionally out of scope: requires holding plaintext codes in transient storage past setup, which contradicts the "show once" security guarantee. The FE-side fallback is the principled fix.

## Refs

- SP5 S3 strict 2FA cutover ops (PR #1597, #1631 release)
- Sibling 2026-05-27 hotfixes: PR #1626 (QR render) + PR #1627 (TotpService persist)
- #1608 (settings tab consolidation, parent issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
