### PR TITLE
feat(library): #1658 expose AdvancedFiltersDrawer game scope on the games tab

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -469,6 +469,8 @@ export function LibraryHub(): ReactElement {
                 view={gamesView}
                 onViewChange={setGamesView}
                 resultCount={gamesFiltered.length}
+                onMoreFilters={() => setDrawerOpen(true)}
+                activeFiltersCount={activeFiltersCount}
               />
               {gamesEffectiveKind === 'default' ? (
                 <GamesResultsGrid entries={gamesFiltered} view={gamesView as GamesResultsView} />

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -904,6 +904,24 @@ describe('LibraryHub — Phase 3b drawer + rail integration (#1593)', () => {
     expect(screen.queryByTestId('cross-entity-filters-more')).toBeNull();
   });
 
+  it('shows "Più filtri" chip on the games tab (#1658)', async () => {
+    const user = userEvent.setup();
+    installMatchMedia(true);
+    renderWithIntl(<LibraryHub />);
+    await user.click(screen.getByRole('tab', { name: /giochi/i }));
+    expect(screen.getByTestId('games-filters-more')).toBeInTheDocument();
+  });
+
+  it('clicking "Più filtri" chip on games tab opens the AdvancedFiltersDrawer (#1658)', async () => {
+    const user = userEvent.setup();
+    installMatchMedia(true);
+    renderWithIntl(<LibraryHub />);
+    await user.click(screen.getByRole('tab', { name: /giochi/i }));
+    const chip = screen.getByTestId('games-filters-more');
+    await user.click(chip);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
   it('shows "Più filtri" chip on the sessions tab', async () => {
     const user = userEvent.setup();
     renderWithIntl(<LibraryHub />);

--- a/apps/web/src/components/features/games/GamesFiltersInline.tsx
+++ b/apps/web/src/components/features/games/GamesFiltersInline.tsx
@@ -66,6 +66,10 @@ export interface GamesFiltersInlineProps {
   readonly resultCount: number;
   readonly compact?: boolean;
   readonly className?: string;
+  /** #1658: opens the AdvancedFiltersDrawer. When undefined, the chip is hidden. */
+  readonly onMoreFilters?: () => void;
+  /** #1658: number of active drawer filters to badge on the chip (0 = no badge). */
+  readonly activeFiltersCount?: number;
 }
 
 const STATUS_KEYS: readonly GamesStatusKey[] = ['all', 'owned', 'wishlist', 'played'];
@@ -87,6 +91,8 @@ export function GamesFiltersInline({
   resultCount,
   compact = false,
   className,
+  onMoreFilters,
+  activeFiltersCount = 0,
 }: GamesFiltersInlineProps): ReactElement {
   const [localQuery, setLocalQuery] = useState(query);
   const debouncedQuery = useDebounce(localQuery, SEARCH_DEBOUNCE_MS);
@@ -169,6 +175,22 @@ export function GamesFiltersInline({
         className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4"
         data-slot="games-filters-controls"
       >
+        {onMoreFilters ? (
+          <button
+            type="button"
+            data-testid="games-filters-more"
+            onClick={onMoreFilters}
+            className={clsx(
+              'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
+              activeFiltersCount > 0
+                ? 'border-primary bg-primary/10 text-foreground'
+                : 'border-border bg-background text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Più filtri{activeFiltersCount > 0 ? ` (${activeFiltersCount})` : ''}
+          </button>
+        ) : null}
+
         <div
           role="tablist"
           aria-label={labels.status.label}

--- a/apps/web/src/components/features/games/__tests__/GamesFiltersInline.test.tsx
+++ b/apps/web/src/components/features/games/__tests__/GamesFiltersInline.test.tsx
@@ -209,4 +209,30 @@ describe('GamesFiltersInline (Wave B.1)', () => {
     renderFilters({ query: '' });
     expect(screen.queryByRole('button', { name: 'Cancella la ricerca' })).toBeNull();
   });
+
+  // #1658: AdvancedFiltersDrawer "Più filtri" chip support
+  it('renders the "Più filtri" chip when onMoreFilters is provided', () => {
+    const onMoreFilters = vi.fn();
+    renderFilters({ onMoreFilters });
+    expect(screen.getByRole('button', { name: /Più filtri/ })).toBeInTheDocument();
+  });
+
+  it('calls onMoreFilters when the "Più filtri" chip is clicked', () => {
+    const onMoreFilters = vi.fn();
+    renderFilters({ onMoreFilters });
+    fireEvent.click(screen.getByRole('button', { name: /Più filtri/ }));
+    expect(onMoreFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays activeFiltersCount badge on the "Più filtri" chip when > 0', () => {
+    const onMoreFilters = vi.fn();
+    renderFilters({ onMoreFilters, activeFiltersCount: 3 });
+    const chip = screen.getByRole('button', { name: /Più filtri/ });
+    expect(chip).toHaveTextContent('Più filtri (3)');
+  });
+
+  it('does not display the "Più filtri" chip when onMoreFilters is undefined', () => {
+    renderFilters({ onMoreFilters: undefined });
+    expect(screen.queryByRole('button', { name: /Più filtri/ })).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #1658

## Summary
- Expose AdvancedFiltersDrawer "Più filtri" chip on the games tab by adding `onMoreFilters` and `activeFiltersCount` props to `GamesFiltersInline`
- Wire drawer state in `LibraryHub` games tab branch
- Phase 3b #1593 follow-up: the drawer scope=game was unreachable from the games tab UI

## Changes
- **GamesFiltersInline.tsx**: Add chip "Più filtri" + 2 new optional props
- **LibraryHub.tsx**: Pass `onMoreFilters={() => setDrawerOpen(true)}` + `activeFiltersCount` to GamesFiltersInline
- **GamesFiltersInline.test.tsx**: 4 new tests (render chip, click handler, badge count, undefined handler hides chip)
- **LibraryHub.test.tsx**: 2 new tests (games tab chip visibility, drawer open on click)

## Test plan
- pnpm test GamesFiltersInline: 18/18 ✓
- pnpm test LibraryHub: 36/36 ✓
- pnpm typecheck: 0 errors ✓
- pnpm lint: 0 errors, 54 pre-existing warnings ✓

🤖 Implemented via test-driven development (TDD)