### PR TITLE
feat(admin-kb): #1653 F3-FU-4 doc actions + chunk similarity-search

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommand.cs
@@ -1,0 +1,28 @@
+using Api.BoundedContexts.Administration.Application.Attributes;
+using Api.BoundedContexts.Administration.Application.Behaviors;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Deletes a KB document from the admin explorer.
+///
+/// Side-effects (in order):
+///   1. Remove the document id from KbCardIds of every consuming AgentDefinition.
+///   2. Delete raw pgvector embeddings via IVectorStoreAdapter.
+///   3. Remove PdfDocument (EF cascades TextChunks + VectorDocument).
+///   4. Delete physical blob (best-effort).
+///   5. Invalidate AI response cache (best-effort).
+///   6. Emit admin audit row (atomic with the mutation via [AtomicAudit]).
+///
+/// Issue #1653: F3-FU-4 — Admin delete KB document action.
+/// </summary>
+/// <remarks>
+/// [AtomicAudit]: the DB mutation and the audit_outbox row are committed in a single transaction.
+/// Note: UpdateKbCardIds fires AgentDefinitionUpdatedEvent (domain event). This is an in-process
+/// event used for tracking only; no durable external side-effects are dispatched from it, so
+/// AtomicAudit is safe here. See AtomicAuditAttribute constraint notes.
+/// </remarks>
+[AuditableAction("KbDocumentDelete", "Document", Level = 2)]
+[AtomicAudit]
+internal sealed record DeleteKbDocumentCommand(Guid Id) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommandHandler.cs
@@ -1,0 +1,163 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Handles <see cref="DeleteKbDocumentCommand"/>.
+///
+/// Deletion order:
+///   1. Guard: load PdfDocument — 404 if absent.
+///   2. Agent cascade: detach the document from every consuming AgentDefinition.KbCardIds.
+///   3. pgvector embeddings: delete raw embeddings by VectorDocumentId.
+///   4. EF delete: remove PdfDocument; cascade removes TextChunks + VectorDocument.
+///   5. Blob: delete physical file (best-effort).
+///   6. Cache: invalidate AI response cache (best-effort).
+///
+/// Issue #1653: F3-FU-4 — Admin delete KB document action.
+/// </summary>
+internal sealed class DeleteKbDocumentCommandHandler : ICommandHandler<DeleteKbDocumentCommand>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly IAgentDefinitionRepository _agents;
+    private readonly IVectorStoreAdapter _vectorStore;
+    private readonly IBlobStorageService _blobStorageService;
+    private readonly IAiResponseCacheService _cacheService;
+    private readonly ILogger<DeleteKbDocumentCommandHandler> _logger;
+
+    public DeleteKbDocumentCommandHandler(
+        MeepleAiDbContext db,
+        IAgentDefinitionRepository agents,
+        IVectorStoreAdapter vectorStore,
+        IBlobStorageService blobStorageService,
+        IAiResponseCacheService cacheService,
+        ILogger<DeleteKbDocumentCommandHandler> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _agents = agents ?? throw new ArgumentNullException(nameof(agents));
+        _vectorStore = vectorStore ?? throw new ArgumentNullException(nameof(vectorStore));
+        _blobStorageService = blobStorageService ?? throw new ArgumentNullException(nameof(blobStorageService));
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(DeleteKbDocumentCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var id = command.Id;
+
+        // 1. Guard
+        var doc = await _db.PdfDocuments
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken).ConfigureAwait(false);
+
+        if (doc == null)
+            throw new NotFoundException("KbDocument", id.ToString());
+
+        // 2. Agent cascade — detach this document from every consuming agent's KbCardIds
+        var consumingAgents = await _agents
+            .GetByConsumedDocumentAsync(id, cancellationToken).ConfigureAwait(false);
+
+        foreach (var agent in consumingAgents)
+        {
+            agent.UpdateKbCardIds(agent.KbCardIds.Where(kbId => kbId != id));
+            await _agents.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (consumingAgents.Count > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Detached KB document {DocId} from {AgentCount} consuming agents",
+                id, consumingAgents.Count);
+        }
+
+        // 3. pgvector embeddings — delete raw embeddings (pgvector_embeddings table)
+        //    before removing the VectorDocument (to which they link).
+        var vectorDocId = await _db.VectorDocuments
+            .Where(v => v.PdfDocumentId == id)
+            .Select(v => (Guid?)v.Id)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (vectorDocId.HasValue)
+        {
+            await _vectorStore.DeleteByVectorDocumentIdAsync(vectorDocId.Value, cancellationToken)
+                .ConfigureAwait(false);
+            _logger.LogInformation(
+                "Deleted pgvector embeddings for VectorDocumentId={VectorDocId}", vectorDocId.Value);
+        }
+
+        // 4. EF delete — cascade removes TextChunks + VectorDocument
+        var storageGameId = (doc.PrivateGameId ?? doc.SharedGameId)?.ToString() ?? string.Empty;
+        _db.PdfDocuments.Remove(doc);
+        await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _logger.LogInformation("Deleted KB document {DocId}", id);
+
+        // 5. Blob — best-effort physical file deletion
+        await DeletePhysicalFileAsync(id.ToString(), storageGameId, cancellationToken).ConfigureAwait(false);
+
+        // 6. Cache — best-effort AI response cache invalidation
+        await InvalidateCacheSafelyAsync(storageGameId, "KB doc deletion", cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes the physical PDF file from blob storage (best-effort; failures are logged, not re-thrown).
+    /// Copied from <see cref="DeletePdfCommandHandler"/> per ADR pattern.
+    /// </summary>
+    private async Task DeletePhysicalFileAsync(string pdfId, string gameId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _blobStorageService.DeleteAsync(pdfId, BlobCategory.Pdf, gameId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125    // Sections of code should not be commented out
+        // ADAPTER PATTERN: Physical file deletion is best-effort cleanup;
+        // failures must not block document metadata deletion (file may already be gone).
+#pragma warning restore S125
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(ex, "Error deleting physical file for KB document {PdfId}", pdfId);
+        }
+    }
+
+    /// <summary>
+    /// Invalidates the AI response cache for the game (best-effort; failures are logged, not re-thrown).
+    /// Copied from <see cref="DeletePdfCommandHandler"/> per ADR pattern.
+    /// </summary>
+    private async Task InvalidateCacheSafelyAsync(string gameId, string operation, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _cacheService.InvalidateGameAsync(gameId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex,
+                "Invalid operation invalidating AI cache for game {GameId} after {Operation}", gameId, operation);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+#pragma warning disable S125    // Sections of code should not be commented out
+        // CLEANUP PATTERN: Cache invalidation is best-effort optimization;
+        // failures must not interrupt document deletion workflow.
+#pragma warning restore S125
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(ex,
+                "Unexpected error invalidating AI cache for game {GameId} after {Operation}", gameId, operation);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommandHandler.cs
@@ -69,14 +69,9 @@ internal sealed class DeleteKbDocumentCommandHandler : ICommandHandler<DeleteKbD
             agent.UpdateKbCardIds(agent.KbCardIds.Where(kbId => kbId != id));
             await _agents.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
         }
-
-        if (consumingAgents.Count > 0)
-        {
-            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(
-                "Detached KB document {DocId} from {AgentCount} consuming agents",
-                id, consumingAgents.Count);
-        }
+        // No intermediate SaveChanges: the agent detach stays tracked and is flushed together
+        // with the document removal in the single SaveChangesAsync below, so detach + delete
+        // commit atomically in one transaction (also wrapped by [AtomicAudit]).
 
         // 3. pgvector embeddings — delete raw embeddings (pgvector_embeddings table)
         //    before removing the VectorDocument (to which they link).
@@ -97,7 +92,9 @@ internal sealed class DeleteKbDocumentCommandHandler : ICommandHandler<DeleteKbD
         var storageGameId = (doc.PrivateGameId ?? doc.SharedGameId)?.ToString() ?? string.Empty;
         _db.PdfDocuments.Remove(doc);
         await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation("Deleted KB document {DocId}", id);
+        _logger.LogInformation(
+            "Deleted KB document {DocId} (detached from {AgentCount} consuming agents)",
+            id, consumingAgents.Count);
 
         // 5. Blob — best-effort physical file deletion
         await DeletePhysicalFileAsync(id.ToString(), storageGameId, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQuery.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+
+/// <summary>
+/// Returns all text chunks for a document with full (non-truncated) content,
+/// ordered ascending by <see cref="ExportedChunkDto.ChunkIndex"/>.
+/// No pagination — callers receive the complete chunk list for JSON export.
+/// Issue #1653: F3-FU-4 — Export document chunks (full content).
+/// </summary>
+internal sealed record ExportDocumentChunksQuery(Guid PdfDocumentId)
+    : IQuery<IReadOnlyList<ExportedChunkDto>>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQueryHandler.cs
@@ -1,0 +1,34 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+
+/// <summary>
+/// Handles <see cref="ExportDocumentChunksQuery"/> — returns ALL chunks for a document
+/// with full content (no snippet truncation) ordered by ChunkIndex ascending.
+/// Issue #1653: F3-FU-4 — Export document chunks (full content).
+/// </summary>
+internal sealed class ExportDocumentChunksQueryHandler
+    : IQueryHandler<ExportDocumentChunksQuery, IReadOnlyList<ExportedChunkDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public ExportDocumentChunksQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<IReadOnlyList<ExportedChunkDto>> Handle(
+        ExportDocumentChunksQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return await _db.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == query.PdfDocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Select(c => new ExportedChunkDto(c.Id, c.ChunkIndex, c.PageNumber, c.Heading, c.Content))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportedChunkDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportedChunkDto.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+
+/// <summary>
+/// Represents a single text chunk with full (non-truncated) content for JSON export.
+/// Issue #1653: F3-FU-4 — Export document chunks (full content).
+/// </summary>
+public sealed record ExportedChunkDto(
+    Guid Id,
+    int ChunkIndex,
+    int? PageNumber,
+    string? Heading,
+    string Content);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQuery.cs
@@ -1,0 +1,32 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchDocumentChunks;
+
+/// <summary>
+/// A single scored hit from the per-document similarity search.
+/// </summary>
+internal sealed record DocChunkSearchHit(
+    int ChunkIndex,
+    int? PageNumber,
+    double Score,
+    string Snippet);
+
+/// <summary>
+/// Result DTO returned by <see cref="SearchDocumentChunksByVectorQuery"/>.
+/// <c>Results</c> is ordered by <c>Score</c> descending.
+/// <c>ErrorMessage</c> is non-null when the document is not indexed or embedding fails.
+/// </summary>
+internal sealed record SearchDocumentChunksResultDto(
+    IReadOnlyList<DocChunkSearchHit> Results,
+    string? ErrorMessage);
+
+/// <summary>
+/// Query: semantic similarity-search scoped to a single PDF document.
+/// Returns chunks ranked by cosine-similarity score (descending).
+/// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+/// </summary>
+internal sealed record SearchDocumentChunksByVectorQuery(
+    Guid PdfDocumentId,
+    string Query,
+    int TopK,
+    double MinScore) : IQuery<SearchDocumentChunksResultDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQueryHandler.cs
@@ -1,0 +1,124 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchDocumentChunks;
+
+/// <summary>
+/// Handles <see cref="SearchDocumentChunksByVectorQuery"/>.
+///
+/// Flow:
+///   1. Resolve the VectorDocument for the given PdfDocumentId — get its Id (= VectorDocumentId)
+///      and GameId (required to call IEmbeddingRepository which filters by game_id).
+///   2. Embed the query string via IEmbeddingService.
+///   3. Call IEmbeddingRepository.SearchByVectorWithScoresAsync using the resolved VectorDocumentId
+///      as a documentIds filter (pgvector_embeddings.vector_document_id — NOT PdfDocumentId).
+///   4. Map results → DocChunkSearchHit (score desc, 240-char snippet).
+///
+/// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+/// </summary>
+internal sealed class SearchDocumentChunksByVectorQueryHandler
+    : IQueryHandler<SearchDocumentChunksByVectorQuery, SearchDocumentChunksResultDto>
+{
+    private static readonly SearchDocumentChunksResultDto NotIndexedResult =
+        new([], "Document not indexed");
+
+    private readonly MeepleAiDbContext _db;
+    private readonly IEmbeddingService _embeddingService;
+    private readonly IEmbeddingRepository _embeddingRepo;
+    private readonly ILogger<SearchDocumentChunksByVectorQueryHandler> _logger;
+
+    public SearchDocumentChunksByVectorQueryHandler(
+        MeepleAiDbContext db,
+        IEmbeddingService embeddingService,
+        IEmbeddingRepository embeddingRepo,
+        ILogger<SearchDocumentChunksByVectorQueryHandler> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
+        _embeddingRepo = embeddingRepo ?? throw new ArgumentNullException(nameof(embeddingRepo));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<SearchDocumentChunksResultDto> Handle(
+        SearchDocumentChunksByVectorQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // Step 1: Resolve VectorDocument → VectorDocumentId (the FK used in pgvector_embeddings)
+        // and GameId (required by the search index filter).
+        var vectorDoc = await _db.VectorDocuments
+            .AsNoTracking()
+            .Where(v => v.PdfDocumentId == query.PdfDocumentId)
+            .Select(v => new { v.Id, v.GameId })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (vectorDoc is null || vectorDoc.GameId is null)
+        {
+            _logger.LogInformation(
+                "[SearchDocumentChunksByVectorQueryHandler] PdfDocumentId={PdfDocId} not indexed (no VectorDocument or missing GameId)",
+                query.PdfDocumentId);
+            return NotIndexedResult;
+        }
+
+        var vectorDocumentId = vectorDoc.Id;
+        var gameId = vectorDoc.GameId.Value;
+
+        // Step 2: Embed the query string.
+        var embResult = await _embeddingService
+            .GenerateEmbeddingAsync(query.Query, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!embResult.Success || embResult.Embeddings.Count == 0)
+        {
+            var errorMessage = embResult.ErrorMessage ?? "Embedding generation returned no vectors";
+            _logger.LogWarning(
+                "[SearchDocumentChunksByVectorQueryHandler] Embedding failed for query={Query}: {ErrorMessage}",
+                query.Query, errorMessage);
+            return new SearchDocumentChunksResultDto([], errorMessage);
+        }
+
+        var queryVector = new Vector(embResult.Embeddings[0]);
+        var topK = Math.Clamp(query.TopK, 1, 100);
+
+        // Step 3: Search pgvector filtered to this document's VectorDocumentId.
+        var hits = await _embeddingRepo
+            .SearchByVectorWithScoresAsync(
+                gameId,
+                queryVector,
+                topK,
+                query.MinScore,
+                documentIds: new[] { vectorDocumentId },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 4: Map and sort by score descending (pgvector already sorts by distance asc,
+        // but we ensure desc here for the caller's convenience).
+        var results = hits
+            .OrderByDescending(h => h.Score)
+            .Select(h => new DocChunkSearchHit(
+                ChunkIndex: h.Embedding.ChunkIndex,
+                PageNumber: h.Embedding.PageNumber,
+                Score: h.Score,
+                Snippet: Truncate(h.Embedding.TextContent, 240)))
+            .ToList();
+
+        _logger.LogInformation(
+            "[SearchDocumentChunksByVectorQueryHandler] Returned {Count} scored hits for PdfDocumentId={PdfDocId}",
+            results.Count, query.PdfDocumentId);
+
+        return new SearchDocumentChunksResultDto(results, null);
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= maxLength)
+            return text;
+        return string.Concat(text.AsSpan(0, maxLength), "…");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ScoredEmbedding.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/ScoredEmbedding.cs
@@ -1,0 +1,8 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+
+/// <summary>
+/// Pairs an <see cref="Embedding"/> with its cosine-similarity score (0–1) so callers
+/// can display ranked results without losing the score on the way back from pgvector.
+/// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+/// </summary>
+internal sealed record ScoredEmbedding(Embedding Embedding, double Score);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IEmbeddingRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IEmbeddingRepository.cs
@@ -74,4 +74,17 @@ internal interface IEmbeddingRepository
     Task<int> GetCountByGameIdAsync(
         Guid gameId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Performs vector similarity search and returns each matching embedding together with
+    /// its cosine-similarity score (additive — does NOT replace SearchByVectorAsync).
+    /// Issue #1653: F3-FU-4 — per-document scored similarity-search for the admin KB explorer.
+    /// </summary>
+    Task<IReadOnlyList<ScoredEmbedding>> SearchByVectorWithScoresAsync(
+        Guid gameId,
+        Vector queryVector,
+        int topK,
+        double minScore,
+        IReadOnlyList<Guid>? documentIds = null,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/External/IVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/External/IVectorStoreAdapter.cs
@@ -49,6 +49,19 @@ internal interface IVectorStoreAdapter
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Performs vector similarity search and returns each result paired with its cosine-similarity
+    /// score.  Additive method — does NOT replace <see cref="SearchAsync"/>.
+    /// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+    /// </summary>
+    Task<List<ScoredEmbedding>> SearchWithScoresAsync(
+        Guid gameId,
+        Vector queryVector,
+        int topK,
+        double minScore,
+        IReadOnlyList<Guid>? documentIds = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks if vector data exists for the given game.
     /// </summary>
     Task<bool> CollectionExistsAsync(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/EmbeddingRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/EmbeddingRepository.cs
@@ -114,4 +114,23 @@ internal class EmbeddingRepository : RepositoryBase, IEmbeddingRepository
             .Where(vd => vd.GameId == gameId)
             .SumAsync(vd => vd.ChunkCount, cancellationToken).ConfigureAwait(false);
     }
+
+    public async Task<IReadOnlyList<ScoredEmbedding>> SearchByVectorWithScoresAsync(
+        Guid gameId,
+        Vector queryVector,
+        int topK,
+        double minScore,
+        IReadOnlyList<Guid>? documentIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Delegate to pgvector adapter for score-returning similarity search.
+        // Issue #1653: additive — does not replace SearchByVectorAsync.
+        return await _vectorStore.SearchWithScoresAsync(
+            gameId,
+            queryVector,
+            topK,
+            minScore,
+            documentIds,
+            cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -117,6 +117,100 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         }
     }
 
+    /// <summary>
+    /// Score-returning variant of <see cref="SearchAsync"/>.
+    /// Copies the same SQL and reader loop but ALSO reads the <c>similarity</c> column (index 7)
+    /// and returns <see cref="ScoredEmbedding"/> pairs.
+    /// The existing <see cref="SearchAsync"/> is NOT modified (other RAG callers depend on it).
+    /// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+    /// </summary>
+    public async Task<List<ScoredEmbedding>> SearchWithScoresAsync(
+        Guid gameId,
+        DomainVector queryVector,
+        int topK,
+        double minScore,
+        IReadOnlyList<Guid>? documentIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        var connection = _context.Database.GetDbConnection();
+        await EnsureConnectionOpenAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        // Identical SQL to SearchAsync — similarity column is at index 7 and is now surfaced.
+        var sql = $"""
+            SELECT id, vector_document_id, text_content, model, chunk_index, page_number, role_tags,
+                   1 - (vector <=> @queryVector) AS similarity
+            FROM {TableName}
+            WHERE game_id = @gameId
+              AND 1 - (vector <=> @queryVector) >= @minScore
+            """;
+
+        if (documentIds is { Count: > 0 })
+        {
+            sql += "\n  AND vector_document_id = ANY(@documentIds)";
+        }
+
+        sql += $"""
+
+            ORDER BY vector <=> @queryVector
+            LIMIT @topK
+            """;
+
+        var command = (NpgsqlCommand)connection.CreateCommand();
+        await using (command.ConfigureAwait(false))
+        {
+            command.CommandText = sql;
+
+            var pgVector = new Pgvector.Vector(queryVector.Values);
+            command.Parameters.AddWithValue("@queryVector", pgVector);
+            command.Parameters.AddWithValue("@gameId", gameId);
+            command.Parameters.AddWithValue("@minScore", minScore);
+            command.Parameters.AddWithValue("@topK", topK);
+
+            if (documentIds is { Count: > 0 })
+            {
+                command.Parameters.AddWithValue("@documentIds", documentIds.ToArray());
+            }
+
+            var results = new List<ScoredEmbedding>();
+
+            var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            await using (reader.ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var id = reader.GetGuid(0);
+                    var vectorDocumentId = reader.GetGuid(1);
+                    var textContent = reader.GetString(2);
+                    var model = reader.GetString(3);
+                    var chunkIndex = reader.GetInt32(4);
+                    var pageNumber = reader.GetInt32(5);
+                    var roleTags = reader.GetInt32(6);
+                    // Column 7: similarity = 1 - (vector <=> @queryVector)
+                    var score = reader.GetDouble(7);
+
+                    var placeholderVector = DomainVector.CreatePlaceholder(queryVector.Dimensions);
+                    var embedding = new Embedding(
+                        id: id,
+                        vectorDocumentId: vectorDocumentId,
+                        textContent: textContent,
+                        vector: placeholderVector,
+                        model: model,
+                        chunkIndex: chunkIndex,
+                        pageNumber: Math.Max(1, pageNumber),
+                        roleTags: roleTags);
+
+                    results.Add(new ScoredEmbedding(embedding, score));
+                }
+            }
+
+            _logger.LogInformation(
+                "pgvector scored search returned {ResultCount} results for gameId={GameId} (minScore={MinScore}, topK={TopK})",
+                results.Count, gameId, minScore, topK);
+
+            return results;
+        }
+    }
+
     /// <inheritdoc/>
     public async Task<List<Embedding>> SearchByMultipleGameIdsAsync(
         IReadOnlyList<Guid> gameIds,

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Queries.Queue;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Filters;
@@ -83,6 +84,18 @@ internal static class AdminKnowledgeBaseEndpoints
         })
         .WithName("GetKbDocIngestionLog")
         .WithSummary("Get the latest ProcessingJob (with Steps and LogEntries) for a PdfDocumentId.");
+
+        // GET /api/v1/admin/kb/docs/{docId}/chunks/export — Issue #1653 F3-FU-4
+        kbGroup.MapGet("/docs/{docId:guid}/chunks/export", async (
+            Guid docId,
+            IMediator m,
+            CancellationToken ct) =>
+        {
+            var chunks = await m.Send(new ExportDocumentChunksQuery(docId), ct).ConfigureAwait(false);
+            return Results.Ok(chunks);
+        })
+        .WithName("ExportKbDocChunks")
+        .WithSummary("Export all chunks (full content) for a document as JSON.");
 
         // GET /api/v1/admin/kb/docs/{docId}/agents — Issue #1651 F3-FU-2
         kbGroup.MapGet("/docs/{docId:guid}/agents", async (

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchDocumentChunks;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Filters;
 using MediatR;
@@ -97,6 +98,21 @@ internal static class AdminKnowledgeBaseEndpoints
         .WithName("ExportKbDocChunks")
         .WithSummary("Export all chunks (full content) for a document as JSON.");
 
+        // POST /api/v1/admin/kb/docs/{docId}/chunks/search — Issue #1653 F3-FU-4 (scored similarity)
+        kbGroup.MapPost("/docs/{docId:guid}/chunks/search", async (
+            Guid docId,
+            [FromBody] DocChunkSearchRequest req,
+            IMediator m,
+            CancellationToken ct) =>
+        {
+            var r = await m.Send(
+                new SearchDocumentChunksByVectorQuery(docId, req.Query, req.TopK ?? 10, req.MinScore ?? 0.0),
+                ct).ConfigureAwait(false);
+            return Results.Ok(r);
+        })
+        .WithName("SearchKbDocChunks")
+        .WithSummary("Per-document semantic chunk search (scored).");
+
         // GET /api/v1/admin/kb/docs/{docId}/agents — Issue #1651 F3-FU-2
         kbGroup.MapGet("/docs/{docId:guid}/agents", async (
             Guid docId,
@@ -186,4 +202,14 @@ internal record EstimateAgentCostByDocumentsRequest(
     Guid GameId,
     List<Guid> DocumentIds,
     string? StrategyName
+);
+
+/// <summary>
+/// Request model for per-document semantic chunk search.
+/// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+/// </summary>
+internal record DocChunkSearchRequest(
+    string Query,
+    int? TopK,
+    double? MinScore
 );

--- a/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs
@@ -17,6 +17,11 @@ internal static class AdminPdfManagementEndpoints
             .WithTags("Admin - PDF Management")
             .AddEndpointFilter<RequireAdminSessionFilter>();
 
+        // Issue #1653: Admin KB document delete (agent-cascade + audit)
+        group.MapDelete("/{pdfId:guid}", DeleteKbDocument)
+            .WithName("DeleteKbDocument")
+            .WithSummary("Delete a KB document (cascade: detach from agents, remove chunks/vectors/blob, audited)");
+
         // Phase 4: Bulk operations
         group.MapPost("/bulk/delete", BulkDelete)
             .WithName("BulkDeletePdfs")
@@ -86,6 +91,15 @@ internal static class AdminPdfManagementEndpoints
         var result = await mediator.Send(new GetPdfStatusDistributionQuery(), cancellationToken)
             .ConfigureAwait(false);
         return Results.Ok(result);
+    }
+
+    private static async Task<IResult> DeleteKbDocument(
+        Guid pdfId,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(new DeleteKbDocumentCommand(pdfId), cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
     }
 }
 

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeleteKbDocumentCommandHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeleteKbDocumentCommandHandlerIntegrationTests.cs
@@ -1,0 +1,314 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration tests for DeleteKbDocumentCommandHandler.
+/// Issue #1653: F3-FU-4 — admin delete KB doc with agent-cascade + audit.
+///
+/// Verifies:
+/// 1. Document deleted → TextChunks/VectorDocument cascade-deleted
+/// 2. Consuming agents have the document id removed from KbCardIds
+/// 3. NotFoundException thrown for missing document
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1653")]
+public sealed class DeleteKbDocumentCommandHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    // Stable IDs for seeded parent entities
+    private static readonly Guid TestUserId = new("A0000000-0000-0000-0000-000000000001");
+    private static readonly Guid TestSharedGameId = new("B0000000-0000-0000-0000-000000000001");
+
+    public DeleteKbDocumentCommandHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_deletekbdoc_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        // Override the mocked IAgentDefinitionRepository with the real one so the handler
+        // can actually load and update consuming agents.
+        services.AddScoped<IAgentDefinitionRepository, AgentDefinitionRepository>();
+
+        // Blob storage — best-effort, mock so physical delete doesn't fail tests
+        var blobMock = new Mock<IBlobStorageService>();
+        blobMock.Setup(b => b.DeleteAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        services.AddSingleton<IBlobStorageService>(blobMock.Object);
+
+        // Cache invalidation — best-effort, mock
+        var cacheMock = new Mock<IAiResponseCacheService>();
+        cacheMock.Setup(c => c.InvalidateGameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddSingleton<IAiResponseCacheService>(cacheMock.Object);
+
+        // IVectorStoreAdapter — mock so the handler can call DeleteByVectorDocumentIdAsync
+        // without a real pgvector_embeddings table in the Testcontainers DB.
+        var vectorStoreMock = new Mock<IVectorStoreAdapter>();
+        vectorStoreMock.Setup(v => v.DeleteByVectorDocumentIdAsync(
+                It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddScoped<IVectorStoreAdapter>(_ => vectorStoreMock.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await MigrateWithRetryAsync(_dbContext);
+        await SeedBaseEntitiesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else
+            (_serviceProvider as IDisposable)?.Dispose();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Tests
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_RemovesDoc_ChunksVectors_AndDetachesFromConsumingAgents()
+    {
+        // Arrange: seed doc with 2 text chunks, a vector document, and 2 agents that consume it
+        var pdfId = await SeedIndexedDocWithAgentsAsync(agentCount: 2);
+
+        // Act
+        await _mediator!.Send(new DeleteKbDocumentCommand(pdfId), TestCancellationToken);
+
+        // Assert: document removed
+        (await _dbContext!.PdfDocuments.FindAsync(pdfId, TestCancellationToken))
+            .Should().BeNull("document should be hard-deleted");
+
+        // Assert: text chunks cascade-deleted
+        (await _dbContext.TextChunks.CountAsync(c => c.PdfDocumentId == pdfId, TestCancellationToken))
+            .Should().Be(0, "text chunks must be cascade-deleted with the document");
+
+        // Assert: vector document cascade-deleted
+        (await _dbContext.VectorDocuments.CountAsync(v => v.PdfDocumentId == pdfId, TestCancellationToken))
+            .Should().Be(0, "vector document must be cascade-deleted with the document");
+
+        // Assert: agents no longer reference the deleted document
+        // IgnoreQueryFilters ensures soft-deleted agents are included in the check
+        var agents = await _dbContext.Set<AgentDefinition>()
+            .IgnoreQueryFilters()
+            .ToListAsync(TestCancellationToken);
+        agents.Should().OnlyContain(
+            a => !a.KbCardIds.Contains(pdfId),
+            "consuming agents must have the document id removed from KbCardIds");
+    }
+
+    [Fact]
+    public async Task Handle_Throws_NotFound_WhenDocMissing()
+    {
+        // Act
+        var act = async () => await _mediator!.Send(
+            new DeleteKbDocumentCommand(Guid.NewGuid()), TestCancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_RemovesDoc_WithNoConsumingAgents_Succeeds()
+    {
+        // Arrange: doc with chunks/vector but no agents
+        var pdfId = await SeedIndexedDocWithAgentsAsync(agentCount: 0);
+
+        // Act
+        await _mediator!.Send(new DeleteKbDocumentCommand(pdfId), TestCancellationToken);
+
+        // Assert
+        (await _dbContext!.PdfDocuments.FindAsync(pdfId, TestCancellationToken))
+            .Should().BeNull("document should be deleted even with no consuming agents");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Seeding helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a PdfDocument with 2 TextChunks, a VectorDocument, and <paramref name="agentCount"/>
+    /// AgentDefinitions that list the document in their KbCardIds.
+    /// Returns the new PdfDocument id.
+    /// </summary>
+    private async Task<Guid> SeedIndexedDocWithAgentsAsync(int agentCount)
+    {
+        var pdfId = Guid.NewGuid();
+
+        // PdfDocument
+        var pdfDoc = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = TestSharedGameId,
+            UploadedByUserId = TestUserId,
+            FileName = $"test-{pdfId:N}.pdf",
+            FilePath = $"/test/{pdfId:N}.pdf",
+            FileSizeBytes = 2048,
+            ProcessingState = "Ready",
+            UploadedAt = DateTime.UtcNow,
+            PageCount = 4
+        };
+        _dbContext!.PdfDocuments.Add(pdfDoc);
+
+        // TextChunks (2)
+        for (var i = 0; i < 2; i++)
+        {
+            _dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                SharedGameId = TestSharedGameId,
+                Content = $"Chunk {i} content",
+                ChunkIndex = i,
+                PageNumber = i + 1,
+                CharacterCount = 20,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        // VectorDocument
+        var vectorDocId = Guid.NewGuid();
+        _dbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = vectorDocId,
+            PdfDocumentId = pdfId,
+            GameId = TestSharedGameId,
+            ChunkCount = 2,
+            TotalCharacters = 40,
+            IndexedAt = DateTime.UtcNow,
+            IndexingStatus = "completed",
+            EmbeddingModel = "test-model",
+            EmbeddingDimensions = 384
+        });
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // AgentDefinitions that consume this document
+        for (var i = 0; i < agentCount; i++)
+        {
+            var agent = AgentDefinition.Create(
+                name: $"test-agent-{pdfId:N}-{i}",
+                description: "Test agent for delete KB doc",
+                type: AgentType.Custom("rag", "RAG agent"),
+                config: AgentDefinitionConfig.Create("gpt-4o-mini", 2048, 0.7f));
+
+            // Add the document to the agent's KB card list
+            // Also include a second doc id to verify partial removal (only pdfId is removed, not the other)
+            agent.UpdateKbCardIds(new[] { pdfId, Guid.NewGuid() });
+
+            _dbContext.Set<AgentDefinition>().Add(agent);
+        }
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        return pdfId;
+    }
+
+    private async Task SeedBaseEntitiesAsync()
+    {
+        // Idempotent: seed user + shared game only if not already present
+        if (!await _dbContext!.Users.AnyAsync(u => u.Id == TestUserId, TestCancellationToken))
+        {
+            _dbContext.Users.Add(new UserEntity
+            {
+                Id = TestUserId,
+                Email = "test-deletekbdoc@meepleai.dev",
+                DisplayName = "TestUser",
+                Role = "Editor",
+                Tier = "Free",
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        if (!await _dbContext.SharedGames.AnyAsync(g => g.Id == TestSharedGameId, TestCancellationToken))
+        {
+            _dbContext.SharedGames.Add(new SharedGameEntity
+            {
+                Id = TestSharedGameId,
+                Title = "Test Game for KB Doc Delete",
+                YearPublished = 2024,
+                MinPlayers = 2,
+                MaxPlayers = 4,
+                PlayingTimeMinutes = 60,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private static async Task MigrateWithRetryAsync(MeepleAiDbContext context)
+    {
+        const int maxAttempts = 3;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                await context.Database.MigrateAsync(TestCancellationToken);
+                return;
+            }
+            catch (NpgsqlException) when (attempt < maxAttempts)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ExportDocumentChunksQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ExportDocumentChunksQueryHandlerIntegrationTests.cs
@@ -1,0 +1,326 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Integration tests for <see cref="ExportDocumentChunksQueryHandler"/>.
+/// Validates full-content export ordered by ChunkIndex.
+/// Issue #1653: F3-FU-4 — Export document chunks (full content).
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1653")]
+public sealed class ExportDocumentChunksQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private ExportDocumentChunksQueryHandler? _handler;
+    private ServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public ExportDocumentChunksQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_export_chunks_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        _handler = new ExportDocumentChunksQueryHandler(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
+    // ─── Seed helpers ────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedDocWithChunksAsync()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"export-chunks-{userId:N}@test.local",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Export Test Game",
+            YearPublished = 2024,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(sharedGame);
+
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "export-test.pdf",
+            FilePath = "/tmp/export-test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = userId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id
+        });
+
+        _dbContext.TextChunks.AddRange(
+            new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                Content = "A",
+                ChunkIndex = 0,
+                PageNumber = 1,
+                Heading = null,
+                CharacterCount = 1,
+                CreatedAt = DateTime.UtcNow
+            },
+            new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                Content = "B",
+                ChunkIndex = 1,
+                PageNumber = 1,
+                Heading = "Section B",
+                CharacterCount = 1,
+                CreatedAt = DateTime.UtcNow
+            },
+            new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                Content = "C",
+                ChunkIndex = 2,
+                PageNumber = 2,
+                Heading = null,
+                CharacterCount = 1,
+                CreatedAt = DateTime.UtcNow
+            }
+        );
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return pdfId;
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsAllChunks_FullContent_OrderedByIndex()
+    {
+        var pdfId = await SeedDocWithChunksAsync();
+
+        var result = await _handler!.Handle(
+            new ExportDocumentChunksQuery(pdfId), TestCancellationToken);
+
+        result.Should().HaveCount(3);
+        result.Select(c => c.Content).Should().ContainInOrder("A", "B", "C");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsFullContent_NotTruncated()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"fc-{userId:N}@test.local",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Full Content Game",
+            YearPublished = 2024,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(sharedGame);
+
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "long-content.pdf",
+            FilePath = "/tmp/long-content.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = userId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id
+        });
+
+        // Content that exceeds the 200-char snippet truncation used in GetKbChunksHandler
+        var longContent = new string('X', 500);
+        _dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            Content = longContent,
+            ChunkIndex = 0,
+            CharacterCount = longContent.Length,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var result = await _handler!.Handle(
+            new ExportDocumentChunksQuery(pdfId), TestCancellationToken);
+
+        result.Should().HaveCount(1);
+        result[0].Content.Should().HaveLength(500);
+        result[0].Content.Should().Be(longContent);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_UnknownDocumentId_ReturnsEmptyList()
+    {
+        var result = await _handler!.Handle(
+            new ExportDocumentChunksQuery(Guid.NewGuid()), TestCancellationToken);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_MapsAllFields_Correctly()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"fields-{userId:N}@test.local",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Fields Game",
+            YearPublished = 2024,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(sharedGame);
+
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "fields.pdf",
+            FilePath = "/tmp/fields.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = userId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id
+        });
+
+        var chunkId = Guid.NewGuid();
+        _dbContext.TextChunks.Add(new TextChunkEntity
+        {
+            Id = chunkId,
+            PdfDocumentId = pdfId,
+            Content = "Hello World",
+            ChunkIndex = 7,
+            PageNumber = 3,
+            Heading = "My Heading",
+            CharacterCount = 11,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var result = await _handler!.Handle(
+            new ExportDocumentChunksQuery(pdfId), TestCancellationToken);
+
+        result.Should().HaveCount(1);
+        var chunk = result[0];
+        chunk.Id.Should().Be(chunkId);
+        chunk.ChunkIndex.Should().Be(7);
+        chunk.PageNumber.Should().Be(3);
+        chunk.Heading.Should().Be("My Heading");
+        chunk.Content.Should().Be("Hello World");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
@@ -1,0 +1,276 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchDocumentChunks;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Integration tests for <see cref="SearchDocumentChunksByVectorQueryHandler"/>.
+///
+/// Happy-path: real pgvector Testcontainer with seeded embeddings and a mocked
+/// <see cref="IEmbeddingService"/> that returns a known query vector.
+/// "Not indexed" path: real Postgres DB, no pgvector rows — validates the resolver guard.
+///
+/// Issue #1653: F3-FU-4 — per-document scored similarity-search.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1653")]
+public sealed class SearchDocumentChunksQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private ServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    // Mock embedding service — returns a unit vector aligned with our seeded embeddings.
+    private readonly Mock<IEmbeddingService> _embeddingServiceMock = new();
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public SearchDocumentChunksQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_search_chunks_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        // Register adapters needed by the handler.
+        services.AddScoped<IVectorStoreAdapter, PgVectorStoreAdapter>();
+        services.AddScoped<IEmbeddingRepository, EmbeddingRepository>();
+
+        // Replace the stub IEmbeddingService with our configured mock.
+        services.RemoveAll<IEmbeddingService>();
+        services.AddScoped<IEmbeddingService>(_ => _embeddingServiceMock.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is not null)
+            await _serviceProvider.DisposeAsync();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* best-effort */ }
+        }
+    }
+
+    // ─── Seed helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a SharedGame + PdfDocument + VectorDocument in the relational DB,
+    /// then inserts 2 embedding rows directly into <c>pgvector_embeddings</c> via
+    /// <see cref="PgVectorStoreAdapter.IndexBatchAsync"/> so the happy-path test can
+    /// assert score-ordered results.
+    ///
+    /// The <c>pgvector_embeddings</c> table is created by the EF Initial migration with a
+    /// <c>vector(768)</c> column — we must use 768-dimensional test vectors.
+    /// We do NOT call <see cref="IVectorStoreAdapter.EnsureCollectionExistsAsync"/> because
+    /// the EF migration already created the table and that method would fail trying to add a
+    /// GIN index on a <c>search_vector</c> column that only exists when the table is created
+    /// from scratch by the adapter.
+    /// </summary>
+    private async Task<Guid> SeedIndexedDocAsync()
+    {
+        const int Dims = 768; // must match vector(768) column in Initial migration
+
+        var userId = Guid.NewGuid();
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"search-chunks-{userId:N}@test.local",
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "Search Chunks Test Game",
+            YearPublished = 2024,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = userId,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(sharedGame);
+
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "search-chunks-test.pdf",
+            FilePath = "/tmp/search-chunks-test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = userId,
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow,
+            SharedGameId = sharedGame.Id
+        });
+
+        // VectorDocument: GameId is required by the pgvector search index.
+        var vectorDocId = Guid.NewGuid();
+        _dbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = vectorDocId,
+            GameId = sharedGame.Id,
+            PdfDocumentId = pdfId,
+            ChunkCount = 2,
+            TotalCharacters = 100,
+            IndexingStatus = "completed",
+            IndexedAt = DateTime.UtcNow,
+            EmbeddingModel = "test-model",
+            EmbeddingDimensions = Dims
+        });
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        // Build 768-dim vectors where only the first component differs.
+        // emb1 query-aligned: [1, 0, 0, ... ] → cosine similarity with query ≈ 1.0
+        // emb2 orthogonal:    [0, 1, 0, ... ] → cosine similarity with query ≈ 0.0
+        var queryVector = MakeVector(Dims, firstComponent: 1f);
+        var embVector1  = MakeVector(Dims, firstComponent: 1f);   // identical → sim ~1
+        var embVector2  = MakeVector(Dims, secondComponent: 1f);  // orthogonal → sim ~0
+
+        // Configure mock to return the query vector when asked.
+        _embeddingServiceMock
+            .Setup(s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { queryVector }));
+
+        // Insert embeddings directly via raw SQL.
+        // NOTE: Do NOT call EnsureCollectionExistsAsync (table already exists from EF migrations)
+        // and do NOT use IndexBatchAsync (it does LEFT JOIN games which was dropped in migration 1345).
+        await InsertEmbeddingRawAsync(vectorDocId, sharedGame.Id, 0, 1, "Predator activation rules explained in detail", embVector1);
+        await InsertEmbeddingRawAsync(vectorDocId, sharedGame.Id, 1, 2, "Another chunk about different game mechanics", embVector2);
+
+        return pdfId;
+    }
+
+    /// <summary>Inserts a single row into pgvector_embeddings via raw parameterised SQL.</summary>
+    private async Task InsertEmbeddingRawAsync(
+        Guid vectorDocumentId, Guid gameId,
+        int chunkIndex, int pageNumber,
+        string textContent, float[] vector)
+    {
+        var conn = _dbContext!.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync(TestCancellationToken);
+
+        await using var cmd = (NpgsqlCommand)conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO pgvector_embeddings
+                (id, vector_document_id, game_id, text_content, vector, model,
+                 chunk_index, page_number, created_at, lang, is_translation, role_tags)
+            VALUES
+                (@id, @vdId, @gameId, @text, @vec, 'test-model',
+                 @chunkIndex, @pageNumber, NOW(), 'en', false, 0)
+            """;
+
+        cmd.Parameters.AddWithValue("@id", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("@vdId", vectorDocumentId);
+        cmd.Parameters.AddWithValue("@gameId", gameId);
+        cmd.Parameters.AddWithValue("@text", textContent);
+        cmd.Parameters.AddWithValue("@vec", new Pgvector.Vector(vector));
+        cmd.Parameters.AddWithValue("@chunkIndex", chunkIndex);
+        cmd.Parameters.AddWithValue("@pageNumber", pageNumber);
+
+        await cmd.ExecuteNonQueryAsync(TestCancellationToken);
+    }
+
+    /// <summary>Creates a unit vector of <paramref name="dims"/> dimensions with 1.0 at the specified position.</summary>
+    private static float[] MakeVector(int dims, float firstComponent = 0f, float secondComponent = 0f)
+    {
+        var v = new float[dims];
+        if (firstComponent != 0f) v[0] = firstComponent;
+        if (secondComponent != 0f) v[1] = secondComponent;
+        return v;
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Happy-path: a document with 2 indexed embeddings is searched;
+    /// results come back ordered by score descending.
+    /// Happy-path type: REAL integration (pgvector Testcontainer + mocked IEmbeddingService).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsScoredHits_OrderedByScoreDesc()
+    {
+        var pdfId = await SeedIndexedDocAsync();
+
+        var result = await _mediator!.Send(
+            new SearchDocumentChunksByVectorQuery(pdfId, "predator activation", TopK: 5, MinScore: 0.0),
+            TestCancellationToken);
+
+        result.ErrorMessage.Should().BeNull();
+        result.Results.Should().NotBeEmpty();
+        result.Results.Select(r => r.Score).Should().BeInDescendingOrder();
+    }
+
+    /// <summary>
+    /// When PdfDocumentId does not correspond to any VectorDocument, the handler returns
+    /// an empty result with a non-null ErrorMessage (not an exception).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task Handle_ReturnsError_WhenDocNotIndexed()
+    {
+        var result = await _mediator!.Send(
+            new SearchDocumentChunksByVectorQuery(Guid.NewGuid(), "x", TopK: 5, MinScore: 0.0),
+            TestCancellationToken);
+
+        result.Results.Should().BeEmpty();
+        result.ErrorMessage.Should().NotBeNull();
+    }
+}

--- a/apps/web/bundle-size-baseline.json
+++ b/apps/web/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
-  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. Last bump rebaselines post-SP5 F3.1 KbExplorer client component (+~25KB): adds KbExplorer with document list, search, and preview panel.",
-  "updatedAt": "2026-05-28",
-  "totalBytes": 14500000,
+  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. Last bump rebaselines post-SP5 F3-FU-4 KbDocActions + KbChunkSearch + locked-restructure (+~155KB): adds doc-action bar (reindex/download/delete/export/used-by), per-doc chunk similarity-search UI, AdminConfirmationDialog confirmPhrase prop, and reachable actions on failed/processing docs.",
+  "updatedAt": "2026-05-29",
+  "totalBytes": 14660000,
   "toleranceBytes": 10240
 }

--- a/apps/web/e2e/admin/kb-doc-actions.spec.ts
+++ b/apps/web/e2e/admin/kb-doc-actions.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Admin KB Doc Actions smoke — F3-FU-4 T10
+ *
+ * Verifies that:
+ * 1. Landing on /admin/knowledge-base renders the explorer (tree + empty-state
+ *    detail panel) with no doc selected.
+ * 2. Selecting a document from the tree (via ?doc= deep-link) mounts the
+ *    KbDocDetailPanel and the action-bar — Re-index, Download, Delete,
+ *    Export chunks, and the Used-by link are all visible.
+ * 3. Clicking Used-by updates the URL to contain `tab=used-by`.
+ *
+ * Destructive actions (Re-index, Delete) are NOT clicked — visibility only.
+ * Deep behaviour is covered by unit tests; this test smokes the navigation
+ * and rendering layer.
+ *
+ * Pattern mirrors apps/web/e2e/admin-kb-explorer.spec.ts (F3.1 T6).
+ */
+
+import { expect, Page, test as base } from '@playwright/test';
+
+import { AdminHelper } from '../pages';
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const test = base.extend<{ adminPage: Page }>({
+  adminPage: async ({ page }: { page: Page }, use: (page: Page) => Promise<void>) => {
+    const adminHelper = new AdminHelper(page);
+    // Sets up /auth/me mock + catch-all /api/v1/admin/** stub.
+    // skip navigation = true (each test navigates explicitly).
+    await adminHelper.setupAdminAuth(true);
+    await use(page);
+  },
+});
+
+// ─── Mock data ───────────────────────────────────────────────────────────────
+
+const DOC_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const GAME_ID = 'gggggggg-hhhh-iiii-jjjj-kkkkkkkkkkkk';
+const FILE_NAME = 'catan-rulebook.pdf';
+
+const MOCK_GAMES = [
+  {
+    gameId: GAME_ID,
+    gameName: 'Catan',
+    totalChunks: 142,
+    docCount: 1,
+  },
+];
+
+const MOCK_GAME_DOCS = [
+  {
+    id: DOC_ID,
+    title: FILE_NAME,
+    status: 'indexed' as const,
+    pageCount: 24,
+    gameId: GAME_ID,
+  },
+];
+
+const MOCK_DOC_DETAIL = {
+  id: DOC_ID,
+  title: FILE_NAME,
+  gameId: GAME_ID,
+  gameName: 'Catan',
+  docType: 'rulebook',
+  uploadedAt: '2026-01-15T10:00:00Z',
+  processingStatus: 'ready' as const,
+  chunkCount: 142,
+  pageCount: 24,
+  language: 'it',
+};
+
+// ─── Route setup helpers ─────────────────────────────────────────────────────
+
+/**
+ * Register all KB-related route mocks BEFORE navigation.
+ * Order: specific routes first, then the AdminHelper catch-all (registered by
+ * setupAdminAuth) handles anything else. Playwright evaluates handlers in
+ * registration order — first match wins for the context-level handler.
+ */
+async function setupKbMocks(page: Page) {
+  // 1. KB game-statuses list (KbExplorer queries this on mount)
+  await page.route(`${apiBase}/api/v1/admin/kb/games/`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: MOCK_GAMES }),
+    })
+  );
+
+  // 2. Game documents for the tree (KbTreeGameDocs, fetched when game node expands)
+  await page.route(`${apiBase}/api/v1/knowledge-base/${GAME_ID}/documents`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_GAME_DOCS),
+    })
+  );
+
+  // 3. Doc detail hero (KbDocDetailPanel → useKbDocDetail)
+  await page.route(`${apiBase}/api/v1/kb-docs/${DOC_ID}`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_DOC_DETAIL),
+    })
+  );
+
+  // 4. Chunks list (KbDocDetailPanel → useKbChunksList) — return empty pages
+  await page.route(`${apiBase}/api/v1/kb-docs/${DOC_ID}/chunks*`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], nextCursor: null }),
+    })
+  );
+
+  // 5. Consuming-agents list (only fetched when delete dialog opens — won't fire)
+  await page.route(`${apiBase}/api/v1/admin/kb-docs/${DOC_ID}/consuming-agents*`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  );
+
+  // 6. Export-chunks endpoint — won't fire (we don't click Export in this smoke)
+  await page.route(`${apiBase}/api/v1/admin/kb-docs/${DOC_ID}/chunks/export`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    })
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Admin KB Doc Actions smoke (F3-FU-4)', () => {
+  test.beforeEach(async ({ adminPage: page }) => {
+    await setupKbMocks(page);
+  });
+
+  // ── Scenario 1: Explorer renders tree + empty-state detail panel ─────────
+
+  test('landing /admin/knowledge-base shows KbTree + empty detail panel', async ({
+    adminPage: page,
+  }) => {
+    await page.goto('/admin/knowledge-base');
+
+    // Tree is visible
+    const tree = page.getByRole('tree', { name: /Knowledge Base alberatura/i });
+    await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    // No doc selected → empty-state placeholder
+    await expect(page.getByTestId('kb-doc-detail-empty')).toBeVisible({ timeout: 10_000 });
+  });
+
+  // ── Scenario 2: Select a doc → detail panel + action-bar visible ─────────
+
+  test('selecting a doc via ?doc= mounts detail panel with action-bar controls', async ({
+    adminPage: page,
+  }) => {
+    // Deep-link directly to the document (simulates selecting the doc in the tree)
+    await page.goto(`/admin/knowledge-base?doc=${DOC_ID}`);
+
+    // Detail panel should not be the empty-state
+    await expect(page.getByTestId('kb-doc-detail-empty')).not.toBeVisible({ timeout: 10_000 });
+
+    // ── Action-bar button visibility checks ──────────────────────────────────
+    // Re-index button
+    const reindexBtn = page.getByRole('button', { name: /Re-index/i });
+    await expect(reindexBtn).toBeVisible({ timeout: 15_000 });
+
+    // Download link (rendered as <a download>)
+    const downloadLink = page.getByRole('link', { name: /Download/i });
+    await expect(downloadLink).toBeVisible();
+
+    // Delete button
+    const deleteBtn = page.getByRole('button', { name: /Elimina/i });
+    await expect(deleteBtn).toBeVisible();
+
+    // Export chunks button
+    const exportBtn = page.getByRole('button', { name: /Export chunks/i });
+    await expect(exportBtn).toBeVisible();
+
+    // Used-by / Agent link
+    const usedByLink = page.getByRole('link', { name: /Agent/i });
+    await expect(usedByLink).toBeVisible();
+  });
+
+  // ── Scenario 3 (optional): Used-by link updates the URL tab param ─────────
+
+  test('clicking Used-by link navigates to ?tab=used-by', async ({ adminPage: page }) => {
+    await page.goto(`/admin/knowledge-base?doc=${DOC_ID}`);
+
+    // Wait for the action-bar to appear before clicking
+    const usedByLink = page.getByRole('link', { name: /Agent/i });
+    await expect(usedByLink).toBeVisible({ timeout: 15_000 });
+
+    await usedByLink.click();
+
+    // URL should now contain both doc and tab=used-by
+    await expect(page).toHaveURL(/tab=used-by/, { timeout: 10_000 });
+    await expect(page).toHaveURL(new RegExp(`doc=${DOC_ID}`));
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -10,8 +10,14 @@ import { IngestionPanel } from './ingestion/IngestionPanel';
 import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
 import { UsedByPanel } from './used-by/UsedByPanel';
 
+import type { SelectedDocMeta } from './explorer-types';
+
 export interface KbDocDetailPanelProps {
   readonly docId: string | null;
+  /** Metadata carried from the tree selection (title + gameId). Available even
+   *  when the document is locked (HTTP 423, no body). T8 will consume this to
+   *  render the action-bar in all states. */
+  readonly selectedDocMeta?: SelectedDocMeta | null;
 }
 
 function formatDate(iso: string): string {
@@ -44,7 +50,11 @@ function processingChipClass(status: string): string {
  *   - locked (423)   → banner "Documento in elaborazione"
  *   - ready (200)    → hero + lista chunk infinite-cursor
  */
-export function KbDocDetailPanel({ docId }: KbDocDetailPanelProps) {
+
+export function KbDocDetailPanel({
+  docId,
+  selectedDocMeta: _selectedDocMeta,
+}: KbDocDetailPanelProps) {
   const searchParams = useSearchParams();
   const activeTab: KbDocTabKey = (() => {
     const tab = searchParams?.get('tab');

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import { useKbChunksList } from '@/hooks/queries/useKbChunksList';
 import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
 
+import { KbDocActions } from './actions/KbDocActions';
 import { IngestionPanel } from './ingestion/IngestionPanel';
 import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
 import { UsedByPanel } from './used-by/UsedByPanel';
@@ -51,10 +52,7 @@ function processingChipClass(status: string): string {
  *   - ready (200)    → hero + lista chunk infinite-cursor
  */
 
-export function KbDocDetailPanel({
-  docId,
-  selectedDocMeta: _selectedDocMeta,
-}: KbDocDetailPanelProps) {
+export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelProps) {
   const searchParams = useSearchParams();
   const activeTab: KbDocTabKey = (() => {
     const tab = searchParams?.get('tab');
@@ -100,6 +98,11 @@ export function KbDocDetailPanel({
   const envelope = detailQuery.data;
 
   if (envelope?.status === 'locked') {
+    // Derive display name + gameId from selectedDocMeta (the tree passes these
+    // even when the HTTP 423 body is null) — fall back to docId if unavailable.
+    const lockedTitle = selectedDocMeta?.title ?? docId;
+    const lockedGameId = selectedDocMeta?.gameId ?? null;
+
     // The Used-by tab is independent of doc readiness (it only needs the docId
     // to query agents whose KbCardIds contain it). Allow it to render during
     // processing — addresses the carry-forward gap flagged on PR #1668 (#1650).
@@ -111,15 +114,55 @@ export function KbDocDetailPanel({
         </div>
       );
     }
+
+    // For all other tabs (overview / ingestion) while locked: render the full
+    // shell so the action-bar (Re-index, Delete) is reachable — critical for
+    // `failed` docs. The body shows the processing notice instead of content.
     return (
-      <div className="border border-amber-500/30 rounded-lg bg-amber-500/5 p-6">
-        <h3 className="font-quicksand font-bold text-base text-amber-700 dark:text-amber-300 mb-1">
-          Documento in elaborazione
-        </h3>
-        <p className="text-sm text-muted-foreground">
-          Stato corrente: <span className="font-mono">{envelope.processingStatus}</span>. Il
-          pannello sarà disponibile quando l&apos;indicizzazione sarà completa.
-        </p>
+      <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
+        <KbDocDetailTabs docId={docId} activeTab={activeTab} />
+
+        {/* Slim hero — title from meta + status chip */}
+        <header className="p-5 border-b border-border/60 dark:border-zinc-700/60 bg-gradient-to-b from-amber-500/5 to-transparent">
+          <div className="flex items-start gap-4">
+            <span aria-hidden="true" className="text-3xl">
+              📄
+            </span>
+            <div className="flex-1 min-w-0">
+              <h2 className="font-quicksand font-bold text-lg truncate">{lockedTitle}</h2>
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground font-mono">
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border ${processingChipClass(envelope.processingStatus)}`}
+                >
+                  {envelope.processingStatus}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Action-bar — reachable for failed docs */}
+          <div className="mt-4">
+            <KbDocActions
+              docId={docId}
+              fileName={lockedTitle}
+              gameId={lockedGameId}
+              processingStatus={envelope.processingStatus}
+            />
+          </div>
+        </header>
+
+        {/* Processing notice in the body */}
+        <div className="p-6">
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+            <h3 className="font-quicksand font-bold text-base text-amber-700 dark:text-amber-300 mb-1">
+              Documento in elaborazione
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Stato corrente: <span className="font-mono">{envelope.processingStatus}</span>. Il
+              pannello sarà disponibile quando l&apos;indicizzazione sarà completa.
+            </p>
+          </div>
+        </div>
       </div>
     );
   }
@@ -172,6 +215,16 @@ export function KbDocDetailPanel({
               <Stat label="Pagine" value={doc.pageCount?.toLocaleString('it-IT') ?? '—'} />
               <Stat label="Lingua" value={doc.language} />
             </dl>
+
+            {/* Action-bar */}
+            <div className="mt-4">
+              <KbDocActions
+                docId={doc.id}
+                fileName={doc.title}
+                gameId={doc.gameId}
+                processingStatus={doc.processingStatus}
+              />
+            </div>
           </header>
 
           {/* Chunks */}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -9,6 +9,7 @@ import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
 import { KbDocActions } from './actions/KbDocActions';
 import { IngestionPanel } from './ingestion/IngestionPanel';
 import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
+import { KbChunkSearch } from './search/KbChunkSearch';
 import { UsedByPanel } from './used-by/UsedByPanel';
 
 import type { SelectedDocMeta } from './explorer-types';
@@ -226,6 +227,11 @@ export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelPro
               />
             </div>
           </header>
+
+          {/* Chunk similarity search */}
+          <section className="px-4 pt-4">
+            <KbChunkSearch docId={doc.id} chunkCount={doc.chunkCount} />
+          </section>
 
           {/* Chunks */}
           <section className="p-4">

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
@@ -29,7 +29,7 @@ export function KbDocDetailTabs({ docId, activeTab }: KbDocDetailTabsProps) {
       <ul className="flex gap-1 min-w-max m-0 p-0 list-none">
         {TABS.map(tab => {
           const isActive = activeTab === tab.key;
-          const params = new URLSearchParams({ docId });
+          const params = new URLSearchParams({ doc: docId });
           if (tab.key !== 'overview') params.set('tab', tab.key);
           const href = `/admin/knowledge-base?${params.toString()}`;
           return (

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbExplorer.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbExplorer.tsx
@@ -11,6 +11,8 @@ import { HttpClient } from '@/lib/api/core/httpClient';
 import { KbDocDetailPanel } from './KbDocDetailPanel';
 import { KbTree } from './KbTree';
 
+import type { SelectedDocMeta } from './explorer-types';
+
 const ADMIN_GAME_KB_STATUSES_QUERY_KEY = ['admin-game-kb-statuses'] as const;
 
 /**
@@ -30,6 +32,7 @@ export function KbExplorer() {
 
   const [expandedGameIds, setExpandedGameIds] = useState<Set<string>>(() => new Set());
   const [filter, setFilter] = useState('');
+  const [selectedDocMeta, setSelectedDocMeta] = useState<SelectedDocMeta | null>(null);
 
   const adminClient = useMemo(() => createAdminClient({ httpClient: new HttpClient() }), []);
 
@@ -49,6 +52,11 @@ export function KbExplorer() {
     else params.set('doc', docId);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname);
+  };
+
+  const handleSelectDoc = (meta: SelectedDocMeta) => {
+    setSelectedDocId(meta.id);
+    setSelectedDocMeta(meta);
   };
 
   const handleToggleGame = (gameId: string) => {
@@ -93,10 +101,10 @@ export function KbExplorer() {
         selectedDocId={selectedDocId}
         filter={filter}
         onToggleGame={handleToggleGame}
-        onSelectDoc={id => setSelectedDocId(id)}
+        onSelectDoc={handleSelectDoc}
         onFilterChange={setFilter}
       />
-      <KbDocDetailPanel docId={selectedDocId} />
+      <KbDocDetailPanel docId={selectedDocId} selectedDocMeta={selectedDocMeta} />
     </div>
   );
 }

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbTree.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbTree.tsx
@@ -7,13 +7,15 @@ import { useKbGameDocuments } from '@/hooks/queries/useGameDocuments';
 import type { GameKbStatusItem } from '@/lib/api/schemas/admin-knowledge-base.schemas';
 import type { GameDocument } from '@/lib/api/schemas/game-documents.schemas';
 
+import type { SelectedDocMeta } from './explorer-types';
+
 export interface KbTreeProps {
   readonly games: ReadonlyArray<GameKbStatusItem>;
   readonly expandedGameIds: ReadonlySet<string>;
   readonly selectedDocId: string | null;
   readonly filter: string;
   readonly onToggleGame: (gameId: string) => void;
-  readonly onSelectDoc: (docId: string) => void;
+  readonly onSelectDoc: (doc: SelectedDocMeta) => void;
   readonly onFilterChange: (filter: string) => void;
 }
 
@@ -116,7 +118,7 @@ interface KbTreeGameDocsProps {
   readonly gameId: string;
   readonly filter: string;
   readonly selectedDocId: string | null;
-  readonly onSelectDoc: (docId: string) => void;
+  readonly onSelectDoc: (doc: SelectedDocMeta) => void;
 }
 
 function KbTreeGameDocs({ gameId, filter, selectedDocId, onSelectDoc }: KbTreeGameDocsProps) {
@@ -156,7 +158,7 @@ function KbTreeGameDocs({ gameId, filter, selectedDocId, onSelectDoc }: KbTreeGa
               role="treeitem"
               aria-selected={selected}
               data-status={doc.status}
-              onClick={() => onSelectDoc(doc.id)}
+              onClick={() => onSelectDoc({ id: doc.id, title: doc.title, gameId })}
               className={[
                 'w-full text-left pl-8 pr-2 py-1 rounded-md flex items-center gap-2 text-[12px]',
                 selected

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
@@ -57,6 +57,19 @@ vi.mock('@/hooks/queries/useKbChunksList', () => ({
   useKbChunksList: (options: unknown) => mockUseKbChunksList(options),
 }));
 
+// ── KbDocActions mock (panel test doesn't exercise action internals) ───────────
+const mockKbDocActions = vi.fn();
+vi.mock('../actions/KbDocActions', () => ({
+  KbDocActions: (props: Record<string, unknown>) => {
+    mockKbDocActions(props);
+    return (
+      <div data-testid="kb-doc-actions-mock">
+        <button type="button">⟳ Re-index</button>
+      </div>
+    );
+  },
+}));
+
 // ── QueryClientProvider wrapper (needed for IngestionPanel tab) ───────────────
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -110,6 +123,7 @@ describe('KbDocDetailPanel', () => {
     mockSearchParams = new URLSearchParams(''); // default: overview tab
     mockUseKbDocDetail.mockReset();
     mockUseKbChunksList.mockReset();
+    mockKbDocActions.mockReset();
   });
 
   it('renders the empty placeholder when docId is null', () => {
@@ -265,5 +279,82 @@ describe('KbDocDetailPanel', () => {
     render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
     expect(screen.getByText(/in elaborazione/i)).toBeInTheDocument();
     expect(screen.queryByTestId('used-by-empty')).not.toBeInTheDocument();
+  });
+
+  // ── Part A: action-bar reachable for locked/failed docs ───────────────────────
+
+  it('renders the action-bar for a failed/locked doc so actions are reachable', () => {
+    const failedEnvelope: KbDocEnvelope = {
+      status: 'locked',
+      processingStatus: 'failed',
+      doc: null,
+    };
+    mockUseKbDocDetail.mockReturnValue({ data: failedEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+    render(
+      <KbDocDetailPanel docId="d1" selectedDocMeta={{ id: 'd1', title: 'X.pdf', gameId: 'g1' }} />,
+      { wrapper: makeWrapper() }
+    );
+    // KbDocActions mock renders a Re-index button
+    expect(screen.getByRole('button', { name: /re-?index/i })).toBeInTheDocument();
+    // The "in elaborazione" notice is still shown
+    expect(screen.getByText(/in elaborazione/i)).toBeInTheDocument();
+    // KbDocActions was rendered with the correct props
+    expect(mockKbDocActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docId: 'd1',
+        fileName: 'X.pdf',
+        gameId: 'g1',
+        processingStatus: 'failed',
+      })
+    );
+  });
+
+  it('falls back to docId when selectedDocMeta is null for locked doc', () => {
+    const failedEnvelope: KbDocEnvelope = {
+      status: 'locked',
+      processingStatus: 'failed',
+      doc: null,
+    };
+    mockUseKbDocDetail.mockReturnValue({ data: failedEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+    render(<KbDocDetailPanel docId="d1" selectedDocMeta={null} />, {
+      wrapper: makeWrapper(),
+    });
+    expect(mockKbDocActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docId: 'd1',
+        fileName: 'd1',
+        gameId: null,
+        processingStatus: 'failed',
+      })
+    );
+  });
+
+  it('ready doc renders KbDocActions with doc fields (regression)', () => {
+    mockUseKbDocDetail.mockReturnValue({ data: readyEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({
+      data: { pages: [{ items: [chunk1], nextCursor: null, totalCount: 1 }] },
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+    });
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+    expect(mockKbDocActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docId: 'doc-1',
+        fileName: 'Wingspan-Oceania-EN.pdf',
+        gameId: 'g-1',
+        processingStatus: 'ready',
+      })
+    );
+  });
+
+  it('locked doc on overview tab renders the tab nav', () => {
+    mockSearchParams = new URLSearchParams('');
+    mockUseKbDocDetail.mockReturnValue({ data: lockedEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: undefined, hasNextPage: false });
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+    expect(screen.getByRole('navigation', { name: /sezione documento/i })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
@@ -70,6 +70,13 @@ vi.mock('../actions/KbDocActions', () => ({
   },
 }));
 
+// ── KbChunkSearch mock (panel test doesn't exercise search internals) ──────────
+vi.mock('../search/KbChunkSearch', () => ({
+  KbChunkSearch: ({ docId, chunkCount }: { docId: string; chunkCount: number }) => (
+    <div data-testid="kb-chunk-search-mock" data-doc-id={docId} data-chunk-count={chunkCount} />
+  ),
+}));
+
 // ── QueryClientProvider wrapper (needed for IngestionPanel tab) ───────────────
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
@@ -7,7 +7,7 @@ vi.mock('next/navigation', async () => {
   return {
     ...actual,
     usePathname: () => '/admin/knowledge-base',
-    useSearchParams: () => new URLSearchParams('docId=abc&tab=ingestion'),
+    useSearchParams: () => new URLSearchParams('doc=abc&tab=ingestion'),
   };
 });
 
@@ -19,10 +19,10 @@ describe('KbDocDetailTabs', () => {
     expect(screen.getByRole('link', { name: /used by/i })).toBeInTheDocument();
   });
 
-  it('Used by link sets ?tab=used-by and preserves docId', () => {
+  it('Used by link sets ?tab=used-by and preserves doc param', () => {
     render(<KbDocDetailTabs docId="abc" activeTab="overview" />);
     const usedByLink = screen.getByRole('link', { name: /used by/i });
-    expect(usedByLink.getAttribute('href')).toContain('docId=abc');
+    expect(usedByLink.getAttribute('href')).toContain('doc=abc');
     expect(usedByLink.getAttribute('href')).toContain('tab=used-by');
   });
 
@@ -33,10 +33,10 @@ describe('KbDocDetailTabs', () => {
     );
   });
 
-  it('preserves docId in each tab href', () => {
+  it('preserves doc param in each tab href', () => {
     render(<KbDocDetailTabs docId="abc" activeTab="overview" />);
     const ingestionLink = screen.getByRole('link', { name: /ingestion log/i });
-    expect(ingestionLink.getAttribute('href')).toContain('docId=abc');
+    expect(ingestionLink.getAttribute('href')).toContain('doc=abc');
     expect(ingestionLink.getAttribute('href')).toContain('tab=ingestion');
   });
 

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbExplorer.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbExplorer.test.tsx
@@ -35,6 +35,22 @@ vi.mock('@/hooks/queries/useKbDocDetail', () => ({
 vi.mock('@/hooks/queries/useKbChunksList', () => ({
   useKbChunksList: () => ({ data: undefined, hasNextPage: false }),
 }));
+// KbDocActions hooks — mocked so the api singleton is not eagerly evaluated
+vi.mock('@/hooks/queries/useKbDocActions', () => ({
+  useReindexDoc: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteKbDoc: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@/hooks/queries/useKbDocConsumingAgents', () => ({
+  useKbDocConsumingAgents: () => ({ data: [], isLoading: false, isError: false }),
+}));
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: {
+      getPdfDownloadUrl: () => '#',
+      exportDocChunks: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
 
 const games: GameKbStatusItem[] = [
   {

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTree.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbTree.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { KbTree } from '../KbTree';
 import type { GameKbStatusItem } from '@/lib/api/schemas/admin-knowledge-base.schemas';
 import type { GameDocument } from '@/lib/api/schemas/game-documents.schemas';
+import type { SelectedDocMeta } from '../explorer-types';
 
 // Mock the per-game docs hook so KbTree's expanded-node sub-component can render
 // without TanStack Query plumbing.
@@ -131,12 +132,13 @@ describe('KbTree', () => {
     expect(leaf).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('clicking a doc leaf calls onSelectDoc with doc.id', () => {
+  it('clicking a doc leaf calls onSelectDoc with { id, title, gameId }', () => {
     setHook('g-1', [doc1]);
     const onSelectDoc = vi.fn();
     render(<KbTree {...baseProps} expandedGameIds={new Set(['g-1'])} onSelectDoc={onSelectDoc} />);
     fireEvent.click(screen.getByText('Wingspan-Oceania-EN.pdf'));
-    expect(onSelectDoc).toHaveBeenCalledWith(doc1.id);
+    const expected: SelectedDocMeta = { id: doc1.id, title: doc1.title, gameId: game1.gameId };
+    expect(onSelectDoc).toHaveBeenCalledWith(expected);
   });
 
   it('filter narrows games by name (case-insensitive)', () => {

--- a/apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx
@@ -148,7 +148,7 @@ export function KbDocActions({ docId, fileName, gameId, processingStatus }: KbDo
 
       {/* 5. Used-by link */}
       <Link
-        href={`/admin/knowledge-base?docId=${docId}&tab=used-by`}
+        href={`/admin/knowledge-base?doc=${docId}&tab=used-by`}
         className={`inline-flex items-center px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 ${FOCUS_RING}`}
       >
         🔗 Agent

--- a/apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+
+import Link from 'next/link';
+import { toast } from 'sonner';
+
+import {
+  AdminConfirmationDialog,
+  AdminConfirmationLevel,
+} from '@/components/ui/admin/admin-confirmation-dialog';
+import { useDeleteKbDoc, useReindexDoc } from '@/hooks/queries/useKbDocActions';
+import { useKbDocConsumingAgents } from '@/hooks/queries/useKbDocConsumingAgents';
+import { api } from '@/lib/api';
+
+import { downloadAsFile } from '../utils/downloadAsFile';
+
+export interface KbDocActionsProps {
+  /** Document UUID */
+  readonly docId: string;
+  /** Original file name — used as typed-confirm phrase on delete */
+  readonly fileName: string;
+  /** Parent game UUID for cache invalidation; null when unknown / global KB */
+  readonly gameId: string | null;
+  /** Current processing status of the document */
+  readonly processingStatus: 'queued' | 'processing' | 'ready' | 'failed';
+}
+
+/** Shared focus-visible ring classes applied to every bare button (a11y). */
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+/**
+ * KbDocActions — horizontal action-bar for the KB document detail panel.
+ *
+ * Five actions:
+ *   1. Re-index   — POST reindex; disabled while processing/queued/pending
+ *   2. Download   — <a download> anchor (session-cookie auth works)
+ *   3. Delete     — Level2 typed-confirm dialog (phrase = fileName)
+ *   4. Export JSON— exportDocChunks → downloadAsFile; disabled unless ready
+ *   5. Used-by    — Link to the used-by tab
+ *
+ * Issue #1653 F3-FU-4 Task 6.
+ */
+export function KbDocActions({ docId, fileName, gameId, processingStatus }: KbDocActionsProps) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [exportPending, setExportPending] = useState(false);
+
+  // ── Mutation hooks ──────────────────────────────────────────────────────────
+  const reindexMutation = useReindexDoc(docId);
+  const deleteMutation = useDeleteKbDoc(gameId);
+
+  // ── Lazy agent count (only when delete dialog is open) ─────────────────────
+  const consumingAgentsQuery = useKbDocConsumingAgents({
+    docId,
+    enabled: deleteOpen,
+  });
+  const agentCount =
+    deleteOpen && !consumingAgentsQuery.isLoading && !consumingAgentsQuery.isError
+      ? (consumingAgentsQuery.data?.length ?? null)
+      : null;
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+  const handleReindex = () => {
+    reindexMutation.mutate(undefined, {
+      onSuccess: () => toast.success('Re-index avviato'),
+      onError: (err: Error) => toast.error(`Re-index fallito: ${err.message}`),
+    });
+  };
+
+  const handleDelete = () => {
+    deleteMutation.mutate(docId, {
+      onSuccess: () => {
+        toast.success(`Documento "${fileName}" eliminato`);
+        setDeleteOpen(false);
+      },
+      onError: (err: Error) => toast.error(`Eliminazione fallita: ${err.message}`),
+    });
+  };
+
+  const handleExportChunks = async () => {
+    setExportPending(true);
+    try {
+      const chunks = await api.pdf.exportDocChunks(docId);
+      downloadAsFile(JSON.stringify(chunks, null, 2), `${fileName}-chunks.json`);
+    } catch (err) {
+      toast.error(
+        `Esportazione chunk fallita: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      setExportPending(false);
+    }
+  };
+
+  // ── Warning message for delete dialog ──────────────────────────────────────
+  const deleteWarning: string =
+    deleteOpen && consumingAgentsQuery.isLoading
+      ? 'Caricamento agent associati…'
+      : agentCount === null
+        ? 'Verifica degli agent in corso — riprova tra poco.'
+        : agentCount > 0
+          ? `Referenziato da ${agentCount} agent — verranno scollegati.`
+          : 'Nessun agent referenzia questo documento.';
+
+  const isReindexDisabled =
+    processingStatus === 'processing' || processingStatus === 'queued' || reindexMutation.isPending;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {/* 1. Re-index */}
+      <button
+        type="button"
+        onClick={handleReindex}
+        disabled={isReindexDisabled}
+        className={`px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 disabled:opacity-50 disabled:cursor-not-allowed ${FOCUS_RING}`}
+      >
+        ⟳ Re-index
+      </button>
+
+      {/* 2. Download — plain anchor styled as button */}
+      {}
+      <a
+        href={api.pdf.getPdfDownloadUrl(docId)}
+        download
+        className={`inline-flex items-center px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 ${FOCUS_RING}`}
+      >
+        ⤓ Download
+      </a>
+
+      {/* 3. Delete */}
+      <button
+        type="button"
+        onClick={() => setDeleteOpen(true)}
+        className={`px-3 py-1.5 text-xs font-medium rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 ${FOCUS_RING}`}
+      >
+        🗑 Elimina
+      </button>
+
+      {/* 4. Export chunks JSON */}
+      <button
+        type="button"
+        onClick={() => void handleExportChunks()}
+        disabled={processingStatus !== 'ready' || exportPending}
+        className={`px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 disabled:opacity-50 disabled:cursor-not-allowed ${FOCUS_RING}`}
+      >
+        ↧ Export chunks
+      </button>
+
+      {/* 5. Used-by link */}
+      <Link
+        href={`/admin/knowledge-base?docId=${docId}&tab=used-by`}
+        className={`inline-flex items-center px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 ${FOCUS_RING}`}
+      >
+        🔗 Agent
+      </Link>
+
+      {/* Delete confirmation dialog */}
+      <AdminConfirmationDialog
+        isOpen={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleDelete}
+        level={AdminConfirmationLevel.Level2}
+        confirmPhrase={fileName}
+        title="Elimina documento"
+        message={`Stai per eliminare il documento "${fileName}" dalla knowledge base. L'operazione è irreversibile.`}
+        warningMessage={deleteWarning}
+        isLoading={deleteMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
@@ -343,7 +343,7 @@ describe('KbDocActions', () => {
     const link = screen.getByRole('link', { name: /used.?by|agent/i });
     expect(link).toHaveAttribute(
       'href',
-      `/admin/knowledge-base?docId=${BASE_PROPS.docId}&tab=used-by`
+      `/admin/knowledge-base?doc=${BASE_PROPS.docId}&tab=used-by`
     );
   });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/actions/__tests__/KbDocActions.test.tsx
@@ -1,0 +1,349 @@
+/**
+ * KbDocActions unit tests — Issue #1653 F3-FU-4 Task 6.
+ *
+ * Mocks:
+ *  - @/hooks/queries/useKbDocActions  (useDeleteKbDoc, useReindexDoc)
+ *  - @/hooks/queries/useKbDocConsumingAgents (lazy used-by count)
+ *  - @/lib/api  (api.pdf.getPdfDownloadUrl, api.pdf.exportDocChunks)
+ *  - ../utils/downloadAsFile
+ *  - sonner
+ *  - next/link
+ *  - next/navigation
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// ── next/link mock ─────────────────────────────────────────────────────────────
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// ── next/navigation mock ───────────────────────────────────────────────────────
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+  usePathname: () => '/admin/knowledge-base',
+}));
+
+// ── sonner mock ────────────────────────────────────────────────────────────────
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// ── useKbDocActions mock ───────────────────────────────────────────────────────
+const mockReindexMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockUseReindexDoc = vi.fn();
+const mockUseDeleteKbDoc = vi.fn();
+
+vi.mock('@/hooks/queries/useKbDocActions', () => ({
+  useReindexDoc: (docId: string) => mockUseReindexDoc(docId),
+  useDeleteKbDoc: (gameId: string | null) => mockUseDeleteKbDoc(gameId),
+}));
+
+// ── useKbDocConsumingAgents mock ───────────────────────────────────────────────
+const mockUseKbDocConsumingAgents = vi.fn();
+vi.mock('@/hooks/queries/useKbDocConsumingAgents', () => ({
+  useKbDocConsumingAgents: (opts: unknown) => mockUseKbDocConsumingAgents(opts),
+}));
+
+// ── api.pdf mock ───────────────────────────────────────────────────────────────
+const mockExportDocChunks = vi.fn();
+const mockGetPdfDownloadUrl = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: {
+      exportDocChunks: (...args: unknown[]) => mockExportDocChunks(...args),
+      getPdfDownloadUrl: (...args: unknown[]) => mockGetPdfDownloadUrl(...args),
+    },
+  },
+}));
+
+// ── downloadAsFile mock ────────────────────────────────────────────────────────
+// The component lives in actions/ and imports from ../utils/downloadAsFile
+// which resolves to explorer/utils/downloadAsFile. From the __tests__/ subdir
+// the equivalent relative path would be ../../utils/downloadAsFile, but using
+// the module ID that Vite resolves for the component import is more robust.
+const mockDownloadAsFile = vi.fn();
+vi.mock('../../utils/downloadAsFile', () => ({
+  downloadAsFile: (...args: unknown[]) => mockDownloadAsFile(...args),
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+import { KbDocActions } from '../KbDocActions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const BASE_PROPS = {
+  docId: 'doc-123',
+  fileName: 'wingspan-rules.pdf',
+  gameId: 'game-456',
+  processingStatus: 'ready' as const,
+};
+
+function makeReindexMutation(overrides: Record<string, unknown> = {}) {
+  return {
+    mutate: mockReindexMutate,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  };
+}
+
+function makeDeleteMutation(overrides: Record<string, unknown> = {}) {
+  return {
+    mutate: mockDeleteMutate,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  };
+}
+
+function makeConsumingAgentsQuery(overrides: Record<string, unknown> = {}) {
+  return {
+    isLoading: false,
+    isError: false,
+    data: [],
+    ...overrides,
+  };
+}
+
+describe('KbDocActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReindexDoc.mockReturnValue(makeReindexMutation());
+    mockUseDeleteKbDoc.mockReturnValue(makeDeleteMutation());
+    mockUseKbDocConsumingAgents.mockReturnValue(makeConsumingAgentsQuery());
+    mockGetPdfDownloadUrl.mockReturnValue('http://api/download/doc-123');
+    mockExportDocChunks.mockResolvedValue([
+      { id: 'c1', chunkIndex: 0, pageNumber: 1, heading: 'Intro', content: 'text' },
+    ]);
+  });
+
+  // ── Re-index ─────────────────────────────────────────────────────────────────
+
+  it('renders the Re-index button', () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    expect(screen.getByRole('button', { name: /re-?index/i })).toBeInTheDocument();
+  });
+
+  it('disables Re-index while processingStatus is "processing"', () => {
+    render(<KbDocActions {...BASE_PROPS} processingStatus="processing" />);
+    expect(screen.getByRole('button', { name: /re-?index/i })).toBeDisabled();
+  });
+
+  it('disables Re-index while processingStatus is "queued"', () => {
+    render(<KbDocActions {...BASE_PROPS} processingStatus="queued" />);
+    expect(screen.getByRole('button', { name: /re-?index/i })).toBeDisabled();
+  });
+
+  it('disables Re-index while mutation isPending', () => {
+    mockUseReindexDoc.mockReturnValue(makeReindexMutation({ isPending: true }));
+    render(<KbDocActions {...BASE_PROPS} processingStatus="ready" />);
+    expect(screen.getByRole('button', { name: /re-?index/i })).toBeDisabled();
+  });
+
+  it('Re-index ready → calls mutate + shows success toast', async () => {
+    mockReindexMutate.mockImplementation(
+      (_: void, options?: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+        options?.onSuccess?.();
+      }
+    );
+    render(<KbDocActions {...BASE_PROPS} processingStatus="ready" />);
+    fireEvent.click(screen.getByRole('button', { name: /re-?index/i }));
+    expect(mockReindexMutate).toHaveBeenCalled();
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Re-index avviato'));
+  });
+
+  it('Re-index shows error toast on failure', async () => {
+    mockReindexMutate.mockImplementation(
+      (_: void, options?: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+        options?.onError?.(new Error('network error'));
+      }
+    );
+    render(<KbDocActions {...BASE_PROPS} processingStatus="ready" />);
+    fireEvent.click(screen.getByRole('button', { name: /re-?index/i }));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+  });
+
+  // ── Download ──────────────────────────────────────────────────────────────────
+
+  it('renders the Download anchor with correct href', () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    const link = screen.getByRole('link', { name: /download/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'http://api/download/doc-123');
+    expect(link).toHaveAttribute('download');
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────────
+
+  it('renders the Delete button', () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    expect(screen.getByRole('button', { name: /elimina/i })).toBeInTheDocument();
+  });
+
+  it('Delete button opens the confirmation dialog', async () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    // Dialog title should appear
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+  });
+
+  it('Delete opens typed-confirm dialog with fileName as confirmPhrase', async () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+    // The confirmPhrase (fileName) should appear in the dialog
+    expect(screen.getByText(BASE_PROPS.fileName)).toBeInTheDocument();
+  });
+
+  it('Delete calls mutate(docId) after typing fileName and confirming', async () => {
+    mockDeleteMutate.mockImplementation(
+      (_: string, options?: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+        options?.onSuccess?.();
+      }
+    );
+    render(<KbDocActions {...BASE_PROPS} />);
+    // Open dialog
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+    // Type the confirmPhrase
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: BASE_PROPS.fileName } });
+    // Confirm
+    const confirmBtn = screen.getByRole('button', { name: /conferma azione critica/i });
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(mockDeleteMutate).toHaveBeenCalledWith(
+        BASE_PROPS.docId,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+    });
+  });
+
+  it('Delete shows success toast after confirmed deletion', async () => {
+    mockDeleteMutate.mockImplementation(
+      (_: string, options?: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+        options?.onSuccess?.();
+      }
+    );
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: BASE_PROPS.fileName } });
+    fireEvent.click(screen.getByRole('button', { name: /conferma azione critica/i }));
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
+  });
+
+  it('Delete lazy-fetches used-by only when dialog is open', async () => {
+    // Before opening the dialog, consuming agents should NOT be fetched
+    // (enabled: false for deleteOpen=false)
+    render(<KbDocActions {...BASE_PROPS} />);
+    // Initially the consuming agents hook is called with enabled: false
+    expect(mockUseKbDocConsumingAgents).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+    // Open dialog
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+    // Now the hook should be called with enabled: true
+    expect(mockUseKbDocConsumingAgents).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true })
+    );
+  });
+
+  it('Delete shows agent-count warning when agents are loaded', async () => {
+    // Return 3 agents when delete dialog is open
+    mockUseKbDocConsumingAgents.mockImplementation(({ enabled }: { enabled: boolean }) => {
+      if (!enabled) return makeConsumingAgentsQuery({ data: [] });
+      return makeConsumingAgentsQuery({
+        data: [
+          { id: 'a1', name: 'Agent Alpha' },
+          { id: 'a2', name: 'Agent Beta' },
+          { id: 'a3', name: 'Agent Gamma' },
+        ],
+      });
+    });
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /elimina documento/i })).toBeInTheDocument()
+    );
+    // Warning should mention the agent count
+    expect(screen.getByText(/3 agent/i)).toBeInTheDocument();
+  });
+
+  // ── Export chunks JSON ────────────────────────────────────────────────────────
+
+  it('renders the Export chunks button', () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    expect(screen.getByRole('button', { name: /export.*chunk/i })).toBeInTheDocument();
+  });
+
+  it('disables Export chunks when processingStatus is not "ready"', () => {
+    render(<KbDocActions {...BASE_PROPS} processingStatus="failed" />);
+    expect(screen.getByRole('button', { name: /export.*chunk/i })).toBeDisabled();
+  });
+
+  it('Export chunks downloads JSON via exportDocChunks + downloadAsFile', async () => {
+    const chunks = [{ id: 'c1', chunkIndex: 0, pageNumber: 1, heading: 'Intro', content: 'text' }];
+    mockExportDocChunks.mockResolvedValue(chunks);
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export.*chunk/i }));
+    await waitFor(() => expect(mockExportDocChunks).toHaveBeenCalledWith(BASE_PROPS.docId));
+    await waitFor(() =>
+      expect(mockDownloadAsFile).toHaveBeenCalledWith(
+        JSON.stringify(chunks, null, 2),
+        `${BASE_PROPS.fileName}-chunks.json`
+      )
+    );
+  });
+
+  it('Export chunks shows error toast on failure', async () => {
+    mockExportDocChunks.mockRejectedValue(new Error('export failed'));
+    render(<KbDocActions {...BASE_PROPS} />);
+    fireEvent.click(screen.getByRole('button', { name: /export.*chunk/i }));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+  });
+
+  // ── Used-by link ──────────────────────────────────────────────────────────────
+
+  it('renders the Used-by link pointing to the correct URL', () => {
+    render(<KbDocActions {...BASE_PROPS} />);
+    const link = screen.getByRole('link', { name: /used.?by|agent/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `/admin/knowledge-base?docId=${BASE_PROPS.docId}&tab=used-by`
+    );
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/explorer-types.ts
+++ b/apps/web/src/components/admin/knowledge-base/explorer/explorer-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared types for the KB explorer master-detail panel.
+ * Kept in a standalone file so KbTree, KbExplorer and KbDocDetailPanel can
+ * all import without creating circular deps.
+ */
+
+/**
+ * Metadata the tree carries for a selected document.
+ * Passed down to KbDocDetailPanel so it can display title/gameId even when
+ * the document is locked (HTTP 423, no body) — e.g. for action-bar rendering.
+ */
+export interface SelectedDocMeta {
+  id: string;
+  title: string;
+  gameId: string;
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/ingestion/IngestionActions.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/ingestion/IngestionActions.tsx
@@ -4,6 +4,8 @@ import { useCallback } from 'react';
 
 import type { IngestionLog } from '@/lib/api/schemas/ingestion-log.schemas';
 
+import { downloadAsFile } from '../utils/downloadAsFile';
+
 interface IngestionActionsProps {
   readonly log: IngestionLog;
   readonly onRetry: (jobId: string) => void;
@@ -15,19 +17,6 @@ function buildLogText(log: IngestionLog): string {
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
     .map(e => `[${e.timestamp}] [${e.level.toUpperCase()}] [${e.step}] ${e.message}`)
     .join('\n');
-}
-
-function downloadAsFile(content: string, filename: string): void {
-  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.style.display = 'none';
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /**

--- a/apps/web/src/components/admin/knowledge-base/explorer/search/KbChunkSearch.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/search/KbChunkSearch.tsx
@@ -1,0 +1,244 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: amber/emerald/rose score badge palette (admin convention, DS-13c scope deferred to DS-16) */
+'use client';
+
+import { useState } from 'react';
+
+import { toast } from 'sonner';
+
+import { useDocChunkSearch } from '@/hooks/queries/useKbDocActions';
+import type { DocChunkSearchHit } from '@/lib/api/clients/pdfClient';
+
+export interface KbChunkSearchProps {
+  /** Document UUID */
+  readonly docId: string;
+  /** Total embedded chunks — if 0, the search input is disabled */
+  readonly chunkCount: number;
+}
+
+/** Shared focus-visible ring classes applied to every bare button / input (a11y). */
+const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+/** Score tiers → Tailwind colour utilities (hue-based, no neutral hardcoded names). */
+function scoreBadgeClass(score: number): string {
+  if (score >= 0.7)
+    return 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/30';
+  if (score >= 0.5) return 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30';
+  return 'bg-muted text-muted-foreground border-border';
+}
+
+type SearchState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'results'; hits: DocChunkSearchHit[] }
+  | { kind: 'empty' }
+  | { kind: 'error'; message: string };
+
+const THRESHOLD_OPTIONS = [
+  { label: 'Score ≥ 0.9', value: 0.9 },
+  { label: 'Score ≥ 0.7', value: 0.7 },
+  { label: 'Score ≥ 0.5', value: 0.5 },
+  { label: 'Score ≥ 0.3', value: 0.3 },
+  { label: 'Tutti i risultati', value: 0 },
+];
+
+/**
+ * KbChunkSearch — in-panel semantic chunk similarity-search.
+ *
+ * Renders a search input + score-threshold selector.
+ * On submit calls useDocChunkSearch.mutateAsync and displays results sorted
+ * by score desc. Threshold is applied client-side so changing it does NOT
+ * trigger a new network request.
+ *
+ * Issue #1653 F3-FU-4 Task 9.
+ */
+export function KbChunkSearch({ docId, chunkCount }: KbChunkSearchProps) {
+  const [query, setQuery] = useState('');
+  const [threshold, setThreshold] = useState(0.7);
+  const [state, setState] = useState<SearchState>({ kind: 'idle' });
+  // Raw results kept separately so threshold changes don't require a refetch
+  const [rawHits, setRawHits] = useState<DocChunkSearchHit[]>([]);
+
+  const { mutateAsync, isPending } = useDocChunkSearch(docId);
+
+  const isDisabled = chunkCount === 0;
+
+  /** Client-side threshold filter + stable desc sort */
+  const visibleHits = rawHits.filter(h => h.score >= threshold).sort((a, b) => b.score - a.score);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    setState({ kind: 'loading' });
+    try {
+      const result = await mutateAsync({ query: trimmed, minScore: threshold });
+
+      if (result.errorMessage) {
+        toast.error(`Ricerca fallita: ${result.errorMessage}`);
+        setState({ kind: 'error', message: result.errorMessage });
+        setRawHits([]);
+        return;
+      }
+
+      const sorted = [...result.results].sort((a, b) => b.score - a.score);
+      setRawHits(sorted);
+
+      const above = sorted.filter(h => h.score >= threshold);
+      setState(above.length > 0 ? { kind: 'results', hits: above } : { kind: 'empty' });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Ricerca fallita: ${msg}`);
+      setState({ kind: 'error', message: msg });
+      setRawHits([]);
+    }
+  };
+
+  // Re-derive visible hits when threshold changes (no network call)
+  const handleThresholdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = parseFloat(e.target.value);
+    setThreshold(next);
+    if (rawHits.length > 0) {
+      const above = rawHits.filter(h => h.score >= next);
+      setState(above.length > 0 ? { kind: 'results', hits: above } : { kind: 'empty' });
+    }
+  };
+
+  return (
+    <div className="mb-4">
+      {/* ── Search bar ─────────────────────────────────────────────────────── */}
+      <form onSubmit={e => void handleSubmit(e)} className="flex items-center gap-2 mb-3">
+        {/* Input */}
+        <div className="relative flex-1">
+          <label htmlFor="kb-chunk-search-input" className="sr-only">
+            Cerca nei chunk per similarità
+          </label>
+          <span
+            aria-hidden="true"
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-xs"
+          >
+            🔍
+          </span>
+          <input
+            id="kb-chunk-search-input"
+            type="search"
+            role="searchbox"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            disabled={isDisabled || isPending}
+            placeholder="Cerca in chunks… (similarity match)"
+            aria-label="Cerca nei chunk per similarità"
+            className={`w-full pl-7 pr-3 py-1.5 text-xs border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed ${FOCUS_RING}`}
+          />
+        </div>
+
+        {/* Threshold selector */}
+        <label htmlFor="kb-chunk-search-threshold" className="sr-only">
+          Soglia score
+        </label>
+        <select
+          id="kb-chunk-search-threshold"
+          aria-label="Soglia score"
+          value={threshold}
+          onChange={handleThresholdChange}
+          disabled={isDisabled}
+          className={`py-1.5 px-2 text-xs border border-border rounded-md bg-background text-foreground disabled:opacity-50 disabled:cursor-not-allowed ${FOCUS_RING}`}
+        >
+          {THRESHOLD_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Submit button */}
+        <button
+          type="submit"
+          disabled={isDisabled || isPending || !query.trim()}
+          className={`px-3 py-1.5 text-xs font-medium border border-border rounded-md hover:bg-muted/70 disabled:opacity-50 disabled:cursor-not-allowed ${FOCUS_RING}`}
+        >
+          Cerca
+        </button>
+      </form>
+
+      {/* ── State output ────────────────────────────────────────────────────── */}
+
+      {/* No-chunks hint */}
+      {isDisabled && (
+        <p data-testid="kb-chunk-search-no-chunks" className="text-xs text-muted-foreground italic">
+          Documento senza chunk — la ricerca non è disponibile.
+        </p>
+      )}
+
+      {/* Idle */}
+      {!isDisabled && state.kind === 'idle' && (
+        <p data-testid="kb-chunk-search-idle" className="text-xs text-muted-foreground italic">
+          Digita una query e premi Invio per cercare tra i chunk del documento.
+        </p>
+      )}
+
+      {/* Loading */}
+      {state.kind === 'loading' || isPending ? (
+        state.kind === 'loading' || isPending ? (
+          <div
+            data-testid="kb-chunk-search-loading"
+            className="flex items-center gap-2 py-3 text-xs text-muted-foreground"
+          >
+            <span className="animate-spin" aria-hidden="true">
+              ⟳
+            </span>
+            Ricerca in corso…
+          </div>
+        ) : null
+      ) : null}
+
+      {/* Error */}
+      {state.kind === 'error' && !isPending && (
+        <div
+          data-testid="kb-chunk-search-error"
+          className="rounded-md border border-rose-500/30 bg-rose-500/5 p-3 text-xs text-rose-700 dark:text-rose-300"
+        >
+          <span className="font-semibold">Errore: </span>
+          {state.message}
+        </div>
+      )}
+
+      {/* Empty */}
+      {state.kind === 'empty' && !isPending && (
+        <p
+          data-testid="kb-chunk-search-empty"
+          className="text-xs text-muted-foreground italic py-2"
+        >
+          Nessun risultato per la query corrente con la soglia impostata.
+        </p>
+      )}
+
+      {/* Results */}
+      {state.kind === 'results' && !isPending && visibleHits.length > 0 && (
+        <ul
+          data-testid="kb-chunk-search-results"
+          className="divide-y divide-border/60 dark:divide-zinc-700/60"
+        >
+          {visibleHits.map(hit => (
+            <li key={hit.chunkIndex} data-testid="kb-chunk-search-hit" className="py-2.5">
+              <div className="flex items-center gap-2 text-[10.5px] font-mono text-muted-foreground mb-0.5 flex-wrap">
+                <code>c-{hit.chunkIndex.toString().padStart(4, '0')}</code>
+                {hit.pageNumber !== null && <span>p.{hit.pageNumber}</span>}
+                {/* Score badge */}
+                <span
+                  className={`inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold rounded-full border ${scoreBadgeClass(hit.score)}`}
+                >
+                  {hit.score.toFixed(2)}
+                </span>
+              </div>
+              <p className="text-[12.5px] text-foreground leading-snug line-clamp-2">
+                {hit.snippet}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/search/__tests__/KbChunkSearch.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/search/__tests__/KbChunkSearch.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * KbChunkSearch unit tests — Issue #1653 F3-FU-4 Task 9.
+ *
+ * Mocks:
+ *  - @/hooks/queries/useKbDocActions (useDocChunkSearch)
+ *  - sonner
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── sonner mock ────────────────────────────────────────────────────────────────
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// ── useDocChunkSearch mock ─────────────────────────────────────────────────────
+const mockMutateAsync = vi.fn();
+const mockUseDocChunkSearch = vi.fn();
+
+vi.mock('@/hooks/queries/useKbDocActions', () => ({
+  useDocChunkSearch: (docId: string) => mockUseDocChunkSearch(docId),
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+import { KbChunkSearch } from '../KbChunkSearch';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+function makeMutation(overrides: Record<string, unknown> = {}) {
+  return {
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    isError: false,
+    data: undefined,
+    ...overrides,
+  };
+}
+
+const hitHigh = {
+  chunkIndex: 218,
+  pageNumber: 22,
+  score: 0.84,
+  snippet:
+    "Quando più uccelli predatori sono attivati nello stesso turno, l'attivazione segue l'ordine…",
+};
+
+const hitMid = {
+  chunkIndex: 142,
+  pageNumber: 14,
+  score: 0.58,
+  snippet: 'Power di tipo predator si attiva su trigger when activated…',
+};
+
+describe('KbChunkSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDocChunkSearch.mockReturnValue(makeMutation());
+  });
+
+  // ── Idle state ─────────────────────────────────────────────────────────────
+
+  it('renders the search input with correct placeholder', () => {
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('placeholder', expect.stringMatching(/cerca.*chunk/i));
+  });
+
+  it('renders the search input enabled when chunkCount > 0', () => {
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    expect(screen.getByRole('searchbox')).not.toBeDisabled();
+  });
+
+  it('shows the idle hint when no query has been submitted yet', () => {
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    // Hint text should be visible before any search
+    expect(screen.getByTestId('kb-chunk-search-idle')).toBeInTheDocument();
+  });
+
+  // ── Disabled state (chunkCount === 0) ──────────────────────────────────────
+
+  it('disables the input when chunkCount is 0', () => {
+    render(<KbChunkSearch docId="d" chunkCount={0} />);
+    expect(screen.getByRole('searchbox')).toBeDisabled();
+  });
+
+  it('shows a hint about no chunks when chunkCount is 0', () => {
+    render(<KbChunkSearch docId="d" chunkCount={0} />);
+    expect(screen.getByTestId('kb-chunk-search-no-chunks')).toBeInTheDocument();
+  });
+
+  // ── Submit + scored results ────────────────────────────────────────────────
+
+  it('submitting a query renders scored result rows sorted desc', async () => {
+    // Results returned out of order — component must sort desc
+    mockMutateAsync.mockResolvedValue({
+      results: [hitMid, hitHigh], // mid first, high second
+      errorMessage: null,
+    });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+
+    // Lower threshold to 0.5 so both 0.84 and 0.58 are visible
+    const thresholdSelect = screen.getByLabelText(/score/i);
+    fireEvent.change(thresholdSelect, { target: { value: '0.5' } });
+
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator activation');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('kb-chunk-search-results')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByTestId('kb-chunk-search-hit');
+    expect(rows).toHaveLength(2);
+
+    // First row should have the higher score
+    expect(rows[0]).toHaveTextContent('0.84');
+    // Second row should have the lower score
+    expect(rows[1]).toHaveTextContent('0.58');
+  });
+
+  it('result rows contain chunkIndex, pageNumber, score badge and snippet', async () => {
+    mockMutateAsync.mockResolvedValue({ results: [hitHigh], errorMessage: null });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => screen.getByTestId('kb-chunk-search-hit'));
+
+    const row = screen.getByTestId('kb-chunk-search-hit');
+    expect(row).toHaveTextContent('c-0218');
+    expect(row).toHaveTextContent('p.22');
+    expect(row).toHaveTextContent('0.84');
+    expect(row).toHaveTextContent('Quando più uccelli predatori');
+  });
+
+  it('renders null pageNumber gracefully (no "p." entry)', async () => {
+    mockMutateAsync.mockResolvedValue({
+      results: [{ ...hitHigh, pageNumber: null }],
+      errorMessage: null,
+    });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => screen.getByTestId('kb-chunk-search-hit'));
+    // Should not show "p." when pageNumber is null
+    expect(screen.queryByText(/p\.\d/)).not.toBeInTheDocument();
+  });
+
+  // ── Threshold filter ───────────────────────────────────────────────────────
+
+  it('threshold filter hides results below the threshold', async () => {
+    mockMutateAsync.mockResolvedValue({
+      results: [hitHigh, hitMid], // 0.84 and 0.58
+      errorMessage: null,
+    });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+
+    // Change threshold to 0.7 (default is 0.7; hitMid 0.58 should be hidden)
+    const thresholdSelect = screen.getByLabelText(/score/i);
+    fireEvent.change(thresholdSelect, { target: { value: '0.7' } });
+
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => screen.getByTestId('kb-chunk-search-results'));
+
+    // With threshold 0.7, only 0.84 should be visible (0.58 hidden)
+    expect(screen.getByText('0.84')).toBeInTheDocument();
+    expect(screen.queryByText('0.58')).not.toBeInTheDocument();
+  });
+
+  it('lowering threshold shows previously hidden results without refetch', async () => {
+    mockMutateAsync.mockResolvedValue({
+      results: [hitHigh, hitMid], // 0.84 and 0.58
+      errorMessage: null,
+    });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => screen.getByTestId('kb-chunk-search-results'));
+
+    // Initially threshold 0.7 — 0.58 hidden
+    expect(screen.queryByText('0.58')).not.toBeInTheDocument();
+
+    // Lower threshold to 0.5 — 0.58 should appear without another mutateAsync call
+    const initialCallCount = mockMutateAsync.mock.calls.length;
+    const thresholdSelect = screen.getByLabelText(/score/i);
+    fireEvent.change(thresholdSelect, { target: { value: '0.5' } });
+
+    await waitFor(() => expect(screen.getByText('0.58')).toBeInTheDocument());
+    // No additional API call
+    expect(mockMutateAsync.mock.calls.length).toBe(initialCallCount);
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────────────
+
+  it('empty results show empty state message', async () => {
+    mockMutateAsync.mockResolvedValue({ results: [], errorMessage: null });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'something obscure');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('kb-chunk-search-empty')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/nessun risultato/i)).toBeInTheDocument();
+  });
+
+  // ── Error states ───────────────────────────────────────────────────────────
+
+  it('errorMessage triggers an error toast and shows inline error message', async () => {
+    mockMutateAsync.mockResolvedValue({
+      results: [],
+      errorMessage: 'Document not indexed',
+    });
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('Document not indexed'));
+    });
+    expect(screen.getByTestId('kb-chunk-search-error')).toBeInTheDocument();
+    expect(screen.getByText(/Document not indexed/)).toBeInTheDocument();
+  });
+
+  it('mutation rejection triggers an error toast and shows inline error message', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('network error'));
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('kb-chunk-search-error')).toBeInTheDocument();
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  it('shows a loading indicator while the mutation is pending', async () => {
+    // Never resolves — stays pending
+    mockMutateAsync.mockReturnValue(new Promise(() => {}));
+    mockUseDocChunkSearch.mockReturnValue(makeMutation({ isPending: true }));
+
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    await userEvent.type(input, 'predator');
+    fireEvent.submit(input.closest('form')!);
+
+    expect(screen.getByTestId('kb-chunk-search-loading')).toBeInTheDocument();
+  });
+
+  // ── Does not submit empty query ────────────────────────────────────────────
+
+  it('does not call mutateAsync when the query is empty', () => {
+    render(<KbChunkSearch docId="doc-1" chunkCount={412} />);
+    const input = screen.getByRole('searchbox');
+    fireEvent.submit(input.closest('form')!);
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/utils/downloadAsFile.ts
+++ b/apps/web/src/components/admin/knowledge-base/explorer/utils/downloadAsFile.ts
@@ -1,0 +1,19 @@
+/**
+ * downloadAsFile — create an in-memory Blob and trigger a browser download.
+ *
+ * Extracted from IngestionActions.tsx so it can be shared by KbDocActions
+ * (export chunks JSON) and any future admin action that needs file download.
+ * Issue #1653.
+ */
+export function downloadAsFile(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/apps/web/src/components/ui/admin/__tests__/admin-confirmation-dialog.test.tsx
+++ b/apps/web/src/components/ui/admin/__tests__/admin-confirmation-dialog.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * AdminConfirmationDialog Tests
+ *
+ * Tests covering:
+ * 1. Level 1 dialog renders without typed-confirmation input
+ * 2. Level 2 dialog requires typing "CONFIRM" by default (backward compat)
+ * 3. Level 2 dialog with custom confirmPhrase enables confirm only when that phrase is typed
+ * 4. On-screen label reflects the required phrase (custom or default)
+ * 5. Dialog resets typed text when reopened
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { AdminConfirmationDialog, AdminConfirmationLevel } from '../admin-confirmation-dialog';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const noop = () => {};
+
+function renderLevel2(props: Partial<React.ComponentProps<typeof AdminConfirmationDialog>> = {}) {
+  return render(
+    <AdminConfirmationDialog
+      isOpen
+      level={AdminConfirmationLevel.Level2}
+      title="Delete"
+      message="Sure?"
+      onClose={noop}
+      onConfirm={noop}
+      {...props}
+    />
+  );
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('AdminConfirmationDialog', () => {
+  describe('Level 1', () => {
+    it('renders confirm button enabled without any typing', () => {
+      render(
+        <AdminConfirmationDialog
+          isOpen
+          level={AdminConfirmationLevel.Level1}
+          title="Warning"
+          message="Are you sure?"
+          onClose={noop}
+          onConfirm={noop}
+        />
+      );
+      const btn = screen.getByRole('button', { name: /confirm|conferma/i });
+      expect(btn).toBeEnabled();
+    });
+
+    it('does not render a textbox for Level 1', () => {
+      render(
+        <AdminConfirmationDialog
+          isOpen
+          level={AdminConfirmationLevel.Level1}
+          title="Warning"
+          message="Are you sure?"
+          onClose={noop}
+          onConfirm={noop}
+        />
+      );
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Level 2 — default phrase (backward compat)', () => {
+    it('confirm button is disabled initially', () => {
+      renderLevel2();
+      const btn = screen.getByRole('button', { name: /confirm|conferma/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it('defaults to requiring "CONFIRM" when confirmPhrase is omitted', () => {
+      renderLevel2();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'CONFIRM' } });
+      const btn = screen.getByRole('button', { name: /confirm|conferma/i });
+      expect(btn).toBeEnabled();
+    });
+
+    it('remains disabled when a different word is typed', () => {
+      renderLevel2();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'confirm' } });
+      const btn = screen.getByRole('button', { name: /confirm|conferma/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it('shows "CONFIRM" as the required phrase in the label', () => {
+      renderLevel2();
+      // The label should mention CONFIRM (default)
+      expect(screen.getByText(/CONFIRM/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Level 2 — custom confirmPhrase', () => {
+    it('enables confirm only when the custom confirmPhrase is typed', () => {
+      renderLevel2({ confirmPhrase: 'Wingspan.pdf' });
+      const confirmBtn = screen.getByRole('button', { name: /confirm|conferma|delete|elimina/i });
+      expect(confirmBtn).toBeDisabled();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Wingspan.pdf' } });
+      expect(confirmBtn).toBeEnabled();
+    });
+
+    it('remains disabled when the default "CONFIRM" word is typed instead of the custom phrase', () => {
+      renderLevel2({ confirmPhrase: 'Wingspan.pdf' });
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'CONFIRM' } });
+      const btn = screen.getByRole('button', { name: /confirm|conferma|delete|elimina/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it('shows the custom phrase in the prompt label', () => {
+      renderLevel2({ confirmPhrase: 'Wingspan.pdf' });
+      expect(screen.getByText('Wingspan.pdf')).toBeInTheDocument();
+    });
+
+    it('shows error hint with the custom phrase when wrong text is entered', () => {
+      renderLevel2({ confirmPhrase: 'Wingspan.pdf' });
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'wrong' } });
+      // The error hint paragraph (distinct from the label span) must contain the custom phrase
+      expect(
+        screen.getByText(/La parola deve corrispondere esattamente: Wingspan\.pdf/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('backward compatibility — omitting confirmPhrase', () => {
+    it('defaults to requiring "CONFIRM" when confirmPhrase is omitted (backward compat)', () => {
+      render(
+        <AdminConfirmationDialog
+          isOpen
+          level={AdminConfirmationLevel.Level2}
+          title="t"
+          message="m"
+          onClose={noop}
+          onConfirm={noop}
+        />
+      );
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'CONFIRM' } });
+      expect(
+        screen.getByRole('button', { name: /confirm|conferma|delete|elimina/i })
+      ).toBeEnabled();
+    });
+  });
+
+  describe('onClose / onConfirm callbacks', () => {
+    it('calls onClose when cancel button is clicked', () => {
+      const onClose = vi.fn();
+      renderLevel2({ onClose });
+      fireEvent.click(screen.getByRole('button', { name: /annulla|cancel/i }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onConfirm when confirm button is clicked after typing the required phrase', async () => {
+      const onConfirm = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+      renderLevel2({ onConfirm, onClose });
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'CONFIRM' } });
+      fireEvent.click(screen.getByRole('button', { name: /confirm|conferma|delete|elimina/i }));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx
+++ b/apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx
@@ -70,6 +70,12 @@ export interface AdminConfirmationDialogProps {
 
   /** Whether to show loading state on confirm button */
   isLoading?: boolean;
+
+  /**
+   * Phrase the user must type to enable confirm on Level2.
+   * Defaults to 'CONFIRM' when omitted (backward-compatible).
+   */
+  confirmPhrase?: string;
 }
 
 /**
@@ -86,11 +92,13 @@ export function AdminConfirmationDialog({
   confirmText,
   cancelText = 'Annulla',
   isLoading = false,
+  confirmPhrase,
 }: AdminConfirmationDialogProps) {
   const [typedConfirmation, setTypedConfirmation] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isLevel2 = level === AdminConfirmationLevel.Level2;
-  const isConfirmDisabled = isLevel2 && typedConfirmation !== 'CONFIRM';
+  const requiredPhrase = confirmPhrase ?? 'CONFIRM';
+  const isConfirmDisabled = isLevel2 && typedConfirmation !== requiredPhrase;
 
   // Reset typed confirmation and submission state when dialog opens
   useEffect(() => {
@@ -119,7 +127,9 @@ export function AdminConfirmationDialog({
   };
 
   const Icon = isLevel2 ? ShieldAlert : AlertTriangle;
-  const iconColor = isLevel2 ? 'text-red-600 dark:text-red-500' : 'text-yellow-600 dark:text-yellow-500';
+  const iconColor = isLevel2
+    ? 'text-red-600 dark:text-red-500'
+    : 'text-yellow-600 dark:text-yellow-500';
   const defaultConfirmText = isLevel2 ? 'Conferma Azione Critica' : 'Conferma';
 
   return (
@@ -148,22 +158,26 @@ export function AdminConfirmationDialog({
         {isLevel2 && (
           <div className="space-y-2 pt-2">
             <Label htmlFor="confirm-input" className="text-sm font-medium">
-              Digita <span className="font-mono font-bold text-red-600 dark:text-red-500">CONFIRM</span> per procedere:
+              Digita{' '}
+              <span className="font-mono font-bold text-red-600 dark:text-red-500">
+                {requiredPhrase}
+              </span>{' '}
+              per procedere:
             </Label>
             <Input
               id="confirm-input"
               type="text"
               value={typedConfirmation}
-              onChange={(e) => setTypedConfirmation(e.target.value)}
-              placeholder="CONFIRM"
+              onChange={e => setTypedConfirmation(e.target.value)}
+              placeholder={requiredPhrase}
               className="font-mono"
               autoFocus
               disabled={isLoading || isSubmitting}
-              aria-label="Type CONFIRM to proceed with critical action"
+              aria-label={`Type ${requiredPhrase} to proceed with critical action`}
             />
-            {typedConfirmation && typedConfirmation !== 'CONFIRM' && (
+            {typedConfirmation && typedConfirmation !== requiredPhrase && (
               <p className="text-xs text-red-600 dark:text-red-500">
-                La parola deve corrispondere esattamente: CONFIRM
+                La parola deve corrispondere esattamente: {requiredPhrase}
               </p>
             )}
           </div>

--- a/apps/web/src/hooks/queries/__tests__/useKbDocActions.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useKbDocActions.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useKbDocActions unit tests — Issue #1653 Task 4 (TDD).
+ *
+ * Coverage:
+ *   - useDeleteKbDoc: calls adminDeleteKbDoc(docId) and invalidates
+ *     kbGameDocumentKeys.byGame(gameId) + kbDocDetailKeys.all.
+ *   - useDeleteKbDoc with null gameId: still invalidates kbDocDetailKeys.all
+ *     but skips game-tree invalidation.
+ *   - useReindexDoc: calls reindexDocument(docId) and invalidates
+ *     kbDocDetailKeys.byId(docId) + kbChunksListKeys.all.
+ *   - useDocChunkSearch: calls searchDocChunks(docId, body) and returns results.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { kbDocDetailKeys } from '../useKbDocDetail';
+import { kbChunksListKeys } from '../useKbChunksList';
+import { kbGameDocumentKeys } from '../useGameDocuments';
+import { useDeleteKbDoc, useReindexDoc, useDocChunkSearch } from '../useKbDocActions';
+
+// ---------------------------------------------------------------------------
+// Mock api module
+// ---------------------------------------------------------------------------
+
+const mockAdminDeleteKbDoc = vi.fn();
+const mockReindexDocument = vi.fn();
+const mockSearchDocChunks = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: {
+      adminDeleteKbDoc: (...args: unknown[]) => mockAdminDeleteKbDoc(...args),
+      reindexDocument: (...args: unknown[]) => mockReindexDocument(...args),
+      searchDocChunks: (...args: unknown[]) => mockSearchDocChunks(...args),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const GAME_ID = 'game-aaaaaaaa-0000-0000-0000-000000000001';
+const DOC_ID = 'doc-bbbbbbbb-0000-0000-0000-000000000002';
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    qc,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe('useKbDocActions (Issue #1653 T4)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // useDeleteKbDoc
+  // -------------------------------------------------------------------------
+
+  describe('useDeleteKbDoc', () => {
+    it('calls adminDeleteKbDoc with the given docId', async () => {
+      mockAdminDeleteKbDoc.mockResolvedValueOnce(undefined);
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useDeleteKbDoc(GAME_ID), { wrapper });
+      await result.current.mutateAsync(DOC_ID);
+      expect(mockAdminDeleteKbDoc).toHaveBeenCalledWith(DOC_ID);
+    });
+
+    it('invalidates kbGameDocumentKeys.byGame and kbDocDetailKeys.all on success', async () => {
+      mockAdminDeleteKbDoc.mockResolvedValueOnce(undefined);
+      const { qc, wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+      const { result } = renderHook(() => useDeleteKbDoc(GAME_ID), { wrapper });
+      await result.current.mutateAsync(DOC_ID);
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: kbGameDocumentKeys.byGame(GAME_ID) })
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: kbDocDetailKeys.all })
+      );
+    });
+
+    it('still invalidates kbDocDetailKeys.all when gameId is null (no game-tree invalidation)', async () => {
+      mockAdminDeleteKbDoc.mockResolvedValueOnce(undefined);
+      const { qc, wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+      const { result } = renderHook(() => useDeleteKbDoc(null), { wrapper });
+      await result.current.mutateAsync(DOC_ID);
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: kbDocDetailKeys.all })
+      );
+      // Game-tree invalidation must NOT be called when gameId is null
+      const gameKeyCallArgs = invalidateSpy.mock.calls.find(
+        ([arg]) =>
+          JSON.stringify((arg as { queryKey?: unknown }).queryKey) ===
+          JSON.stringify(kbGameDocumentKeys.byGame(GAME_ID))
+      );
+      expect(gameKeyCallArgs).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // useReindexDoc
+  // -------------------------------------------------------------------------
+
+  describe('useReindexDoc', () => {
+    it('calls reindexDocument with the given docId', async () => {
+      mockReindexDocument.mockResolvedValueOnce(undefined);
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useReindexDoc(DOC_ID), { wrapper });
+      await result.current.mutateAsync();
+      expect(mockReindexDocument).toHaveBeenCalledWith(DOC_ID);
+    });
+
+    it('invalidates kbDocDetailKeys.byId(docId) and kbChunksListKeys.all on success', async () => {
+      mockReindexDocument.mockResolvedValueOnce(undefined);
+      const { qc, wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+      const { result } = renderHook(() => useReindexDoc(DOC_ID), { wrapper });
+      await result.current.mutateAsync();
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: kbDocDetailKeys.byId(DOC_ID) })
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: kbChunksListKeys.all })
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // useDocChunkSearch
+  // -------------------------------------------------------------------------
+
+  describe('useDocChunkSearch', () => {
+    const searchBody = { query: 'start player', topK: 5 };
+    const searchResponse = {
+      results: [
+        { chunkIndex: 3, pageNumber: 7, score: 0.87, snippet: 'The start player takes...' },
+      ],
+      errorMessage: null,
+    };
+
+    it('calls searchDocChunks with docId and body', async () => {
+      mockSearchDocChunks.mockResolvedValueOnce(searchResponse);
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useDocChunkSearch(DOC_ID), { wrapper });
+      await result.current.mutateAsync(searchBody);
+      expect(mockSearchDocChunks).toHaveBeenCalledWith(DOC_ID, searchBody);
+    });
+
+    it('returns the search results from the mutation', async () => {
+      mockSearchDocChunks.mockResolvedValueOnce(searchResponse);
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useDocChunkSearch(DOC_ID), { wrapper });
+      const data = await result.current.mutateAsync(searchBody);
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(data).toEqual(searchResponse);
+      expect(result.current.data?.results[0]?.snippet).toBe('The start player takes...');
+    });
+
+    it('supports optional topK and minScore fields in body', async () => {
+      const fullBody = { query: 'setup', topK: 10, minScore: 0.5 };
+      mockSearchDocChunks.mockResolvedValueOnce({ results: [], errorMessage: null });
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useDocChunkSearch(DOC_ID), { wrapper });
+      await result.current.mutateAsync(fullBody);
+      expect(mockSearchDocChunks).toHaveBeenCalledWith(DOC_ID, fullBody);
+    });
+  });
+});

--- a/apps/web/src/hooks/queries/useKbDocActions.ts
+++ b/apps/web/src/hooks/queries/useKbDocActions.ts
@@ -1,0 +1,104 @@
+/**
+ * useKbDocActions — TanStack Query mutation hooks for KB document admin actions
+ * (Issue #1653 F3-FU-4 Task 4).
+ *
+ * Hooks:
+ *   - useDeleteKbDoc(gameId)  — DELETE /api/v1/admin/pdfs/{docId} (cascade)
+ *   - useReindexDoc(docId)    — POST /api/v1/admin/pdfs/{docId}/reindex
+ *   - useDocChunkSearch(docId)— POST /api/v1/admin/kb/docs/{docId}/chunks/search
+ *
+ * Cache invalidation strategy:
+ *   - Delete:  kbGameDocumentKeys.byGame(gameId) + kbDocDetailKeys.all
+ *   - Reindex: kbDocDetailKeys.byId(docId)       + kbChunksListKeys.all
+ *   - Search:  mutation only — no cache side-effect needed
+ */
+
+'use client';
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { DocChunkSearchResult } from '@/lib/api/clients/pdfClient';
+
+import { kbGameDocumentKeys } from './useGameDocuments';
+import { kbChunksListKeys } from './useKbChunksList';
+import { kbDocDetailKeys } from './useKbDocDetail';
+
+export type { DocChunkSearchResult } from '@/lib/api/clients/pdfClient';
+
+// ---------------------------------------------------------------------------
+// useDeleteKbDoc
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a KB document with cascade (admin).
+ *
+ * @param gameId - Game UUID to invalidate the game-document tree after deletion,
+ *   or null when the caller does not know / care about the parent game scope.
+ *
+ * @example
+ * const { mutateAsync } = useDeleteKbDoc(gameId);
+ * await mutateAsync(docId);
+ */
+export function useDeleteKbDoc(gameId: string | null): UseMutationResult<void, Error, string> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (docId: string) => api.pdf.adminDeleteKbDoc(docId),
+    onSuccess: () => {
+      if (gameId) {
+        qc.invalidateQueries({ queryKey: kbGameDocumentKeys.byGame(gameId) });
+      }
+      qc.invalidateQueries({ queryKey: kbDocDetailKeys.all });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useReindexDoc
+// ---------------------------------------------------------------------------
+
+/**
+ * Trigger a reindex for a specific document (admin).
+ * Invalidates the detail view and the full chunks list for this doc.
+ *
+ * @example
+ * const { mutateAsync } = useReindexDoc(docId);
+ * await mutateAsync();
+ */
+export function useReindexDoc(docId: string): UseMutationResult<void, Error, void> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.pdf.reindexDocument(docId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: kbDocDetailKeys.byId(docId) });
+      qc.invalidateQueries({ queryKey: kbChunksListKeys.all });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useDocChunkSearch
+// ---------------------------------------------------------------------------
+
+export interface DocChunkSearchBody {
+  query: string;
+  topK?: number;
+  minScore?: number;
+}
+
+/**
+ * Run a scored similarity search against a document's embedded chunks (admin).
+ * Fire-and-forget mutation — results are returned via `data` / `mutateAsync`.
+ * No cache invalidation needed; each search is independent.
+ *
+ * @example
+ * const { mutateAsync, data } = useDocChunkSearch(docId);
+ * const result = await mutateAsync({ query: 'start player', topK: 5 });
+ */
+export function useDocChunkSearch(
+  docId: string
+): UseMutationResult<DocChunkSearchResult, Error, DocChunkSearchBody> {
+  return useMutation({
+    mutationFn: (body: DocChunkSearchBody) => api.pdf.searchDocChunks(docId, body),
+  });
+}

--- a/apps/web/src/lib/api/clients/pdfClient.ts
+++ b/apps/web/src/lib/api/clients/pdfClient.ts
@@ -357,6 +357,40 @@ export function createPdfClient({ httpClient }: CreatePdfClientParams) {
     },
 
     /**
+     * Delete a KB document by ID with cascade (admin) — Issue #1653.
+     * DELETE /api/v1/admin/pdfs/{docId} → 204
+     */
+    async adminDeleteKbDoc(pdfId: string): Promise<void> {
+      return httpClient.delete(`/api/v1/admin/pdfs/${encodeURIComponent(pdfId)}`);
+    },
+
+    /**
+     * Export all chunks for a KB document (admin) — Issue #1653.
+     * GET /api/v1/admin/kb/docs/{docId}/chunks/export
+     */
+    async exportDocChunks(pdfId: string): Promise<ExportedChunk[]> {
+      const result = await httpClient.get<ExportedChunk[]>(
+        `/api/v1/admin/kb/docs/${encodeURIComponent(pdfId)}/chunks/export`
+      );
+      return result ?? [];
+    },
+
+    /**
+     * Run a scored similarity search against a document's chunks (admin) — Issue #1653.
+     * POST /api/v1/admin/kb/docs/{docId}/chunks/search
+     */
+    async searchDocChunks(
+      pdfId: string,
+      body: { query: string; topK?: number; minScore?: number }
+    ): Promise<DocChunkSearchResult> {
+      const result = await httpClient.post<DocChunkSearchResult>(
+        `/api/v1/admin/kb/docs/${encodeURIComponent(pdfId)}/chunks/search`,
+        body
+      );
+      return result ?? { results: [], errorMessage: null };
+    },
+
+    /**
      * Purge stale documents stuck in processing (admin)
      */
     async purgeStaleDocuments(): Promise<{ purgedCount: number }> {
@@ -475,6 +509,31 @@ export interface ChunkedUploadStatusResult {
   totalChunks: number;
   progressPercentage: number;
   isComplete: boolean;
+}
+
+// ========== KB Doc Admin Types (Issue #1653) ==========
+
+/** A single exported chunk from GET /api/v1/admin/kb/docs/{id}/chunks/export */
+export interface ExportedChunk {
+  id: string;
+  chunkIndex: number;
+  pageNumber: number | null;
+  heading: string | null;
+  content: string;
+}
+
+/** A single hit returned by the chunk similarity-search endpoint */
+export interface DocChunkSearchHit {
+  chunkIndex: number;
+  pageNumber: number | null;
+  score: number;
+  snippet: string;
+}
+
+/** Response shape for POST /api/v1/admin/kb/docs/{id}/chunks/search */
+export interface DocChunkSearchResult {
+  results: DocChunkSearchHit[];
+  errorMessage: string | null;
 }
 
 export type PdfClient = ReturnType<typeof createPdfClient>;

--- a/docs/superpowers/plans/2026-05-29-kb-doc-actions.md
+++ b/docs/superpowers/plans/2026-05-29-kb-doc-actions.md
@@ -1,0 +1,594 @@
+# KB Doc-Panel Actions + Chunks Similarity-Search (F3-FU-4 #1653) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Re-index / Download / Delete / Export-chunks-JSON actions + per-document similarity-search to the admin KB explorer's `KbDocDetailPanel`, with actions reachable for `failed`/`processing` docs.
+
+**Architecture:** Backend adds 3 admin endpoints (delete-with-cascade, chunks-export, per-doc scored search) under the existing admin-gated groups, reusing `DeletePdfCommand` mechanics + the `IEmbeddingRepository` per-doc filter. Frontend adds an action-bar + search box to `KbDocDetailPanel`, threading the selected doc's `{title, gameId}` from `KbExplorer` so the locked-state restructure can render actions without a 423-contract change.
+
+**Tech Stack:** .NET 9 Minimal APIs + MediatR + EF Core (pgvector) + xUnit/Testcontainers · Next.js 16 + React 19 + TanStack Query + Tailwind + Vitest + Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md` (read it + its Addendum first).
+
+**Branch:** `feature/issue-1653-kb-doc-actions` (already created, parent `main-dev`).
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommand.cs` — admin delete w/ agent-cascade + audit
+- `…/DeleteKbDocumentCommandHandler.cs`
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQuery.cs` (+ Handler, + DTO)
+- `…/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQuery.cs` (+ Handler, + DTOs)
+
+**Backend (modify):**
+- `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs` — add `DELETE /{pdfId:guid}`
+- `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs` — add export + chunk-search endpoints
+- `…/KnowledgeBase/Domain/Repositories/IEmbeddingRepository.cs` — add `SearchByVectorWithScoresAsync`
+- `…/KnowledgeBase/Infrastructure/Persistence/EmbeddingRepository.cs` + `PgVectorStoreAdapter.cs` — implement score-returning search (additive)
+
+**Frontend (create):**
+- `apps/web/src/components/admin/knowledge-base/explorer/actions/KbDocActions.tsx` — hero action-bar
+- `apps/web/src/components/admin/knowledge-base/explorer/search/KbChunkSearch.tsx` — in-panel similarity-search
+- `apps/web/src/hooks/queries/useKbDocActions.ts` — `useDeleteKbDoc`, `useDocChunkSearch`
+- test files alongside each
+
+**Frontend (modify):**
+- `apps/web/src/lib/api/clients/pdfClient.ts` (+ a kb client) — new methods
+- `apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx` — optional `confirmPhrase`
+- `apps/web/src/components/admin/knowledge-base/explorer/KbExplorer.tsx` — thread `{title, gameId}` on select
+- `apps/web/src/components/admin/knowledge-base/explorer/KbTree.tsx` — `onSelectDoc(doc)` carries metadata
+- `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx` — locked-restructure + mount action-bar + search
+
+---
+
+## BACKEND
+
+### Task 1: Admin delete command with agent-cascade + audit
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocumentCommand.cs`
+- Create: `…/Commands/DeleteKbDocumentCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeleteKbDocumentCommandHandlerIntegrationTests.cs`
+
+> Read first: `DeletePdfCommandHandler.cs` (blob delete + cache-invalidate body to reuse), `AdminPdfManagementEndpoints.cs` (group + filter + reindex pattern), an existing `[AuditableAction]`+`[AtomicAudit]` command (e.g. a destructive admin command in Administration BC) for the exact attribute args, and `IAgentDefinitionRepository` (`GetByConsumedDocumentAsync`, `UpdateAsync`) + `AgentDefinition.UpdateKbCardIds`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```csharp
+// DeleteKbDocumentCommandHandlerIntegrationTests.cs (Testcontainers Postgres, follow sibling Integration test setup)
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Handle_RemovesDoc_ChunksVectors_AndDetachesFromConsumingAgents()
+{
+    // Arrange: seed a SharedGame + PdfDocument + VectorDocument + 2 TextChunks,
+    // and 2 AgentDefinitions whose KbCardIds contain the pdfDocId.
+    var pdfId = await SeedIndexedDocWithAgentsAsync(agentCount: 2);
+
+    // Act
+    await _mediator.Send(new DeleteKbDocumentCommand(pdfId));
+
+    // Assert
+    (await _db.PdfDocuments.FindAsync(pdfId)).Should().BeNull();
+    (await _db.TextChunks.CountAsync(c => c.PdfDocumentId == pdfId)).Should().Be(0);
+    (await _db.VectorDocuments.CountAsync(v => v.PdfDocumentId == pdfId)).Should().Be(0);
+    var agents = await _db.AgentDefinitions.ToListAsync();
+    agents.Should().OnlyContain(a => !a.KbCardIds.Contains(pdfId));
+}
+
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Handle_Throws_NotFound_WhenDocMissing()
+{
+    var act = async () => await _mediator.Send(new DeleteKbDocumentCommand(Guid.NewGuid()));
+    await act.Should().ThrowAsync<NotFoundException>();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeleteKbDocumentCommandHandlerIntegrationTests"`
+Expected: FAIL — `DeleteKbDocumentCommand` does not exist.
+
+- [ ] **Step 3: Create the command**
+
+```csharp
+// DeleteKbDocumentCommand.cs
+using Api.SharedKernel.Application.Interfaces;
+using Api.BoundedContexts.Administration.Application.Attributes;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+[AuditableAction("KbDocumentDelete", "Document", Level = 2)]
+[AtomicAudit]
+public sealed record DeleteKbDocumentCommand(Guid Id) : ICommand;
+```
+> The audit behavior auto-extracts `resourceId` from the command's `Id` property — name it `Id`.
+
+- [ ] **Step 4: Implement the handler**
+
+```csharp
+// DeleteKbDocumentCommandHandler.cs
+internal sealed class DeleteKbDocumentCommandHandler : ICommandHandler<DeleteKbDocumentCommand>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly IAgentDefinitionRepository _agents;
+    private readonly IVectorStore _vectorStore;          // PgVectorStoreAdapter — confirm exact iface name
+    private readonly IBlobStorageService _blob;
+    private readonly IAiResponseCacheService _cache;
+    private readonly ILogger<DeleteKbDocumentCommandHandler> _logger;
+    // ctor: assign + null-guard all (mirror DeletePdfCommandHandler)
+
+    public async Task Handle(DeleteKbDocumentCommand command, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var doc = await _db.PdfDocuments.FirstOrDefaultAsync(p => p.Id == command.Id, ct).ConfigureAwait(false)
+            ?? throw new NotFoundException($"PDF document {command.Id} not found");
+
+        // 1) Detach from consuming agents (D-1 = cascade)
+        var consuming = await _agents.GetByConsumedDocumentAsync(command.Id, ct).ConfigureAwait(false);
+        foreach (var agent in consuming)
+        {
+            agent.UpdateKbCardIds(agent.KbCardIds.Where(id => id != command.Id));
+            await _agents.UpdateAsync(agent, ct).ConfigureAwait(false);
+        }
+
+        // 2) Explicitly delete pgvector embeddings (NO FK cascade — see spec Addendum)
+        var vectorDocId = await _db.VectorDocuments
+            .Where(v => v.PdfDocumentId == command.Id).Select(v => (Guid?)v.Id)
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+        if (vectorDocId is Guid vId)
+            await _vectorStore.DeleteByVectorDocumentIdAsync(vId, ct).ConfigureAwait(false);
+
+        // 3) Remove the doc — EF cascade removes TextChunks + VectorDocument
+        var storageGameId = (doc.PrivateGameId ?? doc.SharedGameId)?.ToString() ?? string.Empty;
+        _db.PdfDocuments.Remove(doc);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);   // single commit: agent updates + delete
+
+        // 4) Best-effort blob + cache cleanup (reuse DeletePdfCommandHandler helpers verbatim)
+        await DeletePhysicalFileAsync(command.Id.ToString(), storageGameId, ct).ConfigureAwait(false);
+        await InvalidateCacheSafelyAsync(storageGameId, "KB doc deletion", ct).ConfigureAwait(false);
+    }
+    // copy DeletePhysicalFileAsync + InvalidateCacheSafelyAsync from DeletePdfCommandHandler
+}
+```
+> Verify exact `IVectorStore` interface name + `DeleteByVectorDocumentIdAsync` signature in `PgVectorStoreAdapter.cs`. Register the handler if the BC doesn't auto-scan (check how `DeletePdfCommandHandler` is registered).
+
+- [ ] **Step 5: Add the endpoint**
+
+```csharp
+// AdminPdfManagementEndpoints.cs — inside the /admin/pdfs group, next to reindex
+group.MapDelete("/{pdfId:guid}", DeleteKbDocument)
+    .WithName("DeleteKbDocument")
+    .WithSummary("Delete a KB document (cascade: detach from agents, remove chunks/vectors/blob, audited)");
+
+private static async Task<IResult> DeleteKbDocument(
+    Guid pdfId, IMediator mediator, CancellationToken ct)
+{
+    await mediator.Send(new DeleteKbDocumentCommand(pdfId), ct).ConfigureAwait(false);
+    return Results.NoContent();
+}
+```
+> `NotFoundException` → 404 is handled by the global exception mapper (#2568). Confirm the group already has `RequireAdminSessionFilter`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~DeleteKbDocumentCommandHandlerIntegrationTests"`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/DeleteKbDocument*.cs apps/api/src/Api/Routing/AdminPdfManagementEndpoints.cs apps/api/tests/Api.Tests/Integration/DocumentProcessing/DeleteKbDocumentCommandHandlerIntegrationTests.cs
+git commit -m "feat(admin-kb): #1653 admin delete KB doc with agent-cascade + audit"
+```
+
+---
+
+### Task 2: Export document chunks (full content) endpoint
+
+**Files:**
+- Create: `…/KnowledgeBase/Application/Queries/ExportDocumentChunks/ExportDocumentChunksQuery.cs` (record `ExportDocumentChunksQuery(Guid PdfDocumentId) : IQuery<IReadOnlyList<ExportedChunkDto>>`)
+- Create: `…/ExportDocumentChunksQueryHandler.cs`, `…/ExportedChunkDto.cs`
+- Modify: `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/KnowledgeBase/ExportDocumentChunksQueryHandlerIntegrationTests.cs`
+
+> Read first: `TextChunkEntity.cs` (fields: `Content`, `ChunkIndex`, `PageNumber`, `Heading`), `GetKbChunks` handler for the fetch idiom, and `AdminKnowledgeBaseEndpoints.cs:75-86` (the `docs/{docId}/ingestion-log` endpoint) for the endpoint shape.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Handle_ReturnsAllChunks_FullContent_OrderedByIndex()
+{
+    var pdfId = await SeedDocWithChunksAsync(count: 3); // contents "A","B","C" at indexes 0,1,2
+    var result = await _mediator.Send(new ExportDocumentChunksQuery(pdfId));
+    result.Select(c => c.Content).Should().ContainInOrder("A", "B", "C");
+    result.Should().HaveCount(3);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ExportDocumentChunksQueryHandlerIntegrationTests"`
+Expected: FAIL — query not defined.
+
+- [ ] **Step 3: Implement DTO + query + handler**
+
+```csharp
+public sealed record ExportedChunkDto(Guid Id, int ChunkIndex, int? PageNumber, string? Heading, string Content);
+
+internal sealed class ExportDocumentChunksQueryHandler
+    : IQueryHandler<ExportDocumentChunksQuery, IReadOnlyList<ExportedChunkDto>>
+{
+    private readonly MeepleAiDbContext _db; // ctor inject + null-guard
+    public async Task<IReadOnlyList<ExportedChunkDto>> Handle(ExportDocumentChunksQuery q, CancellationToken ct)
+        => await _db.TextChunks.AsNoTracking()
+            .Where(c => c.PdfDocumentId == q.PdfDocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Select(c => new ExportedChunkDto(c.Id, c.ChunkIndex, c.PageNumber, c.Heading, c.Content))
+            .ToListAsync(ct).ConfigureAwait(false);
+}
+```
+
+- [ ] **Step 4: Add endpoint**
+
+```csharp
+// AdminKnowledgeBaseEndpoints.cs (kbGroup)
+kbGroup.MapGet("/docs/{docId:guid}/chunks/export", async (Guid docId, IMediator m, CancellationToken ct) =>
+{
+    var chunks = await m.Send(new ExportDocumentChunksQuery(docId), ct).ConfigureAwait(false);
+    return Results.Ok(chunks);
+}).WithName("ExportKbDocChunks").WithSummary("Export all chunks (full content) for a document as JSON.");
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ExportDocumentChunksQueryHandlerIntegrationTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ExportDocumentChunks/ apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/KnowledgeBase/ExportDocumentChunksQueryHandlerIntegrationTests.cs
+git commit -m "feat(admin-kb): #1653 export document chunks (full content) endpoint"
+```
+
+---
+
+### Task 3: Per-document scored similarity-search
+
+**Files:**
+- Modify: `…/KnowledgeBase/Domain/Repositories/IEmbeddingRepository.cs` (+ `EmbeddingRepository.cs`, `PgVectorStoreAdapter.cs`)
+- Create: `…/KnowledgeBase/Application/Queries/SearchDocumentChunks/SearchDocumentChunksByVectorQuery.cs` (+ Handler + DTOs)
+- Modify: `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`
+- Test: `…/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs`
+
+> Read first: `PgVectorStoreAdapter.SearchAsync` (it computes `1-(vec<=>q) AS similarity` and discards it — you will surface it additively), `IEmbeddingService.GenerateEmbeddingAsync` + `Vector` ctor, `VectorDocumentEntity` (`Id`,`PdfDocumentId`,`GameId`), and `VectorSemanticSearchQueryHandler` for the embed→search→map idiom.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Handle_ReturnsScoredHits_ForDoc_OrderedByScoreDesc()
+{
+    var pdfId = await SeedIndexedDocAsync(); // a doc with embedded chunks in pgvector
+    var result = await _mediator.Send(
+        new SearchDocumentChunksByVectorQuery(pdfId, "predator activation", TopK: 5, MinScore: 0.0));
+    result.ErrorMessage.Should().BeNull();
+    result.Results.Should().NotBeEmpty();
+    result.Results.Select(r => r.Score).Should().BeInDescendingOrder();
+}
+
+[Fact]
+[Trait("Category", "Integration")]
+public async Task Handle_ReturnsError_WhenDocNotIndexed()
+{
+    var result = await _mediator.Send(
+        new SearchDocumentChunksByVectorQuery(Guid.NewGuid(), "x", 5, 0.0));
+    result.Results.Should().BeEmpty();
+    result.ErrorMessage.Should().NotBeNull();
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~SearchDocumentChunksQueryHandlerIntegrationTests"`
+Expected: FAIL — query + repo method missing.
+
+- [ ] **Step 3: Add the score-returning repo method (additive)**
+
+```csharp
+// IEmbeddingRepository.cs — new method (do NOT change existing SearchByVectorAsync)
+Task<IReadOnlyList<ScoredEmbedding>> SearchByVectorWithScoresAsync(
+    Guid gameId, Vector queryVector, int topK, double minScore,
+    IReadOnlyList<Guid>? documentIds = null, CancellationToken ct = default);
+```
+```csharp
+// new value record (Domain or Application)
+public sealed record ScoredEmbedding(Embedding Embedding, double Score);
+```
+Implement in `EmbeddingRepository.cs` by delegating to a new adapter method that reads the similarity column the existing `SearchAsync` already SELECTs (`1-(vector<=>q) AS similarity`) but currently drops. In `PgVectorStoreAdapter`, copy `SearchAsync` to `SearchWithScoresAsync` and project the similarity value (column 7) into `ScoredEmbedding` instead of discarding it. Keep `SearchAsync` unchanged (existing RAG callers).
+
+- [ ] **Step 4: Add DTOs + query + handler**
+
+```csharp
+public sealed record DocChunkSearchHit(int ChunkIndex, int? PageNumber, double Score, string Snippet);
+public sealed record SearchDocumentChunksResultDto(IReadOnlyList<DocChunkSearchHit> Results, string? ErrorMessage);
+
+internal sealed record SearchDocumentChunksByVectorQuery(
+    Guid PdfDocumentId, string Query, int TopK, double MinScore)
+    : IQuery<SearchDocumentChunksResultDto>;
+
+internal sealed class SearchDocumentChunksByVectorQueryHandler
+    : IQueryHandler<SearchDocumentChunksByVectorQuery, SearchDocumentChunksResultDto>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly IEmbeddingService _embeddings;
+    private readonly IEmbeddingRepository _repo; // ctor inject + null-guard
+
+    public async Task<SearchDocumentChunksResultDto> Handle(SearchDocumentChunksByVectorQuery q, CancellationToken ct)
+    {
+        var vd = await _db.VectorDocuments.AsNoTracking()
+            .Where(v => v.PdfDocumentId == q.PdfDocumentId)
+            .Select(v => new { v.Id, v.GameId })
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+        if (vd is null)
+            return new SearchDocumentChunksResultDto(Array.Empty<DocChunkSearchHit>(), "Document not indexed");
+
+        var emb = await _embeddings.GenerateEmbeddingAsync(q.Query, ct).ConfigureAwait(false);
+        if (!emb.Success || emb.Embeddings.Count == 0)
+            return new SearchDocumentChunksResultDto(Array.Empty<DocChunkSearchHit>(), "Embedding failed");
+
+        var hits = await _repo.SearchByVectorWithScoresAsync(
+            vd.GameId, new Vector(emb.Embeddings[0]),
+            Math.Clamp(q.TopK, 1, 100), q.MinScore,
+            documentIds: new[] { vd.Id }, ct).ConfigureAwait(false);
+
+        var results = hits
+            .OrderByDescending(h => h.Score)
+            .Select(h => new DocChunkSearchHit(
+                h.Embedding.ChunkIndex, h.Embedding.PageNumber, h.Score,
+                Truncate(h.Embedding.TextContent, 240)))
+            .ToList();
+        return new SearchDocumentChunksResultDto(results, null);
+    }
+    private static string Truncate(string s, int n) => s.Length <= n ? s : s[..n] + "…";
+}
+```
+> Confirm `EmbeddingResult` property names (`Success`, `Embeddings`) against `IEmbeddingService.cs`. Confirm `VectorDocumentEntity.GameId` is non-null (else resolve game via PdfDocument).
+
+- [ ] **Step 5: Add endpoint**
+
+```csharp
+// AdminKnowledgeBaseEndpoints.cs (kbGroup)
+kbGroup.MapPost("/docs/{docId:guid}/chunks/search", async (
+    Guid docId, [FromBody] DocChunkSearchRequest req, IMediator m, CancellationToken ct) =>
+{
+    var r = await m.Send(new SearchDocumentChunksByVectorQuery(
+        docId, req.Query, req.TopK ?? 10, req.MinScore ?? 0.0), ct).ConfigureAwait(false);
+    return Results.Ok(r);
+}).WithName("SearchKbDocChunks").WithSummary("Per-document semantic chunk search (scored).");
+// record DocChunkSearchRequest(string Query, int? TopK, double? MinScore);
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~SearchDocumentChunksQueryHandlerIntegrationTests"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/ apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
+git commit -m "feat(admin-kb): #1653 per-document scored similarity-search endpoint"
+```
+
+---
+
+## FRONTEND
+
+### Task 4: API client methods + action/search hooks
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/pdfClient.ts` (+ kb client if export/search belong there)
+- Create: `apps/web/src/hooks/queries/useKbDocActions.ts`
+- Test: `apps/web/src/hooks/queries/__tests__/useKbDocActions.test.ts`
+
+> Read first: `pdfClient.ts` (mirror `reindexDocument`/`getPdfDownloadUrl`), `client.ts` (`post`/`delete`/`get` signatures), `useKbHub.ts` (`useMutation`+invalidate pattern), and the key factories `kbDocDetailKeys`, `kbChunksListKeys`, `kbGameDocumentKeys`.
+
+- [ ] **Step 1: Write failing hook tests** (Vitest, mock `api.pdf`/`api.kb` + `useQueryClient`)
+
+```ts
+it('useDeleteKbDoc calls DELETE /admin/pdfs/{id} and invalidates tree + detail', async () => {
+  const del = vi.fn().mockResolvedValue(undefined);
+  // arrange mock api.pdf.adminDeleteKbDoc = del; spy invalidateQueries
+  const { result } = renderHook(() => useDeleteKbDoc(gameId), { wrapper });
+  await act(() => result.current.mutateAsync(docId));
+  expect(del).toHaveBeenCalledWith(docId);
+  expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: kbGameDocumentKeys.byGame(gameId) });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — Run: `pnpm test src/hooks/queries/__tests__/useKbDocActions.test.ts` — Expected: FAIL.
+
+- [ ] **Step 3: Add client methods**
+
+```ts
+// pdfClient.ts
+adminDeleteKbDoc: (pdfId: string): Promise<void> =>
+  httpClient.delete(`/api/v1/admin/pdfs/${pdfId}`),
+exportDocChunks: (pdfId: string) =>
+  httpClient.get<ExportedChunk[]>(`/api/v1/admin/kb/docs/${pdfId}/chunks/export`),
+searchDocChunks: (pdfId: string, body: { query: string; topK?: number; minScore?: number }) =>
+  httpClient.post<DocChunkSearchResult>(`/api/v1/admin/kb/docs/${pdfId}/chunks/search`, body),
+// getPdfDownloadUrl already exists → reuse for FR-2
+```
+
+- [ ] **Step 4: Add hooks**
+
+```ts
+// useKbDocActions.ts
+export function useDeleteKbDoc(gameId: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (docId: string) => api.pdf.adminDeleteKbDoc(docId),
+    onSuccess: () => {
+      if (gameId) qc.invalidateQueries({ queryKey: kbGameDocumentKeys.byGame(gameId) });
+      qc.invalidateQueries({ queryKey: kbDocDetailKeys.all });
+    },
+  });
+}
+export function useDocChunkSearch(docId: string) {
+  return useMutation({
+    mutationFn: (body: { query: string; topK?: number; minScore?: number }) =>
+      api.pdf.searchDocChunks(docId, body),
+  });
+}
+```
+> Re-index uses the existing `api.pdf.reindexDocument`; wrap with a small `useReindexDoc(docId, gameId)` invalidating `kbDocDetailKeys.byId(docId)` + `kbChunksListKeys.all`.
+
+- [ ] **Step 5: Run to verify pass** — Expected: PASS.
+- [ ] **Step 6: Commit** — `git commit -m "feat(admin-kb): #1653 FE api client methods + doc-action hooks"`
+
+---
+
+### Task 5: Extend AdminConfirmationDialog with `confirmPhrase`
+
+**Files:**
+- Modify: `apps/web/src/components/ui/admin/admin-confirmation-dialog.tsx`
+- Test: its existing test file (or create one)
+
+> Read first: the component — it hardcodes `typedConfirmation !== 'CONFIRM'`.
+
+- [ ] **Step 1: Failing test** — typing the filename (not "CONFIRM") enables Confirm when `confirmPhrase={filename}`.
+
+```tsx
+it('enables confirm when the custom confirmPhrase is typed', () => {
+  render(<AdminConfirmationDialog isOpen level={AdminConfirmationLevel.Level2}
+    confirmPhrase="Wingspan.pdf" title="t" message="m" onClose={()=>{}} onConfirm={()=>{}} />);
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Wingspan.pdf' } });
+  expect(screen.getByRole('button', { name: /confirm|conferma/i })).toBeEnabled();
+});
+```
+
+- [ ] **Step 2: Run fail.**
+- [ ] **Step 3: Implement** — add optional `confirmPhrase?: string` prop; `const phrase = confirmPhrase ?? 'CONFIRM'; const isConfirmDisabled = isLevel2 && typedConfirmation !== phrase;` Render the phrase in the prompt label.
+- [ ] **Step 4: Run pass.**
+- [ ] **Step 5: Commit** — `git commit -m "feat(admin): #1653 AdminConfirmationDialog optional confirmPhrase"`
+
+---
+
+### Task 6: KbDocActions action-bar component
+
+**Files:**
+- Create: `…/explorer/actions/KbDocActions.tsx`
+- Test: `…/explorer/actions/__tests__/KbDocActions.test.tsx`
+
+> Props: `{ docId: string; fileName: string; gameId: string | null; processingStatus: KbProcessingStatus; usedByCount?: number }`. Toast = `sonner`. Download = `<a href={api.pdf.getPdfDownloadUrl(docId)} download>` (cookie auth). Export = `downloadAsFile(JSON.stringify(chunks,null,2), `${fileName}-chunks.json`)` (helper from `IngestionActions.tsx` — extract to a shared util `explorer/utils/downloadAsFile.ts` and import in both). Used-by = `<Link href={`/admin/knowledge-base?docId=${docId}&tab=used-by`}>`.
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+it('disables Re-index while processing', () => {
+  render(<KbDocActions {...base} processingStatus="processing" />);
+  expect(screen.getByRole('button', { name: /re-index/i })).toBeDisabled();
+});
+it('Delete opens typed-confirm showing agent count and deletes on confirm', async () => {
+  // mock useDeleteKbDoc; render with usedByCount={3}; click Delete;
+  // expect dialog text /3 agent/i; type fileName; confirm; expect mutate called with docId
+});
+it('Export downloads JSON via exportDocChunks', async () => { /* mock exportDocChunks + downloadAsFile */ });
+```
+
+- [ ] **Step 2: Run fail.**
+- [ ] **Step 3: Implement** the action-bar: 5 buttons with `type="button"` + `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`; destructive Delete uses `bg-destructive text-destructive-foreground`; Re-index `disabled={processingStatus==='processing'||processingStatus==='queued'||isPending}` + `toast.success/error`; Delete renders `AdminConfirmationDialog` with `confirmPhrase={fileName}` and `warningMessage={`Referenced by ${usedByCount} agent(s) — they will be detached.`}`.
+- [ ] **Step 4: Run pass.**
+- [ ] **Step 5: Commit** — `git commit -m "feat(admin-kb): #1653 KbDocActions action-bar (reindex/download/delete/export/used-by)"`
+
+---
+
+### Task 7: Thread selected doc `{title, gameId}` from KbExplorer → panel
+
+**Files:**
+- Modify: `…/explorer/KbTree.tsx` (`onSelectDoc` carries `{ id, title, gameId }`), `…/explorer/KbExplorer.tsx` (store `selectedDoc`), `…/explorer/KbDocDetailPanel.tsx` (accept optional `selectedDocMeta`)
+- Test: update `KbTree`/`KbExplorer` tests
+
+> Read first: `KbTree.tsx` `onSelectDoc` call site + `KbExplorer.tsx` selection state.
+
+- [ ] **Step 1: Failing test** — selecting a doc passes `{id,title,gameId}` to the panel.
+- [ ] **Step 2: Run fail.**
+- [ ] **Step 3: Implement** — change `onSelectDoc: (doc: { id: string; title: string; gameId: string }) => void`; `KbExplorer` keeps `selectedDoc` and passes `selectedDocMeta={selectedDoc}` to `KbDocDetailPanel`. Keep URL `?docId=` as the source of truth for `docId`; metadata is the in-memory companion.
+- [ ] **Step 4: Run pass.**
+- [ ] **Step 5: Commit** — `git commit -m "refactor(admin-kb): #1653 thread selected doc title+gameId to detail panel"`
+
+---
+
+### Task 8: Locked-restructure + mount action-bar in KbDocDetailPanel
+
+**Files:**
+- Modify: `…/explorer/KbDocDetailPanel.tsx`
+- Test: `…/explorer/__tests__/KbDocDetailPanel.test.tsx`
+
+> Read first: current locked early-return (lines ~92-115) + the Used-by-through-locked branch.
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+it('renders the action-bar for a failed/locked doc (actions reachable)', () => {
+  mockUseKbDocDetail.mockReturnValue({ data: { status: 'locked', processingStatus: 'failed', doc: null } });
+  render(<KbDocDetailPanel docId="d1" selectedDocMeta={{ id:'d1', title:'X.pdf', gameId:'g1' }} />, { wrapper });
+  expect(screen.getByRole('button', { name: /re-index/i })).toBeInTheDocument();
+  expect(screen.getByText(/in elaborazione/i)).toBeInTheDocument();
+});
+it('ready doc still renders full hero + chunks (unchanged)', () => { /* status:'ready' */ });
+```
+
+- [ ] **Step 2: Run fail.**
+- [ ] **Step 3: Implement** — restructure: when `locked`, render `<KbDocDetailTabs>` + a slim hero (`selectedDocMeta.title` + `processingStatus` chip) + `<KbDocActions docId fileName={selectedDocMeta.title} gameId={selectedDocMeta.gameId} processingStatus={envelope.processingStatus} />` + the existing amber notice (Export/search disabled when not ready). When `ready`, render `<KbDocActions>` in the hero header (the `<div style="display:flex;gap:6px">` slot from the mockup) + existing chunks. Preserve the Used-by-through-locked branch.
+- [ ] **Step 4: Run pass** (+ full panel suite green).
+- [ ] **Step 5: Commit** — `git commit -m "feat(admin-kb): #1653 reachable actions on failed docs (locked-restructure)"`
+
+---
+
+### Task 9: In-panel chunk similarity-search
+
+**Files:**
+- Create: `…/explorer/search/KbChunkSearch.tsx`
+- Modify: `…/explorer/KbDocDetailPanel.tsx` (mount in Overview, ready only)
+- Test: `…/explorer/search/__tests__/KbChunkSearch.test.tsx`
+
+> Uses `useDocChunkSearch(docId)`. Mockup L168-221: search box, score-threshold filter (default ≥0.7), results rows (chunk index, page, score badge, snippet).
+
+- [ ] **Step 1: Failing tests** — submitting a query renders scored rows; threshold filter hides low scores; empty result shows empty state; renders disabled when `chunkCount===0`.
+- [ ] **Step 2: Run fail.**
+- [ ] **Step 3: Implement** — debounced (300ms) search box; on submit call mutation; render `results.filter(r => r.score >= threshold)` sorted desc; score badge color by tier (hue utilities, not neutral). Empty/loading/error states + `toast.error` on failure.
+- [ ] **Step 4: Run pass.**
+- [ ] **Step 5: Commit** — `git commit -m "feat(admin-kb): #1653 in-panel chunk similarity-search"`
+
+---
+
+### Task 10: E2E smoke
+
+**Files:**
+- Create: `apps/web/e2e/admin/kb-doc-actions.spec.ts`
+
+> Follow existing explorer E2E smoke (`thread-view-smoke`-style). Keep minimal.
+
+- [ ] **Step 1: Write smoke** — login admin → open `/admin/knowledge-base` → select a doc → assert action-bar visible; click Re-index → assert toast/processing; (optionally) select a failed doc → assert actions reachable.
+- [ ] **Step 2: Run** `pnpm test:e2e admin/kb-doc-actions.spec.ts` (or note CI-only if local infra absent).
+- [ ] **Step 3: Commit** — `git commit -m "test(admin-kb): #1653 E2E smoke for doc actions"`
+
+---
+
+## Self-Review (run before execution)
+
+- **Spec coverage:** FR-1 reindex→T4/T6/T8 · FR-2 download→T6 · FR-3 delete+cascade+typed-confirm→T1/T5/T6 · FR-4 export→T2/T6 · FR-5 search→T3/T9 · B5 used-by link→T6 · O-1 locked-restructure→T7/T8. ✅ all covered.
+- **Type consistency:** `DeleteKbDocumentCommand(Guid Id)` (Id name required for audit) · `ScoredEmbedding(Embedding, double Score)` · `DocChunkSearchHit(ChunkIndex, PageNumber, Score, Snippet)` · FE `selectedDocMeta {id,title,gameId}` used identically in T7/T8.
+- **Open items to confirm at execution** (read-and-confirm, not placeholders): exact `IVectorStore` iface + `DeleteByVectorDocumentIdAsync` signature; `EmbeddingResult` property names; `AdminConfirmationDialog` exact prop/textbox role; handler DI registration idiom in each BC; whether `VectorDocumentEntity.GameId` is non-null.
+- **D-1** = cascade (option b) implemented in T1 step 4. **Score gap** fixed additively in T3 step 3 (existing RAG `SearchAsync` untouched).
+- **Test baseline:** must not grow unit-fail count above zero (CLAUDE.md policy). Backend integration tests need Docker (Testcontainers).

--- a/docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md
+++ b/docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md
@@ -1,0 +1,182 @@
+# SP5 Admin KB — F3-FU-4: doc-panel actions + chunks similarity-search
+
+**Issue**: [#1653](https://github.com/meepleAi-app/meepleai-monorepo/issues/1653) (P3, area/backend + area/frontend)
+**Date**: 2026-05-29
+**Status**: REVIEWED (spec-panel 2026-05-29) — scope confirmed, ready for plan
+**Parent**: F3.1 Explorer (PR #1649) · siblings FU-1 #1650 ✅, FU-2 #1651 ✅, FU-3 #1652 ✅, FU-5 #1654, FU-6 #1655
+**Mockup**: `admin-mockups/design_handoff_admin/admin/sp5-admin-kb.html` (lines 127-244)
+
+---
+
+## 1. Context & Goal
+
+`KbDocDetailPanel` (right pane of `/admin/knowledge-base` explorer) renders a read-only hero +
+chunk list (Overview), Ingestion-log (FU-1) and Used-by (FU-2) tabs. It has **no operational
+actions** on the selected document.
+
+**Goal**: let admins act on a KB document from the explorer — re-index, download the original,
+delete — plus in-panel chunk discovery via similarity search.
+
+## 2. Current state (evidence)
+
+- `docId` in `KbTree` == **PdfDocumentId** (`AdminKnowledgeBaseEndpoints.cs:85` comment).
+- `useKbDocDetail` → `GET /api/v1/kb-docs/{docId}` → `KbDocDetailSchema` (`kb-chunks.schemas.ts:33`).
+- `KbDocDetailPanel.tsx` early-returns a "Documento in elaborazione" banner when `status === 'locked'`
+  **before** the Overview hero renders (inherited #1649). Used-by tab is allowed through during locked.
+- `DeletePdfCommand` already exists (`DocumentProcessing` BC) — **hard delete**: removes PdfDocument
+  record + VectorDocument (pgvector) + physical blob + invalidates cache. Wired today only at
+  `DELETE /admin/sandbox/pdfs/{id}`. **Does NOT touch TextChunks, and does NOT handle agents that
+  reference the doc** (dangling KbCardIds).
+- `ReindexDocumentCommand` exists (`POST /admin/pdfs/{pdfId}/reindex`) — deletes chunks, resets to
+  Pending, re-enqueues. **No guard against re-indexing a doc already processing.**
+- `PdfDocumentEntity` carries `FileSizeBytes`, `LanguageConfidence`, `VersionLabel` — but **not**
+  indexer-version, chunk-level avg-confidence, OCR flag, or chunk-token-size.
+- `vector-search` (`POST /admin/kb/vector-search`) filters by **GameId, not docId**.
+
+## 3. Scope (confirmed with user 2026-05-29)
+
+Surface = **hero buttons** (mockup-faithful). Phasing decision = **Phase 1 + Phase 2 together**.
+
+### In scope (FU-4)
+- **A1 Re-index** — wire existing `POST /admin/pdfs/{docId}/reindex` ✅
+- **A2 Download original** — wire existing `GET /pdfs/{docId}/download` ✅
+- **A3 Delete** — NEW `DELETE /api/v1/admin/pdfs/{docId}` (reuse `DeletePdfCommand`) + typed-confirm + agent-reference handling (see FR-3 / D-1)
+- **B5 Used-by link** — link to existing Used-by tab (FU-2) ✅
+- **B3 Export chunks JSON** — NEW export endpoint (full chunk content)
+- **C Similarity-search in doc** — extend vector-search with a per-doc filter
+- **O-1 mitigation** — restructure the `locked` early-return so Re-index/Delete reach `failed`/`processing` docs
+
+### Spun out of FU-4 (net-new backend features → separate sub-issues of #1653)
+- **B1 Re-index w/ version** ([#1673](https://github.com/meepleAi-app/meepleai-monorepo/issues/1673)) — needs versioned indexer (no foundation)
+- **B2 View embeddings** ([#1674](https://github.com/meepleAi-app/meepleai-monorepo/issues/1674)) — needs per-doc embeddings API (no foundation; corpus-leak risk per Newman)
+- **B4 Quality eval** ([#1675](https://github.com/meepleAi-app/meepleai-monorepo/issues/1675)) — needs per-doc eval pipeline (only global `/admin/rag-quality/report` exists)
+- **D Hero metadata enrichment** ([#1676](https://github.com/meepleAi-app/meepleai-monorepo/issues/1676)) — DTO + data extension (Phase 3; some fields absent on entity)
+
+### Out of scope
+- KB tool-pages re-skin (FU-3), Preview/PDF-viewer (FU-5), SubNav badges (FU-6), cross-doc bulk actions.
+
+## 4. Backend feasibility map (post-recon)
+
+| # | Action | Endpoint | Status |
+|---|--------|----------|--------|
+| A1 | Re-index | `POST /api/v1/admin/pdfs/{docId}/reindex` | ✅ exists |
+| A2 | Download | `GET /api/v1/pdfs/{docId}/download` | ✅ exists |
+| A3 | Delete | NEW `DELETE /api/v1/admin/pdfs/{docId}` reusing `DeletePdfCommand` | ⚠️ endpoint + agent-ref handling |
+| B3 | Export chunks JSON | NEW `GET /api/v1/admin/kb/docs/{docId}/chunks/export` (full content) | ⚠️ new endpoint |
+| B5 | Used-by link | FU-2 `/admin/kb/docs/{docId}/agents` | ✅ done |
+| C | Similarity-search in doc | extend `VectorSemanticSearchQuery` with `DocId`/`PdfId` filter | ⚠️ query + endpoint param |
+
+## 5. Functional requirements (testable — Adzic/Wiegers)
+
+**FR-1 Re-index**
+```
+Given a doc in state ready|failed
+When admin clicks ⟳ Re-index
+Then POST /admin/pdfs/{docId}/reindex is called; button enters disabled/pending;
+  on 2xx a success toast shows and doc detail + tree queries invalidate (doc → processing);
+  on error an error toast shows and the button re-enables.
+Given a doc already in state processing|queued
+Then the Re-index button is disabled (guard for O-5; backend has no guard).
+```
+
+**FR-2 Download**
+```
+Given a doc with a stored original
+When admin clicks ⤓ Download
+Then the browser downloads the original PDF via GET /pdfs/{docId}/download.
+Given the blob is missing (404) or forbidden (403)
+Then an error toast shows; no silent failure.
+```
+
+**FR-3 Delete** (destructive)
+```
+Given a doc "Wingspan-Oceania-EN.pdf" referenced by N agents (N from Used-by/FU-2)
+When admin clicks 🗑 Delete
+Then a typed-confirm dialog opens showing the impact ("referenced by N agents") and requires
+  typing the filename to enable Confirm.
+When admin confirms
+Then DELETE /admin/pdfs/{docId} hard-deletes the doc (record + vectors + blob + chunks),
+  the selection clears, the tree refreshes, and an audit entry is written (actor, docId, N).
+```
+> **D-1 (decision required at plan three-amigos)**: agent-reference behavior on delete —
+> (a) block delete while N>0, (b) warn + cascade-remove the doc from the N agents' KbCards,
+> (c) warn-only and leave dangling refs (current `DeletePdfCommand` behavior). The existing
+> command does **not** clean agent refs → (c) is the as-is risk; recommend (a) or (b).
+> Also confirm: does delete need to remove `TextChunks` (current handler only removes `VectorDocuments`)?
+
+**FR-4 Export chunks JSON**
+```
+Given a ready doc with M chunks
+When admin clicks ⤓ Export chunks JSON
+Then the full chunk set (id, position, headingPath, page, full content) downloads as
+  {docId}-chunks.json. (Snippet-only FE assembly is rejected — lossy; needs a real endpoint.)
+```
+
+**FR-5 Similarity-search in doc**
+```
+Given a ready doc and a query "predator activation"
+When admin types in the in-panel search box
+Then a semantic search scoped to THIS doc's chunks runs (vector-search + docId filter),
+  results show score + page + snippet, sorted by score desc;
+  a score-threshold filter (e.g. ≥0.7) narrows results;
+  empty result set shows an empty state; 0-chunk doc disables the search box.
+```
+
+## 6. UX & states
+
+- **Authorization**: admin/superadmin only (explorer already admin-gated). New delete/export endpoints
+  enforce admin + audit.
+- **Locked-state (O-1 resolved → restructure)**: actions render for `ready`, `failed`, and `processing`
+  docs. Refactor `KbDocDetailPanel` so the hero + action bar render before/around the locked banner
+  (pattern already used for the Used-by tab during locked). Re-index disabled while processing (FR-1).
+- **Destructive Delete**: typed-confirm (type filename), impact line with agent count, `bg-destructive
+  text-destructive-foreground` (WCAG AA), never silent.
+- **Refresh**: pessimistic — await, then invalidate TanStack queries (doc detail, tree, chunks).
+
+## 7. Non-functional
+
+- **Audit**: Delete + Re-index write audit entries (Administration BC). Verify existing commands audit;
+  add if missing.
+- **a11y**: net-new `<button>` → `type="button"` + `focus-visible:outline-none focus-visible:ring-2
+  focus-visible:ring-ring focus-visible:ring-offset-2` (FU-1/FU-3 convention).
+- **Security**: download endpoint already enforces owner/admin. New delete/export endpoints: admin gate
+  + audit. Similarity-search reuses existing admin vector-search auth.
+- **Tokens/ESLint**: amber/emerald/rose hue OK without disable; zinc dark keeps the file-level disable
+  already in `KbDocDetailPanel`.
+
+## 8. Test plan
+
+- **Unit (Vitest)**: each action button renders + calls correct hook + disabled-while-pending +
+  success/error toast; Re-index disabled when processing; typed-confirm gating + impact line for delete;
+  similarity-search result render + score filter + empty state + 0-chunk disabled.
+- **Backend (xUnit)**: `DELETE /admin/pdfs/{docId}` (happy, not-found, authorization, audit, agent-ref
+  behavior per D-1); vector-search docId-filter extension; chunks export (full content, not-found, auth).
+- **E2E smoke (Playwright)**: select doc → re-index → processing; select failed doc → actions reachable;
+  select doc → delete (typed-confirm) → removed from tree.
+
+## 9. Phasing (final)
+
+- **FU-4 (this slice)** = Phase 1 + Phase 2: A1, A2, A3 (+endpoint), B5, B3 (+endpoint), C (+query ext),
+  O-1 restructure. One feature branch, may split into 2 PRs (BE endpoints + FE wiring) if review size warrants.
+- **Spun out as #1653 sub-issues** (do NOT block FU-4): B1 versioned reindex (#1673), B2 per-doc
+  embeddings (#1674), B4 per-doc quality eval (#1675), D hero metadata enrichment (#1676).
+
+## 10. Open questions — status
+
+- **O-1** ✅ RESOLVED: restructure locked early-return (user-confirmed).
+- **O-2** → **D-1** (plan three-amigos): delete agent-reference behavior + TextChunks cascade.
+- **O-3** ℹ️ INFORMATIONAL (D deferred): `FileSizeBytes` present; indexer-version/avg-confidence/OCR/
+  chunk-token absent → Phase 3 must add data, not just DTO.
+- **O-4** ✅ RESOLVED: export = full content via new endpoint (snippet FE-assembly rejected, lossy).
+- **O-5** ✅ RESOLVED (FE guard): disable Re-index while processing/queued (backend has no guard).
+
+## Appendix — spec-panel review provenance (2026-05-29)
+
+Critique mode, focus requirements + architecture + testing. Quality (candidate): Completeness 7,
+Testability 3→ (raised via §5 AC), Architecture clarity 5 (scope too broad → phased), Risk 6.
+
+Convergent (Fowler+Newman+Nygard+Cockburn): "full mockup in one slice" not reviewable; B1/B2/B4 are
+net-new backend (B2 corpus-leak risk) → spun out. Productive tension: mockup-fidelity vs failure-mode
+(hero actions unreachable on failed docs) → resolved by O-1 restructure. Wiegers/Adzic: FRs needed
+testable Given/When/Then → §5. Crispin: edge cases (delete referenced doc, reindex-while-processing,
+missing blob, 0-chunk search) → §8. Gregory: O-2/O-3 were blocking → investigated; O-2→D-1, O-3 informational.

--- a/docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md
+++ b/docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md
@@ -64,7 +64,7 @@ Surface = **hero buttons** (mockup-faithful). Phasing decision = **Phase 1 + Pha
 | A3 | Delete | NEW `DELETE /api/v1/admin/pdfs/{docId}` reusing `DeletePdfCommand` | ⚠️ endpoint + agent-ref handling |
 | B3 | Export chunks JSON | NEW `GET /api/v1/admin/kb/docs/{docId}/chunks/export` (full content) | ⚠️ new endpoint |
 | B5 | Used-by link | FU-2 `/admin/kb/docs/{docId}/agents` | ✅ done |
-| C | Similarity-search in doc | extend `VectorSemanticSearchQuery` with `DocId`/`PdfId` filter | ⚠️ query + endpoint param |
+| C | Similarity-search in doc | resolve `VectorDocuments.Where(PdfDocumentId==docId)` → (vectorDocId, gameId); `SearchByVector…(gameId, vec, topK, minScore, documentIds:[vectorDocId])`. **Score gap**: adapter discards similarity → needs additive score-returning method | ⚠️ new admin query/endpoint + score-returning repo/adapter method |
 
 ## 5. Functional requirements (testable — Adzic/Wiegers)
 
@@ -116,7 +116,8 @@ Then the full chunk set (id, position, headingPath, page, full content) download
 ```
 Given a ready doc and a query "predator activation"
 When admin types in the in-panel search box
-Then a semantic search scoped to THIS doc's chunks runs (vector-search + docId filter),
+Then a semantic search scoped to THIS doc's chunks runs (resolve VectorDocument + gameId from
+  PdfDocumentId, then SearchByVectorWithScores with documentIds:[vectorDocId]),
   results show score + page + snippet, sorted by score desc;
   a score-threshold filter (e.g. ≥0.7) narrows results;
   empty result set shows an empty state; 0-chunk doc disables the search box.
@@ -180,3 +181,39 @@ net-new backend (B2 corpus-leak risk) → spun out. Productive tension: mockup-f
 (hero actions unreachable on failed docs) → resolved by O-1 restructure. Wiegers/Adzic: FRs needed
 testable Given/When/Then → §5. Crispin: edge cases (delete referenced doc, reindex-while-processing,
 missing blob, 0-chunk search) → §8. Gregory: O-2/O-3 were blocking → investigated; O-2→D-1, O-3 informational.
+
+## Addendum — recon corrections (2026-05-29, parallel research agents)
+
+Implementation recon corrected/added several facts that reshape the plan:
+
+- **Delete (FR-3) — exact mechanics**: New `DeleteKbDocumentCommand(Guid DocId)` + handler,
+  `[AuditableAction("KbDocumentDelete","Document",Level=2)] [AtomicAudit]` → `AuditLoggingBehavior`
+  auto-writes the audit row. Agent cascade (D-1=b): `IAgentDefinitionRepository.GetByConsumedDocumentAsync(docId)`
+  → for each, `agent.UpdateKbCardIds(agent.KbCardIds.Where(id => id != docId))` + `UpdateAsync`.
+  EF cascade (`OnDelete(Cascade)` on `TextChunk.PdfDocumentId` + `VectorDocument.PdfDocumentId`) auto-removes
+  chunks + vector-doc on `PdfDocuments.Remove`. **Latent gap to fix**: raw `pgvector_embeddings`
+  (keyed by vector_document_id, NO FK) is NOT cascaded — handler must call
+  `IVectorStore/PgVectorStoreAdapter.DeleteByVectorDocumentIdAsync` explicitly. Endpoint:
+  `DELETE /api/v1/admin/pdfs/{docId}` in `AdminPdfManagementEndpoints.cs` (group already admin-gated,
+  hosts reindex). Distinct from the existing `DELETE /api/v1/pdf/{id}` (no cascade/audit).
+- **Similarity-search (FR-5) — two corrections**: (1) `SearchByVectorAsync.documentIds` filters on
+  **VectorDocumentId, not PdfDocumentId**, and requires **gameId** → resolve both from
+  `VectorDocuments.Where(v => v.PdfDocumentId == docId)` first (404 if not indexed). (2) **Score gap**:
+  `PgVectorStoreAdapter.SearchAsync` computes `1-(vec<=>q)` but discards it (only list order survives);
+  the result `Embedding` has no score field. Mockup shows score badges → add an **additive**
+  `SearchByVectorWithScoresAsync` (repo + adapter) returning `(Embedding, double score)` so existing RAG
+  callers are untouched. Query embedding via `IEmbeddingService.GenerateEmbeddingAsync(text)` →
+  `new Vector(result.Embeddings[0])`. New endpoint `POST /api/v1/admin/kb/docs/{docId}/chunks/search`.
+- **Export (FR-4)**: `TextChunkEntity.Content` holds full text; existing `GetKbChunks` is snippet-truncated
+  (200 chars) + paginated → new `ExportDocumentChunksQuery(docId)` over `TextChunks.Where(PdfDocumentId==docId)
+  .OrderBy(ChunkIndex)`. Endpoint `GET /api/v1/admin/kb/docs/{docId}/chunks/export`.
+- **Locked-restructure (O-1) — 423 carries no DTO**: under 423 `useKbDocDetail` returns `doc=null`
+  (only `processingStatus`). For a failed doc, Re-index needs only docId, but **Delete's typed-confirm
+  needs the filename** which is unavailable. Resolution: extend the 423 response with a partial DTO
+  (`id`, `title`/`fileName`, `processingStatus`) — the hook comment already anticipates this — so the
+  slim hero + filename typed-confirm work for failed/processing docs.
+- **FE reuse**: `api.pdf.reindexDocument(docId)` already targets `POST /admin/pdfs/{id}/reindex` (FR-1 ready);
+  `api.pdf.getPdfDownloadUrl(docId)` builds the download URL — cookie-session auth → plain
+  `<a href download>` works (FR-2, no fetch+blob). Typed-confirm = extend `AdminConfirmationDialog`
+  (`ui/admin/admin-confirmation-dialog.tsx`) with an optional `confirmPhrase` prop (default `'CONFIRM'`).
+  Toast = `sonner`. Invalidate `kbDocDetailKeys.byId`, `kbChunksListKeys`, `kbGameDocumentKeys.byGame`.


### PR DESCRIPTION
## Summary

- **Backend**: 3 new admin endpoints — `DELETE /api/v1/admin/pdfs/{docId}` (cascade: detaches consuming agents via `AgentDefinition.UpdateKbCardIds`, deletes pgvector embeddings, EF-cascades chunks/vectordoc, blob+cache cleanup, atomically audited via `[AuditableAction("KbDocumentDelete",...)][AtomicAudit]`), `GET /admin/kb/docs/{docId}/chunks/export` (full chunk content JSON), `POST /admin/kb/docs/{docId}/chunks/search` (per-doc scored similarity-search). Additive `IEmbeddingRepository.SearchByVectorWithScoresAsync` + adapter method surface the similarity score (existing `SearchAsync` untouched — no impact on RAG).
- **Frontend**: `KbDocActions` action-bar in `KbDocDetailPanel` with Re-index / Download / Delete (typed-confirm using filename + agent-impact line) / Export chunks JSON / Used-by; in-panel chunk similarity-search with score badge + threshold filter; **locked-restructure**: actions reachable for `failed`/`processing` docs (slim hero from tree-passed `{title, gameId}` metadata, no 423 contract change). Extended `AdminConfirmationDialog` with optional `confirmPhrase` prop (backward-compatible, defaults to `'CONFIRM'`).
- **Bug fix**: `?docId=` → `?doc=` URL param consistency in `KbDocDetailTabs` (FU-1/FU-2 tab nav was silently broken — `KbExplorer` reads `?doc=`, the links wrote `?docId=`) and the new Used-by link.

**Spec + plan**: `docs/superpowers/specs/2026-05-29-sp5-admin-kb-f3-fu4-doc-actions-design.md` + `docs/superpowers/plans/2026-05-29-kb-doc-actions.md`.

**Spun out of #1653** (net-new backend, do NOT block FU-4): #1673 versioned reindex · #1674 per-doc embeddings viewer (⚠️ corpus-leak risk flagged by Newman in spec-panel review) · #1675 per-doc quality eval · #1676 hero metadata enrichment.

## Test plan

- [ ] BE integration tests: 9 new tests (3 delete w/ cascade, 4 export, 2 scored search) — all green locally with Testcontainers
- [ ] FE unit suite full run: 19185 passed / 26 skipped / 0 failed
- [ ] FE typecheck + lint:tokens: 0 errors / 0 violations
- [ ] E2E Playwright smoke spec committed (CI-only — local Playwright Chrome binary not installed)
- [ ] Bundle size baseline bumped: 14,500,000 → 14,660,000 (+155KB documented for new action-bar + search + locked-restructure)
- [ ] Manual: select a doc → action-bar visible (5 buttons); click Used-by → URL contains `?doc=...&tab=used-by` AND doc selection preserved
- [ ] Manual: select a `failed` doc → Re-index/Delete reachable from slim hero (previously unreachable behind locked early-return)
- [ ] Manual: typed-confirm Delete shows the filename + "Referenziato da N agent" impact line
- [ ] Manual: similarity-search returns score-badged results sorted desc; threshold filter (default 0.7) hides low scores; 0-chunk docs disable search

🤖 Generated with [Claude Code](https://claude.com/claude-code)