### PR TITLE
fix(kb): #1345 remove stale LEFT JOIN games from IndexBatchAsync

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -319,12 +319,14 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         await using (lookupCmd.ConfigureAwait(false))
         {
             // Resolve game_id for embeddings: prefer SharedGameId (for RAG search by shared game),
-            // fall back to GameId. Join with games table to resolve SharedGameId when not set on vector_documents.
+            // fall back to GameId. NB: the legacy LEFT JOIN to the 'games' table was removed
+            // after Phase 2d (#1345) dropped that table; resolution now relies on the modern
+            // vd.shared_game_id column populated by post-Phase 2d ingestion, with a defensive
+            // fallback to vd.GameId for legacy rows.
             lookupCmd.CommandText = """
                 SELECT vd."Id",
-                       COALESCE(vd.shared_game_id, g."SharedGameId", vd."GameId") AS resolved_game_id
+                       COALESCE(vd.shared_game_id, vd."GameId") AS resolved_game_id
                 FROM vector_documents vd
-                LEFT JOIN games g ON g."Id" = vd."GameId"
                 WHERE vd."Id" = ANY(@ids)
                 """;
             lookupCmd.Parameters.AddWithValue("@ids", vectorDocumentIds.ToArray());

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
@@ -189,9 +189,9 @@ public sealed class SearchDocumentChunksQueryHandlerIntegrationTests : IAsyncLif
             .Setup(s => s.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { queryVector }));
 
-        // Insert embeddings directly via raw SQL.
-        // NOTE: Do NOT call EnsureCollectionExistsAsync (table already exists from EF migrations)
-        // and do NOT use IndexBatchAsync (it does LEFT JOIN games which was dropped in migration 1345).
+        // Insert embeddings directly via raw SQL for test isolation/speed (bypasses the
+        // production ingestion pipeline). NOTE: Do NOT call EnsureCollectionExistsAsync —
+        // the pgvector_embeddings table already exists via EF migrations.
         await InsertEmbeddingRawAsync(vectorDocId, sharedGame.Id, 0, 1, "Predator activation rules explained in detail", embVector1);
         await InsertEmbeddingRawAsync(vectorDocId, sharedGame.Id, 1, 2, "Another chunk about different game mechanics", embVector2);
 

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/SearchDocumentChunksQueryHandlerIntegrationTests.cs
@@ -104,9 +104,9 @@ public sealed class SearchDocumentChunksQueryHandlerIntegrationTests : IAsyncLif
 
     /// <summary>
     /// Seeds a SharedGame + PdfDocument + VectorDocument in the relational DB,
-    /// then inserts 2 embedding rows directly into <c>pgvector_embeddings</c> via
-    /// <see cref="PgVectorStoreAdapter.IndexBatchAsync"/> so the happy-path test can
-    /// assert score-ordered results.
+    /// then inserts 2 embedding rows directly into <c>pgvector_embeddings</c> via raw
+    /// parameterised SQL (<see cref="InsertEmbeddingRawAsync"/>) so the happy-path test
+    /// can assert score-ordered results.
     ///
     /// The <c>pgvector_embeddings</c> table is created by the EF Initial migration with a
     /// <c>vector(768)</c> column — we must use 768-dimensional test vectors.


### PR DESCRIPTION
## Summary

`PgVectorStoreAdapter.IndexBatchAsync` (`apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs:323-329`) contained a `LEFT JOIN games g ON g."Id" = vd."GameId"` referencing the `games` table that **migration `20260520090039_DropGamesTable_Issue1345` (Phase 2d, 2026-05-20) dropped**. The SQL fails at runtime with `relation "games" does not exist`.

Live callers affected (production indexing paths):
- `PdfProcessingPipelineService:617` — PDF upload pipeline
- `VectorReembeddingService:169` — admin re-index (`POST /admin/pdfs/{id}/reindex`)
- `PhotoBatchProcessor:202` — batch photo processor
- `EmbeddingRepository.IndexBatchAsync:97` — adapter delegate

Surfaced by F3-FU-4 (#1653) review: the new `SearchDocumentChunksQueryHandlerIntegrationTests` had to bypass `IndexBatchAsync` with raw SQL inserts and a comment flagging the stale code path.

## Fix

Simplify the resolver to drop the broken join and the obsolete `g."SharedGameId"` COALESCE term:

```diff
- COALESCE(vd.shared_game_id, g."SharedGameId", vd."GameId") AS resolved_game_id
- FROM vector_documents vd
- LEFT JOIN games g ON g."Id" = vd."GameId"
+ COALESCE(vd.shared_game_id, vd."GameId") AS resolved_game_id
+ FROM vector_documents vd
```

Modern post-Phase 2d ingestion populates `vd.shared_game_id` directly, so the JOIN never contributed anything useful for those rows. Legacy rows with `vd.shared_game_id IS NULL` now fall through to `vd."GameId"` (the old `g."SharedGameId"` lookup is no longer possible — table is gone).

## Test plan

- [ ] CI: Backend Fast (build + unit) + Backend Integration tests pass
- [ ] Manual smoke (post-merge): upload a PDF in dev → indexing pipeline runs without `relation "games" does not exist`
- [ ] Manual smoke: re-index an existing doc via `/admin/pdfs/{id}/reindex` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)