### PR TITLE
feat(play-records): #1663 Phase 2 — statistics fields (winByGame, totalDuration, gameId counts)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayerStatisticsDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/PlayRecords/PlayerStatisticsDto.cs
@@ -3,10 +3,26 @@ namespace Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 /// <summary>
 /// DTO for cross-game player statistics.
 /// Issue #3890: CQRS queries for play records.
+/// Issue #1663: Phase 2 – statistics dashboard fields.
 /// </summary>
 public record PlayerStatisticsDto(
     int TotalSessions,
     int TotalWins,
     Dictionary<string, int> GamePlayCounts,
-    Dictionary<string, double> AverageScoresByGame
+    Dictionary<string, double> AverageScoresByGame,
+    int TotalDurationMinutes,
+    IReadOnlyList<GameWinStats> WinByGame,
+    IReadOnlyList<GamePlayCount> MostPlayedGames
 );
+
+/// <summary>
+/// Per-game win/play breakdown, used in <see cref="PlayerStatisticsDto.WinByGame"/>.
+/// Issue #1663: Phase 2 – statistics dashboard fields.
+/// </summary>
+public record GameWinStats(Guid? GameId, string GameName, int Played, int Won);
+
+/// <summary>
+/// Per-game play count, used in <see cref="PlayerStatisticsDto.MostPlayedGames"/>.
+/// Issue #1663: Phase 2 – statistics dashboard fields.
+/// </summary>
+public record GamePlayCount(Guid? GameId, string GameName, int Plays);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/PlayRecords/GetPlayerStatisticsQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
 using Api.SharedKernel.Application.Interfaces;
@@ -49,12 +50,10 @@ internal class GetPlayerStatisticsQueryHandler : IQueryHandler<GetPlayerStatisti
         // Calculate statistics
         var totalSessions = records.Count;
 
-        // Total wins (count records where user has win score dimension)
-        var totalWins = records.Count(r =>
-            r.Players.Any(p => p.Scores.Any(s =>
-                s.Dimension.Equals("wins", StringComparison.OrdinalIgnoreCase) && s.Value > 0)));
+        // Total wins: reuse PlayRecordOutcomeCalculator.HasWinner (DRY — avoids duplicating "wins">0 logic)
+        var totalWins = records.Count(r => PlayRecordOutcomeCalculator.HasWinner(r.Players));
 
-        // Game play counts
+        // Game play counts (legacy dict — backward compat)
         var gamePlayCounts = records
             .GroupBy(r => r.GameName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
@@ -62,7 +61,7 @@ internal class GetPlayerStatisticsQueryHandler : IQueryHandler<GetPlayerStatisti
                 g => g.Count(),
                 StringComparer.OrdinalIgnoreCase);
 
-        // Average scores by game (for "points" dimension)
+        // Average scores by game (for "points" dimension — legacy dict — backward compat)
         var averageScoresByGame = records
             .Where(r => r.Players.Any(p => p.Scores.Any(s =>
                 s.Dimension.Equals("points", StringComparison.OrdinalIgnoreCase))))
@@ -77,11 +76,45 @@ internal class GetPlayerStatisticsQueryHandler : IQueryHandler<GetPlayerStatisti
                     .Average(),
                 StringComparer.OrdinalIgnoreCase);
 
+        // Total duration: sum nullable durations; null contributes 0
+        var totalDurationMinutes = (int)Math.Round(
+            records.Sum(r => r.Duration?.TotalMinutes ?? 0));
+
+        // Group by (GameId, GameName) for win-rate and play-count breakdowns.
+        // Free-form records (GameId == null) group by (null, GameName) so two records
+        // with the same free-form name aggregate together — per spec.
+        var byGame = records
+            .GroupBy(r => (r.GameId, r.GameName))
+            .ToList();
+
+        var winByGame = byGame
+            .Select(g => new GameWinStats(
+                GameId: g.Key.GameId,
+                GameName: g.Key.GameName,
+                Played: g.Count(),
+                Won: g.Count(r => PlayRecordOutcomeCalculator.HasWinner(r.Players))))
+            .OrderByDescending(x => x.Played)
+            .ThenByDescending(x => x.Won)
+            .ToList()
+            .AsReadOnly();
+
+        var mostPlayedGames = byGame
+            .Select(g => new GamePlayCount(
+                GameId: g.Key.GameId,
+                GameName: g.Key.GameName,
+                Plays: g.Count()))
+            .OrderByDescending(x => x.Plays)
+            .ToList()
+            .AsReadOnly();
+
         return new PlayerStatisticsDto(
             totalSessions,
             totalWins,
             gamePlayCounts,
-            averageScoresByGame
+            averageScoresByGame,
+            totalDurationMinutes,
+            winByGame,
+            mostPlayedGames
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordOutcomeCalculator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayRecordOutcomeCalculator.cs
@@ -52,6 +52,22 @@ internal static class PlayRecordOutcomeCalculator
     }
 
     /// <summary>
