### PR TITLE
fix(kb-docs): #1645 expose updatedAt explicit field in UserKbDocDto

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQuery.cs
@@ -42,6 +42,7 @@ public sealed record KbDocsListResponse(
 /// <param name="PageCount">Number of pages; null until extraction completes.</param>
 /// <param name="ProcessedAt">Timestamp of the most recent processing state transition; null for Pending docs that never started.</param>
 /// <param name="UploadedAt">Upload timestamp; always non-null. Used as the sort fallback when <paramref name="ProcessedAt"/> is null.</param>
+/// <param name="UpdatedAt">Explicit recency signal: ProcessedAt ?? UploadedAt. Mirrors the canonical sort key from the handler. Issue #1645.</param>
 public sealed record UserKbDocDto(
     Guid Id,
     Guid? GameId,
@@ -50,4 +51,5 @@ public sealed record UserKbDocDto(
     string ProcessingState,
     int? PageCount,
     DateTime? ProcessedAt,
-    DateTime UploadedAt);
+    DateTime UploadedAt,
+    DateTime UpdatedAt);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQueryHandler.cs
@@ -147,7 +147,8 @@ internal sealed class ListUserKbDocsQueryHandler
             ProcessingState: r.ProcessingState,
             PageCount: r.PageCount,
             ProcessedAt: r.ProcessedAt,
-            UploadedAt: r.UploadedAt)).ToList();
+            UploadedAt: r.UploadedAt,
+            UpdatedAt: r.ProcessedAt ?? r.UploadedAt)).ToList();
 
         return new KbDocsListResponse(
             Items: items,

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ListUserKbDocsQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ListUserKbDocsQueryHandlerIntegrationTests.cs
@@ -316,4 +316,47 @@ public sealed class ListUserKbDocsQueryHandlerIntegrationTests : IAsyncLifetime
         orphan.GameId.Should().BeNull();
         orphan.GameName.Should().BeNull();
     }
+
+    // ─── AC7: UpdatedAt = ProcessedAt ?? UploadedAt (explicit field) ────────
+
+    [Fact(Timeout = 30000)]
+    public async Task UpdatedAt_equals_ProcessedAt_when_processed()
+    {
+        await SeedUserAsync(UserA);
+        var game = await SeedGameAsync("Catan");
+        var uploadTime = DateTime.UtcNow.AddDays(-5);
+        var processTime = DateTime.UtcNow.AddDays(-1);
+        _dbContext!.PdfDocuments.Add(
+            NewDoc(UserA, game.Id, "Ready", "processed.pdf", uploadTime, processTime));
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var result = await _handler!.Handle(new ListUserKbDocsQuery(UserA), TestCancellationToken);
+
+        result.Items.Should().HaveCount(1);
+        var dto = result.Items.Single();
+        // DB round-trip may lose microsecond precision; use tolerance of 1ms.
+        dto.UpdatedAt.Should().BeCloseTo(processTime, TimeSpan.FromMilliseconds(1),
+            "UpdatedAt should equal ProcessedAt when present");
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task UpdatedAt_equals_UploadedAt_when_ProcessedAt_null()
+    {
+        await SeedUserAsync(UserA);
+        var game = await SeedGameAsync("Catan");
+        var uploadTime = DateTime.UtcNow;
+        _dbContext!.PdfDocuments.Add(
+            NewDoc(UserA, game.Id, "Pending", "unprocessed.pdf", uploadTime, null));
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var result = await _handler!.Handle(
+            new ListUserKbDocsQuery(UserA, State: "all"),
+            TestCancellationToken);
+
+        result.Items.Should().HaveCount(1);
+        var dto = result.Items.Single();
+        // DB round-trip may lose microsecond precision; use tolerance of 1ms.
+        dto.UpdatedAt.Should().BeCloseTo(uploadTime, TimeSpan.FromMilliseconds(1),
+            "UpdatedAt should equal UploadedAt when ProcessedAt is null");
+    }
 }

