### PR TITLE
feat(play-records): #1663 Phase 1 — record outcome fields (BE: gameId, winner, totalScore)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordDto.cs
@@ -5,6 +5,7 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// <summary>
 /// DTO for full play record details including players and scores.
 /// Issue #3890: CQRS queries for play records.
+/// Issue #1663: Phase 1 – WinnerPlayerIds and OutcomeType computed on read.
 /// </summary>
 public record PlayRecordDto(
     Guid Id,
@@ -22,5 +23,7 @@ public record PlayRecordDto(
     string? Notes,
     string? Location,
     DateTime CreatedAt,
-    DateTime UpdatedAt
+    DateTime UpdatedAt,
+    IReadOnlyList<Guid> WinnerPlayerIds,
+    string OutcomeType
 );

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayRecordSummaryDto.cs
@@ -5,6 +5,7 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// <summary>
 /// DTO for play record summary in list views.
 /// Issue #3890: CQRS queries for play records.
+/// Issue #1663: Phase 1 – GameId, WinnerPlayerIds and OutcomeType computed on read.
 /// </summary>
 public record PlayRecordSummaryDto(
     Guid Id,
@@ -12,5 +13,8 @@ public record PlayRecordSummaryDto(
     DateTime SessionDate,
     TimeSpan? Duration,
     PlayRecordStatus Status,
-    int PlayerCount
+    int PlayerCount,
+    Guid? GameId,
+    IReadOnlyList<Guid> WinnerPlayerIds,
+    string OutcomeType
 );

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/SessionPlayerDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/SessionPlayerDto.cs
@@ -3,10 +3,12 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// <summary>
 /// DTO for player in a play record.
 /// Issue #3890: CQRS queries for play records.
+/// Issue #1663: Phase 1 – TotalScore computed on read from "points" dimension.
 /// </summary>
 public record SessionPlayerDto(
     Guid Id,
     Guid? UserId,
     string DisplayName,
-    List<SessionScoreDto> Scores
+    List<SessionScoreDto> Scores,
+    int? TotalScore
 );

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayRecordQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -38,6 +39,10 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
         var scoringConfig = System.Text.Json.JsonSerializer.Deserialize<SessionScoringConfigDto>(entity.ScoringConfigJson)
             ?? new SessionScoringConfigDto(new List<string>(), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
+        // Compute outcome fields from player scores (no storage change — computed on read)
+        var winnerPlayerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds(entity.Players);
+        var outcomeType = PlayRecordOutcomeCalculator.OutcomeType(entity.Players);
+
         return new PlayRecordDto(
             entity.Id,
             entity.GameId,
@@ -53,7 +58,8 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
                     s.Dimension,
                     s.Value,
                     s.Unit
-                )).ToList()
+                )).ToList(),
+                PlayRecordOutcomeCalculator.TotalScore(p)
             )).ToList(),
             scoringConfig,
             entity.CreatedByUserId,
@@ -63,7 +69,9 @@ internal class GetPlayRecordQueryHandler : IQueryHandler<GetPlayRecordQuery, Pla
             entity.Notes,
             entity.Location,
             entity.CreatedAt,
-            entity.UpdatedAt
+            entity.UpdatedAt,
+            winnerPlayerIds,
+            outcomeType
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetUserPlayHistoryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetUserPlayHistoryQueryHandler.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -42,24 +44,39 @@ internal class GetUserPlayHistoryQueryHandler : IQueryHandler<GetUserPlayHistory
         // Get total count
         var totalCount = await dbQuery.CountAsync(cancellationToken).ConfigureAwait(false);
 
-        // Apply pagination and projection
-        var records = await dbQuery
+        // Materialize with players+scores so we can compute WinnerPlayerIds and OutcomeType.
+        // Single Include chain — no N+1 (EF loads scores in a single subsequent query per page).
+        var rawRecords = await dbQuery
             .OrderByDescending(r => r.SessionDate)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(r => new PlayRecordSummaryDto(
-                r.Id,
-                r.GameName,
-                r.SessionDate,
-                r.Duration,
-                (Domain.Enums.PlayRecordStatus)r.Status,
-                r.Players.Count
-            ))
+            .Include(r => r.Players)
+                .ThenInclude(p => p.Scores)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        var records = rawRecords
+            .Select(r => MapToSummary(r))
+            .ToList();
 
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
 
         return new PlayHistoryResponse(records, totalCount, page, pageSize, totalPages);
     }
