### PR TITLE
feat(admin-kb): SP5 F3-FU-3 — re-skin KB tool-pages + section band (#1652)

### DIFF
--- a/admin-mockups/design_handoff_admin/KB_TOOLPAGE_DESIGN_PROMPTS.md
+++ b/admin-mockups/design_handoff_admin/KB_TOOLPAGE_DESIGN_PROMPTS.md
@@ -1,0 +1,202 @@
+# KB_TOOLPAGE_DESIGN_PROMPTS.md — Mock per le 6 KB tool-page mancanti
+
+> Generati 2026-05-28 per F3-FU-3 (issue #1652). Workflow analogo a `SURPLUS_DESIGN_PROMPTS.md`: l'utente genera i mock su claude.ai web, poi l'agente li integra nel codice.
+
+## Contesto
+
+Survey 2026-05-28: delle 7 KB tool-page del prodotto, solo 1 ha un mockup SP5 (`sp5-admin-rag-backup.html` ≈ snapshots). Le altre 6 (vectors, queue, pipeline-monitor, embedding, feedback, settings) non hanno mockup. F3-FU-3 ne richiede il re-skin, quindi servono i 6 mock prima dell'implementazione.
+
+## Decisione header (incorporata nei mock)
+
+Layout `/admin/knowledge-base/layout.tsx` possiede la banda di sezione condivisa: header `<h1>Knowledge Base</h1>` + crumbs (`247 docs · 18.487 chunks · 2.4TB`) + actions (search ⌘K, + Upload PDF) + sub-nav `.admin-tabs` (8 tab, riusata da `sp5-admin-kb-subnav.html`). Le pagine NON ripetono un h1 "Knowledge Base"; l'identità della pagina = il tab attivo della sub-nav. Se serve un titolo di contenuto, `.admin-panel-head` (h3), non h1.
+
+## Workflow su claude.ai
+
+1. **claude.ai** → nuova conversazione, **Artifacts attivi**.
+2. **Messaggio 1**: incolla il Brief (§1) **+** allega i **5 file** (§2). Claude conferma, attende.
+3. **Messaggi 2-7**: invia un prompt-schermata alla volta (§3-§8). Ogni risposta = 1 HTML.
+4. Salva ogni artifact come `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-<id>.html` e passalo all'agente (oppure incolla l'HTML). L'agente penserà a sostituire `<style>` inline con `<link>`, voce nav, SCREENS, ecc.
+
+## 1. Brief (Messaggio 1)
+
+```
+Sei un designer frontend. Produci MOCKUP HTML statici e standalone per le tool-page
+"Knowledge Base" della Admin Console di MeepleAI, nello stile SP5 dei 3 CSS allegati
+(tokens.css, components.css, admin-base.css). Ti allego anche sp5-admin-kb.html (pattern
+chunk-table/KPI/doc-card + stili custom) e sp5-admin-kb-subnav.html (la sub-nav KB).
+
+REGOLE FERME:
+- Vanilla HTML, un file per schermata. NIENTE React/framework/build.
+- Dark theme default, density alta, desktop-first 1440px. SOLO le CSS variables e le classi
+  del design system (admin-shell, admin-top, admin-tabs, admin-table, admin-kpi, admin-panel,
+  status-chip, btn-admin, admin-form-row, admin-search, alert-banner, ecc.).
+- VIETATO hex hardcoded: usa var(--*) e le utility entità .e-game/.e-kb/.e-event/...
+- Dati realistici e plausibili (nomi giochi, numeri, timestamp). Niente Lorem ipsum.
+- Per l'anteprima: inlinea i 3 CSS + gli stili custom di sp5-admin-kb.html in <style>.
+
+STRUTTURA OBBLIGATORIA di OGNI tool-page (riempi solo la parte "CONTENUTO"):
+<!doctype html><html lang="it" data-theme="dark"><head>…<style>/* CSS inline */</style></head>
+<body class="admin-page">
+  <div class="admin-mobile-fallback"><div class="em">🖥️</div><h2>Console solo desktop</h2><p>≥880px.</p></div>
+  <div class="admin-shell">
+    <div data-admin-nav-mount></div>
+    <main>
+      <!-- BANDA DI SEZIONE (uguale per tutte le tool-page) -->
+      <header class="admin-top">
+        <div><h1>Knowledge Base</h1><div class="crumbs">Admin · KB · 247 docs · 18.487 chunks · 2.4TB</div></div>
+        <div class="spacer"></div>
+        <div class="admin-top-actions">
+          <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+          <a href="#" class="btn-admin primary">+ Upload PDF</a>
+        </div>
+      </header>
+      <div class="admin-body">
+        <!-- SUB-NAV: copia la .admin-tabs di sp5-admin-kb-subnav.html (8 tab),
+             con SOLO il tab di QUESTA pagina in stato .active -->
+        <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">… 8 tab …</div>
+        <!-- CONTENUTO SPECIFICO DELLA PAGINA (NIENTE h1 "Knowledge Base" ripetuto:
+             il tab attivo è l'identità della pagina; parti dal contenuto funzionale) -->
+      </div>
+    </main>
+  </div>
+  <script src="admin-nav.js"></script><script>renderAdminNav('kb');</script>
+</body></html>
+
+PRINCIPIO HEADER: la banda "Knowledge Base" + crumbs + sub-nav è condivisa (vive nel layout).
+Le pagine NON ripetono un h1 di sezione; se serve un titolo di contenuto usa .admin-panel-head
+(h3), non un h1 grande. Conferma di aver capito e attendi il primo prompt-schermata.
+```
+
+## 2. File da allegare (5)
+
+```
+admin-mockups\design_handoff_admin\admin\tokens.css
+admin-mockups\design_handoff_admin\admin\components.css
+admin-mockups\design_handoff_admin\admin\admin-base.css
+admin-mockups\design_handoff_admin\admin\sp5-admin-kb.html
+admin-mockups\design_handoff_admin\admin\sp5-admin-kb-subnav.html
+```
+
+## 3. Prompt — Vector Collections
+
+```
+Crea il mockup "Knowledge Base · Vector Collections" (tab "Vector Collections" .active nella sub-nav).
+Contesto: admin ispeziona la salute pgvector e fa ricerca semantica sui chunk. Ruolo: admin.
+CONTENUTO della .admin-body (dopo la sub-nav), in ordine:
+1. KPI strip (4× .admin-kpi): Total Vectors (.e-kb), Games Indexed (.e-game), Dimensions (768),
+   Avg Health % (.e-toolkit) — ognuna con valore + trend + sparkline.
+2. .admin-panel "Ricerca semantica": riga con .admin-search ampia (placeholder "Cerca nei chunk…")
+   + select "Tutti i giochi" + select limit [5/10/20/50] + btn-admin.primary "Cerca".
+3. Risultati: lista di 4-5 item espandibili (mono): documentId (8 char) · pageNumber · chunkIndex
+   · snippet di testo · score. Stile come la chunk-table-row di sp5-admin-kb.html.
+4. .admin-panel "Vettori per gioco": grid di card (1 per gioco) con nome gioco (.e-game),
+   conteggio vettori, dimensione. ~6 giochi realistici (Wingspan, Brass, Tainted Grail…).
+Realtime: no (refresh manuale, btn-admin "⟳ Refresh" in alto a dx della prima panel).
+Endpoint (solo realismo): getVectorStats(), searchVectors(query, limit, gameId?).
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS.
+```
+
+## 4. Prompt — Processing Queue
+
+```
+Crea il mockup "Knowledge Base · Processing Queue" (tab "Processing Queue" .active, badge .count "3").
+Contesto: admin monitora la coda di elaborazione PDF in tempo reale, con azioni bulk e drill-down job. Ruolo: admin.
+CONTENUTO della .admin-body, in ordine:
+1. alert-banner.warning "Coda" (1 alert proattivo, es. "2 job falliti nelle ultime 24h").
+2. Control bar (.admin-panel compatta): toggle Pausa/Riprendi coda (.admin-toggle), n° worker,
+   indicatore backpressure (status-chip).
+3. Capacity indicator + Stats bar: 4 .admin-kpi inline → Attivi (.e-agent, status .running),
+   In coda, Completati (.e-toolkit), Falliti (.e-event).
+4. Bulk actions bar (.bulk-bar, mostrata con "2 selezionati") + filtri (.admin-search + filter-chip stato).
+5. Layout 2 colonne grid 40%/60%: sx = .admin-table lista job (col: PDF mono | Gioco | Stato
+   status-chip queued/running/completed/failed | Progresso | Avviato mono | ⋮); 1 riga .selected .running.
+   dx = .admin-panel "Dettaglio job" (hero job + step timeline + log mono live).
+6. In fondo: MetricsDashboard mini (throughput, tempo medio).
+Realtime: SÌ — aspetto "live", dot status-chip.running "● streaming" in testa alla lista + al dettaglio.
+Endpoint: getQueueList(), getJobDetail() + SSE coda/job.
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS.
+```
+
+## 5. Prompt — RAG Pipeline (monitor)
+
+```
+Crea il mockup "Knowledge Base · RAG Pipeline" (tab "RAG Pipeline" .active).
+Contesto: admin visualizza il flusso pipeline Ingest→Extract→Chunk→Embed→Index con salute e metriche. Ruolo: admin.
+NB: è il MONITOR della pipeline RAG, NON il workflow-builder.
+CONTENUTO della .admin-body, in ordine:
+1. Stage flow: 5 box orizzontali collegati da frecce → (Ingest · Extract · Chunk · Embed · Index),
+   ognuno con status-chip (healthy/warning/error) + micro-metrica. Box cliccabili (espandibili).
+2. Health summary: 3 card "Healthy / Warning / Error" con conteggi (es. "3/5 Healthy") + 4 distribution
+   stat-card (.admin-kpi): Documenti, Chunks, Vettori, Storage.
+3. .admin-panel "Metriche Elaborazione": step-card per fase con barre P50/P95/P99; + .admin-table di
+   confronto col: Fase | Media | P50 | P95 | P99 | Campioni. Evidenzia in .e-event la fase bottleneck.
+Realtime: SÌ — refetch 30s (nota "auto-refresh 30s" + btn ⟳ Refresh).
+Endpoint: getPipelineHealth(), getProcessingMetrics().
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS.
+```
+
+## 6. Prompt — Embedding Service
+
+```
+Crea il mockup "Knowledge Base · Embedding" (tab "Embedding" .active).
+Contesto: admin monitora il servizio di embedding multilingue (specifiche modello + throughput). Ruolo: admin.
+CONTENUTO della .admin-body, in ordine:
+1. .admin-panel "Stato servizio" con status-chip (Healthy/Unavailable) in testa: righe key-value mono →
+   Modello (es. multilingual-e5-base), Device (CPU/GPU), Dimensioni (768), Lingue (EN, IT, DE, FR, ES…),
+   Max input chars, Max batch size, nota "auto-refresh 30s".
+2. "Throughput": 6× .admin-kpi → Total Requests, Total Failures (.e-event), Failure Rate %,
+   Avg Duration (ms), Total Duration (s), Characters Processed (.e-kb). Con sparkline dove sensato.
+Realtime: SÌ — refetch 30s + btn ⟳ Refresh.
+Endpoint: getEmbeddingInfo(), getEmbeddingMetrics().
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS.
+```
+
+## 7. Prompt — Feedback KB
+
+```
+Crea il mockup "Knowledge Base · Feedback" (tab "Feedback" .active, badge .count "12").
+Contesto: admin rivede i feedback 👍/👎 degli utenti sulle risposte KB, filtra per esito, pagina. Ruolo: admin.
+CONTENUTO della .admin-body, in ordine:
+1. .admin-form-row "Game ID": .admin-input mono con placeholder UUID + hint validazione.
+2. Toolbar: select esito [Tutti | Utili | Non utili] (filter-chip) + conteggio totale a dx (mono "12 risultati").
+3. Lista feedback: 5-6 item (.admin-panel righe) → badge esito (status-chip.healthy "Utile" /
+   .danger "Non utile") + messageId (8 char mono) + data + commento opzionale (testo).
+4. Paginazione in fondo: "Pag 1" + btn prev/next (btn-admin.sm).
+Realtime: no.
+Endpoint: getAdminKbFeedback(gameId, {outcome?, page, pageSize}).
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS. Etichette in italiano.
+```
+
+## 8. Prompt — Settings
+
+```
+Crea il mockup "Knowledge Base · Settings" (tab "Settings" .active).
+Contesto: admin vede la config KB (read-only) e lancia operazioni di manutenzione. Ruolo: admin.
+CONTENUTO della .admin-body, in ordine:
+1. alert-banner.info "Configurazione read-only" + btn ⟳ Refresh.
+2. Grid 2-3 colonne di 6 .admin-panel (titolo .admin-panel-head h3 + righe key-value mono):
+   - Embedding Model (Provider, Model, Dimensions)
+   - Vector Database (Type pgvector, Host, Port)
+   - Text Chunking (Default Chunk Size, Overlap, Min/Max, Token Limit, Chars/Token)
+   - Cache Configuration (Redis Host/Port, HybridCache Expiration, L1/L2 TTL, Multi-Tier)
+   - Reranker Service (Provider, Model, stato)
+   - File Storage (Provider, bucket/path)
+3. "Danger Zone" (.admin-panel con bordo .e-event): 2 azioni distruttive btn-admin.danger →
+   "Rebuild Vector Index" e "Clear KB Cache", ognuna con pattern typed-confirm (mostra solo il pattern UI).
+Realtime: no.
+Endpoint: getKBSettings(), rebuildIndex(), clearKBCache().
+Rispetta SCHELETRO + sub-nav. Inlinea i CSS.
+```
+
+## Output finale
+
+Salva i 6 mock come (in ordine di sub-nav):
+
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-vectors.html`
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-queue.html`
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-pipeline.html`
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-embedding.html`
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-feedback.html`
+- `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-settings.html`
+
+Per **snapshots** non serve un nuovo mock: si segue `sp5-admin-rag-backup.html` esistente.

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-embedding.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-embedding.html
@@ -1,0 +1,548 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Embedding · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game: 25 95% 45%; --c-player: 262 83% 58%; --c-session: 240 60% 55%;
+  --c-agent: 38 92% 50%; --c-kb: 174 60% 40%; --c-chat: 220 80% 55%;
+  --c-event: 350 89% 60%; --c-toolkit: 142 70% 45%; --c-tool: 195 80% 50%;
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body: 'Nunito', system-ui, sans-serif;
+  --f-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px;
+  --r-sm: 6px; --r-md: 10px; --r-pill: 9999px;
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { font-family: var(--f-body); background: var(--bg); color: var(--text); font-size: var(--fs-base); line-height: 1.5; -webkit-font-smoothing: antialiased; }
+h1, h2, h3, h4 { font-family: var(--f-display); font-weight: 700; letter-spacing: -.01em; margin: 0; line-height: 1.2; }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: .9em; }
+
+.e-game{--e:var(--c-game);} .e-kb{--e:var(--c-kb);} .e-agent{--e:var(--c-agent);}
+.e-event{--e:var(--c-event);} .e-toolkit{--e:var(--c-toolkit);} .e-chat{--e:var(--c-chat);}
+.e-tool{--e:var(--c-tool);} .e-session{--e:var(--c-session);}
+.e-fg{color:hsl(var(--e));} .e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block;}
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+
+.admin-nav { background: var(--bg-card); border-right: 1px solid var(--border); padding: 16px 0; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-kpi { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px 16px; display: flex; flex-direction: column; gap: 4px; min-height: 96px; position: relative; }
+.admin-kpi-label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.admin-kpi-value { font-family: var(--f-display); font-size: 26px; font-weight: 800; color: var(--text); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.admin-kpi-value .u { font-size: 12px; color: var(--text-muted); font-weight: 700; margin-left: 2px; }
+.admin-kpi-trend { font-family: var(--f-mono); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 3px; }
+.admin-kpi-trend.up { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark { position: absolute; right: 12px; top: 12px; width: 60px; height: 24px; opacity: .85; }
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb));}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event));}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent));}
+.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit));}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat));}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool));}
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); flex-wrap: wrap; }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; display: inline-flex; align-items: center; gap: 6px; }
+.admin-panel-body { padding: 14px; }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); animation: admin-pulse 1.6s ease-in-out infinite; }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger, .status-chip.unavailable { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before, .status-chip.unavailable::before { background: hsl(var(--c-event)); }
+.status-chip.info { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+@keyframes admin-pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.6); opacity: .45; } }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; }
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+.endpoint-note { display: inline-flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); background: var(--bg-sunken); border: 1px dashed var(--border); padding: 2px 8px; border-radius: 4px; }
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+
+/* ═══════════════ page-local: Embedding ═══════════════ */
+.section-lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin: 18px 0 10px; display: flex; align-items: center; gap: 8px; }
+.section-lab .auto { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; }
+.section-lab .auto .dot { width: 6px; height: 6px; border-radius: 50%; background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .2); animation: admin-pulse 1.4s ease-in-out infinite; }
+
+/* ── Stato servizio panel ── */
+.service-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 0;
+}
+.service-grid > .left  { padding: 14px 16px; }
+.service-grid > .right { padding: 14px 16px; border-left: 1px solid var(--border-light); background: var(--bg); }
+
+.kv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0 18px; }
+.kv {
+  display: grid;
+  grid-template-columns: 132px 1fr;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-light);
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  align-items: center;
+}
+.kv:last-child { border-bottom: 0; }
+.kv .k { color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; font-size: 9.5px; font-weight: 700; }
+.kv .v { color: var(--text); font-weight: 600; display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.kv .v.mono-strong { color: hsl(var(--c-kb)); font-weight: 700; }
+
+.lang-chips { display: inline-flex; flex-wrap: wrap; gap: 3px; }
+.lang-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 4px;
+  background: hsl(var(--c-kb) / .12);
+  color: hsl(var(--c-kb));
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: .04em;
+}
+.lang-chip.primary { background: hsl(var(--c-kb) / .22); }
+
+/* Device card */
+.device {
+  display: flex; flex-direction: column; gap: 10px;
+}
+.device .title { font-family: var(--f-display); font-weight: 800; font-size: 13px; display: flex; align-items: center; gap: 8px; }
+.device .gpu-card {
+  border: 1px solid var(--border-light); border-radius: 8px;
+  padding: 10px 12px; background: var(--bg-card);
+  display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center;
+}
+.device .gpu-card .icon {
+  width: 38px; height: 38px; border-radius: 8px;
+  background: linear-gradient(135deg, hsl(var(--c-tool) / .35), hsl(var(--c-toolkit) / .25));
+  display: grid; place-items: center;
+  font-size: 18px; color: hsl(var(--c-tool));
+  flex-shrink: 0;
+}
+.device .gpu-card .gpu-name { font-family: var(--f-display); font-size: 12.5px; font-weight: 800; }
+.device .gpu-card .gpu-sub { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+.device .gpu-card .gpu-load { display: flex; flex-direction: column; gap: 2px; align-items: flex-end; min-width: 80px; }
+.device .gpu-card .gpu-load .pct { font-family: var(--f-mono); font-size: 13px; font-weight: 800; color: hsl(var(--c-toolkit)); }
+.device .gpu-card .gpu-load .bar { width: 80px; height: 4px; background: var(--bg-muted); border-radius: 2px; overflow: hidden; }
+.device .gpu-card .gpu-load .bar > span { display: block; height: 100%; background: hsl(var(--c-toolkit)); border-radius: 2px; }
+
+.health-bars { display: flex; flex-direction: column; gap: 6px; }
+.health-bars .row { display: grid; grid-template-columns: 72px 1fr 56px; gap: 8px; align-items: center; font-family: var(--f-mono); font-size: 10.5px; }
+.health-bars .row .lab { color: var(--text-sec); }
+.health-bars .row .bar { height: 6px; background: var(--bg-muted); border-radius: 3px; overflow: hidden; }
+.health-bars .row .bar > span { display: block; height: 100%; border-radius: 3px; }
+.health-bars .row .val { text-align: right; color: var(--text); font-weight: 700; }
+
+/* ── KPI strip (6 cols) ── */
+.kpi-strip-6 { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 12px; }
+.kpi-strip-6 .admin-kpi-value { font-size: 22px; }
+.kpi-strip-6 .admin-kpi-spark { width: 56px; height: 22px; right: 10px; top: 12px; }
+
+input[type="checkbox"] { accent-color: hsl(var(--c-event)); cursor: pointer; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav ─────────────────────────────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione condivisa ─────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · Embedding · multilingual-e5-base · 768d · GPU T4</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-embedding">
+
+      <!-- ── Sub-nav KB — Embedding .active ── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab" role="tab">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab" role="tab">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab" role="tab">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab active" role="tab" aria-selected="true">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab" role="tab">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab" role="tab">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ══ 1. Stato servizio ══ -->
+      <section class="admin-panel">
+        <div class="admin-panel-head">
+          <h3>🧠 Stato servizio</h3>
+          <span class="status-chip healthy">healthy</span>
+          <span class="endpoint-note"><code>GET</code> getEmbeddingInfo()</span>
+          <span class="meta">
+            <span class="dot" style="width:6px;height:6px;border-radius:50%;background:hsl(var(--c-toolkit));box-shadow:0 0 0 3px hsl(var(--c-toolkit) / .2);animation:admin-pulse 1.4s ease-in-out infinite;"></span>
+            auto-refresh 30s · next 18s
+            <button class="btn-admin sm" style="margin-left: 6px">⟳ Refresh</button>
+          </span>
+        </div>
+
+        <div class="service-grid">
+
+          <!-- LEFT: key-value details -->
+          <div class="left">
+            <div class="kv-grid">
+              <!-- col 1 -->
+              <div>
+                <div class="kv">
+                  <span class="k">Modello</span>
+                  <span class="v mono-strong">multilingual-e5-base</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Provider</span>
+                  <span class="v">intfloat · HuggingFace TEI</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Versione</span>
+                  <span class="v">v1.0.0 · revision 2c87f49</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Dimensioni</span>
+                  <span class="v"><strong>768</strong> <span style="color: var(--text-muted)">· cosine distance</span></span>
+                </div>
+                <div class="kv">
+                  <span class="k">Pooling</span>
+                  <span class="v">mean · normalize=true</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Endpoint</span>
+                  <span class="v">tei.internal:8080/embed</span>
+                </div>
+              </div>
+              <!-- col 2 -->
+              <div>
+                <div class="kv">
+                  <span class="k">Max input chars</span>
+                  <span class="v"><strong>4.096</strong> <span style="color: var(--text-muted)">· ~512 token</span></span>
+                </div>
+                <div class="kv">
+                  <span class="k">Max batch size</span>
+                  <span class="v"><strong>64</strong> <span style="color: var(--text-muted)">· optimal 32</span></span>
+                </div>
+                <div class="kv">
+                  <span class="k">Context tokens</span>
+                  <span class="v">512 · truncate=right</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Quantizzazione</span>
+                  <span class="v">fp16 · safetensors</span>
+                </div>
+                <div class="kv">
+                  <span class="k">Workers attivi</span>
+                  <span class="v">2 / 4 max <span class="status-chip healthy" style="font-size:9px; margin-left:4px">healthy</span></span>
+                </div>
+                <div class="kv">
+                  <span class="k">Last restart</span>
+                  <span class="v">2024-12-04 09:14 · 3g 5h fa</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Languages -->
+            <div class="kv" style="grid-template-columns: 132px 1fr; border-bottom: 0; padding-top: 12px; margin-top: 8px; border-top: 1px solid var(--border-light)">
+              <span class="k">Lingue supportate</span>
+              <span class="v">
+                <span class="lang-chips">
+                  <span class="lang-chip primary" title="English · 1.247k req">EN <span style="opacity:.7">· 51%</span></span>
+                  <span class="lang-chip primary" title="Italiano · 624k req">IT <span style="opacity:.7">· 26%</span></span>
+                  <span class="lang-chip" title="Deutsch · 218k req">DE <span style="opacity:.6">· 9%</span></span>
+                  <span class="lang-chip" title="Français · 172k req">FR <span style="opacity:.6">· 7%</span></span>
+                  <span class="lang-chip" title="Español · 98k req">ES <span style="opacity:.6">· 4%</span></span>
+                  <span class="lang-chip" title="Português">PT</span>
+                  <span class="lang-chip" title="Nederlands">NL</span>
+                  <span class="lang-chip" title="Polski">PL</span>
+                  <span class="lang-chip" title="Türkçe">TR</span>
+                  <span class="lang-chip" title="日本語">JA</span>
+                  <span class="lang-chip" title="한국어">KO</span>
+                  <span class="lang-chip" title="中文">ZH</span>
+                  <span style="font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); padding-left: 4px">+ 88 lingue · totale 100</span>
+                </span>
+              </span>
+            </div>
+          </div>
+
+          <!-- RIGHT: device + health bars -->
+          <div class="right">
+            <div class="device">
+              <div class="title">⚙ Device runtime</div>
+
+              <div class="gpu-card">
+                <div class="icon">⚡</div>
+                <div>
+                  <div class="gpu-name">NVIDIA T4 · 16GB</div>
+                  <div class="gpu-sub">CUDA 12.2 · driver 535.183 · slot pci 0000:00:1e.0</div>
+                </div>
+                <div class="gpu-load">
+                  <span class="pct">68%</span>
+                  <div class="bar"><span style="width: 68%"></span></div>
+                </div>
+              </div>
+
+              <div class="health-bars">
+                <div class="row">
+                  <span class="lab">VRAM</span>
+                  <div class="bar"><span style="width: 44%; background: hsl(var(--c-toolkit));"></span></div>
+                  <span class="val">7.0/16<span style="color:var(--text-muted)">GB</span></span>
+                </div>
+                <div class="row">
+                  <span class="lab">CPU</span>
+                  <div class="bar"><span style="width: 22%; background: hsl(var(--c-tool));"></span></div>
+                  <span class="val">22%</span>
+                </div>
+                <div class="row">
+                  <span class="lab">RAM host</span>
+                  <div class="bar"><span style="width: 38%; background: hsl(var(--c-chat));"></span></div>
+                  <span class="val">9.1/24<span style="color:var(--text-muted)">GB</span></span>
+                </div>
+                <div class="row">
+                  <span class="lab">Network</span>
+                  <div class="bar"><span style="width: 18%; background: hsl(var(--c-kb));"></span></div>
+                  <span class="val">42<span style="color:var(--text-muted)">Mbps</span></span>
+                </div>
+                <div class="row">
+                  <span class="lab">Queue</span>
+                  <div class="bar"><span style="width: 8%; background: hsl(var(--c-session));"></span></div>
+                  <span class="val">3 req</span>
+                </div>
+              </div>
+
+              <div style="display: flex; gap: 6px; flex-wrap: wrap">
+                <button class="btn-admin sm">🔄 Reload model</button>
+                <button class="btn-admin sm">📊 nvidia-smi</button>
+                <button class="btn-admin sm">🧪 Test embed</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ══ 2. Throughput KPI strip ══ -->
+      <div class="section-lab">
+        <span>Throughput · ultime 24h</span>
+        <span class="endpoint-note"><code>GET</code> getEmbeddingMetrics()</span>
+        <span class="auto">
+          <span class="dot"></span> auto-refresh 30s
+          <span style="color: var(--text-muted)">· last 14:38:02</span>
+          <button class="btn-admin sm">⟳ Refresh</button>
+        </span>
+      </div>
+
+      <div class="kpi-strip-6">
+
+        <!-- Total Requests -->
+        <div class="admin-kpi e-chat">
+          <div class="admin-kpi-label">Total Requests</div>
+          <div class="admin-kpi-value">28.4<span class="u">k</span></div>
+          <div class="admin-kpi-trend up">▲ +12.4% · 24h</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-chat))">
+            <path class="spark-fill" d="M0,18 L6,17 L12,14 L18,15 L24,12 L30,10 L36,11 L42,8 L48,9 L54,6 L60,4 L60,22 L0,22 Z"/>
+            <path class="spark" d="M0,18 L6,17 L12,14 L18,15 L24,12 L30,10 L36,11 L42,8 L48,9 L54,6 L60,4"/>
+          </svg>
+        </div>
+
+        <!-- Total Failures -->
+        <div class="admin-kpi e-event">
+          <div class="admin-kpi-label">Total Failures</div>
+          <div class="admin-kpi-value" style="color: hsl(var(--c-event))">14</div>
+          <div class="admin-kpi-trend down">▼ -3 vs ieri</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-event))">
+            <path class="spark" d="M0,18 L6,18 L12,16 L18,18 L24,15 L30,18 L36,17 L42,18 L48,16 L54,18 L60,17"/>
+            <circle cx="12" cy="16" r="1.6" fill="currentColor"/>
+            <circle cx="24" cy="15" r="1.6" fill="currentColor"/>
+            <circle cx="36" cy="17" r="1.6" fill="currentColor"/>
+            <circle cx="48" cy="16" r="1.6" fill="currentColor"/>
+            <circle cx="60" cy="17" r="1.6" fill="currentColor"/>
+          </svg>
+        </div>
+
+        <!-- Failure Rate -->
+        <div class="admin-kpi e-toolkit">
+          <div class="admin-kpi-label">Failure Rate</div>
+          <div class="admin-kpi-value">0.049<span class="u">%</span></div>
+          <div class="admin-kpi-trend up">▲ SLO ≤ 0.5%</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-toolkit))">
+            <path class="spark-fill" d="M0,16 L6,18 L12,17 L18,19 L24,18 L30,19 L36,18 L42,20 L48,19 L54,20 L60,20 L60,22 L0,22 Z"/>
+            <path class="spark" d="M0,16 L6,18 L12,17 L18,19 L24,18 L30,19 L36,18 L42,20 L48,19 L54,20 L60,20"/>
+          </svg>
+        </div>
+
+        <!-- Avg Duration -->
+        <div class="admin-kpi e-agent">
+          <div class="admin-kpi-label">Avg Duration</div>
+          <div class="admin-kpi-value">142<span class="u">ms</span></div>
+          <div class="admin-kpi-trend up">▲ -8ms vs ieri</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-agent))">
+            <path class="spark-fill" d="M0,8 L6,10 L12,7 L18,12 L24,9 L30,11 L36,8 L42,10 L48,7 L54,9 L60,8 L60,22 L0,22 Z"/>
+            <path class="spark" d="M0,8 L6,10 L12,7 L18,12 L24,9 L30,11 L36,8 L42,10 L48,7 L54,9 L60,8"/>
+          </svg>
+        </div>
+
+        <!-- Total Duration -->
+        <div class="admin-kpi e-tool">
+          <div class="admin-kpi-label">Total Duration</div>
+          <div class="admin-kpi-value">4.03<span class="u">k · s</span></div>
+          <div class="admin-kpi-trend flat">≡ 67min CPU+GPU</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-tool))">
+            <path class="spark-fill" d="M0,20 L6,19 L12,16 L18,17 L24,14 L30,12 L36,13 L42,10 L48,11 L54,8 L60,6 L60,22 L0,22 Z"/>
+            <path class="spark" d="M0,20 L6,19 L12,16 L18,17 L24,14 L30,12 L36,13 L42,10 L48,11 L54,8 L60,6"/>
+          </svg>
+        </div>
+
+        <!-- Characters Processed -->
+        <div class="admin-kpi e-kb">
+          <div class="admin-kpi-label">Chars Processed</div>
+          <div class="admin-kpi-value">18.4<span class="u">M</span></div>
+          <div class="admin-kpi-trend up">▲ +2.1M · 24h</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 60 22" preserveAspectRatio="none" style="color: hsl(var(--c-kb))">
+            <path class="spark-fill" d="M0,20 L6,18 L12,19 L18,16 L24,14 L30,12 L36,13 L42,9 L48,10 L54,6 L60,4 L60,22 L0,22 Z"/>
+            <path class="spark" d="M0,20 L6,18 L12,19 L18,16 L24,14 L30,12 L36,13 L42,9 L48,10 L54,6 L60,4"/>
+          </svg>
+        </div>
+
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-feedback.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-feedback.html
@@ -1,0 +1,626 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Feedback · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game: 25 95% 45%; --c-player: 262 83% 58%; --c-session: 240 60% 55%;
+  --c-agent: 38 92% 50%; --c-kb: 174 60% 40%; --c-chat: 220 80% 55%;
+  --c-event: 350 89% 60%; --c-toolkit: 142 70% 45%; --c-tool: 195 80% 50%;
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body: 'Nunito', system-ui, sans-serif;
+  --f-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px;
+  --r-sm: 6px; --r-md: 10px; --r-pill: 9999px;
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { font-family: var(--f-body); background: var(--bg); color: var(--text); font-size: var(--fs-base); line-height: 1.5; -webkit-font-smoothing: antialiased; }
+h1, h2, h3, h4 { font-family: var(--f-display); font-weight: 700; letter-spacing: -.01em; margin: 0; line-height: 1.2; }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: .9em; }
+
+.e-game{--e:var(--c-game);} .e-kb{--e:var(--c-kb);} .e-event{--e:var(--c-event);}
+.e-toolkit{--e:var(--c-toolkit);} .e-chat{--e:var(--c-chat);} .e-agent{--e:var(--c-agent);}
+.e-fg{color:hsl(var(--e));} .e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block;}
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+
+.admin-nav { background: var(--bg-card); border-right: 1px solid var(--border); padding: 16px 0; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin:disabled { opacity: .4; cursor: not-allowed; }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; }
+.admin-panel-body { padding: 14px; }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); }
+.status-chip.danger { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+.admin-form-row { display: grid; grid-template-columns: 200px 1fr; gap: 16px; align-items: flex-start; padding: 12px 0; border-bottom: 1px solid var(--border-light); }
+.admin-form-row:last-child { border-bottom: 0; }
+.admin-form-label { font-family: var(--f-display); font-size: 12.5px; font-weight: 700; }
+.admin-form-label .desc { display: block; margin-top: 3px; font-family: var(--f-body); font-size: 11px; font-weight: 400; color: var(--text-muted); line-height: 1.4; }
+.admin-input, .admin-select { width: 100%; max-width: 360px; padding: 6px 10px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; font-family: var(--f-body); font-size: 12.5px; }
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-input:focus, .admin-select:focus { outline: 0; border-color: hsl(var(--c-event)); box-shadow: 0 0 0 3px hsl(var(--c-event) / .14); }
+.admin-input.valid { border-color: hsl(var(--c-toolkit) / .55); }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; max-width: 1100px; }
+
+.endpoint-note { display: inline-flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); background: var(--bg-sunken); border: 1px dashed var(--border); padding: 2px 8px; border-radius: 4px; }
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+
+/* ═══════════════ page-local: Feedback ═══════════════ */
+.input-with-suffix { position: relative; max-width: 420px; }
+.input-with-suffix .admin-input { padding-right: 80px; max-width: 100%; }
+.input-with-suffix .suffix { position: absolute; right: 8px; top: 50%; transform: translateY(-50%); display: inline-flex; align-items: center; gap: 6px; }
+.input-with-suffix .suffix .status-chip { font-size: 9px; }
+.input-hint { display: flex; align-items: center; gap: 8px; margin-top: 6px; font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); }
+.input-hint .ok { color: hsl(var(--c-toolkit)); font-weight: 700; }
+.input-hint .game-pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 999px;
+  background: hsl(var(--c-game) / .12); color: hsl(var(--c-game));
+  font-weight: 700;
+}
+.uuid-presets { display: inline-flex; gap: 4px; margin-left: auto; }
+.uuid-presets .preset {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 700;
+  padding: 2px 7px; border-radius: 4px;
+  background: var(--bg-muted); color: var(--text-sec);
+  border: 1px solid var(--border-light);
+  cursor: pointer;
+}
+.uuid-presets .preset:hover { background: var(--bg-sunken); color: var(--text); }
+
+/* Toolbar */
+.feedback-toolbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-card); border: 1px solid var(--border-light);
+  border-radius: 10px;
+  margin: 18px 0 14px;
+  flex-wrap: wrap;
+}
+.feedback-toolbar .lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; }
+.feedback-toolbar .chip-group { display: inline-flex; gap: 4px; }
+.filter-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 11px; border-radius: 999px;
+  background: var(--bg); border: 1px solid var(--border);
+  font-family: var(--f-mono); font-size: 11px; font-weight: 700;
+  color: var(--text-sec); cursor: pointer;
+}
+.filter-chip:hover { background: var(--bg-muted); color: var(--text); }
+.filter-chip.active { background: hsl(var(--c-event) / .14); border-color: hsl(var(--c-event) / .4); color: hsl(var(--c-event)); }
+.filter-chip .em { font-size: 11px; line-height: 1; }
+.filter-chip .num {
+  font-size: 10px; opacity: .7;
+  padding-left: 4px; border-left: 1px solid currentColor;
+  margin-left: 2px;
+}
+.feedback-toolbar .right { margin-left: auto; display: inline-flex; align-items: center; gap: 10px; }
+.feedback-toolbar .count-tot { font-family: var(--f-mono); font-size: 11.5px; color: var(--text); font-weight: 700; }
+.feedback-toolbar .count-tot .muted { color: var(--text-muted); font-weight: 500; }
+.feedback-toolbar .page-size { display: inline-flex; align-items: center; gap: 4px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+.feedback-toolbar .page-size select { background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 2px 4px; font-family: var(--f-mono); font-size: 10.5px; color: var(--text); }
+
+/* Feedback list */
+.feedback-list { display: flex; flex-direction: column; gap: 8px; }
+.feedback-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 12px 14px 12px 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  position: relative;
+  border-left: 3px solid hsl(var(--e, var(--c-toolkit)));
+}
+.feedback-item.useful   { --e: var(--c-toolkit); }
+.feedback-item.notuseful { --e: var(--c-event); }
+
+.feedback-item .esito {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  min-width: 70px;
+}
+.feedback-item .esito .em-big {
+  width: 36px; height: 36px; border-radius: 50%;
+  display: grid; place-items: center;
+  font-size: 18px; line-height: 1;
+  background: hsl(var(--e) / .14);
+  color: hsl(var(--e));
+}
+.feedback-item.useful .esito .em-big { color: hsl(var(--c-toolkit)); }
+.feedback-item.notuseful .esito .em-big { color: hsl(var(--c-event)); }
+
+.feedback-item .body { min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.feedback-item .body .row1 { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.feedback-item .body .msgid {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 700;
+  background: var(--bg); border: 1px solid var(--border-light);
+  padding: 2px 7px; border-radius: 4px;
+  color: hsl(var(--c-kb));
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.feedback-item .body .msgid .em { opacity: .55; font-size: 10px; }
+.feedback-item .body .date {
+  font-family: var(--f-mono); font-size: 10.5px;
+  color: var(--text-muted);
+}
+.feedback-item .body .date .rel { color: var(--text-sec); margin-left: 6px; }
+.feedback-item .body .src {
+  font-family: var(--f-mono); font-size: 10px;
+  color: var(--text-muted);
+}
+.feedback-item .body .src .agent-pill {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 6px; border-radius: 4px;
+  background: hsl(var(--c-agent) / .14); color: hsl(var(--c-agent));
+  font-weight: 700; margin-right: 4px;
+}
+.feedback-item .body .comment {
+  font-family: var(--f-body); font-size: 12.5px;
+  color: var(--text);
+  background: var(--bg);
+  border-left: 2px solid hsl(var(--e) / .5);
+  padding: 7px 10px;
+  border-radius: 0 6px 6px 0;
+  line-height: 1.5;
+}
+.feedback-item .body .comment::before {
+  content: '"';
+  color: hsl(var(--e) / .6);
+  font-family: var(--f-display); font-size: 18px; font-weight: 800;
+  margin-right: 2px;
+  vertical-align: -3px;
+}
+.feedback-item .body .comment::after {
+  content: '"';
+  color: hsl(var(--e) / .6);
+  font-family: var(--f-display); font-size: 18px; font-weight: 800;
+  margin-left: 2px;
+  vertical-align: -3px;
+}
+.feedback-item .body .nocomment {
+  font-family: var(--f-mono); font-size: 10.5px;
+  color: var(--text-muted); font-style: italic;
+}
+.feedback-item .actions { display: flex; flex-direction: column; gap: 4px; align-items: flex-end; flex-shrink: 0; }
+.feedback-item .actions .row { display: flex; gap: 4px; }
+.feedback-item .actions .ts { font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); margin-top: 4px; }
+
+/* Pagination */
+.pagination {
+  display: flex; align-items: center; gap: 8px;
+  padding: 14px 0 4px;
+  margin-top: 16px;
+  border-top: 1px solid var(--border-light);
+}
+.pagination .lab {
+  font-family: var(--f-mono); font-size: 11px;
+  color: var(--text-muted);
+}
+.pagination .lab strong { color: var(--text); font-weight: 700; }
+.pagination .pages { display: inline-flex; gap: 4px; margin-left: auto; align-items: center; }
+.pagination .pages .btn-admin.sm.active {
+  background: hsl(var(--c-event)); color: #fff; border-color: hsl(var(--c-event));
+  box-shadow: 0 2px 4px hsl(var(--c-event) / .3);
+}
+.pagination .pages .ellipsis {
+  padding: 0 4px;
+  font-family: var(--f-mono); color: var(--text-muted); font-weight: 700;
+}
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav ─────────────────────────────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione condivisa ─────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · Feedback · 12 risultati · gioco Wingspan</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-feedback">
+
+      <!-- ── Sub-nav KB — Feedback .active ── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab" role="tab">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab" role="tab">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab" role="tab">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab" role="tab">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab active" role="tab" aria-selected="true">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab" role="tab">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ══ 1. Game ID form ══ -->
+      <section class="admin-panel" style="margin-bottom: 4px">
+        <div class="admin-panel-head">
+          <h3>🎯 Filtra per gioco</h3>
+          <span class="endpoint-note"><code>GET</code> getAdminKbFeedback(gameId, &#123;outcome, page, pageSize&#125;)</span>
+        </div>
+        <div class="admin-panel-body">
+          <div class="admin-form-row" style="border-bottom: 0; padding: 4px 0">
+            <div class="admin-form-label">
+              Game ID
+              <span class="desc">UUID v4 del gioco di cui revisionare i feedback. Obbligatorio.</span>
+            </div>
+            <div>
+              <div class="input-with-suffix">
+                <input class="admin-input mono valid" type="text"
+                  value="b3f7c218-4d11-4b9e-9a1c-7f218e4a3c0d"
+                  placeholder="es. 00000000-0000-4000-8000-000000000000"
+                  spellcheck="false"
+                  aria-label="Game ID UUID"/>
+                <span class="suffix">
+                  <span class="status-chip healthy">UUID ok</span>
+                </span>
+              </div>
+              <div class="input-hint">
+                <span class="ok">✓</span>
+                <span>UUID v4 valido · gioco risolto: <span class="game-pill">🎲 Wingspan</span></span>
+                <span class="uuid-presets">
+                  <span class="preset">recenti ▾</span>
+                  <span class="preset">Wingspan</span>
+                  <span class="preset">Brass: Birm.</span>
+                  <span class="preset">Tainted Grail</span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══ 2. Toolbar filtri ══ -->
+      <div class="feedback-toolbar">
+        <span class="lab">Esito</span>
+        <div class="chip-group" role="tablist" aria-label="Filtra esito">
+          <button class="filter-chip active" role="tab" aria-selected="true">
+            <span class="em">●</span> Tutti <span class="num">12</span>
+          </button>
+          <button class="filter-chip" role="tab">
+            <span class="em">👍</span> Utili <span class="num">8</span>
+          </button>
+          <button class="filter-chip" role="tab">
+            <span class="em">👎</span> Non utili <span class="num">4</span>
+          </button>
+        </div>
+
+        <div class="right">
+          <span class="page-size">
+            <span>per pagina</span>
+            <select aria-label="Risultati per pagina">
+              <option>10</option>
+              <option selected>20</option>
+              <option>50</option>
+            </select>
+          </span>
+          <span class="count-tot">12 <span class="muted">risultati</span></span>
+        </div>
+      </div>
+
+      <!-- ══ 3. Lista feedback ══ -->
+      <div class="feedback-list">
+
+        <!-- 1. utile + commento -->
+        <article class="feedback-item useful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👍</div>
+            <span class="status-chip healthy">Utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>a3f7c218</span>
+              <span class="date">2024-12-08 14:22:18 CET <span class="rel">· 3 ore fa</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 RuleExpert v3</span>
+              su domanda «Come si attivano gli uccelli predatori in Wingspan Oceania?»
+            </div>
+            <div class="comment">Risposta molto chiara, ha citato direttamente la regola a pag. 22 e ha distinto bene il caso base dall'espansione. Mi ha tolto il dubbio nel mezzo della partita.</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-2841</span>
+          </div>
+        </article>
+
+        <!-- 2. non utile + commento lungo -->
+        <article class="feedback-item notuseful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👎</div>
+            <span class="status-chip danger">Non utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>b81e09f2</span>
+              <span class="date">2024-12-08 11:47:02 CET <span class="rel">· 6 ore fa</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 RuleExpert v3</span>
+              su domanda «Si possono giocare cibo dal bonus card durante l'attivazione predatori?»
+            </div>
+            <div class="comment">La risposta confonde la regola base con quella di Oceania. Ho dovuto rileggermi il rulebook per capire. Il chunk citato (c-0398) è di una FAQ non ufficiale, non della rulebook.</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">🔬 Apri chunk</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-1098</span>
+          </div>
+        </article>
+
+        <!-- 3. utile senza commento -->
+        <article class="feedback-item useful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👍</div>
+            <span class="status-chip healthy">Utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>4c2a18d7</span>
+              <span class="date">2024-12-08 09:33:41 CET <span class="rel">· 8 ore fa</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 SetupCoach v2</span>
+              su domanda «Setup per 5 giocatori con Oceania?»
+            </div>
+            <div class="nocomment">— nessun commento dal player —</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-3214</span>
+          </div>
+        </article>
+
+        <!-- 4. non utile + commento breve -->
+        <article class="feedback-item notuseful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👎</div>
+            <span class="status-chip danger">Non utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>e1d40a92</span>
+              <span class="date">2024-12-07 22:14:09 CET <span class="rel">· ieri</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 RuleExpert v3</span>
+              su domanda «Quanti punti vale Pelecanus crispus a fine partita?»
+            </div>
+            <div class="comment">Risposta sbagliata: ha detto 5 punti, ma sulla carta sono 6. Forse ha pescato un chunk vecchio prima dell'errata 2024.</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">🔬 Apri chunk</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-0742</span>
+          </div>
+        </article>
+
+        <!-- 5. utile + commento -->
+        <article class="feedback-item useful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👍</div>
+            <span class="status-chip healthy">Utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>7a2c98f4</span>
+              <span class="date">2024-12-07 18:51:33 CET <span class="rel">· ieri</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 RuleExpert v3</span>
+              su domanda «Differenze fra obiettivi round e fine partita?»
+            </div>
+            <div class="comment">Ottima sintesi, ha fatto anche un esempio coi pesi rosa-blu-bianco-giallo. Perfetto per spiegarlo a un nuovo giocatore.</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-1845</span>
+          </div>
+        </article>
+
+        <!-- 6. utile senza commento -->
+        <article class="feedback-item useful">
+          <div class="esito">
+            <div class="em-big" aria-hidden="true">👍</div>
+            <span class="status-chip healthy">Utile</span>
+          </div>
+          <div class="body">
+            <div class="row1">
+              <span class="msgid"><span class="em">#</span>91b3c0a8</span>
+              <span class="date">2024-12-07 14:08:21 CET <span class="rel">· ieri</span></span>
+            </div>
+            <div class="src">
+              <span class="agent-pill">🤖 SetupCoach v2</span>
+              su domanda «Espansioni compatibili tra loro?»
+            </div>
+            <div class="nocomment">— nessun commento dal player —</div>
+          </div>
+          <div class="actions">
+            <div class="row">
+              <button class="btn-admin sm">💬 Vedi chat</button>
+              <button class="btn-admin sm">⋮</button>
+            </div>
+            <span class="ts">player · u-2841</span>
+          </div>
+        </article>
+
+      </div>
+
+      <!-- ══ 4. Paginazione ══ -->
+      <div class="pagination">
+        <span class="lab">
+          Mostrati <strong>1–6</strong> di <strong>12</strong> · pagina <strong>1 / 2</strong>
+        </span>
+        <span class="pages">
+          <button class="btn-admin sm" disabled aria-label="Pagina precedente">‹ Prev</button>
+          <button class="btn-admin sm active" aria-current="page">1</button>
+          <button class="btn-admin sm">2</button>
+          <button class="btn-admin sm" aria-label="Pagina successiva">Next ›</button>
+        </span>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-pipeline.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-pipeline.html
@@ -1,0 +1,789 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>RAG Pipeline · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game:    25 95% 45%;
+  --c-player:  262 83% 58%;
+  --c-session: 240 60% 55%;
+  --c-agent:   38 92% 50%;
+  --c-kb:      174 60% 40%;
+  --c-chat:    220 80% 55%;
+  --c-event:   350 89% 60%;
+  --c-toolkit: 142 70% 45%;
+  --c-tool:    195 80% 50%;
+
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body:    'Nunito', system-ui, sans-serif;
+  --f-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px;
+  --r-xs: 4px; --r-sm: 6px; --r-md: 10px; --r-lg: 14px; --r-pill: 9999px;
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  --shadow-xs: 0 1px 2px rgba(90, 60, 20, 0.06);
+  --shadow-sm: 0 2px 8px rgba(90, 60, 20, 0.08);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { font-family: var(--f-body); background: var(--bg); color: var(--text); font-size: var(--fs-base); line-height: 1.5; -webkit-font-smoothing: antialiased; }
+h1, h2, h3, h4, h5, h6 { font-family: var(--f-display); font-weight: 700; letter-spacing: -.01em; margin: 0; line-height: 1.2; }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: .9em; }
+
+.e-game{--e:var(--c-game);} .e-player{--e:var(--c-player);} .e-session{--e:var(--c-session);}
+.e-agent{--e:var(--c-agent);} .e-kb{--e:var(--c-kb);} .e-chat{--e:var(--c-chat);}
+.e-event{--e:var(--c-event);} .e-toolkit{--e:var(--c-toolkit);} .e-tool{--e:var(--c-tool);}
+.e-fg{color:hsl(var(--e));}
+.e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block;}
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+
+.admin-nav { background: var(--bg-card); border-right: 1px solid var(--border); padding: 16px 0; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger { background: var(--bg-card); border-color: hsl(var(--c-event) / .5); color: hsl(var(--c-event)); }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-kpi { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px 16px; display: flex; flex-direction: column; gap: 4px; min-height: 88px; position: relative; }
+.admin-kpi-label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.admin-kpi-value { font-family: var(--f-display); font-size: 28px; font-weight: 800; color: var(--text); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.admin-kpi-value .u { font-size: 13px; color: var(--text-muted); font-weight: 700; margin-left: 2px; }
+.admin-kpi-trend { font-family: var(--f-mono); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 3px; }
+.admin-kpi-trend.up { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark { position: absolute; right: 12px; top: 12px; width: 70px; height: 28px; opacity: .85; }
+.admin-kpi.e-game{border-left:3px solid hsl(var(--c-game));}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb));}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent));}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event));}
+.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit));}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat));}
+.admin-kpi.e-session{border-left:3px solid hsl(var(--c-session));}
+.admin-kpi.e-tool{border-left:3px solid hsl(var(--c-tool));}
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; }
+.admin-panel-body { padding: 14px; }
+
+.admin-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.admin-table th { text-align: left; padding: 8px 12px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; border-bottom: 1px solid var(--border-light); background: var(--bg); white-space: nowrap; }
+.admin-table td { padding: 8px 12px; border-bottom: 1px solid var(--border-light); vertical-align: middle; font-variant-numeric: tabular-nums; }
+.admin-table tr:hover td { background: var(--bg-muted); }
+.admin-table tr.bottleneck td { background: hsl(var(--c-event) / .06); }
+.admin-table tr.bottleneck td:first-child { box-shadow: inset 3px 0 0 hsl(var(--c-event)); }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger, .status-chip.error { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before, .status-chip.error::before { background: hsl(var(--c-event)); }
+.status-chip.muted { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.running::before { animation: admin-pulse 1.4s ease-in-out infinite; }
+@keyframes admin-pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.6); opacity: .45; } }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; }
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+.endpoint-note { display: inline-flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); background: var(--bg-sunken); border: 1px dashed var(--border); padding: 2px 8px; border-radius: 4px; }
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+
+/* ═══════════════ page-local: RAG Pipeline ═══════════════ */
+.section-lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin: 0 0 8px; display: flex; align-items: center; gap: 8px; }
+.section-lab .auto { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; }
+.section-lab .auto .dot { width: 6px; height: 6px; border-radius: 50%; background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .2); animation: admin-pulse 1.4s ease-in-out infinite; }
+
+/* ── Stage flow ── */
+.stage-flow {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 18px;
+}
+.stage-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 12px 14px 10px;
+  position: relative;
+  display: flex; flex-direction: column; gap: 6px;
+  cursor: pointer;
+  transition: transform .15s var(--ease-out), border-color .15s var(--ease-out), box-shadow .15s var(--ease-out);
+  border-top: 3px solid hsl(var(--e, var(--c-kb)));
+  min-width: 0;
+}
+.stage-card:hover { transform: translateY(-1px); border-color: hsl(var(--e, var(--c-kb)) / .5); box-shadow: 0 4px 12px hsl(var(--e, var(--c-kb)) / .15); }
+.stage-card.expanded { box-shadow: 0 0 0 2px hsl(var(--e, var(--c-kb)) / .35); }
+.stage-card.warn { border-top-color: hsl(38 90% 50%); }
+.stage-card.warn:hover { border-color: hsl(38 90% 50% / .5); box-shadow: 0 4px 12px hsl(38 90% 50% / .18); }
+
+.stage-card .head {
+  display: flex; align-items: center; gap: 8px;
+  min-width: 0;
+}
+.stage-card .num {
+  width: 22px; height: 22px;
+  border-radius: 6px;
+  background: hsl(var(--e, var(--c-kb)) / .15);
+  color: hsl(var(--e, var(--c-kb)));
+  font-family: var(--f-mono); font-weight: 800; font-size: 10px;
+  display: grid; place-items: center;
+  flex-shrink: 0;
+}
+.stage-card.warn .num { background: hsl(38 90% 50% / .15); color: hsl(38 90% 50%); }
+.stage-card .name {
+  font-family: var(--f-display); font-weight: 800; font-size: 14px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1;
+}
+.stage-card .em { font-size: 16px; opacity: .85; flex-shrink: 0; }
+
+.stage-card .impl {
+  font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .04em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.stage-card .metric-row {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 4px;
+}
+.stage-card .metric-row .m { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.stage-card .metric-row .m .k { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; font-weight: 700; }
+.stage-card .metric-row .m .v { font-family: var(--f-display); font-size: 16px; font-weight: 800; color: var(--text); font-variant-numeric: tabular-nums; line-height: 1.1; }
+.stage-card .metric-row .m .v .u { font-size: 10px; color: var(--text-muted); font-weight: 700; margin-left: 1px; }
+.stage-card .foot {
+  display: flex; align-items: center; gap: 6px;
+  font-family: var(--f-mono); font-size: 10px;
+  border-top: 1px solid var(--border-light);
+  padding-top: 6px; margin-top: 2px;
+  color: var(--text-muted);
+}
+.stage-card .foot .expand-hint { margin-left: auto; opacity: .6; font-size: 9px; }
+
+/* Arrow between stages (placed inside grid cell, overlapping gap) */
+.stage-arrow {
+  position: absolute; top: 50%; right: -14px;
+  transform: translateY(-50%);
+  width: 22px; height: 22px;
+  display: grid; place-items: center;
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: 50%;
+  color: var(--text-muted);
+  font-family: var(--f-mono); font-size: 13px; font-weight: 800;
+  z-index: 2;
+}
+.stage-card:last-child .stage-arrow { display: none; }
+.stage-card .stage-arrow.flow-ok { color: hsl(var(--c-toolkit)); border-color: hsl(var(--c-toolkit) / .45); background: hsl(var(--c-toolkit) / .08); }
+.stage-card .stage-arrow.flow-slow { color: hsl(38 90% 50%); border-color: hsl(38 90% 50% / .5); background: hsl(38 90% 50% / .1); animation: admin-pulse 1.6s ease-in-out infinite; }
+
+/* Expanded panel below (full-width across grid) */
+.stage-expanded {
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  background: var(--bg-sunken);
+  border: 1px solid hsl(var(--e, var(--c-kb)) / .25);
+  border-left: 3px solid hsl(var(--e, var(--c-kb)));
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px;
+}
+.stage-expanded.warn { border-color: hsl(38 90% 50% / .35); border-left-color: hsl(38 90% 50%); }
+.stage-expanded h4 { font-family: var(--f-display); font-size: 13px; font-weight: 800; margin: 0 0 6px; display: inline-flex; align-items: center; gap: 8px; }
+.stage-expanded .desc { font-size: 12px; color: var(--text-sec); line-height: 1.5; }
+.stage-expanded .col { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.stage-expanded .kv { display: grid; grid-template-columns: 100px 1fr; gap: 6px; font-family: var(--f-mono); font-size: 10.5px; padding: 3px 0; border-bottom: 1px solid var(--border-light); }
+.stage-expanded .kv:last-child { border-bottom: 0; }
+.stage-expanded .kv .k { color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; font-size: 9.5px; font-weight: 700; }
+.stage-expanded .kv .v { color: var(--text); font-weight: 600; }
+.stage-expanded .kv .v.ok { color: hsl(var(--c-toolkit)); }
+.stage-expanded .kv .v.warn { color: hsl(38 90% 50%); }
+
+/* ── Health summary ── */
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr) repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.health-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 4px;
+  min-height: 88px;
+  position: relative;
+  border-left: 3px solid hsl(var(--e, var(--c-toolkit)));
+}
+.health-card .label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; display: inline-flex; align-items: center; gap: 6px; }
+.health-card .value { font-family: var(--f-display); font-weight: 800; font-size: 28px; line-height: 1.1; font-variant-numeric: tabular-nums; color: hsl(var(--e, var(--c-toolkit))); }
+.health-card .value .of { font-size: 14px; color: var(--text-muted); font-weight: 700; }
+.health-card .sub { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); }
+.health-card.healthy { --e: var(--c-toolkit); }
+.health-card.warning { --e: 38 90% 50%; border-left-color: hsl(38 90% 50%); }
+.health-card.warning .value { color: hsl(38 90% 50%); }
+.health-card.error { --e: var(--c-event); }
+.health-card .icon { position: absolute; right: 14px; top: 14px; font-size: 18px; opacity: .55; }
+
+/* ── Metriche panel ── */
+.metrics-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-bottom: 16px; }
+.metric-step {
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: 10px 12px;
+  border-top: 3px solid hsl(var(--e, var(--c-kb)));
+  display: flex; flex-direction: column; gap: 6px;
+  min-width: 0;
+}
+.metric-step.bottleneck { border-color: hsl(var(--c-event) / .35); background: hsl(var(--c-event) / .04); }
+.metric-step.bottleneck .name { color: hsl(var(--c-event)); }
+.metric-step.bottleneck .name::after { content: '· bottleneck'; font-family: var(--f-mono); font-size: 9px; color: hsl(var(--c-event)); font-weight: 700; margin-left: 4px; text-transform: uppercase; letter-spacing: .04em; }
+.metric-step .head { display: flex; align-items: center; gap: 6px; }
+.metric-step .num { width: 18px; height: 18px; border-radius: 5px; background: hsl(var(--e, var(--c-kb)) / .15); color: hsl(var(--e, var(--c-kb))); font-family: var(--f-mono); font-weight: 800; font-size: 9px; display: grid; place-items: center; flex-shrink: 0; }
+.metric-step.bottleneck .num { background: hsl(var(--c-event) / .15); color: hsl(var(--c-event)); }
+.metric-step .name { font-family: var(--f-display); font-weight: 800; font-size: 12.5px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.metric-step .pbar { display: grid; grid-template-columns: 32px 1fr 48px; gap: 8px; align-items: center; font-family: var(--f-mono); font-size: 9.5px; }
+.metric-step .pbar .lab { color: var(--text-muted); font-weight: 700; }
+.metric-step .pbar .track { height: 5px; background: var(--bg-muted); border-radius: 3px; overflow: hidden; }
+.metric-step .pbar .track > span { display: block; height: 100%; border-radius: 3px; background: hsl(var(--e, var(--c-kb))); }
+.metric-step.bottleneck .pbar .track > span { background: hsl(var(--c-event)); }
+.metric-step .pbar .val { text-align: right; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+.metric-step .foot { font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); border-top: 1px solid var(--border-light); padding-top: 6px; margin-top: 2px; display: flex; justify-content: space-between; }
+
+input[type="checkbox"] { accent-color: hsl(var(--c-event)); cursor: pointer; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav ─────────────────────────────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione condivisa ─────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · RAG Pipeline · 5 fasi · 4/5 healthy · 1 warning</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-rag-pipeline">
+
+      <!-- ── Sub-nav KB (8 tab) — RAG Pipeline .active ── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab" role="tab">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab" role="tab">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab active" role="tab" aria-selected="true">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab" role="tab">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab" role="tab">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab" role="tab">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ══ 1. Stage flow ══ -->
+      <div class="section-lab">
+        <span>Pipeline flow · Ingest → Extract → Chunk → Embed → Index</span>
+        <span class="endpoint-note"><code>GET</code> getPipelineHealth()</span>
+        <span class="auto">
+          <span class="dot"></span> auto-refresh 30s
+          <span style="color: var(--text-muted)">· next in 23s</span>
+          <button class="btn-admin sm">⟳ Refresh</button>
+        </span>
+      </div>
+
+      <div class="stage-flow">
+
+        <!-- 1. Ingest -->
+        <div class="stage-card e-kb" style="--e: var(--c-kb)">
+          <div class="head">
+            <span class="num">1</span>
+            <span class="em">📥</span>
+            <span class="name">Ingest</span>
+          </div>
+          <div class="impl">S3 · multipart upload · validate</div>
+          <div class="metric-row">
+            <div class="m"><span class="k">Throughput</span><span class="v">142<span class="u">/h</span></span></div>
+            <div class="m"><span class="k">Avg latency</span><span class="v">0.31<span class="u">s</span></span></div>
+          </div>
+          <div class="foot">
+            <span class="status-chip healthy">healthy</span>
+            <span style="margin-left:6px">err 0.0%</span>
+            <span class="expand-hint">▾ dettagli</span>
+          </div>
+          <div class="stage-arrow flow-ok">›</div>
+        </div>
+
+        <!-- 2. Extract -->
+        <div class="stage-card e-tool" style="--e: var(--c-tool)">
+          <div class="head">
+            <span class="num">2</span>
+            <span class="em">📑</span>
+            <span class="name">Extract</span>
+          </div>
+          <div class="impl">Unstructured.io · SmolDocling</div>
+          <div class="metric-row">
+            <div class="m"><span class="k">Elements/doc</span><span class="v">2.847</span></div>
+            <div class="m"><span class="k">Avg latency</span><span class="v">7.2<span class="u">s</span></span></div>
+          </div>
+          <div class="foot">
+            <span class="status-chip healthy">healthy</span>
+            <span style="margin-left:6px">err 0.3%</span>
+            <span class="expand-hint">▾ dettagli</span>
+          </div>
+          <div class="stage-arrow flow-ok">›</div>
+        </div>
+
+        <!-- 3. Chunk -->
+        <div class="stage-card e-chat" style="--e: var(--c-chat)">
+          <div class="head">
+            <span class="num">3</span>
+            <span class="em">🧱</span>
+            <span class="name">Chunk</span>
+          </div>
+          <div class="impl">Semantic · 512 tok · overlap 64</div>
+          <div class="metric-row">
+            <div class="m"><span class="k">Avg chunks</span><span class="v">412</span></div>
+            <div class="m"><span class="k">Avg latency</span><span class="v">2.1<span class="u">s</span></span></div>
+          </div>
+          <div class="foot">
+            <span class="status-chip healthy">healthy</span>
+            <span style="margin-left:6px">err 0.0%</span>
+            <span class="expand-hint">▾ dettagli</span>
+          </div>
+          <div class="stage-arrow flow-slow">›</div>
+        </div>
+
+        <!-- 4. Embed — WARNING (bottleneck) — EXPANDED -->
+        <div class="stage-card warn expanded" style="--e: var(--c-agent)">
+          <div class="head">
+            <span class="num">4</span>
+            <span class="em">🧠</span>
+            <span class="name">Embed</span>
+          </div>
+          <div class="impl">bge-base-en-v1.5 · 768d · batch 32</div>
+          <div class="metric-row">
+            <div class="m"><span class="k">Rate</span><span class="v">17.8<span class="u">ch/s</span></span></div>
+            <div class="m"><span class="k">Avg latency</span><span class="v" style="color: hsl(38 90% 50%)">8.8<span class="u">s</span></span></div>
+          </div>
+          <div class="foot">
+            <span class="status-chip warning">warning</span>
+            <span style="margin-left:6px">retries 12 · 24h</span>
+            <span class="expand-hint">▾ aperto</span>
+          </div>
+          <div class="stage-arrow flow-ok">›</div>
+        </div>
+
+        <!-- 5. Index -->
+        <div class="stage-card e-toolkit" style="--e: var(--c-toolkit)">
+          <div class="head">
+            <span class="num">5</span>
+            <span class="em">📦</span>
+            <span class="name">Index</span>
+          </div>
+          <div class="impl">pgvector 0.7.4 · HNSW m=16 ef=200</div>
+          <div class="metric-row">
+            <div class="m"><span class="k">Vectors/doc</span><span class="v">412</span></div>
+            <div class="m"><span class="k">Avg latency</span><span class="v">2.6<span class="u">s</span></span></div>
+          </div>
+          <div class="foot">
+            <span class="status-chip healthy">healthy</span>
+            <span style="margin-left:6px">commit 100%</span>
+            <span class="expand-hint">▾ dettagli</span>
+          </div>
+        </div>
+
+        <!-- Expanded panel for stage 4 (full-width) -->
+        <div class="stage-expanded warn">
+          <div class="col">
+            <h4>🧠 Embed · bge-base-en-v1.5 <span class="status-chip warning">warning</span></h4>
+            <div class="desc">Embedder genera vettori 768d per ogni chunk in batch da 32. Negli ultimi 60' rilevati 12 retry per rate-limit 429 sull'endpoint provider. Latenza p95 oltre soglia.</div>
+            <div style="display:flex; gap:6px; flex-wrap: wrap; margin-top: 6px">
+              <button class="btn-admin sm">🔧 Apri Embedding settings</button>
+              <button class="btn-admin sm">📊 Logs ultimi 60'</button>
+              <button class="btn-admin sm">🧪 Test single chunk</button>
+            </div>
+          </div>
+          <div class="col">
+            <div class="kv"><span class="k">Provider</span><span class="v">HuggingFace TEI (self-hosted)</span></div>
+            <div class="kv"><span class="k">Model</span><span class="v">bge-base-en-v1.5 · 109M</span></div>
+            <div class="kv"><span class="k">Dimensions</span><span class="v">768</span></div>
+            <div class="kv"><span class="k">Batch size</span><span class="v">32 · max 64</span></div>
+            <div class="kv"><span class="k">Workers</span><span class="v">2 attivi / 4 max</span></div>
+            <div class="kv"><span class="k">Endpoint</span><span class="v">tei.internal:8080/embed</span></div>
+          </div>
+          <div class="col">
+            <div class="kv"><span class="k">Throughput · 1h</span><span class="v ok">64.080 chunks</span></div>
+            <div class="kv"><span class="k">Retries · 24h</span><span class="v warn">12 (rate-limit)</span></div>
+            <div class="kv"><span class="k">Errors · 24h</span><span class="v">2 · 0.04%</span></div>
+            <div class="kv"><span class="k">p50 latency</span><span class="v">7.2s</span></div>
+            <div class="kv"><span class="k">p95 latency</span><span class="v warn">14.6s · soglia 12s</span></div>
+            <div class="kv"><span class="k">Cost · 24h</span><span class="v">$3.18</span></div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ══ 2. Health summary + distribution stats ══ -->
+      <div class="section-lab">
+        <span>Health summary · distribution</span>
+      </div>
+
+      <div class="summary-grid">
+
+        <!-- Healthy -->
+        <div class="health-card healthy">
+          <div class="label">Healthy <span class="icon" aria-hidden="true">✓</span></div>
+          <div class="value">3<span class="of">/5</span></div>
+          <div class="sub">Ingest · Chunk · Index</div>
+        </div>
+
+        <!-- Warning -->
+        <div class="health-card warning">
+          <div class="label">Warning <span class="icon" aria-hidden="true">⚠</span></div>
+          <div class="value">2<span class="of">/5</span></div>
+          <div class="sub">Extract (err 0.3%) · Embed (rate-limit)</div>
+        </div>
+
+        <!-- Error -->
+        <div class="health-card error">
+          <div class="label">Error <span class="icon" aria-hidden="true">✕</span></div>
+          <div class="value">0<span class="of">/5</span></div>
+          <div class="sub">Nessuna fase in errore</div>
+        </div>
+
+        <!-- Distribution: Documenti -->
+        <div class="admin-kpi e-kb">
+          <div class="admin-kpi-label">Documenti</div>
+          <div class="admin-kpi-value">247</div>
+          <div class="admin-kpi-trend up">▲ +14 · 7gg</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-kb))">
+            <path class="spark-fill" d="M0,22 L10,20 L20,21 L30,18 L40,16 L50,14 L60,11 L70,9 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,22 L10,20 L20,21 L30,18 L40,16 L50,14 L60,11 L70,9"/>
+          </svg>
+        </div>
+
+        <!-- Chunks -->
+        <div class="admin-kpi e-chat">
+          <div class="admin-kpi-label">Chunks</div>
+          <div class="admin-kpi-value">18.487</div>
+          <div class="admin-kpi-trend up">▲ +5.842 · 7gg</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-chat))">
+            <path class="spark-fill" d="M0,24 L10,22 L20,20 L30,18 L40,14 L50,11 L60,8 L70,5 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,24 L10,22 L20,20 L30,18 L40,14 L50,11 L60,8 L70,5"/>
+          </svg>
+        </div>
+
+        <!-- Vettori -->
+        <div class="admin-kpi e-agent">
+          <div class="admin-kpi-label">Vettori</div>
+          <div class="admin-kpi-value">18.487</div>
+          <div class="admin-kpi-trend flat">≡ 100% chunks</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-agent))">
+            <path class="spark-fill" d="M0,24 L10,22 L20,20 L30,18 L40,14 L50,11 L60,8 L70,5 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,24 L10,22 L20,20 L30,18 L40,14 L50,11 L60,8 L70,5"/>
+          </svg>
+        </div>
+
+        <!-- Storage -->
+        <div class="admin-kpi e-toolkit">
+          <div class="admin-kpi-label">Storage</div>
+          <div class="admin-kpi-value">2.4<span class="u">TB</span></div>
+          <div class="admin-kpi-trend up">▲ +180GB · 7gg</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-toolkit))">
+            <path class="spark-fill" d="M0,20 L10,19 L20,17 L30,16 L40,14 L50,12 L60,10 L70,8 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,20 L10,19 L20,17 L30,16 L40,14 L50,12 L60,10 L70,8"/>
+          </svg>
+        </div>
+
+      </div>
+
+      <!-- ══ 3. Metriche Elaborazione ══ -->
+      <section class="admin-panel">
+        <div class="admin-panel-head">
+          <h3>📊 Metriche Elaborazione</h3>
+          <span class="status-chip info">last 24h · 144 doc</span>
+          <span class="endpoint-note"><code>GET</code> getProcessingMetrics()</span>
+          <span class="meta">snapshot 14:38:02 CET</span>
+        </div>
+        <div class="admin-panel-body">
+
+          <!-- Step cards con P50/P95/P99 -->
+          <div class="metrics-grid">
+
+            <div class="metric-step" style="--e: var(--c-kb)">
+              <div class="head">
+                <span class="num">1</span>
+                <span class="name">Ingest</span>
+              </div>
+              <div class="pbar"><span class="lab">P50</span><div class="track"><span style="width: 12%"></span></div><span class="val">0.28s</span></div>
+              <div class="pbar"><span class="lab">P95</span><div class="track"><span style="width: 22%"></span></div><span class="val">0.51s</span></div>
+              <div class="pbar"><span class="lab">P99</span><div class="track"><span style="width: 34%"></span></div><span class="val">0.78s</span></div>
+              <div class="foot"><span>144 doc</span><span>err 0.0%</span></div>
+            </div>
+
+            <div class="metric-step" style="--e: var(--c-tool)">
+              <div class="head">
+                <span class="num">2</span>
+                <span class="name">Extract</span>
+              </div>
+              <div class="pbar"><span class="lab">P50</span><div class="track"><span style="width: 38%"></span></div><span class="val">6.4s</span></div>
+              <div class="pbar"><span class="lab">P95</span><div class="track"><span style="width: 64%"></span></div><span class="val">11.2s</span></div>
+              <div class="pbar"><span class="lab">P99</span><div class="track"><span style="width: 82%"></span></div><span class="val">18.4s</span></div>
+              <div class="foot"><span>144 doc</span><span>err 0.3%</span></div>
+            </div>
+
+            <div class="metric-step" style="--e: var(--c-chat)">
+              <div class="head">
+                <span class="num">3</span>
+                <span class="name">Chunk</span>
+              </div>
+              <div class="pbar"><span class="lab">P50</span><div class="track"><span style="width: 14%"></span></div><span class="val">1.9s</span></div>
+              <div class="pbar"><span class="lab">P95</span><div class="track"><span style="width: 26%"></span></div><span class="val">3.4s</span></div>
+              <div class="pbar"><span class="lab">P99</span><div class="track"><span style="width: 38%"></span></div><span class="val">5.1s</span></div>
+              <div class="foot"><span>144 doc</span><span>err 0.0%</span></div>
+            </div>
+
+            <div class="metric-step bottleneck" style="--e: var(--c-agent)">
+              <div class="head">
+                <span class="num">4</span>
+                <span class="name">Embed</span>
+              </div>
+              <div class="pbar"><span class="lab">P50</span><div class="track"><span style="width: 48%"></span></div><span class="val">7.2s</span></div>
+              <div class="pbar"><span class="lab">P95</span><div class="track"><span style="width: 88%"></span></div><span class="val">14.6s</span></div>
+              <div class="pbar"><span class="lab">P99</span><div class="track"><span style="width: 100%"></span></div><span class="val">22.8s</span></div>
+              <div class="foot"><span>144 doc</span><span style="color: hsl(var(--c-event))">retries 12</span></div>
+            </div>
+
+            <div class="metric-step" style="--e: var(--c-toolkit)">
+              <div class="head">
+                <span class="num">5</span>
+                <span class="name">Index</span>
+              </div>
+              <div class="pbar"><span class="lab">P50</span><div class="track"><span style="width: 18%"></span></div><span class="val">2.4s</span></div>
+              <div class="pbar"><span class="lab">P95</span><div class="track"><span style="width: 32%"></span></div><span class="val">4.1s</span></div>
+              <div class="pbar"><span class="lab">P99</span><div class="track"><span style="width: 46%"></span></div><span class="val">6.2s</span></div>
+              <div class="foot"><span>144 doc</span><span>err 0.0%</span></div>
+            </div>
+
+          </div>
+
+          <!-- Comparison table -->
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th>Fase</th>
+                <th style="text-align: right">Media</th>
+                <th style="text-align: right">P50</th>
+                <th style="text-align: right">P95</th>
+                <th style="text-align: right">P99</th>
+                <th style="text-align: right">Campioni</th>
+                <th>Stato</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class="e-dot" style="--e: var(--c-kb); margin-right: 6px"></span><strong>Ingest</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· S3 upload</span></td>
+                <td style="text-align: right">0.31s</td>
+                <td style="text-align: right">0.28s</td>
+                <td style="text-align: right">0.51s</td>
+                <td style="text-align: right">0.78s</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip healthy">healthy</span></td>
+              </tr>
+              <tr>
+                <td><span class="e-dot" style="--e: var(--c-tool); margin-right: 6px"></span><strong>Extract</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· Unstructured + SmolDocling</span></td>
+                <td style="text-align: right">7.21s</td>
+                <td style="text-align: right">6.4s</td>
+                <td style="text-align: right">11.2s</td>
+                <td style="text-align: right">18.4s</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip healthy">healthy</span></td>
+              </tr>
+              <tr>
+                <td><span class="e-dot" style="--e: var(--c-chat); margin-right: 6px"></span><strong>Chunk</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· 512 tok · overlap 64</span></td>
+                <td style="text-align: right">2.10s</td>
+                <td style="text-align: right">1.9s</td>
+                <td style="text-align: right">3.4s</td>
+                <td style="text-align: right">5.1s</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip healthy">healthy</span></td>
+              </tr>
+              <tr class="bottleneck">
+                <td><span class="e-dot" style="--e: var(--c-event); margin-right: 6px"></span><strong>Embed</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· bge-base-en-v1.5 · 768d</span></td>
+                <td style="text-align: right; color: hsl(var(--c-event)); font-weight: 700">8.82s</td>
+                <td style="text-align: right; color: hsl(var(--c-event))">7.2s</td>
+                <td style="text-align: right; color: hsl(var(--c-event)); font-weight: 700">14.6s ⚠</td>
+                <td style="text-align: right; color: hsl(var(--c-event)); font-weight: 700">22.8s ⚠</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip warning">bottleneck</span></td>
+              </tr>
+              <tr>
+                <td><span class="e-dot" style="--e: var(--c-toolkit); margin-right: 6px"></span><strong>Index</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· pgvector HNSW</span></td>
+                <td style="text-align: right">2.61s</td>
+                <td style="text-align: right">2.4s</td>
+                <td style="text-align: right">4.1s</td>
+                <td style="text-align: right">6.2s</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip healthy">healthy</span></td>
+              </tr>
+              <tr style="background: var(--bg)">
+                <td><strong>Totale end-to-end</strong> <span style="color: var(--text-muted); font-family: var(--f-mono); font-size: 10px">· per documento</span></td>
+                <td style="text-align: right; font-weight: 800">21.05s</td>
+                <td style="text-align: right; font-weight: 700">18.2s</td>
+                <td style="text-align: right; font-weight: 700">33.8s</td>
+                <td style="text-align: right; font-weight: 700">53.3s</td>
+                <td style="text-align: right">144</td>
+                <td><span class="status-chip warning">≤ target 18s solo a p50</span></td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div style="margin-top: 12px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center">
+            <button class="btn-admin sm">⤓ Export metriche CSV</button>
+            <button class="btn-admin sm">📊 Grafici storici</button>
+            <button class="btn-admin sm">🔧 Configura SLO</button>
+            <span style="margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted)">
+              Finestra · ultime 24h · sample 144 doc · escluso traffic shaping
+            </span>
+          </div>
+
+        </div>
+      </section>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-queue.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-queue.html
@@ -1,0 +1,1040 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Processing Queue · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game:    25 95% 45%;
+  --c-player:  262 83% 58%;
+  --c-session: 240 60% 55%;
+  --c-agent:   38 92% 50%;
+  --c-kb:      174 60% 40%;
+  --c-chat:    220 80% 55%;
+  --c-event:   350 89% 60%;
+  --c-toolkit: 142 70% 45%;
+  --c-tool:    195 80% 50%;
+  --c-success: 142 70% 45%;
+  --c-warning: 38 92% 50%;
+  --c-danger:  350 89% 60%;
+  --c-info:    220 80% 55%;
+
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body:    'Nunito', system-ui, sans-serif;
+  --f-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px; --fs-md: 15px;
+  --fs-lg: 17px; --fs-xl: 20px; --fs-2xl: 24px; --fs-3xl: 32px;
+
+  --r-xs: 4px; --r-sm: 6px; --r-md: 10px; --r-lg: 14px; --r-xl: 18px; --r-pill: 9999px;
+
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+  --dur-sm: 180ms;
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  --shadow-xs: 0 1px 2px rgba(90, 60, 20, 0.06);
+  --shadow-sm: 0 2px 8px rgba(90, 60, 20, 0.08);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { font-family: var(--f-body); background: var(--bg); color: var(--text); font-size: var(--fs-base); line-height: 1.5; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+h1, h2, h3, h4, h5, h6 { font-family: var(--f-display); font-weight: 700; letter-spacing: -.01em; margin: 0; line-height: 1.2; }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: .9em; }
+
+.e-game{--e:var(--c-game);} .e-player{--e:var(--c-player);} .e-session{--e:var(--c-session);}
+.e-agent{--e:var(--c-agent);} .e-kb{--e:var(--c-kb);} .e-chat{--e:var(--c-chat);}
+.e-event{--e:var(--c-event);} .e-toolkit{--e:var(--c-toolkit);} .e-tool{--e:var(--c-tool);}
+.e-fg{color:hsl(var(--e));} .e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block;}
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+
+.admin-nav { background: var(--bg-card); border-right: 1px solid var(--border); padding: 16px 0; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger { background: var(--bg-card); border-color: hsl(var(--c-event) / .5); color: hsl(var(--c-event)); }
+.btn-admin.success { background: hsl(var(--c-toolkit)); border-color: hsl(var(--c-toolkit)); color: #fff; }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin.icon { padding: 6px; width: 28px; height: 28px; justify-content: center; }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-kpi { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px 16px; display: flex; flex-direction: column; gap: 4px; min-height: 88px; position: relative; }
+.admin-kpi-label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; display: inline-flex; align-items: center; gap: 6px; }
+.admin-kpi-value { font-family: var(--f-display); font-size: 28px; font-weight: 800; color: var(--text); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.admin-kpi-value .u { font-size: 13px; color: var(--text-muted); font-weight: 700; margin-left: 2px; }
+.admin-kpi-trend { font-family: var(--f-mono); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 3px; }
+.admin-kpi-trend.up { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark { position: absolute; right: 12px; top: 12px; width: 70px; height: 28px; opacity: .85; }
+.admin-kpi.e-game{border-left:3px solid hsl(var(--c-game));}
+.admin-kpi.e-agent{border-left:3px solid hsl(var(--c-agent));}
+.admin-kpi.e-kb{border-left:3px solid hsl(var(--c-kb));}
+.admin-kpi.e-event{border-left:3px solid hsl(var(--c-event));}
+.admin-kpi.e-toolkit{border-left:3px solid hsl(var(--c-toolkit));}
+.admin-kpi.e-chat{border-left:3px solid hsl(var(--c-chat));}
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; }
+.admin-panel-body { padding: 14px; }
+
+.admin-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.admin-table th { text-align: left; padding: 8px 12px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; border-bottom: 1px solid var(--border-light); background: var(--bg); white-space: nowrap; }
+.admin-table td { padding: 8px 12px; border-bottom: 1px solid var(--border-light); vertical-align: middle; }
+.admin-table tr:hover td { background: var(--bg-muted); }
+.admin-table tr.selected td { background: hsl(var(--c-event) / .06); }
+.admin-table tr.row-running td { background: hsl(var(--c-agent) / .06); }
+.admin-table tr.selected.row-running td { background: hsl(var(--c-event) / .08); }
+.admin-table .checkbox { width: 28px; }
+.admin-table .menu { width: 28px; text-align: right; }
+.admin-table .menu button { background: transparent; border: 0; cursor: pointer; color: var(--text-sec); padding: 4px; border-radius: 4px; }
+.admin-table .menu button:hover { background: var(--bg-muted); color: var(--text); }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.queued { background: hsl(var(--c-session) / .14); color: hsl(var(--c-session)); }
+.status-chip.queued::before { background: hsl(var(--c-session)); }
+.status-chip.running { background: hsl(var(--c-agent) / .14); color: hsl(var(--c-agent)); }
+.status-chip.running::before { background: hsl(var(--c-agent)); animation: admin-pulse 1.4s ease-in-out infinite; }
+@keyframes admin-pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.6); opacity: .45; } }
+
+.bulk-bar { display: flex; align-items: center; gap: 12px; padding: 8px 14px; background: hsl(var(--c-event) / .08); border: 1px solid hsl(var(--c-event) / .25); border-radius: 8px; font-size: 12.5px; margin-bottom: 12px; }
+.bulk-bar .count { font-family: var(--f-display); font-weight: 800; color: hsl(var(--c-event)); }
+.bulk-bar .actions { display: flex; gap: 6px; margin-left: auto; }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+.alert-banner { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border-radius: 8px; font-size: 12.5px; }
+.alert-banner.warning { background: hsl(38 90% 56% / .1); border: 1px solid hsl(38 90% 56% / .35); color: var(--text); }
+.alert-banner.danger { background: hsl(var(--c-event) / .08); border: 1px solid hsl(var(--c-event) / .35); color: var(--text); }
+.alert-banner.info { background: hsl(var(--c-chat) / .08); border: 1px solid hsl(var(--c-chat) / .3); color: var(--text); }
+.alert-banner.success { background: hsl(var(--c-toolkit) / .08); border: 1px solid hsl(var(--c-toolkit) / .3); color: var(--text); }
+.alert-banner .em { font-size: 18px; flex-shrink: 0; }
+.alert-banner .body { flex: 1; }
+.alert-banner .title { font-family: var(--f-display); font-weight: 800; margin-bottom: 2px; font-size: 13px; }
+.alert-banner .actions { display: flex; gap: 6px; margin-left: auto; align-items: center; }
+
+.admin-input, .admin-select, .admin-textarea { width: 100%; max-width: 360px; padding: 6px 10px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; font-family: var(--f-body); font-size: 12.5px; }
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, var(--text-sec) 50%), linear-gradient(135deg, var(--text-sec) 50%, transparent 50%); background-position: calc(100% - 14px) 50%, calc(100% - 9px) 50%; background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 26px; cursor: pointer; }
+
+.admin-toggle { position: relative; width: 36px; height: 20px; background: var(--bg-muted); border: 1px solid var(--border); border-radius: 999px; cursor: pointer; flex-shrink: 0; }
+.admin-toggle::after { content: ''; position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; border-radius: 50%; background: var(--text-sec); transition: all .2s var(--ease-out); }
+.admin-toggle.on { background: hsl(var(--c-toolkit) / .25); border-color: hsl(var(--c-toolkit)); }
+.admin-toggle.on::after { left: 18px; background: hsl(var(--c-toolkit)); }
+
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; }
+
+/* ═══════════════ custom da sp5-admin-kb.html (filter-chip, log) ═══════════════ */
+.filter-chip { display: inline-flex; align-items: center; gap: 4px; padding: 3px 9px; border-radius: 999px; background: var(--bg-card); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-sec); cursor: pointer; }
+.filter-chip.active { background: hsl(var(--c-kb) / .14); border-color: hsl(var(--c-kb) / .4); color: hsl(var(--c-kb)); }
+.filter-chip .x { opacity: .6; font-size: 8px; }
+
+.ingestion-log { font-family: var(--f-mono); font-size: 11px; background: var(--bg-sunken); color: var(--text-sec); padding: 12px 14px; border-radius: 6px; line-height: 1.7; max-height: 280px; overflow: auto; margin: 0; white-space: pre-wrap; word-break: break-word; }
+.ingestion-log .t { color: var(--text-muted); }
+.ingestion-log .ok { color: hsl(var(--c-toolkit)); }
+.ingestion-log .err { color: hsl(var(--c-event)); }
+.ingestion-log .warn { color: hsl(38 90% 50%); }
+.ingestion-log .live-cursor { display: inline-block; width: 7px; height: 12px; background: hsl(var(--c-agent)); vertical-align: middle; margin-left: 2px; animation: log-blink 1s steps(2, end) infinite; }
+@keyframes log-blink { 50% { opacity: 0; } }
+
+/* ═══════════════ page-local: Processing Queue ═══════════════ */
+.control-row { display: grid; grid-template-columns: auto auto 1fr auto auto auto; gap: 14px; align-items: center; padding: 10px 14px; }
+.control-row .ctrl { display: inline-flex; align-items: center; gap: 8px; }
+.control-row .ctrl .lab { font-family: var(--f-display); font-size: 12px; font-weight: 700; color: var(--text); }
+.control-row .ctrl .desc { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+.control-row .ctrl .vbar { width: 1px; height: 26px; background: var(--border-light); }
+.control-row .worker-bar { display: inline-flex; gap: 3px; }
+.control-row .worker-bar .w { width: 10px; height: 18px; border-radius: 2px; background: var(--bg-muted); border: 1px solid var(--border-light); }
+.control-row .worker-bar .w.on { background: hsl(var(--c-agent) / .65); border-color: hsl(var(--c-agent)); }
+.control-row .worker-bar .w.busy { background: hsl(var(--c-agent)); border-color: hsl(var(--c-agent)); animation: admin-pulse 1.4s ease-in-out infinite; }
+
+.kpi-strip { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 14px; }
+
+.tools-row { display: flex; gap: 8px; align-items: center; margin-bottom: 10px; flex-wrap: wrap; }
+.tools-row .admin-search { width: 320px; }
+.tools-row .right { margin-left: auto; display: flex; gap: 6px; align-items: center; }
+.tools-row .live-tag { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+.tools-row .live-tag .status-chip { font-size: 9.5px; }
+
+.queue-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: 16px; align-items: start; }
+
+.queue-table-wrap { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.queue-table-wrap .admin-table { table-layout: fixed; }
+.queue-table-wrap .admin-table th, .queue-table-wrap .admin-table td { padding: 6px 8px; }
+.queue-table-wrap .admin-table th { background: var(--bg); }
+.queue-table-wrap .admin-table th:nth-child(1), .queue-table-wrap .admin-table td:nth-child(1) { width: 24px; padding-right: 2px; }
+.queue-table-wrap .admin-table th:nth-child(2), .queue-table-wrap .admin-table td:nth-child(2) { width: auto; }
+.queue-table-wrap .admin-table th:nth-child(3), .queue-table-wrap .admin-table td:nth-child(3) { width: 92px; }
+.queue-table-wrap .admin-table th:nth-child(4), .queue-table-wrap .admin-table td:nth-child(4) { width: 78px; }
+.queue-table-wrap .admin-table th:nth-child(5), .queue-table-wrap .admin-table td:nth-child(5) { width: 130px; }
+.queue-table-wrap .admin-table th:nth-child(6), .queue-table-wrap .admin-table td:nth-child(6) { width: 70px; }
+.queue-table-wrap .admin-table th:nth-child(7), .queue-table-wrap .admin-table td:nth-child(7) { width: 24px; padding-left: 0; }
+.queue-table-wrap .admin-table .pdf { display: flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 11px; color: var(--text); font-weight: 600; }
+.queue-table-wrap .admin-table .pdf .em { font-size: 12px; opacity: .7; flex-shrink: 0; }
+.queue-table-wrap .admin-table .pdf > div { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.queue-table-wrap .admin-table .pdf .sub { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); font-weight: 500; display: block; margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.queue-table-wrap .admin-table .game { display: inline-flex; align-items: center; gap: 4px; font-family: var(--f-display); font-size: 11.5px; font-weight: 700; color: hsl(var(--c-game)); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.queue-table-wrap .admin-table .started { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); white-space: nowrap; line-height: 1.3; }
+.queue-table-wrap .admin-table .started .sub { display: block; opacity: .7; font-size: 9.5px; }
+.queue-table-wrap .admin-table .status-chip { font-size: 9px; padding: 2px 6px; }
+.queue-table-wrap .admin-table .menu button { padding: 2px 4px; }
+
+.prog { display: flex; flex-direction: column; gap: 3px; min-width: 100px; }
+.prog .bar { height: 5px; background: var(--bg-muted); border-radius: 4px; overflow: hidden; position: relative; }
+.prog .bar > span { display: block; height: 100%; border-radius: 4px; background: hsl(var(--c-agent)); transition: width .4s var(--ease-out); }
+.prog .bar > span.done { background: hsl(var(--c-toolkit)); }
+.prog .bar > span.failed { background: hsl(var(--c-event)); }
+.prog .bar > span.queued { background: hsl(var(--c-session) / .55); }
+.prog .bar.running > span::after {
+  content: ''; position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,.25), transparent);
+  background-size: 60px 100%; background-repeat: no-repeat;
+  animation: bar-shimmer 1.4s linear infinite;
+}
+@keyframes bar-shimmer { 0% { background-position: -60px 0; } 100% { background-position: calc(100% + 60px) 0; } }
+.prog .pct { font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted); display: flex; justify-content: space-between; gap: 6px; }
+.prog .pct .step { color: hsl(var(--c-agent)); font-weight: 700; }
+.prog .pct .step.done { color: hsl(var(--c-toolkit)); }
+.prog .pct .step.failed { color: hsl(var(--c-event)); }
+
+/* ── Job detail panel ── */
+.job-hero { padding: 14px 16px; border-bottom: 1px solid var(--border-light); background: linear-gradient(180deg, hsl(var(--c-agent) / .06), transparent); }
+.job-hero .head { display: flex; align-items: flex-start; gap: 12px; }
+.job-hero .head > div[style*="flex: 1"] { min-width: 0; }
+.job-hero .head .em { font-size: 30px; line-height: 1; flex-shrink: 0; }
+.job-hero h2 { font-family: var(--f-display); font-size: 17px; font-weight: 800; margin: 0; display: flex; align-items: center; gap: 8px; min-width: 0; }
+.job-hero h2 .fname { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 0 1 auto; }
+.job-hero h2 .status-chip { flex-shrink: 0; }
+.job-hero .meta { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.job-hero .actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+.job-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-top: 12px; }
+.job-stats .s { background: var(--bg); border: 1px solid var(--border-light); border-radius: 8px; padding: 8px 10px; }
+.job-stats .s-lb { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.job-stats .s-vl { font-family: var(--f-display); font-size: 16px; font-weight: 800; }
+.job-stats .s-vl .u { font-size: 10px; color: var(--text-muted); font-weight: 700; margin-left: 1px; }
+
+/* ── Timeline step ── */
+.timeline { display: flex; flex-direction: column; gap: 0; padding: 6px 0; }
+.timeline .step {
+  display: grid; grid-template-columns: 28px 1fr auto; gap: 10px;
+  padding: 8px 4px; align-items: center;
+  position: relative;
+}
+.timeline .step::before {
+  content: ''; position: absolute; left: 13px; top: 28px; bottom: -8px;
+  width: 2px; background: var(--border-light);
+}
+.timeline .step:last-child::before { display: none; }
+.timeline .step .ico {
+  width: 24px; height: 24px; border-radius: 50%;
+  display: grid; place-items: center;
+  font-family: var(--f-mono); font-size: 11px; font-weight: 800;
+  background: var(--bg-muted); color: var(--text-muted);
+  border: 2px solid var(--bg-card);
+  z-index: 1;
+}
+.timeline .step.done .ico { background: hsl(var(--c-toolkit) / .2); color: hsl(var(--c-toolkit)); }
+.timeline .step.done::before { background: hsl(var(--c-toolkit) / .35); }
+.timeline .step.running .ico { background: hsl(var(--c-agent)); color: #14100a; animation: admin-pulse 1.4s ease-in-out infinite; }
+.timeline .step.failed .ico { background: hsl(var(--c-event) / .2); color: hsl(var(--c-event)); }
+.timeline .step.pending .ico { background: var(--bg-muted); color: var(--text-muted); }
+.timeline .step .lbl { font-family: var(--f-display); font-size: 12.5px; font-weight: 700; }
+.timeline .step .lbl .sub { display: block; margin-top: 2px; font-family: var(--f-mono); font-size: 10px; font-weight: 500; color: var(--text-muted); }
+.timeline .step.running .lbl { color: hsl(var(--c-agent)); }
+.timeline .step.done .lbl { color: var(--text); }
+.timeline .step.failed .lbl { color: hsl(var(--c-event)); }
+.timeline .step.pending .lbl { color: var(--text-muted); }
+.timeline .step .t { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); white-space: nowrap; }
+
+.section-lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin: 16px 0 8px; display: flex; align-items: center; gap: 8px; }
+.section-lab .status-chip { font-size: 9px; }
+
+/* ── Metrics dashboard mini ── */
+.metrics-grid { display: grid; grid-template-columns: 1.5fr 1.5fr 1fr; gap: 12px; }
+.metric-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 12px 14px; }
+.metric-card .head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+.metric-card .lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.metric-card .val { font-family: var(--f-display); font-size: 22px; font-weight: 800; }
+.metric-card .val .u { font-size: 11px; color: var(--text-muted); font-weight: 700; margin-left: 2px; }
+.metric-card .sub { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+
+.bars { display: flex; align-items: flex-end; gap: 3px; height: 56px; margin-top: 8px; }
+.bars .b { flex: 1; background: hsl(var(--c-toolkit) / .25); border-top: 2px solid hsl(var(--c-toolkit)); border-radius: 2px 2px 0 0; min-height: 4px; position: relative; }
+.bars .b.peak { background: hsl(var(--c-agent) / .35); border-top-color: hsl(var(--c-agent)); }
+.bars .b.fail { background: hsl(var(--c-event) / .3); border-top-color: hsl(var(--c-event)); }
+.bars-x { display: flex; justify-content: space-between; font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); margin-top: 4px; }
+
+.dist { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.dist .row { display: grid; grid-template-columns: 70px 1fr 38px; gap: 8px; align-items: center; font-family: var(--f-mono); font-size: 10.5px; }
+.dist .row .lab { color: var(--text-sec); display: inline-flex; align-items: center; gap: 4px; }
+.dist .row .bar { height: 6px; background: var(--bg-muted); border-radius: 3px; overflow: hidden; }
+.dist .row .bar > span { display: block; height: 100%; border-radius: 3px; }
+.dist .row .v { text-align: right; font-weight: 700; color: var(--text); }
+
+.endpoint-note { display: inline-flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); background: var(--bg-sunken); border: 1px dashed var(--border); padding: 2px 8px; border-radius: 4px; }
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+.endpoint-note .sse { color: hsl(var(--c-agent)); font-weight: 700; }
+
+input[type="checkbox"] { accent-color: hsl(var(--c-event)); cursor: pointer; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav ─────────────────────────────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione condivisa ─────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · Processing Queue · 3 attivi · 7 in coda · SSE live</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-processing-queue">
+
+      <!-- ── Sub-nav KB (8 tab) — Processing Queue .active ── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab" role="tab">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab active" role="tab" aria-selected="true">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab" role="tab">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab" role="tab">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab" role="tab">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab" role="tab">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ── 1. Alert banner proattivo ───────────────────── -->
+      <div class="alert-banner warning" style="margin-bottom: 14px">
+        <span class="em">⚠</span>
+        <div class="body">
+          <div class="title">2 job falliti nelle ultime 24h · 1 per OCR timeout, 1 per parse error</div>
+          <div>Brass-FAQ-thread.txt (parse error: encoding non riconosciuto) · TG-Encounters-EN.pdf (OCR timeout @ p.18). Suggerito re-enqueue con worker dedicato OCR.</div>
+        </div>
+        <div class="actions">
+          <button class="btn-admin sm">📋 Vedi dettagli</button>
+          <button class="btn-admin sm">⟳ Re-enqueue tutti</button>
+          <button class="btn-admin sm ghost">✕</button>
+        </div>
+      </div>
+
+      <!-- ── 2. Control bar ──────────────────────────────── -->
+      <section class="admin-panel" style="margin-bottom: 14px">
+        <div class="control-row">
+
+          <div class="ctrl">
+            <div class="admin-toggle on" role="switch" aria-checked="true" aria-label="Pausa coda"></div>
+            <div>
+              <div class="lab">Coda: in esecuzione</div>
+              <div class="desc">Toggle Pausa / Riprendi · ⌘P</div>
+            </div>
+          </div>
+
+          <div class="ctrl"><span class="vbar"></span></div>
+
+          <div class="ctrl">
+            <div>
+              <div class="lab">Workers</div>
+              <div class="desc">4 attivi / 6 totali · 2 idle</div>
+            </div>
+            <div class="worker-bar" aria-label="Worker occupancy">
+              <span class="w busy" title="w-01 · busy"></span>
+              <span class="w busy" title="w-02 · busy"></span>
+              <span class="w busy" title="w-03 · busy"></span>
+              <span class="w on"   title="w-04 · ready"></span>
+              <span class="w"      title="w-05 · idle"></span>
+              <span class="w"      title="w-06 · idle"></span>
+            </div>
+            <button class="btn-admin sm">▾ Scale</button>
+          </div>
+
+          <div></div>
+
+          <div class="ctrl">
+            <span class="status-chip warning">backpressure · 62%</span>
+            <span class="desc">avg latency 18.4s · soft cap @ 80%</span>
+          </div>
+
+          <div class="ctrl">
+            <span class="endpoint-note"><span class="sse">SSE</span> /queue · /job/{id}</span>
+          </div>
+
+          <div class="ctrl">
+            <button class="btn-admin sm">⟳ Refresh</button>
+            <button class="btn-admin sm danger">⏏ Drain</button>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ── 3. KPI strip ────────────────────────────────── -->
+      <div class="kpi-strip">
+
+        <div class="admin-kpi e-agent">
+          <div class="admin-kpi-label"><span class="status-chip running" style="font-size: 9px">running</span> Attivi</div>
+          <div class="admin-kpi-value">3</div>
+          <div class="admin-kpi-trend flat">≡ workers 1·2·3</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-agent))">
+            <path class="spark-fill" d="M0,18 L8,16 L16,20 L24,14 L32,12 L40,16 L48,10 L56,12 L64,8 L70,10 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,18 L8,16 L16,20 L24,14 L32,12 L40,16 L48,10 L56,12 L64,8 L70,10"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi" style="border-left: 3px solid hsl(var(--c-session))">
+          <div class="admin-kpi-label">In coda</div>
+          <div class="admin-kpi-value">7</div>
+          <div class="admin-kpi-trend down">▼ -2 ultimi 5'</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-session))">
+            <path class="spark-fill" d="M0,4 L8,6 L16,5 L24,9 L32,8 L40,12 L48,14 L56,16 L64,18 L70,20 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,4 L8,6 L16,5 L24,9 L32,8 L40,12 L48,14 L56,16 L64,18 L70,20"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi e-toolkit">
+          <div class="admin-kpi-label">Completati · 24h</div>
+          <div class="admin-kpi-value">142</div>
+          <div class="admin-kpi-trend up">▲ +18% vs ieri</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-toolkit))">
+            <path class="spark-fill" d="M0,22 L8,20 L16,21 L24,18 L32,15 L40,13 L48,10 L56,8 L64,6 L70,4 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,22 L8,20 L16,21 L24,18 L32,15 L40,13 L48,10 L56,8 L64,6 L70,4"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi e-event">
+          <div class="admin-kpi-label">Falliti · 24h</div>
+          <div class="admin-kpi-value">2</div>
+          <div class="admin-kpi-trend up" style="color: hsl(var(--c-event))">▲ +1 vs ieri</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-event))">
+            <path class="spark" d="M0,24 L8,24 L16,24 L24,22 L32,24 L40,24 L48,24 L56,24 L64,18 L70,12"/>
+            <circle cx="64" cy="18" r="2.5" fill="currentColor"/>
+            <circle cx="70" cy="12" r="2.5" fill="currentColor"/>
+          </svg>
+        </div>
+
+      </div>
+
+      <!-- ── 4. Bulk bar + filters ───────────────────────── -->
+      <div class="bulk-bar">
+        <input type="checkbox" checked aria-label="Seleziona tutti"/>
+        <span><span class="count">2</span> job selezionati · su 10 totali</span>
+        <div class="actions">
+          <button class="btn-admin sm">⏸ Pausa</button>
+          <button class="btn-admin sm">⟳ Re-enqueue</button>
+          <button class="btn-admin sm">↑ Priorità ↑</button>
+          <button class="btn-admin sm danger">✕ Cancella job</button>
+          <button class="btn-admin sm ghost">Deseleziona</button>
+        </div>
+      </div>
+
+      <div class="tools-row">
+        <div class="admin-search"><span>🔍</span><input placeholder="Cerca PDF, gioco o jobId…"/></div>
+        <span class="filter-chip active">Stato: tutti <span class="x">▾</span></span>
+        <span class="filter-chip">⏸ queued <span class="x">7</span></span>
+        <span class="filter-chip">⟳ running <span class="x">3</span></span>
+        <span class="filter-chip">✓ completed <span class="x">142</span></span>
+        <span class="filter-chip">✕ failed <span class="x">2</span></span>
+        <div class="right">
+          <span class="live-tag"><span class="status-chip running">● streaming</span> SSE · /admin/kb/queue</span>
+          <button class="btn-admin sm">⤓ Export CSV</button>
+        </div>
+      </div>
+
+      <!-- ── 5. Layout 2-col: tabella + detail ─────────── -->
+      <div class="queue-grid">
+
+        <!-- LEFT: queue table -->
+        <div class="queue-table-wrap">
+          <table class="admin-table">
+            <thead>
+              <tr>
+                <th class="checkbox"><input type="checkbox" aria-label="Seleziona tutto"/></th>
+                <th>PDF</th>
+                <th>Gioco</th>
+                <th>Stato</th>
+                <th>Progresso</th>
+                <th>Avviato</th>
+                <th class="menu"></th>
+              </tr>
+            </thead>
+            <tbody>
+
+              <!-- selected + running -->
+              <tr class="selected row-running">
+                <td class="checkbox"><input type="checkbox" checked aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Spirit-Island-Jagged-Earth-EN.pdf
+                      <span class="sub">job-8f12a · 14.2MB · 68 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Spirit Island</span></td>
+                <td><span class="status-chip running">running</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar running"><span style="width: 64%"></span></div>
+                    <div class="pct"><span class="step">embedding · 264/412</span><span>64%</span></div>
+                  </div>
+                </td>
+                <td class="started">14:36:21<br/><span style="opacity:.7">2m 14s fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr class="row-running">
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Ark-Nova-Marine-Worlds-Rules.pdf
+                      <span class="sub">job-8f12b · 6.8MB · 24 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Ark Nova</span></td>
+                <td><span class="status-chip running">running</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar running"><span style="width: 38%"></span></div>
+                    <div class="pct"><span class="step">chunking · 92/241</span><span>38%</span></div>
+                  </div>
+                </td>
+                <td class="started">14:37:54<br/><span style="opacity:.7">42s fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr class="selected row-running">
+                <td class="checkbox"><input type="checkbox" checked aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Gloomhaven-Frosthaven-Errata-v3.pdf
+                      <span class="sub">job-8f12c · 2.1MB · 8 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Gloomhaven</span></td>
+                <td><span class="status-chip running">running</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar running"><span style="width: 84%"></span></div>
+                    <div class="pct"><span class="step">indexing · pgvector</span><span>84%</span></div>
+                  </div>
+                </td>
+                <td class="started">14:38:02<br/><span style="opacity:.7">34s fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Wingspan-Asia-Expansion-IT.pdf
+                      <span class="sub">job-8f12d · 11.4MB · 38 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Wingspan</span></td>
+                <td><span class="status-chip queued">queued</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="queued" style="width: 8%"></span></div>
+                    <div class="pct"><span>in coda · pos #1</span><span>~2m</span></div>
+                  </div>
+                </td>
+                <td class="started">14:38:18<br/><span style="opacity:.7">in attesa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      ISS-Vanguard-Logbook-vol2.pdf
+                      <span class="sub">job-8f12e · 28.7MB · 124 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 ISS Vanguard</span></td>
+                <td><span class="status-chip queued">queued</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="queued" style="width: 4%"></span></div>
+                    <div class="pct"><span>in coda · pos #2</span><span>~7m</span></div>
+                  </div>
+                </td>
+                <td class="started">14:38:31<br/><span style="opacity:.7">in attesa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Tainted-Grail-Ch5-IT.pdf
+                      <span class="sub">job-8f12f · 4.2MB · 18 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Tainted Grail</span></td>
+                <td><span class="status-chip queued">queued</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="queued" style="width: 4%"></span></div>
+                    <div class="pct"><span>in coda · pos #3</span><span>~8m</span></div>
+                  </div>
+                </td>
+                <td class="started">14:39:02<br/><span style="opacity:.7">in attesa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Brass-FAQ-thread.txt
+                      <span class="sub">job-8f124 · 312KB · n/a</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Brass: Birm.</span></td>
+                <td><span class="status-chip danger">failed</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="failed" style="width: 22%"></span></div>
+                    <div class="pct"><span class="step failed">parse error · p.0</span><span>22%</span></div>
+                  </div>
+                </td>
+                <td class="started">14:18:09<br/><span style="opacity:.7">21m fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      TG-Encounters-EN.pdf
+                      <span class="sub">job-8f125 · 18.3MB · 56 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Tainted Grail</span></td>
+                <td><span class="status-chip danger">failed</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="failed" style="width: 31%"></span></div>
+                    <div class="pct"><span class="step failed">OCR timeout · p.18</span><span>31%</span></div>
+                  </div>
+                </td>
+                <td class="started">13:54:42<br/><span style="opacity:.7">44m fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Wingspan-Oceania-EN.pdf
+                      <span class="sub">job-8f120 · 8.4MB · 42 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Wingspan</span></td>
+                <td><span class="status-chip healthy">completed</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="done" style="width: 100%"></span></div>
+                    <div class="pct"><span class="step done">412 chunks · indicizzato</span><span>13.4s</span></div>
+                  </div>
+                </td>
+                <td class="started">14:22:01<br/><span style="opacity:.7">17m fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+              <tr>
+                <td class="checkbox"><input type="checkbox" aria-label="Riga"/></td>
+                <td>
+                  <div class="pdf">
+                    <span class="em">📄</span>
+                    <div>
+                      Lancaster-Errata-v2.pdf
+                      <span class="sub">job-8f11e · 1.4MB · 4 pag</span>
+                    </div>
+                  </div>
+                </td>
+                <td><span class="game">🎲 Lancaster</span></td>
+                <td><span class="status-chip healthy">completed</span></td>
+                <td>
+                  <div class="prog">
+                    <div class="bar"><span class="done" style="width: 100%"></span></div>
+                    <div class="pct"><span class="step done">28 chunks · indicizzato</span><span>4.1s</span></div>
+                  </div>
+                </td>
+                <td class="started">14:11:38<br/><span style="opacity:.7">27m fa</span></td>
+                <td class="menu"><button>⋮</button></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+
+        <!-- RIGHT: job detail panel -->
+        <div class="admin-panel">
+
+          <div class="job-hero">
+            <div class="head">
+              <span class="em">📄</span>
+              <div style="flex: 1">
+                <h2>
+                  <span class="fname" title="Spirit-Island-Jagged-Earth-EN.pdf">Spirit-Island-Jagged-Earth-EN.pdf</span>
+                  <span class="status-chip running">running · live</span>
+                </h2>
+                <div class="meta">job-8f12a · worker w-01 · started 14:36:21 CET · elapsed 2m 14s · ETA ~1m 18s</div>
+              </div>
+              <div class="actions">
+                <button class="btn-admin sm">⏸ Pausa</button>
+                <button class="btn-admin sm">↑ Boost</button>
+                <button class="btn-admin sm danger">✕ Cancella</button>
+              </div>
+            </div>
+
+            <div class="job-stats">
+              <div class="s"><div class="s-lb">Progresso</div><div class="s-vl" style="color: hsl(var(--c-agent))">64<span class="u">%</span></div></div>
+              <div class="s"><div class="s-lb">Chunks</div><div class="s-vl">264<span class="u">/412</span></div></div>
+              <div class="s"><div class="s-lb">Pages</div><div class="s-vl">42<span class="u">/68</span></div></div>
+              <div class="s"><div class="s-lb">Cost stimato</div><div class="s-vl" style="color: hsl(var(--c-toolkit))">$0.094</div></div>
+            </div>
+          </div>
+
+          <div style="padding: 14px 16px">
+
+            <div class="section-lab">Pipeline · 7 step <span class="status-chip running">live</span></div>
+
+            <div class="timeline">
+              <div class="step done">
+                <div class="ico">✓</div>
+                <div class="lbl">Upload &amp; validate
+                  <span class="sub">PDF integrity check · MIME ok · 14.2MB · 68 pag</span>
+                </div>
+                <div class="t">+ 0.31s</div>
+              </div>
+
+              <div class="step done">
+                <div class="ico">✓</div>
+                <div class="lbl">Unstructured.io parse
+                  <span class="sub">2.847 elements · 142 tables · 38 figures</span>
+                </div>
+                <div class="t">+ 3.18s</div>
+              </div>
+
+              <div class="step done">
+                <div class="ico">✓</div>
+                <div class="lbl">SmolDocling doc-layout
+                  <span class="sub">layout zones · OCR off · lang EN</span>
+                </div>
+                <div class="t">+ 4.02s</div>
+              </div>
+
+              <div class="step done">
+                <div class="ico">✓</div>
+                <div class="lbl">Chunker · 512 tok
+                  <span class="sub">412 chunks · avg 421 tok · overlap 64</span>
+                </div>
+                <div class="t">+ 2.14s</div>
+              </div>
+
+              <div class="step running">
+                <div class="ico">▸</div>
+                <div class="lbl">Embedder · bge-base-en-v1.5
+                  <span class="sub">264/412 chunks · batch 32 · 768d · rate 18ch/s</span>
+                </div>
+                <div class="t">in corso · 8.2s</div>
+              </div>
+
+              <div class="step pending">
+                <div class="ico">5</div>
+                <div class="lbl">Indexer · pgvector spirit-island-v3
+                  <span class="sub">HNSW m=16 ef=200 · stima 4.1s</span>
+                </div>
+                <div class="t">in attesa</div>
+              </div>
+
+              <div class="step pending">
+                <div class="ico">6</div>
+                <div class="lbl">Quality eval &amp; commit
+                  <span class="sub">retrieval gold-set · entity-link · commit tx</span>
+                </div>
+                <div class="t">in attesa</div>
+              </div>
+            </div>
+
+            <div class="section-lab">Live log <span class="status-chip running">● streaming</span> <span class="endpoint-note" style="margin-left:auto"><span class="sse">SSE</span> /job/8f12a</span></div>
+
+            <pre class="ingestion-log">
+<span class="t">[14:36:21.082]</span> <span class="ok">▸ Started</span> job-8f12a · Spirit-Island-Jagged-Earth-EN.pdf · 14.2MB · 68 pag · worker w-01
+<span class="t">[14:36:21.394]</span> <span class="ok">✓ Validate</span> integrity ok · sha256 7a2c..f019 · MIME application/pdf
+<span class="t">[14:36:24.561]</span> <span class="ok">✓ Unstructured.io</span> parsed in 3.18s · 2.847 elements · 142 tables · 38 figures
+<span class="t">[14:36:28.585]</span> <span class="ok">✓ SmolDocling</span> doc-layout in 4.02s · zones=412 · OCR=off
+<span class="t">[14:36:30.728]</span> <span class="ok">✓ Chunker</span> 412 chunks @ 512 tok · avg 421 · overlap 64
+<span class="t">[14:36:30.802]</span> <span class="ok">▸ Embedder</span> bge-base-en-v1.5 · batch 32 · target 768d
+<span class="t">[14:36:34.118]</span> <span class="ok">  · batch 1</span> 32/412 chunks · 1.84s · 17.4ch/s
+<span class="t">[14:36:37.402]</span> <span class="ok">  · batch 2</span> 64/412 chunks · 1.79s · 17.9ch/s
+<span class="t">[14:36:40.683]</span> <span class="ok">  · batch 3</span> 96/412 chunks · 1.81s · 17.7ch/s
+<span class="t">[14:36:44.041]</span> <span class="warn">  · batch 4</span> rate-limit 429 → backoff 1.2s
+<span class="t">[14:36:46.952]</span> <span class="ok">  · batch 5</span> 128/412 chunks · resumed
+<span class="t">[14:36:50.218]</span> <span class="ok">  · batch 6</span> 160/412 chunks · 1.78s · 18.0ch/s
+<span class="t">[14:36:53.611]</span> <span class="ok">  · batch 7</span> 192/412 chunks · 1.82s · 17.6ch/s
+<span class="t">[14:36:57.084]</span> <span class="ok">  · batch 8</span> 224/412 chunks · 1.80s · 17.8ch/s
+<span class="t">[14:38:33.471]</span> <span class="ok">  · batch 9</span> 264/412 chunks · 1.79s · 17.9ch/s<span class="live-cursor"></span></pre>
+
+            <div style="margin-top: 12px; display: flex; gap: 6px; flex-wrap: wrap">
+              <button class="btn-admin sm">⤓ Download log</button>
+              <button class="btn-admin sm">📋 Copy job ID</button>
+              <button class="btn-admin sm">🔗 Apri doc</button>
+              <button class="btn-admin sm">🧪 Test embedding</button>
+              <span class="endpoint-note" style="margin-left:auto"><code>GET</code> getJobDetail(8f12a)</span>
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+      <!-- ── 6. Metrics dashboard mini ─────────────────── -->
+      <div class="section-lab" style="margin-top: 20px">📊 Metrics · ultime 6h</div>
+
+      <div class="metrics-grid">
+
+        <div class="metric-card">
+          <div class="head">
+            <span class="lab">Throughput</span>
+            <span class="status-chip healthy" style="font-size: 9px">stable</span>
+          </div>
+          <div class="val">24<span class="u">job/h</span></div>
+          <div class="sub">peak 38 @ 11:00 · media 21 · p95 32</div>
+          <div class="bars" aria-label="Throughput per ora">
+            <div class="b" style="height: 30%" title="09:00 · 14"></div>
+            <div class="b" style="height: 42%" title="10:00 · 19"></div>
+            <div class="b peak" style="height: 88%" title="11:00 · 38"></div>
+            <div class="b" style="height: 56%" title="12:00 · 25"></div>
+            <div class="b" style="height: 48%" title="13:00 · 21"></div>
+            <div class="b" style="height: 62%" title="14:00 · 28 (in corso)"></div>
+          </div>
+          <div class="bars-x"><span>09</span><span>10</span><span>11</span><span>12</span><span>13</span><span>14</span></div>
+        </div>
+
+        <div class="metric-card">
+          <div class="head">
+            <span class="lab">Tempo medio · per step</span>
+            <span class="sub">Ø 14.2s · target ≤ 18s</span>
+          </div>
+          <div class="dist">
+            <div class="row">
+              <span class="lab"><span class="e-dot" style="--e: var(--c-kb)"></span>Parse</span>
+              <span class="bar"><span style="width: 22%; background: hsl(var(--c-kb))"></span></span>
+              <span class="v">3.1s</span>
+            </div>
+            <div class="row">
+              <span class="lab"><span class="e-dot" style="--e: var(--c-tool)"></span>Doc-layout</span>
+              <span class="bar"><span style="width: 28%; background: hsl(var(--c-tool))"></span></span>
+              <span class="v">4.0s</span>
+            </div>
+            <div class="row">
+              <span class="lab"><span class="e-dot" style="--e: var(--c-chat)"></span>Chunking</span>
+              <span class="bar"><span style="width: 15%; background: hsl(var(--c-chat))"></span></span>
+              <span class="v">2.1s</span>
+            </div>
+            <div class="row">
+              <span class="lab"><span class="e-dot" style="--e: var(--c-agent)"></span>Embedding</span>
+              <span class="bar"><span style="width: 62%; background: hsl(var(--c-agent))"></span></span>
+              <span class="v">8.8s</span>
+            </div>
+            <div class="row">
+              <span class="lab"><span class="e-dot" style="--e: var(--c-toolkit)"></span>Index</span>
+              <span class="bar"><span style="width: 18%; background: hsl(var(--c-toolkit))"></span></span>
+              <span class="v">2.6s</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="metric-card">
+          <div class="head">
+            <span class="lab">Success rate · 24h</span>
+            <span class="status-chip healthy" style="font-size: 9px">98.6%</span>
+          </div>
+          <div class="val">142<span class="u">/ 144</span></div>
+          <div class="sub">2 falliti · 0 timeout coda · 1 retry success</div>
+          <div class="dist" style="margin-top: 12px">
+            <div class="row">
+              <span class="lab" style="color: hsl(var(--c-toolkit))">✓ done</span>
+              <span class="bar"><span style="width: 98.6%; background: hsl(var(--c-toolkit))"></span></span>
+              <span class="v">142</span>
+            </div>
+            <div class="row">
+              <span class="lab" style="color: hsl(var(--c-event))">✕ failed</span>
+              <span class="bar"><span style="width: 1.4%; background: hsl(var(--c-event))"></span></span>
+              <span class="v">2</span>
+            </div>
+          </div>
+          <div class="sub" style="margin-top: 8px">Costo medio job · <strong style="color: var(--text)">$0.062</strong> · totale 24h $8.81</div>
+        </div>
+
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-settings.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-settings.html
@@ -1,0 +1,617 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Settings · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game: 25 95% 45%; --c-player: 262 83% 58%; --c-session: 240 60% 55%;
+  --c-agent: 38 92% 50%; --c-kb: 174 60% 40%; --c-chat: 220 80% 55%;
+  --c-event: 350 89% 60%; --c-toolkit: 142 70% 45%; --c-tool: 195 80% 50%;
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body: 'Nunito', system-ui, sans-serif;
+  --f-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px;
+  --r-sm: 6px; --r-md: 10px; --r-pill: 9999px;
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { font-family: var(--f-body); background: var(--bg); color: var(--text); font-size: var(--fs-base); line-height: 1.5; -webkit-font-smoothing: antialiased; }
+h1, h2, h3, h4 { font-family: var(--f-display); font-weight: 700; letter-spacing: -.01em; margin: 0; line-height: 1.2; }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: .9em; }
+
+.e-game{--e:var(--c-game);} .e-kb{--e:var(--c-kb);} .e-agent{--e:var(--c-agent);}
+.e-event{--e:var(--c-event);} .e-toolkit{--e:var(--c-toolkit);} .e-chat{--e:var(--c-chat);}
+.e-tool{--e:var(--c-tool);} .e-session{--e:var(--c-session);}
+.e-fg{color:hsl(var(--e));} .e-dot{width:8px;height:8px;border-radius:50%;background:hsl(var(--e));flex-shrink:0;display:inline-block;}
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+
+.admin-nav { background: var(--bg-card); border-right: 1px solid var(--border); padding: 16px 0; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; height: 100vh; overflow-y: auto; }
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin:disabled { opacity: .35; cursor: not-allowed; filter: grayscale(.3); }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger { background: var(--bg-card); border-color: hsl(var(--c-event) / .55); color: hsl(var(--c-event)); }
+.btn-admin.danger:hover { background: hsl(var(--c-event) / .08); }
+.btn-admin.danger.solid { background: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; display: inline-flex; align-items: center; gap: 8px; }
+.admin-panel-head h3 .em { font-size: 15px; opacity: .9; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; }
+.admin-panel-body { padding: 14px; }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .2); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.readonly { background: var(--bg-muted); color: var(--text-sec); }
+.status-chip.readonly::before { background: var(--text-muted); }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+.alert-banner { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border-radius: 8px; font-size: 12.5px; }
+.alert-banner.warning { background: hsl(38 90% 56% / .1); border: 1px solid hsl(38 90% 56% / .35); color: var(--text); }
+.alert-banner.danger { background: hsl(var(--c-event) / .08); border: 1px solid hsl(var(--c-event) / .35); color: var(--text); }
+.alert-banner.info { background: hsl(var(--c-chat) / .08); border: 1px solid hsl(var(--c-chat) / .3); color: var(--text); }
+.alert-banner.success { background: hsl(var(--c-toolkit) / .08); border: 1px solid hsl(var(--c-toolkit) / .3); color: var(--text); }
+.alert-banner .em { font-size: 18px; flex-shrink: 0; }
+.alert-banner .body { flex: 1; min-width: 0; }
+.alert-banner .title { font-family: var(--f-display); font-weight: 800; margin-bottom: 2px; font-size: 13px; }
+.alert-banner .actions { display: flex; gap: 6px; margin-left: auto; align-items: center; flex-shrink: 0; }
+
+.admin-input { width: 100%; max-width: 360px; padding: 6px 10px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; font-family: var(--f-body); font-size: 12.5px; }
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-input:focus { outline: 0; border-color: hsl(var(--c-event)); box-shadow: 0 0 0 3px hsl(var(--c-event) / .14); }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; }
+
+.endpoint-note { display: inline-flex; align-items: center; gap: 6px; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); background: var(--bg-sunken); border: 1px dashed var(--border); padding: 2px 8px; border-radius: 4px; }
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+.endpoint-note code.danger { color: hsl(var(--c-event)); }
+
+/* ═══════════════ page-local: Settings ═══════════════ */
+.section-lab { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; margin: 18px 0 10px; display: flex; align-items: center; gap: 8px; }
+
+/* ── KV rows ── */
+.kv-list { display: flex; flex-direction: column; }
+.kv {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-light);
+  font-family: var(--f-mono); font-size: 11.5px;
+  align-items: center;
+  min-height: 30px;
+}
+.kv:first-child { padding-top: 0; }
+.kv:last-child { border-bottom: 0; padding-bottom: 0; }
+.kv .k {
+  color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .04em;
+  font-size: 9.5px; font-weight: 700;
+}
+.kv .v {
+  color: var(--text); font-weight: 600;
+  display: inline-flex; align-items: center; gap: 6px;
+  flex-wrap: wrap; min-width: 0;
+}
+.kv .v.accent { color: hsl(var(--c-kb)); font-weight: 700; }
+.kv .v.muted { color: var(--text-muted); }
+.kv .v .sub { color: var(--text-muted); font-weight: 500; }
+.kv .v .copy {
+  border: 0; background: transparent; cursor: pointer;
+  color: var(--text-muted); font-family: var(--f-mono);
+  padding: 0 2px; font-size: 10px;
+}
+.kv .v .copy:hover { color: hsl(var(--c-kb)); }
+
+/* Settings grid (auto 2-3 cols) */
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.panel-head-status { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; }
+
+/* ── Danger Zone ── */
+.danger-zone {
+  border: 1px solid hsl(var(--c-event) / .35);
+  background: var(--bg-card);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px hsl(var(--c-event) / .08) inset, 0 4px 14px hsl(var(--c-event) / .08);
+}
+.danger-zone > .head {
+  padding: 12px 16px;
+  background: linear-gradient(90deg, hsl(var(--c-event) / .14), hsl(var(--c-event) / .04));
+  border-bottom: 1px solid hsl(var(--c-event) / .25);
+  display: flex; align-items: center; gap: 10px;
+}
+.danger-zone > .head h3 {
+  font-family: var(--f-display); font-size: 14px; font-weight: 800;
+  color: hsl(var(--c-event));
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.danger-zone > .head .desc { font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted); margin-left: 8px; }
+.danger-zone > .head .desc strong { color: var(--text); font-weight: 700; }
+
+.danger-list { display: grid; grid-template-columns: 1fr 1fr; gap: 0; }
+.danger-list > .op {
+  padding: 16px;
+  border-right: 1px solid hsl(var(--c-event) / .15);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.danger-list > .op:last-child { border-right: 0; }
+.danger-list .op-head {
+  display: flex; align-items: flex-start; gap: 10px;
+}
+.danger-list .op-head .icon {
+  width: 32px; height: 32px; border-radius: 8px;
+  background: hsl(var(--c-event) / .14); color: hsl(var(--c-event));
+  display: grid; place-items: center; font-size: 16px;
+  flex-shrink: 0;
+}
+.danger-list .op-head .title {
+  font-family: var(--f-display); font-weight: 800; font-size: 13.5px;
+  display: flex; align-items: center; gap: 6px;
+}
+.danger-list .op-head .desc {
+  font-family: var(--f-body); font-size: 12px;
+  color: var(--text-sec); margin-top: 2px; line-height: 1.45;
+}
+.danger-list .op-meta {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  font-family: var(--f-mono); font-size: 10px;
+}
+.danger-list .op-meta .tag {
+  padding: 2px 7px; border-radius: 4px;
+  background: var(--bg-muted); color: var(--text-sec);
+  font-weight: 700;
+}
+.danger-list .op-meta .tag.warn { background: hsl(38 90% 56% / .15); color: hsl(38 90% 50%); }
+.danger-list .op-meta .tag.danger { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+
+.confirm-card {
+  background: var(--bg);
+  border: 1px solid hsl(var(--c-event) / .25);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.confirm-card .ask {
+  font-family: var(--f-mono); font-size: 11px;
+  color: var(--text-sec);
+  display: flex; align-items: center; flex-wrap: wrap; gap: 4px;
+}
+.confirm-card .ask code {
+  background: hsl(var(--c-event) / .14); color: hsl(var(--c-event));
+  padding: 1px 6px; border-radius: 4px; font-weight: 700;
+  font-family: var(--f-mono); font-size: 11px;
+  user-select: all;
+}
+.confirm-card .input-row {
+  display: flex; gap: 6px; align-items: center;
+}
+.confirm-card .input-row input {
+  flex: 1; max-width: none;
+  font-family: var(--f-mono); font-size: 12px;
+}
+.confirm-card .input-row input.matched {
+  border-color: hsl(var(--c-event) / .6);
+  box-shadow: 0 0 0 3px hsl(var(--c-event) / .12);
+}
+.confirm-card .input-row input.empty {
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+.confirm-card .row-actions {
+  display: flex; gap: 6px; align-items: center;
+  justify-content: space-between;
+}
+.confirm-card .last-run {
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+}
+.confirm-card .last-run strong { color: var(--text); font-weight: 700; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav ─────────────────────────────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione condivisa ─────────────────────── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · Settings · config v2024.12.04 · read-only</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-settings">
+
+      <!-- ── Sub-nav KB — Settings .active ── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab" role="tab">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab" role="tab">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab" role="tab">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab" role="tab">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab" role="tab">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab active" role="tab" aria-selected="true">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ══ 1. Alert read-only ══ -->
+      <div class="alert-banner info" style="margin-bottom: 16px">
+        <span class="em">ℹ</span>
+        <div class="body">
+          <div class="title">Configurazione read-only · gestita dal repo infra</div>
+          <div>I valori mostrati provengono da <code style="font-family: var(--f-mono); background: var(--bg-sunken); padding: 1px 5px; border-radius: 4px; color: hsl(var(--c-kb))">config/kb.prod.yaml</code>. Per modificarli apri una PR su <code style="font-family: var(--f-mono); background: var(--bg-sunken); padding: 1px 5px; border-radius: 4px">meepleai-infra</code>. Le operazioni distruttive in fondo sono l'unica eccezione (richiedono typed-confirm).</div>
+        </div>
+        <div class="actions">
+          <span class="endpoint-note"><code>GET</code> getKBSettings()</span>
+          <span class="status-chip readonly">read-only</span>
+          <button class="btn-admin">⟳ Refresh</button>
+        </div>
+      </div>
+
+      <!-- ══ 2. Settings grid · 6 panel ══ -->
+      <div class="settings-grid">
+
+        <!-- 1. Embedding Model -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">🧠</span> Embedding Model</h3>
+            <span class="panel-head-status">
+              <span class="status-chip healthy">healthy</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Provider</span><span class="v accent">HuggingFace TEI</span></div>
+              <div class="kv"><span class="k">Model</span><span class="v">intfloat/multilingual-e5-base</span></div>
+              <div class="kv"><span class="k">Revision</span><span class="v muted">2c87f49 · 2024-08-12</span></div>
+              <div class="kv"><span class="k">Dimensions</span><span class="v"><strong>768</strong> <span class="sub">· cosine</span></span></div>
+              <div class="kv"><span class="k">Pooling</span><span class="v">mean · normalize=true</span></div>
+              <div class="kv"><span class="k">Batch size</span><span class="v">32 <span class="sub">· max 64</span></span></div>
+              <div class="kv"><span class="k">Quantization</span><span class="v">fp16 · safetensors</span></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 2. Vector Database -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">📦</span> Vector Database</h3>
+            <span class="panel-head-status">
+              <span class="status-chip healthy">online</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Type</span><span class="v accent">pgvector</span></div>
+              <div class="kv"><span class="k">Version</span><span class="v">0.7.4</span></div>
+              <div class="kv"><span class="k">Host</span><span class="v">vec-prod.meepleai.internal <button class="copy" aria-label="Copia">⎘</button></span></div>
+              <div class="kv"><span class="k">Port</span><span class="v">5432</span></div>
+              <div class="kv"><span class="k">Database</span><span class="v">meeple_kb_prod</span></div>
+              <div class="kv"><span class="k">Index type</span><span class="v">HNSW <span class="sub">· m=16 · ef=200</span></span></div>
+              <div class="kv"><span class="k">Total vectors</span><span class="v">18.487 <span class="sub">· 2.4TB</span></span></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 3. Text Chunking -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">🧱</span> Text Chunking</h3>
+            <span class="panel-head-status">
+              <span class="status-chip info">semantic · v2</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Default chunk size</span><span class="v"><strong>512</strong> <span class="sub">tokens</span></span></div>
+              <div class="kv"><span class="k">Overlap</span><span class="v"><strong>64</strong> <span class="sub">tokens</span></span></div>
+              <div class="kv"><span class="k">Min size</span><span class="v">128 tokens</span></div>
+              <div class="kv"><span class="k">Max size</span><span class="v">768 tokens</span></div>
+              <div class="kv"><span class="k">Token limit / doc</span><span class="v">524.288 <span class="sub">· hard cap</span></span></div>
+              <div class="kv"><span class="k">Chars / token</span><span class="v">~4.0 <span class="sub">· avg EN+IT</span></span></div>
+              <div class="kv"><span class="k">Strategy</span><span class="v">semantic splitter <span class="sub">· headings-aware</span></span></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 4. Cache Configuration -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">⚡</span> Cache Configuration</h3>
+            <span class="panel-head-status">
+              <span class="status-chip healthy">hit 84%</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Layer</span><span class="v accent">HybridCache <span class="sub">· L1 mem + L2 Redis</span></span></div>
+              <div class="kv"><span class="k">Redis host</span><span class="v">cache-prod.meepleai.internal <button class="copy" aria-label="Copia">⎘</button></span></div>
+              <div class="kv"><span class="k">Redis port</span><span class="v">6379 <span class="sub">· tls 6380</span></span></div>
+              <div class="kv"><span class="k">Multi-tier</span><span class="v">enabled · L1 → L2</span></div>
+              <div class="kv"><span class="k">L1 TTL</span><span class="v">60s <span class="sub">· LRU 4096 entries</span></span></div>
+              <div class="kv"><span class="k">L2 TTL</span><span class="v">3.600s <span class="sub">· 1h</span></span></div>
+              <div class="kv"><span class="k">Expiration policy</span><span class="v">sliding · absolute 24h</span></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 5. Reranker Service -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">🔬</span> Reranker Service</h3>
+            <span class="panel-head-status">
+              <span class="status-chip warning">opt-in</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Provider</span><span class="v accent">Cohere</span></div>
+              <div class="kv"><span class="k">Model</span><span class="v">rerank-multilingual-v3.0</span></div>
+              <div class="kv"><span class="k">Enabled</span><span class="v">false <span class="sub">· opt-in per agent</span></span></div>
+              <div class="kv"><span class="k">Top-K input</span><span class="v">20 → 5</span></div>
+              <div class="kv"><span class="k">Endpoint</span><span class="v">api.cohere.com/v1/rerank</span></div>
+              <div class="kv"><span class="k">Timeout</span><span class="v">2.000ms</span></div>
+              <div class="kv"><span class="k">Status</span><span class="v"><span class="status-chip warning" style="font-size: 9px">opt-in · 3/14 agents</span></span></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- 6. File Storage -->
+        <section class="admin-panel">
+          <div class="admin-panel-head">
+            <h3><span class="em">🗄</span> File Storage</h3>
+            <span class="panel-head-status">
+              <span class="status-chip healthy">online</span>
+            </span>
+          </div>
+          <div class="admin-panel-body">
+            <div class="kv-list">
+              <div class="kv"><span class="k">Provider</span><span class="v accent">AWS S3</span></div>
+              <div class="kv"><span class="k">Region</span><span class="v">eu-west-1 · Dublin</span></div>
+              <div class="kv"><span class="k">Bucket</span><span class="v">meepleai-kb-prod <button class="copy" aria-label="Copia">⎘</button></span></div>
+              <div class="kv"><span class="k">Path prefix</span><span class="v">/docs/&#123;gameId&#125;/&#123;docId&#125;</span></div>
+              <div class="kv"><span class="k">Encryption</span><span class="v">SSE-KMS <span class="sub">· kms/kb-prod-key</span></span></div>
+              <div class="kv"><span class="k">Versioning</span><span class="v">enabled · 30gg</span></div>
+              <div class="kv"><span class="k">Total objects</span><span class="v">247 docs · 2.4TB</span></div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+
+      <!-- ══ 3. Danger Zone ══ -->
+      <div class="section-lab">
+        <span style="color: hsl(var(--c-event))">⚠ Danger Zone</span>
+        <span>Operazioni distruttive · richiedono typed-confirm</span>
+      </div>
+
+      <div class="danger-zone">
+        <div class="head">
+          <h3>⚠ Danger Zone</h3>
+          <span class="desc">
+            Le seguenti azioni sono <strong>irreversibili</strong> e impattano la KB di <strong>produzione</strong>.
+            Vengono loggate in <strong>audit</strong> con user, IP e timestamp.
+          </span>
+        </div>
+
+        <div class="danger-list">
+
+          <!-- Op 1: Rebuild Vector Index -->
+          <div class="op">
+            <div class="op-head">
+              <div class="icon">🔄</div>
+              <div>
+                <div class="title">Rebuild Vector Index</div>
+                <div class="desc">
+                  Riconstruisce l'indice HNSW <code style="background: var(--bg-muted); padding: 1px 5px; border-radius: 4px">pgvector</code>
+                  a partire dai chunk esistenti. Durante il rebuild la ricerca semantica è
+                  <strong>indisponibile</strong> (degraded mode).
+                </div>
+              </div>
+            </div>
+            <div class="op-meta">
+              <span class="tag warn">~38min stimati</span>
+              <span class="tag warn">search degraded</span>
+              <span class="tag">18.487 vectors</span>
+              <span class="tag">9 collections</span>
+            </div>
+
+            <div class="confirm-card">
+              <div class="ask">
+                Per confermare, digita <code>REBUILD-INDEX</code> qui sotto:
+              </div>
+              <div class="input-row">
+                <input class="admin-input mono empty" type="text" placeholder="REBUILD-INDEX" aria-label="Conferma rebuild"/>
+                <button class="btn-admin danger" disabled aria-disabled="true">🔄 Rebuild</button>
+              </div>
+              <div class="row-actions">
+                <span class="last-run">Ultimo run · <strong>2024-11-22 03:14 CET</strong> · da admin@meepleai · 41min · ok</span>
+                <span class="endpoint-note"><code class="danger">POST</code> rebuildIndex()</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Op 2: Clear KB Cache -->
+          <div class="op">
+            <div class="op-head">
+              <div class="icon">🧹</div>
+              <div>
+                <div class="title">Clear KB Cache</div>
+                <div class="desc">
+                  Svuota L1 (in-memory) e L2 (Redis) di tutte le entry KB. Le prime query post-flush
+                  saranno più lente (cold cache, +~40% latency) fino al riscaldamento.
+                </div>
+              </div>
+            </div>
+            <div class="op-meta">
+              <span class="tag">~2s op</span>
+              <span class="tag warn">+40% latency 10min</span>
+              <span class="tag">14.218 keys L2</span>
+              <span class="tag">3.842 keys L1</span>
+            </div>
+
+            <div class="confirm-card">
+              <div class="ask">
+                Per confermare, digita <code>CLEAR-CACHE</code> qui sotto:
+              </div>
+              <div class="input-row">
+                <input class="admin-input mono matched" type="text" value="CLEAR-CACHE" aria-label="Conferma clear cache"/>
+                <button class="btn-admin danger solid">🧹 Clear</button>
+              </div>
+              <div class="row-actions">
+                <span class="last-run">Ultimo run · <strong>2024-12-05 09:42 CET</strong> · da admin@meepleai · 1.8s · ok</span>
+                <span class="endpoint-note"><code class="danger">POST</code> clearKBCache()</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-vectors.html
+++ b/admin-mockups/design_handoff_admin/admin/sp5-admin-kb-vectors.html
@@ -1,0 +1,795 @@
+<!doctype html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Vector Collections · Knowledge Base · MeepleAI Admin</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+<style>
+/* ═══════════════ tokens.css ═══════════════ */
+:root {
+  --c-game:    25 95% 45%;
+  --c-player:  262 83% 58%;
+  --c-session: 240 60% 55%;
+  --c-agent:   38 92% 50%;
+  --c-kb:      174 60% 40%;
+  --c-chat:    220 80% 55%;
+  --c-event:   350 89% 60%;
+  --c-toolkit: 142 70% 45%;
+  --c-tool:    195 80% 50%;
+
+  --c-success: 142 70% 45%;
+  --c-warning: 38 92% 50%;
+  --c-danger:  350 89% 60%;
+  --c-info:    220 80% 55%;
+
+  --brand: var(--c-game);
+  --brand-fg: hsl(var(--c-game));
+
+  --f-display: 'Quicksand', system-ui, sans-serif;
+  --f-body:    'Nunito', system-ui, sans-serif;
+  --f-mono:    'JetBrains Mono', ui-monospace, monospace;
+
+  --fs-xs: 11px; --fs-sm: 12px; --fs-base: 14px; --fs-md: 15px;
+  --fs-lg: 17px; --fs-xl: 20px; --fs-2xl: 24px; --fs-3xl: 32px; --fs-4xl: 40px;
+
+  --fw-reg: 400; --fw-med: 500; --fw-semi: 600; --fw-bold: 700; --fw-ext: 800;
+  --lh-tight: 1.2; --lh-snug: 1.35; --lh-body: 1.5; --lh-relax: 1.65;
+
+  --s-0: 0; --s-1: 4px; --s-2: 8px; --s-3: 12px; --s-4: 16px; --s-5: 20px;
+  --s-6: 24px; --s-7: 32px; --s-8: 40px; --s-9: 48px; --s-10: 64px;
+
+  --r-xs: 4px; --r-sm: 6px; --r-md: 10px; --r-lg: 14px; --r-xl: 18px; --r-2xl: 24px; --r-pill: 9999px;
+
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+  --ease-in-out: cubic-bezier(.65, 0, .35, 1);
+  --ease-spring: cubic-bezier(.34, 1.56, .64, 1);
+  --dur-xs: 120ms; --dur-sm: 180ms; --dur-md: 280ms; --dur-lg: 400ms; --dur-xl: 600ms;
+
+  --z-base: 0; --z-sticky: 10; --z-nav: 20; --z-overlay: 50; --z-drawer: 51; --z-modal: 60; --z-toast: 70; --z-tooltip: 80;
+}
+:root, :root[data-theme="light"] {
+  --bg: #f7f3ee; --bg-card: #ffffff; --bg-muted: #efe6d9; --bg-sunken: #ede2d0;
+  --bg-hover: rgba(180, 130, 80, 0.06);
+  --text: #2b1f12; --text-sec: #5a4a38; --text-muted: #9a8870;
+  --border: rgba(180, 130, 80, 0.18); --border-light: rgba(180, 130, 80, 0.1); --border-strong: rgba(180, 130, 80, 0.32);
+  --shadow-xs: 0 1px 2px rgba(90, 60, 20, 0.06);
+  --shadow-sm: 0 2px 8px rgba(90, 60, 20, 0.08);
+  --shadow-md: 0 4px 16px rgba(90, 60, 20, 0.1);
+  --shadow-lg: 0 12px 36px rgba(90, 60, 20, 0.14);
+  --glass-bg: rgba(255, 255, 255, 0.88);
+  --glass-border: rgba(255, 255, 255, 0.6);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #14100a; --bg-card: #1e1710; --bg-muted: #241c13; --bg-sunken: #0f0c08;
+  --bg-hover: rgba(255, 200, 130, 0.05);
+  --text: #f0e4d2; --text-sec: #c8b896; --text-muted: #8a7860;
+  --border: rgba(224, 180, 110, 0.14); --border-light: rgba(224, 180, 110, 0.08); --border-strong: rgba(224, 180, 110, 0.28);
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 36px rgba(0, 0, 0, 0.6);
+  --glass-bg: rgba(30, 22, 14, 0.85);
+  --glass-border: rgba(224, 180, 110, 0.14);
+  --c-game: 28 95% 58%; --c-player: 262 75% 70%; --c-session: 235 70% 70%;
+  --c-agent: 38 92% 62%; --c-kb: 174 60% 55%; --c-chat: 218 80% 68%;
+  --c-event: 350 85% 70%; --c-toolkit: 142 60% 58%; --c-tool: 195 75% 62%;
+  color-scheme: dark;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--f-body);
+  background: var(--bg); color: var(--text);
+  font-size: var(--fs-base); line-height: var(--lh-body);
+  -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+}
+h1, h2, h3, h4, h5, h6 { font-family: var(--f-display); font-weight: var(--fw-bold); letter-spacing: -0.01em; margin: 0; line-height: var(--lh-tight); }
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+code, kbd { font-family: var(--f-mono); font-size: 0.9em; }
+
+.e-game    { --e: var(--c-game); }
+.e-player  { --e: var(--c-player); }
+.e-session { --e: var(--c-session); }
+.e-agent   { --e: var(--c-agent); }
+.e-kb      { --e: var(--c-kb); }
+.e-chat    { --e: var(--c-chat); }
+.e-event   { --e: var(--c-event); }
+.e-toolkit { --e: var(--c-toolkit); }
+.e-tool    { --e: var(--c-tool); }
+.e-fg   { color: hsl(var(--e)); }
+.e-bg   { background: hsl(var(--e)); color: #fff; }
+.e-tint { background: hsl(var(--e) / 0.1); color: hsl(var(--e)); }
+.e-ring { box-shadow: 0 0 0 2px hsl(var(--e) / 0.35); }
+
+/* ═══════════════ components.css (estratto) ═══════════════ */
+.e-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px; border-radius: var(--r-sm);
+  background: hsl(var(--e) / 0.12); color: hsl(var(--e));
+  font-size: var(--fs-xs); font-weight: var(--fw-bold);
+  font-family: var(--f-display); text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.e-dot { width: 8px; height: 8px; border-radius: 50%; background: hsl(var(--e)); flex-shrink: 0; display: inline-block; }
+
+/* ═══════════════ admin-base.css ═══════════════ */
+.admin-page { background: var(--bg); color: var(--text); min-height: 100vh; font-family: var(--f-body); font-size: var(--fs-sm); line-height: 1.5; }
+.admin-shell { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+.admin-shell-3col { display: grid; grid-template-columns: 240px 1fr 360px; min-height: 100vh; }
+
+.admin-nav {
+  background: var(--bg-card); border-right: 1px solid var(--border);
+  padding: 16px 0; display: flex; flex-direction: column; gap: 2px;
+  position: sticky; top: 0; height: 100vh; overflow-y: auto;
+}
+.admin-nav-brand { padding: 4px 16px 16px; display: flex; align-items: center; gap: 8px; border-bottom: 1px solid var(--border-light); margin-bottom: 12px; }
+.admin-nav-brand-mark { width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event))); color: #fff; display: grid; place-items: center; font-family: var(--f-display); font-weight: 900; font-size: 14px; }
+.admin-nav-brand-name { font-family: var(--f-display); font-weight: 800; font-size: 14px; }
+.admin-nav-brand-tag { font-family: var(--f-mono); font-size: 9px; font-weight: 700; color: hsl(var(--c-event)); text-transform: uppercase; letter-spacing: .08em; padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-event) / .12); margin-left: auto; }
+.admin-nav-group { padding: 10px 16px 4px; font-family: var(--f-mono); font-size: 9.5px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .08em; }
+.admin-nav-item { display: flex; align-items: center; gap: 10px; padding: 7px 16px; color: var(--text-sec); font-family: var(--f-display); font-size: 13px; font-weight: 600; cursor: pointer; border-left: 2px solid transparent; text-decoration: none; }
+.admin-nav-item:hover { background: var(--bg-muted); color: var(--text); }
+.admin-nav-item.active { background: hsl(var(--c-event) / .08); color: hsl(var(--c-event)); border-left-color: hsl(var(--c-event)); }
+.admin-nav-item .em { font-size: 14px; opacity: .9; }
+.admin-nav-item .count { margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); font-weight: 700; }
+.admin-nav-foot { margin-top: auto; padding: 12px 16px; border-top: 1px solid var(--border-light); font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); display: flex; align-items: center; gap: 8px; }
+.admin-nav-foot .badge { padding: 2px 6px; border-radius: 4px; background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); font-weight: 700; font-size: 9px; text-transform: uppercase; letter-spacing: .05em; }
+
+.admin-top { background: var(--bg); border-bottom: 1px solid var(--border-light); padding: 12px 24px; display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
+.admin-top h1 { font-family: var(--f-display); font-size: 20px; font-weight: 800; margin: 0; line-height: 1.2; }
+.admin-top .crumbs { font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.admin-top .spacer { flex: 1; }
+.admin-top-actions { display: flex; gap: 8px; align-items: center; }
+
+.admin-search { display: flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; width: 280px; font-size: 12px; }
+.admin-search input { flex: 1; border: 0; background: transparent; color: var(--text); font-family: var(--f-body); font-size: 12.5px; outline: 0; }
+.admin-search kbd { padding: 1px 5px; border-radius: 4px; background: var(--bg-muted); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); }
+
+.btn-admin { padding: 6px 12px; border-radius: 6px; font-family: var(--f-display); font-size: 12.5px; font-weight: 700; cursor: pointer; border: 1px solid var(--border); background: var(--bg-card); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.btn-admin:hover { background: var(--bg-muted); }
+.btn-admin.primary { background: hsl(var(--c-event)); border-color: hsl(var(--c-event)); color: #fff; box-shadow: 0 2px 6px hsl(var(--c-event) / .3); }
+.btn-admin.primary:hover { filter: brightness(1.08); }
+.btn-admin.danger { background: var(--bg-card); border-color: hsl(var(--c-event) / .5); color: hsl(var(--c-event)); }
+.btn-admin.success { background: hsl(var(--c-toolkit)); border-color: hsl(var(--c-toolkit)); color: #fff; }
+.btn-admin.ghost { background: transparent; border-color: transparent; }
+.btn-admin.icon { padding: 6px; width: 28px; height: 28px; justify-content: center; }
+.btn-admin.sm { padding: 3px 8px; font-size: 11px; }
+.btn-admin kbd { padding: 1px 4px; border-radius: 3px; background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.2); font-family: var(--f-mono); font-size: 9px; margin-left: 4px; }
+.btn-admin.primary kbd { background: rgba(0,0,0,.18); border-color: rgba(0,0,0,.25); }
+
+.admin-kpi { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; padding: 14px 16px; display: flex; flex-direction: column; gap: 4px; min-height: 88px; position: relative; }
+.admin-kpi-label { font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.admin-kpi-value { font-family: var(--f-display); font-size: 28px; font-weight: 800; color: var(--text); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.admin-kpi-value .u { font-size: 13px; color: var(--text-muted); font-weight: 700; margin-left: 2px; }
+.admin-kpi-trend { font-family: var(--f-mono); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; gap: 3px; }
+.admin-kpi-trend.up   { color: hsl(var(--c-toolkit)); }
+.admin-kpi-trend.down { color: hsl(var(--c-event)); }
+.admin-kpi-trend.flat { color: var(--text-muted); }
+.admin-kpi-spark { position: absolute; right: 12px; top: 12px; width: 70px; height: 28px; opacity: .85; }
+.admin-kpi-icon  { position: absolute; right: 14px; bottom: 12px; font-size: 22px; opacity: .35; }
+.admin-kpi.e-game    { border-left: 3px solid hsl(var(--c-game)); }
+.admin-kpi.e-player  { border-left: 3px solid hsl(var(--c-player)); }
+.admin-kpi.e-session { border-left: 3px solid hsl(var(--c-session)); }
+.admin-kpi.e-agent   { border-left: 3px solid hsl(var(--c-agent)); }
+.admin-kpi.e-kb      { border-left: 3px solid hsl(var(--c-kb)); }
+.admin-kpi.e-chat    { border-left: 3px solid hsl(var(--c-chat)); }
+.admin-kpi.e-event   { border-left: 3px solid hsl(var(--c-event)); }
+.admin-kpi.e-toolkit { border-left: 3px solid hsl(var(--c-toolkit)); }
+
+.admin-panel { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: 10px; overflow: hidden; }
+.admin-panel-head { padding: 10px 14px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 10px; background: var(--bg); }
+.admin-panel-head h3 { margin: 0; font-family: var(--f-display); font-size: 13px; font-weight: 800; }
+.admin-panel-head .meta { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); margin-left: auto; }
+.admin-panel-body { padding: 14px; }
+
+.admin-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.admin-table th { text-align: left; padding: 8px 12px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; border-bottom: 1px solid var(--border-light); background: var(--bg); position: sticky; top: 0; white-space: nowrap; }
+.admin-table td { padding: 8px 12px; border-bottom: 1px solid var(--border-light); vertical-align: middle; }
+.admin-table tr:hover td { background: var(--bg-muted); }
+
+.status-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+.status-chip::before { content: ''; width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status-chip.healthy { background: hsl(var(--c-toolkit) / .12); color: hsl(var(--c-toolkit)); }
+.status-chip.healthy::before { background: hsl(var(--c-toolkit)); box-shadow: 0 0 0 3px hsl(var(--c-toolkit) / .25); }
+.status-chip.warning { background: hsl(38 90% 56% / .14); color: hsl(38 90% 50%); }
+.status-chip.warning::before { background: hsl(38 90% 50%); }
+.status-chip.danger  { background: hsl(var(--c-event) / .12); color: hsl(var(--c-event)); }
+.status-chip.danger::before { background: hsl(var(--c-event)); }
+.status-chip.muted   { background: var(--bg-muted); color: var(--text-muted); }
+.status-chip.muted::before { background: var(--text-muted); }
+.status-chip.info    { background: hsl(var(--c-chat) / .12); color: hsl(var(--c-chat)); }
+.status-chip.info::before { background: hsl(var(--c-chat)); }
+.status-chip.running::before { animation: admin-pulse 1.4s ease-in-out infinite; }
+@keyframes admin-pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.5); opacity: .5; } }
+
+.role-chip { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 999px; font-family: var(--f-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+
+.spark { stroke: currentColor; stroke-width: 1.5; fill: none; }
+.spark-fill { fill: currentColor; opacity: .14; }
+
+.admin-input, .admin-select, .admin-textarea { width: 100%; max-width: 360px; padding: 6px 10px; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px; font-family: var(--f-body); font-size: 12.5px; }
+.admin-input.mono { font-family: var(--f-mono); }
+.admin-select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, var(--text-sec) 50%), linear-gradient(135deg, var(--text-sec) 50%, transparent 50%); background-position: calc(100% - 14px) 50%, calc(100% - 9px) 50%; background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 26px; cursor: pointer; }
+
+.admin-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
+.admin-tab { padding: 8px 14px; background: transparent; border: 0; font-family: var(--f-display); font-size: 13px; font-weight: 700; color: var(--text-sec); cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+.admin-tab .count { padding: 1px 6px; border-radius: 999px; background: var(--bg-muted); color: var(--text-muted); font-family: var(--f-mono); font-size: 10px; font-weight: 700; }
+.admin-tab:hover { color: var(--text); }
+.admin-tab.active { color: hsl(var(--c-event)); border-bottom-color: hsl(var(--c-event)); }
+.admin-tab.active .count { background: hsl(var(--c-event) / .14); color: hsl(var(--c-event)); }
+
+.alert-banner { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border-radius: 8px; font-size: 12.5px; }
+.alert-banner.info { background: hsl(var(--c-chat) / .08); border: 1px solid hsl(var(--c-chat) / .3); color: var(--text); }
+.alert-banner .em { font-size: 18px; flex-shrink: 0; }
+.alert-banner .title { font-family: var(--f-display); font-weight: 800; margin-bottom: 2px; font-size: 13px; }
+
+@media (max-width: 880px) {
+  .admin-mobile-fallback { display: flex !important; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 32px; text-align: center; gap: 16px; }
+  .admin-mobile-fallback .em { font-size: 56px; }
+  .admin-mobile-fallback h2 { margin: 0; font-family: var(--f-display); font-size: 20px; }
+  .admin-mobile-fallback p { color: var(--text-sec); max-width: 320px; margin: 0; line-height: 1.5; }
+  .admin-shell, .admin-shell-3col { display: none; }
+}
+.admin-mobile-fallback { display: none; }
+
+.admin-body { padding: 20px 24px; }
+.admin-body-grid { display: grid; gap: 16px; }
+
+/* ═══════════════ custom da sp5-admin-kb.html (chunk + filter chip + log) ═══════════════ */
+.chunk-table-row { display: grid; grid-template-columns: 90px 1fr 60px 70px 30px; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--border-light); font-size: 11.5px; align-items: center; }
+.chunk-table-row code { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+.chunk-table-row .preview { color: var(--text-sec); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chunk-table-row .score { text-align: right; font-family: var(--f-mono); font-weight: 700; }
+.chunk-table-row .score.hi { color: hsl(var(--c-kb)); }
+.chunk-table-row .score.md { color: hsl(38 90% 50%); }
+.chunk-table-row .score.lo { color: var(--text-muted); }
+
+.filter-chip { display: inline-flex; align-items: center; gap: 4px; padding: 3px 9px; border-radius: 999px; background: var(--bg-card); border: 1px solid var(--border); font-family: var(--f-mono); font-size: 10px; font-weight: 700; color: var(--text-sec); cursor: pointer; }
+.filter-chip.active { background: hsl(var(--c-kb) / .14); border-color: hsl(var(--c-kb) / .4); color: hsl(var(--c-kb)); }
+.filter-chip .x { opacity: .6; font-size: 8px; }
+
+/* ═══════════════ page-local: Vector Collections ═══════════════ */
+.kpi-strip { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 16px; }
+
+.search-row { display: grid; grid-template-columns: 1fr 200px 150px auto; gap: 8px; align-items: center; }
+.search-row .admin-search { width: 100%; max-width: none; }
+.search-row .admin-select { max-width: none; }
+
+.result-row {
+  display: grid;
+  grid-template-columns: 110px 110px 1fr 70px 28px;
+  gap: 12px; padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+  font-size: 11.5px; align-items: center;
+  cursor: pointer;
+}
+.result-row:last-child { border-bottom: 0; }
+.result-row:hover { background: var(--bg-muted); }
+.result-row.expanded { background: hsl(var(--c-kb) / .04); }
+.result-row .doc-id { font-family: var(--f-mono); font-size: 10.5px; color: hsl(var(--c-kb)); font-weight: 700; display: inline-flex; align-items: center; gap: 6px; }
+.result-row .doc-id .e-dot { width: 6px; height: 6px; background: hsl(var(--c-game)); }
+.result-row .loc { font-family: var(--f-mono); font-size: 10px; color: var(--text-muted); }
+.result-row .snippet { color: var(--text-sec); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.result-row .snippet mark { background: hsl(var(--c-kb) / .22); color: var(--text); padding: 0 2px; border-radius: 3px; }
+.result-row .score { text-align: right; font-family: var(--f-mono); font-weight: 700; font-size: 12px; }
+.result-row .score.hi { color: hsl(var(--c-kb)); }
+.result-row .score.md { color: hsl(38 90% 50%); }
+.result-row .score.lo { color: var(--text-muted); }
+.result-row .caret { color: var(--text-muted); font-family: var(--f-mono); font-size: 12px; transition: transform .15s var(--ease-out); }
+.result-row.expanded .caret { transform: rotate(90deg); color: hsl(var(--c-kb)); }
+
+.result-expanded {
+  padding: 12px 14px 14px 14px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border-light);
+  display: grid; grid-template-columns: 1fr 280px; gap: 16px;
+}
+.result-expanded .snippet-full {
+  font-family: var(--f-body);
+  font-size: 12.5px; line-height: 1.6;
+  color: var(--text-sec);
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: 6px; padding: 10px 12px;
+}
+.result-expanded .snippet-full mark { background: hsl(var(--c-kb) / .22); color: var(--text); padding: 0 2px; border-radius: 3px; }
+.result-expanded .meta-table { display: flex; flex-direction: column; gap: 4px; }
+.result-expanded .meta-table .row { display: flex; gap: 8px; font-family: var(--f-mono); font-size: 10.5px; align-items: center; }
+.result-expanded .meta-table .row .k { color: var(--text-muted); min-width: 90px; text-transform: uppercase; letter-spacing: .04em; font-size: 9.5px; font-weight: 700; }
+.result-expanded .meta-table .row .v { color: var(--text-sec); }
+.result-expanded .meta-table .row .v.mono-strong { color: var(--text); font-weight: 700; }
+.result-expanded .actions { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+.result-expanded .vec-thumb {
+  height: 28px; border-radius: 4px; margin-top: 6px;
+  background: linear-gradient(90deg, hsl(var(--c-kb) / .35), hsl(var(--c-kb) / .05), hsl(var(--c-kb) / .25), hsl(var(--c-event) / .25), hsl(var(--c-kb) / .15));
+  position: relative; overflow: hidden;
+}
+.result-expanded .vec-thumb::after {
+  content: '768d · float32'; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
+  font-family: var(--f-mono); font-size: 9px; color: var(--text); opacity: .75; font-weight: 700;
+}
+
+.result-table-head {
+  display: grid;
+  grid-template-columns: 110px 110px 1fr 70px 28px;
+  gap: 12px; padding: 8px 14px;
+  font-family: var(--f-mono); font-size: 9.5px; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .06em; font-weight: 700;
+  border-bottom: 1px solid var(--border-light); background: var(--bg);
+}
+
+.game-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.game-card {
+  background: var(--bg); border: 1px solid var(--border-light);
+  border-radius: 8px; padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+  border-left: 3px solid hsl(var(--e, var(--c-game)));
+  position: relative;
+}
+.game-card .head { display: flex; align-items: center; gap: 8px; }
+.game-card .head .em { font-size: 18px; }
+.game-card .head .name { font-family: var(--f-display); font-weight: 800; font-size: 13.5px; flex: 1; }
+.game-card .head .status-chip { font-size: 9px; }
+.game-card .body { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+.game-card .body .cell { display: flex; flex-direction: column; gap: 2px; }
+.game-card .body .cell .k { font-family: var(--f-mono); font-size: 9px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 700; }
+.game-card .body .cell .v { font-family: var(--f-display); font-size: 16px; font-weight: 800; color: var(--text); font-variant-numeric: tabular-nums; line-height: 1.1; }
+.game-card .body .cell .v .u { font-size: 10px; color: var(--text-muted); font-weight: 700; margin-left: 1px; }
+.game-card .foot {
+  display: flex; align-items: center; justify-content: space-between;
+  border-top: 1px solid var(--border-light); padding-top: 6px;
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+}
+.game-card .foot a { color: hsl(var(--c-kb)); font-weight: 700; }
+.game-card .foot a:hover { text-decoration: underline; }
+
+.endpoint-note {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);
+  background: var(--bg-sunken); border: 1px dashed var(--border);
+  padding: 2px 8px; border-radius: 4px;
+}
+.endpoint-note code { color: hsl(var(--c-kb)); font-weight: 700; }
+</style>
+</head>
+<body class="admin-page">
+
+<div class="admin-mobile-fallback">
+  <div class="em">🖥️</div>
+  <h2>Console solo desktop</h2>
+  <p>La console admin è ottimizzata per schermi ≥ 880px.</p>
+</div>
+
+<div class="admin-shell">
+
+  <!-- ── Sidebar nav (renderAdminNav('kb')) ─────────────────── -->
+  <nav class="admin-nav" data-admin-nav-mount>
+    <div class="admin-nav-brand">
+      <div class="admin-nav-brand-mark">M</div>
+      <div class="admin-nav-brand-name">MeepleAI</div>
+      <div class="admin-nav-brand-tag">Admin</div>
+    </div>
+
+    <div class="admin-nav-group">Overview</div>
+    <a href="/admin" class="admin-nav-item"><span class="em">⌂</span> Dashboard</a>
+    <a href="/admin/activity" class="admin-nav-item"><span class="em">⚡</span> Activity <span class="count">128</span></a>
+
+    <div class="admin-nav-group">Catalog</div>
+    <a href="/admin/games" class="admin-nav-item"><span class="em">🎲</span> Games <span class="count">48</span></a>
+    <a href="/admin/players" class="admin-nav-item"><span class="em">👥</span> Players <span class="count">3.2k</span></a>
+    <a href="/admin/sessions" class="admin-nav-item"><span class="em">🃏</span> Sessions <span class="count">912</span></a>
+
+    <div class="admin-nav-group">AI Stack</div>
+    <a href="/admin/agents" class="admin-nav-item"><span class="em">🤖</span> Agents <span class="count">14</span></a>
+    <a href="/admin/knowledge-base" class="admin-nav-item active"><span class="em">📚</span> Knowledge Base <span class="count">247</span></a>
+    <a href="/admin/chats" class="admin-nav-item"><span class="em">💬</span> Chats <span class="count">2.8k</span></a>
+    <a href="/admin/toolkits" class="admin-nav-item"><span class="em">🧰</span> Toolkits <span class="count">9</span></a>
+    <a href="/admin/tools" class="admin-nav-item"><span class="em">🔧</span> Tools <span class="count">41</span></a>
+
+    <div class="admin-nav-group">Observe</div>
+    <a href="/admin/events" class="admin-nav-item"><span class="em">📡</span> Events</a>
+    <a href="/admin/audit" class="admin-nav-item"><span class="em">🛡</span> Audit log</a>
+    <a href="/admin/settings" class="admin-nav-item"><span class="em">⚙</span> Settings</a>
+
+    <div class="admin-nav-foot">
+      <span>v2024.12.04</span>
+      <span class="badge">prod</span>
+    </div>
+  </nav>
+
+  <main>
+    <!-- ── Banda di sezione (uguale per tutte le tool-page KB) ── -->
+    <header class="admin-top">
+      <div>
+        <h1>Knowledge Base</h1>
+        <div class="crumbs">Admin · KB · Vector Collections · 9 indici · pgvector 0.7.4 · 18.487 vectors</div>
+      </div>
+      <div class="spacer"></div>
+      <div class="admin-top-actions">
+        <div class="admin-search"><span>🔍</span><input placeholder="Search docs, chunks, games…"/><kbd>⌘K</kbd></div>
+        <a href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</a>
+      </div>
+    </header>
+
+    <div class="admin-body" data-screen-label="kb-vector-collections">
+
+      <!-- ── Sub-nav KB (8 tab) ─────────────────────────────── -->
+      <div class="admin-tabs" role="tablist" aria-label="Knowledge Base sezioni">
+        <a href="/admin/knowledge-base"            class="admin-tab" role="tab">Explorer</a>
+        <a href="/admin/knowledge-base/vectors"    class="admin-tab active" role="tab" aria-selected="true">Vector Collections</a>
+        <a href="/admin/knowledge-base/queue"      class="admin-tab" role="tab">Processing Queue <span class="count">3</span></a>
+        <a href="/admin/knowledge-base/pipeline"   class="admin-tab" role="tab">RAG Pipeline</a>
+        <a href="/admin/knowledge-base/embedding"  class="admin-tab" role="tab">Embedding</a>
+        <a href="/admin/knowledge-base/feedback"   class="admin-tab" role="tab">Feedback <span class="count">12</span></a>
+        <a href="/admin/knowledge-base/settings"   class="admin-tab" role="tab">Settings</a>
+        <a href="/admin/knowledge-base/snapshots"  class="admin-tab" role="tab">Snapshots</a>
+      </div>
+
+      <!-- ── 1. KPI strip ──────────────────────────────────── -->
+      <div class="kpi-strip">
+
+        <div class="admin-kpi e-kb">
+          <div class="admin-kpi-label">Total Vectors</div>
+          <div class="admin-kpi-value">18.487</div>
+          <div class="admin-kpi-trend up">▲ +412 last 24h</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-kb))">
+            <path class="spark-fill" d="M0,22 L6,21 L12,19 L18,20 L24,17 L30,15 L36,14 L42,11 L48,12 L54,9 L60,7 L66,5 L70,4 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,22 L6,21 L12,19 L18,20 L24,17 L30,15 L36,14 L42,11 L48,12 L54,9 L60,7 L66,5 L70,4"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi e-game">
+          <div class="admin-kpi-label">Games Indexed</div>
+          <div class="admin-kpi-value">8<span class="u">/ 48</span></div>
+          <div class="admin-kpi-trend up">▲ +1 questa settimana</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-game))">
+            <path class="spark-fill" d="M0,24 L10,24 L10,22 L20,22 L20,20 L30,20 L30,18 L40,18 L40,15 L50,15 L50,12 L60,12 L60,8 L70,8 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,24 L10,24 L10,22 L20,22 L20,20 L30,20 L30,18 L40,18 L40,15 L50,15 L50,12 L60,12 L60,8 L70,8"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi" style="border-left: 3px solid hsl(var(--c-chat))">
+          <div class="admin-kpi-label">Dimensions</div>
+          <div class="admin-kpi-value">768<span class="u">d</span></div>
+          <div class="admin-kpi-trend flat">≡ bge-base-en-v1.5</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-chat)); opacity: .5">
+            <path class="spark" d="M0,14 L8,14 L8,10 L14,10 L14,18 L22,18 L22,8 L28,8 L28,16 L36,16 L36,11 L44,11 L44,14 L52,14 L52,9 L60,9 L60,14 L70,14"/>
+          </svg>
+        </div>
+
+        <div class="admin-kpi e-toolkit">
+          <div class="admin-kpi-label">Avg Health</div>
+          <div class="admin-kpi-value">98.4<span class="u">%</span></div>
+          <div class="admin-kpi-trend up">▲ +0.6% vs. ieri</div>
+          <svg class="admin-kpi-spark" viewBox="0 0 70 28" preserveAspectRatio="none" style="color: hsl(var(--c-toolkit))">
+            <path class="spark-fill" d="M0,8 L6,10 L12,7 L18,12 L24,9 L30,11 L36,6 L42,8 L48,5 L54,7 L60,4 L66,6 L70,3 L70,28 L0,28 Z"/>
+            <path class="spark" d="M0,8 L6,10 L12,7 L18,12 L24,9 L30,11 L36,6 L42,8 L48,5 L54,7 L60,4 L66,6 L70,3"/>
+          </svg>
+        </div>
+
+      </div>
+
+      <!-- ── 2. Panel: Ricerca semantica ─────────────────────── -->
+      <section class="admin-panel" style="margin-bottom: 16px">
+        <div class="admin-panel-head">
+          <h3>🔬 Ricerca semantica</h3>
+          <span class="status-chip info">cosine · top-k</span>
+          <span class="endpoint-note"><code>POST</code> searchVectors(query, limit, gameId?)</span>
+          <span class="meta">Last query · 132ms · 8 results</span>
+          <button class="btn-admin sm" style="margin-left: 8px">⟳ Refresh</button>
+        </div>
+        <div class="admin-panel-body">
+
+          <div class="search-row">
+            <div class="admin-search">
+              <span>🔍</span>
+              <input placeholder="Cerca nei chunk… (es. «come si attiva un predatore in Wingspan»)" value="attivazione predatori in espansione Oceania"/>
+            </div>
+            <select class="admin-select" aria-label="Filtra per gioco">
+              <option>Tutti i giochi</option>
+              <option selected>🎲 Wingspan</option>
+              <option>🎲 Brass: Birmingham</option>
+              <option>🎲 Tainted Grail</option>
+              <option>🎲 Spirit Island</option>
+              <option>🎲 Ark Nova</option>
+              <option>🎲 ISS Vanguard</option>
+              <option>🎲 Gloomhaven</option>
+              <option>🎲 Lancaster</option>
+            </select>
+            <select class="admin-select" aria-label="Limit">
+              <option>limit 5</option>
+              <option selected>limit 10</option>
+              <option>limit 20</option>
+              <option>limit 50</option>
+            </select>
+            <button class="btn-admin primary">⌕ Cerca <kbd>↵</kbd></button>
+          </div>
+
+          <!-- ── 3. Risultati ──────────────────────────────── -->
+          <div style="margin-top: 14px; border: 1px solid var(--border-light); border-radius: 8px; overflow: hidden">
+
+            <div class="result-table-head">
+              <div>Doc ID</div>
+              <div>Page · Chunk</div>
+              <div>Snippet</div>
+              <div style="text-align: right">Score ↓</div>
+              <div></div>
+            </div>
+
+            <!-- result 1 — expanded -->
+            <div class="result-row expanded">
+              <div class="doc-id"><span class="e-dot"></span>a3f7c218</div>
+              <div class="loc">p.22 · ch[#218]</div>
+              <div class="snippet">"Quando più uccelli con keyword <mark>predator</mark> sono attivati nello stesso turno, l'<mark>attivazione</mark> segue l'ordine di piazzamento da sinistra a destra…"</div>
+              <div class="score hi">0.912</div>
+              <div class="caret">›</div>
+            </div>
+            <div class="result-expanded">
+              <div>
+                <div class="snippet-full">
+                  «Quando più uccelli con keyword <mark>predator</mark> sono attivati nello stesso turno, l'<mark>attivazione</mark> segue l'ordine di piazzamento da sinistra a destra nell'habitat foresta. Se l'effetto richiede un dado e il risultato non è soddisfatto, il <mark>predatore</mark> non riceve cibo ma il giocatore può comunque deporre un uovo sulla carta. In <mark>espansione Oceania</mark> alcuni uccelli sostituiscono l'<mark>attivazione</mark> a fine round con un trigger immediato.»
+                </div>
+                <div class="vec-thumb"></div>
+              </div>
+              <div class="meta-table">
+                <div class="row"><span class="k">document</span><span class="v mono-strong">Wingspan-Oceania-EN.pdf</span></div>
+                <div class="row"><span class="k">doc id</span><span class="v">a3f7c218-4d11-4b9e</span></div>
+                <div class="row"><span class="k">game</span><span class="v" style="color: hsl(var(--c-game))">🎲 Wingspan</span></div>
+                <div class="row"><span class="k">collection</span><span class="v">wingspan-v3</span></div>
+                <div class="row"><span class="k">embedding</span><span class="v">bge-base-en-v1.5 · 768d</span></div>
+                <div class="row"><span class="k">tokens</span><span class="v">387 / 512</span></div>
+                <div class="row"><span class="k">distance</span><span class="v">0.088 (cosine)</span></div>
+                <div class="actions">
+                  <button class="btn-admin sm">📋 Copy chunk</button>
+                  <button class="btn-admin sm">🔗 Apri doc</button>
+                  <button class="btn-admin sm">🤖 Test in agent</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- result 2 -->
+            <div class="result-row">
+              <div class="doc-id"><span class="e-dot"></span>a3f7c218</div>
+              <div class="loc">p.14 · ch[#142]</div>
+              <div class="snippet">"Power di tipo <mark>predator</mark> si attiva su trigger 'when activated'. In <mark>espansione Oceania</mark>, l'ordine di risoluzione è importante per i power…"</div>
+              <div class="score hi">0.847</div>
+              <div class="caret">›</div>
+            </div>
+
+            <!-- result 3 -->
+            <div class="result-row">
+              <div class="doc-id"><span class="e-dot"></span>a3f7c218</div>
+              <div class="loc">p.31 · ch[#312]</div>
+              <div class="snippet">"Tabella riepilogativa dei power per habitat: foresta (<mark>predator activation</mark>), prateria (egg lay), zona umida (food cache)…"</div>
+              <div class="score hi">0.781</div>
+              <div class="caret">›</div>
+            </div>
+
+            <!-- result 4 -->
+            <div class="result-row">
+              <div class="doc-id"><span class="e-dot"></span>b81e09f2</div>
+              <div class="loc">p.9 · ch[#086]</div>
+              <div class="snippet">"Carte uccello con keyword <mark>predator</mark> hanno priorità sull'<mark>attivazione</mark> fine round se viene innescato il trigger group simultaneo…"</div>
+              <div class="score md">0.694</div>
+              <div class="caret">›</div>
+            </div>
+
+            <!-- result 5 -->
+            <div class="result-row">
+              <div class="doc-id"><span class="e-dot"></span>4c2a18d7</div>
+              <div class="loc">p.40 · ch[#398]</div>
+              <div class="snippet">"FAQ: caso simultaneo di esaurimento cibo durante <mark>attivazione</mark> <mark>predatori</mark> (non trattato nella prima stampa, vedi errata 2024)…"</div>
+              <div class="score md">0.612</div>
+              <div class="caret">›</div>
+            </div>
+
+          </div>
+
+          <div style="margin-top: 10px; display: flex; align-items: center; gap: 10px; font-family: var(--f-mono); font-size: 10.5px; color: var(--text-muted)">
+            <span>5 / 8 risultati · embedded in 18ms · search 114ms · rerank off</span>
+            <span style="margin-left: auto">
+              <button class="btn-admin sm">Carica altri 3 ▾</button>
+              <button class="btn-admin sm">⤓ Export JSON</button>
+            </span>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ── 4. Panel: Vettori per gioco ─────────────────────── -->
+      <section class="admin-panel">
+        <div class="admin-panel-head">
+          <h3>📦 Vettori per gioco</h3>
+          <span class="status-chip healthy">pgvector 0.7.4 · online</span>
+          <span class="endpoint-note"><code>GET</code> getVectorStats()</span>
+          <span class="meta">Ordinati per # vettori · agg. 14:38:02 CET</span>
+        </div>
+        <div class="admin-panel-body">
+
+          <div class="game-grid">
+
+            <!-- Tainted Grail -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Tainted Grail</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">6.443</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">14</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">187<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Gloomhaven -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Gloomhaven</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">4.218</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">31</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">124<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- ISS Vanguard -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">ISS Vanguard</span>
+                <span class="status-chip warning">re-embed pendente</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">3.124</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">22</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">92<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Wingspan -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Wingspan</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">1.892</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">12</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">54<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Ark Nova -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Ark Nova</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">1.247</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">11</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">38<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Brass: Birmingham -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Brass: Birmingham</span>
+                <span class="status-chip danger">1 doc failed</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">876</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">8</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">24<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Spirit Island -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Spirit Island</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">521</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">9</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">15<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- Lancaster -->
+            <div class="game-card e-game">
+              <div class="head">
+                <span class="em">🎲</span>
+                <span class="name">Lancaster</span>
+                <span class="status-chip healthy">healthy</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">166</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">5</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">4.8<span class="u">MB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>768d · cos · HNSW m=16</span>
+                <a href="#">Apri →</a>
+              </div>
+            </div>
+
+            <!-- aggregate / unassigned -->
+            <div class="game-card" style="--e: var(--c-event); opacity: .85">
+              <div class="head">
+                <span class="em">🗂</span>
+                <span class="name">Unassigned / orphan</span>
+                <span class="status-chip warning">cleanup</span>
+              </div>
+              <div class="body">
+                <div class="cell"><span class="k">Vectors</span><span class="v">0</span></div>
+                <div class="cell"><span class="k">Docs</span><span class="v">2</span></div>
+                <div class="cell"><span class="k">Size</span><span class="v">12<span class="u">KB</span></span></div>
+              </div>
+              <div class="foot">
+                <span>Da re-assegnare</span>
+                <a href="#">Risolvi →</a>
+              </div>
+            </div>
+
+          </div>
+
+        </div>
+      </section>
+
+    </div>
+  </main>
+</div>
+
+<script>
+  /* admin-nav.js — nel repo è un file separato (src="admin-nav.js").
+     Qui inlined per mockup standalone: la sidebar è già scritta inline,
+     quindi questa funzione è no-op. */
+  window.renderAdminNav = function (activeId) { return activeId; };
+  renderAdminNav('kb');
+</script>
+</body>
+</html>

--- a/apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx
+++ b/apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx
@@ -95,13 +95,10 @@ describe('VectorCollectionsPage', () => {
     mockGetVectorStats.mockResolvedValue(MOCK_VECTOR_STATS);
   });
 
-  it('should render page header', async () => {
+  it('should render Semantic Search panel', () => {
     renderWithQuery(<VectorStorePage />);
 
-    expect(screen.getByText('Vector Store')).toBeInTheDocument();
-    expect(
-      screen.getByText('pgvector knowledge base — embeddings health and semantic search')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Semantic Search')).toBeInTheDocument();
   });
 
   it('should render stats cards with calculated values', async () => {

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx
@@ -6,7 +6,6 @@
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 // ── Mock Next.js Link ─────────────────────────────────────────────────────────
@@ -186,71 +185,6 @@ vi.mock('@tanstack/react-query', async importOriginal => {
       invalidateQueries: vi.fn(),
     })),
   };
-});
-
-// ── Hub page tests ────────────────────────────────────────────────────────────
-
-function renderWithQueryClient(ui: React.ReactElement) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
-}
-
-// TODO(F3-FU-3): rewrite for Explorer; pre-existing test for hub-cards landing is obsolete after F3.1 rebuild
-describe('KnowledgeBasePage — Hub Gap Fixes', () => {
-  it.skip('renders Embedding Service card with correct link', async () => {
-    const { default: KnowledgeBasePage } = await import('../page');
-    renderWithQueryClient(<KnowledgeBasePage />);
-
-    const embeddingLink = screen.getByRole('link', { name: /embedding service/i });
-    expect(embeddingLink).toBeDefined();
-    expect(embeddingLink.getAttribute('href')).toBe('/admin/knowledge-base/embedding');
-  });
-
-  it.skip('renders Usage & Costs quick link', async () => {
-    const { default: KnowledgeBasePage } = await import('../page');
-    renderWithQueryClient(<KnowledgeBasePage />);
-
-    const usageLink = screen.getByRole('link', { name: /usage.*costs/i });
-    expect(usageLink).toBeDefined();
-    expect(usageLink.getAttribute('href')).toBe('/admin/agents/usage');
-  });
-
-  it.skip('renders all 7 section cards (original 6 + Embedding)', async () => {
-    const { default: KnowledgeBasePage } = await import('../page');
-    renderWithQueryClient(<KnowledgeBasePage />);
-
-    const expectedSections = [
-      'Documents',
-      'Vector Collections',
-      'Processing Queue',
-      'Upload & Process',
-      'RAG Pipeline',
-      'Settings',
-      'Embedding Service',
-    ];
-
-    for (const section of expectedSections) {
-      expect(screen.getByText(section)).toBeDefined();
-    }
-  });
-
-  it.skip('renders 5 quick links including the new Usage & Costs', async () => {
-    const { default: KnowledgeBasePage } = await import('../page');
-    renderWithQueryClient(<KnowledgeBasePage />);
-
-    const expectedLinks = [
-      { text: /rag executions log/i, href: '/admin/agents/analytics' },
-      { text: /ai models/i, href: '/admin/agents/models' },
-      { text: /strategy config/i, href: '/admin/agents/strategy' },
-      { text: /kb settings/i, href: '/admin/knowledge-base/settings' },
-      { text: /usage.*costs/i, href: '/admin/agents/usage' },
-    ];
-
-    for (const { text, href } of expectedLinks) {
-      const link = screen.getByRole('link', { name: text });
-      expect(link.getAttribute('href')).toBe(href);
-    }
-  });
 });
 
 // ── Vector Search Panel tests ─────────────────────────────────────────────────

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
@@ -24,7 +24,12 @@ import { HttpClient } from '@/lib/api/core/httpClient';
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
 
-function StatCard({ label, value, icon: Icon, color }: {
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+}: {
   label: string;
   value: string | number;
   icon: React.ElementType;
@@ -105,16 +110,8 @@ export default function EmbeddingServicePage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-4">
-        <div>
-          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-            Embedding Service
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Monitor the multilingual embedding model and throughput
-          </p>
-        </div>
+      {/* Page toolbar */}
+      <div className="flex justify-end">
         <Button
           variant="outline"
           size="sm"
@@ -142,26 +139,34 @@ export default function EmbeddingServicePage() {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Model</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Model
+              </div>
               <div className="text-sm font-medium text-foreground dark:text-zinc-100">
                 {info?.model ?? '\u2014'}
               </div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Device</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Device
+              </div>
               <div className="text-sm font-medium text-foreground dark:text-zinc-100 flex items-center gap-1.5">
                 <CpuIcon className="h-3.5 w-3.5" />
                 {info?.device?.toUpperCase() ?? '\u2014'}
               </div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Dimensions</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Dimensions
+              </div>
               <div className="text-sm font-medium text-foreground dark:text-zinc-100">
                 {info?.dimension ?? '\u2014'}
               </div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Languages</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Languages
+              </div>
               <div className="text-sm font-medium text-foreground dark:text-zinc-100 flex items-center gap-1.5">
                 <GlobeIcon className="h-3.5 w-3.5" />
                 {info?.supportedLanguages?.join(', ').toUpperCase() ?? '\u2014'}
@@ -171,19 +176,25 @@ export default function EmbeddingServicePage() {
 
           <div className="mt-4 pt-4 border-t border-border/50 dark:border-zinc-700/50 grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Max Input</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Max Input
+              </div>
               <div className="text-sm text-foreground dark:text-zinc-300">
                 {info?.maxInputChars ? `${info.maxInputChars.toLocaleString()} chars` : '\u2014'}
               </div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Max Batch</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Max Batch
+              </div>
               <div className="text-sm text-foreground dark:text-zinc-300">
                 {info?.maxBatchSize ? `${info.maxBatchSize} texts` : '\u2014'}
               </div>
             </div>
             <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">Auto-refresh</div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+                Auto-refresh
+              </div>
               <div className="text-sm text-foreground dark:text-zinc-300">Every 30s</div>
             </div>
           </div>
@@ -220,7 +231,9 @@ export default function EmbeddingServicePage() {
               label="Failure Rate"
               value={`${metrics?.failureRate ?? 0}%`}
               icon={AlertCircleIcon}
-              color={metrics?.failureRate && metrics.failureRate > 5 ? 'text-red-500' : 'text-green-500'}
+              color={
+                metrics?.failureRate && metrics.failureRate > 5 ? 'text-red-500' : 'text-green-500'
+              }
             />
             <StatCard
               label="Avg Duration"

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
@@ -24,36 +23,14 @@ import { HttpClient } from '@/lib/api/core/httpClient';
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
 
-function StatCard({
-  label,
-  value,
-  icon: Icon,
-  color,
-}: {
-  label: string;
-  value: string | number;
-  icon: React.ElementType;
-  color?: string;
-}) {
-  return (
-    <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-lg p-4 border border-border dark:border-zinc-700/40">
-      <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground mb-1">
-        <Icon className={`h-4 w-4 ${color ?? ''}`} />
-        {label}
-      </div>
-      <div className="text-2xl font-bold text-foreground dark:text-zinc-100">{value}</div>
-    </div>
-  );
-}
-
 function StatusBadge({ status }: { status: string }) {
   const isHealthy = status === 'healthy' || status === 'ok';
   const isUnavailable = status === 'unavailable' || status === 'unhealthy';
 
   if (isHealthy) {
     return (
-      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
-        <CheckCircleIcon className="h-3.5 w-3.5" />
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wide bg-entity-toolkit/12 text-entity-toolkit">
+        <CheckCircleIcon className="h-3 w-3" />
         Healthy
       </span>
     );
@@ -61,18 +38,28 @@ function StatusBadge({ status }: { status: string }) {
 
   if (isUnavailable) {
     return (
-      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">
-        <XCircleIcon className="h-3.5 w-3.5" />
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wide bg-entity-event/12 text-entity-event">
+        <XCircleIcon className="h-3 w-3" />
         Unavailable
       </span>
     );
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-      <AlertCircleIcon className="h-3.5 w-3.5" />
+    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase tracking-wide bg-amber-500/14 text-amber-600">
+      <AlertCircleIcon className="h-3 w-3" />
       {status}
     </span>
+  );
+}
+
+function KpiSkeleton() {
+  return (
+    <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb animate-pulse min-h-[88px]">
+      <div className="h-2.5 w-24 bg-muted rounded" />
+      <div className="h-7 w-16 bg-muted rounded mt-1" />
+      <div className="h-2.5 w-20 bg-muted rounded mt-1" />
+    </div>
   );
 }
 
@@ -126,133 +113,194 @@ export default function EmbeddingServicePage() {
 
       {/* Service Health */}
       {infoLoading ? (
-        <div className="h-32 bg-card/40 dark:bg-zinc-800/40 rounded-xl animate-pulse" />
+        <div className="h-32 bg-muted rounded-[10px] animate-pulse" />
       ) : (
-        <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border dark:border-zinc-700/40">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground dark:text-zinc-100 flex items-center gap-2">
-              <BrainCircuitIcon className="h-5 w-5 text-violet-500" />
+        <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+          {/* Panel header */}
+          <div className="flex items-center gap-2 border-b border-border/60 bg-background px-3.5 py-2.5">
+            <BrainCircuitIcon className="h-4 w-4 text-entity-kb shrink-0" />
+            <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
               Service Status
             </h2>
             <StatusBadge status={info?.status ?? 'unknown'} />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+          {/* Panel body */}
+          <div className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Model
-              </div>
-              <div className="text-sm font-medium text-foreground dark:text-zinc-100">
-                {info?.model ?? '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[12px] font-semibold text-entity-kb">
+                {info?.model ?? '—'}
+              </span>
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+            <div className="flex flex-col gap-1">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Device
-              </div>
-              <div className="text-sm font-medium text-foreground dark:text-zinc-100 flex items-center gap-1.5">
-                <CpuIcon className="h-3.5 w-3.5" />
-                {info?.device?.toUpperCase() ?? '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[12px] font-semibold text-foreground flex items-center gap-1.5">
+                <CpuIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                {info?.device?.toUpperCase() ?? '—'}
+              </span>
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+            <div className="flex flex-col gap-1">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Dimensions
-              </div>
-              <div className="text-sm font-medium text-foreground dark:text-zinc-100">
-                {info?.dimension ?? '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[12px] font-semibold text-foreground">
+                {info?.dimension ?? '—'}
+              </span>
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+            <div className="flex flex-col gap-1">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Languages
-              </div>
-              <div className="text-sm font-medium text-foreground dark:text-zinc-100 flex items-center gap-1.5">
-                <GlobeIcon className="h-3.5 w-3.5" />
-                {info?.supportedLanguages?.join(', ').toUpperCase() ?? '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[12px] font-semibold text-foreground flex items-center gap-1.5">
+                <GlobeIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                {info?.supportedLanguages?.join(', ').toUpperCase() ?? '—'}
+              </span>
             </div>
           </div>
 
-          <div className="mt-4 pt-4 border-t border-border/50 dark:border-zinc-700/50 grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+          <div className="border-t border-border/60 px-4 py-3 grid grid-cols-1 sm:grid-cols-3 gap-4 bg-background">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Max Input
-              </div>
-              <div className="text-sm text-foreground dark:text-zinc-300">
-                {info?.maxInputChars ? `${info.maxInputChars.toLocaleString()} chars` : '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[11px] text-foreground">
+                {info?.maxInputChars ? `${info.maxInputChars.toLocaleString()} chars` : '—'}
+              </span>
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Max Batch
-              </div>
-              <div className="text-sm text-foreground dark:text-zinc-300">
-                {info?.maxBatchSize ? `${info.maxBatchSize} texts` : '\u2014'}
-              </div>
+              </span>
+              <span className="font-mono text-[11px] text-foreground">
+                {info?.maxBatchSize ? `${info.maxBatchSize} texts` : '—'}
+              </span>
             </div>
-            <div>
-              <div className="text-xs text-muted-foreground dark:text-muted-foreground uppercase tracking-wider mb-1">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                 Auto-refresh
-              </div>
-              <div className="text-sm text-foreground dark:text-zinc-300">Every 30s</div>
+              </span>
+              <span className="font-mono text-[11px] text-foreground">Every 30s</span>
             </div>
           </div>
-        </div>
+        </section>
       )}
 
       {/* Throughput Metrics */}
       {metricsLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-24 bg-card/40 dark:bg-zinc-800/40 rounded-lg animate-pulse" />
+            <KpiSkeleton key={i} />
           ))}
         </div>
       ) : (
         <>
-          <h2 className="text-lg font-semibold text-foreground dark:text-zinc-100 flex items-center gap-2">
-            <ActivityIcon className="h-5 w-5 text-blue-500" />
-            Throughput Metrics
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <StatCard
-              label="Total Requests"
-              value={metrics?.requestsTotal?.toLocaleString() ?? '0'}
-              icon={ZapIcon}
-              color="text-blue-500"
-            />
-            <StatCard
-              label="Total Failures"
-              value={metrics?.failuresTotal?.toLocaleString() ?? '0'}
-              icon={XCircleIcon}
-              color="text-red-500"
-            />
-            <StatCard
-              label="Failure Rate"
-              value={`${metrics?.failureRate ?? 0}%`}
-              icon={AlertCircleIcon}
-              color={
-                metrics?.failureRate && metrics.failureRate > 5 ? 'text-red-500' : 'text-green-500'
-              }
-            />
-            <StatCard
-              label="Avg Duration"
-              value={`${metrics?.avgDurationMs ?? 0} ms`}
-              icon={TimerIcon}
-              color="text-amber-500"
-            />
-            <StatCard
-              label="Total Duration"
-              value={`${((metrics?.durationMsSum ?? 0) / 1000).toFixed(1)} s`}
-              icon={HashIcon}
-              color="text-violet-500"
-            />
-            <StatCard
-              label="Characters Processed"
-              value={(metrics?.totalCharsSum ?? 0).toLocaleString()}
-              icon={TextIcon}
-              color="text-emerald-500"
-            />
+          <div className="flex items-center gap-2">
+            <ActivityIcon className="h-4 w-4 text-entity-kb" />
+            <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
+              Throughput Metrics
+            </h2>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {/* Total Requests */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Total Requests
+              </span>
+              <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+                {metrics?.requestsTotal?.toLocaleString() ?? '0'}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <ZapIcon className="h-3 w-3 text-entity-kb" />
+                embedding requests
+              </span>
+            </div>
+
+            {/* Total Failures */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-event min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Total Failures
+              </span>
+              <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-entity-event leading-tight">
+                {metrics?.failuresTotal?.toLocaleString() ?? '0'}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <XCircleIcon className="h-3 w-3 text-entity-event" />
+                failed requests
+              </span>
+            </div>
+
+            {/* Failure Rate */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-event min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Failure Rate
+              </span>
+              <span
+                className={`font-quicksand text-[28px] font-extrabold tabular-nums leading-tight ${
+                  metrics?.failureRate && metrics.failureRate > 5
+                    ? 'text-entity-event'
+                    : 'text-entity-toolkit'
+                }`}
+              >
+                {`${metrics?.failureRate ?? 0}%`}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <AlertCircleIcon className="h-3 w-3" />
+                of total requests
+              </span>
+            </div>
+
+            {/* Avg Duration */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-chat min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Avg Duration
+              </span>
+              <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+                {`${metrics?.avgDurationMs ?? 0}`}
+                <span className="font-quicksand text-[14px] font-bold text-muted-foreground ml-0.5">
+                  ms
+                </span>
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <TimerIcon className="h-3 w-3 text-entity-chat" />
+                per request
+              </span>
+            </div>
+
+            {/* Total Duration */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-chat min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Total Duration
+              </span>
+              <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+                {`${((metrics?.durationMsSum ?? 0) / 1000).toFixed(1)}`}
+                <span className="font-quicksand text-[14px] font-bold text-muted-foreground ml-0.5">
+                  s
+                </span>
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <HashIcon className="h-3 w-3 text-entity-chat" />
+                cumulative
+              </span>
+            </div>
+
+            {/* Characters Processed */}
+            <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-toolkit min-h-[88px]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                Characters Processed
+              </span>
+              <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+                {(metrics?.totalCharsSum ?? 0).toLocaleString()}
+              </span>
+              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
+                <TextIcon className="h-3 w-3 text-entity-toolkit" />
+                total chars embedded
+              </span>
+            </div>
           </div>
         </>
       )}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx
@@ -8,12 +8,8 @@ import {
   CheckCircleIcon,
   CpuIcon,
   GlobeIcon,
-  HashIcon,
   RefreshCwIcon,
-  TextIcon,
-  TimerIcon,
   XCircleIcon,
-  ZapIcon,
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/primitives/button';
@@ -58,7 +54,6 @@ function KpiSkeleton() {
     <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb animate-pulse min-h-[88px]">
       <div className="h-2.5 w-24 bg-muted rounded" />
       <div className="h-7 w-16 bg-muted rounded mt-1" />
-      <div className="h-2.5 w-20 bg-muted rounded mt-1" />
     </div>
   );
 }
@@ -117,7 +112,7 @@ export default function EmbeddingServicePage() {
       ) : (
         <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
           {/* Panel header */}
-          <div className="flex items-center gap-2 border-b border-border/60 bg-background px-3.5 py-2.5">
+          <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
             <BrainCircuitIcon className="h-4 w-4 text-entity-kb shrink-0" />
             <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
               Service Status
@@ -214,10 +209,6 @@ export default function EmbeddingServicePage() {
               <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
                 {metrics?.requestsTotal?.toLocaleString() ?? '0'}
               </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <ZapIcon className="h-3 w-3 text-entity-kb" />
-                embedding requests
-              </span>
             </div>
 
             {/* Total Failures */}
@@ -227,10 +218,6 @@ export default function EmbeddingServicePage() {
               </span>
               <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-entity-event leading-tight">
                 {metrics?.failuresTotal?.toLocaleString() ?? '0'}
-              </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <XCircleIcon className="h-3 w-3 text-entity-event" />
-                failed requests
               </span>
             </div>
 
@@ -248,10 +235,6 @@ export default function EmbeddingServicePage() {
               >
                 {`${metrics?.failureRate ?? 0}%`}
               </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <AlertCircleIcon className="h-3 w-3" />
-                of total requests
-              </span>
             </div>
 
             {/* Avg Duration */}
@@ -264,10 +247,6 @@ export default function EmbeddingServicePage() {
                 <span className="font-quicksand text-[14px] font-bold text-muted-foreground ml-0.5">
                   ms
                 </span>
-              </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <TimerIcon className="h-3 w-3 text-entity-chat" />
-                per request
               </span>
             </div>
 
@@ -282,10 +261,6 @@ export default function EmbeddingServicePage() {
                   s
                 </span>
               </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <HashIcon className="h-3 w-3 text-entity-chat" />
-                cumulative
-              </span>
             </div>
 
             {/* Characters Processed */}
@@ -295,10 +270,6 @@ export default function EmbeddingServicePage() {
               </span>
               <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
                 {(metrics?.totalCharsSum ?? 0).toLocaleString()}
-              </span>
-              <span className="font-mono text-[11px] text-muted-foreground flex items-center gap-1">
-                <TextIcon className="h-3 w-3 text-entity-toolkit" />
-                total chars embedded
               </span>
             </div>
           </div>

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/feedback/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/feedback/page.tsx
@@ -19,9 +19,12 @@ export default function KbFeedbackPage() {
       </div>
 
       <div className="space-y-2 max-w-sm">
-        <Label htmlFor="game-id-input">Game ID</Label>
+        <Label htmlFor="game-id-input" className="text-foreground">
+          Game ID
+        </Label>
         <Input
           id="game-id-input"
+          className="text-foreground"
           placeholder="Inserisci l'UUID del gioco..."
           value={gameId}
           onChange={e => setGameId(e.target.value)}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx
@@ -1,21 +1,16 @@
 import { type ReactNode } from 'react';
 
 import { KbSubNav } from '@/components/admin/knowledge-base/explorer/KbSubNav';
+import { KbTopBand } from '@/components/admin/knowledge-base/explorer/KbTopBand';
 
-/**
- * Layout condiviso di tutte le route /admin/knowledge-base/*.
- * Inserisce la sub-nav KB sopra il contenuto di ogni sub-page; le pagine
- * esistenti restano invariate (ereditano la sub-nav senza modifiche).
- *
- * Padding orizzontale `px-6`: la KbSubNav usa `-mx-6 px-6` per bleed
- * full-width del border-bottom; questo wrapper deve fornire i 24px che
- * compensano il margine negativo.
- */
 export default function KnowledgeBaseLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="space-y-6 px-6">
-      <KbSubNav />
-      {children}
+    <div className="px-6">
+      <KbTopBand />
+      <div className="space-y-6 pt-6">
+        <KbSubNav />
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/page.tsx
@@ -9,18 +9,5 @@ export const metadata: Metadata = {
 };
 
 export default function KnowledgeBasePage() {
-  return (
-    <div className="space-y-4">
-      <header>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          Knowledge Base
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Esplora i documenti indicizzati per gioco.
-        </p>
-      </header>
-
-      <KbExplorer />
-    </div>
-  );
+  return <KbExplorer />;
 }

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/pipeline/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/pipeline/page.tsx
@@ -11,16 +11,6 @@ export const metadata: Metadata = {
 export default function PipelineOverviewPage() {
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          RAG Pipeline Overview
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Monitor the RAG pipeline stages and health
-        </p>
-      </div>
-
       {/* Pipeline Flow + Distribution + Recent Activity */}
       <RAGPipelineFlow />
 

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
@@ -82,16 +82,16 @@ export function QueueDashboardClient({
       {/* Page toolbar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Link href={gameId ? `/admin/shared-games/${gameId}` : '/admin/knowledge-base'}>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <ArrowLeftIcon className="h-4 w-4" />
-            </Button>
-          </Link>
-          <p className="text-sm text-muted-foreground">
-            {gameId
-              ? 'Processing jobs for selected game'
-              : 'Monitor and manage PDF processing jobs'}
-          </p>
+          {gameId && (
+            <>
+              <Link href={`/admin/shared-games/${gameId}`}>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <ArrowLeftIcon className="h-4 w-4" />
+                </Button>
+              </Link>
+              <p className="text-sm text-muted-foreground">Processing jobs for selected game</p>
+            </>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <SSEConnectionIndicator state={queueSSEState} onReconnect={reconnectQueueSSE} />

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
@@ -130,7 +129,7 @@ export function QueueDashboardClient({
       {/* Main Content: List (40%) + Detail (60%) */}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 min-h-[500px]">
         {/* Queue List - 2/5 = 40% */}
-        <div className="lg:col-span-2 bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-border/50 dark:border-zinc-700/50 overflow-hidden">
+        <div className="lg:col-span-2 rounded-[10px] border border-border/60 bg-card overflow-hidden">
           <QueueList
             data={queueData}
             isLoading={isQueueLoading}
@@ -142,7 +141,7 @@ export function QueueDashboardClient({
         </div>
 
         {/* Detail Panel - 3/5 = 60% */}
-        <div className="lg:col-span-3 bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-border/50 dark:border-zinc-700/50 overflow-hidden">
+        <div className="lg:col-span-3 rounded-[10px] border border-border/60 bg-card overflow-hidden">
           <JobDetailPanel job={jobDetail} isLoading={isDetailLoading} />
         </div>
       </div>

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx
@@ -80,7 +80,7 @@ export function QueueDashboardClient({
 
   return (
     <div className="space-y-4 h-full">
-      {/* Header */}
+      {/* Page toolbar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Link href={gameId ? `/admin/shared-games/${gameId}` : '/admin/knowledge-base'}>
@@ -88,16 +88,11 @@ export function QueueDashboardClient({
               <ArrowLeftIcon className="h-4 w-4" />
             </Button>
           </Link>
-          <div>
-            <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-              Processing Queue
-            </h1>
-            <p className="text-sm text-muted-foreground mt-0.5">
-              {gameId
-                ? 'Processing jobs for selected game'
-                : 'Monitor and manage PDF processing jobs'}
-            </p>
-          </div>
+          <p className="text-sm text-muted-foreground">
+            {gameId
+              ? 'Processing jobs for selected game'
+              : 'Monitor and manage PDF processing jobs'}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <SSEConnectionIndicator state={queueSSEState} onReconnect={reconnectQueueSSE} />

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/settings/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/settings/page.tsx
@@ -10,17 +10,6 @@ export const metadata: Metadata = {
 export default function KBSettingsPage() {
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          Knowledge Base Settings
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          View knowledge base and RAG pipeline configuration
-        </p>
-      </div>
-
-      {/* Settings */}
       <KBSettings />
     </div>
   );

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -21,7 +20,6 @@ import {
   PlusIcon,
 } from 'lucide-react';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -60,21 +58,21 @@ function RestoreResultBanner({ result }: { result: KbImportResult }) {
     <div
       className={`rounded-xl border p-4 ${
         hasErrors
-          ? 'bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-800'
-          : 'bg-emerald-50 border-emerald-200 dark:bg-emerald-900/20 dark:border-emerald-800'
+          ? 'bg-entity-event/12 border-entity-event/30'
+          : 'bg-entity-toolkit/12 border-entity-toolkit/30'
       }`}
     >
       <div className="flex items-start gap-3">
         <CheckCircle2Icon
-          className={`h-5 w-5 mt-0.5 ${hasErrors ? 'text-red-500' : 'text-emerald-500'}`}
+          className={`h-5 w-5 mt-0.5 ${hasErrors ? 'text-entity-event' : 'text-entity-toolkit'}`}
         />
         <div className="flex-1">
           <p
-            className={`text-sm font-semibold ${hasErrors ? 'text-red-700 dark:text-red-400' : 'text-emerald-700 dark:text-emerald-400'}`}
+            className={`text-sm font-semibold ${hasErrors ? 'text-entity-event' : 'text-entity-toolkit'}`}
           >
             {hasErrors ? 'Restore completato con errori' : 'Restore completato con successo'}
           </p>
-          <div className="mt-1 text-xs text-muted-foreground dark:text-muted-foreground space-y-0.5">
+          <div className="mt-1 text-xs text-muted-foreground space-y-0.5">
             <p>
               Documenti: {result.imported} importati · {result.skipped} già presenti ·{' '}
               {result.failed} falliti
@@ -82,7 +80,7 @@ function RestoreResultBanner({ result }: { result: KbImportResult }) {
             {result.reEmbedded > 0 && <p>{result.reEmbedded} documenti ri-embeddati</p>}
           </div>
           {result.errors.length > 0 && (
-            <ul className="mt-2 text-xs text-red-600 dark:text-red-400 space-y-0.5">
+            <ul className="mt-2 text-xs text-entity-event space-y-0.5">
               {result.errors.map((e, i) => (
                 <li key={i}>• {e}</li>
               ))}
@@ -110,16 +108,16 @@ function SnapshotCard({
   const isLatest = snapshot.id === 'latest';
 
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center gap-4 py-4 px-4 rounded-xl hover:bg-muted dark:hover:bg-zinc-800/50 transition-colors">
+    <div className="flex flex-col sm:flex-row sm:items-center gap-4 py-4 px-4 hover:bg-muted transition-colors">
       {/* Icon */}
       <div className="flex-shrink-0">
         <div
           className={`h-10 w-10 rounded-lg flex items-center justify-center ${
-            isLatest ? 'bg-blue-100 dark:bg-blue-900/30' : 'bg-muted dark:bg-zinc-700/50'
+            isLatest ? 'bg-entity-chat/12' : 'bg-muted'
           }`}
         >
           <FileArchiveIcon
-            className={`h-5 w-5 ${isLatest ? 'text-blue-600 dark:text-blue-400' : 'text-muted-foreground dark:text-muted-foreground'}`}
+            className={`h-5 w-5 ${isLatest ? 'text-entity-chat' : 'text-muted-foreground'}`}
           />
         </div>
       </div>
@@ -127,16 +125,14 @@ function SnapshotCard({
       {/* Metadata */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <p className="text-sm font-medium text-foreground dark:text-zinc-100 font-mono truncate">
-            {snapshot.id}
-          </p>
+          <p className="text-sm font-medium text-foreground font-mono truncate">{snapshot.id}</p>
           {isLatest && (
-            <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 px-1.5 py-0.5 rounded font-medium">
+            <span className="text-xs bg-entity-chat/12 text-entity-chat px-1.5 py-0.5 rounded font-mono font-bold">
               auto
             </span>
           )}
         </div>
-        <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground dark:text-muted-foreground">
+        <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
           <span>{formatSnapshotDate(snapshot.exportedAt)}</span>
           {snapshot.totalDocuments !== null && (
             <span>
@@ -151,26 +147,24 @@ function SnapshotCard({
 
       {/* Actions */}
       <div className="flex items-center gap-2 flex-shrink-0">
-        <Button
-          variant="outline"
-          size="sm"
+        <button
+          type="button"
           onClick={() => onRestore(snapshot.id)}
           disabled={isRestoring || isDeleting}
-          className="gap-1.5 text-xs"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <RotateCcwIcon className={`h-3.5 w-3.5 ${isRestoring ? 'animate-spin' : ''}`} />
           {isRestoring ? 'Restore...' : 'Ripristina'}
-        </Button>
+        </button>
         {!isLatest && (
-          <Button
-            variant="ghost"
-            size="sm"
+          <button
+            type="button"
             onClick={() => onDelete(snapshot.id)}
             disabled={isRestoring || isDeleting}
-            className="gap-1.5 text-xs text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+            className="inline-flex items-center gap-1.5 rounded-md border border-entity-event/55 bg-card px-2 py-1 text-[11px] font-quicksand font-bold text-entity-event hover:bg-entity-event/8 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Trash2Icon className="h-3.5 w-3.5" />
-          </Button>
+          </button>
         )}
       </div>
     </div>
@@ -249,7 +243,7 @@ export default function KbSnapshotsPage() {
 
       {/* Export error */}
       {exportError && (
-        <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-800 text-sm text-red-600 dark:text-red-400">
+        <div className="flex items-center gap-2 p-3 rounded-xl bg-entity-event/12 border border-entity-event/30 text-sm text-entity-event">
           <AlertCircleIcon className="h-4 w-4 flex-shrink-0" />
           {exportError}
         </div>
@@ -259,71 +253,65 @@ export default function KbSnapshotsPage() {
       {restoreResult && <RestoreResultBanner result={restoreResult} />}
 
       {/* Info box */}
-      <div className="rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4">
-        <p className="text-sm text-blue-700 dark:text-blue-300">
+      <div className="rounded-xl border border-entity-chat/30 bg-entity-chat/12 p-4">
+        <p className="text-sm text-entity-chat">
           <strong>Come funziona:</strong> Lo snapshot{' '}
-          <code className="font-mono text-xs bg-blue-100 dark:bg-blue-900/50 px-1 rounded">
-            latest
-          </code>{' '}
-          viene aggiornato automaticamente dopo ogni indicizzazione PDF. Gli snapshot con data sono
-          backup manuali completi. Ripristina per ricaricare chunks ed embeddings nel database senza
+          <code className="font-mono text-xs bg-entity-chat/12 px-1 rounded">latest</code> viene
+          aggiornato automaticamente dopo ogni indicizzazione PDF. Gli snapshot con data sono backup
+          manuali completi. Ripristina per ricaricare chunks ed embeddings nel database senza
           rielaborare i PDF originali.
         </p>
       </div>
 
       {/* Snapshots list */}
-      <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base font-semibold flex items-center gap-2">
-            <ArchiveIcon className="h-4 w-4 text-purple-500" />
+      <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+        <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+          <ArchiveIcon className="h-3.5 w-3.5 text-entity-kb shrink-0" />
+          <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
             Snapshot disponibili
-            {snapshots.length > 0 && (
-              <span className="ml-auto text-sm font-normal text-muted-foreground dark:text-muted-foreground">
-                {snapshots.length} snapshot
-              </span>
-            )}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="px-2">
-          {isLoading ? (
-            <div className="space-y-2 p-2">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-16 rounded-xl bg-muted dark:bg-zinc-700/50 animate-pulse"
-                />
-              ))}
-            </div>
-          ) : error ? (
-            <div className="flex items-center gap-2 p-4 text-red-500 dark:text-red-400">
-              <AlertCircleIcon className="h-4 w-4" />
-              <span className="text-sm">Errore nel caricamento degli snapshot</span>
-            </div>
-          ) : snapshots.length === 0 ? (
-            <div className="flex flex-col items-center gap-3 py-12 text-muted-foreground dark:text-muted-foreground">
-              <ArchiveIcon className="h-10 w-10" />
-              <p className="text-sm">Nessuno snapshot disponibile</p>
-              <p className="text-xs text-center max-w-xs">
-                Gli snapshot vengono creati automaticamente dopo ogni indexing PDF, oppure
-                manualmente con il bottone &quot;Nuovo snapshot&quot;.
-              </p>
-            </div>
-          ) : (
-            <div className="divide-y divide-slate-100 dark:divide-zinc-700/50">
-              {snapshots.map(snapshot => (
-                <SnapshotCard
-                  key={snapshot.id}
-                  snapshot={snapshot}
-                  onRestore={id => setRestoreTarget(id)}
-                  onDelete={id => setDeleteTarget(id)}
-                  isRestoring={restoreMutation.isPending && restoreTarget === snapshot.id}
-                  isDeleting={deleteMutation.isPending && deleteTarget === snapshot.id}
-                />
-              ))}
-            </div>
+          </h2>
+          {snapshots.length > 0 && (
+            <span className="font-mono text-[10px] text-muted-foreground ml-auto">
+              {snapshots.length} snapshot
+            </span>
           )}
-        </CardContent>
-      </Card>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2 p-3.5">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-16 rounded-xl bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 p-4 text-entity-event">
+            <AlertCircleIcon className="h-4 w-4" />
+            <span className="text-sm">Errore nel caricamento degli snapshot</span>
+          </div>
+        ) : snapshots.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-12 text-muted-foreground">
+            <ArchiveIcon className="h-10 w-10" />
+            <p className="text-sm">Nessuno snapshot disponibile</p>
+            <p className="text-xs text-center max-w-xs">
+              Gli snapshot vengono creati automaticamente dopo ogni indexing PDF, oppure manualmente
+              con il bottone &quot;Nuovo snapshot&quot;.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/60">
+            {snapshots.map(snapshot => (
+              <SnapshotCard
+                key={snapshot.id}
+                snapshot={snapshot}
+                onRestore={id => setRestoreTarget(id)}
+                onDelete={id => setDeleteTarget(id)}
+                isRestoring={restoreMutation.isPending && restoreTarget === snapshot.id}
+                isDeleting={deleteMutation.isPending && deleteTarget === snapshot.id}
+              />
+            ))}
+          </div>
+        )}
+      </section>
 
       {/* Restore confirm dialog */}
       <AlertDialog
@@ -372,7 +360,7 @@ export default function KbSnapshotsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Annulla</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-red-600 hover:bg-red-700 text-white"
+              className="bg-entity-event text-white hover:bg-entity-event/90"
               onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget)}
             >
               Elimina

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
@@ -229,36 +229,22 @@ export default function KbSnapshotsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground dark:text-zinc-100">Snapshot RAG</h1>
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground mt-1">
-            Gestisci i backup della Knowledge Base. Ripristina uno snapshot per evitare di
-            rielaborare i PDF.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => refetch()}
-            disabled={isRefetching}
-            className="gap-2"
-          >
-            <RefreshCwIcon className={`h-4 w-4 ${isRefetching ? 'animate-spin' : ''}`} />
-            Aggiorna
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleCreateSnapshot}
-            disabled={exportLoading}
-            className="gap-2"
-          >
-            <PlusIcon className="h-4 w-4" />
-            {exportLoading ? 'Creazione...' : 'Nuovo snapshot'}
-          </Button>
-        </div>
+      {/* Page toolbar */}
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isRefetching}
+          className="gap-2"
+        >
+          <RefreshCwIcon className={`h-4 w-4 ${isRefetching ? 'animate-spin' : ''}`} />
+          Aggiorna
+        </Button>
+        <Button size="sm" onClick={handleCreateSnapshot} disabled={exportLoading} className="gap-2">
+          <PlusIcon className="h-4 w-4" />
+          {exportLoading ? 'Creazione...' : 'Nuovo snapshot'}
+        </Button>
       </div>
 
       {/* Export error */}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx
@@ -151,7 +151,7 @@ function SnapshotCard({
           type="button"
           onClick={() => onRestore(snapshot.id)}
           disabled={isRestoring || isDeleting}
-          className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <RotateCcwIcon className={`h-3.5 w-3.5 ${isRestoring ? 'animate-spin' : ''}`} />
           {isRestoring ? 'Restore...' : 'Ripristina'}
@@ -161,7 +161,7 @@ function SnapshotCard({
             type="button"
             onClick={() => onDelete(snapshot.id)}
             disabled={isRestoring || isDeleting}
-            className="inline-flex items-center gap-1.5 rounded-md border border-entity-event/55 bg-card px-2 py-1 text-[11px] font-quicksand font-bold text-entity-event hover:bg-entity-event/8 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="inline-flex items-center gap-1.5 rounded-md border border-entity-event/55 bg-card px-2 py-1 text-[11px] font-quicksand font-bold text-entity-event hover:bg-entity-event/8 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             <Trash2Icon className="h-3.5 w-3.5" />
           </button>
@@ -360,7 +360,7 @@ export default function KbSnapshotsPage() {
           <AlertDialogFooter>
             <AlertDialogCancel>Annulla</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-entity-event text-white hover:bg-entity-event/90"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget)}
             >
               Elimina

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
@@ -116,16 +116,8 @@ export default function VectorStorePage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-4">
-        <div>
-          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-            Vector Store
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            pgvector knowledge base — embeddings health and semantic search
-          </p>
-        </div>
+      {/* Page toolbar */}
+      <div className="flex justify-end">
         <Button
           variant="outline"
           size="sm"

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
@@ -310,15 +310,18 @@ export default function VectorStorePage() {
                     <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
                       Snippet
                     </span>
-                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground text-right">
-                      Score ↓
+                    <span
+                      className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground text-right"
+                      title="Score not exposed by the current API"
+                    >
+                      Score
                     </span>
                     <span />
                   </div>
 
                   {searchResults.map(item => {
                     const isExpanded = expandedResult === item.documentId;
-                    const shortId = item.documentId.slice(0, 8);
+                    const shortId = item.documentId.slice(0, 8) || item.documentId || '—';
                     return (
                       <div key={`${item.documentId}-${item.chunkIndex}`}>
                         <button

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or admin-decorative inline gradient; DS-13a admin scope, mockup .e-bg pattern. Future: extract --admin-* token family (deferred to DS-15 audit). */
 'use client';
 
 /**
@@ -26,7 +25,6 @@ import {
 } from 'lucide-react';
 
 import { VectorGameCard } from '@/components/admin/knowledge-base/vector-game-card';
-import { Card, CardContent } from '@/components/ui/data-display/card';
 import {
   Select,
   SelectContent,
@@ -47,17 +45,11 @@ const LIMIT_OPTIONS = [5, 10, 20, 50] as const;
 
 function StatSkeleton() {
   return (
-    <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-lg bg-muted dark:bg-zinc-700 animate-pulse" />
-          <div className="space-y-2">
-            <div className="h-3 w-24 bg-muted dark:bg-zinc-700 rounded animate-pulse" />
-            <div className="h-6 w-16 bg-muted dark:bg-zinc-700 rounded animate-pulse" />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb animate-pulse min-h-[88px]">
+      <div className="h-2.5 w-24 bg-muted rounded" />
+      <div className="h-7 w-16 bg-muted rounded mt-1" />
+      <div className="h-2.5 w-20 bg-muted rounded mt-1" />
+    </div>
   );
 }
 
@@ -109,13 +101,13 @@ export default function VectorStorePage() {
 
   const healthColor =
     avgHealth >= 90
-      ? 'text-green-600 dark:text-green-400'
+      ? 'text-entity-toolkit'
       : avgHealth >= 70
-        ? 'text-amber-600 dark:text-amber-400'
-        : 'text-red-600 dark:text-red-400';
+        ? 'text-entity-agent'
+        : 'text-entity-event';
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Page toolbar */}
       <div className="flex justify-end">
         <Button
@@ -132,13 +124,11 @@ export default function VectorStorePage() {
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg p-4 flex items-center gap-3">
-          <AlertCircleIcon className="h-5 w-5 text-red-500 shrink-0" />
+        <div className="rounded-lg border border-entity-event/30 bg-entity-event/12 p-4 flex items-center gap-3">
+          <AlertCircleIcon className="h-5 w-5 text-entity-event shrink-0" />
           <div className="flex-1">
-            <p className="text-sm font-medium text-red-800 dark:text-red-200">
-              Failed to load vector stats
-            </p>
-            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+            <p className="text-sm font-medium text-entity-event">Failed to load vector stats</p>
+            <p className="text-xs text-entity-event/80 mt-1">
               {error instanceof Error ? error.message : 'Unknown error'}
             </p>
           </div>
@@ -148,256 +138,288 @@ export default function VectorStorePage() {
         </div>
       )}
 
-      {/* Stats Row */}
+      {/* KPI Strip */}
       {isLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <StatSkeleton key={i} />
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
           {/* Total Vectors */}
-          <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-                  <DatabaseIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Total Vectors</p>
-                  <p className="text-xl font-bold text-foreground">
-                    {totalVectors.toLocaleString()}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb min-h-[88px]">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+              Total Vectors
+            </span>
+            <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+              {totalVectors.toLocaleString()}
+            </span>
+            <span className="font-mono text-[11px] text-entity-toolkit">
+              <DatabaseIcon className="inline h-3 w-3 mr-0.5 -mt-px" />
+              pgvector store
+            </span>
+          </div>
 
           {/* Games Indexed */}
-          <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center">
-                  <GridIcon className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Games Indexed</p>
-                  <p className="text-xl font-bold text-foreground">{gamesIndexed}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-game min-h-[88px]">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+              Games Indexed
+            </span>
+            <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+              {gamesIndexed}
+            </span>
+            <span className="font-mono text-[11px] text-entity-toolkit">
+              <GridIcon className="inline h-3 w-3 mr-0.5 -mt-px" />
+              with vectors
+            </span>
+          </div>
 
           {/* Dimensions */}
-          <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-cyan-100 dark:bg-cyan-900/30 flex items-center justify-center">
-                  <LayersIcon className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Dimensions</p>
-                  <p className="text-xl font-bold text-foreground">
-                    {dimensions > 0 ? dimensions : '\u2014'}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-chat min-h-[88px]">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+              Dimensions
+            </span>
+            <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+              {dimensions > 0 ? dimensions : '—'}
+            </span>
+            <span className="font-mono text-[11px] text-muted-foreground">
+              <LayersIcon className="inline h-3 w-3 mr-0.5 -mt-px" />
+              float32 embedding
+            </span>
+          </div>
 
           {/* Avg Health */}
-          <Card className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md border-border/60 dark:border-zinc-700/40">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
-                  <ActivityIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Avg Health</p>
-                  <p className={`text-xl font-bold ${healthColor}`}>
-                    {data ? `${Math.round(avgHealth)}%` : '\u2014'}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-toolkit min-h-[88px]">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+              Avg Health
+            </span>
+            <span
+              className={`font-quicksand text-[28px] font-extrabold tabular-nums leading-tight ${healthColor}`}
+            >
+              {data ? `${Math.round(avgHealth)}%` : '—'}
+            </span>
+            <span className="font-mono text-[11px] text-entity-toolkit">
+              <ActivityIcon className="inline h-3 w-3 mr-0.5 -mt-px" />
+              chunk completeness
+            </span>
+          </div>
         </div>
       )}
 
       {/* Semantic Search Panel */}
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-border/60 dark:border-zinc-700/40 p-6 space-y-4">
-        <div>
-          <h2 className="font-quicksand font-semibold text-lg text-foreground flex items-center gap-2">
-            <SearchIcon className="h-5 w-5 text-blue-500" />
+      <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+        <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+          <SearchIcon className="h-3.5 w-3.5 text-entity-kb shrink-0" />
+          <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
             Semantic Search
           </h2>
-          <p className="text-sm text-muted-foreground mt-1">
+          <span className="font-mono text-[10px] text-muted-foreground ml-1">cosine · top-k</span>
+        </div>
+        <div className="p-3.5 space-y-3">
+          <p className="text-xs text-muted-foreground">
             Run a similarity search against the pgvector knowledge base.
           </p>
-        </div>
 
-        {/* Search Controls */}
-        <div className="flex flex-col sm:flex-row gap-3">
-          {/* Query input */}
-          <div className="relative flex-1">
-            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-            <Input
-              placeholder="Enter a query to search vectors..."
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') void handleSearch();
-              }}
-              className="pl-9 bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md"
-            />
-          </div>
-
-          {/* Game filter */}
-          <Select value={searchGameId} onValueChange={setSearchGameId}>
-            <SelectTrigger className="w-full sm:w-48 bg-card/70 dark:bg-zinc-800/70">
-              <SelectValue placeholder="All games" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All games</SelectItem>
-              {gameBreakdown.map(game => (
-                <SelectItem key={game.gameId} value={game.gameId}>
-                  {game.gameName}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {/* Limit selector */}
-          <Select value={searchLimit} onValueChange={setSearchLimit}>
-            <SelectTrigger className="w-full sm:w-28 bg-card/70 dark:bg-zinc-800/70">
-              <SelectValue placeholder="Limit" />
-            </SelectTrigger>
-            <SelectContent>
-              {LIMIT_OPTIONS.map(n => (
-                <SelectItem key={n} value={String(n)}>
-                  {n} results
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          <Button
-            onClick={() => void handleSearch()}
-            disabled={searchLoading || !searchQuery.trim()}
-            className="gap-2 bg-blue-600 hover:bg-blue-700 text-white"
-          >
-            {searchLoading ? (
-              <RefreshCwIcon className="h-4 w-4 animate-spin" />
-            ) : (
-              <SearchIcon className="h-4 w-4" />
-            )}
-            Search
-          </Button>
-        </div>
-
-        {/* Search Error */}
-        {searchError && (
-          <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded-lg px-3 py-2 border border-red-200 dark:border-red-800/40">
-            <XCircleIcon className="h-4 w-4 shrink-0" />
-            {searchError}
-          </div>
-        )}
-
-        {/* Search Results */}
-        {searchResults !== null && (
-          <div className="space-y-2">
-            <div className="text-sm font-medium text-foreground">
-              {searchResults.length > 0
-                ? `${searchResults.length} result${searchResults.length !== 1 ? 's' : ''} found`
-                : 'No results found for this query.'}
+          {/* Search Controls */}
+          <div className="flex flex-col sm:flex-row gap-2">
+            {/* Query input */}
+            <div className="relative flex-1">
+              <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+              <Input
+                placeholder="Enter a query to search vectors..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') void handleSearch();
+                }}
+                className="pl-9 bg-background"
+              />
             </div>
-            {searchResults.map(item => (
-              <div
-                key={`${item.documentId}-${item.chunkIndex}`}
-                className="bg-muted/70 dark:bg-zinc-900/50 rounded-lg border border-border/50 dark:border-zinc-700/50 overflow-hidden"
-              >
-                <button
-                  type="button"
-                  onClick={() =>
-                    setExpandedResult(expandedResult === item.documentId ? null : item.documentId)
-                  }
-                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/60 dark:hover:bg-zinc-800/60 transition-colors"
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <span className="text-xs font-mono text-muted-foreground shrink-0">
-                      p.{item.pageNumber} c.{item.chunkIndex}
-                    </span>
-                    <span className="text-sm text-foreground truncate">{item.text}</span>
-                  </div>
-                  <div className="shrink-0 ml-2">
-                    {expandedResult === item.documentId ? (
-                      <ChevronUpIcon className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <ChevronDownIcon className="h-4 w-4 text-muted-foreground" />
-                    )}
-                  </div>
-                </button>
 
-                {expandedResult === item.documentId && (
-                  <div className="px-4 py-3 border-t border-border/50 dark:border-zinc-700/50 bg-card/50 dark:bg-zinc-900/30">
-                    <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-                      Details
-                    </div>
-                    <div className="space-y-1 text-xs">
-                      <div className="flex gap-2">
-                        <span className="text-muted-foreground font-mono shrink-0">
-                          documentId:
-                        </span>
-                        <span className="text-foreground break-all">{item.documentId}</span>
-                      </div>
-                      <div className="flex gap-2">
-                        <span className="text-muted-foreground font-mono shrink-0">page:</span>
-                        <span className="text-foreground">{item.pageNumber}</span>
-                      </div>
-                      <div className="flex gap-2">
-                        <span className="text-muted-foreground font-mono shrink-0">chunk:</span>
-                        <span className="text-foreground">{item.chunkIndex}</span>
-                      </div>
-                      <div className="flex gap-2">
-                        <span className="text-muted-foreground font-mono shrink-0">text:</span>
-                        <span className="text-foreground break-all">{item.text}</span>
-                      </div>
-                    </div>
-                  </div>
-                )}
+            {/* Game filter */}
+            <Select value={searchGameId} onValueChange={setSearchGameId}>
+              <SelectTrigger className="w-full sm:w-48 bg-background">
+                <SelectValue placeholder="All games" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All games</SelectItem>
+                {gameBreakdown.map(game => (
+                  <SelectItem key={game.gameId} value={game.gameId}>
+                    {game.gameName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Limit selector */}
+            <Select value={searchLimit} onValueChange={setSearchLimit}>
+              <SelectTrigger className="w-full sm:w-28 bg-background">
+                <SelectValue placeholder="Limit" />
+              </SelectTrigger>
+              <SelectContent>
+                {LIMIT_OPTIONS.map(n => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n} results
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Button
+              onClick={() => void handleSearch()}
+              disabled={searchLoading || !searchQuery.trim()}
+              className="gap-2 bg-entity-kb text-white hover:bg-entity-kb/90"
+            >
+              {searchLoading ? (
+                <RefreshCwIcon className="h-4 w-4 animate-spin" />
+              ) : (
+                <SearchIcon className="h-4 w-4" />
+              )}
+              Search
+            </Button>
+          </div>
+
+          {/* Search Error */}
+          {searchError && (
+            <div className="flex items-center gap-2 text-xs text-entity-event bg-entity-event/12 rounded-lg px-3 py-2 border border-entity-event/30">
+              <XCircleIcon className="h-4 w-4 shrink-0" />
+              {searchError}
+            </div>
+          )}
+
+          {/* Search Results */}
+          {searchResults !== null && (
+            <div className="space-y-1.5">
+              <div className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground px-1">
+                {searchResults.length > 0
+                  ? `${searchResults.length} result${searchResults.length !== 1 ? 's' : ''} found`
+                  : 'No results found for this query.'}
               </div>
+
+              {searchResults.length > 0 && (
+                <div className="rounded-[8px] border border-border/60 overflow-hidden">
+                  {/* Table header */}
+                  <div className="grid grid-cols-[110px_110px_1fr_70px_28px] gap-3 px-3.5 py-2 bg-background border-b border-border/60">
+                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
+                      Doc ID
+                    </span>
+                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
+                      Page · Chunk
+                    </span>
+                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
+                      Snippet
+                    </span>
+                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground text-right">
+                      Score ↓
+                    </span>
+                    <span />
+                  </div>
+
+                  {searchResults.map(item => {
+                    const isExpanded = expandedResult === item.documentId;
+                    const shortId = item.documentId.slice(0, 8);
+                    return (
+                      <div key={`${item.documentId}-${item.chunkIndex}`}>
+                        <button
+                          type="button"
+                          onClick={() => setExpandedResult(isExpanded ? null : item.documentId)}
+                          className={`w-full grid grid-cols-[110px_110px_1fr_70px_28px] gap-3 px-3.5 py-2.5 text-left border-b border-border/60 last:border-0 hover:bg-muted/50 transition-colors ${isExpanded ? 'bg-entity-kb/4' : ''}`}
+                        >
+                          <span className="font-mono text-[10.5px] font-bold text-entity-kb flex items-center gap-1.5 shrink-0 truncate">
+                            <span className="h-1.5 w-1.5 rounded-full bg-entity-game shrink-0" />
+                            {shortId}
+                          </span>
+                          <span className="font-mono text-[10px] text-muted-foreground shrink-0">
+                            p.{item.pageNumber} · ch[#{item.chunkIndex}]
+                          </span>
+                          <span className="text-[11.5px] text-muted-foreground truncate">
+                            {item.text}
+                          </span>
+                          <span className="font-mono text-[12px] font-bold text-entity-kb text-right shrink-0">
+                            —
+                          </span>
+                          <span className="text-muted-foreground font-mono text-[12px] shrink-0">
+                            {isExpanded ? (
+                              <ChevronUpIcon className="h-3.5 w-3.5" />
+                            ) : (
+                              <ChevronDownIcon className="h-3.5 w-3.5" />
+                            )}
+                          </span>
+                        </button>
+
+                        {isExpanded && (
+                          <div className="px-3.5 py-3 border-b border-border/60 bg-muted/30 grid grid-cols-1 md:grid-cols-[1fr_260px] gap-4">
+                            <div className="text-[12.5px] text-muted-foreground leading-relaxed bg-background border border-border/60 rounded-[6px] p-3">
+                              {item.text}
+                            </div>
+                            <div className="flex flex-col gap-1.5">
+                              <div className="flex gap-2 font-mono text-[10.5px]">
+                                <span className="text-muted-foreground uppercase tracking-wide text-[9.5px] font-bold min-w-[90px]">
+                                  documentId
+                                </span>
+                                <span className="text-foreground break-all">{item.documentId}</span>
+                              </div>
+                              <div className="flex gap-2 font-mono text-[10.5px]">
+                                <span className="text-muted-foreground uppercase tracking-wide text-[9.5px] font-bold min-w-[90px]">
+                                  page
+                                </span>
+                                <span className="text-foreground">{item.pageNumber}</span>
+                              </div>
+                              <div className="flex gap-2 font-mono text-[10.5px]">
+                                <span className="text-muted-foreground uppercase tracking-wide text-[9.5px] font-bold min-w-[90px]">
+                                  chunk
+                                </span>
+                                <span className="text-foreground">{item.chunkIndex}</span>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Game Breakdown Panel */}
+      {isLoading && (
+        <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+          <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+            <div className="h-3 w-24 bg-muted rounded animate-pulse" />
+          </div>
+          <div className="p-3.5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-36 bg-muted rounded-[8px] animate-pulse" />
             ))}
           </div>
-        )}
-      </div>
-
-      {/* Game Cards Grid */}
-      {isLoading && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-40 bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-border/60 dark:border-zinc-700/40 animate-pulse"
-            />
-          ))}
-        </div>
+        </section>
       )}
 
       {!isLoading && gameBreakdown.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="font-quicksand font-semibold text-lg text-foreground">Game Breakdown</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+          <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+            <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
+              Game Breakdown
+            </h2>
+            <span className="font-mono text-[10px] text-muted-foreground ml-auto">
+              sorted by vectors
+            </span>
+          </div>
+          <div className="p-3.5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
             {gameBreakdown.map(game => (
               <VectorGameCard key={game.gameId} game={game} />
             ))}
           </div>
-        </div>
+        </section>
       )}
 
       {/* Empty State */}
       {!isLoading && !error && gameBreakdown.length === 0 && (
-        <div className="text-center py-12 bg-card/50 dark:bg-zinc-800/50 backdrop-blur-sm rounded-xl border border-border/40 dark:border-zinc-700/30">
+        <div className="text-center py-12 rounded-[10px] border border-border/60 bg-card">
           <DatabaseIcon className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
           <p className="text-muted-foreground font-medium">No vectors indexed yet</p>
           <p className="text-xs text-muted-foreground mt-1">

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx
@@ -327,7 +327,7 @@ export default function VectorStorePage() {
                         <button
                           type="button"
                           onClick={() => setExpandedResult(isExpanded ? null : item.documentId)}
-                          className={`w-full grid grid-cols-[110px_110px_1fr_70px_28px] gap-3 px-3.5 py-2.5 text-left border-b border-border/60 last:border-0 hover:bg-muted/50 transition-colors ${isExpanded ? 'bg-entity-kb/4' : ''}`}
+                          className={`w-full grid grid-cols-[110px_110px_1fr_70px_28px] gap-3 px-3.5 py-2.5 text-left border-b border-border/60 last:border-0 hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${isExpanded ? 'bg-entity-kb/4' : ''}`}
                         >
                           <span className="font-mono text-[10.5px] font-bold text-entity-kb flex items-center gap-1.5 shrink-0 truncate">
                             <span className="h-1.5 w-1.5 rounded-full bg-entity-game shrink-0" />

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbCrumbs.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbCrumbs.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+const KB_BASE = '/admin/knowledge-base';
+
+const LABELS: ReadonlyArray<readonly [string, string]> = [
+  [`${KB_BASE}/vectors`, 'Vector Collections'],
+  [`${KB_BASE}/queue`, 'Processing Queue'],
+  [`${KB_BASE}/pipeline`, 'RAG Pipeline'],
+  [`${KB_BASE}/embedding`, 'Embedding'],
+  [`${KB_BASE}/feedback`, 'Feedback'],
+  [`${KB_BASE}/settings`, 'Settings'],
+  [`${KB_BASE}/snapshots`, 'Snapshots'],
+  [`${KB_BASE}/upload`, 'Upload'],
+];
+
+function labelFor(pathname: string): string {
+  if (pathname === KB_BASE) return 'Explorer';
+  const hit = LABELS.find(([href]) => pathname === href || pathname.startsWith(`${href}/`));
+  return hit ? hit[1] : 'Explorer';
+}
+
+export function KbCrumbs() {
+  const pathname = usePathname();
+  return (
+    <div className="font-mono text-[11px] text-muted-foreground mt-0.5">
+      Admin · KB · {labelFor(pathname)}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export function KbTopActions() {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="hidden md:flex items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-1.5 text-sm text-muted-foreground w-[280px]">
+        <span aria-hidden>🔍</span>
+        <input
+          className="flex-1 bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
+          placeholder="Search docs, chunks, games…"
+          aria-label="Search knowledge base"
+        />
+        <kbd className="rounded border border-border/60 bg-muted px-1.5 font-mono text-[10px]">
+          ⌘K
+        </kbd>
+      </div>
+      <Link
+        href="/admin/knowledge-base/upload"
+        className="inline-flex items-center gap-1.5 rounded-md bg-entity-kb px-3 py-1.5 text-sm font-semibold font-quicksand text-white shadow-sm hover:brightness-110"
+      >
+        + Upload PDF
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx
@@ -9,6 +9,8 @@ export function KbTopActions() {
           className="flex-1 bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
           placeholder="Search docs, chunks, games…"
           aria-label="Search knowledge base"
+          readOnly
+          tabIndex={-1}
         />
         <kbd className="rounded border border-border/60 bg-muted px-1.5 font-mono text-[10px]">
           ⌘K

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx
@@ -1,0 +1,17 @@
+import { KbCrumbs } from './KbCrumbs';
+import { KbTopActions } from './KbTopActions';
+
+export function KbTopBand() {
+  return (
+    <header className="sticky top-0 z-40 -mx-6 flex items-center gap-4 border-b border-border/60 bg-background/80 px-6 py-3 backdrop-blur-md">
+      <div>
+        <h1 className="font-quicksand text-xl font-extrabold tracking-tight text-foreground">
+          Knowledge Base
+        </h1>
+        <KbCrumbs />
+      </div>
+      <div className="flex-1" />
+      <KbTopActions />
+    </header>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx
@@ -3,7 +3,10 @@ import { KbTopActions } from './KbTopActions';
 
 export function KbTopBand() {
   return (
-    <header className="sticky top-0 z-40 -mx-6 flex items-center gap-4 border-b border-border/60 bg-background/80 px-6 py-3 backdrop-blur-md">
+    <header
+      aria-label="Knowledge Base section"
+      className="sticky top-0 z-40 -mx-6 flex items-center gap-4 border-b border-border/60 bg-background/80 px-6 py-3 backdrop-blur-md"
+    >
       <div>
         <h1 className="font-quicksand text-xl font-extrabold tracking-tight text-foreground">
           Knowledge Base

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTree.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTree.tsx
@@ -85,7 +85,7 @@ export function KbTree({
                 aria-expanded={expanded}
                 aria-label={game.gameName}
                 onClick={() => onToggleGame(game.gameId)}
-                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/70 dark:hover:bg-zinc-800/70 font-semibold text-[13px] text-left"
+                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/70 dark:hover:bg-zinc-800/70 font-semibold text-[13px] text-left text-foreground"
               >
                 <span aria-hidden="true" className="text-muted-foreground">
                   {expanded ? '▾' : '▸'}

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { usePathname } from 'next/navigation';
+
+import { KbCrumbs } from '../KbCrumbs';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+const mockUsePathname = usePathname as ReturnType<typeof vi.fn>;
+
+describe('KbCrumbs', () => {
+  it('renders Explorer label at KB root', () => {
+    mockUsePathname.mockReturnValue('/admin/knowledge-base');
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Explorer/)).toBeInTheDocument();
+  });
+  it('renders Vector Collections label on /vectors', () => {
+    mockUsePathname.mockReturnValue('/admin/knowledge-base/vectors');
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Vector Collections/)).toBeInTheDocument();
+  });
+  it('renders Processing Queue label on /queue', () => {
+    mockUsePathname.mockReturnValue('/admin/knowledge-base/queue');
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Processing Queue/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { usePathname } from 'next/navigation';
+
+import { KbTopBand } from '../KbTopBand';
+
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+const mockUsePathname = usePathname as ReturnType<typeof vi.fn>;
+
+describe('KbTopBand', () => {
+  it('renders a single h1 "Knowledge Base"', () => {
+    mockUsePathname.mockReturnValue('/admin/knowledge-base/vectors');
+    render(<KbTopBand />);
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent('Knowledge Base');
+  });
+  it('renders the Upload PDF action', () => {
+    mockUsePathname.mockReturnValue('/admin/knowledge-base/vectors');
+    render(<KbTopBand />);
+    expect(screen.getByRole('link', { name: /Upload PDF/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- admin KB chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13b admin scope (see token-bridge-map.md for --admin-* decision deferred to DS-15). */
 'use client';
 
 import { useState } from 'react';
@@ -35,10 +34,11 @@ export function KbFeedbackPanel({ gameId }: Props) {
   });
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-3">
+    <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+      {/* Panel header: filter + meta */}
+      <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
         <Select value={outcomeFilter} onValueChange={setOutcomeFilter}>
-          <SelectTrigger className="w-40">
+          <SelectTrigger className="h-7 w-36 text-[11px] font-quicksand font-bold bg-card border-border/60">
             <SelectValue placeholder="Tutti" />
           </SelectTrigger>
           <SelectContent>
@@ -48,41 +48,65 @@ export function KbFeedbackPanel({ gameId }: Props) {
           </SelectContent>
         </Select>
         {data && (
-          <span className="text-sm text-muted-foreground">{data.total} feedback totali</span>
+          <span className="font-mono text-[10px] text-muted-foreground ml-auto">
+            {data.total} feedback totali
+          </span>
         )}
       </div>
 
-      {isLoading && <div className="animate-pulse h-48 bg-muted rounded-lg" />}
+      {/* Panel body */}
+      <div className="p-3.5 space-y-2">
+        {/* Loading skeleton */}
+        {isLoading && <div className="animate-pulse h-48 rounded-lg bg-muted" />}
 
-      <div className="space-y-2">
+        {/* Feedback list */}
         {data?.items.map(item => (
           <div
             key={item.id}
-            className="flex items-start gap-3 p-3 border rounded-lg bg-card/60 dark:bg-zinc-800/60"
+            className={`flex items-start gap-3 rounded-lg border p-3 bg-background ${
+              item.outcome === 'helpful' ? 'border-entity-toolkit/30' : 'border-entity-event/30'
+            }`}
           >
+            {/* Thumb icon */}
             {item.outcome === 'helpful' ? (
-              <ThumbsUp className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+              <ThumbsUp className="h-4 w-4 text-entity-toolkit mt-0.5 shrink-0" />
             ) : (
-              <ThumbsDown className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+              <ThumbsDown className="h-4 w-4 text-entity-event mt-0.5 shrink-0" />
             )}
+
+            {/* Body */}
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                {/* Outcome badge */}
                 <Badge
-                  variant={item.outcome === 'helpful' ? 'default' : 'destructive'}
-                  className="text-xs"
+                  className={`text-[10px] font-mono font-bold uppercase tracking-wide rounded-full px-2 py-0.5 border-0 ${
+                    item.outcome === 'helpful'
+                      ? 'bg-entity-toolkit/12 text-entity-toolkit'
+                      : 'bg-entity-event/12 text-entity-event'
+                  }`}
                 >
                   {item.outcome === 'helpful' ? 'Utile' : 'Non utile'}
                 </Badge>
-                <span className="text-xs text-muted-foreground font-mono">
+                {/* Message ID */}
+                <span className="font-mono text-[10.5px] font-bold text-entity-kb bg-background border border-border/60 rounded px-1.5 py-px">
                   msg: {item.messageId.slice(0, 8)}&hellip;
                 </span>
-                <span className="text-xs text-muted-foreground">
+                {/* Date */}
+                <span className="font-mono text-[10px] text-muted-foreground">
                   {new Date(item.createdAt).toLocaleDateString('it-IT')}
                 </span>
               </div>
+
+              {/* Optional comment */}
               {item.comment && (
-                <p className="text-sm text-muted-foreground flex items-start gap-1">
-                  <MessageSquare className="h-3 w-3 mt-0.5 shrink-0" />
+                <p
+                  className={`text-[12.5px] text-foreground leading-relaxed bg-background border-l-2 pl-2.5 pr-2 py-1.5 rounded-r-[6px] flex items-start gap-1 ${
+                    item.outcome === 'helpful'
+                      ? 'border-entity-toolkit/50'
+                      : 'border-entity-event/50'
+                  }`}
+                >
+                  <MessageSquare className="h-3 w-3 mt-0.5 shrink-0 text-muted-foreground" />
                   {item.comment}
                 </p>
               )}
@@ -90,30 +114,34 @@ export function KbFeedbackPanel({ gameId }: Props) {
           </div>
         ))}
 
+        {/* Empty state */}
         {data && data.items.length === 0 && !isLoading && (
-          <div className="text-center py-8 text-muted-foreground">Nessun feedback trovato</div>
+          <div className="text-center py-8 font-mono text-[11px] text-muted-foreground">
+            Nessun feedback trovato
+          </div>
+        )}
+
+        {/* Pagination */}
+        {data && data.total > 20 && (
+          <div className="flex items-center justify-center gap-2 pt-2 border-t border-border/60 mt-2">
+            <button
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40"
+              disabled={page === 1}
+              onClick={() => setPage(p => p - 1)}
+            >
+              &larr; Prec
+            </button>
+            <span className="font-mono text-[11px] text-muted-foreground px-1">Pag {page}</span>
+            <button
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40"
+              disabled={page * 20 >= data.total}
+              onClick={() => setPage(p => p + 1)}
+            >
+              Succ &rarr;
+            </button>
+          </div>
         )}
       </div>
-
-      {data && data.total > 20 && (
-        <div className="flex justify-center gap-2">
-          <button
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-            disabled={page === 1}
-            onClick={() => setPage(p => p - 1)}
-          >
-            &larr; Prec
-          </button>
-          <span className="px-3 py-1 text-sm">Pag {page}</span>
-          <button
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
-            disabled={page * 20 >= data.total}
-            onClick={() => setPage(p => p + 1)}
-          >
-            Succ &rarr;
-          </button>
-        </div>
-      )}
-    </div>
+    </section>
   );
 }

--- a/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
@@ -127,7 +127,7 @@ export function KbFeedbackPanel({ gameId }: Props) {
           <div className="flex items-center justify-center gap-2 pt-2 border-t border-border/60 mt-2">
             <button
               type="button"
-              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               disabled={page === 1}
               onClick={() => setPage(p => p - 1)}
             >
@@ -136,7 +136,7 @@ export function KbFeedbackPanel({ gameId }: Props) {
             <span className="font-mono text-[11px] text-muted-foreground px-1">Pag {page}</span>
             <button
               type="button"
-              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               disabled={page * 20 >= data.total}
               onClick={() => setPage(p => p + 1)}
             >

--- a/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
@@ -79,7 +79,8 @@ export function KbFeedbackPanel({ gameId }: Props) {
               <div className="flex items-center gap-2 mb-1 flex-wrap">
                 {/* Outcome badge */}
                 <Badge
-                  className={`text-[10px] font-mono font-bold uppercase tracking-wide rounded-full px-2 py-0.5 border-0 ${
+                  variant="outline"
+                  className={`border-0 text-[10px] font-mono font-bold uppercase tracking-wide rounded-full px-2 py-0.5 ${
                     item.outcome === 'helpful'
                       ? 'bg-entity-toolkit/12 text-entity-toolkit'
                       : 'bg-entity-event/12 text-entity-event'
@@ -125,7 +126,8 @@ export function KbFeedbackPanel({ gameId }: Props) {
         {data && data.total > 20 && (
           <div className="flex items-center justify-center gap-2 pt-2 border-t border-border/60 mt-2">
             <button
-              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40"
+              type="button"
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
               disabled={page === 1}
               onClick={() => setPage(p => p - 1)}
             >
@@ -133,7 +135,8 @@ export function KbFeedbackPanel({ gameId }: Props) {
             </button>
             <span className="font-mono text-[11px] text-muted-foreground px-1">Pag {page}</span>
             <button
-              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40"
+              type="button"
+              className="rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
               disabled={page * 20 >= data.total}
               onClick={() => setPage(p => p + 1)}
             >

--- a/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- admin KB chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13b admin scope (see token-bridge-map.md for --admin-* decision deferred to DS-15). */
 'use client';
 
 import { useState } from 'react';
@@ -78,17 +77,19 @@ interface ClearCacheResult {
 function SettingRow({ label, value }: { label: string; value: string | number | boolean }) {
   const displayValue =
     typeof value === 'boolean' ? (value ? 'Enabled' : 'Disabled') : String(value);
-  const boolColor =
+  const valueClass =
     typeof value === 'boolean'
       ? value
-        ? 'text-green-600 dark:text-green-400'
-        : 'text-muted-foreground dark:text-muted-foreground'
-      : 'text-foreground dark:text-zinc-100';
+        ? 'text-entity-toolkit'
+        : 'text-muted-foreground'
+      : 'text-foreground';
 
   return (
-    <div className="flex items-center justify-between py-2 border-b border-border dark:border-zinc-800 last:border-0">
-      <span className="text-sm text-muted-foreground dark:text-muted-foreground">{label}</span>
-      <span className={`text-sm font-mono ${boolColor}`}>{displayValue}</span>
+    <div className="flex items-center justify-between py-1.5 border-b border-border/60 last:border-0">
+      <span className="font-mono text-[9.5px] font-bold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className={`font-mono text-[11.5px] font-semibold ${valueClass}`}>{displayValue}</span>
     </div>
   );
 }
@@ -103,12 +104,12 @@ function SettingsCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-5 border border-border/50 dark:border-zinc-700/50">
-      <div className="flex items-center gap-2 mb-4">
-        <Icon className="h-5 w-5 text-blue-500" />
-        <h3 className="font-semibold text-foreground dark:text-zinc-100">{title}</h3>
+    <div className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+      <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+        <Icon className="h-3.5 w-3.5 text-entity-kb shrink-0" />
+        <h3 className="font-quicksand text-[13px] font-extrabold text-foreground">{title}</h3>
       </div>
-      <div className="space-y-0">{children}</div>
+      <div className="p-3.5 space-y-0">{children}</div>
     </div>
   );
 }
@@ -153,7 +154,7 @@ export function KBSettings() {
     return (
       <div className="space-y-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-48 bg-card/40 dark:bg-zinc-800/40 rounded-xl animate-pulse" />
+          <div key={i} className="h-48 rounded-[10px] bg-muted animate-pulse" />
         ))}
       </div>
     );
@@ -161,8 +162,8 @@ export function KBSettings() {
 
   if (!settings) {
     return (
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border/50 dark:border-zinc-700/50">
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground">Unable to load KB settings</p>
+      <div className="rounded-[10px] border border-border/60 bg-card p-4">
+        <p className="text-sm text-muted-foreground">Unable to load KB settings</p>
       </div>
     );
   }
@@ -170,35 +171,36 @@ export function KBSettings() {
   return (
     <div className="space-y-6">
       {/* Info Banner */}
-      <div className="flex items-start gap-3 bg-blue-50/70 dark:bg-blue-900/20 backdrop-blur-md rounded-xl p-4 border border-blue-200/50 dark:border-blue-800/50">
-        <InfoIcon className="h-5 w-5 text-blue-500 mt-0.5 shrink-0" />
-        <div>
-          <p className="text-sm font-medium text-blue-900 dark:text-blue-200">
+      <div className="flex items-start gap-3 rounded-[10px] border border-entity-chat/30 bg-entity-chat/12 p-4">
+        <InfoIcon className="h-4 w-4 text-entity-chat mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="font-quicksand text-[13px] font-extrabold text-entity-chat">
             Read-only Configuration
           </p>
-          <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
+          <p className="mt-1 text-xs text-muted-foreground">
             These settings are configured via environment variables and config files. To modify
             them, update the server configuration and restart the API service.
           </p>
         </div>
-      </div>
-
-      {/* Refresh Button */}
-      <div className="flex justify-end">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => refetch()}
-          disabled={isRefetching}
-          className="gap-2"
-        >
-          <RefreshCwIcon className={`h-4 w-4 ${isRefetching ? 'animate-spin' : ''}`} />
-          Refresh
-        </Button>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-mono text-[10px] font-bold text-muted-foreground">
+            read-only
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="gap-1.5 h-7 px-2.5 text-[11px]"
+          >
+            <RefreshCwIcon className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
       </div>
 
       {/* Settings Cards Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
         {/* Embedding Model */}
         <SettingsCard title="Embedding Model" icon={CpuIcon}>
           <SettingRow label="Provider" value={settings.embedding.provider} />
@@ -252,7 +254,7 @@ export function KBSettings() {
           <SettingRow label="Configured" value={settings.reranker.configured} />
           {settings.reranker.url && <SettingRow label="URL" value={settings.reranker.url} />}
           {!settings.reranker.configured && (
-            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+            <p className="text-xs text-entity-agent mt-2">
               Reranker not configured. Set RERANKER_URL to enable cross-encoder reranking.
             </p>
           )}
@@ -261,7 +263,7 @@ export function KBSettings() {
         {/* Storage */}
         <SettingsCard title="File Storage" icon={HardDriveIcon}>
           <SettingRow label="Provider" value={settings.storage.provider} />
-          <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-2">
+          <p className="text-xs text-muted-foreground mt-2">
             {settings.storage.provider === 'local'
               ? 'Using local filesystem storage. Set STORAGE_PROVIDER=s3 for cloud storage.'
               : 'Using S3-compatible cloud storage.'}
@@ -273,146 +275,160 @@ export function KBSettings() {
       <RagEnhancementsTab />
 
       {/* Danger Zone */}
-      <div className="bg-red-50/70 dark:bg-red-900/20 backdrop-blur-md rounded-xl p-6 border-2 border-red-200 dark:border-red-800">
-        <div className="flex items-center gap-2 mb-4">
-          <AlertTriangleIcon className="w-5 h-5 text-red-600 dark:text-red-400" />
-          <h2 className="font-quicksand text-xl font-bold text-red-900 dark:text-red-300">
+      <div className="rounded-[10px] border border-entity-event/40 bg-entity-event/5 overflow-hidden">
+        {/* Danger Zone header */}
+        <div className="flex items-center gap-2.5 border-b border-entity-event/25 px-4 py-3 bg-gradient-to-r from-entity-event/14 to-entity-event/4">
+          <AlertTriangleIcon className="h-4 w-4 text-entity-event shrink-0" />
+          <h2 className="font-quicksand text-[14px] font-extrabold text-entity-event">
             Danger Zone
           </h2>
+          <span className="font-mono text-[10.5px] text-muted-foreground ml-2">
+            These actions may affect system performance and data availability.
+          </span>
         </div>
-        <p className="text-sm text-red-700 dark:text-red-400 mb-4">
-          These actions may affect system performance and data availability.
-        </p>
 
-        <div className="space-y-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-entity-event/15">
           {/* Rebuild Index */}
-          {!showRebuildConfirm ? (
-            <div className="flex items-center justify-between">
+          <div className="p-4 flex flex-col gap-3">
+            <div className="flex items-start gap-3">
+              <div className="h-8 w-8 rounded-lg bg-entity-event/14 flex items-center justify-center shrink-0">
+                <RefreshCwIcon className="h-4 w-4 text-entity-event" />
+              </div>
               <div>
-                <p className="text-sm font-medium text-red-900 dark:text-red-200">
+                <p className="font-quicksand text-[13.5px] font-extrabold text-foreground">
                   Rebuild Vector Index
                 </p>
-                <p className="text-xs text-red-600 dark:text-red-400">
+                <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
                   Triggers reindexing of all pgvector embeddings. May temporarily affect search.
                 </p>
               </div>
+            </div>
+
+            {!showRebuildConfirm ? (
               <Button
                 variant="destructive"
                 size="sm"
                 onClick={() => setShowRebuildConfirm(true)}
                 disabled={rebuildIndexMutation.isPending}
+                className="self-start gap-1.5"
               >
-                <RefreshCwIcon className="h-4 w-4 mr-1" />
+                <RefreshCwIcon className="h-4 w-4" />
                 Rebuild Index
               </Button>
-            </div>
-          ) : (
-            <div className="bg-red-100 dark:bg-red-900/40 rounded-lg p-4">
-              <p className="text-sm font-medium text-red-900 dark:text-red-200 mb-3">
-                Are you sure you want to rebuild all vector indices?
-              </p>
-              <div className="flex gap-2">
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => rebuildIndexMutation.mutate()}
-                  disabled={rebuildIndexMutation.isPending}
-                >
-                  {rebuildIndexMutation.isPending ? (
-                    <>
-                      <RefreshCwIcon className="h-4 w-4 mr-1 animate-spin" />
-                      Rebuilding...
-                    </>
-                  ) : (
-                    'Yes, Rebuild'
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowRebuildConfirm(false)}
-                  disabled={rebuildIndexMutation.isPending}
-                >
-                  Cancel
-                </Button>
+            ) : (
+              <div className="rounded-lg border border-entity-event/25 bg-background p-3 flex flex-col gap-2">
+                <p className="font-mono text-[11px] text-muted-foreground">
+                  Are you sure you want to rebuild all vector indices?
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => rebuildIndexMutation.mutate()}
+                    disabled={rebuildIndexMutation.isPending}
+                  >
+                    {rebuildIndexMutation.isPending ? (
+                      <>
+                        <RefreshCwIcon className="h-4 w-4 mr-1 animate-spin" />
+                        Rebuilding...
+                      </>
+                    ) : (
+                      'Yes, Rebuild'
+                    )}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowRebuildConfirm(false)}
+                    disabled={rebuildIndexMutation.isPending}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                {rebuildIndexMutation.isSuccess && (
+                  <p className="text-xs text-entity-toolkit mt-1">
+                    Rebuild triggered successfully.
+                  </p>
+                )}
+                {rebuildIndexMutation.isError && (
+                  <p className="text-xs text-entity-event mt-1">
+                    Failed to trigger rebuild. Please try again.
+                  </p>
+                )}
               </div>
-              {rebuildIndexMutation.isSuccess && (
-                <p className="text-xs text-green-600 dark:text-green-400 mt-2">
-                  Rebuild triggered successfully.
-                </p>
-              )}
-              {rebuildIndexMutation.isError && (
-                <p className="text-xs text-red-600 dark:text-red-400 mt-2">
-                  Failed to trigger rebuild. Please try again.
-                </p>
-              )}
-            </div>
-          )}
-
-          <div className="border-t border-red-200 dark:border-red-800" />
+            )}
+          </div>
 
           {/* Clear Cache */}
-          {!showClearConfirm ? (
-            <div className="flex items-center justify-between">
+          <div className="p-4 flex flex-col gap-3">
+            <div className="flex items-start gap-3">
+              <div className="h-8 w-8 rounded-lg bg-entity-event/14 flex items-center justify-center shrink-0">
+                <Trash2Icon className="h-4 w-4 text-entity-event" />
+              </div>
               <div>
-                <p className="text-sm font-medium text-red-900 dark:text-red-200">Clear KB Cache</p>
-                <p className="text-xs text-red-600 dark:text-red-400">
+                <p className="font-quicksand text-[13.5px] font-extrabold text-foreground">
+                  Clear KB Cache
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
                   Signals a cache reset. Cached entries will expire based on their TTL.
                 </p>
               </div>
+            </div>
+
+            {!showClearConfirm ? (
               <Button
                 variant="outline"
                 size="sm"
-                className="border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                className="self-start gap-1.5 border-entity-event/55 text-entity-event hover:bg-entity-event/8"
                 onClick={() => setShowClearConfirm(true)}
                 disabled={clearCacheMutation.isPending}
               >
-                <Trash2Icon className="h-4 w-4 mr-1" />
+                <Trash2Icon className="h-4 w-4" />
                 Clear Cache
               </Button>
-            </div>
-          ) : (
-            <div className="bg-red-100 dark:bg-red-900/40 rounded-lg p-4">
-              <p className="text-sm font-medium text-red-900 dark:text-red-200 mb-3">
-                Are you sure you want to clear the KB cache?
-              </p>
-              <div className="flex gap-2">
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => clearCacheMutation.mutate()}
-                  disabled={clearCacheMutation.isPending}
-                >
-                  {clearCacheMutation.isPending ? (
-                    <>
-                      <RefreshCwIcon className="h-4 w-4 mr-1 animate-spin" />
-                      Clearing...
-                    </>
-                  ) : (
-                    'Yes, Clear Cache'
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowClearConfirm(false)}
-                  disabled={clearCacheMutation.isPending}
-                >
-                  Cancel
-                </Button>
+            ) : (
+              <div className="rounded-lg border border-entity-event/25 bg-background p-3 flex flex-col gap-2">
+                <p className="font-mono text-[11px] text-muted-foreground">
+                  Are you sure you want to clear the KB cache?
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => clearCacheMutation.mutate()}
+                    disabled={clearCacheMutation.isPending}
+                  >
+                    {clearCacheMutation.isPending ? (
+                      <>
+                        <RefreshCwIcon className="h-4 w-4 mr-1 animate-spin" />
+                        Clearing...
+                      </>
+                    ) : (
+                      'Yes, Clear Cache'
+                    )}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowClearConfirm(false)}
+                    disabled={clearCacheMutation.isPending}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                {clearCacheMutation.isSuccess && (
+                  <p className="text-xs text-entity-toolkit mt-1">
+                    {clearCacheMutation.data?.message}
+                  </p>
+                )}
+                {clearCacheMutation.isError && (
+                  <p className="text-xs text-entity-event mt-1">
+                    Failed to clear cache. Please try again.
+                  </p>
+                )}
               </div>
-              {clearCacheMutation.isSuccess && (
-                <p className="text-xs text-green-600 dark:text-green-400 mt-2">
-                  {clearCacheMutation.data?.message}
-                </p>
-              )}
-              {clearCacheMutation.isError && (
-                <p className="text-xs text-red-600 dark:text-red-400 mt-2">
-                  Failed to clear cache. Please try again.
-                </p>
-              )}
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
@@ -254,7 +254,7 @@ export function KBSettings() {
           <SettingRow label="Configured" value={settings.reranker.configured} />
           {settings.reranker.url && <SettingRow label="URL" value={settings.reranker.url} />}
           {!settings.reranker.configured && (
-            <p className="text-xs text-entity-agent mt-2">
+            <p className="text-xs text-muted-foreground mt-2">
               Reranker not configured. Set RERANKER_URL to enable cross-encoder reranking.
             </p>
           )}
@@ -282,7 +282,7 @@ export function KBSettings() {
           <h2 className="font-quicksand text-[14px] font-extrabold text-entity-event">
             Danger Zone
           </h2>
-          <span className="font-mono text-[10.5px] text-muted-foreground ml-2">
+          <span className="font-mono text-[10.5px] text-foreground ml-2">
             These actions may affect system performance and data availability.
           </span>
         </div>

--- a/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
+++ b/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- admin KB chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13b admin scope (see token-bridge-map.md for --admin-* decision deferred to DS-15). */
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
@@ -31,22 +30,22 @@ const AMBER_THRESHOLD = 30;
 const RED_THRESHOLD = 120;
 
 function formatDuration(seconds: number): string {
-  if (seconds === 0) return '\u2014';
+  if (seconds === 0) return '—';
   if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
   if (seconds < 60) return `${seconds.toFixed(1)}s`;
   return `${(seconds / 60).toFixed(1)}m`;
 }
 
 function durationColor(seconds: number): string {
-  if (seconds >= RED_THRESHOLD) return 'text-red-600 dark:text-red-400';
-  if (seconds >= AMBER_THRESHOLD) return 'text-amber-600 dark:text-amber-400';
-  return 'text-green-600 dark:text-green-400';
+  if (seconds >= RED_THRESHOLD) return 'text-entity-event';
+  if (seconds >= AMBER_THRESHOLD) return 'text-amber-600';
+  return 'text-entity-toolkit';
 }
 
 function barColor(seconds: number): string {
-  if (seconds >= RED_THRESHOLD) return 'bg-red-500';
+  if (seconds >= RED_THRESHOLD) return 'bg-entity-event';
   if (seconds >= AMBER_THRESHOLD) return 'bg-amber-500';
-  return 'bg-green-500';
+  return 'bg-entity-toolkit';
 }
 
 export function ProcessingMetrics() {
@@ -66,13 +65,10 @@ export function ProcessingMetrics() {
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <div className="h-8 w-48 bg-card/40 dark:bg-zinc-800/40 rounded animate-pulse" />
+        <div className="h-8 w-48 bg-card/40 rounded animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-48 bg-card/40 dark:bg-zinc-800/40 rounded-lg animate-pulse"
-            />
+            <div key={i} className="h-48 bg-card/40 rounded-[10px] animate-pulse" />
           ))}
         </div>
       </div>
@@ -81,11 +77,9 @@ export function ProcessingMetrics() {
 
   if (!metrics) {
     return (
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border/50 dark:border-zinc-700/50">
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-          Nessuna metrica di elaborazione disponibile
-        </p>
-      </div>
+      <section className="rounded-[10px] border border-border/60 bg-card p-6">
+        <p className="text-sm text-muted-foreground">Nessuna metrica di elaborazione disponibile</p>
+      </section>
     );
   }
 
@@ -98,13 +92,13 @@ export function ProcessingMetrics() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-4">
-        <h2 className="font-quicksand text-xl font-bold text-foreground dark:text-zinc-100 flex items-center gap-2">
-          <ActivityIcon className="h-5 w-5 text-blue-500" />
+        <h2 className="font-quicksand text-xl font-bold text-foreground flex items-center gap-2">
+          <ActivityIcon className="h-5 w-5 text-entity-kb" />
           Metriche Elaborazione
         </h2>
         <div className="flex items-center gap-3">
           <time
-            className="text-xs text-muted-foreground dark:text-muted-foreground"
+            className="text-xs text-muted-foreground font-mono"
             dateTime={metrics.lastUpdated}
             suppressHydrationWarning
           >
@@ -147,26 +141,26 @@ export function ProcessingMetrics() {
       </div>
 
       {/* Comparison Table */}
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-border/50 dark:border-zinc-700/50 overflow-hidden">
+      <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-border dark:border-zinc-700">
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+            <tr className="border-b border-border/60 bg-muted">
+              <th className="text-left px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 Fase
               </th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+              <th className="text-right px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 Media
               </th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+              <th className="text-right px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 P50
               </th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+              <th className="text-right px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 P95
               </th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+              <th className="text-right px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 P99
               </th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground dark:text-muted-foreground">
+              <th className="text-right px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
                 Campioni
               </th>
             </tr>
@@ -179,11 +173,9 @@ export function ProcessingMetrics() {
               return (
                 <tr
                   key={stepName}
-                  className={`border-b border-border dark:border-zinc-800 ${
-                    isBottleneck ? 'bg-amber-50/50 dark:bg-amber-900/10' : ''
-                  }`}
+                  className={`border-b border-border/60 ${isBottleneck ? 'bg-amber-500/6' : ''}`}
                 >
-                  <td className="px-4 py-3 font-medium text-foreground dark:text-zinc-100 flex items-center gap-2">
+                  <td className="px-4 py-3 font-medium text-foreground flex items-center gap-2">
                     {isBottleneck && <AlertTriangleIcon className="h-3.5 w-3.5 text-amber-500" />}
                     {avg?.step ?? stepName}
                   </td>
@@ -201,7 +193,7 @@ export function ProcessingMetrics() {
                   <td className={`text-right px-4 py-3 font-mono ${durationColor(pct?.p99 ?? 0)}`}>
                     {formatDuration(pct?.p99 ?? 0)}
                   </td>
-                  <td className="text-right px-4 py-3 text-muted-foreground dark:text-muted-foreground">
+                  <td className="text-right px-4 py-3 font-mono text-muted-foreground">
                     {avg?.sampleSize ?? 0}
                   </td>
                 </tr>
@@ -209,7 +201,7 @@ export function ProcessingMetrics() {
             })}
           </tbody>
         </table>
-      </div>
+      </section>
     </div>
   );
 }
@@ -235,23 +227,23 @@ function StepMetricCard({
 }) {
   return (
     <div
-      className={`bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-5 border ${
+      className={`rounded-[10px] p-5 border ${
         isBottleneck
-          ? 'border-amber-300 dark:border-amber-700 ring-1 ring-amber-200 dark:ring-amber-800'
-          : 'border-border/50 dark:border-zinc-700/50'
+          ? 'border-amber-500/40 ring-1 ring-amber-500/20 bg-amber-500/6'
+          : 'border-border/60 bg-card'
       }`}
     >
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <h3 className="font-semibold text-foreground dark:text-zinc-100">{stepName}</h3>
+          <h3 className="font-quicksand font-semibold text-foreground">{stepName}</h3>
           {isBottleneck && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-mono text-[10px] font-bold bg-amber-500/14 text-amber-600">
               <AlertTriangleIcon className="h-3 w-3" />
               Collo di bottiglia
             </span>
           )}
         </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground dark:text-muted-foreground">
+        <div className="flex items-center gap-1 font-mono text-xs text-muted-foreground">
           <HashIcon className="h-3 w-3" />
           {sampleSize} campioni
         </div>
@@ -260,7 +252,7 @@ function StepMetricCard({
       {/* Average Duration */}
       <div className="flex items-center gap-2 mb-4">
         <ClockIcon className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm text-muted-foreground dark:text-muted-foreground">Avg:</span>
+        <span className="text-sm text-muted-foreground">Avg:</span>
         <span className={`text-lg font-bold font-mono ${durationColor(avgDuration)}`}>
           {formatDuration(avgDuration)}
         </span>
@@ -281,8 +273,8 @@ function PercentileBar({ label, value, max }: { label: string; value: number; ma
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-[10px] font-mono text-muted-foreground dark:text-muted-foreground w-6">{label}</span>
-      <div className="flex-1 h-2 bg-muted dark:bg-zinc-700 rounded-full overflow-hidden">
+      <span className="text-[10px] font-mono text-muted-foreground w-6">{label}</span>
+      <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
         <div
           className={`h-full rounded-full transition-all ${barColor(value)}`}
           style={{ width: `${widthPct}%` }}

--- a/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
+++ b/apps/web/src/components/admin/knowledge-base/processing-metrics.tsx
@@ -65,7 +65,7 @@ export function ProcessingMetrics() {
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <div className="h-8 w-48 bg-card/40 rounded animate-pulse" />
+        <div className="h-8 w-48 bg-card/40 rounded-[10px] animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="h-48 bg-card/40 rounded-[10px] animate-pulse" />

--- a/apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx
+++ b/apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- admin KB chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13b admin scope (see token-bridge-map.md for --admin-* decision deferred to DS-15). */
 'use client';
 
 import { useState } from 'react';
@@ -24,40 +23,40 @@ import { HttpClient } from '@/lib/api/core/httpClient';
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
 
-function statusColor(status: PipelineStageStatus) {
+function statusDotColor(status: PipelineStageStatus) {
   switch (status) {
     case 'healthy':
-      return 'bg-green-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]';
+      return 'bg-entity-toolkit shadow-[0_0_8px_hsl(var(--entity-toolkit)/0.5)]';
     case 'warning':
       return 'bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.5)]';
     case 'error':
-      return 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.5)]';
+      return 'bg-entity-event shadow-[0_0_8px_hsl(var(--entity-event)/0.5)]';
     default:
       return 'bg-muted-foreground';
   }
 }
 
-function statusBorder(status: PipelineStageStatus) {
+function statusBorderColor(status: PipelineStageStatus) {
   switch (status) {
     case 'healthy':
-      return 'border-green-400/40 dark:border-green-600/40';
+      return 'border-entity-toolkit/40';
     case 'warning':
-      return 'border-amber-400/40 dark:border-amber-600/40';
+      return 'border-amber-500/40';
     case 'error':
-      return 'border-red-400/40 dark:border-red-600/40';
+      return 'border-entity-event/40';
     default:
       return 'border-border/40';
   }
 }
 
 function formatDuration(ms: number | null): string {
-  if (ms === null) return '\u2014';
+  if (ms === null) return '—';
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
 function formatRelativeTime(dateStr: string | null): string {
-  if (!dateStr) return '\u2014';
+  if (!dateStr) return '—';
   const date = new Date(dateStr);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
@@ -87,10 +86,10 @@ export function RAGPipelineFlow() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="h-48 bg-card/40 dark:bg-zinc-800/40 rounded-xl animate-pulse" />
+        <div className="h-48 bg-card/40 rounded-[10px] animate-pulse" />
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-20 bg-card/40 dark:bg-zinc-800/40 rounded-lg animate-pulse" />
+            <div key={i} className="h-20 bg-card/40 rounded-[10px] animate-pulse" />
           ))}
         </div>
       </div>
@@ -105,9 +104,10 @@ export function RAGPipelineFlow() {
   return (
     <div className="space-y-6">
       {/* Pipeline Flow */}
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-8 border border-amber-200/50 dark:border-zinc-700/50">
-        <div className="flex items-center justify-between mb-8">
-          <h2 className="font-quicksand text-xl font-bold text-foreground dark:text-zinc-100">
+      <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+        {/* Panel header */}
+        <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+          <h2 className="font-quicksand text-[13px] font-extrabold text-foreground flex-1">
             RAG Pipeline Flow
           </h2>
           <Button
@@ -122,118 +122,126 @@ export function RAGPipelineFlow() {
           </Button>
         </div>
 
-        {/* Pipeline Visualization */}
-        <div className="flex items-center justify-between gap-4 mb-6 overflow-x-auto pb-4">
-          {stages.map((stage, index) => {
-            const isExpanded = expandedStage === stage.name;
-            return (
-              <div key={stage.name} className="flex items-center gap-4">
-                <div className="flex flex-col items-center">
-                  <button
-                    type="button"
-                    onClick={() => setExpandedStage(isExpanded ? null : stage.name)}
-                    className={`bg-muted dark:bg-zinc-900 rounded-lg p-4 border-2 ${statusBorder(stage.status)} min-w-[110px] transition-all hover:shadow-md hover:-translate-y-0.5 ${isExpanded ? 'ring-2 ring-blue-400/60' : ''}`}
-                  >
-                    <div className="text-center">
-                      <div className="font-semibold text-foreground dark:text-zinc-100 text-sm mb-2">
-                        {stage.name}
-                      </div>
-                      <div className={`w-3 h-3 rounded-full mx-auto ${statusColor(stage.status)} animate-pulse`} />
-                      {stage.metrics && Object.keys(stage.metrics).length > 0 && (
-                        <div className="mt-2 text-[10px] text-muted-foreground dark:text-muted-foreground leading-tight">
-                          {renderStageMetric(stage.name, stage.metrics)}
-                        </div>
-                      )}
-                      <div className="mt-2 flex justify-center">
-                        {isExpanded
-                          ? <ChevronUpIcon className="h-3 w-3 text-muted-foreground" />
-                          : <ChevronDownIcon className="h-3 w-3 text-muted-foreground" />}
-                      </div>
-                    </div>
-                  </button>
-                </div>
-                {index < stages.length - 1 && (
-                  <ArrowRightIcon className="w-6 h-6 text-amber-500 dark:text-amber-400 flex-shrink-0" />
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Stage Drill-Down Panel */}
-        {expandedStage && (() => {
-          const stage = stages.find((s) => s.name === expandedStage);
-          if (!stage) return null;
-          const metricsEntries = stage.metrics ? Object.entries(stage.metrics) : [];
-          return (
-            <div className="mb-6 bg-muted/80 dark:bg-zinc-900/60 rounded-xl border border-border/50 dark:border-zinc-700/50 p-5 space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="font-semibold text-foreground dark:text-zinc-100 flex items-center gap-2">
-                  <span className={`w-2.5 h-2.5 rounded-full ${statusColor(stage.status)}`} />
-                  {stage.name} — Stage Details
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => setExpandedStage(null)}
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  Close
-                </button>
-              </div>
-              {metricsEntries.length > 0 ? (
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-                  {metricsEntries.map(([key, value]) => (
-                    <div
-                      key={key}
-                      className="bg-card/70 dark:bg-zinc-800/70 rounded-lg px-3 py-2 border border-border/40 dark:border-zinc-700/40"
+        {/* Panel body */}
+        <div className="p-4 space-y-4">
+          {/* Pipeline Visualization */}
+          <div className="flex items-center justify-between gap-4 overflow-x-auto pb-2">
+            {stages.map((stage, index) => {
+              const isExpanded = expandedStage === stage.name;
+              return (
+                <div key={stage.name} className="flex items-center gap-4">
+                  <div className="flex flex-col items-center">
+                    <button
+                      type="button"
+                      onClick={() => setExpandedStage(isExpanded ? null : stage.name)}
+                      className={`bg-muted rounded-[10px] p-4 border-2 ${statusBorderColor(stage.status)} min-w-[110px] transition-all hover:shadow-md hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${isExpanded ? 'ring-2 ring-ring/50' : ''}`}
                     >
-                      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-0.5">
-                        {key.replace(/([A-Z])/g, ' $1').trim()}
+                      <div className="text-center">
+                        <div className="font-quicksand font-bold text-foreground text-sm mb-2">
+                          {stage.name}
+                        </div>
+                        <div
+                          className={`w-3 h-3 rounded-full mx-auto ${statusDotColor(stage.status)} animate-pulse`}
+                        />
+                        {stage.metrics && Object.keys(stage.metrics).length > 0 && (
+                          <div className="mt-2 text-[10px] text-muted-foreground leading-tight">
+                            {renderStageMetric(stage.name, stage.metrics)}
+                          </div>
+                        )}
+                        <div className="mt-2 flex justify-center">
+                          {isExpanded ? (
+                            <ChevronUpIcon className="h-3 w-3 text-muted-foreground" />
+                          ) : (
+                            <ChevronDownIcon className="h-3 w-3 text-muted-foreground" />
+                          )}
+                        </div>
                       </div>
-                      <div className="text-sm font-semibold text-foreground truncate">
-                        {value !== null && value !== undefined ? String(value) : '—'}
-                      </div>
-                    </div>
-                  ))}
+                    </button>
+                  </div>
+                  {index < stages.length - 1 && (
+                    <ArrowRightIcon className="w-6 h-6 text-entity-agent flex-shrink-0" />
+                  )}
                 </div>
-              ) : (
-                <p className="text-sm text-muted-foreground italic">No detailed metrics available for this stage.</p>
-              )}
-            </div>
-          );
-        })()}
+              );
+            })}
+          </div>
 
-        {/* Health Summary */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 border border-green-200 dark:border-green-800">
-            <div className="text-sm font-medium text-green-900 dark:text-green-300 flex items-center gap-1.5">
-              <CheckCircleIcon className="h-4 w-4" />
-              Healthy Stages
+          {/* Stage Drill-Down Panel */}
+          {expandedStage &&
+            (() => {
+              const stage = stages.find(s => s.name === expandedStage);
+              if (!stage) return null;
+              const metricsEntries = stage.metrics ? Object.entries(stage.metrics) : [];
+              return (
+                <div className="bg-background rounded-[10px] border border-border/60 border-l-4 border-l-entity-kb p-5 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-quicksand font-bold text-foreground flex items-center gap-2">
+                      <span
+                        className={`w-2.5 h-2.5 rounded-full ${statusDotColor(stage.status)}`}
+                      />
+                      {stage.name} — Stage Details
+                    </h3>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedStage(null)}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
+                    >
+                      Close
+                    </button>
+                  </div>
+                  {metricsEntries.length > 0 ? (
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+                      {metricsEntries.map(([key, value]) => (
+                        <div
+                          key={key}
+                          className="bg-card rounded-[10px] px-3 py-2 border border-border/60"
+                        >
+                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-0.5 font-mono font-bold">
+                            {key.replace(/([A-Z])/g, ' $1').trim()}
+                          </div>
+                          <div className="text-sm font-semibold text-foreground truncate font-mono">
+                            {value !== null && value !== undefined ? String(value) : '—'}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground italic">
+                      No detailed metrics available for this stage.
+                    </p>
+                  )}
+                </div>
+              );
+            })()}
+
+          {/* Health Summary */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="rounded-[10px] p-4 border bg-entity-toolkit/10 border-entity-toolkit/30">
+              <div className="text-sm font-medium text-entity-toolkit flex items-center gap-1.5">
+                <CheckCircleIcon className="h-4 w-4" />
+                Healthy Stages
+              </div>
+              <div className="text-2xl font-bold text-entity-toolkit">
+                {summary.healthyCount}/{stages.length}
+              </div>
             </div>
-            <div className="text-2xl font-bold text-green-700 dark:text-green-400">
-              {summary.healthyCount}/{stages.length}
+            <div className="rounded-[10px] p-4 border bg-amber-500/12 border-amber-500/30">
+              <div className="text-sm font-medium text-amber-600 flex items-center gap-1.5">
+                <AlertCircleIcon className="h-4 w-4" />
+                Warnings
+              </div>
+              <div className="text-2xl font-bold text-amber-600">{summary.warningCount}</div>
             </div>
-          </div>
-          <div className="bg-amber-50 dark:bg-amber-900/20 rounded-lg p-4 border border-amber-200 dark:border-amber-800">
-            <div className="text-sm font-medium text-amber-900 dark:text-amber-300 flex items-center gap-1.5">
-              <AlertCircleIcon className="h-4 w-4" />
-              Warnings
-            </div>
-            <div className="text-2xl font-bold text-amber-700 dark:text-amber-400">
-              {summary.warningCount}
-            </div>
-          </div>
-          <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-4 border border-red-200 dark:border-red-800">
-            <div className="text-sm font-medium text-red-900 dark:text-red-300 flex items-center gap-1.5">
-              <XCircleIcon className="h-4 w-4" />
-              Errors
-            </div>
-            <div className="text-2xl font-bold text-red-700 dark:text-red-400">
-              {summary.errorCount}
+            <div className="rounded-[10px] p-4 border bg-entity-event/10 border-entity-event/30">
+              <div className="text-sm font-medium text-entity-event flex items-center gap-1.5">
+                <XCircleIcon className="h-4 w-4" />
+                Errors
+              </div>
+              <div className="text-2xl font-bold text-entity-event">{summary.errorCount}</div>
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
       {/* Distribution Stats */}
       {distribution && (
@@ -242,92 +250,112 @@ export function RAGPipelineFlow() {
             icon={FileTextIcon}
             label="Documents"
             value={distribution.totalDocuments.toLocaleString()}
-            color="text-blue-500"
+            accent="border-l-entity-kb"
+            iconColor="text-entity-kb"
           />
           <StatCard
             icon={DatabaseIcon}
             label="Chunks"
             value={distribution.totalChunks.toLocaleString()}
-            color="text-violet-500"
+            accent="border-l-entity-chat"
+            iconColor="text-entity-chat"
           />
           <StatCard
             icon={DatabaseIcon}
             label="Vectors"
             value={distribution.vectorCount.toLocaleString()}
-            color="text-emerald-500"
+            accent="border-l-entity-agent"
+            iconColor="text-entity-agent"
           />
           <StatCard
             icon={FileTextIcon}
             label="Storage"
             value={distribution.storageSizeFormatted}
-            color="text-amber-500"
+            accent="border-l-entity-toolkit"
+            iconColor="text-entity-toolkit"
           />
         </div>
       )}
 
       {/* Recent Activity */}
-      <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-border/50 dark:border-zinc-700/50">
-        <h2 className="font-quicksand text-xl font-bold text-foreground dark:text-zinc-100 mb-4">
-          Recent Activity
-        </h2>
-        {recentActivity.length === 0 ? (
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground">
-            No recent processing activity
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {recentActivity.map((item) => (
-              <div
-                key={item.jobId}
-                className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-muted dark:hover:bg-zinc-800 transition-colors"
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <JobStatusIcon status={item.status} />
-                  <span className="text-sm font-medium text-foreground dark:text-zinc-100 truncate">
-                    {item.fileName}
-                  </span>
-                </div>
-                <div className="flex items-center gap-4 text-xs text-muted-foreground dark:text-muted-foreground flex-shrink-0">
-                  {item.durationMs !== null && (
-                    <span className="flex items-center gap-1">
-                      <ClockIcon className="h-3 w-3" />
-                      {formatDuration(item.durationMs)}
+      <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+        {/* Panel header */}
+        <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+          <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">
+            Recent Activity
+          </h2>
+        </div>
+
+        {/* Panel body */}
+        <div className="p-4">
+          {recentActivity.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No recent processing activity</p>
+          ) : (
+            <div className="space-y-1">
+              {recentActivity.map(item => (
+                <div
+                  key={item.jobId}
+                  className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-muted transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <JobStatusIcon status={item.status} />
+                    <span className="text-sm font-medium text-foreground truncate">
+                      {item.fileName}
                     </span>
-                  )}
-                  <span>{formatRelativeTime(item.completedAt)}</span>
+                  </div>
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground flex-shrink-0">
+                    {item.durationMs !== null && (
+                      <span className="flex items-center gap-1 font-mono">
+                        <ClockIcon className="h-3 w-3" />
+                        {formatDuration(item.durationMs)}
+                      </span>
+                    )}
+                    <span className="font-mono">{formatRelativeTime(item.completedAt)}</span>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   );
 }
 
-function StatCard({ icon: Icon, label, value, color }: {
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  accent,
+  iconColor,
+}: {
   icon: React.ElementType;
   label: string;
   value: string;
-  color: string;
+  accent: string;
+  iconColor: string;
 }) {
   return (
-    <div className="bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-lg p-4 border border-border dark:border-zinc-700/40">
-      <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground mb-1">
-        <Icon className={`h-4 w-4 ${color}`} />
+    <div
+      className={`flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 ${accent} min-h-[88px]`}
+    >
+      <div className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+        <Icon className={`h-4 w-4 ${iconColor}`} />
         {label}
       </div>
-      <div className="text-2xl font-bold text-foreground dark:text-zinc-100">{value}</div>
+      <div className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground leading-tight">
+        {value}
+      </div>
     </div>
   );
 }
 
 function JobStatusIcon({ status }: { status: string }) {
   if (status.toLowerCase() === 'completed') {
-    return <CheckCircleIcon className="h-4 w-4 text-green-500 flex-shrink-0" />;
+    return <CheckCircleIcon className="h-4 w-4 text-entity-toolkit flex-shrink-0" />;
   }
   if (status.toLowerCase() === 'failed') {
-    return <XCircleIcon className="h-4 w-4 text-red-500 flex-shrink-0" />;
+    return <XCircleIcon className="h-4 w-4 text-entity-event flex-shrink-0" />;
   }
   return <AlertCircleIcon className="h-4 w-4 text-amber-500 flex-shrink-0" />;
 }

--- a/apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx
+++ b/apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx
@@ -26,11 +26,11 @@ const adminClient = createAdminClient({ httpClient });
 function statusDotColor(status: PipelineStageStatus) {
   switch (status) {
     case 'healthy':
-      return 'bg-entity-toolkit shadow-[0_0_8px_hsl(var(--entity-toolkit)/0.5)]';
+      return 'bg-entity-toolkit shadow-[0_0_8px_hsl(var(--c-toolkit)/0.5)]';
     case 'warning':
       return 'bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.5)]';
     case 'error':
-      return 'bg-entity-event shadow-[0_0_8px_hsl(var(--entity-event)/0.5)]';
+      return 'bg-entity-event shadow-[0_0_8px_hsl(var(--c-event)/0.5)]';
     default:
       return 'bg-muted-foreground';
   }

--- a/audits/2026-05-12-token-violations.md
+++ b/audits/2026-05-12-token-violations.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Date** | 2026-05-12 |
+| **Date** | 2026-05-28 |
 | **Generator** | `pnpm lint:tokens` (DS-2) |
 | **Spec** | [`2026-05-12-token-canonicalization.md`](../docs/for-developers/specs/2026-05-12-token-canonicalization.md) |
 | **Rule** | `local/no-hardcoded-color-utility` |

--- a/docs/superpowers/plans/2026-05-28-sp5-admin-kb-toolpages-reskin.md
+++ b/docs/superpowers/plans/2026-05-28-sp5-admin-kb-toolpages-reskin.md
@@ -1,0 +1,633 @@
+# SP5 F3-FU-3 — KB Tool-Pages Re-skin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-skin the 7 admin Knowledge Base tool-pages to match the SP5 mockups, moving the page title into a shared layout band, using Tailwind utilities only — no logic, no SSE, no data-flow changes.
+
+**Architecture:** A shared `<KbTopBand>` (sticky h1 "Knowledge Base" + dynamic crumbs + actions) is added to `knowledge-base/layout.tsx` above the existing `<KbSubNav>`. Each tool-page loses its local `<h1>` and its body is restyled with Tailwind utilities mapped from the mockups. Behavioral logic (hooks, useQuery, SSE, refetch intervals) is untouched — existing tests are the regression gate.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind v4 (semantic + entity tokens, post DS-16), Vitest, TypeScript.
+
+**Design doc:** `docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md` (read the ADDENDUM section first — it overrides earlier assumptions).
+
+**Mockup reference (committed `2a0ab1117`):** `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-{vectors,queue,pipeline,embedding,feedback,settings}.html` + existing `sp5-admin-rag-backup.html` (snapshots).
+
+---
+
+## Ground rules (read before any task)
+
+1. **Tailwind utilities only.** No new `.admin-*` CSS file. No new React primitive components (KpiCard/AdminPanel etc.). Mockups are the *visual* reference, translated to utilities.
+2. **Contenuti testuali invariati.** Re-skin = className + DOM structure. Do NOT translate EN→IT or change copy. Mockup IT labels (`Ricerca semantica`) do NOT replace runtime EN (`Semantic Search`) — that would break `VectorStorePage` tests.
+3. **No logic changes.** `useQuery`, `useMutation`, `useQueueSSE`, `useJobSSE`, `refetchInterval`, state, handlers stay byte-identical. If you spot a real bug, note it for a follow-up issue — do not fix it here.
+4. **Token mapping** — use the table in design-doc §A3. Quick reference:
+   - `font-quicksand` (display) · `font-mono` (labels/values/IDs) · body = no class
+   - `text-foreground` (+ `dark:text-zinc-100` where existing code does) · `text-muted-foreground`
+   - `bg-card` (pattern `bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md`) · `bg-muted`
+   - `border-border/60` (there is NO `border-border-light` utility)
+   - entity accent: `text-entity-kb` / `bg-entity-kb/12` / `border-l-4 border-l-entity-kb`
+   - status chip: success → `bg-entity-toolkit/12 text-entity-toolkit`; danger → `bg-entity-event/12 text-entity-event`; warning → `bg-amber-500/14 text-amber-600`
+5. **ESLint.** Files that use `zinc`/`amber`/`emerald`/`rose` raw palette need a file-level disable on line 1 (admin pattern):
+   ```tsx
+   /* eslint-disable local/no-hardcoded-color-utility -- admin KB tool-page chrome: zinc/amber dark palette (admin convention, DS-13c scope deferred to DS-16) */
+   ```
+   Many target files already have this (F3.1). Add only if missing AND you introduce a flagged utility.
+6. **Commands run from `apps/web/`** for tests/lint/typecheck; **git runs from repo root.** All on branch `feature/issue-1652-kb-toolpages-reskin` (already created, parent `main-dev`).
+7. **One commit per task**, message `refactor(admin-kb): re-skin <surface> (#1652)` (header task uses `feat(admin-kb): KB layout section band (#1652)`).
+8. **Refactoring, not feature** — the classic "write failing test first" applies ONLY to Task 1 (which changes tested DOM). Re-skin tasks follow: capture baseline green → re-skin → confirm still green/typecheck/lint → commit.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx` — sticky section band (h1 + crumbs slot + actions slot)
+- `apps/web/src/components/admin/knowledge-base/explorer/KbCrumbs.tsx` — pathname → static breadcrumb label
+- `apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx` — search affordance (⌘K visual) + "+ Upload PDF" link
+- `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx` — band renders single h1 "Knowledge Base"
+- `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx` — crumb label per route
+
+**Modify (layout + 7 surfaces):**
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx` — wrap band + body
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx` — remove h1, re-skin
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx`
+- `apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx` + `feedback/page.tsx` (h2)
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx` — remove h1, re-skin
+- `apps/web/src/components/admin/knowledge-base/kb-settings.tsx` + `settings/page.tsx` (h1)
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx` — remove h1, re-skin scaffold
+- `apps/web/src/components/admin/knowledge-base/processing-metrics.tsx` + `rag-pipeline-flow.tsx` + `pipeline/page.tsx` (h1)
+
+**Modify (tests):**
+- `apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx` — relocate the "page header" assertion
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx` — remove 4 obsolete `it.skip`
+
+---
+
+## Task 1: KB layout section band + header-move
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/KbCrumbs.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx`
+- Modify: 7 surfaces (remove local h1 — see A4 table)
+- Modify: `apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx`
+
+- [ ] **Step 1: Baseline — confirm the suite is green before touching anything**
+
+Run (from `apps/web/`):
+```bash
+pnpm test __tests__/admin/knowledge-base/vector-collections.test.tsx
+```
+Expected: PASS (6 tests). Note the test `should render page header` asserts `getByText('Vector Store')`.
+
+- [ ] **Step 2: Write failing test for KbCrumbs (pathname → label)**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx`:
+```tsx
+import { render, screen } from '@testing-library/react';
+import { KbCrumbs } from '../KbCrumbs';
+
+vi.mock('next/navigation', () => ({ usePathname: () => mockPath }));
+let mockPath = '/admin/knowledge-base';
+
+describe('KbCrumbs', () => {
+  it('renders Explorer label at KB root', () => {
+    mockPath = '/admin/knowledge-base';
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Explorer/)).toBeInTheDocument();
+  });
+
+  it('renders Vector Collections label on /vectors', () => {
+    mockPath = '/admin/knowledge-base/vectors';
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Vector Collections/)).toBeInTheDocument();
+  });
+
+  it('renders Processing Queue label on /queue', () => {
+    mockPath = '/admin/knowledge-base/queue';
+    render(<KbCrumbs />);
+    expect(screen.getByText(/Processing Queue/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run it — verify it fails (module not found)**
+
+Run: `pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx`
+Expected: FAIL — `Cannot find module '../KbCrumbs'`.
+
+- [ ] **Step 4: Implement KbCrumbs**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/KbCrumbs.tsx`:
+```tsx
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+const KB_BASE = '/admin/knowledge-base';
+
+const LABELS: ReadonlyArray<readonly [string, string]> = [
+  [`${KB_BASE}/vectors`, 'Vector Collections'],
+  [`${KB_BASE}/queue`, 'Processing Queue'],
+  [`${KB_BASE}/pipeline`, 'RAG Pipeline'],
+  [`${KB_BASE}/embedding`, 'Embedding'],
+  [`${KB_BASE}/feedback`, 'Feedback'],
+  [`${KB_BASE}/settings`, 'Settings'],
+  [`${KB_BASE}/snapshots`, 'Snapshots'],
+  [`${KB_BASE}/upload`, 'Upload'],
+];
+
+function labelFor(pathname: string): string {
+  if (pathname === KB_BASE) return 'Explorer';
+  const hit = LABELS.find(([href]) => pathname === href || pathname.startsWith(`${href}/`));
+  return hit ? hit[1] : 'Explorer';
+}
+
+export function KbCrumbs() {
+  const pathname = usePathname();
+  return (
+    <div className="font-mono text-[11px] text-muted-foreground mt-0.5">
+      Admin · KB · {labelFor(pathname)}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run KbCrumbs test — verify pass**
+
+Run: `pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbCrumbs.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Write failing test for KbTopBand**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx`:
+```tsx
+import { render, screen } from '@testing-library/react';
+import { KbTopBand } from '../KbTopBand';
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/admin/knowledge-base/vectors' }));
+
+describe('KbTopBand', () => {
+  it('renders a single h1 "Knowledge Base"', () => {
+    render(<KbTopBand />);
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent('Knowledge Base');
+  });
+
+  it('renders the Upload PDF action', () => {
+    render(<KbTopBand />);
+    expect(screen.getByRole('link', { name: /Upload PDF/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 7: Run it — verify it fails**
+
+Run: `pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx`
+Expected: FAIL — `Cannot find module '../KbTopBand'`.
+
+- [ ] **Step 8: Implement KbTopActions + KbTopBand**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/KbTopActions.tsx`:
+```tsx
+import Link from 'next/link';
+
+export function KbTopActions() {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="hidden md:flex items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-1.5 text-sm text-muted-foreground w-[280px]">
+        <span aria-hidden>🔍</span>
+        <input
+          className="flex-1 bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
+          placeholder="Search docs, chunks, games…"
+          aria-label="Search knowledge base"
+        />
+        <kbd className="rounded border border-border/60 bg-muted px-1.5 font-mono text-[10px]">⌘K</kbd>
+      </div>
+      <Link
+        href="/admin/knowledge-base/upload"
+        className="inline-flex items-center gap-1.5 rounded-md bg-entity-kb px-3 py-1.5 text-sm font-semibold font-quicksand text-white shadow-sm hover:brightness-110"
+      >
+        + Upload PDF
+      </Link>
+    </div>
+  );
+}
+```
+> The search input is a visual affordance (matches mockup); wiring ⌘K behavior is out of scope (follow-up #1655). `text-white` on colored `bg-entity-kb` is ESLint-allowed (the `.e-bg` exemption).
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/KbTopBand.tsx`:
+```tsx
+import { KbCrumbs } from './KbCrumbs';
+import { KbTopActions } from './KbTopActions';
+
+export function KbTopBand() {
+  return (
+    <header className="sticky top-0 z-40 -mx-6 flex items-center gap-4 border-b border-border/60 bg-background/80 px-6 py-3 backdrop-blur-md">
+      <div>
+        <h1 className="font-quicksand text-xl font-extrabold tracking-tight text-foreground">
+          Knowledge Base
+        </h1>
+        <KbCrumbs />
+      </div>
+      <div className="flex-1" />
+      <KbTopActions />
+    </header>
+  );
+}
+```
+
+- [ ] **Step 9: Run KbTopBand test — verify pass**
+
+Run: `pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbTopBand.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 10: Wire band into layout**
+
+Modify `apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx`:
+```tsx
+import { type ReactNode } from 'react';
+
+import { KbSubNav } from '@/components/admin/knowledge-base/explorer/KbSubNav';
+import { KbTopBand } from '@/components/admin/knowledge-base/explorer/KbTopBand';
+
+export default function KnowledgeBaseLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="px-6">
+      <KbTopBand />
+      <div className="space-y-6 pt-6">
+        <KbSubNav />
+        {children}
+      </div>
+    </div>
+  );
+}
+```
+> `KbTopBand` uses `-mx-6` for full-bleed border (the `px-6` wrapper compensates), same trick `KbSubNav` already uses.
+
+- [ ] **Step 11: Remove local h1 from the 7 surfaces**
+
+For each file, replace its top-level `<h1>` page header with nothing (the band owns it). Where a subtitle `<p>` existed beside the h1, keep it ONLY if it carries page-specific info not in the crumbs; otherwise remove the whole header `<div>`. Exact edits:
+- `vectors/page.tsx` — remove the `<div className="flex items-center justify-between flex-wrap gap-4">` header block containing `<h1>Vector Store</h1>` + subtitle; keep the Refresh `<Button>` by moving it into the first content row (e.g. the KPI strip header or a small right-aligned toolbar). Re-skin proper happens in Task 2 — here only delete the h1 block, preserving the Refresh button somewhere valid.
+- `embedding/page.tsx` — remove `<h1>Embedding Service</h1>` header block; preserve Refresh button.
+- `snapshots/page.tsx` — remove `<h1>Snapshot RAG</h1>` header block; preserve Refresh + Create buttons.
+- `settings/page.tsx` — remove `<h1>Knowledge Base Settings</h1>` (wrapper).
+- `pipeline/page.tsx` — remove `<h1>RAG Pipeline Overview</h1>` (wrapper). The `<h2>` headings inside `processing-metrics.tsx` / `rag-pipeline-flow.tsx` STAY (section headings).
+- `queue/components/queue-dashboard-client.tsx` — demote `<h1>Processing Queue</h1>` (line ~92): remove it (the back-arrow Link + SSE indicator row stays). The crumb + tab express identity.
+- `feedback/page.tsx` — the heading is already `<h2>Feedback KB Utenti</h2>` (not h1). Leave as-is OR demote to a section label during Task 4. No change required here.
+
+> Keep all non-heading JSX, buttons, and logic intact. This step ONLY removes/relocates headings.
+
+- [ ] **Step 12: Update vector-collections.test.tsx — relocate the "page header" assertion**
+
+The page no longer renders `<h1>Vector Store</h1>` (it's in the layout band, not in the page under test). In `apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx`, change the `should render page header` test to assert on a stable page element instead. Replace the `getByText('Vector Store')` assertion (line ~101) with an assertion on the KPI label that survives the re-skin:
+```tsx
+it('should render the stats KPIs', () => {
+  // ...existing render setup...
+  expect(screen.getByText('Total Vectors')).toBeInTheDocument();
+});
+```
+> If `Total Vectors` text differs in the current file, use whatever stat label the page renders today (the recon shows a "Total Vectors" KPI). The point: assert on page-owned content, not the relocated h1.
+
+- [ ] **Step 13: Run impacted suites — verify all green**
+
+Run (from `apps/web/`):
+```bash
+pnpm test __tests__/admin/knowledge-base/vector-collections.test.tsx src/components/admin/knowledge-base/explorer/__tests__/
+```
+Expected: PASS (6 vectors + 2 KbTopBand + 3 KbCrumbs = 11).
+
+- [ ] **Step 14: Typecheck + token lint**
+
+Run (from `apps/web/`):
+```bash
+pnpm typecheck
+pnpm lint:tokens
+```
+Expected: typecheck 0 errors; lint:tokens 0 violations.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/ apps/web/src/app/admin/\(dashboard\)/knowledge-base/layout.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/vectors/page.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/embedding/page.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/snapshots/page.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/settings/page.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/pipeline/page.tsx apps/web/src/app/admin/\(dashboard\)/knowledge-base/queue/components/queue-dashboard-client.tsx apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx
+git commit -m "feat(admin-kb): KB layout section band + header-move (#1652)"
+```
+
+---
+
+## Task 2: Re-skin vectors page
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx`
+- Reference mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-vectors.html`
+- Test: `apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx` + `kb-hub-gaps.test.tsx` (VectorStorePage 5)
+
+- [ ] **Step 1: Baseline green**
+
+Run (from `apps/web/`):
+```bash
+pnpm test __tests__/admin/knowledge-base/vector-collections.test.tsx "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+```
+Expected: PASS.
+
+- [ ] **Step 2: Re-skin the 3 visual blocks (className only)**
+
+Open the mockup `sp5-admin-kb-vectors.html` side-by-side. Translate these blocks; keep all hooks, state, handlers, and text content:
+
+**(a) KPI strip** — 4-col grid. Each KPI:
+```tsx
+<div className="flex flex-col gap-1 rounded-[10px] border border-border/60 bg-card p-4 border-l-4 border-l-entity-kb">
+  <span className="font-mono text-[10px] font-bold uppercase tracking-wide text-muted-foreground">Total Vectors</span>
+  <span className="font-quicksand text-[28px] font-extrabold tabular-nums text-foreground">{totalVectors}</span>
+  <span className="font-mono text-[11px] text-entity-toolkit">▲ +{delta} last 24h</span>
+</div>
+```
+Entity accent per card: Total Vectors → `border-l-entity-kb`; Games Indexed → `border-l-entity-game`; Dimensions → `border-l-entity-chat`; Avg Health → `border-l-entity-toolkit`.
+
+**(b) Semantic search panel** — wrap in admin-panel pattern:
+```tsx
+<section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
+  <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
+    <h2 className="font-quicksand text-[13px] font-extrabold text-foreground">Semantic Search</h2>
+    {/* keep existing status/meta inline elements */}
+  </div>
+  <div className="p-3.5">{/* existing search row + results, restyled */}</div>
+</section>
+```
+> KEEP heading text `Semantic Search` (EN) — `kb-hub-gaps.test.tsx` asserts it. Do NOT use mockup's `Ricerca semantica`.
+
+**(c) Game breakdown grid** — same `section` panel wrapper, grid of game cards inside.
+
+- [ ] **Step 3: Run tests — verify still green**
+
+Run (from `apps/web/`):
+```bash
+pnpm test __tests__/admin/knowledge-base/vector-collections.test.tsx "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+```
+Expected: PASS (same count as baseline). If a test that asserts text/behavior fails, you changed content — revert that part.
+
+- [ ] **Step 4: Typecheck + token lint**
+```bash
+pnpm typecheck && pnpm lint:tokens
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add "apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx"
+git commit -m "refactor(admin-kb): re-skin vectors page (#1652)"
+```
+
+---
+
+## Task 3: Re-skin embedding page
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx`
+- Reference mockup: `sp5-admin-kb-embedding.html`
+- Tests: none (gate = typecheck + lint + manual)
+
+- [ ] **Step 1: Confirm no unit test exists, capture typecheck baseline**
+```bash
+pnpm typecheck
+```
+Expected: 0 errors (baseline).
+
+- [ ] **Step 2: Re-skin 2 blocks (className only; KEEP both `useQuery` + `refetchInterval: 30_000`)**
+
+**(a) Service status card** — `rounded-[10px] border border-border/60 bg-card p-4`; header `flex items-center gap-2` with icon + `<h2 className="font-quicksand text-[13px] font-extrabold">Service Status</h2>` + a `status-chip` (`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] font-bold uppercase bg-entity-toolkit/12 text-entity-toolkit` for healthy). Inner grid of model/device/dims/languages stays.
+
+**(b) Throughput KPI grid** — 6 KPIs, `grid grid-cols-2 md:grid-cols-3 gap-3`, each using the KPI pattern from Task 2 step 2(a). Entity accents: requests → `entity-kb`, failures → `entity-event`, failure rate → `entity-event`, avg/total duration → `entity-chat`, chars → `entity-toolkit`.
+
+- [ ] **Step 3: Typecheck + token lint**
+```bash
+pnpm typecheck && pnpm lint:tokens
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+```bash
+git add "apps/web/src/app/admin/(dashboard)/knowledge-base/embedding/page.tsx"
+git commit -m "refactor(admin-kb): re-skin embedding page (#1652)"
+```
+
+---
+
+## Task 4: Re-skin feedback panel
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx`
+- Modify (optional, heading): `apps/web/src/app/admin/(dashboard)/knowledge-base/feedback/page.tsx`
+- Reference mockup: `sp5-admin-kb-feedback.html`
+- Tests: none
+
+- [ ] **Step 1: Typecheck baseline**
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 2: Re-skin (className only; KEEP `useQuery` + Italian labels Utile/Non utile/Tutti/Prec/Succ)**
+
+Wrap the filter row + list in the admin-panel pattern. Each feedback item:
+```tsx
+<div className="flex items-start gap-3 rounded-lg border border-border/60 bg-card p-3">
+  {/* keep thumbs icon, Badge (Utile/Non utile), message id, date, optional comment */}
+</div>
+```
+Outcome filter `<Select>` stays functionally identical; only restyle the wrapper row to `flex items-center gap-3`. Pagination buttons → `btn-admin sm` equivalent: `rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] font-quicksand font-bold hover:bg-muted disabled:opacity-40`.
+
+- [ ] **Step 3: Typecheck + token lint**
+```bash
+pnpm typecheck && pnpm lint:tokens
+```
+
+- [ ] **Step 4: Commit**
+```bash
+git add apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx "apps/web/src/app/admin/(dashboard)/knowledge-base/feedback/page.tsx"
+git commit -m "refactor(admin-kb): re-skin feedback panel (#1652)"
+```
+
+---
+
+## Task 5: Re-skin snapshots page
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx`
+- Reference mockup: `sp5-admin-rag-backup.html` (pre-existing)
+- Tests: none
+
+- [ ] **Step 1: Typecheck baseline** — `pnpm typecheck`
+
+- [ ] **Step 2: Re-skin (className only; KEEP `useQuery` + restore/delete `useMutation` + AlertDialog confirms)**
+
+Backup list → admin-panel pattern with `divide-y divide-border/60`. Each `SnapshotCard` row: icon + metadata + restore/delete buttons (`btn-admin sm` pattern). Info/error/success banners → use semantic tokens (info `bg-entity-chat/12 text-entity-chat`, success `bg-entity-toolkit/12 text-entity-toolkit`, error `bg-entity-event/12 text-entity-event`) instead of raw `bg-blue-50`/`bg-emerald-50`/`bg-red-50` where present. Status chips for backup state per mockup.
+
+- [ ] **Step 3: Typecheck + token lint** — `pnpm typecheck && pnpm lint:tokens`
+
+- [ ] **Step 4: Commit**
+```bash
+git add "apps/web/src/app/admin/(dashboard)/knowledge-base/snapshots/page.tsx"
+git commit -m "refactor(admin-kb): re-skin snapshots page (#1652)"
+```
+
+---
+
+## Task 6: Re-skin settings panel
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/kb-settings.tsx`
+- Reference mockup: `sp5-admin-kb-settings.html`
+- Tests: none
+
+- [ ] **Step 1: Typecheck baseline** — `pnpm typecheck`
+
+- [ ] **Step 2: Re-skin (className only; KEEP `useQuery` settings + clearCache/rebuildIndex `useMutation` + typed-confirm logic)**
+
+6 setting cards → `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3` (mockup is 3-up). Each `SettingsCard`: admin-panel pattern, header `flex items-center gap-2` (icon + `<h3 className="font-quicksand text-[13px] font-extrabold">`), body `space-y-0` setting rows. Read-only chips → `status-chip readonly` = `bg-muted text-muted-foreground`. Danger Zone → `rounded-[10px] border border-entity-event/40 bg-entity-event/5 p-4` with header `text-entity-event`; Rebuild Index + Clear Cache buttons keep typed-confirm flow, restyle to `btn-admin danger` = `rounded-md border border-entity-event/55 bg-card px-3 py-1.5 text-entity-event hover:bg-entity-event/8`.
+
+- [ ] **Step 3: Typecheck + token lint** — `pnpm typecheck && pnpm lint:tokens`
+
+- [ ] **Step 4: Commit**
+```bash
+git add apps/web/src/components/admin/knowledge-base/kb-settings.tsx
+git commit -m "refactor(admin-kb): re-skin settings panel (#1652)"
+```
+
+---
+
+## Task 7: Re-skin queue dashboard scaffold
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx`
+- Reference mockup: `sp5-admin-kb-queue.html`
+- Tests: `apps/web/__tests__/admin/queue/{queue-alerts-banner,queue-filters}.test.tsx`
+
+- [ ] **Step 1: Baseline green**
+```bash
+pnpm test __tests__/admin/queue/
+```
+Expected: PASS (13 tests).
+
+- [ ] **Step 2: Re-skin SCAFFOLD ONLY (className only — CRITICAL: do NOT touch `useQueueSSE`, `useJobSSE`, `useQueueList`, `useJobDetail`, EventSource, reconnect, or the sub-components' internals)**
+
+In `queue-dashboard-client.tsx`, restyle only the wrapper layout:
+- Header row: keep back-arrow Link + `SSEConnectionIndicator` + Refresh + Add PDF buttons; restyle to mockup control-bar look. (h1 already removed in Task 1.)
+- 2-column split: keep `grid grid-cols-1 lg:grid-cols-5 gap-4`, restyle the two column containers (`lg:col-span-2` list / `lg:col-span-3` detail) with admin-panel pattern (`rounded-[10px] border border-border/60 bg-card`).
+- Spacing between `<QueueAlertsBanner>`, `<QueueControlBar>`, `<QueueCapacityIndicator>`, `<QueueStatsBar>`, `<BulkActionsBar>`, `<QueueFiltersBar>`, `<MetricsDashboard>` stays via `space-y-4`.
+> Re-skinning each sub-component (`QueueControlBar`, `QueueList`, `JobDetailPanel`, `MetricsDashboard`) deeper than the wrapper is OPTIONAL and per-component — only if time allows and tests stay green. The scaffold restyle is the required deliverable.
+
+- [ ] **Step 3: Run tests — verify still green**
+```bash
+pnpm test __tests__/admin/queue/
+```
+Expected: PASS (13). SSE/behavior unchanged.
+
+- [ ] **Step 4: Typecheck + token lint** — `pnpm typecheck && pnpm lint:tokens`
+
+- [ ] **Step 5: Commit**
+```bash
+git add "apps/web/src/app/admin/(dashboard)/knowledge-base/queue/"
+git commit -m "refactor(admin-kb): re-skin queue dashboard scaffold (#1652)"
+```
+
+---
+
+## Task 8: Re-skin pipeline components
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/processing-metrics.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx`
+- Reference mockup: `sp5-admin-kb-pipeline.html`
+- Test: `kb-hub-gaps.test.tsx` (RAGPipelineFlow Stage Drill-Down — 4 tests MUST stay green)
+
+- [ ] **Step 1: Baseline green**
+```bash
+pnpm test "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+```
+Expected: PASS (VectorStorePage 5 + RAGPipelineFlow 4 = 9 active; 4 skipped).
+
+- [ ] **Step 2: Re-skin `rag-pipeline-flow.tsx` (className only — KEEP `useQuery` 30s refetch, stage click handlers, `expandedStage` state)**
+
+5-stage flow → `flex items-center justify-between gap-4 overflow-x-auto`; each stage button keeps its onClick + state, restyle to `rounded-lg border-2 bg-muted p-4` with status dot. **The stage buttons must remain `role=button`/clickable with the same accessible names** — the 4 drill-down tests click them by text. Health summary 3 cards → semantic tokens (healthy `bg-entity-toolkit/10`, warning `bg-amber-500/10`, error `bg-entity-event/10`). Distribution stat cards + Recent Activity list → admin-panel pattern.
+
+- [ ] **Step 3: Run RAGPipelineFlow tests — verify still green**
+```bash
+pnpm test "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx" -t "RAGPipelineFlow"
+```
+Expected: PASS (4). If a drill-down test fails, you changed a stage button's text or click behavior — revert.
+
+- [ ] **Step 4: Re-skin `processing-metrics.tsx` (className only — KEEP `useQuery` 60s refetch)**
+
+Step metric cards → KPI/admin-panel pattern grid. Percentile comparison table → restyle `<table>` with `text-sm`, header row `bg-muted font-mono text-[10px] uppercase text-muted-foreground`, keep `font-mono` on numeric cells + `durationColor()` logic intact.
+
+- [ ] **Step 5: Run full suite — verify green**
+```bash
+pnpm test "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+```
+Expected: PASS (9 active).
+
+- [ ] **Step 6: Typecheck + token lint** — `pnpm typecheck && pnpm lint:tokens`
+
+- [ ] **Step 7: Commit**
+```bash
+git add apps/web/src/components/admin/knowledge-base/processing-metrics.tsx apps/web/src/components/admin/knowledge-base/rag-pipeline-flow.tsx
+git commit -m "refactor(admin-kb): re-skin pipeline components (#1652)"
+```
+
+---
+
+## Task 9: Cleanup obsolete tests + final gate + PR
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx`
+
+- [ ] **Step 1: Remove the 4 obsolete `it.skip` blocks**
+
+In `kb-hub-gaps.test.tsx`, delete the entire `describe('KnowledgeBasePage — Hub Gap Fixes', ...)` block (lines ~199–254) — the 4 `it.skip` with `TODO(F3-FU-3): rewrite for Explorer; pre-existing test for hub-cards landing is obsolete after F3.1 rebuild`. They tested the pre-F3.1 hub-cards landing which no longer exists (replaced by Explorer in PR #1649). The `VectorStorePage` (5) and `RAGPipelineFlow` (4) describe blocks STAY untouched.
+
+- [ ] **Step 2: Run the file — verify only the live suites remain green**
+```bash
+pnpm test "src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+```
+Expected: PASS (9 tests, 0 skipped).
+
+- [ ] **Step 3: Full frontend gate**
+
+Run (from `apps/web/`):
+```bash
+pnpm test:admin-dashboard
+pnpm typecheck
+pnpm lint
+pnpm lint:tokens
+```
+Expected: all green, 0 token violations. If the full `pnpm test` is fast enough, run it to confirm zero regressions against `main-dev` baseline.
+
+- [ ] **Step 4: Commit cleanup**
+```bash
+git add "apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx"
+git commit -m "test(admin-kb): drop obsolete F3.1 hub-cards tests (#1652)"
+```
+
+- [ ] **Step 5: Push + open PR to main-dev**
+
+```bash
+git push -u origin feature/issue-1652-kb-toolpages-reskin
+gh pr create --base main-dev --title "feat(admin-kb): SP5 F3-FU-3 — re-skin KB tool-pages + section band (#1652)" --body "<see body template below>"
+```
+PR body must include: link to #1652, the header-decision rationale (band owns h1, sub-pages lose local h1), Tailwind-utilities strategy (per user decision), list of 7 re-skinned surfaces, the `vector-collections.test.tsx` assertion relocation, the 4 obsolete tests removed, and a request for manual designer (Sara) review. Confirm base is `main-dev` NOT `main`.
+
+- [ ] **Step 6: Code review before merge** (per CLAUDE.md + global rule)
+
+Run `/code-review:code-review <PR-URL>` and address any BLOCKER/HIGH findings before merge. Then update issue #1652 DoD locally + on GitHub. Merge only after review + green CI; the branch auto-deletes on merge.
+
+---
+
+## Self-Review (checked against design doc + recon)
+
+**Spec coverage:** Every surface in design-doc §3 table → Tasks 2–8. Header decision §2/§A4 → Task 1. Test cleanup §A7 → Task 9. ✅
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to" — each task names exact files, mockup, token classes, and commands. Re-skin steps reference the committed mockup as the complete visual source (legitimate — duplicating 2000+ lines of JSX inline is not feasible; the mockup HTML IS the spec). ✅
+**Type/name consistency:** `KbTopBand`, `KbCrumbs`, `KbTopActions` defined in Task 1 and referenced consistently. `labelFor`/`LABELS` internal to KbCrumbs. ✅
+**Known soft spots flagged:** (1) Task 1 step 11 relocates the Refresh button when deleting the vectors/embedding/snapshots h1 header block — executor must keep it reachable; (2) Task 7 queue sub-component depth is explicitly optional; (3) crumbs are static labels (live counts deferred — not in scope, avoids logic change). ✅

--- a/docs/superpowers/plans/2026-05-28-sp5-admin-kb-toolpages-reskin.md
+++ b/docs/superpowers/plans/2026-05-28-sp5-admin-kb-toolpages-reskin.md
@@ -617,7 +617,7 @@ git commit -m "test(admin-kb): drop obsolete F3.1 hub-cards tests (#1652)"
 git push -u origin feature/issue-1652-kb-toolpages-reskin
 gh pr create --base main-dev --title "feat(admin-kb): SP5 F3-FU-3 — re-skin KB tool-pages + section band (#1652)" --body "<see body template below>"
 ```
-PR body must include: link to #1652, the header-decision rationale (band owns h1, sub-pages lose local h1), Tailwind-utilities strategy (per user decision), list of 7 re-skinned surfaces, the `vector-collections.test.tsx` assertion relocation, the 4 obsolete tests removed, and a request for manual designer (Sara) review. Confirm base is `main-dev` NOT `main`.
+PR body must include: link to #1652, the header-decision rationale (band owns h1, sub-pages lose local h1), Tailwind-utilities strategy (per user decision), list of 7 re-skinned surfaces, the `vector-collections.test.tsx` assertion relocation, the 4 obsolete tests removed, and a request for manual designer review (visual-regression gate removed 2026-05-20 — see CLAUDE.md). Confirm base is `main-dev` NOT `main`.
 
 - [ ] **Step 6: Code review before merge** (per CLAUDE.md + global rule)
 

--- a/docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md
+++ b/docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md
@@ -1,0 +1,274 @@
+# SP5 F3-FU-3 — KB Tool-Pages Re-skin Design
+
+**Issue**: [#1652](https://github.com/meepleAi-app/meepleai-monorepo/issues/1652) (P2, area/frontend)
+**Parent epic**: SP5 Admin Console integration (F3.1 Explorer mergiato in PR #1649 `1e03aaa4d`)
+**Branch**: `feature/issue-1652-kb-toolpages-reskin` (parent `main-dev`)
+**WIP context**: `~/.claude/.../memory/project_sp5_admin_f3_fu3_kb_toolpages_wip.md`
+
+## 1. Cosa fa F3-FU-3 (e cosa non fa)
+
+Re-skin **className/CSS-only** delle 7 KB tool-page del runtime Next.js per allinearle ai mockup `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-*.html`. **Zero refactor logica**: handler, query, hook, contratti API rimangono identici. Le suite test comportamentali esistenti sono il gate.
+
+**In scope** (un'unica branch/PR):
+- Banda di sezione condivisa nel layout `/admin/knowledge-base/layout.tsx` (header h1 "Knowledge Base" + crumbs dinamiche + search ⌘K + + Upload PDF).
+- Rimozione h1 locali da 7 page/component (assorbiti dalla banda).
+- Re-skin del body di 7 surface: vectors, queue, pipeline (2 file componente), embedding, feedback, settings, snapshots.
+- Cleanup di 4 `it.skip` con TODO F3-FU-3 in `kb-hub-gaps.test.tsx`.
+
+**Out of scope** (tracked separatamente):
+- Funzionalità nuove: ingestion log #1650, used-by tab agents #1651, azioni avanzate + similarity-search #1653, PDF preview #1654, badge count sub-nav wired #1655.
+- Refactor handler/query/repo. Aggiunte API. Cambi rotte.
+- Visual-regression gate (rimosso 2026-05-20). Sostituto: manual designer review su PR + ESLint `local/no-hardcoded-color-utility` verde + behavioral test verdi.
+
+## 2. Decisione headline — Header semantics
+
+**Problema**: l'issue originale richiedeva "remove local h1 from sub-pages", ma ogni tool-page ha un titolo proprio (Vector Collections, Processing Queue, …). Rimuovere senza compensare = perdita di identità.
+
+**Soluzione**: il layout possiede la banda di sezione condivisa con `h1 "Knowledge Base"` (entità). Le sub-page **NON ripetono un h1**; l'identità della pagina è espressa dalla **sub-nav tab attiva** + dalle **crumbs dinamiche** (es. `Admin · KB · Vector Collections · 9 indici · pgvector 0.7.4 · 18.487 vectors`). Se una pagina necessita un titolo interno per una sotto-sezione, usa `<h3 class="admin-panel-head">`, non un h1 grande.
+
+Rationale:
+- Allineato ai mockup: ogni `sp5-admin-kb-*.html` ha la stessa `<header class="admin-top">` con h1 "Knowledge Base" + crumbs page-specific.
+- Accessibility: 1 h1 per page (l'h1 della banda), gerarchia heading lineare.
+- Sticky: la banda è `position: sticky; top: 0; z-index: 50` → resta visibile durante lo scroll, ed è il punto naturale per shortcut globali (search ⌘K, + Upload).
+- F3.1 Explorer page.tsx ha attualmente un `<h1>Knowledge Base</h1>` + sottotitolo locale → da assorbire in layout band, **NO regressione**.
+
+## 3. Inventario surface (7 tool-page)
+
+| # | Surface | Effort | File runtime | Sezioni chiave (da mockup) |
+|---|---------|--------|--------------|----------------------------|
+| 1 | vectors | LOW | `apps/web/src/app/admin/(dashboard)/knowledge-base/vectors/page.tsx` (418 inline) | KPI 4× (Total Vectors / Games Indexed / Dimensions / Avg Health %) · Semantic search panel · Results expandable · Game breakdown grid. Mockup: `sp5-admin-kb-vectors.html` |
+| 2 | embedding | LOW | `embedding/page.tsx` (248 inline) | Service status card · 6 throughput KPI (requests / failures / failure rate / avg duration / total duration / chars). Mockup: `sp5-admin-kb-embedding.html`. **30s refetch invariato.** |
+| 3 | feedback | LOW | `apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx` | gameId input · outcome filter · list (Utile/Non utile) · pagination. Italian labels invariate. Mockup: `sp5-admin-kb-feedback.html` |
+| 4 | snapshots | MEDIUM | `snapshots/page.tsx` (399 inline) | Mockup esistente `sp5-admin-rag-backup.html` (NON ri-generato in questo round). |
+| 5 | settings | MEDIUM | `kb-settings.tsx` | 6-card grid read-only (Embedding / Vector DB / Chunking / Cache / Reranker / Storage) · Danger Zone (Rebuild Index, Clear Cache, typed-confirm). Mockup: `sp5-admin-kb-settings.html` |
+| 6 | queue | MEDIUM | `components/queue-dashboard-client.tsx` (SSE live) | Alert banner · Control bar (workers, backpressure, drain) · KPI strip · Bulk+filter · 2-col list+detail (40/60) · MetricsDashboard. Mockup: `sp5-admin-kb-queue.html`. **SSE logic invariata.** |
+| 7 | pipeline | MED-HIGH | `processing-metrics.tsx` + `rag-pipeline-flow.tsx` | 30s refetch. Stage flow 5 box (Ingest→Extract→Chunk→Embed→Index) · Health summary · Distribution stat · Metric percentile table. Mockup: `sp5-admin-kb-pipeline.html`. **2 file componente.** |
+
+**Ordine di esecuzione**: LOW first (1-3) → MEDIUM (4-6) → MED-HIGH (7) → cleanup + PR. Ogni surface = 1 commit incrementale `refactor(admin-kb): re-skin <surface> (#1652)`.
+
+## 4. Layout band design
+
+### Struttura
+
+Il layout esistente è minimal (`<div className="space-y-6 px-6"><KbSubNav />{children}</div>`). Viene esteso preservando la sub-nav F3.1:
+
+```tsx
+// apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx
+import { KbSubNav } from '@/components/admin/knowledge-base/explorer/KbSubNav';
+import { KbTopBand } from '@/components/admin/knowledge-base/explorer/KbTopBand';
+
+export default function KnowledgeBaseLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="kb-shell">
+      <KbTopBand />
+      <div className="kb-body">
+        <KbSubNav />
+        <div className="kb-content">{children}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+### Componenti nuovi
+
+**`KbTopBand.tsx`** (nuovo, in `apps/web/src/components/admin/knowledge-base/explorer/`):
+- Render statico: `<h1>Knowledge Base</h1>` + slot `<KbCrumbs />` + slot `<KbTopActions />`.
+- Sticky `top-0 z-50 backdrop-blur` (Tailwind, NO className raw `bg-white`).
+- Border-bottom `border-border-light` (token-bridge).
+
+**`KbCrumbs.tsx`** (nuovo): consuma `usePathname()` e mostra crumbs derivate dalla route:
+- `/admin/knowledge-base` → `Admin · KB · Explorer · {totalDocs} docs · {totalChunks} chunks`
+- `/admin/knowledge-base/vectors` → `Admin · KB · Vector Collections · {totalVectors} vectors · {dims}d`
+- `/admin/knowledge-base/queue` → `Admin · KB · Processing Queue · {active} attivi · {pending} in coda · SSE live`
+- … (mapping completo per 8 route)
+
+I counts vivi (es. `totalVectors`, `active`) sono opzionali. Pattern: hook lightweight `useKbBandMeta(pathname)` che ritorna `{ pageLabel, meta?: string }` tramite query già esistenti (es. `useEmbeddingStatus`, `useVectorStats`, `useQueueStatus`). **NON refactor handler**, solo aggregazione client-side dei dati già fetched.
+
+**`KbTopActions.tsx`** (nuovo): contiene `<KbSearchInput />` (⌘K shortcut, già implementato in F3.1 → re-use) + `<Link href="/admin/knowledge-base/upload" class="btn-admin primary">+ Upload PDF</Link>`.
+
+### Mobile
+
+I mockup usano `.admin-mobile-fallback "Console solo desktop"` (viewport < 880px). Il runtime admin Next.js già ha mobile-fallback al livello del `(dashboard)` segment — NO duplicazione. Verifica al task 3.
+
+## 5. Re-skin rules (Nygard, non negoziabili)
+
+1. **className/CSS-only**. Niente refactor di handler, hook, repository, contratti API. Se durante il re-skin emerge un bug logico genuino, **lo si traccia in nuova issue F3-FU-X**, non lo si fix in questo PR.
+2. **Token semantic obbligatori**. Pattern admin DS-13c già consolidato (vedi F3.1 PR #1649). Per palette amber/zinc/emerald/rose: `eslint-disable local/no-hardcoded-color-utility` a livello **file** (NON line-level), come F3.1. Per il resto: `bg-card`, `text-foreground`, `bg-muted`, `border-border`, ecc.
+3. **Pattern Tailwind v4 + admin tokens**. Il mockup usa CSS variables (`hsl(var(--c-kb))`, `var(--text-muted)`, ecc.). Il runtime usa Tailwind v4 con design-tokens-canonical + token-bridge.css. **Mapping diretto**: `.admin-kpi.e-kb { border-left: 3px solid hsl(var(--c-kb)) }` → `<div class="admin-kpi border-l-[3px] border-l-entity-kb">…</div>` (entity utilities già DS-15 stabili).
+4. **Component primitives**: dove esiste un primitive (Card, Badge, …), si usa. Dove il mockup ha pattern admin-specific (`.admin-kpi`, `.admin-panel`, `.admin-tabs`, `.admin-top`), si replica la classe **come className applicata**, **NON** si crea un nuovo wrapper component "AdminKpi" in questo PR (rinviato a futuro F3-FU-X consolidation se serve).
+5. **Behavioral test esistenti** = gate. Se cambia un test, deve essere perché il test cercava strutture DOM rimosse (es. h1 locale), non perché il behavior cambia.
+
+## 6. Sketch per-surface (pseudocode → file diff)
+
+### 6.1 vectors (LOW)
+
+**File**: `vectors/page.tsx` (418 inline). Body attuale: KPI inline + ricerca + risultati + breakdown. Re-skin → struttura mockup:
+
+```tsx
+<div className="space-y-4">
+  {/* KPI strip 4-col */}
+  <div className="grid grid-cols-4 gap-3">
+    <div className="admin-kpi border-l-[3px] border-l-entity-kb"> {/* totalVectors */} </div>
+    <div className="admin-kpi border-l-[3px] border-l-entity-game"> {/* gamesIndexed */} </div>
+    <div className="admin-kpi border-l-[3px] border-l-entity-chat"> {/* dimensions */} </div>
+    <div className="admin-kpi border-l-[3px] border-l-entity-toolkit"> {/* avgHealth */} </div>
+  </div>
+
+  {/* Semantic search panel */}
+  <section className="admin-panel">
+    <div className="admin-panel-head"><h3>🔬 Ricerca semantica</h3>…</div>
+    <div className="admin-panel-body">{/* search row + results table */}</div>
+  </section>
+
+  {/* Game breakdown panel */}
+  <section className="admin-panel"><div className="admin-panel-head"><h3>📦 Vettori per gioco</h3>…</div>…</section>
+</div>
+```
+
+I `.admin-kpi`, `.admin-panel`, `.admin-panel-head` sono classi del design system admin già in uso da SP5 Mockup-1 (`sp5-admin-kb.html`). Verifica che esistano nel runtime CSS (file `apps/web/src/styles/admin-base.css` o equivalente) — se mancano, le aggiungiamo nel task 3 al setup layout band.
+
+### 6.2 embedding (LOW)
+
+**File**: `embedding/page.tsx` (248 inline). Body attuale: service status + 6 KPI. Re-skin → 1 service status card + 6-col KPI grid (`grid grid-cols-6 gap-3`). 30s refetch invariato.
+
+### 6.3 feedback (LOW)
+
+**File**: `kb-feedback-panel.tsx`. Body attuale: input + filter + list + pagination. Re-skin → wrap in `admin-panel` + filter row come mockup. Italian labels invariate.
+
+### 6.4 snapshots (MEDIUM)
+
+**File**: `snapshots/page.tsx` (399 inline). Mockup `sp5-admin-rag-backup.html`. Backup list + restore actions + retention policy. Re-skin → admin-panel pattern + status-chip per backup state.
+
+### 6.5 settings (MEDIUM)
+
+**File**: `kb-settings.tsx`. 6 read-only setting card grid → `grid grid-cols-3 gap-3` (or 2 col su viewport stretto, deferred a CSS responsive del mockup). Danger Zone → `admin-panel` con border accent rosso (entity-event token).
+
+### 6.6 queue (MEDIUM)
+
+**File**: `queue-dashboard-client.tsx`. SSE live + 2-col layout 40/60. Alert banner top + control bar + KPI strip + bulk bar + filter chips + list/detail split. Re-skin **mantenendo SSE handler + subscriptions identici**.
+
+### 6.7 pipeline (MED-HIGH)
+
+**File**: `processing-metrics.tsx` + `rag-pipeline-flow.tsx`. Stage flow 5-box (Ingest→Extract→Chunk→Embed→Index) → `flex` con frecce CSS, OR `grid grid-cols-5` con border-right divider. Health summary card + metric percentile table. 30s refetch invariato.
+
+## 7. Criteri di accettazione
+
+**Gate hard** (PR blocker se rosso):
+- [ ] `pnpm lint:tokens` → 0 violazioni (`local/no-hardcoded-color-utility` verde).
+- [ ] `pnpm test` (Vitest, frontend) → tutto verde, **0 regressioni** rispetto a baseline `main-dev`.
+- [ ] `pnpm typecheck` → 0 errori.
+- [ ] `pnpm lint` → 0 errori (warning admiti se file-level disable documentato).
+- [ ] Header decision applicato: layout band ha 1 `<h1>Knowledge Base</h1>`, sub-page hanno 0 h1.
+- [ ] 4 `it.skip` con TODO F3-FU-3 in `kb-hub-gaps.test.tsx` rimossi/riscritti.
+- [ ] Manual designer review (Sara) OK su PR.
+
+**Gate soft** (verifica ma non blocker):
+- [ ] 7 tool-page navigabili manuali su `http://localhost:3000/admin/knowledge-base/*`, no errori console.
+- [ ] Sub-nav 8 tab attiva correttamente per ogni route.
+- [ ] Crumbs cambiano per pagina (almeno page label hard-coded; counts live opzionali, fallback a label statico).
+- [ ] Sticky band rimane visibile su scroll.
+
+## 8. Out of scope esplicito
+
+- **Funzionalità nuove**: tutte le feature follow-up SP5 F3 (#1650-#1655) restano backlog separato.
+- **Refactor logica**: handler, query, hook, repo, API contracts invariati.
+- **Visual-regression test**: gate rimosso 2026-05-20 (CLAUDE.md), NON re-introduced in questo PR.
+- **Admin-nav.js cambio**: già revertito in setup branch (era un test scrap nei file untracked pre-clear).
+- **Componenti primitive admin** (AdminKpi, AdminPanel, AdminTopBand reusable): NON estratti come primitives in questo PR. Replicati come className pattern. Estrazione = futuro F3-FU-X consolidation.
+- **i18n**: labels italiane (Utile/Non utile, Pausa, Riprendi, …) invariate. NO migrazione a i18n keys.
+
+## 9. Rischi noti
+
+| Rischio | Mitigazione |
+|---------|-------------|
+| Classi `.admin-kpi`, `.admin-panel`, `.admin-tabs`, `.admin-top` non esistono ancora nel CSS runtime | Verificare al task 3 (header move). Se mancano, aggiungere come CSS nel layout component, NON come `<style>` inline. |
+| Crumbs dinamiche richiedono hook che non esistono per ogni surface | Fallback a label statico hardcoded (es. "Admin · KB · Vector Collections" senza counts). Le counts vengono wired progressivamente. |
+| `KbSubNav` esistente di F3.1 potrebbe avere CSS confliggente con la nuova `.admin-tabs` del mockup | Audit visivo durante task 3. Se conflitto, sovrascrivere KbSubNav className come `.admin-tabs` (NO duplicate component). |
+| Test E2E che cercano `<h1>Knowledge Base</h1>` su sub-page falliranno | Aggiornare query selector: cercare nella banda, non nel children. Patch nel commit di header-move. |
+| Le 30+ entry mock standalone (sp5-admin-*.html) e i 6 nuovi mock condividono `.admin-*` CSS pattern → cambio centralizzato impatta tutti i mock visivi | Mock sono asset di design, non runtime. Cambi al runtime CSS NON propagano ai mock HTML. Risk = zero. |
+
+## 10. Riferimenti
+
+- Issue: [#1652](https://github.com/meepleAi-app/meepleai-monorepo/issues/1652)
+- Parent PR (F3.1 Explorer): `1e03aaa4d` (#1649)
+- WIP memory: `~/.claude/.../memory/project_sp5_admin_f3_fu3_kb_toolpages_wip.md`
+- Mockup design system: `admin-mockups/design_handoff_admin/admin/{tokens.css, components.css, admin-base.css}`
+- 6 nuovi mockup: `admin-mockups/design_handoff_admin/admin/sp5-admin-kb-{vectors,queue,pipeline,embedding,feedback,settings}.html` (commit `2a0ab1117`)
+- Mockup snapshots esistente: `sp5-admin-rag-backup.html` (pre-existing)
+- Prompts generation: `admin-mockups/design_handoff_admin/KB_TOOLPAGE_DESIGN_PROMPTS.md`
+- Sub-nav F3.1: `apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx`
+- Layout F3.1: `apps/web/src/app/admin/(dashboard)/knowledge-base/layout.tsx`
+- Token system: `apps/web/src/styles/design-tokens-canonical.css` + `token-bridge.css`
+- ESLint rule: `local/no-hardcoded-color-utility` (mode error since DS-15)
+- Visual gate removal: CLAUDE.md "Visual Gate REMOVED 2026-05-20"
+
+---
+
+## ADDENDUM — correzioni post-recon (2026-05-28)
+
+3 agent di ricognizione hanno verificato le assunzioni del doc. Correzioni che prevalgono sulle sezioni sopra:
+
+### A1. CSS classes `.admin-*` NON esistono nel runtime (era rischio #9.1, ora confermato)
+TUTTE le classi del mockup (`.admin-kpi`, `.admin-panel`, `.admin-panel-head/body`, `.admin-tabs`, `.admin-tab`, `.admin-top`, `.btn-admin`, `.status-chip`, `.admin-search`, `.admin-form-row`, `.admin-input`, `.admin-select`) sono **mockup-only**. Il runtime usa **Tailwind utilities** (pattern F3.1 `KbSubNav`).
+
+**DECISIONE UTENTE (2026-05-28)**: re-skin con **Tailwind utilities inline** (NO file CSS `.admin-*`, NO nuovi componenti primitives). Coerente DS-16 + ESLint + F3.1. §4 e §5.4 del doc sopra sono **superate** da questa decisione: i mockup HTML sono il riferimento *visivo*, tradotto in utility Tailwind, NON copiato come classi.
+
+### A2. `token-bridge.css` RIMOSSO in DS-16 (§10 era errato)
+Non esiste più. I token vivono in `src/styles/design-tokens-canonical.css` (`:root` + `[data-theme="dark"]`) e le utility entity sono generate via `@theme` in globals. **Niente riferimenti a token-bridge nel codice nuovo.**
+
+### A3. Token mapping mockup → Tailwind (verificato uso reale)
+| Mockup CSS | Tailwind runtime | Note |
+|---|---|---|
+| `var(--f-display)` (Quicksand) | `font-quicksand` | headings |
+| `var(--f-mono)` (JetBrains) | `font-mono` | KPI label, valori, ID |
+| `var(--f-body)` (Nunito) | *(default)* | nessuna classe |
+| `var(--text)` | `text-foreground` | + opz. `dark:text-zinc-100` |
+| `var(--text-muted)` | `text-muted-foreground` | |
+| `var(--bg-card)` | `bg-card` | pattern `bg-card/70 dark:bg-zinc-800/70 backdrop-blur-md` |
+| `var(--bg-muted)` | `bg-muted` | |
+| `var(--border-light)` | `border-border/60` | NON esiste `border-border-light` utility |
+| `hsl(var(--c-kb))` | `text-entity-kb` / `bg-entity-kb` / `border-entity-kb` | + opacity `/12` `/30` |
+| `.admin-kpi.e-kb` border-left | `border-l-4 border-l-entity-kb` | accento entità |
+| `.status-chip.healthy` | `bg-entity-toolkit/12 text-entity-toolkit` | success=toolkit green |
+| `.status-chip.danger` | `bg-entity-event/12 text-entity-event` | danger=event rose |
+
+`dark:bg-zinc-800/70`, `dark:text-zinc-100`, `dark:border-zinc-700/60` ⇒ richiedono `eslint-disable local/no-hardcoded-color-utility` a livello file (pattern admin F3.1, zinc palette).
+
+### A4. Header decision — h1 reali sono DIVERSI da "Knowledge Base"
+Ogni surface ha un h1/h2 proprio (NON "Knowledge Base"):
+| Surface | Heading attuale | Tag | File:linea | Ha test che lo asserisce? |
+|---|---|---|---|---|
+| vectors | "Vector Store" | h1 | `vectors/page.tsx` | **SÌ** — `vector-collections.test.tsx:101` `getByText('Vector Store')` |
+| embedding | "Embedding Service" | h1 | `embedding/page.tsx` | no |
+| feedback | "Feedback KB Utenti" | h2 (in parent page) | `feedback/page.tsx:15` | no |
+| snapshots | "Snapshot RAG" | h1 | `snapshots/page.tsx:235` | no |
+| settings | "Knowledge Base Settings" | h1 (in wrapper) | `settings/page.tsx:15` | no |
+| queue | "Processing Queue" | h1 | `queue/components/queue-dashboard-client.tsx:92` | no |
+| pipeline | "RAG Pipeline Overview" | h1 (wrapper) | `pipeline/page.tsx:16` | no |
+
+**Header-move rivisto**: la banda layout ottiene `<h1>Knowledge Base</h1>`. Le sub-page perdono il loro **h1** (diventa al più un `<h2>`/heading di sezione, o sparisce assorbito nelle crumbs/sub-nav). L'unico test impattato è `vector-collections.test.tsx:101` → aggiornare l'assertion (cercare la nuova posizione del titolo, es. crumbs o tab attivo). È un cambio legittimo: il test cercava l'h1 locale che il design rimuove.
+
+### A5. Contenuti testuali INVARIATI (regola rafforzata)
+Il re-skin cambia **className + struttura visiva**, NON il testo dei contenuti. Dove il mockup ha IT (`Ricerca semantica`) e il runtime EN (`Semantic Search`), **prevale il runtime** per non rompere i 5 test `VectorStorePage` in `kb-hub-gaps.test.tsx` che asseriscono il heading "Semantic Search". Traduzione IT = follow-up separato (i18n + test). Il mockup guida l'aspetto, non le stringhe.
+
+### A6. Path reali corretti (§3 aveva 1 path errato)
+- queue dashboard: `apps/web/src/app/admin/(dashboard)/knowledge-base/queue/components/queue-dashboard-client.tsx` (159 righe, NON `components/admin/...`). SSE via `useQueueSSE`/`useJobSSE` (hooks in `queue/hooks/`), sub-componenti `QueueAlertsBanner`/`QueueControlBar`/`QueueList`/`JobDetailPanel`/`MetricsDashboard`. **Il re-skin del client wrapper tocca solo lo scaffold (header, grid 2-col, spacing); i sub-componenti hanno scope proprio** — valutare per-componente nel task.
+- pipeline: 2 componenti `processing-metrics.tsx` (297) + `rag-pipeline-flow.tsx` (363), montati da `pipeline/page.tsx` (31, h1 wrapper).
+
+### A7. Test baseline reali
+- `apps/web/__tests__/admin/knowledge-base/vector-collections.test.tsx` (6 test, asserisce "Vector Store")
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/__tests__/kb-hub-gaps.test.tsx` (449 righe): **4 `it.skip` TODO F3-FU-3** (da rimuovere) + **VectorStorePage 5 test** (Semantic Search — restano verdi) + **RAGPipelineFlow 4 test** (Stage Drill-Down — restano verdi)
+- `apps/web/__tests__/admin/queue/{queue-alerts-banner,queue-filters}.test.tsx` (5+8 test)
+- embedding / feedback / settings / snapshots / processing-metrics: **nessun unit test** → gate = typecheck + lint + manual + non-regressione delle suite vicine
+- Comando: da `apps/web/` → `pnpm test <path>` (vitest run). Suite admin completa: `pnpm test:admin-dashboard`.
+
+### A8. Mobile già gestito upstream
+`AdminShell` + `AdminSidebar` (`hidden lg:flex`). NESSUN mobile fallback da aggiungere nel KB layout. Il `.admin-mobile-fallback` del mockup NON va portato.
+
+### A9. KbSubNav riusabile
+`apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx` (75 righe) già fa 8-tab + `usePathname` active (amber). Il re-skin lo **riusa**; eventuale ritocco className per allineare al look `.admin-tabs` del mockup è OK (nessun test diretto su KbSubNav). NON duplicare.
+
+---
+
+**Prossimo step**: writing-plans skill → genera plan task-by-task. ESEGUITO → vedi `docs/superpowers/plans/2026-05-28-sp5-admin-kb-toolpages-reskin.md`.

--- a/docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md
+++ b/docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md
@@ -161,7 +161,7 @@ I `.admin-kpi`, `.admin-panel`, `.admin-panel-head` sono classi del design syste
 - [ ] `pnpm lint` → 0 errori (warning admiti se file-level disable documentato).
 - [ ] Header decision applicato: layout band ha 1 `<h1>Knowledge Base</h1>`, sub-page hanno 0 h1.
 - [ ] 4 `it.skip` con TODO F3-FU-3 in `kb-hub-gaps.test.tsx` rimossi/riscritti.
-- [ ] Manual designer review (Sara) OK su PR.
+- [ ] Manual designer review OK su PR (visual-regression gate rimosso il 2026-05-20 — vedi CLAUDE.md).
 
 **Gate soft** (verifica ma non blocker):
 - [ ] 7 tool-page navigabili manuali su `http://localhost:3000/admin/knowledge-base/*`, no errori console.


### PR DESCRIPTION
## SP5 F3-FU-3 — Re-skin KB tool-pages + section band

Closes #1652 (P2, area/frontend). Continuazione di F3.1 (Explorer, PR #1649).

### Cosa fa

Re-skin **className/Tailwind-only** delle 7 KB tool-page per allinearle ai mockup SP5, + una **banda di sezione condivisa** nel layout. Zero refactor logico: hook, query, SSE, `refetchInterval`, handler e contratti API sono byte-identici — i test esistenti sono il gate.

### Decisione header (perché la banda)

L'issue chiedeva di rimuovere l'h1 locale dalle sub-page, ma ognuna aveva un titolo proprio (`Vector Store`, `Embedding Service`, `Snapshot RAG`, `Processing Queue`, `RAG Pipeline Overview`…). Soluzione: il **layout** possiede ora un'unica banda sticky `KbTopBand` con `<h1>Knowledge Base</h1>` + crumbs dinamiche (`KbCrumbs`, derivate da `usePathname`) + azioni (search ⌘K affordance, + Upload PDF). Le sub-page perdono l'h1 locale; l'identità della pagina è data dalla sub-nav attiva + dalla crumb. Risultato: **un solo h1** per route, gerarchia heading lineare.

### Strategia CSS

I mockup usano classi `.admin-kpi`/`.admin-panel`/`.admin-top` che **non esistono nel runtime** (post DS-16, tutto Tailwind utilities). Scelta concordata: tradurre i pattern del mockup in **utility Tailwind inline** (come F3.1 `KbSubNav`), nessun nuovo layer CSS, nessun nuovo componente primitive. Token semantici/entity (`bg-card`, `border-border/60`, `text-entity-kb`, `border-l-entity-*`, `font-quicksand`/`font-mono`), 0 violazioni `lint:tokens`.

### Superfici ri-skinnate

| Surface | File | Note |
|---|---|---|
| Layout band | `knowledge-base/layout.tsx` + `explorer/Kb{TopBand,Crumbs,TopActions}.tsx` (net-new) | h1 unico + crumbs + actions |
| Explorer root | `knowledge-base/page.tsx` | h1 locale rimosso (assorbito) |
| Vector Collections | `vectors/page.tsx` | KPI 4× + Semantic Search panel + game breakdown |
| Embedding | `embedding/page.tsx` | service status + 6 throughput KPI (30s refetch) |
| Feedback | `kb-feedback-panel.tsx` | filter + list + pagination (label IT invariate) |
| Snapshots | `snapshots/page.tsx` | backup list + restore/delete AlertDialog |
| Settings | `kb-settings.tsx` | 6-card grid + Danger Zone (typed-confirm) |
| Processing Queue | `queue/components/queue-dashboard-client.tsx` | **solo scaffold**; hook SSE intoccati |
| RAG Pipeline | `processing-metrics.tsx` + `rag-pipeline-flow.tsx` | 5-stage flow + health + percentile table |

### Test

- `vector-collections.test.tsx`: l'assertion `should render page header` (cercava l'h1 locale rimosso) è stata rilocata su un elemento page-owned (`Semantic Search` panel). Altri 5 test invariati.
- `kb-hub-gaps.test.tsx`: rimossi i 4 `it.skip` `TODO(F3-FU-3)` obsoleti (testavano la hub-cards landing pre-F3.1, sostituita dall'Explorer). Le suite `VectorStorePage` (5) e `RAGPipelineFlow` (4) restano verdi.
- Net-new: `KbTopBand.test.tsx` (2), `KbCrumbs.test.tsx` (3).

**Gate**: typecheck 0 · `lint:tokens` 0 · ESLint file re-skinnati 0 errori · admin-dashboard 558/558 · KB toccati 142/142.

### A11y migliorata in corso d'opera

- `focus-visible` ring sui bare `<button>` introdotti dal re-skin (stage pipeline, snapshot actions, vectors result row, feedback pagination).
- Bottoni distruttivi → token `bg-destructive`/`text-destructive-foreground` (WCAG-safe in dark mode) invece di `text-white` su `bg-entity-event` (2.78:1 fail).
- Contrasto WCAG sistemato su reranker warning + Danger Zone descriptor.
- Shadow-glow status dot pipeline: corretto `var(--entity-*)` (inesistente, glow invisibile) → triplet `var(--c-*)`.

### Follow-up noti (fuori scope, non bloccanti)

- `kb-feedback-panel`: il cambio del filtro outcome non resetta `page=1` (bug **pre-esistente**, non introdotto qui). Trattare come fix logico separato.

### Review

🎨 **Richiesta review designer (Sara)**: il visual-regression gate è stato rimosso il 2026-05-20 → la conformità visiva ai mockup va verificata manualmente sulla PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