+    /// Returns <c>true</c> when at least one player in the collection has a "wins" score
+    /// with <see cref="RecordScoreEntity.Value"/> &gt; 0.
+    /// Avoids allocating a list; use this instead of <see cref="WinnerPlayerIds"/> when
+    /// only the boolean result is needed (e.g. counting wins across many records).
+    /// Issue #1663: Phase 2 – statistics dashboard fields.
+    /// </summary>
+    public static bool HasWinner(IEnumerable<RecordPlayerEntity> players)
+    {
+        ArgumentNullException.ThrowIfNull(players);
+
+        return players.Any(p => p.Scores.Any(s =>
+            string.Equals(s.Dimension, WinsDimension, StringComparison.OrdinalIgnoreCase)
+            && s.Value > 0));
+    }
+
+    /// <summary>
     /// Returns the "points" dimension <see cref="RecordScoreEntity.Value"/> for the given player,
     /// or <c>null</c> if the player has no "points" score recorded.
     /// </summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/GetPlayerStatisticsQueryHandlerTests.cs
@@ -1,0 +1,282 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.PlayRecords;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.PlayRecords;
+
+/// <summary>
+/// Unit tests for <see cref="GetPlayerStatisticsQueryHandler"/>.
+/// Verifies Phase 2 statistics dashboard fields:
+/// TotalDurationMinutes, WinByGame, MostPlayedGames.
+/// Also provides a regression guard ensuring existing TotalWins behaviour
+/// is preserved after refactoring to <see cref="Api.BoundedContexts.GameManagement.Application.Services.PlayRecordOutcomeCalculator.HasWinner"/>.
+/// Issue #1663: Phase 2 – statistics dashboard fields.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "1663")]
+public class GetPlayerStatisticsQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _context;
+    private readonly GetPlayerStatisticsQueryHandler _handler;
+
+    public GetPlayerStatisticsQueryHandlerTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetPlayerStatisticsQueryHandler(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TotalWins regression guard (existing behaviour unchanged after refactor)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TotalWins_ThreeRecordsTwoWithWinner_ReturnsTwoAfterRefactor()
+    {
+        // Arrange — regression check: refactoring totalWins to use HasWinner must not change the result
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var win1 = MakePlayRecord(Guid.NewGuid(), userId, gameId, "Game A");
+        win1.Players = [MakePlayer(Guid.NewGuid(), win1.Id, ("wins", 1))];
+
+        var win2 = MakePlayRecord(Guid.NewGuid(), userId, gameId, "Game A");
+        win2.Players = [MakePlayer(Guid.NewGuid(), win2.Id, ("wins", 1))];
+
+        var loss = MakePlayRecord(Guid.NewGuid(), userId, gameId, "Game A");
+        loss.Players = [MakePlayer(Guid.NewGuid(), loss.Id, ("wins", 0))];
+
+        _context.PlayRecords.AddRange(win1, win2, loss);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayerStatisticsQuery(userId), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.TotalWins.Should().Be(2);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // WinByGame
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WinByGame_ThreeGameARecordsAndTwoGameBRecords_CorrectCountsAndOrder()
+    {
+        // Arrange
+        // Game A: 3 records — 2 with winner, 1 without
+        // Game B: 2 records — 1 with winner
+        var userId = Guid.NewGuid();
+        var gameAId = Guid.NewGuid();
+        var gameBId = Guid.NewGuid();
+
+        var a1 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a1.Players = [MakePlayer(Guid.NewGuid(), a1.Id, ("wins", 1))];
+
+        var a2 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a2.Players = [MakePlayer(Guid.NewGuid(), a2.Id, ("wins", 1))];
+
+        var a3 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a3.Players = [MakePlayer(Guid.NewGuid(), a3.Id, ("wins", 0))];
+
+        var b1 = MakePlayRecord(Guid.NewGuid(), userId, gameBId, "Game B");
+        b1.Players = [MakePlayer(Guid.NewGuid(), b1.Id, ("wins", 1))];
+
+        var b2 = MakePlayRecord(Guid.NewGuid(), userId, gameBId, "Game B");
+        b2.Players = [MakePlayer(Guid.NewGuid(), b2.Id, ("wins", 0))];
+
+        _context.PlayRecords.AddRange(a1, a2, a3, b1, b2);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayerStatisticsQuery(userId), TestContext.Current.CancellationToken);
+
+        // Assert — ordered by Played desc
+        result.WinByGame.Should().HaveCount(2);
+
+        var first = result.WinByGame[0]; // Game A — most played
+        first.GameId.Should().Be(gameAId);
+        first.GameName.Should().Be("Game A");
+        first.Played.Should().Be(3);
+        first.Won.Should().Be(2);
+
+        var second = result.WinByGame[1]; // Game B
+        second.GameId.Should().Be(gameBId);
+        second.GameName.Should().Be("Game B");
+        second.Played.Should().Be(2);
+        second.Won.Should().Be(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // MostPlayedGames
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MostPlayedGames_ThreeGameAAndTwoGameB_OrderedByPlaysDesc()
+    {
+        // Arrange — same setup as WinByGame test (shared scenario)
+        var userId = Guid.NewGuid();
+        var gameAId = Guid.NewGuid();
+        var gameBId = Guid.NewGuid();
+
+        var a1 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a1.Players = [MakePlayer(Guid.NewGuid(), a1.Id, ("wins", 1))];
+
+        var a2 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a2.Players = [MakePlayer(Guid.NewGuid(), a2.Id, ("wins", 1))];
+
+        var a3 = MakePlayRecord(Guid.NewGuid(), userId, gameAId, "Game A");
+        a3.Players = [MakePlayer(Guid.NewGuid(), a3.Id, ("wins", 0))];
+
+        var b1 = MakePlayRecord(Guid.NewGuid(), userId, gameBId, "Game B");
+        b1.Players = [MakePlayer(Guid.NewGuid(), b1.Id, ("wins", 1))];
+
+        var b2 = MakePlayRecord(Guid.NewGuid(), userId, gameBId, "Game B");
+        b2.Players = [MakePlayer(Guid.NewGuid(), b2.Id, ("wins", 0))];
+
+        _context.PlayRecords.AddRange(a1, a2, a3, b1, b2);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayerStatisticsQuery(userId), TestContext.Current.CancellationToken);
+
+        // Assert — ordered by Plays desc
+        result.MostPlayedGames.Should().HaveCount(2);
+
+        result.MostPlayedGames[0].GameId.Should().Be(gameAId);
+        result.MostPlayedGames[0].Plays.Should().Be(3);
+
+        result.MostPlayedGames[1].GameId.Should().Be(gameBId);
+        result.MostPlayedGames[1].Plays.Should().Be(2);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // TotalDurationMinutes
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TotalDurationMinutes_OneAndHalfHoursPlusTwoHoursPlusNullDuration_Returns210Minutes()
+    {
+        // Arrange: 01:30:00 + 02:00:00 + null → 90 + 120 + 0 = 210
+        var userId = Guid.NewGuid();
+
+        var r1 = MakePlayRecord(Guid.NewGuid(), userId, Guid.NewGuid(), "Game A", duration: TimeSpan.FromHours(1.5));
+        r1.Players = [MakePlayer(Guid.NewGuid(), r1.Id)];
+
+        var r2 = MakePlayRecord(Guid.NewGuid(), userId, Guid.NewGuid(), "Game B", duration: TimeSpan.FromHours(2));
+        r2.Players = [MakePlayer(Guid.NewGuid(), r2.Id)];
+
+        var r3 = MakePlayRecord(Guid.NewGuid(), userId, Guid.NewGuid(), "Game C", duration: null);
+        r3.Players = [MakePlayer(Guid.NewGuid(), r3.Id)];
+
+        _context.PlayRecords.AddRange(r1, r2, r3);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayerStatisticsQuery(userId), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.TotalDurationMinutes.Should().Be(210);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Free-form game (GameId == null)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WinByGame_FreeFormRecordsWithSameName_GroupedByNullGameIdAndGameName()
+    {
+        // Arrange — two free-form records with GameId=null but same GameName should aggregate
+        var userId = Guid.NewGuid();
+
+        var r1 = MakePlayRecord(Guid.NewGuid(), userId, gameId: null, gameName: "Home Rules");
+        r1.Players = [MakePlayer(Guid.NewGuid(), r1.Id, ("wins", 1))];
+
+        var r2 = MakePlayRecord(Guid.NewGuid(), userId, gameId: null, gameName: "Home Rules");
+        r2.Players = [MakePlayer(Guid.NewGuid(), r2.Id, ("wins", 0))];
+
+        _context.PlayRecords.AddRange(r1, r2);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await _handler.Handle(new GetPlayerStatisticsQuery(userId), TestContext.Current.CancellationToken);
+
+        // Assert — grouped into a single entry with GameId == null
+        var entry = result.WinByGame.Should().ContainSingle().Subject;
+        entry.GameId.Should().BeNull();
+        entry.GameName.Should().Be("Home Rules");
+        entry.Played.Should().Be(2);
+        entry.Won.Should().Be(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Empty record set
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EmptyRecordSet_AllNewFieldsReturnDefaultValues()
+    {
+        // Arrange — no records for this user
+        var query = new GetPlayerStatisticsQuery(Guid.NewGuid());
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.TotalDurationMinutes.Should().Be(0);
+        result.WinByGame.Should().BeEmpty();
+        result.MostPlayedGames.Should().BeEmpty();
+
+        // Existing fields also default correctly
+        result.TotalSessions.Should().Be(0);
+        result.TotalWins.Should().Be(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static PlayRecordEntity MakePlayRecord(
+        Guid id,
+        Guid userId,
+        Guid? gameId,
+        string gameName = "Test Game",
+        TimeSpan? duration = null) => new()
+    {
+        Id = id,
+        GameId = gameId,
+        GameName = gameName,
+        CreatedByUserId = userId,
+        Visibility = 0,
+        SessionDate = DateTime.UtcNow.AddDays(-1),
+        Duration = duration,
+        Status = 2, // Completed
+        ScoringConfigJson = """{"Dimensions":["points","wins"],"Units":{"points":"pts","wins":"W"}}""",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+
+    private static RecordPlayerEntity MakePlayer(
+        Guid id,
+        Guid playRecordId,
+        params (string Dimension, int Value)[] scores) =>
+        new()
+        {
+            Id = id,
+            PlayRecordId = playRecordId,
+            DisplayName = $"Player-{id:N}",
+            Scores = scores.Select(s => new RecordScoreEntity
+            {
+                Id = Guid.NewGuid(),
+                RecordPlayerId = id,
+                Dimension = s.Dimension,
+                Value = s.Value
+            }).ToList()
+        };
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordOutcomeCalculatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/PlayRecordOutcomeCalculatorTests.cs
@@ -264,6 +264,70 @@ public class PlayRecordOutcomeCalculatorTests
 
     #endregion
 
+    #region HasWinner
+
+    [Fact]
+    public void HasWinner_OnePlayerWithWinsGreaterThanZero_ReturnsTrue()
+    {
+        // Arrange
+        var winner = MakePlayer(Guid.NewGuid(), ("wins", 1));
+        var loser = MakePlayer(Guid.NewGuid(), ("wins", 0));
+        var noScore = MakePlayer(Guid.NewGuid());
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.HasWinner([winner, loser, noScore]);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasWinner_NoPlayerHasWinsDimension_ReturnsFalse()
+    {
+        // Arrange — non-competitive: no "wins" dimension at all
+        var player1 = MakePlayer(Guid.NewGuid(), ("points", 42));
+        var player2 = MakePlayer(Guid.NewGuid(), ("points", 30));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.HasWinner([player1, player2]);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasWinner_WinsDimensionExistsButValueZero_ReturnsFalse()
+    {
+        // Arrange — "wins" dimension present with value 0 (player did not win)
+        var player = MakePlayer(Guid.NewGuid(), ("wins", 0));
+
+        // Act
+        var result = PlayRecordOutcomeCalculator.HasWinner([player]);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasWinner_EmptyPlayerList_ReturnsFalse()
+    {
+        // Act
+        var result = PlayRecordOutcomeCalculator.HasWinner([]);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasWinner_NullArgument_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var act = () => PlayRecordOutcomeCalculator.HasWinner(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+
     #region Scenario: Competitive vs Non-competitive combinations
 
     [Fact]

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -89,11 +89,31 @@ export const PlayRecordSummarySchema = z.object({
 });
 export type PlayRecordSummary = z.infer<typeof PlayRecordSummarySchema>;
 
+// #1663 Phase 2: per-game win/play stats keyed by gameId (gameName fallback).
+export const GameWinStatsSchema = z.object({
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string(),
+  played: z.number().int().nonnegative(),
+  won: z.number().int().nonnegative(),
+});
+export type GameWinStats = z.infer<typeof GameWinStatsSchema>;
+
+export const GamePlayCountSchema = z.object({
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string(),
+  plays: z.number().int().nonnegative(),
+});
+export type GamePlayCount = z.infer<typeof GamePlayCountSchema>;
+
 export const PlayerStatisticsSchema = z.object({
   totalSessions: z.number().int().nonnegative(),
   totalWins: z.number().int().nonnegative(),
   gamePlayCounts: z.record(z.string(), z.number().int()),
   averageScoresByGame: z.record(z.string(), z.number()),
+  // #1663 Phase 2: new fields, optional during BE rollout.
+  totalDurationMinutes: z.number().int().nonnegative().optional(),
+  winByGame: z.array(GameWinStatsSchema).optional(),
+  mostPlayedGames: z.array(GamePlayCountSchema).optional(),
 });
 export type PlayerStatistics = z.infer<typeof PlayerStatisticsSchema>;
 


### PR DESCRIPTION
## Summary

**Phase 2 of #1663** — backend statistics fields for the `/play-records` v2 reskin (Epic #1475 / mockup #1488). Extends `PlayerStatisticsDto` + `GetPlayerStatisticsQueryHandler` with the stats-dashboard fields, **computed on-read (no migration)**. Follows Phase 1 (PR #1666 `b52183544`).

**Closes #1663** — Phase 1 + Phase 2 complete.

## What's in this PR

**New DTO types** (`PlayerStatisticsDto.cs`):
- `GameWinStats(Guid? GameId, string GameName, int Played, int Won)`
- `GamePlayCount(Guid? GameId, string GameName, int Plays)`

**`PlayerStatisticsDto` extended (additive, positional append)**:
- `int TotalDurationMinutes` — sum of `Duration.TotalMinutes`, rounded
- `IReadOnlyList<GameWinStats> WinByGame` — per-game played + won, ordered by `played desc`
- `IReadOnlyList<GamePlayCount> MostPlayedGames` — per-game plays, ordered by `plays desc`

Existing `GamePlayCounts` + `AverageScoresByGame` retained for backward compat.

**Helper extension** (`PlayRecordOutcomeCalculator`):
- `+ HasWinner(IEnumerable<RecordPlayerEntity>) → bool` — no list allocation; reused by the stats handler (DRY with the win-rule, no duplication).

**Handler** (`GetPlayerStatisticsQueryHandler`):
- Inline `totalWins` count refactored to call `PlayRecordOutcomeCalculator.HasWinner` (eliminates the duplicated `"wins">0` logic that lived inline).
- Groups records by `(GameId, GameName)` tuple — records with `GameId == null` (free-form games) group correctly by `(null, GameName)`.

**FE Zod** (`play-records.schemas.ts`):
- `GameWinStatsSchema` + `GamePlayCountSchema` (new).
- `PlayerStatisticsSchema`: 3 new fields **optional** (rollout-safe; schemas non-strict).

## Verification

```
dotnet test --filter "FullyQualifiedName~PlayRecord&Category=Unit"
Superato!  Non superati: 0  Superati: 81  (Phase 1: 70 + Phase 2: 11 new)

pnpm typecheck (apps/web) → exit 0
```

## Test matrix

| Scenario | Expected | ✓ |
|---|---|---|
| 3 records Game A (2 winners) + 2 Game B (1 winner) | WinByGame: A(3,2), B(2,1) ordered | ✅ |
| MostPlayedGames from same set | A(3), B(2) ordered | ✅ |
| Durations 01:30:00 + 02:00:00 + null | TotalDurationMinutes = 210 | ✅ |
| Free-form game (GameId null) | groups by (null, GameName) | ✅ |
| Empty record set | TotalDurationMinutes=0, WinByGame=[], MostPlayedGames=[] | ✅ |
| `HasWinner` true/false/zero-value/empty/null | helper unit tests | ✅ |
| Existing `totalWins` regression | unchanged after refactor | ✅ |

## Epic #1475 context

After this PR lands, the BE side of the play-records v2 reskin is complete. The **FE reskin** (still in standby per Epic #1475 plan) can now dispatch route-by-route consuming the new fields. Phase D mockup #1488 unblocks for implementation.

Refs #1663 · Epic #1475 · mockup #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