+
+    /// <summary>
+    /// Maps an entity to <see cref="PlayRecordSummaryDto"/>, computing outcome fields via the shared helper.
+    /// </summary>
+    private static PlayRecordSummaryDto MapToSummary(PlayRecordEntity r) =>
+        new(
+            r.Id,
+            r.GameName,
+            r.SessionDate,
+            r.Duration,
+            (Domain.Enums.PlayRecordStatus)r.Status,
+            r.Players.Count,
+            r.GameId,
+            PlayRecordOutcomeCalculator.WinnerPlayerIds(r.Players),
+            PlayRecordOutcomeCalculator.OutcomeType(r.Players)
+        );
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordOutcomeCalculator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordOutcomeCalculator.cs
@@ -1,0 +1,67 @@
+using Api.Infrastructure.Entities.GameManagement;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Pure static helper that computes outcome fields from EF infrastructure entities.
+/// Operates on <see cref="RecordPlayerEntity"/> and <see cref="RecordScoreEntity"/> —
+/// no EF queries, no async — safe to call inside any handler mapping.
+///
+/// Dimension convention (documented in GetPlayerStatisticsQueryHandler):
+///   "wins"   – victory flag: Value &gt; 0 means this player won the competitive game.
+///   "points" – primary numeric score: the player's raw point total.
+///
+/// Issue #1663: Phase 1 – reskin-required fields computed on read.
+/// </summary>
+internal static class PlayRecordOutcomeCalculator
+{
+    private const string WinsDimension = "wins";
+    private const string PointsDimension = "points";
+
+    /// <summary>
+    /// Returns the IDs of all players who have a "wins" score with Value &gt; 0.
+    /// Returns an empty list when no player has the "wins" dimension (non-competitive / in-progress).
+    /// </summary>
+    public static IReadOnlyList<Guid> WinnerPlayerIds(IEnumerable<RecordPlayerEntity> players)
+    {
+        ArgumentNullException.ThrowIfNull(players);
+
+        return players
+            .Where(p => p.Scores.Any(s =>
+                string.Equals(s.Dimension, WinsDimension, StringComparison.OrdinalIgnoreCase)
+                && s.Value > 0))
+            .Select(p => p.Id)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <summary>
+    /// Returns <c>"competitive"</c> if ANY player has a score with Dimension "wins"
+    /// (regardless of value — mere presence signals a competitive game).
+    /// Returns <c>"none"</c> when no player has the "wins" dimension (cooperative / narrative / unscored).
+    /// </summary>
+    public static string OutcomeType(IEnumerable<RecordPlayerEntity> players)
+    {
+        ArgumentNullException.ThrowIfNull(players);
+
+        var hasWinsDimension = players.Any(p =>
+            p.Scores.Any(s =>
+                string.Equals(s.Dimension, WinsDimension, StringComparison.OrdinalIgnoreCase)));
+
+        return hasWinsDimension ? "competitive" : "none";
+    }
+
+    /// <summary>
+    /// Returns the "points" dimension <see cref="RecordScoreEntity.Value"/> for the given player,
+    /// or <c>null</c> if the player has no "points" score recorded.
+    /// </summary>
+    public static int? TotalScore(RecordPlayerEntity player)
+    {
+        ArgumentNullException.ThrowIfNull(player);
+
+        var pointsScore = player.Scores.FirstOrDefault(s =>
+            string.Equals(s.Dimension, PointsDimension, StringComparison.OrdinalIgnoreCase));
+
+        return pointsScore?.Value;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayRecordQueryHandlerTests.cs
@@ -1,0 +1,235 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for <see cref="GetPlayRecordQueryHandler"/>.
+/// Verifies Phase 1 outcome fields: TotalScore on SessionPlayerDto,
+/// WinnerPlayerIds and OutcomeType on PlayRecordDto.
+/// Issue #1663: Phase 1 – reskin-required fields computed on read.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1663")]
+public class GetPlayRecordQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly GetPlayRecordQueryHandler _handler;
+
+    public GetPlayRecordQueryHandlerTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetPlayRecordQueryHandler(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task Handle_RecordWithWinner_ReturnsCorrectWinnerPlayerIds()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+        var loserId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(winnerId, recordId, ("wins", 1)),
+            MakePlayer(loserId, recordId, ("wins", 0))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.WinnerPlayerIds.Should().ContainSingle().Which.Should().Be(winnerId);
+    }
+
+    [Fact]
+    public async Task Handle_TieGame_ReturnsBothPlayersAsWinners()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var player1Id = Guid.NewGuid();
+        var player2Id = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(player1Id, recordId, ("wins", 1)),
+            MakePlayer(player2Id, recordId, ("wins", 1))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.WinnerPlayerIds.Should().HaveCount(2)
+            .And.Contain(player1Id)
+            .And.Contain(player2Id);
+    }
+
+    [Fact]
+    public async Task Handle_NoWinsDimension_ReturnsEmptyWinnersAndNoneOutcome()
+    {
+        // Arrange — cooperative / in-progress: no "wins" dimension
+        var recordId = Guid.NewGuid();
+        var player1Id = Guid.NewGuid();
+        var player2Id = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(player1Id, recordId, ("points", 30)),
+            MakePlayer(player2Id, recordId, ("points", 45))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.WinnerPlayerIds.Should().BeEmpty();
+        result.OutcomeType.Should().Be("none");
+    }
+
+    [Fact]
+    public async Task Handle_PlayerWithPoints_ReturnsCorrectTotalScore()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(playerId, recordId, ("points", 42))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        var player = result.Players.Should().ContainSingle().Subject;
+        player.TotalScore.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task Handle_PlayerWithNoPoints_ReturnsTotalScoreNull()
+    {
+        // Arrange — player has "wins" but not "points"
+        var recordId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(playerId, recordId, ("wins", 1))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Players.Should().ContainSingle().Subject.TotalScore.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_CompetitiveGame_OutcomeTypeIsCompetitive()
+    {
+        // Arrange
+        var recordId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(playerId, recordId, ("wins", 1))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetPlayRecordQuery(recordId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.OutcomeType.Should().Be("competitive");
+    }
+
+    [Fact]
+    public async Task Handle_RecordNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var query = new GetPlayRecordQuery(Guid.NewGuid());
+
+        // Act & Assert
+        var act = () => _handler.Handle(query, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    #region Test Helpers
+
+    private static PlayRecordEntity MakePlayRecord(Guid id) => new()
+    {
+        Id = id,
+        GameId = Guid.NewGuid(),
+        GameName = "Test Game",
+        CreatedByUserId = Guid.NewGuid(),
+        Visibility = 0,
+        SessionDate = DateTime.UtcNow.AddDays(-1),
+        Status = 2, // Completed
+        ScoringConfigJson = """{"Dimensions":["points","wins"],"Units":{"points":"pts","wins":"W"}}""",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+
+    private static RecordPlayerEntity MakePlayer(
+        Guid id,
+        Guid playRecordId,
+        params (string Dimension, int Value)[] scores) =>
+        new()
+        {
+            Id = id,
+            PlayRecordId = playRecordId,
+            DisplayName = $"Player-{id:N}",
+            Scores = scores.Select(s => new RecordScoreEntity
+            {
+                Id = Guid.NewGuid(),
+                RecordPlayerId = id,
+                Dimension = s.Dimension,
+                Value = s.Value
+            }).ToList()
+        };
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetUserPlayHistoryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetUserPlayHistoryQueryHandlerTests.cs
@@ -1,0 +1,252 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for <see cref="GetUserPlayHistoryQueryHandler"/>.
+/// Verifies Phase 1 outcome fields in <see cref="Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords.PlayRecordSummaryDto"/>:
+/// GameId, WinnerPlayerIds, OutcomeType.
+/// Issue #1663: Phase 1 – reskin-required fields computed on read.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1663")]
+public class GetUserPlayHistoryQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly GetUserPlayHistoryQueryHandler _handler;
+
+    public GetUserPlayHistoryQueryHandlerTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetUserPlayHistoryQueryHandler(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task Handle_SummaryWithWinner_ReturnsCorrectWinnerPlayerIds()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+        var loserId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId, userId, gameId: Guid.NewGuid());
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(winnerId, recordId, ("wins", 1)),
+            MakePlayer(loserId, recordId, ("wins", 0))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        var summary = result.Records.Should().ContainSingle().Subject;
+        summary.WinnerPlayerIds.Should().ContainSingle().Which.Should().Be(winnerId);
+    }
+
+    [Fact]
+    public async Task Handle_SummaryWithNoWinsDimension_ReturnsEmptyWinnersAndNoneOutcome()
+    {
+        // Arrange — no "wins" dimension → non-competitive
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId, userId, gameId: Guid.NewGuid());
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(Guid.NewGuid(), recordId, ("points", 20)),
+            MakePlayer(Guid.NewGuid(), recordId, ("points", 35))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        var summary = result.Records.Should().ContainSingle().Subject;
+        summary.WinnerPlayerIds.Should().BeEmpty();
+        summary.OutcomeType.Should().Be("none");
+    }
+
+    [Fact]
+    public async Task Handle_SummaryWithWinsDimension_OutcomeTypeIsCompetitive()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId, userId, gameId: Guid.NewGuid());
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(Guid.NewGuid(), recordId, ("wins", 1)),
+            MakePlayer(Guid.NewGuid(), recordId, ("wins", 0))
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Records.Should().ContainSingle().Subject.OutcomeType.Should().Be("competitive");
+    }
+
+    [Fact]
+    public async Task Handle_FreeFormGame_GameIdIsNull()
+    {
+        // Arrange — free-form record: GameId = null
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId, userId, gameId: null);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(Guid.NewGuid(), recordId)
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Records.Should().ContainSingle().Subject.GameId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_CatalogGame_GameIdIsExposed()
+    {
+        // Arrange — catalog record: GameId is set
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var entity = MakePlayRecord(recordId, userId, gameId: gameId);
+        entity.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(Guid.NewGuid(), recordId)
+        };
+        _context.PlayRecords.Add(entity);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Records.Should().ContainSingle().Subject.GameId.Should().Be(gameId);
+    }
+
+    [Fact]
+    public async Task Handle_NoRecords_ReturnsEmptyList()
+    {
+        // Arrange
+        var query = new GetUserPlayHistoryQuery(Guid.NewGuid());
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Records.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleRecords_AllHaveOutcomeFields()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        // Record 1: competitive with winner
+        var record1Id = Guid.NewGuid();
+        var winner1Id = Guid.NewGuid();
+        var record1 = MakePlayRecord(record1Id, userId, gameId: Guid.NewGuid());
+        record1.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(winner1Id, record1Id, ("wins", 1)),
+            MakePlayer(Guid.NewGuid(), record1Id, ("wins", 0))
+        };
+
+        // Record 2: free-form (no wins dimension)
+        var record2Id = Guid.NewGuid();
+        var record2 = MakePlayRecord(record2Id, userId, gameId: null);
+        record2.Players = new List<RecordPlayerEntity>
+        {
+            MakePlayer(Guid.NewGuid(), record2Id, ("points", 99))
+        };
+
+        _context.PlayRecords.AddRange(record1, record2);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var query = new GetUserPlayHistoryQuery(userId, PageSize: 10);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Records.Should().HaveCount(2);
+        var competitive = result.Records.First(r => r.OutcomeType == "competitive");
+        competitive.WinnerPlayerIds.Should().ContainSingle().Which.Should().Be(winner1Id);
+        var none = result.Records.First(r => r.OutcomeType == "none");
+        none.WinnerPlayerIds.Should().BeEmpty();
+        none.GameId.Should().BeNull();
+    }
+
+    #region Test Helpers
+
+    private static PlayRecordEntity MakePlayRecord(Guid id, Guid userId, Guid? gameId) => new()
+    {
+        Id = id,
+        GameId = gameId,
+        GameName = "Test Game",
+        CreatedByUserId = userId,
+        Visibility = 0,
+        SessionDate = DateTime.UtcNow.AddDays(-1),
+        Status = 2, // Completed
+        ScoringConfigJson = """{"Dimensions":["points","wins"],"Units":{"points":"pts","wins":"W"}}""",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+
+    private static RecordPlayerEntity MakePlayer(
+        Guid id,
+        Guid playRecordId,
+        params (string Dimension, int Value)[] scores) =>
+        new()
+        {
+            Id = id,
+            PlayRecordId = playRecordId,
+            DisplayName = $"Player-{id:N}",
+            Scores = scores.Select(s => new RecordScoreEntity
+            {
+                Id = Guid.NewGuid(),
+                RecordPlayerId = id,
+                Dimension = s.Dimension,
+                Value = s.Value
+            }).ToList()
+        };
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordOutcomeCalculatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordOutcomeCalculatorTests.cs
@@ -1,0 +1,355 @@
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for <see cref="PlayRecordOutcomeCalculator"/>.
+/// Tests the pure static helper that computes outcome fields from EF entities.
+/// Issue #1663: Phase 1 – reskin-required fields computed on read.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1663")]
+public class PlayRecordOutcomeCalculatorTests
+{
+    #region WinnerPlayerIds
+
+    [Fact]
+    public void WinnerPlayerIds_OnePlayerWithWins1_ReturnsOnlyThatPlayer()
+    {
+        // Arrange
+        var winner = MakePlayer(Guid.NewGuid(), ("wins", 1));
+        var loser = MakePlayer(Guid.NewGuid(), ("wins", 0));
+        var noScore = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([winner, loser, noScore]);
+
+        // Assert
+        result.Should().ContainSingle().Which.Should().Be(winner.Id);
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_TwoPlayersWithWins1_ReturnsBothIds()
+    {
+        // Arrange — tie: two winners
+        var player1 = MakePlayer(Guid.NewGuid(), ("wins", 1));
+        var player2 = MakePlayer(Guid.NewGuid(), ("wins", 1));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([player1, player2]);
+
+        // Assert
+        result.Should().HaveCount(2)
+            .And.Contain(player1.Id)
+            .And.Contain(player2.Id);
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_NoPlayerHasWinsDimension_ReturnsEmpty()
+    {
+        // Arrange
+        var player1 = MakePlayer(Guid.NewGuid(), ("points", 42));
+        var player2 = MakePlayer(Guid.NewGuid(), ("points", 30));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([player1, player2]);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_WinsDimensionExistsButValue0_NotIncluded()
+    {
+        // Arrange — "wins" dimension present but value = 0 (did not win)
+        var player = MakePlayer(Guid.NewGuid(), ("wins", 0));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([player]);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_WinsDimensionCaseInsensitive_Detected()
+    {
+        // Arrange — dimension stored as "Wins" (mixed case)
+        var player = MakePlayerWithRawDimension(Guid.NewGuid(), "Wins", 1);
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([player]);
+
+        // Assert — must be detected regardless of casing
+        result.Should().ContainSingle().Which.Should().Be(player.Id);
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_EmptyPlayerList_ReturnsEmpty()
+    {
+        // Act
+        var result = PlayRecordOutcomeCalculator.WinnerPlayerIds([]);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WinnerPlayerIds_NullArgument_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var act = () => PlayRecordOutcomeCalculator.WinnerPlayerIds(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region OutcomeType
+
+    [Fact]
+    public void OutcomeType_AnyPlayerHasWinsDimension_ReturnsCompetitive()
+    {
+        // Arrange — presence of "wins" dimension = competitive game, regardless of value
+        var player1 = MakePlayer(Guid.NewGuid(), ("wins", 1));
+        var player2 = MakePlayer(Guid.NewGuid(), ("wins", 0));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.OutcomeType([player1, player2]);
+
+        // Assert
+        result.Should().Be("competitive");
+    }
+
+    [Fact]
+    public void OutcomeType_NoPlayerHasWinsDimension_ReturnsNone()
+    {
+        // Arrange — cooperative / narrative / unscored game
+        var player1 = MakePlayer(Guid.NewGuid(), ("points", 10));
+        var player2 = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.OutcomeType([player1, player2]);
+
+        // Assert
+        result.Should().Be("none");
+    }
+
+    [Fact]
+    public void OutcomeType_WinsDimensionOnOnlyOnePlayer_ReturnsCompetitive()
+    {
+        // Arrange — only one player has the "wins" dimension (enough to mark as competitive)
+        var winner = MakePlayer(Guid.NewGuid(), ("wins", 1));
+        var noScore = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.OutcomeType([winner, noScore]);
+
+        // Assert
+        result.Should().Be("competitive");
+    }
+
+    [Fact]
+    public void OutcomeType_EmptyPlayerList_ReturnsNone()
+    {
+        // Act
+        var result = PlayRecordOutcomeCalculator.OutcomeType([]);
+
+        // Assert
+        result.Should().Be("none");
+    }
+
+    [Fact]
+    public void OutcomeType_InProgressRecordNoWinsDimension_ReturnsNone()
+    {
+        // Arrange — in-progress record: players exist but no wins dimension yet
+        var player1 = MakePlayer(Guid.NewGuid());
+        var player2 = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.OutcomeType([player1, player2]);
+
+        // Assert
+        result.Should().Be("none");
+    }
+
+    [Fact]
+    public void OutcomeType_NullArgument_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var act = () => PlayRecordOutcomeCalculator.OutcomeType(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region TotalScore
+
+    [Fact]
+    public void TotalScore_PlayerHasPointsDimension_ReturnsValue()
+    {
+        // Arrange
+        var player = MakePlayer(Guid.NewGuid(), ("points", 42));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.TotalScore(player);
+
+        // Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void TotalScore_PlayerHasNoPointsDimension_ReturnsNull()
+    {
+        // Arrange — player has "wins" but not "points"
+        var player = MakePlayer(Guid.NewGuid(), ("wins", 1));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.TotalScore(player);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TotalScore_PlayerHasNoScores_ReturnsNull()
+    {
+        // Arrange
+        var player = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.TotalScore(player);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TotalScore_PointsDimensionCaseInsensitive_ReturnsValue()
+    {
+        // Arrange — dimension stored as "Points" (mixed case)
+        var player = MakePlayerWithRawDimension(Guid.NewGuid(), "Points", 99);
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.TotalScore(player);
+
+        // Assert
+        result.Should().Be(99);
+    }
+
+    [Fact]
+    public void TotalScore_PlayerHasBothWinsAndPoints_ReturnsPointsValue()
+    {
+        // Arrange
+        var player = MakePlayer(Guid.NewGuid(), ("wins", 1), ("points", 42));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.TotalScore(player);
+
+        // Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void TotalScore_NullArgument_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var act = () => PlayRecordOutcomeCalculator.TotalScore(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region Scenario: Competitive vs Non-competitive combinations
+
+    [Fact]
+    public void Scenario_CompetitiveGame_WinnerAndNonWinner()
+    {
+        // Arrange: player A wins (wins=1), player B does not (wins=0), both have points
+        var playerA = MakePlayer(Guid.NewGuid(), ("wins", 1), ("points", 100));
+        var playerB = MakePlayer(Guid.NewGuid(), ("wins", 0), ("points", 60));
+
+        // Act
+        var winnerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds([playerA, playerB]);
+        var outcomeType = PlayRecordOutcomeCalculator.OutcomeType([playerA, playerB]);
+        var scoreA = PlayRecordOutcomeCalculator.TotalScore(playerA);
+        var scoreB = PlayRecordOutcomeCalculator.TotalScore(playerB);
+
+        // Assert
+        winnerIds.Should().ContainSingle().Which.Should().Be(playerA.Id);
+        outcomeType.Should().Be("competitive");
+        scoreA.Should().Be(100);
+        scoreB.Should().Be(60);
+    }
+
+    [Fact]
+    public void Scenario_FreeFormGame_NullGameId_NoWinsDimension()
+    {
+        // Arrange: free-form/cooperative game — no "wins" dimension for any player
+        var player1 = MakePlayer(Guid.NewGuid(), ("points", 30));
+        var player2 = MakePlayer(Guid.NewGuid(), ("points", 45));
+
+        // Act
+        var winnerIds = PlayRecordOutcomeCalculator.WinnerPlayerIds([player1, player2]);
+        var outcomeType = PlayRecordOutcomeCalculator.OutcomeType([player1, player2]);
+
+        // Assert
+        winnerIds.Should().BeEmpty();
+        outcomeType.Should().Be("none");
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    /// <summary>
+    /// Creates a <see cref="RecordPlayerEntity"/> with named score dimensions.
+    /// Each tuple is (dimension, value).
+    /// </summary>
+    private static RecordPlayerEntity MakePlayer(Guid id, params (string Dimension, int Value)[] scores)
+    {
+        var player = new RecordPlayerEntity
+        {
+            Id = id,
+            PlayRecordId = Guid.NewGuid(),
+            DisplayName = $"Player-{id:N}",
+            Scores = scores.Select(s => new RecordScoreEntity
+            {
+                Id = Guid.NewGuid(),
+                RecordPlayerId = id,
+                Dimension = s.Dimension,
+                Value = s.Value
+            }).ToList()
+        };
+        return player;
+    }
+
+    /// <summary>
+    /// Creates a player with a single score using a raw dimension string (for case-insensitivity tests).
+    /// </summary>
+    private static RecordPlayerEntity MakePlayerWithRawDimension(Guid id, string dimension, int value)
+    {
+        return new RecordPlayerEntity
+        {
+            Id = id,
+            PlayRecordId = Guid.NewGuid(),
+            DisplayName = $"Player-{id:N}",
+            Scores = new List<RecordScoreEntity>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    RecordPlayerId = id,
+                    Dimension = dimension,
+                    Value = value
+                }
+            }
+        };
+    }
+
+    #endregion
+}

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -37,8 +37,16 @@ export const SessionPlayerSchema = z.object({
   userId: z.string().uuid().nullable(),
   displayName: z.string(),
   scores: z.array(SessionScoreSchema),
+  // #1663 Phase 1: derived from the "points" dimension (null if absent).
+  // Optional during BE rollout; tighten once the BE ships the field.
+  totalScore: z.number().int().nullable().optional(),
 });
 export type SessionPlayer = z.infer<typeof SessionPlayerSchema>;
+
+// #1663: outcome classification for a record. "competitive" when any player
+// carries a "wins" dimension; "none" for cooperative/narrative/unscored games.
+export const PlayRecordOutcomeTypeSchema = z.enum(['competitive', 'none']);
+export type PlayRecordOutcomeType = z.infer<typeof PlayRecordOutcomeTypeSchema>;
 
 // ========== DTOs ==========
 
@@ -59,6 +67,10 @@ export const PlayRecordDtoSchema = z.object({
   location: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  // #1663 Phase 1: derived on-read (winner = players with "wins" dimension > 0).
+  // Optional during BE rollout; tighten once the BE ships the fields.
+  winnerPlayerIds: z.array(z.string().uuid()).optional(),
+  outcomeType: PlayRecordOutcomeTypeSchema.optional(),
 });
 export type PlayRecordDto = z.infer<typeof PlayRecordDtoSchema>;
 
@@ -69,6 +81,11 @@ export const PlayRecordSummarySchema = z.object({
   duration: z.string().nullable(),
   status: PlayRecordStatusSchema,
   playerCount: z.number().int().nonnegative(),
+  // #1663 Phase 1: enable cover/deep-link + outcome badge in the list view.
+  // Optional during BE rollout; tighten once the BE ships the fields.
+  gameId: z.string().uuid().nullable().optional(),
+  winnerPlayerIds: z.array(z.string().uuid()).optional(),
+  outcomeType: PlayRecordOutcomeTypeSchema.optional(),
 });
 export type PlayRecordSummary = z.infer<typeof PlayRecordSummarySchema>;
 


### PR DESCRIPTION
## Summary

**Phase 1 of #1663** — backend extensions for the `/play-records` v2 reskin (Epic #1475 / mockup #1488). Adds reskin-required outcome fields to the record DTOs, **computed on-read (no migration, no new storage)**.

Spec refined via `/sc:spec-panel` (Fowler, Wiegers, Newman, Nygard, Adzic, Crispin). This PR is **Phase 1 (record fields)**; Phase 2 (statistics fields) is a separate PR per the spec's split.

## The win-rule (extracted, not invented)

The backend already determines wins in `GetPlayerStatisticsQueryHandler.cs:53`: a player won if they have a score with `Dimension == "wins"` (OrdinalIgnoreCase) and `Value > 0`. There's an implicit dimension convention — `"wins"` = victory flag, `"points"` = primary score. This PR **extracts that rule into a shared helper** rather than reinventing it.

## Changes

**New:**
- `PlayRecordOutcomeCalculator` — shared pure static helper:
  - `WinnerPlayerIds(players)` → players with `"wins" > 0` (empty for in-progress / non-competitive)
  - `OutcomeType(players)` → `"competitive"` if any player has a `"wins"` dimension, else `"none"`
  - `TotalScore(player)` → the `"points"` dimension value, or `null`

**DTOs extended (compute-on-read):**
- `PlayRecordSummaryDto`: + `GameId`, `WinnerPlayerIds`, `OutcomeType`
- `PlayRecordDto`: + `WinnerPlayerIds`, `OutcomeType`
- `SessionPlayerDto`: + `TotalScore`

**Handlers:**
- `GetUserPlayHistoryQueryHandler`: now `Include(Players).ThenInclude(Scores)` + maps the new summary fields
- `GetPlayRecordQueryHandler`: maps the new detail + per-player fields

**FE (rollout-safe):**
- `play-records.schemas.ts`: new fields added as **optional** + `PlayRecordOutcomeTypeSchema` enum. Schemas are non-`.strict()`, so pre-BE parsing is unaffected; optional keeps existing fixtures valid.

## Verification

```
dotnet test --filter "FullyQualifiedName~PlayRecord&Category=Unit"
Superato!  Non superati: 0  Superati: 70  (35 pre-existing + 35 new)

pnpm typecheck (apps/web)  →  exit 0
```

## Test matrix (win-rule)

| Scenario | Expected | ✓ |
|---|---|---|
| 1 player "wins"=1 | WinnerPlayerIds=[that], outcomeType=competitive | ✅ |
| 2 players "wins"=1 (tie) | WinnerPlayerIds=[both] | ✅ |
| no "wins" dim | WinnerPlayerIds=[], outcomeType=none | ✅ |
| "points"=42, no "wins" | TotalScore=42 | ✅ |
| no "points" | TotalScore=null | ✅ |
| InProgress | WinnerPlayerIds=[] | ✅ |
| free-form (GameId null) | summary GameId=null | ✅ |

## Notes

- `GameId` was already on the domain/infra entity — no domain change needed.
- Helper operates on EF `*Entity` types (codebase convention; handlers map entities, not domain types).
- Integration tests (`PlayRecordCommandTests`, Testcontainers) compile cleanly; unaffected (they test commands, not query outcome fields).
- `dimension` magic strings (`"wins"`/`"points"`) are now documented in the helper as a contract.

## Out of scope (Phase 2 / deferred per spec)

Statistics fields (`winByGame`, `totalDurationMinutes`, gameId-keyed counts); chat chip, turn, groups; cross-BC winner unification.

Refs #1663 · Epic #1475 · mockup #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
