### PR TITLE
test(toolkit-detail): #1479 unit tests for ToolkitSummaryPanel + ToolkitIncludesGrid

### DIFF
--- a/apps/web/src/components/features/toolkit-detail/__tests__/ToolkitIncludesGrid.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/ToolkitIncludesGrid.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ToolkitIncludesGrid - Unit tests (Issue #1479).
+ *
+ * "Cosa include" 3-cell grid for the Overview tab of `/toolkits/[id]`.
+ * Renders three fixed cells — agent name, KB documents count, tools count —
+ * each backed by the private `Cell` component. Pure presentational.
+ * Source: PR #1163 (closes #1145).
+ *
+ * Test matrix (Crispin):
+ *   T1. Renders 3 cells (data-slot="toolkit-detail-includes-cell").
+ *   T2. Root grid data-slot present.
+ *   T3. Agent cell shows labels.agent and agentName value.
+ *   T4. KB docs cell shows labels.kbDocs and String(kbDocsCount).
+ *   T5. Tools cell shows labels.tools and String(toolsCount).
+ *   T6. Counts rendered as strings — 0 renders "0".
+ *   T7. Large count numbers rendered correctly via String() (not toLocaleString).
+ *   T8. All three label keys are rendered in the document.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ToolkitIncludesGrid, type ToolkitIncludesGridLabels } from '../ToolkitIncludesGrid';
+
+const labels: ToolkitIncludesGridLabels = {
+  agent: 'Agente',
+  kbDocs: 'Documenti KB',
+  tools: 'Strumenti',
+};
+
+const baseProps = {
+  agentName: 'MeepleBot',
+  kbDocsCount: 5,
+  toolsCount: 3,
+  labels,
+};
+
+describe('ToolkitIncludesGrid (Issue #1479)', () => {
+  // T1
+  it('renders exactly 3 cells with data-slot="toolkit-detail-includes-cell"', () => {
+    const { container } = render(<ToolkitIncludesGrid {...baseProps} />);
+    expect(container.querySelectorAll('[data-slot="toolkit-detail-includes-cell"]')).toHaveLength(
+      3
+    );
+  });
+
+  // T2
+  it('exposes data-slot on the root grid', () => {
+    const { container } = render(<ToolkitIncludesGrid {...baseProps} />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-includes-grid"]')
+    ).toBeInTheDocument();
+  });
+
+  // T3
+  it('renders the agent label and agentName value', () => {
+    render(<ToolkitIncludesGrid {...baseProps} agentName="MeepleBot" />);
+    expect(screen.getByText('Agente')).toBeInTheDocument();
+    expect(screen.getByText('MeepleBot')).toBeInTheDocument();
+  });
+
+  // T4
+  it('renders the kbDocs label and String(kbDocsCount) value', () => {
+    render(<ToolkitIncludesGrid {...baseProps} kbDocsCount={5} />);
+    expect(screen.getByText('Documenti KB')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  // T5
+  it('renders the tools label and String(toolsCount) value', () => {
+    render(<ToolkitIncludesGrid {...baseProps} toolsCount={3} />);
+    expect(screen.getByText('Strumenti')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  // T6
+  it('renders "0" when counts are zero', () => {
+    render(<ToolkitIncludesGrid {...baseProps} kbDocsCount={0} toolsCount={0} />);
+    // Both cells render "0"; getAllByText covers both
+    const zeros = screen.getAllByText('0');
+    expect(zeros).toHaveLength(2);
+  });
+
+  // T7
+  it('renders large counts as plain strings (no locale formatting)', () => {
+    render(<ToolkitIncludesGrid {...baseProps} kbDocsCount={1000} toolsCount={999} />);
+    // String(1000) = "1000", NOT "1,000"
+    expect(screen.getByText('1000')).toBeInTheDocument();
+    expect(screen.getByText('999')).toBeInTheDocument();
+  });
+
+  // T8
+  it('renders all three label keys in the document', () => {
+    render(<ToolkitIncludesGrid {...baseProps} />);
+    expect(screen.getByText('Agente')).toBeInTheDocument();
+    expect(screen.getByText('Documenti KB')).toBeInTheDocument();
+    expect(screen.getByText('Strumenti')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/toolkit-detail/__tests__/ToolkitSummaryPanel.test.tsx
+++ b/apps/web/src/components/features/toolkit-detail/__tests__/ToolkitSummaryPanel.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * ToolkitSummaryPanel - Unit tests (Issue #1479).
+ *
+ * Hero summary block for `/toolkits/[id]`. Renders cover gradient backdrop,
+ * author chip (with avatar image or fallback emoji), optional game chip,
+ * title, description, and a 3-stat <dl> (installCount / ratingAverage via
+ * Stars / currentVersion). Pure presentational; slots into the `hero` of
+ * DetailPageLayout. Source: PR #1163 (closes #1145).
+ *
+ * Stars is a re-export of the canonical ui/feedback/Stars and is covered by
+ * that canonical's own tests; here we assert only that the rating region is
+ * present/absent and that the ratingCount suffix is correct.
+ *
+ * Test matrix (Crispin):
+ *   T1. Renders title and description.
+ *   T2. Author chip shows authorChipPrefix + authorName.
+ *   T3. Author chip uses img tag when authorAvatarUrl is provided.
+ *   T4. Author chip uses fallback emoji when authorAvatarUrl is null.
+ *   T5. Game chip shown when gameName is a non-empty string.
+ *   T6. Game chip absent when gameName is null.
+ *   T7. Game chip absent when gameName is undefined.
+ *   T8. installCount rendered via toLocaleString().
+ *   T9. Rating cell shows Stars region (role=img) when ratingAverage is set.
+ *   T10. Rating cell shows noRatings label when ratingAverage is null.
+ *   T11. ratingCount suffix "(N)" rendered when ratingCount > 0.
+ *   T12. ratingCount suffix absent when ratingCount === 0.
+ *   T13. currentVersion rendered.
+ *   T14. data-slot attributes present (4 slots).
+ *   T15. className composition on the root header.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ToolkitSummaryPanel, type ToolkitSummaryPanelLabels } from '../ToolkitSummaryPanel';
+
+const labels: ToolkitSummaryPanelLabels = {
+  authorChipPrefix: 'by',
+  gameChipPrefix: 'for',
+  statsHeading: 'Statistiche toolkit',
+  installCountLabel: 'Installazioni',
+  ratingLabel: 'Rating',
+  versionLabel: 'Versione',
+  noRatings: 'Nessuna valutazione',
+};
+
+const baseProps = {
+  title: 'My Toolkit',
+  description: 'A useful toolkit for board games.',
+  authorName: 'Alice',
+  authorAvatarUrl: null,
+  coverImageUrl: null,
+  gameName: null,
+  installCount: 1234,
+  ratingAverage: 4.5,
+  ratingCount: 42,
+  currentVersion: '2.1.0',
+  labels,
+};
+
+describe('ToolkitSummaryPanel (Issue #1479)', () => {
+  // T1
+  it('renders title and description', () => {
+    render(<ToolkitSummaryPanel {...baseProps} />);
+    expect(screen.getByText('My Toolkit')).toBeInTheDocument();
+    expect(screen.getByText('A useful toolkit for board games.')).toBeInTheDocument();
+  });
+
+  // T2
+  it('renders author chip with authorChipPrefix and authorName', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} authorName="Alice" />);
+    const chip = container.querySelector('[data-slot="toolkit-detail-author-chip"]');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('by Alice');
+  });
+
+  // T3
+  it('renders an img tag inside the author chip when authorAvatarUrl is provided', () => {
+    const { container } = render(
+      <ToolkitSummaryPanel {...baseProps} authorAvatarUrl="https://example.com/avatar.png" />
+    );
+    const chip = container.querySelector('[data-slot="toolkit-detail-author-chip"]');
+    expect(chip?.querySelector('img')).toBeInTheDocument();
+    expect(chip?.querySelector('img')).toHaveAttribute('src', 'https://example.com/avatar.png');
+  });
+
+  // T4
+  it('renders the fallback emoji (👤) when authorAvatarUrl is null', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} authorAvatarUrl={null} />);
+    const chip = container.querySelector('[data-slot="toolkit-detail-author-chip"]');
+    expect(chip?.querySelector('img')).not.toBeInTheDocument();
+    expect(chip).toHaveTextContent('👤');
+  });
+
+  // T5
+  it('shows the game chip when gameName is a non-empty string', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} gameName="Catan" />);
+    const chip = container.querySelector('[data-slot="toolkit-detail-game-chip"]');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('for Catan');
+  });
+
+  // T6
+  it('does not render the game chip when gameName is null', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} gameName={null} />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-game-chip"]')
+    ).not.toBeInTheDocument();
+  });
+
+  // T7
+  it('does not render the game chip when gameName is undefined', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} gameName={undefined} />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-game-chip"]')
+    ).not.toBeInTheDocument();
+  });
+
+  // T8
+  it('renders installCount via toLocaleString()', () => {
+    render(<ToolkitSummaryPanel {...baseProps} installCount={1234} />);
+    // toLocaleString() output is locale-dependent; assert the label and the number is present
+    expect(screen.getByText('Installazioni')).toBeInTheDocument();
+    // The dd containing the formatted install count is in the document
+    expect(screen.getByText((1234).toLocaleString())).toBeInTheDocument();
+  });
+
+  // T9
+  it('shows the Stars region (role=img) when ratingAverage is provided', () => {
+    render(<ToolkitSummaryPanel {...baseProps} ratingAverage={4.5} ratingCount={10} />);
+    // Stars renders with role="img"
+    expect(screen.getByRole('img', { name: /Rating:/i })).toBeInTheDocument();
+  });
+
+  // T10
+  it('shows the noRatings label when ratingAverage is null', () => {
+    render(<ToolkitSummaryPanel {...baseProps} ratingAverage={null} ratingCount={0} />);
+    expect(screen.getByText('Nessuna valutazione')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: /Rating:/i })).not.toBeInTheDocument();
+  });
+
+  // T11
+  it('renders the ratingCount suffix "(N)" when ratingCount > 0', () => {
+    render(<ToolkitSummaryPanel {...baseProps} ratingAverage={3.0} ratingCount={7} />);
+    expect(screen.getByText('(7)')).toBeInTheDocument();
+  });
+
+  // T12
+  it('does not render the ratingCount suffix when ratingCount is 0', () => {
+    render(<ToolkitSummaryPanel {...baseProps} ratingAverage={3.0} ratingCount={0} />);
+    expect(screen.queryByText(/\(\d+\)/)).not.toBeInTheDocument();
+  });
+
+  // T13
+  it('renders currentVersion', () => {
+    render(<ToolkitSummaryPanel {...baseProps} currentVersion="2.1.0" />);
+    expect(screen.getByText('2.1.0')).toBeInTheDocument();
+  });
+
+  // T14
+  it('exposes all 4 data-slot attributes', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} gameName="Catan" />);
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-summary-panel"]')
+    ).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="toolkit-detail-author-chip"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="toolkit-detail-game-chip"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="toolkit-detail-summary-stats"]')
+    ).toBeInTheDocument();
+  });
+
+  // T15
+  it('composes custom className with base classes on the root header', () => {
+    const { container } = render(<ToolkitSummaryPanel {...baseProps} className="custom-class" />);
+    const root = container.querySelector('[data-slot="toolkit-detail-summary-panel"]');
+    expect(root).toHaveClass('custom-class');
+    expect(root).toHaveClass('rounded-2xl');
+  });
+});

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -303,16 +303,18 @@ the PR review.
 | `sp4-player-detail.jsx` | `FavoriteAgentCard` | `apps/web/src/components/features/player-detail/FavoriteAgentCard.tsx` | `/players/[id]` | done | #1539 | T A V | #1544 |
 | `sp4-player-detail.jsx` | `AchievementBadgeGrid` | `apps/web/src/components/features/player-detail/AchievementBadgeGrid.tsx` | `/players/[id]` | done | #1539 | T A V | #1544 |
 
