### PR TITLE
feat(admin-kb): #1651 F3-FU-2 — Used-by tab in KbDocDetailPanel

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Read DTO for the "Used by" tab in KbDocDetailPanel.
+/// Identifies an agent that explicitly consumes a given PDF document via AgentDefinition.KbCardIds.
+/// Issue #1651: F3-FU-2 — Used-by tab.
+/// </summary>
+internal sealed record KbDocConsumingAgentDto(
+    Guid Id,
+    string Name,
+    string Type,
+    bool IsActive,
+    string Status,
+    bool IsSystemDefined,
+    string? TypologySlug,
+    Guid? GameId,
+    string? GameName,
+    int InvocationCount,
+    DateTime? LastInvokedAt
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Lists the agent definitions that explicitly consume a given PDF document
+/// (i.e. AgentDefinition.KbCardIds contains DocumentId).
+/// Returns an empty list when no agent consumes the document.
+/// Issue #1651: F3-FU-2 — Used-by tab.
+/// </summary>
+internal sealed record GetConsumingAgentsByDocumentIdQuery(Guid DocumentId)
+    : IQuery<IReadOnlyList<KbDocConsumingAgentDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for GetConsumingAgentsByDocumentIdQuery — Issue #1651, F3-FU-2 Used-by tab.
+/// Lists agents that explicitly consume the document (KbCardIds containment), resolves
+/// GameName via bulk lookup, and maps to KbDocConsumingAgentDto. Soft-deleted agents are
+/// excluded by the repository implementation; the global query filter is not relied upon.
+/// </summary>
+internal sealed class GetConsumingAgentsByDocumentIdQueryHandler
+    : IQueryHandler<GetConsumingAgentsByDocumentIdQuery, IReadOnlyList<KbDocConsumingAgentDto>>
+{
+    private readonly IAgentDefinitionRepository _agentRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public GetConsumingAgentsByDocumentIdQueryHandler(
+        IAgentDefinitionRepository agentRepository,
+        ISharedGameRepository sharedGameRepository)
+    {
+        _agentRepository = agentRepository
+            ?? throw new ArgumentNullException(nameof(agentRepository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    public async Task<IReadOnlyList<KbDocConsumingAgentDto>> Handle(
+        GetConsumingAgentsByDocumentIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var agents = await _agentRepository
+            .GetByConsumedDocumentAsync(query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (agents.Count == 0)
+            return Array.Empty<KbDocConsumingAgentDto>();
+
+        var gameIds = agents
+            .Where(a => a.GameId.HasValue)
+            .Select(a => a.GameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(gameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        return agents.Select(a => MapToDto(a, gameNames)).ToList();
+    }
+
+    private static KbDocConsumingAgentDto MapToDto(
+        Domain.Entities.AgentDefinition agent,
+        IReadOnlyDictionary<Guid, string> gameNames)
+    {
+        var gameName = agent.GameId.HasValue
+            && gameNames.TryGetValue(agent.GameId.Value, out var name)
+                ? name
+                : null;
+
+        return new KbDocConsumingAgentDto(
+            Id: agent.Id,
+            Name: agent.Name,
+            Type: agent.Type.Value,
+            IsActive: agent.IsActive,
+            Status: agent.Status.ToString(),
+            IsSystemDefined: agent.IsSystemDefined,
+            TypologySlug: agent.TypologySlug,
+            GameId: agent.GameId,
+            GameName: gameName,
+            InvocationCount: agent.InvocationCount,
+            LastInvokedAt: agent.LastInvokedAt);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs
@@ -72,4 +72,14 @@ public interface IAgentDefinitionRepository
     /// Issue #904: SG3 — agent slot quota.
     /// </summary>
     Task<int> CountActiveByGameIdsAsync(IReadOnlyList<Guid> gameIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the agent definitions whose KbCardIds explicitly contains the given document id.
+    /// Uses Postgres JSONB containment (kb_card_ids @>); soft-deleted agents are excluded.
+    /// Returns an empty list when documentId is Guid.Empty.
+    /// Issue #1651: F3-FU-2 — Used-by tab.
+    /// </summary>
+    Task<IReadOnlyList<AgentDefinition>> GetByConsumedDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs
@@ -143,4 +143,26 @@ public sealed class AgentDefinitionRepository : RepositoryBase, IAgentDefinition
             .CountAsync(a => a.GameId != null && gameIds.Contains(a.GameId.Value), cancellationToken)
             .ConfigureAwait(false);
     }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<AgentDefinition>> GetByConsumedDocumentAsync(
+        Guid documentId, CancellationToken cancellationToken = default)
+    {
+        if (documentId == Guid.Empty)
+            return Array.Empty<AgentDefinition>();
+
+        // JSONB containment: agents whose kb_card_ids array contains documentId.
+        // is_deleted = false is asserted explicitly in SQL — the global query filter
+        // is not guaranteed to compose over FromSqlInterpolated.
+        var docIdJsonLiteral = $"[\"{documentId}\"]";
+
+        return await DbContext.Set<AgentDefinition>()
+            .FromSqlInterpolated(
+                $@"SELECT * FROM knowledge_base.agent_definitions
+                   WHERE kb_card_ids @> {docIdJsonLiteral}::jsonb
+                   AND is_deleted = false")
+            .AsNoTracking()
+            .OrderBy(a => a.Name)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs
@@ -79,6 +79,12 @@ public sealed class AgentDefinitionConfiguration : IEntityTypeConfiguration<Agen
             .HasDefaultValue("[]")
             .IsRequired();
 
+        // Issue #1651: GIN index on kb_card_ids to support `@>` containment query
+        // for the Used-by tab (agents that consume a given PDF document).
+        builder.HasIndex("_kbCardIdsJson")
+            .HasDatabaseName("ix_agent_definitions_kb_card_ids")
+            .HasMethod("gin");
+
         // ChatLanguage (E5-3) - ISO 639-1 code or "auto"
         builder.Property(a => a.ChatLanguage)
             .HasColumnName("chat_language")

--- a/apps/api/src/Api/Infrastructure/Migrations/20260529102535_AddKbCardIdsGinIndex.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260529102535_AddKbCardIdsGinIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529102535_AddKbCardIdsGinIndex")]
+    partial class AddKbCardIdsGinIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260529102535_AddKbCardIdsGinIndex.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260529102535_AddKbCardIdsGinIndex.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKbCardIdsGinIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_agent_definitions_kb_card_ids",
+                schema: "knowledge_base",
+                table: "agent_definitions",
+                column: "kb_card_ids")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_agent_definitions_kb_card_ids",
+                schema: "knowledge_base",
+                table: "agent_definitions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -84,6 +84,19 @@ internal static class AdminKnowledgeBaseEndpoints
         .WithName("GetKbDocIngestionLog")
         .WithSummary("Get the latest ProcessingJob (with Steps and LogEntries) for a PdfDocumentId.");
 
+        // GET /api/v1/admin/kb/docs/{docId}/agents — Issue #1651 F3-FU-2
+        kbGroup.MapGet("/docs/{docId:guid}/agents", async (
+            Guid docId,
+            IMediator mediator,
+            CancellationToken cancellationToken) =>
+        {
+            var query = new GetConsumingAgentsByDocumentIdQuery(docId);
+            var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetKbDocConsumingAgents")
+        .WithSummary("List agent definitions that consume a given PDF document (KbCardIds containment).");
+
         // POST /api/v1/admin/kb/agents/estimate-cost - Pre-chat cost estimation
         kbGroup.MapPost("/agents/estimate-cost", async (
             [FromBody] EstimateAgentCostByDocumentsRequest request,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs
@@ -1,0 +1,178 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1651")]
+public sealed class GetConsumingAgentsByDocumentIdQueryHandlerTests
+{
+    private readonly Mock<IAgentDefinitionRepository> _agentRepo = new(MockBehavior.Strict);
+    private readonly Mock<ISharedGameRepository> _gameRepo = new(MockBehavior.Strict);
+
+    private GetConsumingAgentsByDocumentIdQueryHandler CreateHandler() =>
+        new(_agentRepo.Object, _gameRepo.Object);
+
+    private static AgentDefinition MakeCustomAgent(string name, Guid? gameId = null)
+    {
+        var agent = AgentDefinition.Create(
+            name: name,
+            description: "test",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: AgentDefinitionConfig.Create("gpt-4o-mini", 1024, 0.5f));
+        if (gameId.HasValue) agent.SetGameId(gameId);
+        return agent;
+    }
+
+    private static AgentDefinition MakeSystemAgent(string name, string typologySlug)
+    {
+        return AgentDefinition.CreateSystem(
+            name: name,
+            description: "system",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: AgentDefinitionConfig.Create("gpt-4o-mini", 1024, 0.5f),
+            typologySlug: typologySlug);
+    }
+
+    [Fact]
+    public async Task Handle_NoConsumingAgents_ReturnsEmptyList()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AgentDefinition>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().BeEmpty();
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never, "no agents → no game-name resolution needed");
+    }
+
+    [Fact]
+    public async Task Handle_MapsCustomAgent_WithGameNameResolved()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var agent = MakeCustomAgent("Alpha", gameId);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(gameId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [gameId] = "Wingspan" });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.Id.Should().Be(agent.Id);
+        dto.Name.Should().Be("Alpha");
+        dto.IsSystemDefined.Should().BeFalse();
+        dto.TypologySlug.Should().BeNull();
+        dto.GameId.Should().Be(gameId);
+        dto.GameName.Should().Be("Wingspan");
+        dto.Status.Should().Be(AgentDefinitionStatus.Draft.ToString());
+    }
+
+    [Fact]
+    public async Task Handle_MapsSystemAgent_WithFlagAndTypologySlug()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var agent = MakeSystemAgent("Arbitro", typologySlug: "arbitro");
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.IsSystemDefined.Should().BeTrue();
+        dto.TypologySlug.Should().Be("arbitro");
+        dto.GameId.Should().BeNull();
+        dto.GameName.Should().BeNull();
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never, "no agent has a GameId → no resolution call");
+    }
+
+    [Fact]
+    public async Task Handle_AgentWithMissingGame_LeavesGameNameNull()
+    {
+        // Arrange — the agent has a GameId, but the game has been removed from the catalog.
+        var docId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var agent = MakeCustomAgent("Beta", gameId);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>()); // empty — game not found
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].GameId.Should().Be(gameId);
+        result[0].GameName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_BulkResolvesGameNames_OneCallForMultipleAgents()
+    {
+        // Arrange — two agents, each with a distinct game. Must call GetNamesByIdsAsync ONCE.
+        var docId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        var a1 = MakeCustomAgent("A1", g1);
+        var a2 = MakeCustomAgent("A2", g2);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { a1, a2 });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [g1] = "Game1", [g2] = "Game2" });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(2);
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Once, "bulk lookup, no N+1");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs
@@ -1,0 +1,268 @@
+using System.Net;
+using System.Text.Json;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Integration tests for GET /api/v1/admin/kb/docs/{docId}/agents.
+/// Issue #1651: F3-FU-2 Used-by tab — verifies JSONB containment, soft-delete exclusion,
+/// system-agent visibility, GameName bulk resolution, and admin authentication.
+/// Uses Testcontainers Postgres because the @> containment is not translatable on EF InMemory.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1651")]
+public sealed class ConsumingAgentsEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ConsumingAgentsEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"used_by_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ========================================
+    // AC8 — Authentication
+    // ========================================
+
+    [Fact]
+    public async Task GET_NoSession_Returns401()
+    {
+        var docId = Guid.NewGuid();
+        var response = await _client.GetAsync($"/api/v1/admin/kb/docs/{docId}/agents");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ========================================
+    // AC5 — Zero consumers
+    // ========================================
+
+    [Fact]
+    public async Task GET_NoConsumingAgents_Returns200WithEmptyArray()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var request = AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("[]");
+    }
+
+    // ========================================
+    // AC7 — Guid.Empty defensive
+    // ========================================
+
+    [Fact]
+    public async Task GET_EmptyGuid_Returns200WithEmptyArray()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var request = AuthRequest(
+            HttpMethod.Get,
+            $"/api/v1/admin/kb/docs/{Guid.Empty}/agents",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("[]");
+    }
+
+    // ========================================
+    // AC1 + AC2 — Includes consumers, excludes non-consumers
+    // ========================================
+
+    [Fact]
+    public async Task GET_OneConsumingAgent_ReturnsThatAgentOnly()
+    {
+        // Arrange — Agent A consumes docId; Agent B does not.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var otherDocId = Guid.NewGuid();
+
+        var agentA = MakeAgent("Agent A");
+        agentA.UpdateKbCardIds(new[] { docId });
+        var agentB = MakeAgent("Agent B");
+        agentB.UpdateKbCardIds(new[] { otherDocId });
+
+        dbContext.Set<AgentDefinition>().AddRange(agentA, agentB);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("name").GetString().Should().Be("Agent A");
+    }
+
+    // ========================================
+    // AC3 — Soft-deleted excluded
+    // ========================================
+
+    [Fact]
+    public async Task GET_SoftDeletedAgent_IsExcluded()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var agent = MakeAgent("Soft Deleted");
+        agent.UpdateKbCardIds(new[] { docId });
+        agent.SoftDelete();
+
+        dbContext.Set<AgentDefinition>().Add(agent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await ReadArray(response)).Should().BeEmpty();
+    }
+
+    // ========================================
+    // AC4 — System agent included with flag
+    // ========================================
+
+    [Fact]
+    public async Task GET_SystemAgent_IsIncludedWithIsSystemDefinedTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var sysAgent = AgentDefinition.CreateSystem(
+            name: "Arbitro",
+            description: "system",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: AgentDefinitionConfig.Create("gpt-4o-mini", 1024, 0.5f),
+            typologySlug: "arbitro");
+        sysAgent.UpdateKbCardIds(new[] { docId });
+
+        dbContext.Set<AgentDefinition>().Add(sysAgent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("isSystemDefined").GetBoolean().Should().BeTrue();
+        items[0].GetProperty("typologySlug").GetString().Should().Be("arbitro");
+    }
+
+    // ========================================
+    // AC6 — GameName null when game is missing
+    // ========================================
+
+    [Fact]
+    public async Task GET_AgentWithMissingGame_HasGameNameNull()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var phantomGameId = Guid.NewGuid(); // not in shared_games table
+
+        var agent = MakeAgent("Beta");
+        agent.SetGameId(phantomGameId);
+        agent.UpdateKbCardIds(new[] { docId });
+
+        dbContext.Set<AgentDefinition>().Add(agent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("gameId").GetGuid().Should().Be(phantomGameId);
+        items[0].TryGetProperty("gameName", out var gameNameProp).Should().BeTrue();
+        (gameNameProp.ValueKind == JsonValueKind.Null).Should().BeTrue();
+    }
+
+    // ========================================
+    // Helpers
+    // ========================================
+
+    private static AgentDefinition MakeAgent(string name) =>
+        AgentDefinition.Create(
+            name: name,
+            description: "test",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: AgentDefinitionConfig.Create("gpt-4o-mini", 1024, 0.5f));
+
+    private static HttpRequestMessage AuthRequest(HttpMethod method, string uri, string sessionToken)
+    {
+        var request = new HttpRequestMessage(method, uri);
+        request.Headers.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={sessionToken}");
+        return request;
+    }
+
+    private static async Task<List<JsonElement>> ReadArray(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        return json.RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
+    }
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -90,6 +90,17 @@ export function KbDocDetailPanel({ docId }: KbDocDetailPanelProps) {
   const envelope = detailQuery.data;
 
   if (envelope?.status === 'locked') {
+    // The Used-by tab is independent of doc readiness (it only needs the docId
+    // to query agents whose KbCardIds contain it). Allow it to render during
+    // processing — addresses the carry-forward gap flagged on PR #1668 (#1650).
+    if (activeTab === 'used-by') {
+      return (
+        <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
+          <KbDocDetailTabs docId={docId} activeTab={activeTab} />
+          <UsedByPanel docId={docId} />
+        </div>
+      );
+    }
     return (
       <div className="border border-amber-500/30 rounded-lg bg-amber-500/5 p-6">
         <h3 className="font-quicksand font-bold text-base text-amber-700 dark:text-amber-300 mb-1">

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -8,6 +8,7 @@ import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
 
 import { IngestionPanel } from './ingestion/IngestionPanel';
 import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
+import { UsedByPanel } from './used-by/UsedByPanel';
 
 export interface KbDocDetailPanelProps {
   readonly docId: string | null;
@@ -45,8 +46,12 @@ function processingChipClass(status: string): string {
  */
 export function KbDocDetailPanel({ docId }: KbDocDetailPanelProps) {
   const searchParams = useSearchParams();
-  const activeTab: KbDocTabKey =
-    searchParams?.get('tab') === 'ingestion' ? 'ingestion' : 'overview';
+  const activeTab: KbDocTabKey = (() => {
+    const tab = searchParams?.get('tab');
+    if (tab === 'ingestion') return 'ingestion';
+    if (tab === 'used-by') return 'used-by';
+    return 'overview';
+  })();
 
   const detailQuery = useKbDocDetail({ docId: docId ?? undefined, enabled: docId !== null });
   const chunksQuery = useKbChunksList({
@@ -110,9 +115,13 @@ export function KbDocDetailPanel({ docId }: KbDocDetailPanelProps) {
     <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
       <KbDocDetailTabs docId={doc.id} activeTab={activeTab} />
 
-      {activeTab === 'ingestion' ? (
+      {activeTab === 'ingestion' && (
         <IngestionPanel docId={doc.id} chunkCount={doc.chunkCount} pageCount={doc.pageCount ?? 0} />
-      ) : (
+      )}
+
+      {activeTab === 'used-by' && <UsedByPanel docId={doc.id} />}
+
+      {activeTab === 'overview' && (
         <>
           {/* Hero */}
           <header className="p-5 border-b border-border/60 dark:border-zinc-700/60 bg-gradient-to-b from-amber-500/5 to-transparent">

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 
-export type KbDocTabKey = 'overview' | 'ingestion';
+export type KbDocTabKey = 'overview' | 'ingestion' | 'used-by';
 
 interface KbDocDetailTabsProps {
   readonly docId: string;
@@ -12,12 +12,13 @@ interface KbDocDetailTabsProps {
 const TABS: ReadonlyArray<{ readonly key: KbDocTabKey; readonly label: string }> = [
   { key: 'overview', label: 'Overview' },
   { key: 'ingestion', label: 'Ingestion log' },
+  { key: 'used-by', label: 'Used by' },
 ];
 
 /**
  * Inner tab nav for `KbDocDetailPanel`. URL-driven via `?tab=overview` (default)
- * or `?tab=ingestion`. Preserves `docId` in each link. Issue #1650.
- * Future follow-ups (#1651/#1653/#1654) will add more tabs here.
+ * | `?tab=ingestion` | `?tab=used-by`. Preserves `docId` in each link.
+ * Issues #1650 (Ingestion log) + #1651 (Used by). Future follow-ups #1653/#1654.
  */
 export function KbDocDetailTabs({ docId, activeTab }: KbDocDetailTabsProps) {
   return (

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
@@ -247,4 +247,23 @@ describe('KbDocDetailPanel', () => {
       screen.queryByRole('heading', { name: /Wingspan-Oceania-EN\.pdf/ })
     ).not.toBeInTheDocument();
   });
+
+  it('renders UsedByPanel even when document is locked (independent of doc readiness)', async () => {
+    mockSearchParams = new URLSearchParams('tab=used-by');
+    mockUseKbDocDetail.mockReturnValue({ data: lockedEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+    // Used-by tab renders (empty state mock resolves []), NOT the locked banner.
+    await waitFor(() => expect(screen.getByTestId('used-by-empty')).toBeInTheDocument());
+    expect(screen.queryByText(/in elaborazione/i)).not.toBeInTheDocument();
+  });
+
+  it('still shows the locked banner when activeTab is overview', () => {
+    mockSearchParams = new URLSearchParams(''); // default: overview
+    mockUseKbDocDetail.mockReturnValue({ data: lockedEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+    expect(screen.getByText(/in elaborazione/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('used-by-empty')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
@@ -42,6 +42,11 @@ vi.mock('@/lib/api/admin-kb-ingestion', () => ({
   retryIngestionJob: vi.fn().mockResolvedValue(undefined),
 }));
 
+// ── admin-kb-used-by mock (UsedByPanel uses fetchKbDocConsumingAgents) ─────────
+vi.mock('@/lib/api/admin-kb-used-by', () => ({
+  fetchKbDocConsumingAgents: vi.fn().mockResolvedValue([]),
+}));
+
 const mockUseKbDocDetail = vi.fn();
 const mockUseKbChunksList = vi.fn();
 
@@ -220,6 +225,24 @@ describe('KbDocDetailPanel', () => {
     // IngestionPanel empty state should appear (fetchKbDocIngestionLog resolves null)
     await waitFor(() => expect(screen.getByTestId('ingestion-panel-empty')).toBeInTheDocument());
     // Overview hero should NOT be visible
+    expect(
+      screen.queryByRole('heading', { name: /Wingspan-Oceania-EN\.pdf/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders UsedByPanel when ?tab=used-by', async () => {
+    mockSearchParams = new URLSearchParams('tab=used-by');
+    mockUseKbDocDetail.mockReturnValue({ data: readyEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({
+      data: undefined,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+    });
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+    // Empty state appears because fetchKbDocConsumingAgents mock resolves [].
+    await waitFor(() => expect(screen.getByTestId('used-by-empty')).toBeInTheDocument());
+    // Overview hero must NOT render when used-by is active.
     expect(
       screen.queryByRole('heading', { name: /Wingspan-Oceania-EN\.pdf/ })
     ).not.toBeInTheDocument();

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
@@ -12,10 +12,25 @@ vi.mock('next/navigation', async () => {
 });
 
 describe('KbDocDetailTabs', () => {
-  it('renders two tabs: Overview and Ingestion log', () => {
+  it('renders three tabs: Overview, Ingestion log, Used by', () => {
     render(<KbDocDetailTabs docId="abc" activeTab="overview" />);
     expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /ingestion log/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /used by/i })).toBeInTheDocument();
+  });
+
+  it('Used by link sets ?tab=used-by and preserves docId', () => {
+    render(<KbDocDetailTabs docId="abc" activeTab="overview" />);
+    const usedByLink = screen.getByRole('link', { name: /used by/i });
+    expect(usedByLink.getAttribute('href')).toContain('docId=abc');
+    expect(usedByLink.getAttribute('href')).toContain('tab=used-by');
+  });
+
+  it('marks Used by as active when activeTab="used-by"', () => {
+    render(<KbDocDetailTabs docId="abc" activeTab="used-by" />);
+    expect(screen.getByRole('link', { name: /used by/i }).getAttribute('aria-current')).toBe(
+      'page'
+    );
   });
 
   it('preserves docId in each tab href', () => {

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+interface UsedByAgentRowProps {
+  readonly agent: KbDocConsumingAgent;
+}
+
+function statusChipClass(status: KbDocConsumingAgent['status']): string {
+  switch (status) {
+    case 'Published':
+      return 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/30';
+    case 'Testing':
+      return 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30';
+    default: // Draft
+      return 'bg-muted text-muted-foreground border-border';
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (iso === null) return 'mai';
+  const date = new Date(iso);
+  return date.toLocaleDateString('it-IT', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+/**
+ * Single row in the "Used by" tab. Read-only — links out to the agent detail
+ * in the AI Lab. Issue #1651.
+ */
+export function UsedByAgentRow({ agent }: UsedByAgentRowProps) {
+  const gameLabel = agent.gameName ?? 'KB globale';
+
+  return (
+    <li className="py-3" data-testid="used-by-agent-row">
+      <Link
+        href={`/admin/agents/definitions/${agent.id}`}
+        className="block hover:bg-muted/40 rounded-md px-3 py-2 -mx-3 transition-colors"
+      >
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-quicksand font-bold text-sm truncate">{agent.name}</span>
+          {agent.isSystemDefined && (
+            <span
+              data-testid="used-by-system-badge"
+              className="inline-flex items-center px-1.5 py-0.5 text-[9.5px] font-semibold rounded-full border bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30 uppercase tracking-wider"
+              title={agent.typologySlug ?? undefined}
+            >
+              sistema
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${statusChipClass(agent.status)}`}
+          >
+            {agent.status}
+          </span>
+          <span className="ml-auto text-[10.5px] font-mono text-muted-foreground">
+            {agent.type}
+          </span>
+        </div>
+        <div className="mt-1 flex items-center gap-3 text-[11.5px] text-muted-foreground font-mono">
+          <span>{gameLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span>
+            {agent.invocationCount.toLocaleString('it-IT')} invocaz · ultimo{' '}
+            {formatRelative(agent.lastInvokedAt)}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+export function UsedByEmptyState() {
+  return (
+    <div
+      data-testid="used-by-empty"
+      className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 p-8 text-center text-sm text-muted-foreground min-h-[200px] flex flex-col items-center justify-center gap-2"
+    >
+      <span aria-hidden="true" className="text-3xl">
+        🧑‍🤝‍🧑
+      </span>
+      <p>Nessun agent consuma questo documento.</p>
+      <p className="text-xs">Aggiungi il documento alla KB di un agent per vederlo apparire qui.</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: zinc dark overrides (admin convention, DS-13c scope deferred to DS-16) */
 'use client';
 
 export function UsedByEmptyState() {

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useKbDocConsumingAgents } from '@/hooks/queries/useKbDocConsumingAgents';
+
+import { UsedByAgentRow } from './UsedByAgentRow';
+import { UsedByEmptyState } from './UsedByEmptyState';
+
+interface UsedByPanelProps {
+  readonly docId: string;
+}
+
+/**
+ * Container of the "Used by" tab inside KbDocDetailPanel. Wires the React Query
+ * hook to UsedByAgentRow + UsedByEmptyState. Read-only. Issue #1651.
+ */
+export function UsedByPanel({ docId }: UsedByPanelProps) {
+  const query = useKbDocConsumingAgents({ docId });
+
+  if (query.isLoading) {
+    return (
+      <div
+        data-testid="used-by-panel-loading"
+        className="border border-border/60 rounded-lg bg-card/80 p-6 animate-pulse min-h-[200px]"
+      >
+        <div className="h-4 w-1/2 bg-muted rounded mb-3" />
+        <div className="h-4 w-1/3 bg-muted rounded mb-3" />
+        <div className="h-4 w-2/3 bg-muted rounded" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div
+        data-testid="used-by-panel-error"
+        className="border border-rose-500/30 rounded-lg bg-rose-500/5 p-6 text-sm text-rose-700 dark:text-rose-300"
+      >
+        Errore caricamento agent consumatori: {query.error.message}
+      </div>
+    );
+  }
+
+  const agents = query.data ?? [];
+  if (agents.length === 0) {
+    return <UsedByEmptyState />;
+  }
+
+  return (
+    <section
+      data-testid="used-by-panel"
+      className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden"
+    >
+      <header className="p-4 border-b border-border/60 dark:border-zinc-700/60">
+        <h3 className="font-quicksand font-bold text-sm">
+          Agent che consumano questo documento ({agents.length})
+        </h3>
+      </header>
+      <ul className="divide-y divide-border/60 dark:divide-zinc-700/60 px-4">
+        {agents.map(a => (
+          <UsedByAgentRow key={a.id} agent={a} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: rose error palette + zinc dark overrides (admin convention, DS-13c scope deferred to DS-16) */
 'use client';
 
 import { useKbDocConsumingAgents } from '@/hooks/queries/useKbDocConsumingAgents';

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { UsedByAgentRow } from '../UsedByAgentRow';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseAgent: KbDocConsumingAgent = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Alpha',
+  type: 'HybridSearch',
+  isActive: true,
+  status: 'Published',
+  isSystemDefined: false,
+  typologySlug: null,
+  gameId: '22222222-2222-2222-2222-222222222222',
+  gameName: 'Wingspan',
+  invocationCount: 42,
+  lastInvokedAt: '2026-05-20T10:30:00Z',
+};
+
+function renderRow(overrides: Partial<KbDocConsumingAgent> = {}) {
+  return render(
+    <ul>
+      <UsedByAgentRow agent={{ ...baseAgent, ...overrides }} />
+    </ul>
+  );
+}
+
+describe('UsedByAgentRow', () => {
+  it('renders the agent name and game name', () => {
+    renderRow();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('links to the agent detail in the AI Lab', () => {
+    renderRow();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      '/admin/agents/definitions/11111111-1111-1111-1111-111111111111'
+    );
+  });
+
+  it('shows "KB globale" label when gameName is null', () => {
+    renderRow({ gameName: null, gameId: null });
+    expect(screen.getByText('KB globale')).toBeInTheDocument();
+  });
+
+  it('shows the system badge for system agents', () => {
+    renderRow({ isSystemDefined: true, typologySlug: 'arbitro' });
+    expect(screen.getByTestId('used-by-system-badge')).toBeInTheDocument();
+  });
+
+  it('hides the system badge for custom agents', () => {
+    renderRow({ isSystemDefined: false });
+    expect(screen.queryByTestId('used-by-system-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders the status chip with the correct status label', () => {
+    renderRow({ status: 'Draft' });
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+
+  it('renders "mai" when lastInvokedAt is null', () => {
+    renderRow({ lastInvokedAt: null });
+    expect(screen.getByText(/ultimo mai/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { UsedByPanel } from '../UsedByPanel';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockUseKbDocConsumingAgents = vi.fn();
+vi.mock('@/hooks/queries/useKbDocConsumingAgents', () => ({
+  useKbDocConsumingAgents: (opts: unknown) => mockUseKbDocConsumingAgents(opts),
+}));
+
+const agent: KbDocConsumingAgent = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Alpha',
+  type: 'HybridSearch',
+  isActive: true,
+  status: 'Published',
+  isSystemDefined: false,
+  typologySlug: null,
+  gameId: null,
+  gameName: null,
+  invocationCount: 0,
+  lastInvokedAt: null,
+};
+
+describe('UsedByPanel', () => {
+  beforeEach(() => {
+    mockUseKbDocConsumingAgents.mockReset();
+  });
+
+  it('renders the loading skeleton', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      error: new Error('boom'),
+      data: undefined,
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel-error')).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no consumers', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [],
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-empty')).toBeInTheDocument();
+  });
+
+  it('renders the list when consumers are present', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [agent, { ...agent, id: '22222222-2222-2222-2222-222222222222', name: 'Beta' }],
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel')).toBeInTheDocument();
+    expect(screen.getByText(/Agent che consumano questo documento \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/api/admin-kb-used-by', () => ({
+  fetchKbDocConsumingAgents: vi.fn(),
+}));
+
+import { fetchKbDocConsumingAgents } from '@/lib/api/admin-kb-used-by';
+import { useKbDocConsumingAgents } from '../useKbDocConsumingAgents';
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useKbDocConsumingAgents', () => {
+  beforeEach(() => {
+    vi.mocked(fetchKbDocConsumingAgents).mockReset();
+  });
+
+  it('does not fetch when docId is null', () => {
+    const { result } = renderHook(() => useKbDocConsumingAgents({ docId: null }), {
+      wrapper: wrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when docId is empty string', () => {
+    renderHook(() => useKbDocConsumingAgents({ docId: '' }), { wrapper: wrapper() });
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when enabled=false', () => {
+    renderHook(() => useKbDocConsumingAgents({ docId: 'doc-1', enabled: false }), {
+      wrapper: wrapper(),
+    });
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns the agents when docId is valid and enabled', async () => {
+    vi.mocked(fetchKbDocConsumingAgents).mockResolvedValue([
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        name: 'Alpha',
+        type: 'HybridSearch',
+        isActive: true,
+        status: 'Published',
+        isSystemDefined: false,
+        typologySlug: null,
+        gameId: null,
+        gameName: null,
+        invocationCount: 0,
+        lastInvokedAt: null,
+      },
+    ]);
+
+    const { result } = renderHook(() => useKbDocConsumingAgents({ docId: 'doc-1' }), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].name).toBe('Alpha');
+    expect(fetchKbDocConsumingAgents).toHaveBeenCalledWith('doc-1');
+  });
+});

--- a/apps/web/src/hooks/queries/useKbDocConsumingAgents.ts
+++ b/apps/web/src/hooks/queries/useKbDocConsumingAgents.ts
@@ -1,0 +1,34 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { fetchKbDocConsumingAgents } from '@/lib/api/admin-kb-used-by';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+export const kbDocConsumingAgentsKeys = {
+  all: ['kb', 'doc', 'consuming-agents'] as const,
+  byId: (docId: string) => [...kbDocConsumingAgentsKeys.all, docId] as const,
+};
+
+export interface UseKbDocConsumingAgentsOptions {
+  readonly docId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * TanStack Query hook listing agents that consume a given document.
+ * No polling — the association is static (changes only on agent edit).
+ * Backend contract: GET /api/v1/admin/kb/docs/{docId}/agents.
+ * Issue #1651.
+ */
+export function useKbDocConsumingAgents(
+  options: UseKbDocConsumingAgentsOptions
+): UseQueryResult<KbDocConsumingAgent[], Error> {
+  const { docId, enabled = true } = options;
+  const isValid = typeof docId === 'string' && docId.length > 0;
+
+  return useQuery<KbDocConsumingAgent[], Error>({
+    queryKey: isValid ? kbDocConsumingAgentsKeys.byId(docId) : kbDocConsumingAgentsKeys.all,
+    queryFn: async () => (isValid ? fetchKbDocConsumingAgents(docId) : []),
+    enabled: enabled && isValid,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/lib/api/admin-kb-used-by.ts
+++ b/apps/web/src/lib/api/admin-kb-used-by.ts
@@ -1,0 +1,23 @@
+/**
+ * Admin KB Used-by API client.
+ * Issue #1651: F3-FU-2 — agents that consume a PDF document.
+ */
+
+import { apiClient } from '@/lib/api/client';
+import {
+  KbDocConsumingAgentsResponseSchema,
+  type KbDocConsumingAgent,
+} from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+/**
+ * GET /api/v1/admin/kb/docs/{docId}/agents
+ * Returns the agents that explicitly consume the document via KbCardIds.
+ * Empty array when no agent consumes it.
+ */
+export async function fetchKbDocConsumingAgents(docId: string): Promise<KbDocConsumingAgent[]> {
+  const result = await apiClient.get<KbDocConsumingAgent[]>(
+    `/api/v1/admin/kb/docs/${docId}/agents`,
+    KbDocConsumingAgentsResponseSchema
+  );
+  return result ?? [];
+}

--- a/apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * Mirrors backend `KbDocConsumingAgentDto`
+ * (BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs).
+ * Issue #1651: F3-FU-2 — Used-by tab.
+ */
+export const KbDocConsumingAgentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  type: z.string(),
+  isActive: z.boolean(),
+  status: z.enum(['Draft', 'Testing', 'Published']),
+  isSystemDefined: z.boolean(),
+  typologySlug: z.string().nullable(),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  invocationCount: z.number().int().nonnegative(),
+  lastInvokedAt: z.string().datetime({ offset: true }).nullable(),
+});
+export type KbDocConsumingAgent = z.infer<typeof KbDocConsumingAgentSchema>;
+
+export const KbDocConsumingAgentsResponseSchema = z.array(KbDocConsumingAgentSchema);

--- a/docs/superpowers/plans/2026-05-29-kb-used-by-tab.md
+++ b/docs/superpowers/plans/2026-05-29-kb-used-by-tab.md
@@ -1,0 +1,1948 @@
+# KB Used-by Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Used by" tab inside `KbDocDetailPanel` that lists, given a PDF document, the AI agents that explicitly consume it via `AgentDefinition.KbCardIds`.
+
+**Architecture:** New `GET /api/v1/admin/kb/docs/{docId}/agents` endpoint backed by a JSONB containment query (`kb_card_ids @> '["docId"]'::jsonb`) + GIN index. Read-only FE tab mirroring the F3-FU-1 (#1650) pattern: URL-driven `?tab=used-by`, dedicated `used-by/` folder under the KB explorer, dedicated Zod schemas + API client + React Query hook (no polling — the association is static).
+
+**Tech Stack:** .NET 9 + EF Core + Npgsql (jsonb `@>`) + MediatR (IQuery/IQueryHandler) + xUnit + Testcontainers (Postgres) · Next.js 16 + React 19 + TanStack Query + Zod + Vitest
+
+**Design doc:** `docs/superpowers/specs/2026-05-29-kb-used-by-tab-design.md`
+**Issue:** [#1651](https://github.com/meepleAi-app/meepleai-monorepo/issues/1651) (P3) — sibling of [#1650](https://github.com/meepleAi-app/meepleai-monorepo/issues/1650) (PR #1668)
+**Parent branch:** `main-dev`
+
+---
+
+## File Structure
+
+### Backend — new files
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs` | Read DTO returned by the endpoint (Id, Name, Type, IsActive, Status, IsSystemDefined, TypologySlug, GameId, GameName, InvocationCount, LastInvokedAt). |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs` | Query record `(Guid DocumentId) : IQuery<IReadOnlyList<KbDocConsumingAgentDto>>`. |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs` | Handler — calls repo + bulk-resolves GameName + maps to DTO. |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs` | Unit tests for mapping logic (repo mocked). |
+| `apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs` | Testcontainers integration tests covering AC1–AC8. |
+| (auto-generated) `apps/api/src/Api/Migrations/<timestamp>_AddKbCardIdsGinIndex.cs` + Designer | EF migration creating the GIN index on `kb_card_ids`. |
+
+### Backend — modified files
+
+| Path | Change |
+|---|---|
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs` | Add `GetByConsumedDocumentAsync(Guid, CancellationToken)`. |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs` | Implement `GetByConsumedDocumentAsync` via `FromSqlInterpolated` + `kb_card_ids @>`. |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs` | Add `HasIndex("_kbCardIdsJson").HasDatabaseName("ix_agent_definitions_kb_card_ids").HasMethod("gin")`. |
+| `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs` | Map `GET /docs/{docId:guid}/agents`. |
+
+### Frontend — new files
+
+| Path | Responsibility |
+|---|---|
+| `apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts` | Zod schemas — single source for the JSON contract. |
+| `apps/web/src/lib/api/admin-kb-used-by.ts` | API client — `fetchKbDocConsumingAgents(docId)`. |
+| `apps/web/src/hooks/queries/useKbDocConsumingAgents.ts` | React Query hook — no polling, enabled when tab active. |
+| `apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.ts` | Hook unit tests. |
+| `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx` | Empty state ("Nessun agent consuma questo documento"). |
+| `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx` | Single agent row — name, type, system badge, status, game, usage, link. |
+| `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx` | Container — orchestrates query + loading/error/empty/ready. |
+| `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx` | Row tests (badge, link, game-null fallback, status chips). |
+| `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx` | Panel tests (4 states). |
+| `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx` | Tabs nav tests (3 tabs present, link preserves docId). |
+
+### Frontend — modified files
+
+| Path | Change |
+|---|---|
+| `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx` | Add `'used-by'` to `KbDocTabKey` + `TABS` array. |
+| `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx` | Read `?tab=used-by` and branch render to `<UsedByPanel docId={...}/>`. |
+| `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx` | Add mock for `admin-kb-used-by` + test for `?tab=used-by` branch. |
+
+---
+
+## Task 0: Pre-flight & branch creation
+
+**Files:** (none — git only)
+
+- [ ] **Step 0.1: Verify clean working tree on parent branch**
+
+Run:
+```bash
+git branch --show-current
+git status
+```
+Expected: `main-dev`, clean tree. **If HEAD is on another `feature/*` branch, STOP and run `git checkout main-dev`.** (CLAUDE.md branch hygiene rule, issue #806.)
+
+- [ ] **Step 0.2: Fast-forward main-dev**
+
+Run:
+```bash
+git pull --ff-only
+```
+Expected: `Already up to date.` or successful FF.
+
+- [ ] **Step 0.3: Create feature branch**
+
+Run:
+```bash
+git checkout -b feature/issue-1651-used-by-tab
+git config branch.feature/issue-1651-used-by-tab.parent main-dev
+```
+Expected: switched to new branch; parent config recorded for PR target detection.
+
+---
+
+## Task 1: Backend — DTO `KbDocConsumingAgentDto`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs`
+
+- [ ] **Step 1.1: Write the DTO**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Read DTO for the "Used by" tab in KbDocDetailPanel.
+/// Identifies an agent that explicitly consumes a given PDF document via AgentDefinition.KbCardIds.
+/// Issue #1651: F3-FU-2 — Used-by tab.
+/// </summary>
+internal sealed record KbDocConsumingAgentDto(
+    Guid Id,
+    string Name,
+    string Type,
+    bool IsActive,
+    string Status,
+    bool IsSystemDefined,
+    string? TypologySlug,
+    Guid? GameId,
+    string? GameName,
+    int InvocationCount,
+    DateTime? LastInvokedAt
+);
+```
+
+- [ ] **Step 1.2: Build to verify compilation**
+
+Run from `apps/api/src/Api/`:
+```bash
+dotnet build --nologo -clp:NoSummary
+```
+Expected: build succeeds with 0 errors.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs
+git commit -m "feat(admin-kb): #1651 add KbDocConsumingAgentDto"
+```
+
+---
+
+## Task 2: Backend — Query record
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs`
+
+- [ ] **Step 2.1: Write the query record**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Lists the agent definitions that explicitly consume a given PDF document
+/// (i.e. AgentDefinition.KbCardIds contains DocumentId).
+/// Returns an empty list when no agent consumes the document.
+/// Issue #1651: F3-FU-2 — Used-by tab.
+/// </summary>
+internal sealed record GetConsumingAgentsByDocumentIdQuery(Guid DocumentId)
+    : IQuery<IReadOnlyList<KbDocConsumingAgentDto>>;
+```
+
+- [ ] **Step 2.2: Build**
+
+Run from `apps/api/src/Api/`:
+```bash
+dotnet build --nologo -clp:NoSummary
+```
+Expected: build succeeds.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs
+git commit -m "feat(admin-kb): #1651 add GetConsumingAgentsByDocumentIdQuery record"
+```
+
+---
+
+## Task 3: Backend — Repository method + GIN index + migration
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs`
+- Create (auto): `apps/api/src/Api/Migrations/<timestamp>_AddKbCardIdsGinIndex.cs`
+
+- [ ] **Step 3.1: Add method to repository interface**
+
+Edit `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs`. After the existing `CountActiveByGameIdsAsync` declaration (last method), add:
+
+```csharp
+    /// <summary>
+    /// Returns the agent definitions whose KbCardIds explicitly contains the given document id.
+    /// Uses Postgres JSONB containment (kb_card_ids @>); soft-deleted agents are excluded.
+    /// Returns an empty list when documentId is Guid.Empty.
+    /// Issue #1651: F3-FU-2 — Used-by tab.
+    /// </summary>
+    Task<IReadOnlyList<AgentDefinition>> GetByConsumedDocumentAsync(
+        Guid documentId,
+        CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 3.2: Implement the method**
+
+Edit `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs`. After the existing `CountActiveByGameIdsAsync` implementation (last method), add:
+
+```csharp
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<AgentDefinition>> GetByConsumedDocumentAsync(
+        Guid documentId, CancellationToken cancellationToken = default)
+    {
+        if (documentId == Guid.Empty)
+            return Array.Empty<AgentDefinition>();
+
+        // JSONB containment: agents whose kb_card_ids array contains documentId.
+        // is_deleted = false is asserted explicitly in SQL — the global query filter
+        // is not guaranteed to compose over FromSqlInterpolated.
+        var docIdJsonLiteral = $"[\"{documentId}\"]";
+
+        return await DbContext.Set<AgentDefinition>()
+            .FromSqlInterpolated(
+                $@"SELECT * FROM knowledge_base.agent_definitions
+                   WHERE kb_card_ids @> {docIdJsonLiteral}::jsonb
+                   AND is_deleted = false")
+            .AsNoTracking()
+            .OrderBy(a => a.Name)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+```
+
+- [ ] **Step 3.3: Add GIN index to entity configuration**
+
+Edit `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs`. Find the block (around line 76):
+
+```csharp
+        // KbCardIds (Issue #4932) - stored as JSONB array of Guid
+        builder.Ignore(a => a.KbCardIds);
+        builder.Property<string>("_kbCardIdsJson")
+            .HasColumnName("kb_card_ids")
+            .HasColumnType("jsonb")
+            .HasDefaultValue("[]")
+            .IsRequired();
+```
+
+Append, immediately after the `.IsRequired();` line of that property:
+
+```csharp
+        // Issue #1651: GIN index on kb_card_ids to support `@>` containment query
+        // for the Used-by tab (agents that consume a given PDF document).
+        builder.HasIndex("_kbCardIdsJson")
+            .HasDatabaseName("ix_agent_definitions_kb_card_ids")
+            .HasMethod("gin");
+```
+
+- [ ] **Step 3.4: Generate the migration**
+
+Run from `apps/api/src/Api/`:
+```bash
+dotnet ef migrations add AddKbCardIdsGinIndex --output-dir Migrations --no-build
+```
+Wait — the project does have a build context; if `--no-build` fails, drop it.
+
+Run:
+```bash
+dotnet ef migrations add AddKbCardIdsGinIndex --output-dir Migrations
+```
+Expected: two new files appear under `apps/api/src/Api/Migrations/` — `<timestamp>_AddKbCardIdsGinIndex.cs` and `.Designer.cs`, plus an update to `MeepleAiDbContextModelSnapshot.cs`.
+
+- [ ] **Step 3.5: Verify migration content**
+
+Open the generated `apps/api/src/Api/Migrations/<timestamp>_AddKbCardIdsGinIndex.cs`. It MUST contain a `CreateIndex` call equivalent to:
+
+```csharp
+migrationBuilder.CreateIndex(
+    name: "ix_agent_definitions_kb_card_ids",
+    schema: "knowledge_base",
+    table: "agent_definitions",
+    column: "kb_card_ids")
+    .Annotation("Npgsql:IndexMethod", "gin");
+```
+
+If the generated migration contains anything **else** (e.g., re-creating unrelated indexes, dropping tables), STOP — the snapshot may be stale. Investigate before continuing.
+
+- [ ] **Step 3.6: Apply migration to dev DB**
+
+From `apps/api/src/Api/`:
+```bash
+dotnet ef database update
+```
+Expected: `Done.` and the index appears in Postgres. If it fails because the dev DB is unreachable, ensure `make dev-core` is running (`cd infra && make dev-core`).
+
+- [ ] **Step 3.7: Build**
+
+```bash
+dotnet build --nologo -clp:NoSummary
+```
+Expected: 0 errors.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentDefinitionRepository.cs \
+        apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentDefinitionRepository.cs \
+        apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs \
+        apps/api/src/Api/Migrations/*AddKbCardIdsGinIndex* \
+        apps/api/src/Api/Migrations/MeepleAiDbContextModelSnapshot.cs
+git commit -m "feat(admin-kb): #1651 repo GetByConsumedDocumentAsync + GIN index on kb_card_ids"
+```
+
+> **Staging note**: per project memory, staging migrations are not auto-applied. The deploy will need a manual `dotnet ef database update` on staging. Flag this in the PR description.
+
+---
+
+## Task 4: Backend — Handler + unit tests (TDD)
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs`
+
+- [ ] **Step 4.1: Write the failing unit tests first**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1651")]
+public sealed class GetConsumingAgentsByDocumentIdQueryHandlerTests
+{
+    private readonly Mock<IAgentDefinitionRepository> _agentRepo = new(MockBehavior.Strict);
+    private readonly Mock<ISharedGameRepository> _gameRepo = new(MockBehavior.Strict);
+
+    private GetConsumingAgentsByDocumentIdQueryHandler CreateHandler() =>
+        new(_agentRepo.Object, _gameRepo.Object);
+
+    private static AgentDefinition MakeCustomAgent(string name, Guid? gameId = null)
+    {
+        var agent = AgentDefinition.Create(
+            name: name,
+            description: "test",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: new AgentDefinitionConfig("gpt-4o-mini", 1024, 0.5));
+        if (gameId.HasValue) agent.SetGameId(gameId);
+        return agent;
+    }
+
+    private static AgentDefinition MakeSystemAgent(string name, string typologySlug)
+    {
+        return AgentDefinition.CreateSystem(
+            name: name,
+            description: "system",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: new AgentDefinitionConfig("gpt-4o-mini", 1024, 0.5),
+            typologySlug: typologySlug);
+    }
+
+    [Fact]
+    public async Task Handle_NoConsumingAgents_ReturnsEmptyList()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AgentDefinition>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().BeEmpty();
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never, "no agents → no game-name resolution needed");
+    }
+
+    [Fact]
+    public async Task Handle_MapsCustomAgent_WithGameNameResolved()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var agent = MakeCustomAgent("Alpha", gameId);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(gameId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [gameId] = "Wingspan" });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.Id.Should().Be(agent.Id);
+        dto.Name.Should().Be("Alpha");
+        dto.IsSystemDefined.Should().BeFalse();
+        dto.TypologySlug.Should().BeNull();
+        dto.GameId.Should().Be(gameId);
+        dto.GameName.Should().Be("Wingspan");
+        dto.Status.Should().Be(AgentDefinitionStatus.Draft.ToString());
+    }
+
+    [Fact]
+    public async Task Handle_MapsSystemAgent_WithFlagAndTypologySlug()
+    {
+        // Arrange
+        var docId = Guid.NewGuid();
+        var agent = MakeSystemAgent("Arbitro", typologySlug: "arbitro");
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.IsSystemDefined.Should().BeTrue();
+        dto.TypologySlug.Should().Be("arbitro");
+        dto.GameId.Should().BeNull();
+        dto.GameName.Should().BeNull();
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Never, "no agent has a GameId → no resolution call");
+    }
+
+    [Fact]
+    public async Task Handle_AgentWithMissingGame_LeavesGameNameNull()
+    {
+        // Arrange — the agent has a GameId, but the game has been removed from the catalog.
+        var docId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var agent = MakeCustomAgent("Beta", gameId);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { agent });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string>()); // empty — game not found
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].GameId.Should().Be(gameId);
+        result[0].GameName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_BulkResolvesGameNames_OneCallForMultipleAgents()
+    {
+        // Arrange — two agents, each with a distinct game. Must call GetNamesByIdsAsync ONCE.
+        var docId = Guid.NewGuid();
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        var a1 = MakeCustomAgent("A1", g1);
+        var a2 = MakeCustomAgent("A2", g2);
+
+        _agentRepo.Setup(r => r.GetByConsumedDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { a1, a2 });
+        _gameRepo.Setup(g => g.GetNamesByIdsAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, string> { [g1] = "Game1", [g2] = "Game2" });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(new GetConsumingAgentsByDocumentIdQuery(docId), default);
+
+        // Assert
+        result.Should().HaveCount(2);
+        _gameRepo.Verify(g => g.GetNamesByIdsAsync(
+            It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()),
+            Times.Once, "bulk lookup, no N+1");
+    }
+}
+```
+
+- [ ] **Step 4.2: Run tests — verify they fail (handler doesn't exist yet)**
+
+Run from `apps/api/tests/Api.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~GetConsumingAgentsByDocumentIdQueryHandlerTests" --nologo
+```
+Expected: compilation **fails** with "GetConsumingAgentsByDocumentIdQueryHandler does not exist in the current context" (handler not implemented yet). This is the failing-test signal.
+
+- [ ] **Step 4.3: Implement the handler**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Handler for GetConsumingAgentsByDocumentIdQuery — Issue #1651, F3-FU-2 Used-by tab.
+/// Lists agents that explicitly consume the document (KbCardIds containment), resolves
+/// GameName via bulk lookup, and maps to KbDocConsumingAgentDto. Soft-deleted agents are
+/// excluded by the repository implementation; the global query filter is not relied upon.
+/// </summary>
+internal sealed class GetConsumingAgentsByDocumentIdQueryHandler
+    : IQueryHandler<GetConsumingAgentsByDocumentIdQuery, IReadOnlyList<KbDocConsumingAgentDto>>
+{
+    private readonly IAgentDefinitionRepository _agentRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public GetConsumingAgentsByDocumentIdQueryHandler(
+        IAgentDefinitionRepository agentRepository,
+        ISharedGameRepository sharedGameRepository)
+    {
+        _agentRepository = agentRepository
+            ?? throw new ArgumentNullException(nameof(agentRepository));
+        _sharedGameRepository = sharedGameRepository
+            ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    public async Task<IReadOnlyList<KbDocConsumingAgentDto>> Handle(
+        GetConsumingAgentsByDocumentIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var agents = await _agentRepository
+            .GetByConsumedDocumentAsync(query.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (agents.Count == 0)
+            return Array.Empty<KbDocConsumingAgentDto>();
+
+        var gameIds = agents
+            .Where(a => a.GameId.HasValue)
+            .Select(a => a.GameId!.Value)
+            .Distinct()
+            .ToList();
+
+        var gameNames = gameIds.Count > 0
+            ? await _sharedGameRepository
+                .GetNamesByIdsAsync(gameIds, cancellationToken)
+                .ConfigureAwait(false)
+            : new Dictionary<Guid, string>();
+
+        return agents.Select(a => MapToDto(a, gameNames)).ToList();
+    }
+
+    private static KbDocConsumingAgentDto MapToDto(
+        AgentDefinition agent,
+        IReadOnlyDictionary<Guid, string> gameNames)
+    {
+        var gameName = agent.GameId.HasValue
+            && gameNames.TryGetValue(agent.GameId.Value, out var name)
+                ? name
+                : null;
+
+        return new KbDocConsumingAgentDto(
+            Id: agent.Id,
+            Name: agent.Name,
+            Type: agent.Type.Value,
+            IsActive: agent.IsActive,
+            Status: agent.Status.ToString(),
+            IsSystemDefined: agent.IsSystemDefined,
+            TypologySlug: agent.TypologySlug,
+            GameId: agent.GameId,
+            GameName: gameName,
+            InvocationCount: agent.InvocationCount,
+            LastInvokedAt: agent.LastInvokedAt);
+    }
+}
+```
+
+- [ ] **Step 4.4: Run tests — verify they pass**
+
+```bash
+dotnet test --filter "FullyQualifiedName~GetConsumingAgentsByDocumentIdQueryHandlerTests" --nologo
+```
+Expected: 5 passed, 0 failed.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetConsumingAgentsByDocumentIdQueryHandlerTests.cs
+git commit -m "feat(admin-kb): #1651 GetConsumingAgentsByDocumentIdQueryHandler + unit tests"
+```
+
+---
+
+## Task 5: Backend — Endpoint registration
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`
+
+- [ ] **Step 5.1: Register the endpoint**
+
+Edit `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`. Find the block:
+
+```csharp
+        // GET /api/v1/admin/kb/docs/{docId}/ingestion-log — Issue #1650
+        kbGroup.MapGet("/docs/{docId:guid}/ingestion-log", async (
+            Guid docId,
+            IMediator mediator,
+            CancellationToken cancellationToken) =>
+        {
+            var query = new GetLatestIngestionLogByDocumentIdQuery(docId);
+            var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetKbDocIngestionLog")
+        .WithSummary("Get the latest ProcessingJob (with Steps and LogEntries) for a PdfDocumentId.");
+```
+
+Immediately AFTER it, add:
+
+```csharp
+        // GET /api/v1/admin/kb/docs/{docId}/agents — Issue #1651 F3-FU-2
+        kbGroup.MapGet("/docs/{docId:guid}/agents", async (
+            Guid docId,
+            IMediator mediator,
+            CancellationToken cancellationToken) =>
+        {
+            var query = new GetConsumingAgentsByDocumentIdQuery(docId);
+            var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetKbDocConsumingAgents")
+        .WithSummary("List agent definitions that consume a given PDF document (KbCardIds containment).");
+```
+
+- [ ] **Step 5.2: Build**
+
+```bash
+dotnet build --nologo -clp:NoSummary
+```
+Expected: 0 errors. If the compiler complains about `GetConsumingAgentsByDocumentIdQuery` not found, double-check the `using` directive at top of `AdminKnowledgeBaseEndpoints.cs` — `using Api.BoundedContexts.KnowledgeBase.Application.Queries;` should already cover it (it's used for other KB queries).
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+git commit -m "feat(admin-kb): #1651 map GET /admin/kb/docs/{docId}/agents endpoint"
+```
+
+---
+
+## Task 6: Backend — Integration tests (Testcontainers, AC1–AC8)
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs`
+
+- [ ] **Step 6.1: Write the integration test file**
+
+Create `apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs`:
+
+```csharp
+using System.Net;
+using System.Text.Json;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Integration tests for GET /api/v1/admin/kb/docs/{docId}/agents.
+/// Issue #1651: F3-FU-2 Used-by tab — verifies JSONB containment, soft-delete exclusion,
+/// system-agent visibility, GameName bulk resolution, and admin authentication.
+/// Uses Testcontainers Postgres because the @> containment is not translatable on EF InMemory.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1651")]
+public sealed class ConsumingAgentsEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public ConsumingAgentsEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"used_by_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ========================================
+    // AC8 — Authentication
+    // ========================================
+
+    [Fact]
+    public async Task GET_NoSession_Returns401()
+    {
+        var docId = Guid.NewGuid();
+        var response = await _client.GetAsync($"/api/v1/admin/kb/docs/{docId}/agents");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ========================================
+    // AC5 — Zero consumers
+    // ========================================
+
+    [Fact]
+    public async Task GET_NoConsumingAgents_Returns200WithEmptyArray()
+    {
+        // Arrange
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var request = AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("[]");
+    }
+
+    // ========================================
+    // AC7 — Guid.Empty defensive
+    // ========================================
+
+    [Fact]
+    public async Task GET_EmptyGuid_Returns200WithEmptyArray()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var request = AuthRequest(
+            HttpMethod.Get,
+            $"/api/v1/admin/kb/docs/{Guid.Empty}/agents",
+            sessionToken);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("[]");
+    }
+
+    // ========================================
+    // AC1 + AC2 — Includes consumers, excludes non-consumers
+    // ========================================
+
+    [Fact]
+    public async Task GET_OneConsumingAgent_ReturnsThatAgentOnly()
+    {
+        // Arrange — Agent A consumes docId; Agent B does not.
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var otherDocId = Guid.NewGuid();
+
+        var agentA = MakeAgent("Agent A");
+        agentA.UpdateKbCardIds(new[] { docId });
+        var agentB = MakeAgent("Agent B");
+        agentB.UpdateKbCardIds(new[] { otherDocId });
+
+        dbContext.Set<AgentDefinition>().AddRange(agentA, agentB);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("name").GetString().Should().Be("Agent A");
+    }
+
+    // ========================================
+    // AC3 — Soft-deleted excluded
+    // ========================================
+
+    [Fact]
+    public async Task GET_SoftDeletedAgent_IsExcluded()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var agent = MakeAgent("Soft Deleted");
+        agent.UpdateKbCardIds(new[] { docId });
+        agent.SoftDelete();
+
+        dbContext.Set<AgentDefinition>().Add(agent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await ReadArray(response)).Should().BeEmpty();
+    }
+
+    // ========================================
+    // AC4 — System agent included with flag
+    // ========================================
+
+    [Fact]
+    public async Task GET_SystemAgent_IsIncludedWithIsSystemDefinedTrue()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var sysAgent = AgentDefinition.CreateSystem(
+            name: "Arbitro",
+            description: "system",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: new AgentDefinitionConfig("gpt-4o-mini", 1024, 0.5),
+            typologySlug: "arbitro");
+        sysAgent.UpdateKbCardIds(new[] { docId });
+
+        dbContext.Set<AgentDefinition>().Add(sysAgent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("isSystemDefined").GetBoolean().Should().BeTrue();
+        items[0].GetProperty("typologySlug").GetString().Should().Be("arbitro");
+    }
+
+    // ========================================
+    // AC6 — GameName null when game is missing
+    // ========================================
+
+    [Fact]
+    public async Task GET_AgentWithMissingGame_HasGameNameNull()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, sessionToken) = await TestSessionHelper.CreateAdminSessionAsync(dbContext);
+
+        var docId = Guid.NewGuid();
+        var phantomGameId = Guid.NewGuid(); // not in shared_games table
+
+        var agent = MakeAgent("Beta");
+        agent.SetGameId(phantomGameId);
+        agent.UpdateKbCardIds(new[] { docId });
+
+        dbContext.Set<AgentDefinition>().Add(agent);
+        await dbContext.SaveChangesAsync();
+
+        var response = await _client.SendAsync(
+            AuthRequest(HttpMethod.Get, $"/api/v1/admin/kb/docs/{docId}/agents", sessionToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var items = await ReadArray(response);
+        items.Should().HaveCount(1);
+        items[0].GetProperty("gameId").GetGuid().Should().Be(phantomGameId);
+        items[0].TryGetProperty("gameName", out var gameNameProp).Should().BeTrue();
+        (gameNameProp.ValueKind == JsonValueKind.Null).Should().BeTrue();
+    }
+
+    // ========================================
+    // Helpers
+    // ========================================
+
+    private static AgentDefinition MakeAgent(string name) =>
+        AgentDefinition.Create(
+            name: name,
+            description: "test",
+            type: AgentType.Custom("HybridSearch", "Hybrid search"),
+            config: new AgentDefinitionConfig("gpt-4o-mini", 1024, 0.5));
+
+    private static HttpRequestMessage AuthRequest(HttpMethod method, string uri, string sessionToken)
+    {
+        var request = new HttpRequestMessage(method, uri);
+        request.Headers.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={sessionToken}");
+        return request;
+    }
+
+    private static async Task<List<JsonElement>> ReadArray(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(body);
+        return json.RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
+    }
+}
+```
+
+- [ ] **Step 6.2: Run the integration tests**
+
+From `apps/api/tests/Api.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ConsumingAgentsEndpointTests" --nologo
+```
+Expected: 7 passed (AC1, AC2 covered by `GET_OneConsumingAgent_ReturnsThatAgentOnly`; AC3, AC4, AC5, AC6, AC7, AC8 each one test).
+
+If any test fails: investigate. Common likely failures:
+- "kb_card_ids @> ... operator does not exist" → schema name wrong in repo SQL; confirm it's `knowledge_base.agent_definitions`.
+- 500 instead of 200 → `JsonContains` typo or AgentDefinition.Create signature mismatch — check error stack trace.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs
+git commit -m "test(admin-kb): #1651 integration tests for /docs/{id}/agents (AC1-AC8)"
+```
+
+---
+
+## Task 7: Frontend — Zod schemas + API client + hook + tests
+
+**Files:**
+- Create: `apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts`
+- Create: `apps/web/src/lib/api/admin-kb-used-by.ts`
+- Create: `apps/web/src/hooks/queries/useKbDocConsumingAgents.ts`
+- Create: `apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.ts`
+
+- [ ] **Step 7.1: Write Zod schemas**
+
+Create `apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts`:
+
+```ts
+import { z } from 'zod';
+
+/**
+ * Mirrors backend `KbDocConsumingAgentDto`
+ * (BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs).
+ * Issue #1651: F3-FU-2 — Used-by tab.
+ */
+export const KbDocConsumingAgentSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  type: z.string(),
+  isActive: z.boolean(),
+  status: z.enum(['Draft', 'Testing', 'Published']),
+  isSystemDefined: z.boolean(),
+  typologySlug: z.string().nullable(),
+  gameId: z.string().uuid().nullable(),
+  gameName: z.string().nullable(),
+  invocationCount: z.number().int().nonnegative(),
+  lastInvokedAt: z.string().datetime({ offset: true }).nullable(),
+});
+export type KbDocConsumingAgent = z.infer<typeof KbDocConsumingAgentSchema>;
+
+export const KbDocConsumingAgentsResponseSchema = z.array(KbDocConsumingAgentSchema);
+```
+
+- [ ] **Step 7.2: Write API client**
+
+Create `apps/web/src/lib/api/admin-kb-used-by.ts`:
+
+```ts
+/**
+ * Admin KB Used-by API client.
+ * Issue #1651: F3-FU-2 — agents that consume a PDF document.
+ */
+
+import { apiClient } from '@/lib/api/client';
+import {
+  KbDocConsumingAgentsResponseSchema,
+  type KbDocConsumingAgent,
+} from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+/**
+ * GET /api/v1/admin/kb/docs/{docId}/agents
+ * Returns the agents that explicitly consume the document via KbCardIds.
+ * Empty array when no agent consumes it.
+ */
+export async function fetchKbDocConsumingAgents(
+  docId: string,
+): Promise<KbDocConsumingAgent[]> {
+  return apiClient.get<KbDocConsumingAgent[]>(
+    `/api/v1/admin/kb/docs/${docId}/agents`,
+    KbDocConsumingAgentsResponseSchema,
+  );
+}
+```
+
+- [ ] **Step 7.3: Write the React Query hook**
+
+Create `apps/web/src/hooks/queries/useKbDocConsumingAgents.ts`:
+
+```ts
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { fetchKbDocConsumingAgents } from '@/lib/api/admin-kb-used-by';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+export const kbDocConsumingAgentsKeys = {
+  all: ['kb', 'doc', 'consuming-agents'] as const,
+  byId: (docId: string) => [...kbDocConsumingAgentsKeys.all, docId] as const,
+};
+
+export interface UseKbDocConsumingAgentsOptions {
+  readonly docId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * TanStack Query hook listing agents that consume a given document.
+ * No polling — the association is static (changes only on agent edit).
+ * Backend contract: GET /api/v1/admin/kb/docs/{docId}/agents.
+ * Issue #1651.
+ */
+export function useKbDocConsumingAgents(
+  options: UseKbDocConsumingAgentsOptions,
+): UseQueryResult<KbDocConsumingAgent[], Error> {
+  const { docId, enabled = true } = options;
+  const isValid = typeof docId === 'string' && docId.length > 0;
+
+  return useQuery<KbDocConsumingAgent[], Error>({
+    queryKey: isValid ? kbDocConsumingAgentsKeys.byId(docId) : kbDocConsumingAgentsKeys.all,
+    queryFn: async () => (isValid ? fetchKbDocConsumingAgents(docId) : []),
+    enabled: enabled && isValid,
+    staleTime: 30_000,
+  });
+}
+```
+
+- [ ] **Step 7.4: Write hook tests**
+
+Create `apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.ts`:
+
+```ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/api/admin-kb-used-by', () => ({
+  fetchKbDocConsumingAgents: vi.fn(),
+}));
+
+import { fetchKbDocConsumingAgents } from '@/lib/api/admin-kb-used-by';
+import { useKbDocConsumingAgents } from '../useKbDocConsumingAgents';
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useKbDocConsumingAgents', () => {
+  beforeEach(() => {
+    vi.mocked(fetchKbDocConsumingAgents).mockReset();
+  });
+
+  it('does not fetch when docId is null', () => {
+    const { result } = renderHook(() => useKbDocConsumingAgents({ docId: null }), {
+      wrapper: wrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when docId is empty string', () => {
+    renderHook(() => useKbDocConsumingAgents({ docId: '' }), { wrapper: wrapper() });
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when enabled=false', () => {
+    renderHook(
+      () => useKbDocConsumingAgents({ docId: 'doc-1', enabled: false }),
+      { wrapper: wrapper() },
+    );
+    expect(fetchKbDocConsumingAgents).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns the agents when docId is valid and enabled', async () => {
+    vi.mocked(fetchKbDocConsumingAgents).mockResolvedValue([
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        name: 'Alpha',
+        type: 'HybridSearch',
+        isActive: true,
+        status: 'Published',
+        isSystemDefined: false,
+        typologySlug: null,
+        gameId: null,
+        gameName: null,
+        invocationCount: 0,
+        lastInvokedAt: null,
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => useKbDocConsumingAgents({ docId: 'doc-1' }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].name).toBe('Alpha');
+    expect(fetchKbDocConsumingAgents).toHaveBeenCalledWith('doc-1');
+  });
+});
+```
+
+- [ ] **Step 7.5: Run hook tests**
+
+From `apps/web/`:
+```bash
+pnpm test --run hooks/queries/__tests__/useKbDocConsumingAgents
+```
+Expected: 4 passed.
+
+- [ ] **Step 7.6: Typecheck**
+
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts \
+        apps/web/src/lib/api/admin-kb-used-by.ts \
+        apps/web/src/hooks/queries/useKbDocConsumingAgents.ts \
+        apps/web/src/hooks/queries/__tests__/useKbDocConsumingAgents.test.ts
+git commit -m "feat(admin-kb): #1651 FE schemas + API client + useKbDocConsumingAgents hook"
+```
+
+---
+
+## Task 8: Frontend — UsedByEmptyState + UsedByAgentRow + tests
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx`
+
+- [ ] **Step 8.1: Write UsedByEmptyState**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx`:
+
+```tsx
+'use client';
+
+export function UsedByEmptyState() {
+  return (
+    <div
+      data-testid="used-by-empty"
+      className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 p-8 text-center text-sm text-muted-foreground min-h-[200px] flex flex-col items-center justify-center gap-2"
+    >
+      <span aria-hidden="true" className="text-3xl">
+        🧑‍🤝‍🧑
+      </span>
+      <p>Nessun agent consuma questo documento.</p>
+      <p className="text-xs">
+        Aggiungi il documento alla KB di un agent per vederlo apparire qui.
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8.2: Write UsedByAgentRow**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx`:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: amber/emerald/rose chip palette (admin convention, DS-13c scope deferred to DS-16) */
+'use client';
+
+import Link from 'next/link';
+
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+interface UsedByAgentRowProps {
+  readonly agent: KbDocConsumingAgent;
+}
+
+function statusChipClass(status: KbDocConsumingAgent['status']): string {
+  switch (status) {
+    case 'Published':
+      return 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/30';
+    case 'Testing':
+      return 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30';
+    default: // Draft
+      return 'bg-muted text-muted-foreground border-border';
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (iso === null) return 'mai';
+  const date = new Date(iso);
+  return date.toLocaleDateString('it-IT', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+/**
+ * Single row in the "Used by" tab. Read-only — links out to the agent detail
+ * in the AI Lab. Issue #1651.
+ */
+export function UsedByAgentRow({ agent }: UsedByAgentRowProps) {
+  const gameLabel = agent.gameName ?? 'KB globale';
+
+  return (
+    <li className="py-3" data-testid="used-by-agent-row">
+      <Link
+        href={`/admin/agents/definitions/${agent.id}`}
+        className="block hover:bg-muted/40 rounded-md px-3 py-2 -mx-3 transition-colors"
+      >
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-quicksand font-bold text-sm truncate">{agent.name}</span>
+          {agent.isSystemDefined && (
+            <span
+              data-testid="used-by-system-badge"
+              className="inline-flex items-center px-1.5 py-0.5 text-[9.5px] font-semibold rounded-full border bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30 uppercase tracking-wider"
+              title={agent.typologySlug ?? undefined}
+            >
+              sistema
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${statusChipClass(agent.status)}`}
+          >
+            {agent.status}
+          </span>
+          <span className="ml-auto text-[10.5px] font-mono text-muted-foreground">
+            {agent.type}
+          </span>
+        </div>
+        <div className="mt-1 flex items-center gap-3 text-[11.5px] text-muted-foreground font-mono">
+          <span>{gameLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span>
+            {agent.invocationCount.toLocaleString('it-IT')} invocaz · ultimo {formatRelative(agent.lastInvokedAt)}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 8.3: Write the row tests**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { UsedByAgentRow } from '../UsedByAgentRow';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode; [k: string]: unknown }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseAgent: KbDocConsumingAgent = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Alpha',
+  type: 'HybridSearch',
+  isActive: true,
+  status: 'Published',
+  isSystemDefined: false,
+  typologySlug: null,
+  gameId: '22222222-2222-2222-2222-222222222222',
+  gameName: 'Wingspan',
+  invocationCount: 42,
+  lastInvokedAt: '2026-05-20T10:30:00Z',
+};
+
+function renderRow(overrides: Partial<KbDocConsumingAgent> = {}) {
+  return render(<ul><UsedByAgentRow agent={{ ...baseAgent, ...overrides }} /></ul>);
+}
+
+describe('UsedByAgentRow', () => {
+  it('renders the agent name and game name', () => {
+    renderRow();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('links to the agent detail in the AI Lab', () => {
+    renderRow();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      '/admin/agents/definitions/11111111-1111-1111-1111-111111111111',
+    );
+  });
+
+  it('shows "KB globale" label when gameName is null', () => {
+    renderRow({ gameName: null, gameId: null });
+    expect(screen.getByText('KB globale')).toBeInTheDocument();
+  });
+
+  it('shows the system badge for system agents', () => {
+    renderRow({ isSystemDefined: true, typologySlug: 'arbitro' });
+    expect(screen.getByTestId('used-by-system-badge')).toBeInTheDocument();
+  });
+
+  it('hides the system badge for custom agents', () => {
+    renderRow({ isSystemDefined: false });
+    expect(screen.queryByTestId('used-by-system-badge')).not.toBeInTheDocument();
+  });
+
+  it('renders the status chip with the correct status label', () => {
+    renderRow({ status: 'Draft' });
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+
+  it('renders "mai" when lastInvokedAt is null', () => {
+    renderRow({ lastInvokedAt: null });
+    expect(screen.getByText(/ultimo mai/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 8.4: Run row tests**
+
+From `apps/web/`:
+```bash
+pnpm test --run components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow
+```
+Expected: 7 passed.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByEmptyState.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByAgentRow.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByAgentRow.test.tsx
+git commit -m "feat(admin-kb): #1651 UsedByEmptyState + UsedByAgentRow + tests"
+```
+
+---
+
+## Task 9: Frontend — UsedByPanel (container) + tests
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx`
+
+- [ ] **Step 9.1: Write UsedByPanel**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx`:
+
+```tsx
+'use client';
+
+import { useKbDocConsumingAgents } from '@/hooks/queries/useKbDocConsumingAgents';
+
+import { UsedByAgentRow } from './UsedByAgentRow';
+import { UsedByEmptyState } from './UsedByEmptyState';
+
+interface UsedByPanelProps {
+  readonly docId: string;
+}
+
+/**
+ * Container of the "Used by" tab inside KbDocDetailPanel. Wires the React Query
+ * hook to UsedByAgentRow + UsedByEmptyState. Read-only. Issue #1651.
+ */
+export function UsedByPanel({ docId }: UsedByPanelProps) {
+  const query = useKbDocConsumingAgents({ docId });
+
+  if (query.isLoading) {
+    return (
+      <div
+        data-testid="used-by-panel-loading"
+        className="border border-border/60 rounded-lg bg-card/80 p-6 animate-pulse min-h-[200px]"
+      >
+        <div className="h-4 w-1/2 bg-muted rounded mb-3" />
+        <div className="h-4 w-1/3 bg-muted rounded mb-3" />
+        <div className="h-4 w-2/3 bg-muted rounded" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div
+        data-testid="used-by-panel-error"
+        className="border border-rose-500/30 rounded-lg bg-rose-500/5 p-6 text-sm text-rose-700 dark:text-rose-300"
+      >
+        Errore caricamento agent consumatori: {query.error.message}
+      </div>
+    );
+  }
+
+  const agents = query.data ?? [];
+  if (agents.length === 0) {
+    return <UsedByEmptyState />;
+  }
+
+  return (
+    <section
+      data-testid="used-by-panel"
+      className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden"
+    >
+      <header className="p-4 border-b border-border/60 dark:border-zinc-700/60">
+        <h3 className="font-quicksand font-bold text-sm">
+          Agent che consumano questo documento ({agents.length})
+        </h3>
+      </header>
+      <ul className="divide-y divide-border/60 dark:divide-zinc-700/60 px-4">
+        {agents.map(a => (
+          <UsedByAgentRow key={a.id} agent={a} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 9.2: Write UsedByPanel tests**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { UsedByPanel } from '../UsedByPanel';
+import type { KbDocConsumingAgent } from '@/lib/api/schemas/kb-consuming-agents.schemas';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode; [k: string]: unknown }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+const mockUseKbDocConsumingAgents = vi.fn();
+vi.mock('@/hooks/queries/useKbDocConsumingAgents', () => ({
+  useKbDocConsumingAgents: (opts: unknown) => mockUseKbDocConsumingAgents(opts),
+}));
+
+const agent: KbDocConsumingAgent = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Alpha',
+  type: 'HybridSearch',
+  isActive: true,
+  status: 'Published',
+  isSystemDefined: false,
+  typologySlug: null,
+  gameId: null,
+  gameName: null,
+  invocationCount: 0,
+  lastInvokedAt: null,
+};
+
+describe('UsedByPanel', () => {
+  beforeEach(() => {
+    mockUseKbDocConsumingAgents.mockReset();
+  });
+
+  it('renders the loading skeleton', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({ isLoading: true, isError: false, data: undefined });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      error: new Error('boom'),
+      data: undefined,
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel-error')).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no consumers', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({ isLoading: false, isError: false, data: [] });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-empty')).toBeInTheDocument();
+  });
+
+  it('renders the list when consumers are present', () => {
+    mockUseKbDocConsumingAgents.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [agent, { ...agent, id: '22222222-2222-2222-2222-222222222222', name: 'Beta' }],
+    });
+    render(<UsedByPanel docId="doc-1" />);
+    expect(screen.getByTestId('used-by-panel')).toBeInTheDocument();
+    expect(screen.getByText(/Agent che consumano questo documento \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 9.3: Run panel tests**
+
+```bash
+pnpm test --run components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel
+```
+Expected: 4 passed.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/used-by/UsedByPanel.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/used-by/__tests__/UsedByPanel.test.tsx
+git commit -m "feat(admin-kb): #1651 UsedByPanel container + 4-state tests"
+```
+
+---
+
+## Task 10: Frontend — Extend KbDocDetailTabs with "Used by" + test
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx`
+
+- [ ] **Step 10.1: Modify KbDocDetailTabs**
+
+Edit `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`. Replace ONLY the `KbDocTabKey` type declaration (line 5) and the `TABS` array (lines 12-15). Do NOT touch the `KbDocDetailTabsProps` interface (lines 7-10) — it stays as-is.
+
+New `KbDocTabKey` line:
+
+```tsx
+export type KbDocTabKey = 'overview' | 'ingestion' | 'used-by';
+```
+
+New `TABS` array:
+
+```tsx
+const TABS: ReadonlyArray<{ readonly key: KbDocTabKey; readonly label: string }> = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'ingestion', label: 'Ingestion log' },
+  { key: 'used-by', label: 'Used by' },
+];
+```
+
+Update the doc comment (line 17-21) to reflect that this issue lands the third tab:
+
+```tsx
+/**
+ * Inner tab nav for `KbDocDetailPanel`. URL-driven via `?tab=overview` (default)
+ * | `?tab=ingestion` | `?tab=used-by`. Preserves `docId` in each link.
+ * Issues #1650 (Ingestion log) + #1651 (Used by). Future follow-ups #1653/#1654.
+ */
+```
+
+- [ ] **Step 10.2: Write tabs test**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { KbDocDetailTabs } from '../KbDocDetailTabs';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode; [k: string]: unknown }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+describe('KbDocDetailTabs', () => {
+  it('renders three tabs: Overview, Ingestion log, Used by', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="overview" />);
+    expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Ingestion log' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Used by' })).toBeInTheDocument();
+  });
+
+  it('Overview link omits the tab param (default)', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="overview" />);
+    const link = screen.getByRole('link', { name: 'Overview' });
+    expect(link).toHaveAttribute('href', '/admin/knowledge-base?docId=doc-1');
+  });
+
+  it('Used by link sets ?tab=used-by and preserves docId', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="overview" />);
+    const link = screen.getByRole('link', { name: 'Used by' });
+    expect(link).toHaveAttribute('href', '/admin/knowledge-base?docId=doc-1&tab=used-by');
+  });
+
+  it('marks the active tab with aria-current="page"', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="used-by" />);
+    const link = screen.getByRole('link', { name: 'Used by' });
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+});
+```
+
+- [ ] **Step 10.3: Run tabs tests**
+
+```bash
+pnpm test --run components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs
+```
+Expected: 4 passed.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+git commit -m "feat(admin-kb): #1651 add Used-by tab to KbDocDetailTabs"
+```
+
+---
+
+## Task 11: Frontend — Wire KbDocDetailPanel branch + extend existing test
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx`
+
+- [ ] **Step 11.1: Modify KbDocDetailPanel**
+
+Edit `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`. Add the new import after the existing `IngestionPanel` import (line 9):
+
+```tsx
+import { IngestionPanel } from './ingestion/IngestionPanel';
+import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
+import { UsedByPanel } from './used-by/UsedByPanel';
+```
+
+Then replace the `activeTab` parsing line (line 48-49):
+
+```tsx
+  const activeTab: KbDocTabKey =
+    searchParams?.get('tab') === 'ingestion' ? 'ingestion' : 'overview';
+```
+
+with:
+
+```tsx
+  const activeTab: KbDocTabKey = (() => {
+    const tab = searchParams?.get('tab');
+    if (tab === 'ingestion') return 'ingestion';
+    if (tab === 'used-by') return 'used-by';
+    return 'overview';
+  })();
+```
+
+Then replace the ready-branch render block (lines 109-184) — specifically the ternary `{activeTab === 'ingestion' ? <IngestionPanel ... /> : <>... overview ...</>}` — with a 3-branch render. Replace the block:
+
+```tsx
+      {activeTab === 'ingestion' ? (
+        <IngestionPanel docId={doc.id} chunkCount={doc.chunkCount} pageCount={doc.pageCount ?? 0} />
+      ) : (
+        <>
+          {/* Hero */}
+          ...
+        </>
+      )}
+```
+
+with:
+
+```tsx
+      {activeTab === 'ingestion' && (
+        <IngestionPanel docId={doc.id} chunkCount={doc.chunkCount} pageCount={doc.pageCount ?? 0} />
+      )}
+
+      {activeTab === 'used-by' && <UsedByPanel docId={doc.id} />}
+
+      {activeTab === 'overview' && (
+        <>
+          {/* Hero */}
+          <header className="p-5 border-b border-border/60 dark:border-zinc-700/60 bg-gradient-to-b from-amber-500/5 to-transparent">
+            <div className="flex items-start gap-4">
+              <span aria-hidden="true" className="text-3xl">
+                📄
+              </span>
+              <div className="flex-1 min-w-0">
+                <h2 className="font-quicksand font-bold text-lg truncate">{doc.title}</h2>
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground font-mono">
+                  <span>{doc.gameName ?? 'KB globale'}</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{doc.docType}</span>
+                  <span aria-hidden="true">·</span>
+                  <span>uploaded {formatDate(doc.uploadedAt)}</span>
+                  <span
+                    className={`ml-auto inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${processingChipClass(doc.processingStatus)}`}
+                  >
+                    {doc.processingStatus}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <dl className="mt-4 grid grid-cols-3 gap-2">
+              <Stat label="Chunks" value={doc.chunkCount.toLocaleString('it-IT')} />
+              <Stat label="Pagine" value={doc.pageCount?.toLocaleString('it-IT') ?? '—'} />
+              <Stat label="Lingua" value={doc.language} />
+            </dl>
+          </header>
+
+          {/* Chunks */}
+          <section className="p-4">
+            <h3 className="font-quicksand font-semibold text-sm mb-2">Chunks</h3>
+            <ul className="divide-y divide-border/60 dark:divide-zinc-700/60">
+              {chunks.map(c => (
+                <li key={c.id} className="py-2.5">
+                  <div className="flex items-center gap-2 text-[10.5px] font-mono text-muted-foreground mb-0.5">
+                    <code>c-{c.position.toString().padStart(4, '0')}</code>
+                    {c.pageNumber !== null && <span>· p. {c.pageNumber}</span>}
+                    {c.headingPath.length > 0 && (
+                      <>
+                        <span aria-hidden="true">·</span>
+                        <span className="truncate" data-testid="kb-chunk-heading">
+                          {c.headingPath.join(' › ')}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <p className="text-[12.5px] text-foreground leading-snug line-clamp-2">
+                    {c.snippet}
+                  </p>
+                </li>
+              ))}
+            </ul>
+            {chunksQuery.hasNextPage && (
+              <button
+                type="button"
+                onClick={() => chunksQuery.fetchNextPage()}
+                disabled={chunksQuery.isFetchingNextPage}
+                className="mt-3 w-full text-center text-xs font-medium text-amber-700 dark:text-amber-300 border border-border/60 dark:border-zinc-700/60 rounded-md py-2 hover:bg-muted/70 disabled:opacity-60"
+              >
+                {chunksQuery.isFetchingNextPage ? 'Caricamento…' : 'Carica altri'}
+              </button>
+            )}
+          </section>
+        </>
+      )}
+```
+
+- [ ] **Step 11.2: Add mock + test for used-by branch in existing panel test**
+
+Edit `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx`. Find the existing `vi.mock('@/lib/api/admin-kb-ingestion', ...)` block (around line 40) and add immediately AFTER it:
+
+```tsx
+// ── admin-kb-used-by mock (UsedByPanel uses fetchKbDocConsumingAgents) ─────────
+vi.mock('@/lib/api/admin-kb-used-by', () => ({
+  fetchKbDocConsumingAgents: vi.fn().mockResolvedValue([]),
+}));
+```
+
+Then at the end of the `describe('KbDocDetailPanel', ...)` block, immediately BEFORE the closing `});`, add the new test:
+
+```tsx
+  it('renders the Used-by tab when ?tab=used-by is present', async () => {
+    mockSearchParams = new URLSearchParams('tab=used-by');
+    mockUseKbDocDetail.mockReturnValue({ data: readyEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      // Empty list (mock returns []) → empty state renders.
+      expect(screen.getByTestId('used-by-empty')).toBeInTheDocument();
+    });
+
+    // Overview content must NOT be present when used-by is active.
+    expect(screen.queryByText('Chunks')).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 11.3: Run panel tests**
+
+```bash
+pnpm test --run components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel
+```
+Expected: all previous tests still pass + 1 new test passes. If a pre-existing test fails because the `used-by-empty` testid pollutes another test's render, check the `beforeEach` resets `mockSearchParams` to `''`.
+
+- [ ] **Step 11.4: Typecheck**
+
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+git commit -m "feat(admin-kb): #1651 wire UsedByPanel into KbDocDetailPanel"
+```
+
+---
+
+## Task 12: Final verification + PR
+
+**Files:** (none — verification only)
+
+- [ ] **Step 12.1: Full backend test sweep**
+
+From `apps/api/tests/Api.Tests/`:
+```bash
+dotnet test --filter "Trait[Issue]=1651" --nologo
+```
+Expected: all #1651 tests pass (5 unit + 7 integration = 12 tests minimum).
+
+- [ ] **Step 12.2: Full frontend test + lint + typecheck**
+
+From `apps/web/`:
+```bash
+pnpm lint && pnpm typecheck && pnpm test --run
+```
+Expected: 0 lint errors, 0 type errors, no new test failures vs. baseline.
+
+- [ ] **Step 12.3: Push branch**
+
+```bash
+git push -u origin feature/issue-1651-used-by-tab
+```
+
+- [ ] **Step 12.4: Open PR to main-dev**
+
+```bash
+gh pr create --base main-dev --title "feat(admin-kb): #1651 F3-FU-2 — Used-by tab in KbDocDetailPanel" --body "$(cat <<'EOF'
+## Summary
+
+Implements F3-FU-2 (#1651): a new **Used by** tab inside `KbDocDetailPanel` showing the AI agents that explicitly consume the selected PDF document via `AgentDefinition.KbCardIds`.
+
+- **Backend**: `GET /api/v1/admin/kb/docs/{docId}/agents` backed by Postgres JSONB containment `kb_card_ids @> '["docId"]'::jsonb` + GIN index; new dedicated DTO `KbDocConsumingAgentDto` (system agents included with `isSystemDefined` flag + typology slug).
+- **Frontend**: URL-driven tab `?tab=used-by` mirroring #1650 pattern. New `used-by/` folder: `UsedByPanel` + `UsedByAgentRow` + `UsedByEmptyState`. Hook `useKbDocConsumingAgents` (no polling — association is static). Read-only with link to `/admin/agents/definitions/{agentId}`.
+
+**Design doc**: `docs/superpowers/specs/2026-05-29-kb-used-by-tab-design.md`
+**Plan**: `docs/superpowers/plans/2026-05-29-kb-used-by-tab.md`
+
+## Decisions (product)
+- Consumo = solo `KbCardIds` esplicito (no game-scoping → zero falsi positivi) · read-only + link (no detach) · mostra anche system agent con badge "sistema".
+
+## Decisions (technical, post spec-panel review)
+- JSONB `@>` containment + GIN index (NOT in-memory scan — auto-agent private-game rendono il totale non limitato).
+- DTO dedicato (NOT `AgentDto` riusato — no shared models, regola di progetto + system flag mancante).
+
+## Test plan
+- [x] Backend: 5 unit tests (handler mapping) + 7 integration tests Testcontainers (AC1–AC8) — JSONB `@>` non è mockabile su EF InMemory.
+- [x] Frontend: hook (4) + row (7) + panel (4) + tabs (4) + existing panel test extension (1) = 20+ tests.
+- [x] Lint + typecheck verdi (FE), `dotnet build` + test #1651 verdi (BE).
+- [ ] CI: full BE + FE suite — confirm no regression vs baseline.
+- [ ] Manual: `/admin/knowledge-base?docId=<existing>&tab=used-by` → lista o empty state; click riga → naviga al detail agent.
+
+## Deployment note
+Staging migrations are not auto-applied. After merge, run `dotnet ef database update` on staging (per project memory).
+
+## Out of scope (follow-ups)
+- Detach (rimuovi doc da agent.KbCardIds) — deferito.
+- Paginazione / filtri / polling — non necessari a questa scala.
+- Badge count nel sub-nav — coperto da #1655.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 12.5: Verify PR URL + base branch**
+
+Run:
+```bash
+gh pr view --json baseRefName,url
+```
+Expected: `baseRefName: "main-dev"` (CRITICAL — NOT `main`); URL printed.
+
+---
+
+## Self-Review Checklist (run after writing plan; this section informational)
+
+1. **Spec coverage**: all 6 spec-panel findings → addressed by tasks (JSONB+GIN T3, dedicated DTO T1, AC1-AC8 T6, integration tests T6, edge cases T6, link target T8). ✅
+2. **Placeholder scan**: every step has complete code or exact commands. ✅
+3. **Type consistency**: `KbDocConsumingAgentDto` field names (camelCase in JSON, PascalCase in C#) consistent across DTO, schema, hook, row, test. ✅

--- a/docs/superpowers/specs/2026-05-29-kb-used-by-tab-design.md
+++ b/docs/superpowers/specs/2026-05-29-kb-used-by-tab-design.md
@@ -1,0 +1,231 @@
+# SP5 F3-FU-2 — KB Used-by tab (Design)
+
+- **Date**: 2026-05-29
+- **Issue**: [#1651](https://github.com/meepleAi-app/meepleai-monorepo/issues/1651) (P3, `enhancement`, `area/backend`, `area/frontend`)
+- **Branch**: `feature/issue-1651-used-by-tab` (parent: `main-dev`)
+- **Wave**: SP5 F3-FU (gemello di #1650 — Ingestion log tab, già mergiato PR #1668)
+- **Sibling follow-ups**: #1650 (Ingestion log ✅), #1653 (Azioni avanzate), #1654 (Preview PDF), #1655 (Badge count sub-nav)
+- **Status**: Draft — reviewed via `/sc:spec-panel` (Wiegers, Fowler, Nygard, Crispin), pending user approval per implementazione
+
+## Contesto
+
+La PR [#1649](https://github.com/meepleAi-app/meepleai-monorepo/pull/1649) ha introdotto `KbDocDetailPanel` come pannello destro dell'Explorer KB. La PR [#1668](https://github.com/meepleAi-app/meepleai-monorepo/pull/1668) (#1650) ha aggiunto il pattern tabbed interno URL-driven (`KbDocDetailTabs`, tab `?tab=ingestion`).
+
+Questa issue aggiunge un **secondo tab interno** — `?tab=used-by` — che, dato il documento selezionato, elenca **gli agent AI che lo consumano**. È read-only.
+
+### Decisioni di prodotto (AskUserQuestion 2026-05-29)
+
+| # | Domanda | Scelta | Implicazione |
+|---|---|---|---|
+| D1 | Cosa conta come "consumo" | **Solo `KbCardIds` esplicito** | L'agent ha il `docId` nella sua lista KB. È il link autoritativo: il retrieval RAG a query-time usa esattamente `KbCardIds`. Zero falsi positivi. NON si includono agent game-scoped senza il doc. |
+| D2 | Azioni per riga | **Read-only + link** | Nessuna scrittura. Detach documento differito (eventuale follow-up). |
+| D3 | Agent di sistema | **Mostra tutti, con badge "sistema"** | Include `IsSystemDefined` con badge distintivo (arbitro/game-master/chat). |
+
+## Decisioni tecniche (post spec-panel review)
+
+Il panel di esperti ha sollevato 6 finding sulla bozza iniziale (che riusava in-memory scan + `AgentDto`). Le decisioni qui sotto incorporano i fix.
+
+| # | Finding (esperto) | Decisione |
+|---|---|---|
+| T1 | Scan in-memory di *tutti* gli agent non limitato — gli auto-agent private-game (`AutoCreateAgentOnPdfReadyHandler`) fanno crescere il totale con utenti×giochi (Nygard) | **Query JSONB containment** `kb_card_ids @> '["{docId}"]'::jsonb` + **indice GIN** su `kb_card_ids`. Il filtro è in Postgres; il result set scala col numero di match, non col totale agent. |
+| T2 | `AgentDto` non espone `IsSystemDefined`/`TypologySlug` ed è condiviso con la chat user-facing (Fowler) | **DTO dedicato** `KbDocConsumingAgentDto`. Coerente con la regola "no shared models between queries" e col precedente `IngestionLogDto` (#1650). |
+| T3 | Criteri di accettazione non misurabili (Wiegers) | 8 AC testabili espliciti (sotto). |
+| T4 | Containment JSONB non traducibile su EF InMemory (Crispin) | Integration test con **Testcontainers Postgres** per-AC (no unit-mock per il filtro). |
+| T5 | Edge case: gioco rimosso, docId duplicato in KbCardIds, `Guid.Empty` (Crispin) | Tabella edge case + empty state dedicato. |
+| T6 | Target link e `GameName` null non specificati (Wiegers) | Link → `/admin/agents/definitions/{agentId}`; `GameName` null → label "KB globale". |
+
+## Architettura
+
+```
+GET /api/v1/admin/kb/docs/{docId:guid}/agents
+       │  (RequireAdminSessionFilter ereditato dal group /admin/kb)
+       ▼
+GetConsumingAgentsByDocumentIdQuery(docId) → IMediator
+       │
+       ▼
+GetConsumingAgentsByDocumentIdQueryHandler
+   1. _agentRepository.GetByConsumedDocumentAsync(docId, ct)
+        → EF: WHERE kb_card_ids @> '["{docId}"]'::jsonb  (HasQueryFilter esclude is_deleted)
+        → indice GIN ix_agent_definitions_kb_card_ids
+   2. Bulk-resolve GameName via ISharedGameRepository.GetNamesByIdsAsync(gameIds)  (no N+1, pattern #660)
+   3. Map → KbDocConsumingAgentDto[]
+       │
+       ▼
+IReadOnlyList<KbDocConsumingAgentDto>
+       │
+       ▼ (frontend)
+useKbDocConsumingAgents(docId)  ◄── React Query
+   - queryKey: ['kb', 'doc', docId, 'consuming-agents']
+   - refetchInterval: false   (associazione statica — niente polling, a differenza di ingestion-log)
+   - enabled: docId !== null && tab === 'used-by'
+       │
+       ▼
+KbDocDetailPanel  (legge ?tab via useSearchParams)
+   ├─ <KbDocDetailTabs activeTab/>  (MODIFY: aggiunge tab "Used by")
+   ├─ Tab "Overview"  (esistente)
+   ├─ Tab "Ingestion log"  (#1650)
+   └─ Tab "Used by"  (NEW)
+        └─ UsedByPanel
+             ├─ UsedByAgentRow[]   (nome, type chip, badge "sistema", status, gioco, usage, link)
+             └─ UsedByEmptyState   ("Nessun agent consuma questo documento")
+```
+
+### Perché JSONB containment e non in-memory
+
+`AgentDefinition.KbCardIds` è una proprietà calcolata (`builder.Ignore`) backed dalla shadow `_kbCardIdsJson` (colonna `kb_card_ids` di tipo `jsonb`, default `"[]"`). Due strade:
+
+- ❌ **In-memory** (`GetAllAsync` + `.Where(a => a.KbCardIds.Contains(docId))`): coerente col pattern di `GetAllAgentsQueryHandler`, MA carica *ogni* agent del sistema e deserializza il JSON di ciascuno per restituirne pochi. Gli auto-agent private-game rendono il totale non limitato → non scala.
+- ✅ **JSONB `@>`** (scelta): il containment è valutato da Postgres. Con Npgsql si esprime via `EF.Functions.JsonContains(EF.Property<string>(a, "_kbCardIdsJson"), $"[\"{docId}\"]")` oppure, se la traduzione LINQ risulta scomoda, via `FromSqlInterpolated` sulla entity (tutte le colonne mappate). Indice GIN `jsonb_path_ops` per performance.
+
+> **Nota**: il `HasQueryFilter(a => !a.IsDeleted)` resta attivo → gli agent soft-deleted sono esclusi automaticamente, anche via `FromSql`.
+
+## Componenti
+
+### Backend (nuovi sotto `BoundedContexts/KnowledgeBase/`)
+
+- `Application/Queries/GetConsumingAgentsByDocumentIdQuery.cs` — record `(Guid DocumentId) : IRequest<IReadOnlyList<KbDocConsumingAgentDto>>`
+- `Application/Queries/GetConsumingAgentsByDocumentIdQueryHandler.cs` — internal sealed; usa `IAgentDefinitionRepository` + `ISharedGameRepository`
+- `Application/DTOs/KbDocConsumingAgentDto.cs` — DTO dedicato (sotto)
+- `Domain/Repositories/IAgentDefinitionRepository.cs` — **MODIFY**: aggiungi `Task<IReadOnlyList<AgentDefinition>> GetByConsumedDocumentAsync(Guid documentId, CancellationToken ct = default)`
+- `Infrastructure/Persistence/AgentDefinitionRepository.cs` — **MODIFY**: implementa containment JSONB
+- `Infrastructure/Persistence/Migrations/` — **NEW migration**: indice GIN su `kb_card_ids`
+- `Routing/AdminKnowledgeBaseEndpoints.cs` — **MODIFY**: map `GET /docs/{docId:guid}/agents` (dentro `kbGroup`, dopo `ingestion-log`)
+
+DTO dedicato:
+
+```csharp
+internal record KbDocConsumingAgentDto(
+    Guid Id,
+    string Name,
+    string Type,
+    bool IsActive,
+    string Status,              // Draft | Testing | Published
+    bool IsSystemDefined,
+    string? TypologySlug,       // "arbitro" | "game-master" | "chat" | null
+    Guid? GameId,
+    string? GameName,           // null → FE mostra "KB globale"
+    int InvocationCount,
+    DateTime? LastInvokedAt
+);
+```
+
+> **DI**: nessuna nuova registrazione — MediatR auto-discovery del handler; entrambi i repository sono già registrati (usati da `GetAllAgentsQueryHandler`).
+
+### Frontend (nuovi sotto `apps/web/src/`)
+
+```
+components/admin/knowledge-base/explorer/
+├── KbDocDetailPanel.tsx          (MODIFY: branch render tab 'used-by')
+├── KbDocDetailTabs.tsx           (MODIFY: KbDocTabKey += 'used-by'; TABS += {key:'used-by', label:'Used by'})
+└── used-by/
+    ├── UsedByPanel.tsx           (NEW: container — orchestra query + stati loading/empty/error/ready)
+    ├── UsedByAgentRow.tsx        (NEW: riga agent — nome, type chip, badge sistema, status, gioco, usage, link)
+    ├── UsedByEmptyState.tsx      (NEW: empty state)
+    └── __tests__/
+        ├── UsedByPanel.test.tsx
+        └── UsedByAgentRow.test.tsx
+
+hooks/queries/
+└── useKbDocConsumingAgents.ts    (NEW: React Query, refetchInterval=false)
+
+lib/api/
+└── admin-kb.ts                   (MODIFY: aggiungi fetchConsumingAgents(docId))
+```
+
+Path discipline: tutto sotto `components/admin/knowledge-base/explorer/`, allineato a `ingestion/` (#1650).
+
+## Criteri di accettazione (testabili)
+
+| AC | Dato | Quando | Allora |
+|---|---|---|---|
+| AC1 | Agent A con `docId` ∈ KbCardIds | GET `/docs/{docId}/agents` | A è nella lista |
+| AC2 | Agent B senza `docId` ∈ KbCardIds | idem | B **non** è nella lista |
+| AC3 | Agent C soft-deleted con `docId` ∈ KbCardIds | idem | C **non** è nella lista (query filter) |
+| AC4 | System agent S con `docId` ∈ KbCardIds | idem | S presente, `IsSystemDefined = true`, `TypologySlug` valorizzato |
+| AC5 | `docId` consumato da 0 agent | idem | 200 + lista vuota → FE empty state |
+| AC6 | Agent con `GameId` valorizzato | idem | `GameName` risolto; se gioco rimosso/null → `GameName = null` → FE "KB globale" |
+| AC7 | `docId = Guid.Empty` | idem | 200 + lista vuota (difensivo) |
+| AC8 | Utente non-admin | idem | 401/403 (`RequireAdminSessionFilter`) |
+
+## Edge case
+
+| Scenario | Behavior |
+|---|---|
+| `docId` null (FE) | Tab non monta la query; placeholder "Seleziona un documento" |
+| Doc consumato da system + custom agent | Entrambi mostrati; system con badge |
+| `docId` duplicato in KbCardIds di un agent | L'agent compare **una sola volta** (containment `@>` è set-membership) |
+| Agent con `GameId` → SharedGame rimosso | `GameName` null → label "KB globale" (no crash) |
+| docId malformato (non-guid) | Route constraint `{docId:guid}` → 404 routing |
+| Backend 5xx | React Query retry 2× → error state con "Riprova" |
+| Tab Overview/Ingestion attiva | `useKbDocConsumingAgents` non parte (`enabled: tab === 'used-by'`) |
+
+## Testing
+
+### Backend
+
+**Integration** (`Integration/KnowledgeBase/ConsumingAgentsEndpointTests.cs` — Testcontainers Postgres, il containment JSONB **non** è traducibile su EF InMemory):
+- `GET 200` con agent che ha docId in KbCardIds → lista contiene l'agent (AC1)
+- `GET 200` esclude agent senza docId (AC2)
+- `GET 200` esclude agent soft-deleted (AC3)
+- `GET 200` include system agent con flag (AC4)
+- `GET 200` lista vuota se 0 match (AC5)
+- `GET 200` risolve GameName; null se gioco assente (AC6)
+- `GET 200` con Guid.Empty → lista vuota (AC7)
+- `GET 401` senza auth (AC8)
+
+**Unit** (`Application.Tests/.../GetConsumingAgentsByDocumentIdQueryHandlerTests.cs`) — solo la logica di mapping/bulk-name (il repo è mockato; il containment è coperto dagli integration):
+- mapping DTO completo (system flag, typology, status string)
+- bulk GameName resolution (no N+1, dictionary lookup)
+- repo ritorna lista vuota → handler ritorna lista vuota
+
+### Frontend (target 85%+ Vitest)
+
+- `useKbDocConsumingAgents.test.ts`: `enabled` solo se `docId !== null && tab === 'used-by'`; `refetchInterval=false`
+- `UsedByAgentRow.test.tsx`: badge "sistema" solo se `isSystemDefined`; label "KB globale" se `gameName` null; href `/admin/agents/definitions/{id}`; status chip per Draft/Testing/Published
+- `UsedByPanel.test.tsx`: stati loading (skeleton) / empty (0 agent) / ready (lista) / error (retry)
+- `KbDocDetailTabs.test.tsx`: terzo tab "Used by" presente, link preserva `docId`, `?tab=used-by`
+- `KbDocDetailPanel.test.tsx`: render branch `tab=used-by` (preserva i 7+2 test esistenti)
+
+### E2E smoke (Playwright, opzionale P3)
+
+`apps/web/e2e/admin/kb-used-by.smoke.spec.ts`: login admin → `/admin/knowledge-base?docId={existing}&tab=used-by` → verifica lista o empty state; click riga → naviga a `/admin/agents/definitions/{id}`.
+
+## Out of scope (follow-up)
+
+- ❌ **Detach documento** (rimuovi docId da KbCardIds) — D2 = read-only. Eventuale follow-up con command + conferma.
+- ❌ **Paginazione** — il result set è piccolo (un doc appartiene a un gioco → pochi agent). Da rivedere solo se emergono doc condivisi da decine di agent.
+- ❌ **Polling** — l'associazione è statica (cambia solo su edit agent).
+- ❌ **Filtri (per type/status)** — over-engineering per P3.
+- ❌ **Reverse view** (documenti di un agent) — è già coperto altrove nel detail dell'agent.
+
+## Rischi noti
+
+| Rischio | Probabilità | Mitigazione |
+|---|---|---|
+| Traduzione LINQ `EF.Functions.JsonContains` su shadow property scomoda | Media | Fallback `FromSqlInterpolated` con `@>` parametrizzato (no SQL injection — `{docId}` è Guid) |
+| Indice GIN non applicato in staging (migration manuale, vedi memoria) | Media | Verificare applicazione migration in deploy; il containment funziona anche senza indice (solo più lento) |
+| Link `/admin/agents/definitions/{id}` per agent system | Bassa | Route esistente gestisce tutti gli agent; verificare che il detail renderizzi system agent (read-only) |
+| `KbCardIds` contiene docId di un doc poi eliminato | Bassa | Fuori scope qui — è un dato stale lato agent, non un problema di questa view (mostra solo agent → doc, non viceversa) |
+
+## Definition of Done
+
+- [ ] Backend: query + handler + DTO dedicato + repo method JSONB `@>` + migration indice GIN + integration tests (Testcontainers) + unit tests
+- [ ] Frontend: 3 nuovi componenti + 1 hook + admin-kb.ts + tests (≥85% sulle nuove righe)
+- [ ] `KbDocDetailTabs` esteso con tab "Used by"; `KbDocDetailPanel` branch render
+- [ ] Lint + typecheck verdi (FE); `dotnet build` + test verdi (BE)
+- [ ] PR verso `main-dev` che linka questo design doc
+- [ ] `/code-review:code-review` eseguito, issue P0/P1 risolti
+- [ ] Issue #1651 aggiornata su GitHub con riferimento PR
+- [ ] Merge in `main-dev` + issue #1651 chiusa con auto-link al commit
+
+## Riferimenti
+
+- Issue: [#1651](https://github.com/meepleAi-app/meepleai-monorepo/issues/1651) · gemello [#1650](https://github.com/meepleAi-app/meepleai-monorepo/issues/1650) (PR #1668)
+- Design doc gemello: `docs/superpowers/specs/2026-05-29-kb-ingestion-log-tab-design.md`
+- Backend entity: `BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs` (KbCardIds #4932)
+- EF config: `BoundedContexts/KnowledgeBase/Infrastructure/Persistence/Configurations/AgentDefinitionConfiguration.cs` (kb_card_ids jsonb)
+- Pattern bulk-name: `BoundedContexts/KnowledgeBase/Application/Queries/GetAllAgentsQueryHandler.cs` (#660)
+- Routing: `Routing/AdminKnowledgeBaseEndpoints.cs` (group `/admin/kb`, endpoint `ingestion-log` #1650)
+- FE detail panel: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`
+- FE tabs: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`
+- FE agent detail route (link target): `apps/web/src/app/admin/(dashboard)/agents/definitions/[id]/page.tsx`


### PR DESCRIPTION
## Summary

Implements F3-FU-2 (#1651): a new **Used by** tab inside `KbDocDetailPanel` showing the AI agents that explicitly consume the selected PDF document via `AgentDefinition.KbCardIds`.

- **Backend**: `GET /api/v1/admin/kb/docs/{docId}/agents` backed by Postgres JSONB containment \`kb_card_ids @> '["docId"]'::jsonb\` + GIN index; new dedicated DTO \`KbDocConsumingAgentDto\` (system agents included with \`isSystemDefined\` flag + typology slug).
- **Frontend**: URL-driven tab \`?tab=used-by\` mirroring #1650 pattern. New \`used-by/\` folder: \`UsedByPanel\` + \`UsedByAgentRow\` + \`UsedByEmptyState\`. Hook \`useKbDocConsumingAgents\` (no polling — association is static). Read-only with link to \`/admin/agents/definitions/{agentId}\`.

**Design doc**: \`docs/superpowers/specs/2026-05-29-kb-used-by-tab-design.md\`
**Plan**: \`docs/superpowers/plans/2026-05-29-kb-used-by-tab.md\`

## Decisions (product, via brainstorming)
- Consumo = solo \`KbCardIds\` esplicito (no game-scoping → zero falsi positivi) · read-only + link (no detach) · mostra anche system agent con badge "sistema".

## Decisions (technical, post spec-panel review)
- JSONB \`@>\` containment + GIN index (NOT in-memory scan — auto-agent private-game rendono il totale non limitato).
- DTO dedicato (NOT \`AgentDto\` riusato — no shared models, regola di progetto + system flag mancante).
- Repository method via \`FromSqlInterpolated\` con \`is_deleted = false\` esplicito in SQL (il global query filter non si compone sempre su FromSql).

## Test plan
- [x] Backend: 5 unit tests (handler mapping) + 7 integration tests Testcontainers (AC1–AC8) — JSONB \`@>\` non è mockabile su EF InMemory. **12/12 verdi locali**.
- [x] Frontend: hook (4) + row (7) + panel (4) + tabs (5 totali, 2 nuovi) + KbDocDetailPanel test extension (10 totali, 1 nuovo) = **30 test verdi**.
- [x] Lint + typecheck verdi (FE), \`dotnet build\` verde (BE).
- [ ] CI: full BE + FE suite — confirm no regression vs baseline.
- [ ] Manual: \`/admin/knowledge-base?docId=<existing>&tab=used-by\` → lista o empty state; click riga → naviga al detail agent.

## Deployment note
Staging migrations are not auto-applied. After merge, run \`dotnet ef database update\` on staging (per project memory).

## Out of scope (follow-ups)
- Detach (rimuovi doc da agent.KbCardIds) — deferito.
- Paginazione / filtri / polling — non necessari a questa scala.
- Badge count nel sub-nav — coperto da #1655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)