--- a/apps/web/src/hooks/queries/__tests__/useUserKbDocs.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useUserKbDocs.test.tsx
@@ -25,17 +25,22 @@ const dtoBase: UserKbDocDto = {
   pageCount: 24,
   processedAt: '2026-05-28T11:00:00+00:00',
   uploadedAt: '2026-05-28T09:00:00+00:00',
+  updatedAt: '2026-05-28T11:00:00+00:00',
 };
 
 describe('toKbDoc (adapter)', () => {
-  it('uses processedAt as updatedAt when present (K1.1 last-activity)', () => {
+  it('passes through BE updatedAt when ProcessedAt is present (#1645 canonical BE-side)', () => {
     const result = toKbDoc(dtoBase);
-    expect(result.updatedAt).toBe('2026-05-28T11:00:00+00:00');
+    expect(result.updatedAt).toBe(dtoBase.updatedAt);
   });
 
-  it('falls back to uploadedAt when processedAt is null (K1.1)', () => {
-    const result = toKbDoc({ ...dtoBase, processedAt: null });
-    expect(result.updatedAt).toBe('2026-05-28T09:00:00+00:00');
+  it('passes through BE updatedAt when ProcessedAt is null (BE returns uploadedAt as updatedAt) (#1645)', () => {
+    const result = toKbDoc({
+      ...dtoBase,
+      processedAt: null,
+      updatedAt: dtoBase.uploadedAt,
+    });
+    expect(result.updatedAt).toBe(dtoBase.uploadedAt);
   });
 
   it('preserves the other fields unchanged', () => {

--- a/apps/web/src/hooks/queries/useUserKbDocs.ts
+++ b/apps/web/src/hooks/queries/useUserKbDocs.ts
@@ -3,10 +3,9 @@
  * listing (BE-1 #1588). Calls `GET /api/v1/kb-docs` with default
  * `{ page:1, pageSize:20, sortBy:'recent', state:'ready' }` (K3 #1592).
  *
- * Adapter (K1.1): the BE DTO has `processedAt?` + `uploadedAt` but NOT a single
- * `updatedAt`. Server-side `sortBy=recent` orders by `ProcessedAt ?? UploadedAt`;
- * we mirror that on the FE so the `kbDocToHubItem` mapper signature stays
- * unchanged (AC2.b.4). Follow-up #1645 tracks exposing `updatedAt` explicit BE-side.
+ * Adapter (K1.1, #1645): the BE DTO now explicitly exposes `updatedAt`,
+ * which is computed server-side as `ProcessedAt ?? UploadedAt` (the canonical
+ * sort key). This eliminates the FE adapter derivation.
  */
 
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
@@ -15,7 +14,7 @@ import { api } from '@/lib/api';
 import type { KbDocsListResponse, UserKbDocDto } from '@/lib/api/schemas/kb-docs.schemas';
 import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
 
-/** Adapter: DTO → FE `KbDoc` (derives `updatedAt`). Pure, unit-testable. */
+/** Adapter: DTO → FE `KbDoc`. Pure, unit-testable. */
 export function toKbDoc(dto: UserKbDocDto): KbDoc {
   return {
     id: dto.id,
@@ -25,8 +24,8 @@ export function toKbDoc(dto: UserKbDocDto): KbDoc {
     processingState: dto.processingState,
     pageCount: dto.pageCount,
     processedAt: dto.processedAt,
-    // K1.1: server-side sortBy=recent uses ProcessedAt ?? UploadedAt — mirror it.
-    updatedAt: dto.processedAt ?? dto.uploadedAt,
+    uploadedAt: dto.uploadedAt,
+    updatedAt: dto.updatedAt,
   };
 }
 

--- a/apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-docs.schemas.test.ts
@@ -16,6 +16,7 @@ describe('kb-docs schemas', () => {
     pageCount: 24,
     processedAt: '2026-05-28T11:00:00+00:00',
     uploadedAt: '2026-05-28T09:00:00+00:00',
+    updatedAt: '2026-05-28T11:00:00+00:00',
   };
 
   it('accepts a full Ready doc', () => {

--- a/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
@@ -31,6 +31,8 @@ export type ProcessingState = z.infer<typeof ProcessingStateSchema>;
 /**
  * UserKbDocDto — lightweight cross-game user-scoped projection (BE-1).
  * Does NOT include `filePath`, `fileSizeBytes`, `documentType`, etc. — see issue #1592.
+ * The `updatedAt` field (issue #1645) is explicit BE-side: equals ProcessedAt ?? UploadedAt,
+ * mirroring the canonical sort key from the handler.
  */
 export const UserKbDocDtoSchema = z.object({
   id: z.string().uuid(),
@@ -41,6 +43,7 @@ export const UserKbDocDtoSchema = z.object({
   pageCount: z.number().int().positive().nullable(),
   processedAt: z.string().datetime({ offset: true }).nullable(),
   uploadedAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
 });
 
 export type UserKbDocDto = z.infer<typeof UserKbDocDtoSchema>;

--- a/apps/web/src/lib/library/hybrid-hub.mappers.ts
+++ b/apps/web/src/lib/library/hybrid-hub.mappers.ts
@@ -46,6 +46,7 @@ export interface KbDoc {
   readonly processingState: string;
   readonly pageCount?: number | null;
   readonly processedAt: string | null;
+  readonly uploadedAt: string;
   readonly updatedAt: string;
 }
 


### PR DESCRIPTION
## Summary - Expose `UpdatedAt` field explicitly in `UserKbDocDto` (BE-side) - `UpdatedAt` mirrors canonical sort key: `ProcessedAt ?? UploadedAt` - Eliminates FE adapter derivation (#1645 follow-up to Phase 2b #1592)  ## Changes  ### Backend (.NET 9) - **UserKbDocDto**: Add `DateTime UpdatedAt` param to record - **ListUserKbDocsQueryHandler**: Project `UpdatedAt = r.ProcessedAt ?? r.UploadedAt` - **Tests**: Add 2 integration tests validating UpdatedAt computation (AC7)  ### Frontend (Next.js 16) - **Zod schema**: Add `updatedAt: z.string().datetime()` to UserKbDocDtoSchema - **KbDoc interface**: Add explicit `uploadedAt` and `updatedAt` fields - **useUserKbDocs hook**: Simplify toKbDoc adapter — pass updatedAt directly from BE  ## Test Results  **Backend (dotnet test)** - All 15 tests PASS: 2 new AC7 tests + 13 existing ListUserKbDocs tests - Executed in ~31 seconds  **Frontend (pnpm typecheck)** - Typecheck PASS: No type errors - Updated Zod schema validates all BE payload fields  ## AC Checklist - ✅ AC1-AC6 (existing): user-scoping, cross-game, pagination, state filtering, name resolution - ✅ AC7 (new): UpdatedAt equals ProcessedAt when processed - ✅ AC7 (new): UpdatedAt equals UploadedAt when ProcessedAt is null - ✅ FE Zod schema extended and validated - ✅ FE adapter simplified and passing  ## Files Modified - `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQuery.cs` - `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQueryHandler.cs` - `apps/api/tests/Api.Tests/Integration/KnowledgeBase/ListUserKbDocsQueryHandlerIntegrationTests.cs` - `apps/web/src/lib/api/schemas/kb-docs.schemas.ts` - `apps/web/src/lib/library/hybrid-hub.mappers.ts` - `apps/web/src/hooks/queries/useUserKbDocs.ts`  Closes #1645