-### Toolkit detail — `/toolkits/[id]` — 6 components — **Tier M**
+### Toolkit detail — `/toolkits/[id]` — 6 components — **Tier M** ✅ done
+
+> **Status (#1479, 2026-05-28)**: route fully implemented + wired (orchestrator `ToolkitDetailView` + tab panels). All 6 components shipped via PR #1163 (`Stage 3 FE — DetailPageLayout adoption`, closes #1145) — `VersionTimeline`/`RatingBreakdown`/`PromptPreviewBlock` tested earlier (#1531), `ToolkitSummaryPanel`/`ToolkitIncludesGrid` component tests added 2026-05-28 (23 tests), `Stars` is a thin re-export of the canonical `ui/feedback/Stars` (#1469, covered by the canonical's tests).
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-toolkit-detail.jsx` | `ToolkitSummaryPanel` | `apps/web/src/components/features/toolkit-detail/ToolkitSummaryPanel.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
-| `sp4-toolkit-detail.jsx` | `ToolkitIncludesGrid` | `apps/web/src/components/features/toolkit-detail/ToolkitIncludesGrid.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
+| `sp4-toolkit-detail.jsx` | `ToolkitSummaryPanel` | `apps/web/src/components/features/toolkit-detail/ToolkitSummaryPanel.tsx` | `/toolkits/[id]` | done | #1163 | T A V | — |
+| `sp4-toolkit-detail.jsx` | `ToolkitIncludesGrid` | `apps/web/src/components/features/toolkit-detail/ToolkitIncludesGrid.tsx` | `/toolkits/[id]` | done | #1163 | T A V | — |
 | `sp4-toolkit-detail.jsx` | `VersionTimeline` | `apps/web/src/components/features/toolkit-detail/VersionTimeline.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
 | `sp4-toolkit-detail.jsx` | `RatingBreakdown` | `apps/web/src/components/features/toolkit-detail/RatingBreakdown.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
 | `sp4-toolkit-detail.jsx` | `PromptPreviewBlock` | `apps/web/src/components/features/toolkit-detail/PromptPreviewBlock.tsx` | `/toolkits/[id]` | done | #1531 | T A V | — |
-| `sp4-toolkit-detail.jsx` | `Stars` | `apps/web/src/components/features/toolkit-detail/Stars.tsx` | `/toolkits/[id]` | pending | — | T A V | — |
+| `sp4-toolkit-detail.jsx` | `Stars` | `apps/web/src/components/features/toolkit-detail/Stars.tsx` | `/toolkits/[id]` | done | #1469 | T A V | — |
 
 ### KB detail — `/kb/[id]` — 6 components — **Tier M**
 


### PR DESCRIPTION
## Summary

Closes #1479 (`feat(toolkit-detail): implement /toolkits/[id] — 6 components Tier M`).

**Discovery (P124)**: during the Epic #1475 cleanup pass, `/toolkits/[id]` turned out to be **already fully implemented + wired** — the route, orchestrator (`ToolkitDetailView`), and tab panels ship all 6 components via **PR #1163** (`Stage 3 FE — DetailPageLayout adoption`, closes #1145). The matrix showed 3 of 6 rows as stale-`pending` purely as bookkeeping drift.

The only real gap was missing direct unit tests for `ToolkitSummaryPanel` + `ToolkitIncludesGrid` (the other 3 were tested in #1531; `Stars` is a re-export of the canonical `ui/feedback/Stars` from #1469).

## What's in this PR

- **23 RTL unit tests** across 2 new files under `apps/web/src/components/features/toolkit-detail/__tests__/`:

  | Component | Tests | Coverage |
  |---|---|---|
  | `ToolkitSummaryPanel` | 15 | title/description, author chip (avatar vs 👤 fallback), game chip present/null/undefined, installCount locale format, Stars region when rating present, noRatings label when null, `(N)` rating-count suffix, version, 4 data-slots, className |
  | `ToolkitIncludesGrid` | 8 | 3 cells (agent/kbDocs/tools) label+value, data-slots, `String()` count conversion incl. zero |

- **Matrix update**: 3 `/toolkits/[id]` rows `pending → done` (`ToolkitSummaryPanel`/`ToolkitIncludesGrid` #1163, `Stars` #1469), section header status refreshed.

## Verification

```
pnpm vitest run …/toolkit-detail/__tests__/ToolkitSummaryPanel.test.tsx …/ToolkitIncludesGrid.test.tsx
Test Files  2 passed (2)
      Tests  23 passed (23)

pnpm typecheck  →  exit 0 (clean)
```

## Notes

- Characterization tests — components were NOT modified.
- **Behavioral observation (not a bug, not fixed)**: in `ToolkitSummaryPanel`, the `ratingCount > 0` suffix renders *outside* the `ratingAverage != null` branch, so `ratingAverage=null, ratingCount=5` would show both the `noRatings` label and `(5)`. Documented as current behavior; potential minor follow-up if product cares.

## Epic context

Part of Epic #1475. 5th Phase-B issue found "implemented but not formally closed" during the 2026-05-28 cleanup pass (after #1476, #1477, #1483). After this, Phase B is **8/9 closed** — only #1482 (`/kb/global`) remains, BE-blocked by #1661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
