### PR TITLE
feat(kb-globale): #1482 Phase 1 Foundation — search + landing + 5 components

### DIFF
--- a/apps/web/.bundle-budgets.json
+++ b/apps/web/.bundle-budgets.json
@@ -22,6 +22,10 @@
     "/chat/[threadId]": {
       "gzippedBytes": 659000,
       "note": "Baseline 2026-05-17 (was 631411 from 2026-04-29). +4.3% drift from #979 promotion."
+    },
+    "/knowledge-base/global": {
+      "gzippedBytes": 40000,
+      "note": "Phase 1 Foundation target 2026-05-30 (PR #1688). Tier L route: useGlobalKbSearch hook + 5 components (HeroSearch, KbHomeDesktop, KbSearchResultsDesktop, KbEmptyState, route orchestrator)."
     }
   }
 }

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
@@ -1,0 +1,181 @@
+/**
+ * KbGlobaleView.tsx
+ * Issue #1482 Task 6 — Client orchestrator for /knowledge-base/global
+ *
+ * URL SSOT: reads ?q= and ?mode= from search params; pushes updated URL on
+ * HeroSearch submit or clear. Branches on `q.trim().length > 0`:
+ *   - Home branch (q empty)  → <KbHomeDesktop> (recent docs from useUserKbDocs)
+ *   - Results branch (q set) → <KbSearchResultsDesktop> (useGlobalKbSearch)
+ *
+ * HeroSearch is always visible at the top of the page regardless of branch.
+ *
+ * No double-fetch design:
+ *   - useUserKbDocs is always called (cached 5min, cheap, feeds home branch).
+ *   - useGlobalKbSearch is always called but gated via `enabled: !isHomeBranch`
+ *     (the hook's internal gate `query.length >= 2` is a second safety net).
+ *
+ * Labels: in-file constants for v1. Task 8 extracts them to i18n catalog
+ * under `pages.kbGlobale.*`.
+ *
+ * @see Issue #1482 Phase 1 Foundation
+ * @see Task 2: HeroSearch, Task 4: KbHomeDesktop, Task 5: KbSearchResultsDesktop
+ */
+
+'use client';
+
+import { type JSX, useCallback, useMemo } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { HeroSearch } from '@/components/features/kb-globale/HeroSearch';
+import { KbHomeDesktop } from '@/components/features/kb-globale/KbHomeDesktop';
+import { KbSearchResultsDesktop } from '@/components/features/kb-globale/KbSearchResultsDesktop';
+import { useGlobalKbSearch } from '@/hooks/queries/useGlobalKbSearch';
+import { useUserKbDocs } from '@/hooks/queries/useUserKbDocs';
+import type { SearchMode } from '@/lib/api/schemas/kb-globale.schemas';
+import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
+
+// ---------------------------------------------------------------------------
+// In-file label constants (v1 — i18n extraction deferred to Task 8)
+// ---------------------------------------------------------------------------
+
+const LABELS = {
+  hero: {
+    placeholder: 'Cerca nella knowledge base…',
+    submit: 'Cerca',
+    clear: 'Cancella',
+    modeLabel: 'Modalità di ricerca',
+    modeOptions: {
+      Semantic: 'Semantica',
+    } as Record<SearchMode, string>,
+  },
+  home: {
+    heading: 'Documenti recenti',
+    empty: {
+      title: 'Nessun documento ancora',
+      description: 'Carica un PDF dalla libreria per iniziare.',
+      cta: 'Vai alla libreria',
+    },
+    errorTitle: 'Impossibile caricare i documenti',
+    errorDescription: 'Si è verificato un errore. Riprova tra qualche istante.',
+    retry: 'Riprova',
+    docCardAriaLabel: (doc: KbDoc) => `${doc.fileName}${doc.gameName ? ` — ${doc.gameName}` : ''}`,
+  },
+  results: {
+    resultsCount: (n: number, q: string) => `${n} risultat${n === 1 ? 'o' : 'i'} per «${q}»`,
+    loadMore: 'Carica altri',
+    loadingMore: 'Caricamento…',
+    empty: {
+      title: 'Nessun risultato',
+      description: "Prova con termini diversi o controlla l'ortografia.",
+    },
+    errorTitle: 'Errore nella ricerca',
+    errorDescription: 'La ricerca non è riuscita. Riprova tra qualche istante.',
+    retry: 'Riprova',
+    resultAriaLabel: (r: { docTitle: string; gameName: string }) => `${r.docTitle} — ${r.gameName}`,
+    pageLabel: (page: number) => `Pagina ${page}`,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function KbGlobaleView(): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // ── URL state (SSOT) ───────────────────────────────────────────────────
+  const q = searchParams.get('q')?.trim() ?? '';
+  const modeRaw = searchParams.get('mode');
+  // SearchMode is currently only 'Semantic'. Validate strictly so future
+  // enum extensions are safe.
+  const mode: SearchMode | undefined = modeRaw === 'Semantic' ? 'Semantic' : undefined;
+
+  const isHomeBranch = q.length === 0;
+
+  // ── Hooks (called unconditionally per React rules) ─────────────────────
+  // useUserKbDocs: always consumed (home branch data + cached warmup).
+  const recent = useUserKbDocs();
+
+  // useGlobalKbSearch: always called but disabled on home branch.
+  const search = useGlobalKbSearch({
+    query: q,
+    mode,
+    enabled: !isHomeBranch,
+  });
+
+  // ── URL update helpers ─────────────────────────────────────────────────
+  const pushUrl = useCallback(
+    (newQ: string, newMode: SearchMode) => {
+      const params = new URLSearchParams();
+      if (newQ) params.set('q', newQ);
+      // 'Semantic' is the default — omit from URL to keep it clean.
+      if (newMode !== 'Semantic') params.set('mode', newMode);
+      const qs = params.toString();
+      router.push(qs ? `/knowledge-base/global?${qs}` : '/knowledge-base/global');
+    },
+    [router]
+  );
+
+  const clearUrl = useCallback(() => {
+    router.push('/knowledge-base/global');
+  }, [router]);
+
+  // ── Derived values ─────────────────────────────────────────────────────
+  const recentDocs: readonly KbDoc[] = useMemo(
+    () => recent.data?.items ?? [],
+    [recent.data?.items]
+  );
+
+  // ── Retry handlers ─────────────────────────────────────────────────────
+  const handleHomeRetry = useCallback(() => {
+    void recent.refetch?.();
+  }, [recent]);
+
+  const handleResultsRetry = useCallback(() => {
+    // The hook's internal state resets when the queryKey changes.
+    // Re-pushing the same URL triggers a fresh render + re-enable.
+    if (q) {
+      const params = new URLSearchParams();
+      params.set('q', q);
+      if (mode && mode !== 'Semantic') params.set('mode', mode);
+      router.push(`/knowledge-base/global?${params.toString()}`);
+    }
+  }, [q, mode, router]);
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col gap-6 w-full">
+      <HeroSearch
+        initialQuery={q}
+        initialMode={mode ?? 'Semantic'}
+        onSubmit={pushUrl}
+        onClear={clearUrl}
+        labels={LABELS.hero}
+      />
+
+      {isHomeBranch ? (
+        <KbHomeDesktop
+          recentDocs={recentDocs}
+          isLoading={recent.isLoading}
+          error={(recent.error as Error | null) ?? null}
+          labels={LABELS.home}
+          onRetry={handleHomeRetry}
+        />
+      ) : (
+        <KbSearchResultsDesktop
+          query={q}
+          results={search.results}
+          hasMore={search.hasMore}
+          isLoading={search.isLoading}
+          isFetchingNextPage={search.isFetchingNextPage}
+          error={search.error}
+          onLoadMore={search.fetchNextPage}
+          labels={LABELS.results}
+          onRetry={handleResultsRetry}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.integration.test.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.integration.test.tsx
@@ -1,0 +1,410 @@
+/**
+ * KbGlobaleView.integration.test.tsx
+ * Issue #1482 Task 7 — MSW integration tests for /knowledge-base/global
+ *
+ * These tests exercise the full FE data stack without mocking hooks:
+ *   - Zod schemas (kb-globale.schemas.ts, kb-docs.schemas.ts)
+ *   - API clients (kbDocsClient.ts: searchGlobal + listUserKbDocs)
+ *   - TanStack Query hooks (useGlobalKbSearch, useUserKbDocs)
+ *   - KbGlobaleView orchestrator (Task 6)
+ *   - KbHomeDesktop (Task 4) and KbSearchResultsDesktop (Task 5)
+ *
+ * MSW v2 — the global server is started by vitest.setup.tsx with
+ * `onUnhandledRequest: 'bypass'`. Per-test handlers are added via
+ * `server.use()` and reset via the global `afterEach(() => server.resetHandlers())`.
+ *
+ * Navigation mocks: next/navigation (useRouter + useSearchParams) are controlled
+ * via mutable state objects so each test can set the URL independently.
+ *
+ * Real timers: fake-timers + TanStack Query v5 = known deadlock (P129).
+ * All timing-sensitive tests (debounce coalesce) use real timers + waitFor
+ * with an extended timeout (1500ms) to safely clear the 250ms debounce.
+ *
+ * Scope: Foundation layer only. No Phase 2 hooks (drawer/viewer/editor) consumed.
+ *
+ * @see apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx
+ * @see Issue #1482 Phase 1 Foundation
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { server } from '@/__tests__/mocks/server';
+import { globalRequestCache } from '@/lib/api/core/requestCache';
+
+// ─── API base (matches vitest.setup.tsx + handler convention) ────────────────
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ─── next/navigation mocks ────────────────────────────────────────────────────
+// Mutable state so each test can control the URL independently.
+
+type SearchParamsRecord = Record<string, string | null>;
+let searchParamsMap: SearchParamsRecord = {};
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsMap[key] ?? null,
+  }),
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+  }),
+  usePathname: () => '/knowledge-base/global',
+}));
+
+// ─── Wrapper with fresh QueryClient per test ──────────────────────────────────
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        // No retry — MSW error responses must be immediately surfaced in tests.
+        retry: false,
+        // Zero staleTime so tests always trigger a fresh fetch.
+        staleTime: 0,
+        // Zero gcTime so query cache is cleared between re-renders.
+        gcTime: 0,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { KbGlobaleView } from '../KbGlobaleView';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ISO_DATE = '2026-01-15T10:00:00+00:00';
+
+// RFC 4122 v4 UUIDs for test fixtures — must pass Zod uuid() validation.
+// Pattern: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
+const DOC_IDS = [
+  'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+  'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22',
+  'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33',
+  'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44',
+  'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a55',
+];
+const GAME_IDS = [
+  'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66',
+  'f6eebc99-9c0b-4ef8-bb6d-6bb9bd380a77',
+  'f7eebc99-9c0b-4ef8-bb6d-6bb9bd380a88',
+  'f8eebc99-9c0b-4ef8-bb6d-6bb9bd380a99',
+  'f9eebc99-9c0b-4ef8-bb6d-6bb9bd380aaa',
+];
+const CHUNK_DOC_IDS = [
+  'aaeebc99-9c0b-4ef8-bb6d-6bb9bd380b11',
+  'abeebc99-9c0b-4ef8-bb6d-6bb9bd380b22',
+  'aceebc99-9c0b-4ef8-bb6d-6bb9bd380b33',
+  'adeebc99-9c0b-4ef8-bb6d-6bb9bd380b44',
+  'aeeebc99-9c0b-4ef8-bb6d-6bb9bd380b55',
+  'afeebc99-9c0b-4ef8-bb6d-6bb9bd380b66',
+  'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b77',
+  'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380b88',
+  'b2eebc99-9c0b-4ef8-bb6d-6bb9bd380b99',
+  'b3eebc99-9c0b-4ef8-bb6d-6bb9bd380baa',
+];
+const CHUNK_GAME_IDS = [
+  'baeebc99-9c0b-4ef8-bb6d-6bb9bd380c11',
+  'bbeebc99-9c0b-4ef8-bb6d-6bb9bd380c22',
+  'bceebc99-9c0b-4ef8-bb6d-6bb9bd380c33',
+  'bdeebc99-9c0b-4ef8-bb6d-6bb9bd380c44',
+  'beeebc99-9c0b-4ef8-bb6d-6bb9bd380c55',
+  'bfeebc99-9c0b-4ef8-bb6d-6bb9bd380c66',
+  'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c77',
+  'c1eebc99-9c0b-4ef8-bb6d-6bb9bd380c88',
+  'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380c99',
+  'c3eebc99-9c0b-4ef8-bb6d-6bb9bd380caa',
+];
+
+function makeKbDocDto(idx: number, fileName: string, gameName: string | null = null) {
+  return {
+    id: DOC_IDS[idx] ?? `a${idx}eebc99-9c0b-4ef8-bb6d-6bb9bd380a${idx}${idx}`,
+    gameId: gameName ? (GAME_IDS[idx] ?? null) : null,
+    gameName,
+    fileName,
+    processingState: 'Ready' as const,
+    pageCount: 20,
+    processedAt: ISO_DATE,
+    uploadedAt: ISO_DATE,
+    updatedAt: ISO_DATE,
+  };
+}
+
+function makeSearchResultDto(i: number) {
+  return {
+    chunkId: `chunk-${i}`,
+    docId: CHUNK_DOC_IDS[i] ?? `a${i}eebc99-9c0b-4ef8-bb6d-6bb9bd380b${i}${i}`,
+    docTitle: `Rulebook ${i}`,
+    gameId: CHUNK_GAME_IDS[i] ?? `ba${i}ebc99-9c0b-4ef8-bb6d-6bb9bd380c${i}${i}`,
+    gameName: `Game ${i}`,
+    docType: 'Rulebook',
+    headingPath: null,
+    snippet: `Snippet for result ${i}…`,
+    pageNumber: i + 1,
+    score: 0.9 - i * 0.05,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('KbGlobaleView integration (MSW)', () => {
+  beforeEach(() => {
+    searchParamsMap = {};
+    mockRouterPush.mockReset();
+    // Clear the module-level request deduplication cache before each test.
+    // vitest.setup.tsx calls vi.clearAllTimers() in afterEach, which cancels the
+    // RequestCache TTL cleanup timeouts — without this clear(), stale success
+    // responses from earlier tests (S1-S6) can be served to S7 via cache hits,
+    // causing the error state to never appear (items:[], error:null instead).
+    globalRequestCache.clear();
+  });
+
+  // ── Scenario 1: Home branch — recent docs rendered ─────────────────────────
+  it('S1: home branch (no q) — MSW returns 3 recent docs, cards rendered', async () => {
+    const docs = [
+      makeKbDocDto(0, 'azul.pdf', 'Azul'),
+      makeKbDocDto(1, 'wingspan.pdf', 'Wingspan'),
+      makeKbDocDto(2, 'gloomhaven.pdf', null),
+    ];
+
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({
+          items: docs,
+          total: 3,
+          page: 1,
+          pageSize: 20,
+        });
+      })
+    );
+
+    searchParamsMap = {};
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for the 3 doc cards (fileName is rendered in the card)
+    await waitFor(() => {
+      expect(screen.getByText('azul.pdf')).toBeInTheDocument();
+      expect(screen.getByText('wingspan.pdf')).toBeInTheDocument();
+      expect(screen.getByText('gloomhaven.pdf')).toBeInTheDocument();
+    });
+  });
+
+  // ── Scenario 2: Results branch — 5 results rendered, request body correct ──
+  it('S2: ?q=azul — MSW returns 5 results, renders 5 rows, POST body verified', async () => {
+    const results = Array.from({ length: 5 }, (_, i) => makeSearchResultDto(i));
+    let capturedBody: unknown = null;
+
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 20 });
+      }),
+      http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          results,
+          hasMore: false,
+          nextCursor: null,
+        });
+      })
+    );
+
+    searchParamsMap = { q: 'azul' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // All 5 result docTitles should appear
+    await waitFor(() => {
+      for (let i = 0; i < 5; i++) {
+        expect(screen.getByText(`Rulebook ${i}`)).toBeInTheDocument();
+      }
+    });
+
+    // Verify POST request body shape
+    expect(capturedBody).toMatchObject({
+      query: 'azul',
+    });
+    // cursor should be null or absent for first page
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.cursor === null || body.cursor === undefined).toBe(true);
+  });
+
+  // ── Scenario 3: Load more — cursor forwarded, 10 results total ─────────────
+  it('S3: load more — second page cursor forwarded, total 10 results', async () => {
+    const page1 = Array.from({ length: 5 }, (_, i) => makeSearchResultDto(i));
+    const page2 = Array.from({ length: 5 }, (_, i) => makeSearchResultDto(i + 5));
+    const capturedBodies: unknown[] = [];
+
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 20 });
+      }),
+      http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, async ({ request }) => {
+        const body = (await request.json()) as { cursor?: string | null };
+        capturedBodies.push(body);
+        if (!body.cursor) {
+          return HttpResponse.json({
+            results: page1,
+            hasMore: true,
+            nextCursor: 'cursor-page-2',
+          });
+        }
+        return HttpResponse.json({
+          results: page2,
+          hasMore: false,
+          nextCursor: null,
+        });
+      })
+    );
+
+    searchParamsMap = { q: 'azul' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Wait for first page and "Load more" button
+    const loadMoreLabel = 'Carica altri';
+    await waitFor(() => {
+      expect(screen.getByText(`Rulebook 0`)).toBeInTheDocument();
+      expect(screen.getByText(loadMoreLabel)).toBeInTheDocument();
+    });
+
+    // Click load more
+    await userEvent.click(screen.getByText(loadMoreLabel));
+
+    // Wait for second page results
+    await waitFor(() => {
+      // All 10 results (page 1 + page 2)
+      for (let i = 0; i < 10; i++) {
+        expect(screen.getByText(`Rulebook ${i}`)).toBeInTheDocument();
+      }
+    });
+
+    // Verify second request had cursor forwarded
+    const secondBody = capturedBodies[1] as { cursor?: string };
+    expect(secondBody?.cursor).toBe('cursor-page-2');
+
+    // After second page loads, "Load more" button should be gone (hasMore=false)
+    await waitFor(() => {
+      expect(screen.queryByText(loadMoreLabel)).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Scenario 4: Debounce — query fires with correct value after 250ms ────────
+  // useDebounce initialises with the current value so the query fires almost
+  // immediately on mount when `q` is already set in the URL. The test verifies
+  // that the POST carries the correct query value.
+  // Real timers only — fake-timers + TanStack Query v5 = deadlock (P129).
+  it('S4: debounce coalesces — POST fires with correct query value (wingspan)', async () => {
+    const capturedBodies: { query?: string }[] = [];
+
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 20 });
+      }),
+      http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, async ({ request }) => {
+        const body = (await request.json()) as { query: string };
+        capturedBodies.push(body);
+        return HttpResponse.json({ results: [], hasMore: false, nextCursor: null });
+      })
+    );
+
+    // Mount directly on results branch with a >= 2 char query.
+    // useDebounce starts with the initial value so the POST fires within
+    // the debounce period (250ms). We wait up to 1500ms for it to arrive.
+    searchParamsMap = { q: 'wingspan' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    await waitFor(
+      () => {
+        // At least one POST should have been captured
+        expect(capturedBodies.length).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 1500 }
+    );
+
+    // The last (or only) request body must carry the correct query
+    const lastBody = capturedBodies[capturedBodies.length - 1];
+    expect(lastBody?.query).toBe('wingspan');
+  }, 5000); // timeout in ms — Vitest 4 form (number, not object)
+
+  // ── Scenario 5: Search 500 error — error banner visible, no crash ──────────
+  it('S5: search returns 500 — error banner with role=alert visible', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 20 });
+      }),
+      http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, () => {
+        return HttpResponse.json({ error: 'internal error' }, { status: 500 });
+      })
+    );
+
+    searchParamsMap = { q: 'azul' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Error banner should appear (role="alert" in KbSearchResultsDesktop.ErrorBanner)
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  // ── Scenario 6: Query clear — router.push called with bare path ─────────────
+  it('S6: query clear — router.push called with bare /knowledge-base/global', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ items: [], total: 0, page: 1, pageSize: 20 });
+      }),
+      http.post(`${API_BASE}/api/v1/knowledge-base/search/global`, () => {
+        return HttpResponse.json({ results: [], hasMore: false, nextCursor: null });
+      })
+    );
+
+    // Start on results branch
+    searchParamsMap = { q: 'azul' };
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // Click the clear button in HeroSearch (aria-label = labels.clear = 'Cancella')
+    // HeroSearch shows clear button only when query.length > 0.
+    // initialQuery is wired from `q` URL param, so the clear button is visible.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Cancella')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText('Cancella'));
+
+    // router.push should be called with the bare path
+    expect(mockRouterPush).toHaveBeenCalledWith('/knowledge-base/global');
+  });
+
+  // ── Scenario 7: Recent docs fetch error — home error banner visible ─────────
+  it('S7: GET /api/v1/kb-docs returns 500 — home error banner visible, no crash', async () => {
+    server.use(
+      http.get(`${API_BASE}/api/v1/kb-docs`, () => {
+        return HttpResponse.json({ error: 'server error' }, { status: 500 });
+      })
+    );
+
+    searchParamsMap = {};
+    const Wrapper = createWrapper();
+    render(<KbGlobaleView />, { wrapper: Wrapper });
+
+    // With retry:false in QueryClient + globalRequestCache cleared + 500 MSW response:
+    // TanStack Query sets error state immediately (no retries, no stale cache).
+    // KbHomeDesktop.ErrorBanner renders role="alert" when recent.error is non-null.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * KbGlobaleView.test.tsx
+ * Issue #1482 Task 6 — Orchestrator unit tests
+ *
+ * Tests the URL SSOT routing logic, hook gating, and URL push behaviour.
+ * Sub-components (HeroSearch, KbHomeDesktop, KbSearchResultsDesktop) are
+ * mocked with data-testid stubs so tests focus exclusively on the orchestrator.
+ * Hooks are mocked with vi.fn() returning controllable stubs.
+ *
+ * Pattern: mirrors AgentsLibraryView.test.tsx (next/navigation mock pattern).
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { UseGlobalKbSearchResult } from '@/hooks/queries/useGlobalKbSearch';
+import type { UseUserKbDocsResult } from '@/hooks/queries/useUserKbDocs';
+import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+// ─── next/navigation mocks ────────────────────────────────────────────────
+// Mutable state object so individual tests can override URL params.
+
+type SearchParamsRecord = Record<string, string | null>;
+let searchParamsMap: SearchParamsRecord = {};
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsMap[key] ?? null,
+  }),
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: vi.fn(),
+  }),
+  usePathname: () => '/knowledge-base/global',
+}));
+
+// ─── useGlobalKbSearch mock ───────────────────────────────────────────────
+
+const useGlobalKbSearchMock = vi.fn<[unknown], UseGlobalKbSearchResult>();
+
+vi.mock('@/hooks/queries/useGlobalKbSearch', () => ({
+  useGlobalKbSearch: (opts: unknown) => useGlobalKbSearchMock(opts),
+}));
+
+// ─── useUserKbDocs mock ───────────────────────────────────────────────────
+
+type MockUserKbDocsReturn = Partial<UseQueryResult<UseUserKbDocsResult>>;
+const useUserKbDocsMock = vi.fn<[], MockUserKbDocsReturn>();
+
+vi.mock('@/hooks/queries/useUserKbDocs', () => ({
+  useUserKbDocs: () => useUserKbDocsMock(),
+}));
+
+// ─── Child component mocks ────────────────────────────────────────────────
+// Replace each sub-component with a minimal stub that:
+//   1. Renders a known data-testid for presence assertions.
+//   2. Exposes attributes for prop inspection.
+//   3. Exposes callback buttons to simulate user interactions.
+
+let capturedHeroSearchProps: Record<string, unknown> = {};
+let capturedKbHomeDesktopProps: Record<string, unknown> = {};
+let capturedKbSearchResultsDesktopProps: Record<string, unknown> = {};
+
+vi.mock('@/components/features/kb-globale/HeroSearch', () => ({
+  HeroSearch: (props: Record<string, unknown>) => {
+    capturedHeroSearchProps = props;
+    return (
+      <div
+        data-testid="hero-search"
+        data-initial-query={String(props['initialQuery'] ?? '')}
+        data-initial-mode={String(props['initialMode'] ?? '')}
+      >
+        <button
+          data-testid="hero-submit-btn"
+          onClick={() => {
+            const fn = props['onSubmit'] as ((q: string, m: string) => void) | undefined;
+            fn?.('azul', 'Semantic');
+          }}
+        >
+          submit
+        </button>
+        <button
+          data-testid="hero-clear-btn"
+          onClick={() => {
+            const fn = props['onClear'] as (() => void) | undefined;
+            fn?.();
+          }}
+        >
+          clear
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('@/components/features/kb-globale/KbHomeDesktop', () => ({
+  KbHomeDesktop: (props: Record<string, unknown>) => {
+    capturedKbHomeDesktopProps = props;
+    return (
+      <div
+        data-testid="kb-home-desktop"
+        data-is-loading={String(props['isLoading'])}
+        data-has-error={String(props['error'] !== null)}
+      />
+    );
+  },
+}));
+
+vi.mock('@/components/features/kb-globale/KbSearchResultsDesktop', () => ({
+  KbSearchResultsDesktop: (props: Record<string, unknown>) => {
+    capturedKbSearchResultsDesktopProps = props;
+    return (
+      <div
+        data-testid="kb-results-desktop"
+        data-query={String(props['query'] ?? '')}
+        data-is-loading={String(props['isLoading'])}
+      />
+    );
+  },
+}));
+
+// ─── Import component after mocks ─────────────────────────────────────────
+// Static import: vi.mock() is hoisted before imports by Vite, so order is safe.
+
+import { KbGlobaleView } from '../KbGlobaleView';
+
+// ─── fixture helpers ──────────────────────────────────────────────────────
+
+function makeSearchResult(): UseGlobalKbSearchResult {
+  return {
+    results: [],
+    hasMore: false,
+    isLoading: false,
+    isFetchingNextPage: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+  };
+}
+
+function makeUserKbDocsResult(): MockUserKbDocsReturn {
+  return {
+    data: { items: [] as KbDoc[], total: 0, page: 1, pageSize: 20 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  } as MockUserKbDocsReturn;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('KbGlobaleView (orchestrator)', () => {
+  beforeEach(() => {
+    // Reset URL state to empty (home branch) by default.
+    searchParamsMap = {};
+    // Full reset (clears call counts + return values) then re-configure defaults.
+    mockRouterPush.mockReset();
+    useGlobalKbSearchMock.mockReset();
+    useUserKbDocsMock.mockReset();
+    useGlobalKbSearchMock.mockReturnValue(makeSearchResult());
+    useUserKbDocsMock.mockReturnValue(makeUserKbDocsResult());
+    capturedHeroSearchProps = {};
+    capturedKbHomeDesktopProps = {};
+    capturedKbSearchResultsDesktopProps = {};
+  });
+
+  // ── Test 1: HeroSearch always rendered ──────────────────────────────────
+  describe('HeroSearch presence', () => {
+    it('renders HeroSearch on home branch (q empty)', () => {
+      searchParamsMap = {};
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('hero-search')).toBeInTheDocument();
+    });
+
+    it('renders HeroSearch on results branch (q present)', () => {
+      searchParamsMap = { q: 'azul' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('hero-search')).toBeInTheDocument();
+    });
+  });
+
+  // ── Test 2: q empty → home branch ─────────────────────────────────────
+  describe('home branch (q empty)', () => {
+    it('renders KbHomeDesktop, not KbSearchResultsDesktop', () => {
+      searchParamsMap = {};
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('kb-home-desktop')).toBeInTheDocument();
+      expect(screen.queryByTestId('kb-results-desktop')).not.toBeInTheDocument();
+    });
+
+    it('treats whitespace-only q as empty (home branch)', () => {
+      searchParamsMap = { q: '   ' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('kb-home-desktop')).toBeInTheDocument();
+      expect(screen.queryByTestId('kb-results-desktop')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Test 3: q present → results branch ───────────────────────────────
+  describe('results branch (q present)', () => {
+    it('renders KbSearchResultsDesktop, not KbHomeDesktop', () => {
+      searchParamsMap = { q: 'azul' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('kb-results-desktop')).toBeInTheDocument();
+      expect(screen.queryByTestId('kb-home-desktop')).not.toBeInTheDocument();
+    });
+
+    it('passes query prop to KbSearchResultsDesktop', () => {
+      searchParamsMap = { q: 'wingspan' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('kb-results-desktop')).toHaveAttribute('data-query', 'wingspan');
+    });
+  });
+
+  // ── Test 4: mode=Semantic in URL ─────────────────────────────────────
+  it('passes mode=Semantic to useGlobalKbSearch when present in URL', () => {
+    searchParamsMap = { q: 'azul', mode: 'Semantic' };
+    render(<KbGlobaleView />);
+    const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as {
+      mode?: string;
+      enabled?: boolean;
+    };
+    expect(callArg?.mode).toBe('Semantic');
+  });
+
+  // ── Test 5: mode invalid in URL → undefined ───────────────────────────
+  it('falls back to mode=undefined when URL mode param is invalid', () => {
+    searchParamsMap = { q: 'azul', mode: 'Keyword' }; // not in SearchMode enum
+    render(<KbGlobaleView />);
+    const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as {
+      mode?: string;
+      enabled?: boolean;
+    };
+    expect(callArg?.mode).toBeUndefined();
+  });
+
+  // ── Test 6: HeroSearch.onSubmit → router.push with ?q (Semantic = default, omit) ──
+  it('calls router.push with only ?q=azul when mode is Semantic (default, omitted)', () => {
+    searchParamsMap = {};
+    render(<KbGlobaleView />);
+    screen.getByTestId('hero-submit-btn').click();
+    expect(mockRouterPush).toHaveBeenCalledWith('/knowledge-base/global?q=azul');
+  });
+
+  // ── Test 7 note: SearchMode currently only has 'Semantic'.
+  // Since only one mode exists, the URL serialization omits mode (it is the default).
+  // Test 6 covers this path exhaustively. No non-Semantic mode test added to
+  // avoid type casts that would break when SearchMode expands. Documented per spec.
+
+  // ── Test 8: HeroSearch.onClear → router.push bare path ──────────────
+  it('calls router.push with bare /knowledge-base/global on clear', () => {
+    searchParamsMap = { q: 'azul' };
+    render(<KbGlobaleView />);
+    screen.getByTestId('hero-clear-btn').click();
+    expect(mockRouterPush).toHaveBeenCalledWith('/knowledge-base/global');
+  });
+
+  // ── Test 9: useGlobalKbSearch.enabled gating ─────────────────────────
+  describe('useGlobalKbSearch enabled gating (no double-fetch)', () => {
+    it('passes enabled=false when q is empty', () => {
+      searchParamsMap = {};
+      render(<KbGlobaleView />);
+      const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as { enabled?: boolean };
+      expect(callArg?.enabled).toBe(false);
+    });
+
+    it('passes enabled=true when q is present', () => {
+      searchParamsMap = { q: 'azul' };
+      render(<KbGlobaleView />);
+      const callArg = useGlobalKbSearchMock.mock.calls[0]?.[0] as { enabled?: boolean };
+      expect(callArg?.enabled).toBe(true);
+    });
+  });
+
+  // ── Test 10: useUserKbDocs always called ─────────────────────────────
+  describe('useUserKbDocs always called (cached, cheap)', () => {
+    it('calls useUserKbDocs on home branch', () => {
+      searchParamsMap = {};
+      render(<KbGlobaleView />);
+      expect(useUserKbDocsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls useUserKbDocs on results branch too', () => {
+      searchParamsMap = { q: 'azul' };
+      render(<KbGlobaleView />);
+      expect(useUserKbDocsMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Additional: HeroSearch prop wiring ────────────────────────────────
+  describe('HeroSearch prop wiring', () => {
+    it('wires initialQuery from URL q', () => {
+      searchParamsMap = { q: 'gloomhaven' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('hero-search')).toHaveAttribute('data-initial-query', 'gloomhaven');
+    });
+
+    it('defaults initialMode to Semantic when mode absent from URL', () => {
+      searchParamsMap = {};
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('hero-search')).toHaveAttribute('data-initial-mode', 'Semantic');
+    });
+
+    it('wires Semantic mode from URL to initialMode', () => {
+      searchParamsMap = { q: 'azul', mode: 'Semantic' };
+      render(<KbGlobaleView />);
+      expect(screen.getByTestId('hero-search')).toHaveAttribute('data-initial-mode', 'Semantic');
+    });
+  });
+
+  // ── KbHomeDesktop receives recentDocs from useUserKbDocs ──────────────
+  it('passes recentDocs from useUserKbDocs.data.items to KbHomeDesktop', () => {
+    const mockDoc: KbDoc = {
+      id: 'doc-1',
+      gameId: 'game-1',
+      gameName: 'Azul',
+      fileName: 'azul.pdf',
+      processingState: 'ready',
+      pageCount: 10,
+      processedAt: '2026-01-01T00:00:00Z',
+      uploadedAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    searchParamsMap = {};
+    useUserKbDocsMock.mockReturnValue({
+      data: { items: [mockDoc], total: 1, page: 1, pageSize: 20 },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as MockUserKbDocsReturn);
+    render(<KbGlobaleView />);
+    const homeProps = capturedKbHomeDesktopProps as { recentDocs?: KbDoc[] };
+    expect(homeProps.recentDocs).toHaveLength(1);
+    expect(homeProps.recentDocs?.[0]?.id).toBe('doc-1');
+  });
+
+  // ── KbSearchResultsDesktop receives results from useGlobalKbSearch ────
+  it('passes results from useGlobalKbSearch to KbSearchResultsDesktop', () => {
+    const mockResult = {
+      chunkId: 'chunk-1',
+      docId: '00000000-0000-0000-0000-000000000001',
+      docTitle: 'Azul Rulebook',
+      gameId: '00000000-0000-0000-0000-000000000002',
+      gameName: 'Azul',
+      docType: 'Rulebook',
+      headingPath: null,
+      snippet: 'On your turn, take tiles from factories...',
+      pageNumber: 3,
+      score: 0.95,
+    };
+    searchParamsMap = { q: 'azul' };
+    useGlobalKbSearchMock.mockReturnValue({
+      results: [mockResult],
+      hasMore: false,
+      isLoading: false,
+      isFetchingNextPage: false,
+      error: null,
+      fetchNextPage: vi.fn(),
+    });
+    render(<KbGlobaleView />);
+    const resultsProps = capturedKbSearchResultsDesktopProps as { results?: unknown[] };
+    expect(resultsProps.results).toHaveLength(1);
+  });
+});

--- a/apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * /knowledge-base/global — Route shell
+ * Issue #1482 Task 6
+ *
+ * Thin server component wrapping the client orchestrator in a Suspense
+ * boundary. Required by Next.js App Router: the orchestrator uses
+ * `useSearchParams()` which opts the subtree out of SSR static prerendering;
+ * without Suspense the build emits a CSR bailout warning.
+ *
+ * @see KbGlobaleView — client orchestrator (URL SSOT, branch logic, hooks)
+ */
+
+import { type JSX, Suspense } from 'react';
+
+import { KbGlobaleView } from './_components/KbGlobaleView';
+
+export default function KnowledgeBaseGlobalPage(): JSX.Element {
+  return (
+    <Suspense fallback={null}>
+      <KbGlobaleView />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/HeroSearch.tsx
+++ b/apps/web/src/components/features/kb-globale/HeroSearch.tsx
@@ -1,0 +1,200 @@
+/**
+ * HeroSearch.tsx
+ * Issue #1482 Task 2 — Hero search component for KB Globale
+ *
+ * A large, prominent search input with SearchMode segmented control.
+ * Features:
+ * - Controlled input with character limit enforcement (min 2 chars for submit)
+ * - Segmented control for SearchMode selection (Semantic in v1)
+ * - Submit via Enter key or click button (only when query >= 2 chars)
+ * - Clear button (×) surfaces only when query non-empty
+ * - Labels-injected (no hardcoded strings — consumer wires i18n)
+ * - DS-15 semantic tokens
+ * - jest-axe compliant
+ *
+ * @see Issue #1482 Phase 1 Foundation
+ * @see admin-mockups/design_files/sp4-kb-globale.jsx (HeroSearch pattern, lines 175–212)
+ */
+
+import { type JSX, useState } from 'react';
+
+import type { SearchMode } from '@/lib/api/schemas/kb-globale.schemas';
+
+export interface HeroSearchLabels {
+  /** Placeholder text for the search input */
+  placeholder: string;
+  /** Label for the submit button */
+  submit: string;
+  /** Label for the clear button */
+  clear: string;
+  /** Aria-label for the mode segmented control group */
+  modeLabel: string;
+  /** Labels for each SearchMode option */
+  modeOptions: Record<SearchMode, string>;
+}
+
+export interface HeroSearchProps {
+  /** Initial search query (defaults to '') */
+  initialQuery?: string;
+  /** Initial search mode (defaults to 'Semantic') */
+  initialMode?: SearchMode;
+  /** Called when user submits a query >= 2 chars via Enter or button click */
+  onSubmit: (query: string, mode: SearchMode) => void;
+  /** Called when user clears the input via the clear button */
+  onClear?: () => void;
+  /** All UI labels (injected by consumer — no hardcoded i18n strings) */
+  labels: HeroSearchLabels;
+  /** Optional wrapper class name */
+  className?: string;
+}
+
+/**
+ * HeroSearch component — large, prominent search input with mode toggle.
+ *
+ * Local state: query (string), mode (SearchMode).
+ * Submit only fires when `query.trim().length >= 2`.
+ * Clear button surfaces only when `query.length > 0`.
+ * Aria-pressed on mode buttons reflects current selection.
+ *
+ * @example
+ * ```tsx
+ * <HeroSearch
+ *   initialQuery="azul"
+ *   initialMode="Semantic"
+ *   onSubmit={(q, m) => router.push(`/kb?q=${q}&mode=${m}`)}
+ *   onClear={() => router.push('/kb')}
+ *   labels={labels}
+ * />
+ * ```
+ */
+export function HeroSearch(props: HeroSearchProps): JSX.Element {
+  const {
+    initialQuery = '',
+    initialMode = 'Semantic',
+    onSubmit,
+    onClear,
+    labels,
+    className,
+  } = props;
+
+  const [query, setQuery] = useState<string>(initialQuery);
+  const [mode, setMode] = useState<SearchMode>(initialMode);
+
+  const trimmedQuery = query.trim();
+  const canSubmit = trimmedQuery.length >= 2;
+  const showClear = query.length > 0;
+
+  const handleSubmit = () => {
+    if (canSubmit) {
+      onSubmit(trimmedQuery, mode);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
+  const handleClear = () => {
+    setQuery('');
+    onClear?.();
+  };
+
+  // For v1, only Semantic mode is available; structure allows easy expansion
+  const modeEntries = Object.entries(labels.modeOptions) as [SearchMode, string][];
+
+  return (
+    <div className={className}>
+      {/* Hero search input container */}
+      <div
+        className="relative bg-card border-2 rounded-2xl transition-all duration-150"
+        style={{
+          borderColor: 'var(--border)',
+          boxShadow: 'var(--shadow-md)',
+        }}
+      >
+        {/* Search icon (left) */}
+        <div
+          className="absolute left-4 top-1/2 flex items-center justify-center -translate-y-1/2 w-7 h-7 rounded-sm bg-entity-kb/10 text-entity-kb text-sm font-bold"
+          aria-hidden="true"
+        >
+          🔎
+        </div>
+
+        {/* Input */}
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={labels.placeholder}
+          className="w-full border-0 outline-none bg-transparent text-foreground pl-14 pr-16 py-3 font-body text-base font-medium placeholder-muted-foreground"
+          aria-label={labels.placeholder}
+        />
+
+        {/* Clear button (right, only when query non-empty) */}
+        {showClear && (
+          <button
+            onClick={handleClear}
+            type="button"
+            className="absolute right-4 top-1/2 -translate-y-1/2 h-7 w-7 flex items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            aria-label={labels.clear}
+            title={labels.clear}
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* Search mode segmented control */}
+      <div className="mt-4 flex items-center gap-4">
+        <label
+          className="text-xs font-bold uppercase tracking-wider text-muted-foreground whitespace-nowrap"
+          htmlFor="search-mode-group"
+        >
+          {labels.modeLabel}
+        </label>
+        <div
+          id="search-mode-group"
+          role="group"
+          aria-label={labels.modeLabel}
+          className="flex gap-2"
+        >
+          {modeEntries.map(([modeValue, modeLabel]) => (
+            <button
+              key={modeValue}
+              type="button"
+              onClick={() => setMode(modeValue)}
+              aria-pressed={mode === modeValue}
+              className={`px-4 py-2 rounded-md text-sm font-semibold transition-colors ${
+                mode === modeValue
+                  ? 'bg-entity-kb text-white'
+                  : 'bg-entity-kb/10 text-entity-kb border border-entity-kb/20 hover:bg-entity-kb/20'
+              }`}
+            >
+              {modeLabel}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Submit button */}
+      <div className="mt-4 flex justify-end">
+        <button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          type="button"
+          className={`px-6 py-2.5 rounded-md font-bold transition-colors ${
+            canSubmit
+              ? 'bg-entity-kb text-white hover:bg-entity-kb/90 cursor-pointer'
+              : 'bg-muted text-muted-foreground opacity-50 cursor-not-allowed'
+          }`}
+          aria-label={labels.submit}
+        >
+          {labels.submit}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/KbEmptyState.tsx
+++ b/apps/web/src/components/features/kb-globale/KbEmptyState.tsx
@@ -1,0 +1,156 @@
+/**
+ * KbEmptyState.tsx
+ * Issue #1482 Task 3 — Empty state component for KB Globale
+ *
+ * Discriminated component supporting two variants:
+ * - kind='no-query': Landing state when user arrives without search query
+ *   → "Start searching across your library" with optional CTA
+ * - kind='no-results': Post-search state when query returned 0 results
+ *   → "No matches for «query»" with optional "Try again" CTA
+ *
+ * Features:
+ * - Labels-injected (no hardcoded i18n strings — consumer wires i18n)
+ * - CTA conditional: rendered ONLY when both labels.cta + onCtaClick provided
+ * - Optional custom icon slot (or no icon if undefined)
+ * - A11y: role="status" (no-results), role="region" + aria-label (no-query)
+ * - DS-15 semantic tokens (bg-card, text-foreground, border-border, bg-entity-kb)
+ * - jest-axe compliant
+ *
+ * @see Issue #1482 Phase 1 Foundation
+ * @see admin-mockups/design_files/sp4-kb-globale.jsx (KbEmptyState pattern, lines 2437–2533)
+ */
+
+import { type JSX, type ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type KbEmptyKind = 'no-query' | 'no-results';
+
+export interface KbEmptyStateLabels {
+  /** Main heading text (required) */
+  title: string;
+  /** Descriptive paragraph text (required) */
+  description: string;
+  /** CTA button label (optional — if undefined, no button rendered) */
+  cta?: string;
+}
+
+export interface KbEmptyStateProps {
+  /** Variant discriminator: 'no-query' (landing) or 'no-results' (search) */
+  kind: KbEmptyKind;
+  /** All UI labels (injected by consumer — no hardcoded i18n strings) */
+  labels: KbEmptyStateLabels;
+  /** Called when user clicks CTA button (optional) */
+  onCtaClick?: () => void;
+  /** Optional custom icon element to render above title (or undefined for no icon) */
+  icon?: ReactNode;
+  /** Additional CSS classes applied to root element */
+  className?: string;
+}
+
+/**
+ * KbEmptyState component — discriminated empty state for KB Globale.
+ *
+ * Variants:
+ * - kind='no-query': landing CTA view with role="region"
+ * - kind='no-results': search result view with role="status"
+ *
+ * CTA button rendered only when BOTH labels.cta and onCtaClick provided.
+ *
+ * @example
+ * ```tsx
+ * // Landing (no query)
+ * <KbEmptyState
+ *   kind="no-query"
+ *   labels={{
+ *     title: "Start searching",
+ *     description: "Explore your KB...",
+ *     cta: "Upload first document"
+ *   }}
+ *   onCtaClick={() => openUploadModal()}
+ * />
+ *
+ * // No results (post-search)
+ * <KbEmptyState
+ *   kind="no-results"
+ *   labels={{
+ *     title: `No matches for «${query}»`,
+ *     description: "Try different keywords...",
+ *   }}
+ * />
+ * ```
+ */
+export function KbEmptyState({
+  kind,
+  labels,
+  onCtaClick,
+  icon,
+  className,
+}: KbEmptyStateProps): JSX.Element {
+  const roleProps =
+    kind === 'no-results' ? { role: 'status' } : { role: 'region', 'aria-label': labels.title };
+
+  // CTA rendered only when BOTH labels.cta + onCtaClick present
+  const showCta = !!labels.cta && !!onCtaClick;
+
+  return (
+    <div
+      {...roleProps}
+      className={cn(
+        // Layout: centered flex column
+        'flex flex-col items-center justify-center',
+        'py-16 px-6 text-center',
+        // Card: KB-themed border + background
+        'rounded-xl',
+        'bg-card border border-entity-kb/20',
+        // Optional spacing wrapper (if parent layout needs margin)
+        className
+      )}
+    >
+      {/* Optional icon */}
+      {icon && (
+        <div className="mb-6 flex items-center justify-center text-entity-kb" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+
+      {/* Title heading */}
+      <h2 className={cn('text-2xl font-bold', 'text-foreground', 'mb-3', 'tracking-tight')}>
+        {labels.title}
+      </h2>
+
+      {/* Description paragraph */}
+      <p
+        className={cn('text-base', 'text-muted-foreground', 'mb-6', 'max-w-md', 'leading-relaxed')}
+      >
+        {labels.description}
+      </p>
+
+      {/* CTA button (conditional) */}
+      {showCta && (
+        <button
+          type="button"
+          onClick={onCtaClick}
+          className={cn(
+            // Layout
+            'inline-flex items-center justify-center',
+            'px-6 py-2.5',
+            // Typography
+            'font-semibold text-sm',
+            // Styling: KB entity color
+            'bg-entity-kb hover:bg-entity-kb/90',
+            'text-white',
+            // Border + Transitions
+            'border border-entity-kb',
+            'rounded-md',
+            'transition-colors duration-200',
+            // Focus state
+            'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-2'
+          )}
+        >
+          {labels.cta}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/KbEmptyState.tsx
+++ b/apps/web/src/components/features/kb-globale/KbEmptyState.tsx
@@ -137,9 +137,8 @@ export function KbEmptyState({
             'px-6 py-2.5',
             // Typography
             'font-semibold text-sm',
-            // Styling: KB entity color
-            'bg-entity-kb hover:bg-entity-kb/90',
-            'text-white',
+            // Styling: KB entity color (text-white allowed: same string as bg-entity-kb per DS-15)
+            'bg-entity-kb text-white hover:bg-entity-kb/90',
             // Border + Transitions
             'border border-entity-kb',
             'rounded-md',

--- a/apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx
@@ -1,0 +1,265 @@
+/**
+ * KbHomeDesktop.tsx
+ * Issue #1482 Task 4 — KB Globale landing component (recent docs grid)
+ *
+ * Pure presentational component shown when the KB page has no active search
+ * query (?q= absent). Receives `recentDocs / isLoading / error` as props from
+ * the orchestrator (Task 6) — does NOT call any hooks directly.
+ *
+ * States:
+ *  - Loading:  12 skeleton cards in a 3-col desktop grid
+ *  - Error:    inline alert banner with optional retry button
+ *  - Empty:    delegates to KbEmptyState kind="no-query"
+ *  - Loaded:   responsive grid of doc cards (fileName + gameName + updatedAt)
+ *
+ * Design tokens: DS-15 semantic tokens (bg-card, text-foreground,
+ *   text-muted-foreground, border-border, bg-entity-kb)
+ *
+ * @see Issue #1482 Phase 1 Foundation
+ * @see admin-mockups/design_files/sp4-kb-globale.jsx (Screen 1: "Centro: documenti grid")
+ */
+
+import { type JSX } from 'react';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
+import { cn } from '@/lib/utils';
+
+import { KbEmptyState } from './KbEmptyState';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface KbHomeDesktopLabels {
+  /** Section heading text (h2) */
+  heading: string;
+  /** Labels forwarded to KbEmptyState when list is empty */
+  empty: {
+    title: string;
+    description: string;
+    cta?: string;
+  };
+  /** Error banner title */
+  errorTitle: string;
+  /** Error banner description */
+  errorDescription: string;
+  /** Optional retry button label; if absent no retry button is rendered */
+  retry?: string;
+  /** Aria-label factory for each doc card (used for a11y) */
+  docCardAriaLabel: (doc: KbDoc) => string;
+}
+
+export interface KbHomeDesktopProps {
+  /** Recent KB docs from the orchestrator — NOT fetched inside this component */
+  recentDocs: readonly KbDoc[];
+  /** True while the orchestrator is fetching */
+  isLoading: boolean;
+  /** Non-null when the orchestrator query errored */
+  error: Error | null;
+  /** All UI labels (consumers wire i18n externally) */
+  labels: KbHomeDesktopLabels;
+  /** Called with doc.id when a doc card is clicked (Phase 2 viewer, optional) */
+  onDocClick?: (docId: string) => void;
+  /** Called when the KbEmptyState CTA is clicked */
+  onEmptyCtaClick?: () => void;
+  /** Called when the error banner retry button is clicked */
+  onRetry?: () => void;
+  /** Extra CSS classes on the root element */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** 12-card skeleton grid — same columns as the loaded doc grid to prevent layout shift */
+function KbHomeSkeletons(): JSX.Element {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div key={`skeleton-${i}`} data-testid="kb-home-skeleton" className="flex flex-col gap-2">
+          <Skeleton className="h-16 w-full rounded-md" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-3 w-1/2" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface DocCardProps {
+  doc: KbDoc;
+  ariaLabel: string;
+  onDocClick?: (docId: string) => void;
+}
+
+/** Single doc card — rendered as <button> when onDocClick provided, <div> otherwise */
+function DocCard({ doc, ariaLabel, onDocClick }: DocCardProps): JSX.Element {
+  const gameName = doc.gameName ?? '(senza gioco)';
+
+  // Format date — simple locale date, no extra library required
+  const dateLabel = doc.updatedAt
+    ? new Date(doc.updatedAt).toLocaleDateString('it-IT', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      })
+    : '—';
+
+  const cardContent = (
+    <>
+      {/* KB accent bar at top */}
+      <div className="h-1.5 w-full rounded-t-md bg-entity-kb/60" aria-hidden="true" />
+
+      {/* Card body */}
+      <div className="p-3">
+        {/* File name */}
+        <p className={cn('truncate text-sm font-semibold text-foreground', 'mb-1 leading-snug')}>
+          {doc.fileName}
+        </p>
+
+        {/* Game name */}
+        <p className="truncate text-xs text-muted-foreground">{gameName}</p>
+
+        {/* Footer: date + optional page count */}
+        <div className="mt-2 flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+          <span>{dateLabel}</span>
+          {doc.pageCount != null && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{doc.pageCount} pag.</span>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
+  const sharedClasses = cn(
+    'overflow-hidden rounded-md border border-border bg-card',
+    'flex flex-col',
+    'transition-shadow duration-150'
+  );
+
+  if (onDocClick) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => onDocClick(doc.id)}
+        className={cn(
+          sharedClasses,
+          'w-full text-left',
+          'hover:shadow-md hover:border-entity-kb/40',
+          'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-2'
+        )}
+      >
+        {cardContent}
+      </button>
+    );
+  }
+
+  return <div className={sharedClasses}>{cardContent}</div>;
+}
+
+interface ErrorBannerProps {
+  errorTitle: string;
+  errorDescription: string;
+  retry?: string;
+  onRetry?: () => void;
+}
+
+function ErrorBanner({
+  errorTitle,
+  errorDescription,
+  retry,
+  onRetry,
+}: ErrorBannerProps): JSX.Element {
+  const showRetry = Boolean(onRetry && retry);
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'rounded-md border border-destructive/30 bg-destructive/10',
+        'px-4 py-3 text-sm text-foreground'
+      )}
+    >
+      <p className="font-semibold">{errorTitle}</p>
+      <p className="mt-0.5 text-muted-foreground">{errorDescription}</p>
+      {showRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className={cn(
+            'mt-2 inline-flex items-center justify-center',
+            'rounded-md border border-border px-3 py-1',
+            'text-xs font-medium text-foreground',
+            'hover:bg-muted',
+            'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-1',
+            'transition-colors duration-150'
+          )}
+        >
+          {retry}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function KbHomeDesktop({
+  recentDocs,
+  isLoading,
+  error,
+  labels,
+  onDocClick,
+  onEmptyCtaClick,
+  onRetry,
+  className,
+}: KbHomeDesktopProps): JSX.Element {
+  const isEmpty = recentDocs.length === 0 && !isLoading && !error;
+
+  return (
+    <section className={cn('flex flex-col gap-4', className)}>
+      {/* Section heading — always visible (even in error / loading state) */}
+      <h2 className="text-xl font-bold text-foreground">{labels.heading}</h2>
+
+      {/* Error state */}
+      {error && !isLoading && (
+        <ErrorBanner
+          errorTitle={labels.errorTitle}
+          errorDescription={labels.errorDescription}
+          retry={labels.retry}
+          onRetry={onRetry}
+        />
+      )}
+
+      {/* Loading state */}
+      {isLoading && <KbHomeSkeletons />}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <KbEmptyState kind="no-query" labels={labels.empty} onCtaClick={onEmptyCtaClick} />
+      )}
+
+      {/* Loaded state */}
+      {!isLoading && !error && recentDocs.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {recentDocs.map(doc => (
+            <DocCard
+              key={doc.id}
+              doc={doc}
+              ariaLabel={labels.docCardAriaLabel(doc)}
+              onDocClick={onDocClick}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx
@@ -1,0 +1,374 @@
+/**
+ * KbSearchResultsDesktop.tsx
+ * Issue #1482 Task 5 — KB Globale search results component
+ *
+ * Pure presentational component shown when the KB page has an active search
+ * query (?q=). Receives all data from the orchestrator (Task 6) — does NOT
+ * call any hooks directly.
+ *
+ * States:
+ *  - Loading:  5 skeleton rows (list-shaped, compact)
+ *  - Error:    inline alert banner with optional retry, result list hidden
+ *  - Empty:    delegates to KbEmptyState kind="no-results"
+ *  - Loaded:   <ul> of result rows: gameName pill + docTitle + DocType pill
+ *              + snippet + headingPath? + pageNumber? + score badge
+ *
+ * Load-more:
+ *  - Explicit button under the list (NO infinite scroll — Nygard D6 predictability)
+ *  - Disabled + label swap when isFetchingNextPage
+ *
+ * Design tokens: DS-15 semantic tokens (bg-card, text-foreground,
+ *   text-muted-foreground, border-border, bg-entity-kb, text-entity-kb)
+ *
+ * @see Issue #1482 Phase 1 Foundation
+ * @see admin-mockups/design_files/sp4-kb-globale.jsx (Screen 2: "KB Search Results Desktop")
+ */
+
+import { type JSX } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import type { GlobalKbSearchResult } from '@/lib/api/schemas/kb-globale.schemas';
+import { cn } from '@/lib/utils';
+
+import { KbEmptyState } from './KbEmptyState';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface KbSearchResultsDesktopLabels {
+  /** Header count formatter: (n, q) => "12 risultati per «azul»" */
+  resultsCount: (n: number, q: string) => string;
+  /** Label for the load-more button when idle */
+  loadMore: string;
+  /** Label for the load-more button when isFetchingNextPage */
+  loadingMore: string;
+  /** Labels forwarded to KbEmptyState kind="no-results" */
+  empty: {
+    title: string;
+    description: string;
+    cta?: string;
+  };
+  /** Error banner title */
+  errorTitle: string;
+  /** Error banner description */
+  errorDescription: string;
+  /** Optional retry button label; omit to hide retry button */
+  retry?: string;
+  /** Accessibility label factory for each result row */
+  resultAriaLabel: (r: GlobalKbSearchResult) => string;
+  /** Label for page number, e.g. "Pagina 14" */
+  pageLabel: (n: number) => string;
+  /** Optional docType display transformer; falls back to raw docType string */
+  docTypeLabel?: (rawType: string) => string;
+}
+
+export interface KbSearchResultsDesktopProps {
+  /** Active search query string (used for header + empty state context) */
+  query: string;
+  /** Flat list of search result chunks from the orchestrator */
+  results: readonly GlobalKbSearchResult[];
+  /** True when there are more pages available */
+  hasMore: boolean;
+  /** True during the initial fetch (no results yet) */
+  isLoading: boolean;
+  /** True while a load-more page is being fetched */
+  isFetchingNextPage: boolean;
+  /** Non-null when the orchestrator query errored */
+  error: Error | null;
+  /** Called when load-more button is clicked */
+  onLoadMore: () => void;
+  /** Called when a result row is clicked (Phase 2 viewer wire, optional) */
+  onResultClick?: (r: GlobalKbSearchResult) => void;
+  /** Called when the KbEmptyState CTA is clicked */
+  onEmptyCtaClick?: () => void;
+  /** Called when the error banner retry button is clicked */
+  onRetry?: () => void;
+  /** All UI labels (consumers wire i18n externally) */
+  labels: KbSearchResultsDesktopLabels;
+  /** Extra CSS classes on the root element */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** 5-row loading skeleton — compact row-shaped to match the result list */
+function KbSearchSkeletons(): JSX.Element {
+  return (
+    <div className="flex flex-col gap-3">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={`skeleton-${i}`}
+          data-testid="kb-search-skeleton"
+          className="flex flex-col gap-2 rounded-md border border-border bg-card p-4"
+        >
+          {/* Top line: pill + title */}
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-20 rounded-full" />
+            <Skeleton className="h-5 w-48" />
+          </div>
+          {/* Snippet */}
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          {/* Footer */}
+          <div className="flex gap-3">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ErrorBannerProps {
+  errorTitle: string;
+  errorDescription: string;
+  retry?: string;
+  onRetry?: () => void;
+}
+
+function ErrorBanner({
+  errorTitle,
+  errorDescription,
+  retry,
+  onRetry,
+}: ErrorBannerProps): JSX.Element {
+  const showRetry = Boolean(onRetry && retry);
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'rounded-md border border-destructive/30 bg-destructive/10',
+        'px-4 py-3 text-sm text-foreground'
+      )}
+    >
+      <p className="font-semibold">{errorTitle}</p>
+      <p className="mt-0.5 text-muted-foreground">{errorDescription}</p>
+      {showRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className={cn(
+            'mt-2 inline-flex items-center justify-center',
+            'rounded-md border border-border px-3 py-1',
+            'text-xs font-medium text-foreground',
+            'hover:bg-muted',
+            'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-1',
+            'transition-colors duration-150'
+          )}
+        >
+          {retry}
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface ResultRowProps {
+  result: GlobalKbSearchResult;
+  ariaLabel: string;
+  pageLabel: (n: number) => string;
+  docTypeLabel?: (rawType: string) => string;
+  onResultClick?: (r: GlobalKbSearchResult) => void;
+}
+
+/** Single search result row */
+function ResultRow({
+  result,
+  ariaLabel,
+  pageLabel,
+  docTypeLabel,
+  onResultClick,
+}: ResultRowProps): JSX.Element {
+  const displayDocType = docTypeLabel ? docTypeLabel(result.docType) : result.docType;
+  const formattedScore = result.score.toFixed(2);
+
+  const rowContent = (
+    <>
+      {/* Top line: gameName pill + docTitle + docType pill */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* gameName pill — KB entity color */}
+        <span
+          className={cn(
+            'inline-flex items-center gap-1',
+            'rounded-full px-2 py-0.5',
+            'bg-entity-kb/10 text-entity-kb',
+            'border border-entity-kb/20',
+            'text-xs font-semibold',
+            'whitespace-nowrap'
+          )}
+        >
+          {result.gameName}
+        </span>
+
+        {/* docTitle */}
+        <span className="text-sm font-bold text-foreground leading-snug">{result.docTitle}</span>
+
+        {/* DocType pill */}
+        <Badge
+          variant="outline"
+          className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          {displayDocType}
+        </Badge>
+      </div>
+
+      {/* Snippet */}
+      <p className="mt-2 text-sm text-foreground leading-relaxed line-clamp-3">{result.snippet}</p>
+
+      {/* Footer: headingPath + pageNumber + score */}
+      <div className="mt-2 flex flex-wrap items-center gap-3 font-mono text-[11px] text-muted-foreground">
+        {result.headingPath != null && (
+          <span data-testid="result-heading-path" className="truncate max-w-xs">
+            {result.headingPath}
+          </span>
+        )}
+
+        {result.pageNumber != null && (
+          <span data-testid="result-page-number">{pageLabel(result.pageNumber)}</span>
+        )}
+
+        {/* Score badge — always shown */}
+        <span
+          className={cn(
+            'ml-auto inline-flex items-center',
+            'rounded-full px-2 py-0.5',
+            'bg-muted text-muted-foreground',
+            'text-[10px] font-mono font-semibold'
+          )}
+        >
+          {formattedScore}
+        </span>
+      </div>
+    </>
+  );
+
+  const sharedClasses = cn(
+    'w-full rounded-md border border-border bg-card',
+    'p-4 flex flex-col',
+    'transition-shadow duration-150'
+  );
+
+  if (onResultClick) {
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => onResultClick(result)}
+        className={cn(
+          sharedClasses,
+          'text-left',
+          'hover:shadow-md hover:border-entity-kb/40',
+          'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-2'
+        )}
+      >
+        {rowContent}
+      </button>
+    );
+  }
+
+  return <div className={sharedClasses}>{rowContent}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function KbSearchResultsDesktop({
+  query,
+  results,
+  hasMore,
+  isLoading,
+  isFetchingNextPage,
+  error,
+  onLoadMore,
+  onResultClick,
+  onEmptyCtaClick,
+  onRetry,
+  labels,
+  className,
+}: KbSearchResultsDesktopProps): JSX.Element {
+  const isEmpty = results.length === 0 && !isLoading && !error;
+  const showResults = !isLoading && !error && results.length > 0;
+  const showLoadMore = hasMore && !error && !isLoading;
+
+  return (
+    <section className={cn('flex flex-col gap-4', className)}>
+      {/* Header: resultsCount — shown when not in error and not initial loading */}
+      {!error && !isLoading && (
+        <h2 className="text-xl font-bold text-foreground">
+          {labels.resultsCount(results.length, query)}
+        </h2>
+      )}
+
+      {/* Loading skeleton (initial fetch, no results yet) */}
+      {isLoading && results.length === 0 && <KbSearchSkeletons />}
+
+      {/* Error state — hides result list */}
+      {error && !isLoading && (
+        <ErrorBanner
+          errorTitle={labels.errorTitle}
+          errorDescription={labels.errorDescription}
+          retry={labels.retry}
+          onRetry={onRetry}
+        />
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <KbEmptyState kind="no-results" labels={labels.empty} onCtaClick={onEmptyCtaClick} />
+      )}
+
+      {/* Loaded state — vertical result list */}
+      {showResults && (
+        <ul className="flex flex-col gap-3 list-none p-0 m-0">
+          {results.map(result => (
+            <li key={result.chunkId}>
+              <ResultRow
+                result={result}
+                ariaLabel={labels.resultAriaLabel(result)}
+                pageLabel={labels.pageLabel}
+                docTypeLabel={labels.docTypeLabel}
+                onResultClick={onResultClick}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Load-more button — explicit click, no infinite scroll */}
+      {showLoadMore && (
+        <div className="flex justify-center pt-2">
+          <button
+            type="button"
+            disabled={isFetchingNextPage}
+            onClick={onLoadMore}
+            className={cn(
+              'inline-flex items-center justify-center gap-2',
+              'px-6 py-2.5 rounded-md',
+              'border border-border',
+              'text-sm font-medium text-foreground',
+              'bg-card hover:bg-muted',
+              'transition-colors duration-150',
+              'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-2',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+          >
+            {isFetchingNextPage && (
+              <span
+                aria-hidden="true"
+                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+              />
+            )}
+            {isFetchingNextPage ? labels.loadingMore : labels.loadMore}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/kb-globale/__tests__/HeroSearch.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/HeroSearch.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * HeroSearch.test.tsx
+ * Issue #1482 Task 2 — Unit tests for HeroSearch component
+ *
+ * Test scenarios:
+ * 1. Renders input with placeholder from labels
+ * 2. Renders mode segmented control with each mode option
+ * 3. Current mode button has aria-pressed="true"
+ * 4. Typing in input updates value (controlled)
+ * 5. Submit via Enter calls onSubmit with trimmed query + current mode
+ * 6. Submit via click button calls onSubmit with same args
+ * 7. Submit NOT called when query empty or length < 2
+ * 8. Clear button rendered only when query non-empty
+ * 9. Clear button click clears input + calls onClear
+ * 10. Mode change updates aria-pressed; next submit uses new mode
+ * 11. jest-axe: no a11y violations
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, it, expect, vi } from 'vitest';
+import { HeroSearch, type HeroSearchProps, type HeroSearchLabels } from '../HeroSearch';
+import type { SearchMode } from '@/lib/api/schemas/kb-globale.schemas';
+
+expect.extend(toHaveNoViolations);
+
+const defaultLabels: HeroSearchLabels = {
+  placeholder: 'Search across all your games',
+  submit: 'Search',
+  clear: 'Clear',
+  modeLabel: 'Search mode',
+  modeOptions: {
+    Semantic: 'Semantic Search',
+  },
+};
+
+const defaultProps: HeroSearchProps = {
+  onSubmit: vi.fn(),
+  labels: defaultLabels,
+};
+
+describe('HeroSearch', () => {
+  it('renders input with placeholder from labels', () => {
+    render(<HeroSearch {...defaultProps} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder);
+    expect(input).toBeInTheDocument();
+  });
+
+  it('renders mode segmented control with each mode option', () => {
+    render(<HeroSearch {...defaultProps} />);
+    // For v1 with only Semantic, expect one button labeled "Semantic Search"
+    const modeButton = screen.getByRole('button', { name: /semantic search/i });
+    expect(modeButton).toBeInTheDocument();
+  });
+
+  it('current mode button has aria-pressed="true"', () => {
+    render(<HeroSearch {...defaultProps} initialMode="Semantic" />);
+    const modeButton = screen.getByRole('button', { name: /semantic search/i });
+    expect(modeButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('typing in input updates value (controlled)', async () => {
+    const user = userEvent.setup();
+    render(<HeroSearch {...defaultProps} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+
+    await user.type(input, 'azul rules');
+    expect(input.value).toBe('azul rules');
+  });
+
+  it('submit via Enter calls onSubmit with trimmed query + current mode', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+
+    await user.type(input, '  azul rules  ');
+    await user.keyboard('{Enter}');
+
+    expect(onSubmit).toHaveBeenCalledWith('azul rules', 'Semantic');
+  });
+
+  it('submit via click button calls onSubmit with same args', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: defaultLabels.submit });
+
+    await user.type(input, 'wingspan');
+    await user.click(submitButton);
+
+    expect(onSubmit).toHaveBeenCalledWith('wingspan', 'Semantic');
+  });
+
+  it('submit NOT called when query empty after trim', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: defaultLabels.submit });
+
+    await user.type(input, '   ');
+    await user.click(submitButton);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submit NOT called when query length < 2', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: defaultLabels.submit });
+
+    await user.type(input, 'a');
+    await user.click(submitButton);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('clear button rendered only when query non-empty', async () => {
+    const user = userEvent.setup();
+    render(<HeroSearch {...defaultProps} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+
+    // Initially no clear button
+    expect(screen.queryByRole('button', { name: /clear/i })).not.toBeInTheDocument();
+
+    // Type something
+    await user.type(input, 'azul');
+    expect(screen.getByRole('button', { name: /clear|×/i })).toBeInTheDocument();
+
+    // Clear via button
+    const clearButton = screen.getByRole('button', { name: /clear|×/i });
+    await user.click(clearButton);
+    expect(input.value).toBe('');
+    expect(screen.queryByRole('button', { name: /clear|×/i })).not.toBeInTheDocument();
+  });
+
+  it('clear button click clears input + calls onClear', async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+    render(<HeroSearch {...defaultProps} onClear={onClear} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+
+    await user.type(input, 'gloomhaven');
+    expect(input.value).toBe('gloomhaven');
+
+    const clearButton = screen.getByRole('button', { name: /clear|×/i });
+    await user.click(clearButton);
+
+    expect(input.value).toBe('');
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('mode change updates aria-pressed; next submit uses new mode', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    // Create labels with multiple modes for this test
+    const multiModeLabels: HeroSearchLabels = {
+      placeholder: 'Search',
+      submit: 'Search',
+      clear: 'Clear',
+      modeLabel: 'Search mode',
+      modeOptions: {
+        Semantic: 'Semantic',
+        // Note: Task 2 spec only has Semantic in v1, so this test uses Semantic as "current"
+        // In future when more modes are added, this will test the toggle behavior
+      } as any,
+    };
+
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} initialMode="Semantic" />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    const modeButton = screen.getByRole('button', { name: /semantic/i });
+
+    // Mode button is initially pressed
+    expect(modeButton).toHaveAttribute('aria-pressed', 'true');
+
+    // Type and submit
+    await user.type(input, 'azul');
+    await user.keyboard('{Enter}');
+
+    expect(onSubmit).toHaveBeenCalledWith('azul', 'Semantic');
+  });
+
+  it('jest-axe: no a11y violations', async () => {
+    const { container } = render(<HeroSearch {...defaultProps} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('renders with initialQuery and initialMode', () => {
+    render(<HeroSearch {...defaultProps} initialQuery="brass rules" initialMode="Semantic" />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    expect(input.value).toBe('brass rules');
+  });
+
+  it('className prop is applied to wrapper', () => {
+    const { container } = render(<HeroSearch {...defaultProps} className="custom-wrapper" />);
+    const wrapper = container.querySelector('.custom-wrapper');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it('submit button is disabled when query < 2 chars', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<HeroSearch {...defaultProps} onSubmit={onSubmit} />);
+    const input = screen.getByPlaceholderText(defaultLabels.placeholder) as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: defaultLabels.submit });
+
+    // Initially button should be disabled (empty query)
+    expect(submitButton).toBeDisabled();
+
+    // Type 1 char — button still disabled
+    await user.type(input, 'a');
+    expect(submitButton).toBeDisabled();
+
+    // Type more to reach 2 chars — button enabled
+    await user.type(input, 'b');
+    expect(submitButton).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/features/kb-globale/__tests__/KbEmptyState.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/KbEmptyState.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * KbEmptyState.test.tsx
+ * Issue #1482 Task 3 — KbEmptyState component tests
+ *
+ * Tests for the discriminated KbEmptyState component supporting:
+ * - kind='no-query': landing state with CTA "Start searching"
+ * - kind='no-results': post-search state with "No matches for query"
+ *
+ * A11y: role="status" (no-results), role="region" + aria-label (no-query)
+ * jest-axe: no violations on either variant ± CTA
+ */
+
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { KbEmptyStateProps } from '../KbEmptyState';
+import { KbEmptyState } from '../KbEmptyState';
+
+expect.extend(toHaveNoViolations);
+
+describe('KbEmptyState', () => {
+  describe('no-query variant (landing)', () => {
+    it('renders title + description for kind="no-query"', () => {
+      const labels = {
+        title: 'Start searching across your library',
+        description: 'Explore documents from all your games in one place.',
+      };
+
+      render(<KbEmptyState kind="no-query" labels={labels} />);
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(labels.title);
+      expect(screen.getByText(labels.description)).toBeInTheDocument();
+    });
+
+    it('renders CTA button when labels.cta + onCtaClick provided', () => {
+      const handleCtaClick = vi.fn();
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore your KB',
+        cta: 'Get Started',
+      };
+
+      render(<KbEmptyState kind="no-query" labels={labels} onCtaClick={handleCtaClick} />);
+
+      const button = screen.getByRole('button', { name: /Get Started/i });
+      expect(button).toBeInTheDocument();
+
+      button.click();
+      expect(handleCtaClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT render CTA when labels.cta is missing', () => {
+      const handleCtaClick = vi.fn();
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore',
+        // cta intentionally omitted
+      };
+
+      render(<KbEmptyState kind="no-query" labels={labels} onCtaClick={handleCtaClick} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render CTA when onCtaClick is missing', () => {
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore',
+        cta: 'Get Started',
+      };
+
+      render(<KbEmptyState kind="no-query" labels={labels} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders with aria-role="region" + aria-label', () => {
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore',
+      };
+
+      const { container } = render(<KbEmptyState kind="no-query" labels={labels} />);
+
+      const region = container.querySelector('[role="region"]');
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAttribute('aria-label');
+    });
+  });
+
+  describe('no-results variant (search results empty)', () => {
+    it('renders title + description for kind="no-results"', () => {
+      const labels = {
+        title: 'No matches found',
+        description: 'Try different keywords or filters.',
+      };
+
+      render(<KbEmptyState kind="no-results" labels={labels} />);
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(labels.title);
+      expect(screen.getByText(labels.description)).toBeInTheDocument();
+    });
+
+    it('renders aria-role="status" for kind="no-results"', () => {
+      const labels = {
+        title: 'No results',
+        description: 'Try again',
+      };
+
+      const { container } = render(<KbEmptyState kind="no-results" labels={labels} />);
+
+      const status = container.querySelector('[role="status"]');
+      expect(status).toBeInTheDocument();
+    });
+
+    it('renders CTA button when labels.cta + onCtaClick provided (variant no-results)', () => {
+      const handleCtaClick = vi.fn();
+      const labels = {
+        title: 'No results',
+        description: 'Try again',
+        cta: 'Clear Filters',
+      };
+
+      render(<KbEmptyState kind="no-results" labels={labels} onCtaClick={handleCtaClick} />);
+
+      const button = screen.getByRole('button', { name: /Clear Filters/i });
+      button.click();
+      expect(handleCtaClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT render CTA when labels.cta missing (variant no-results)', () => {
+      const labels = {
+        title: 'No results',
+        description: 'Try again',
+      };
+
+      render(<KbEmptyState kind="no-results" labels={labels} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('icon rendering', () => {
+    it('renders custom icon when provided', () => {
+      const CustomIcon = () => <span data-testid="custom-icon">🎯</span>;
+      const labels = {
+        title: 'No data',
+        description: 'Custom icon test',
+      };
+
+      render(<KbEmptyState kind="no-query" labels={labels} icon={<CustomIcon />} />);
+
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    });
+
+    it('renders without icon when icon prop is undefined', () => {
+      const labels = {
+        title: 'No data',
+        description: 'No icon test',
+      };
+
+      const { container } = render(<KbEmptyState kind="no-query" labels={labels} />);
+
+      // Should not render a default icon element
+      expect(container.querySelector('[aria-hidden="true"]')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('a11y: jest-axe', () => {
+    it('no violations on kind="no-query" without CTA', async () => {
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore your KB',
+      };
+
+      const { container } = render(<KbEmptyState kind="no-query" labels={labels} />);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('no violations on kind="no-query" with CTA', async () => {
+      const labels = {
+        title: 'Start searching',
+        description: 'Explore',
+        cta: 'Get Started',
+      };
+
+      const { container } = render(
+        <KbEmptyState kind="no-query" labels={labels} onCtaClick={() => {}} />
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('no violations on kind="no-results" without CTA', async () => {
+      const labels = {
+        title: 'No matches',
+        description: 'Try different keywords',
+      };
+
+      const { container } = render(<KbEmptyState kind="no-results" labels={labels} />);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('no violations on kind="no-results" with CTA', async () => {
+      const labels = {
+        title: 'No matches',
+        description: 'Try different keywords',
+        cta: 'Clear Search',
+      };
+
+      const { container } = render(
+        <KbEmptyState kind="no-results" labels={labels} onCtaClick={() => {}} />
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('className prop', () => {
+    it('applies custom className to root element', () => {
+      const labels = {
+        title: 'Title',
+        description: 'Description',
+      };
+
+      const { container } = render(
+        <KbEmptyState kind="no-query" labels={labels} className="custom-class" />
+      );
+
+      // Assuming root element has data-testid or similar
+      // We'll check by finding the region/status role
+      const root = container.querySelector('[role="region"]');
+      expect(root?.className).toMatch(/custom-class/);
+    });
+  });
+});

--- a/apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * KbHomeDesktop.test.tsx
+ * Issue #1482 Task 4 — KbHomeDesktop landing component tests
+ *
+ * Tests for the pure-presentational KbHomeDesktop component that renders
+ * recent KB docs when there is no active search query.
+ *
+ * States tested:
+ * - Loading: 12 skeleton cards, no doc cards
+ * - Error: inline banner with role="alert", optional retry button
+ * - Empty: delegates to KbEmptyState kind="no-query"
+ * - Loaded: grid of doc cards, fileName + gameName + updatedAt visible
+ *
+ * A11y: jest-axe on loaded / loading / empty states
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { KbDoc } from '@/lib/library/hybrid-hub.mappers';
+
+import type { KbHomeDesktopProps } from '../KbHomeDesktop';
+import { KbHomeDesktop } from '../KbHomeDesktop';
+
+expect.extend(toHaveNoViolations);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const HEADING = 'Documenti recenti';
+
+const LABELS: KbHomeDesktopProps['labels'] = {
+  heading: HEADING,
+  empty: {
+    title: 'Nessun documento ancora',
+    description: 'Carica il tuo primo PDF per iniziare.',
+    cta: 'Carica PDF',
+  },
+  errorTitle: 'Errore nel caricamento',
+  errorDescription: 'Non è stato possibile recuperare i documenti.',
+  retry: 'Riprova',
+  docCardAriaLabel: doc => `Apri documento ${doc.fileName}`,
+};
+
+function makeDoc(overrides: Partial<KbDoc> = {}): KbDoc {
+  return {
+    id: 'doc-1',
+    gameId: 'game-1',
+    gameName: 'Gloomhaven',
+    fileName: 'gloomhaven-rulebook.pdf',
+    processingState: 'ready',
+    pageCount: 72,
+    processedAt: '2026-05-20T10:00:00Z',
+    uploadedAt: '2026-05-19T08:00:00Z',
+    updatedAt: '2026-05-20T10:00:00Z',
+    ...overrides,
+  };
+}
+
+const THREE_DOCS: readonly KbDoc[] = [
+  makeDoc({ id: 'doc-1', fileName: 'gloomhaven-rulebook.pdf', gameName: 'Gloomhaven' }),
+  makeDoc({
+    id: 'doc-2',
+    fileName: 'wingspan-guide.pdf',
+    gameName: 'Wingspan',
+    gameId: 'game-2',
+  }),
+  makeDoc({
+    id: 'doc-3',
+    fileName: 'brass-rules.pdf',
+    gameName: null,
+    gameId: null,
+    processingState: 'indexing',
+  }),
+];
+
+function defaultProps(overrides: Partial<KbHomeDesktopProps> = {}): KbHomeDesktopProps {
+  return {
+    recentDocs: [],
+    isLoading: false,
+    error: null,
+    labels: LABELS,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KbHomeDesktop', () => {
+  // ── 1. Renders heading ──────────────────────────────────────────────────
+  it('renders heading with labels.heading', () => {
+    // Use a loaded state (3 docs) to avoid KbEmptyState also rendering an h2
+    render(<KbHomeDesktop {...defaultProps({ recentDocs: THREE_DOCS })} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: HEADING })).toBeInTheDocument();
+  });
+
+  // ── 2. Loading state: 12 skeleton cards, no doc cards ──────────────────
+  it('renders 12 skeleton cards when isLoading is true, no doc cards visible', () => {
+    render(<KbHomeDesktop {...defaultProps({ isLoading: true })} />);
+
+    const skeletons = screen.getAllByTestId('kb-home-skeleton');
+    expect(skeletons).toHaveLength(12);
+
+    // No actual document cards rendered
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  // ── 3. Error state with retry ───────────────────────────────────────────
+  it('renders error banner with role="alert" and retry button when error + onRetry + labels.retry provided', async () => {
+    const onRetry = vi.fn();
+    const error = new Error('Network error');
+
+    render(
+      <KbHomeDesktop
+        {...defaultProps({
+          error,
+          onRetry,
+        })}
+      />
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(LABELS.errorTitle);
+    expect(alert).toHaveTextContent(LABELS.errorDescription);
+
+    const retryBtn = screen.getByRole('button', { name: /riprova/i });
+    expect(retryBtn).toBeInTheDocument();
+
+    await userEvent.click(retryBtn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 4. Error state WITHOUT retry button when onRetry missing ───────────
+  it('renders error banner WITHOUT retry button when onRetry is not provided', () => {
+    const error = new Error('Network error');
+
+    render(<KbHomeDesktop {...defaultProps({ error })} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /riprova/i })).not.toBeInTheDocument();
+  });
+
+  // ── 5. Empty state — delegates to KbEmptyState kind="no-query" ─────────
+  it('renders KbEmptyState kind="no-query" when recentDocs=[], not loading, no error', () => {
+    const onEmptyCtaClick = vi.fn();
+
+    render(
+      <KbHomeDesktop
+        {...defaultProps({
+          recentDocs: [],
+          isLoading: false,
+          error: null,
+          onEmptyCtaClick,
+        })}
+      />
+    );
+
+    // KbEmptyState renders the empty.title and empty.description
+    expect(screen.getByText(LABELS.empty.title)).toBeInTheDocument();
+    expect(screen.getByText(LABELS.empty.description)).toBeInTheDocument();
+  });
+
+  // ── 5b. Empty CTA click invokes onEmptyCtaClick ─────────────────────────
+  it('invokes onEmptyCtaClick when KbEmptyState CTA is clicked', async () => {
+    const onEmptyCtaClick = vi.fn();
+
+    render(
+      <KbHomeDesktop
+        {...defaultProps({
+          recentDocs: [],
+          onEmptyCtaClick,
+        })}
+      />
+    );
+
+    const ctaBtn = screen.getByRole('button', { name: LABELS.empty.cta });
+    await userEvent.click(ctaBtn);
+    expect(onEmptyCtaClick).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 6. Loaded state — renders N doc cards ──────────────────────────────
+  it('renders N doc cards when recentDocs is populated', () => {
+    render(<KbHomeDesktop {...defaultProps({ recentDocs: THREE_DOCS })} />);
+
+    // Each doc card shows fileName
+    expect(screen.getByText('gloomhaven-rulebook.pdf')).toBeInTheDocument();
+    expect(screen.getByText('wingspan-guide.pdf')).toBeInTheDocument();
+    expect(screen.getByText('brass-rules.pdf')).toBeInTheDocument();
+
+    // gameName visible for docs that have it
+    expect(screen.getByText('Gloomhaven')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  // ── 7. Clicking a card invokes onDocClick(docId) ───────────────────────
+  it('invokes onDocClick with the docId when a card is clicked', async () => {
+    const onDocClick = vi.fn();
+
+    render(<KbHomeDesktop {...defaultProps({ recentDocs: THREE_DOCS, onDocClick })} />);
+
+    const cardBtn = screen.getByRole('button', {
+      name: LABELS.docCardAriaLabel(THREE_DOCS[0]),
+    });
+    await userEvent.click(cardBtn);
+    expect(onDocClick).toHaveBeenCalledWith(THREE_DOCS[0].id);
+  });
+
+  // ── 8. Card NOT clickable when onDocClick missing ──────────────────────
+  it('does NOT render a button wrapper on doc cards when onDocClick is not provided', () => {
+    render(<KbHomeDesktop {...defaultProps({ recentDocs: THREE_DOCS })} />);
+
+    // No interactive role for doc cards
+    expect(
+      screen.queryByRole('button', { name: LABELS.docCardAriaLabel(THREE_DOCS[0]) })
+    ).not.toBeInTheDocument();
+
+    // But doc content still renders
+    expect(screen.getByText('gloomhaven-rulebook.pdf')).toBeInTheDocument();
+  });
+
+  // ── 9. gameName fallback when doc.gameName is null ─────────────────────
+  it('renders fallback text "(senza gioco)" when doc.gameName is null', () => {
+    const docNoGame = makeDoc({ id: 'doc-no-game', gameName: null, gameId: null });
+
+    render(<KbHomeDesktop {...defaultProps({ recentDocs: [docNoGame] })} />);
+
+    expect(screen.getByText('(senza gioco)')).toBeInTheDocument();
+  });
+
+  // ── 10. jest-axe: loaded state ─────────────────────────────────────────
+  it('has no axe violations in the loaded state', async () => {
+    const { container } = render(<KbHomeDesktop {...defaultProps({ recentDocs: THREE_DOCS })} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  // ── 11. jest-axe: loading state ────────────────────────────────────────
+  it('has no axe violations in the loading state', async () => {
+    const { container } = render(<KbHomeDesktop {...defaultProps({ isLoading: true })} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  // ── 12. jest-axe: empty state ──────────────────────────────────────────
+  it('has no axe violations in the empty state', async () => {
+    const { container } = render(
+      <KbHomeDesktop {...defaultProps({ recentDocs: [], isLoading: false, error: null })} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/kb-globale/__tests__/KbSearchResultsDesktop.test.tsx
+++ b/apps/web/src/components/features/kb-globale/__tests__/KbSearchResultsDesktop.test.tsx
@@ -1,0 +1,413 @@
+/**
+ * KbSearchResultsDesktop.test.tsx
+ * Issue #1482 Task 5 — KbSearchResultsDesktop search results component tests
+ *
+ * Tests for the pure-presentational KbSearchResultsDesktop component that
+ * renders cross-game search results when the KB page has an active query (?q=).
+ *
+ * States tested:
+ * - Loading:         5 skeleton rows, no result rows
+ * - Error:           inline alert banner with optional retry, results hidden
+ * - Empty:           delegates to KbEmptyState kind="no-results"
+ * - Loaded:          vertical list rows with gameName pill + docTitle + snippet + metadata
+ * - Load-more:       explicit button (not infinite scroll), disabled when fetching
+ * - Click handlers:  rows clickable only when onResultClick provided
+ * - docTypeLabel:    called when provided, falls back to raw docType
+ *
+ * A11y: jest-axe on loaded / loading / empty states
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GlobalKbSearchResult } from '@/lib/api/schemas/kb-globale.schemas';
+
+import type { KbSearchResultsDesktopProps } from '../KbSearchResultsDesktop';
+import { KbSearchResultsDesktop } from '../KbSearchResultsDesktop';
+
+expect.extend(toHaveNoViolations);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const LABELS: KbSearchResultsDesktopProps['labels'] = {
+  resultsCount: (n, q) => `${n} risultati per «${q}»`,
+  loadMore: 'Carica altri',
+  loadingMore: 'Caricamento...',
+  empty: {
+    title: 'Nessun risultato trovato',
+    description: 'Prova a cambiare i termini di ricerca.',
+    cta: 'Nuovo tentativo',
+  },
+  errorTitle: 'Errore nella ricerca',
+  errorDescription: 'Non è stato possibile recuperare i risultati.',
+  retry: 'Riprova',
+  resultAriaLabel: r => `Vai al risultato: ${r.docTitle}`,
+  pageLabel: n => `Pagina ${n}`,
+};
+
+function makeResult(overrides: Partial<GlobalKbSearchResult> = {}): GlobalKbSearchResult {
+  return {
+    chunkId: 'chunk-1',
+    docId: '00000000-0000-0000-0000-000000000001',
+    docTitle: 'Regole base Gloomhaven',
+    gameId: '00000000-0000-0000-0000-000000000010',
+    gameName: 'Gloomhaven',
+    docType: 'rulebook',
+    headingPath: 'Capitolo 1 > Regole di base',
+    snippet: 'Il giocatore attivo pesca una carta dalla sua mano.',
+    pageNumber: 14,
+    score: 0.92,
+    ...overrides,
+  };
+}
+
+const THREE_RESULTS: readonly GlobalKbSearchResult[] = [
+  makeResult({
+    chunkId: 'chunk-1',
+    docId: '00000000-0000-0000-0000-000000000001',
+    docTitle: 'Regole base Gloomhaven',
+    gameName: 'Gloomhaven',
+    docType: 'rulebook',
+    headingPath: 'Capitolo 1 > Regole di base',
+    snippet: 'Il giocatore attivo pesca una carta.',
+    pageNumber: 14,
+    score: 0.92,
+  }),
+  makeResult({
+    chunkId: 'chunk-2',
+    docId: '00000000-0000-0000-0000-000000000002',
+    docTitle: 'Scout abilità speciali',
+    gameName: 'Gloomhaven',
+    docType: 'clarification',
+    headingPath: null,
+    snippet: 'Le abilità scout includono movimento silenzioso.',
+    pageNumber: null,
+    score: 0.85,
+  }),
+  makeResult({
+    chunkId: 'chunk-3',
+    docId: '00000000-0000-0000-0000-000000000003',
+    docTitle: 'Regole Azul',
+    gameName: 'Azul',
+    gameId: '00000000-0000-0000-0000-000000000020',
+    docType: 'rulebook',
+    headingPath: 'Sezione Finale',
+    snippet: 'Il punteggio finale viene calcolato a fine partita.',
+    pageNumber: 8,
+    score: 0.74,
+  }),
+];
+
+function defaultProps(
+  overrides: Partial<KbSearchResultsDesktopProps> = {}
+): KbSearchResultsDesktopProps {
+  return {
+    query: 'scout abilities',
+    results: [],
+    hasMore: false,
+    isLoading: false,
+    isFetchingNextPage: false,
+    error: null,
+    onLoadMore: vi.fn(),
+    labels: LABELS,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KbSearchResultsDesktop', () => {
+  // ── 1. Header with resultsCount ─────────────────────────────────────────
+  it('renders header with resultsCount formatted', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS, query: 'azul' })} />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: /3 risultati per «azul»/i })
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Loading state ────────────────────────────────────────────────────
+  it('renders 5 skeleton rows when isLoading && results=[], no result rows', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ isLoading: true, results: [] })} />);
+
+    const skeletons = screen.getAllByTestId('kb-search-skeleton');
+    expect(skeletons).toHaveLength(5);
+
+    // No actual result rows
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+
+  // ── 3. Error state with retry ───────────────────────────────────────────
+  it('renders error banner with retry when error + onRetry, results hidden', async () => {
+    const onRetry = vi.fn();
+    const error = new Error('Network error');
+
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          error,
+          onRetry,
+          // Even with results, they should be hidden on error
+          results: THREE_RESULTS,
+        })}
+      />
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(LABELS.errorTitle);
+    expect(alert).toHaveTextContent(LABELS.errorDescription);
+
+    const retryBtn = screen.getByRole('button', { name: /riprova/i });
+    expect(retryBtn).toBeInTheDocument();
+    await userEvent.click(retryBtn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // Result list is hidden in error state
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  // ── 4. Error state WITHOUT retry button ─────────────────────────────────
+  it('renders error banner WITHOUT retry button when onRetry missing', () => {
+    const error = new Error('Network error');
+
+    render(<KbSearchResultsDesktop {...defaultProps({ error })} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    // No retry prop and no labels.retry → no button
+    const propsNoRetryLabel = { ...LABELS };
+    delete propsNoRetryLabel.retry;
+    expect(screen.queryByRole('button', { name: /riprova/i })).not.toBeInTheDocument();
+  });
+
+  // ── 5. Empty state — delegates to KbEmptyState kind="no-results" ────────
+  it('renders KbEmptyState kind="no-results" when results=[] + !isLoading + !error', async () => {
+    const onEmptyCtaClick = vi.fn();
+
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          results: [],
+          isLoading: false,
+          error: null,
+          onEmptyCtaClick,
+        })}
+      />
+    );
+
+    expect(screen.getByText(LABELS.empty.title)).toBeInTheDocument();
+    expect(screen.getByText(LABELS.empty.description)).toBeInTheDocument();
+
+    const ctaBtn = screen.getByRole('button', { name: LABELS.empty.cta });
+    await userEvent.click(ctaBtn);
+    expect(onEmptyCtaClick).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 6. Loaded state — renders N result rows ─────────────────────────────
+  it('renders N result rows with gameName, docTitle, snippet, pageNumber, score', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS })} />);
+
+    // Result list present
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    // First result
+    expect(screen.getByText('Regole base Gloomhaven')).toBeInTheDocument();
+    expect(screen.getByText('Il giocatore attivo pesca una carta.')).toBeInTheDocument();
+    expect(screen.getByText('Pagina 14')).toBeInTheDocument();
+    expect(screen.getByText('0.92')).toBeInTheDocument();
+
+    // gameName pills present
+    const gloomhavenChips = screen.getAllByText('Gloomhaven');
+    expect(gloomhavenChips.length).toBeGreaterThanOrEqual(1);
+
+    // All 3 items
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  // ── 7. headingPath rendered when non-null, hidden when null ─────────────
+  it('renders headingPath when non-null, does not render when null', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS })} />);
+
+    // First result has headingPath
+    expect(screen.getByText('Capitolo 1 > Regole di base')).toBeInTheDocument();
+
+    // Third result (Azul) also has headingPath
+    expect(screen.getByText('Sezione Finale')).toBeInTheDocument();
+
+    // Second result (Scout) has headingPath=null — should NOT render anything for it
+    // Only 2 headingPaths should be visible (chunk-1 and chunk-3)
+    const headingPaths = screen.queryAllByTestId('result-heading-path');
+    expect(headingPaths).toHaveLength(2);
+  });
+
+  // ── 8. pageNumber via labels.pageLabel when non-null, hidden when null ───
+  it('renders pageNumber via labels.pageLabel when non-null, not rendered when null', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS })} />);
+
+    // First result has pageNumber 14
+    expect(screen.getByText('Pagina 14')).toBeInTheDocument();
+
+    // Third result has pageNumber 8
+    expect(screen.getByText('Pagina 8')).toBeInTheDocument();
+
+    // Second result has pageNumber null — 'Pagina null' should NOT appear
+    expect(screen.queryByText('Pagina null')).not.toBeInTheDocument();
+
+    // Only 2 page number labels
+    const pageNumbers = screen.queryAllByTestId('result-page-number');
+    expect(pageNumbers).toHaveLength(2);
+  });
+
+  // ── 9. clicking a row invokes onResultClick(result) ─────────────────────
+  it('clicking a row invokes onResultClick with the result when onResultClick provided', async () => {
+    const onResultClick = vi.fn();
+
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS, onResultClick })} />);
+
+    const firstRowBtn = screen.getByRole('button', {
+      name: LABELS.resultAriaLabel(THREE_RESULTS[0]),
+    });
+    await userEvent.click(firstRowBtn);
+    expect(onResultClick).toHaveBeenCalledWith(THREE_RESULTS[0]);
+  });
+
+  // ── 10. rows NOT interactive when onResultClick missing ──────────────────
+  it('rows are NOT interactive buttons when onResultClick is not provided', () => {
+    render(<KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS })} />);
+
+    // No button with result aria-label
+    expect(
+      screen.queryByRole('button', { name: LABELS.resultAriaLabel(THREE_RESULTS[0]) })
+    ).not.toBeInTheDocument();
+
+    // Content still renders
+    expect(screen.getByText('Regole base Gloomhaven')).toBeInTheDocument();
+  });
+
+  // ── 11. load-more rendered when hasMore + !error + !isLoading + !empty ───
+  it('renders load-more button when hasMore + !error + !isLoading, click invokes onLoadMore', async () => {
+    const onLoadMore = vi.fn();
+
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({ results: THREE_RESULTS, hasMore: true, onLoadMore })}
+      />
+    );
+
+    const loadMoreBtn = screen.getByRole('button', { name: LABELS.loadMore });
+    expect(loadMoreBtn).toBeInTheDocument();
+    expect(loadMoreBtn).not.toBeDisabled();
+
+    await userEvent.click(loadMoreBtn);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  // ── 12. load-more shows loadingMore + disabled when isFetchingNextPage ───
+  it('shows loadingMore label and disabled state when isFetchingNextPage is true', () => {
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          results: THREE_RESULTS,
+          hasMore: true,
+          isFetchingNextPage: true,
+        })}
+      />
+    );
+
+    const loadMoreBtn = screen.getByRole('button', { name: LABELS.loadingMore });
+    expect(loadMoreBtn).toBeInTheDocument();
+    expect(loadMoreBtn).toBeDisabled();
+  });
+
+  // ── 13. load-more NOT rendered when hasMore=false ───────────────────────
+  it('does not render load-more button when hasMore=false', () => {
+    render(
+      <KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS, hasMore: false })} />
+    );
+
+    expect(screen.queryByRole('button', { name: LABELS.loadMore })).not.toBeInTheDocument();
+  });
+
+  // ── 14. load-more NOT rendered when error present ───────────────────────
+  it('does not render load-more button when error is present', () => {
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          results: THREE_RESULTS,
+          hasMore: true,
+          error: new Error('fail'),
+        })}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: LABELS.loadMore })).not.toBeInTheDocument();
+  });
+
+  // ── 15. docTypeLabel called when provided, falls back to raw docType ─────
+  it('uses docTypeLabel when provided, falls back to raw docType when absent', () => {
+    const docTypeLabel = vi.fn((rawType: string) => rawType.toUpperCase());
+
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          results: THREE_RESULTS,
+          labels: { ...LABELS, docTypeLabel },
+        })}
+      />
+    );
+
+    // docTypeLabel was called for each result's docType
+    expect(docTypeLabel).toHaveBeenCalledWith('rulebook');
+    expect(docTypeLabel).toHaveBeenCalledWith('clarification');
+
+    // The transformed values appear (not lowercase originals)
+    expect(screen.getAllByText('RULEBOOK').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('CLARIFICATION')).toBeInTheDocument();
+  });
+
+  it('renders raw docType when docTypeLabel is not provided', () => {
+    render(
+      <KbSearchResultsDesktop
+        {...defaultProps({
+          results: [makeResult({ docType: 'house-rule' })],
+          labels: { ...LABELS, docTypeLabel: undefined },
+        })}
+      />
+    );
+
+    expect(screen.getByText('house-rule')).toBeInTheDocument();
+  });
+
+  // ── 16. jest-axe: loaded state ──────────────────────────────────────────
+  it('has no axe violations in the loaded state', async () => {
+    const { container } = render(
+      <KbSearchResultsDesktop {...defaultProps({ results: THREE_RESULTS })} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  // ── 17. jest-axe: loading state ─────────────────────────────────────────
+  it('has no axe violations in the loading state', async () => {
+    const { container } = render(
+      <KbSearchResultsDesktop {...defaultProps({ isLoading: true, results: [] })} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  // ── 18. jest-axe: empty state ────────────────────────────────────────────
+  it('has no axe violations in the empty state', async () => {
+    const { container } = render(
+      <KbSearchResultsDesktop {...defaultProps({ results: [], isLoading: false, error: null })} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useGlobalKbSearch unit tests — Issue #1482 Phase 1 Foundation.
+ *
+ * Strategy: mock useDebounce to return the input synchronously, enabling
+ * real-timer waitFor calls (no fake-timer/waitFor deadlock). Debounce
+ * coalescing is tested by watching the debounced value propagation.
+ *
+ * Coverage:
+ *   - enabled=false when query empty or < 2 chars
+ *   - fetches on debounced query (query propagated from useDebounce)
+ *   - debounce coalescing: hook NOT called when debouncedQuery still short
+ *   - fetchNextPage appends results + passes cursor
+ *   - query change resets cursor (via queryKey change)
+ *   - mode change resets cursor (via queryKey change)
+ *   - hasMore reflects last page only
+ *   - error surfaces, no throw
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useGlobalKbSearch } from '../useGlobalKbSearch';
+import type {
+  GlobalKbSearchResponse,
+  GlobalKbSearchResult,
+} from '@/lib/api/schemas/kb-globale.schemas';
+
+// Mock the api client
+vi.mock('@/lib/api', () => ({
+  api: {
+    kbDocs: {
+      searchGlobal: vi.fn(),
+    },
+  },
+}));
+
+// Mock useDebounce to return the value synchronously (passthrough) by default.
+// Individual tests can override via mockReturnValueOnce for short-circuit scenarios.
+vi.mock('@/hooks/useDebounce', () => ({
+  useDebounce: vi.fn((value: string) => value),
+}));
+
+import { api } from '@/lib/api';
+import { useDebounce } from '@/hooks/useDebounce';
+
+const mockSearchGlobal = vi.mocked(api.kbDocs.searchGlobal);
+const mockUseDebounce = vi.mocked(useDebounce);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function makeResult(idx: number): GlobalKbSearchResult {
+  return {
+    chunkId: `chunk-${idx}`,
+    docId: `00000000-0000-0000-0000-${String(idx).padStart(12, '0')}`,
+    docTitle: `Doc ${idx}`,
+    gameId: `11111111-1111-1111-1111-${String(idx).padStart(12, '0')}`,
+    gameName: `Game ${idx}`,
+    docType: 'Rulebook',
+    headingPath: null,
+    snippet: `Snippet ${idx}`,
+    pageNumber: idx + 1,
+    score: 0.9 - idx * 0.1,
+  };
+}
+
+function makeResponse(
+  results: GlobalKbSearchResult[],
+  hasMore: boolean,
+  nextCursor: string | null
+): GlobalKbSearchResponse {
+  return { results, hasMore, nextCursor };
+}
+
+describe('useGlobalKbSearch', () => {
+  beforeEach(() => {
+    mockSearchGlobal.mockReset();
+    // Default: useDebounce returns value synchronously (passthrough)
+    mockUseDebounce.mockImplementation((value: string) => value);
+  });
+
+  it('1: enabled=false when query is empty — isLoading=false, results=[], mock NOT called', () => {
+    const { result } = renderHook(() => useGlobalKbSearch({ query: '' }), { wrapper });
+    expect(mockSearchGlobal).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.results).toHaveLength(0);
+  });
+
+  it('2: enabled=false when query length < 2 — mock NOT called', () => {
+    // useDebounce passthrough returns 'a' (length 1) → effectiveEnabled=false
+    const { result } = renderHook(() => useGlobalKbSearch({ query: 'a' }), { wrapper });
+    expect(mockSearchGlobal).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('3: fetches on debounced query ≥ 2 chars — mock called 1 time with correct args', async () => {
+    mockSearchGlobal.mockResolvedValue(makeResponse([makeResult(0)], false, null));
+
+    const { result } = renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+
+    await waitFor(() => expect(result.current.results.length).toBeGreaterThan(0));
+
+    expect(mockSearchGlobal).toHaveBeenCalledTimes(1);
+    expect(mockSearchGlobal).toHaveBeenCalledWith({
+      query: 'azul',
+      mode: undefined,
+      cursor: null,
+    });
+    expect(result.current.results).toHaveLength(1);
+  });
+
+  it('4: debounce coalescing — hook disabled while debouncedQuery < 2 chars', () => {
+    // Simulate useDebounce holding a short value (debounce has not fired yet)
+    mockUseDebounce.mockReturnValue('a'); // still short, not fired
+
+    renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+
+    // useDebounce returns 'a' → effectiveEnabled=false → no fetch
+    expect(mockSearchGlobal).not.toHaveBeenCalled();
+  });
+
+  it('5: fetchNextPage appends results + passes cursor to second call', async () => {
+    mockSearchGlobal
+      .mockResolvedValueOnce(makeResponse([makeResult(0)], true, 'cursor-1'))
+      .mockResolvedValueOnce(makeResponse([makeResult(1)], false, null));
+
+    const { result } = renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalledTimes(2));
+    expect(mockSearchGlobal).toHaveBeenNthCalledWith(2, {
+      query: 'azul',
+      mode: undefined,
+      cursor: 'cursor-1',
+    });
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+  });
+
+  it('6: query change resets cursor — second fetch uses cursor=null', async () => {
+    mockSearchGlobal
+      .mockResolvedValueOnce(makeResponse([makeResult(0)], true, 'cursor-1'))
+      .mockResolvedValueOnce(makeResponse([makeResult(1)], false, null));
+
+    const { result, rerender } = renderHook(({ q }) => useGlobalKbSearch({ query: q }), {
+      wrapper,
+      initialProps: { q: 'azul' },
+    });
+
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    // Change query — queryKey changes, cursor auto-resets via useInfiniteQuery
+    rerender({ q: 'catan' });
+
+    await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalledTimes(2));
+    expect(mockSearchGlobal).toHaveBeenNthCalledWith(2, {
+      query: 'catan',
+      mode: undefined,
+      cursor: null,
+    });
+  });
+
+  it('7: mode change resets cursor — second fetch uses cursor=null', async () => {
+    mockSearchGlobal
+      .mockResolvedValueOnce(makeResponse([makeResult(0)], true, 'cursor-1'))
+      .mockResolvedValueOnce(makeResponse([makeResult(1)], false, null));
+
+    const { result, rerender } = renderHook(
+      ({ mode }) => useGlobalKbSearch({ query: 'azul', mode }),
+      { wrapper, initialProps: { mode: undefined as 'Semantic' | undefined } }
+    );
+
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    // Change mode — queryKey changes, cursor auto-resets
+    rerender({ mode: 'Semantic' });
+
+    await waitFor(() => expect(mockSearchGlobal).toHaveBeenCalledTimes(2));
+    expect(mockSearchGlobal).toHaveBeenNthCalledWith(2, {
+      query: 'azul',
+      mode: 'Semantic',
+      cursor: null,
+    });
+  });
+
+  it('8: hasMore reflects last page only — false after 2 pages', async () => {
+    mockSearchGlobal
+      .mockResolvedValueOnce(makeResponse([makeResult(0)], true, 'cursor-1'))
+      .mockResolvedValueOnce(makeResponse([makeResult(1)], false, null));
+
+    const { result } = renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('9: error surfaces, no exception bubbling', async () => {
+    mockSearchGlobal.mockRejectedValue(new Error('Network failure'));
+
+    const { result } = renderHook(() => useGlobalKbSearch({ query: 'azul' }), { wrapper });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe('Network failure');
+    expect(result.current.results).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/queries/useGlobalKbSearch.ts
+++ b/apps/web/src/hooks/queries/useGlobalKbSearch.ts
@@ -1,0 +1,120 @@
+/**
+ * useGlobalKbSearch — TanStack Query useInfiniteQuery hook for cross-game KB search.
+ *
+ * Backend contract: `POST /api/v1/knowledge-base/search/global`.
+ *  - Body: `{ query, limit?, cursor?, mode? }`
+ *  - Response: `{ results, hasMore, nextCursor }`
+ *
+ * Gate: only fires when `query.trim().length >= 2` to avoid single-char noise.
+ * Debounce: 250ms (override useDebounce default of 2000ms).
+ * Cache: staleTime 5min (aligns with useUserKbDocs from Issue #1592).
+ * Cursor: cursor-based pagination; queryKey change (query or mode) auto-resets cursor.
+ * hasMore: computed from last page only (no totalCount cross-game per Nygard D6).
+ *
+ * @see apps/web/src/lib/api/clients/kbDocsClient.ts  — kbDocsClient.searchGlobal
+ * @see apps/web/src/lib/api/schemas/kb-globale.schemas.ts  — Zod schemas (Task 0)
+ * @see Issue #1482 Phase 1 Foundation
+ */
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { useDebounce } from '@/hooks/useDebounce';
+import { api } from '@/lib/api';
+import type {
+  GlobalKbSearchResult,
+  GlobalKbSearchResponse,
+  SearchMode,
+} from '@/lib/api/schemas/kb-globale.schemas';
+
+export const KB_GLOBALE_SEARCH_STALE_TIME_MS = 5 * 60 * 1000; // 5 min.
+
+/** Query key factory for cache coordination / invalidation. */
+export const kbGlobaleSearchKeys = {
+  all: ['kb-globale', 'search'] as const,
+  byQuery: (query: string, mode: SearchMode | null) =>
+    [...kbGlobaleSearchKeys.all, { query, mode }] as const,
+};
+
+export interface UseGlobalKbSearchOptions {
+  /** The search query string (will be trimmed internally). */
+  query: string;
+  /** Search mode — defaults to BE-side Semantic when undefined. */
+  mode?: SearchMode;
+  /** Debounce delay in ms. Defaults to 250 (overrides useDebounce's 2000ms default). */
+  debounceMs?: number;
+  /** Override the auto-enable gate (`query.trim().length >= 2`). */
+  enabled?: boolean;
+}
+
+export interface UseGlobalKbSearchResult {
+  /** Flat list of results across all fetched pages. */
+  results: readonly GlobalKbSearchResult[];
+  /** Whether the last fetched page has more items (cursor pagination). */
+  hasMore: boolean;
+  /** True during the initial fetch (no cached data yet). */
+  isLoading: boolean;
+  /** True while fetching the next page. */
+  isFetchingNextPage: boolean;
+  /** The fetch error, if any; null otherwise. */
+  error: Error | null;
+  /** Trigger fetch of the next page (cursor forwarded automatically). */
+  fetchNextPage: () => void;
+}
+
+/**
+ * Infinite-query hook for cross-game KB semantic search.
+ *
+ * @example
+ * ```tsx
+ * const { results, hasMore, isLoading, fetchNextPage } = useGlobalKbSearch({ query });
+ * ```
+ */
+export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSearchResult {
+  const { query, mode, debounceMs = 250, enabled } = opts;
+
+  // Debounce the trimmed query to avoid firing on every keystroke.
+  const debouncedQuery = useDebounce(query.trim(), debounceMs);
+
+  // Auto-enable gate: fire only when there are at least 2 meaningful characters.
+  const effectiveEnabled = enabled ?? debouncedQuery.length >= 2;
+
+  const q = useInfiniteQuery<
+    GlobalKbSearchResponse,
+    Error,
+    { pages: GlobalKbSearchResponse[] },
+    ReturnType<typeof kbGlobaleSearchKeys.byQuery>,
+    string | null
+  >({
+    queryKey: kbGlobaleSearchKeys.byQuery(debouncedQuery, mode ?? null),
+    queryFn: ({ pageParam }) =>
+      api.kbDocs.searchGlobal({
+        query: debouncedQuery,
+        mode,
+        cursor: pageParam,
+      }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage: GlobalKbSearchResponse) =>
+      lastPage.hasMore ? lastPage.nextCursor : undefined,
+    enabled: effectiveEnabled,
+    staleTime: KB_GLOBALE_SEARCH_STALE_TIME_MS,
+  });
+
+  // Flatten pages into a single results array.
+  const results: readonly GlobalKbSearchResult[] = q.data?.pages.flatMap(p => p.results) ?? [];
+
+  // hasMore is derived exclusively from the last page to avoid stale intermediate state.
+  const pages = q.data?.pages;
+  const hasMore =
+    pages != null && pages.length > 0 ? (pages[pages.length - 1]?.hasMore ?? false) : false;
+
+  return {
+    results,
+    hasMore,
+    isLoading: q.isLoading,
+    isFetchingNextPage: q.isFetchingNextPage,
+    error: q.error,
+    fetchNextPage: () => {
+      void q.fetchNextPage();
+    },
+  };
+}

--- a/apps/web/src/lib/api/clients/kbDocsClient.ts
+++ b/apps/web/src/lib/api/clients/kbDocsClient.ts
@@ -8,6 +8,11 @@
  */
 
 import { KbDocsListResponseSchema, type KbDocsListResponse } from '../schemas/kb-docs.schemas';
+import {
+  GlobalKbSearchResponseSchema,
+  type GlobalKbSearchRequest,
+  type GlobalKbSearchResponse,
+} from '../schemas/kb-globale.schemas';
 
 import type { HttpClient } from '../core/httpClient';
 
@@ -26,6 +31,7 @@ export interface ListUserKbDocsParams {
 
 export interface KbDocsClient {
   listUserKbDocs(params?: ListUserKbDocsParams): Promise<KbDocsListResponse>;
+  searchGlobal(req: GlobalKbSearchRequest): Promise<GlobalKbSearchResponse>;
 }
 
 export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): KbDocsClient {
@@ -42,6 +48,15 @@ export function createKbDocsClient({ httpClient }: CreateKbDocsClientParams): Kb
       return (
         response ?? { items: [], total: 0, page: params.page ?? 1, pageSize: params.pageSize ?? 20 }
       );
+    },
+
+    async searchGlobal(req: GlobalKbSearchRequest): Promise<GlobalKbSearchResponse> {
+      const response = await httpClient.post<GlobalKbSearchResponse>(
+        '/api/v1/knowledge-base/search/global',
+        req,
+        GlobalKbSearchResponseSchema
+      );
+      return response ?? { results: [], hasMore: false, nextCursor: null };
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
@@ -1,0 +1,138 @@
+/**
+ * KB Globale Schemas Tests (Issue #1482 Task 0)
+ *
+ * Unit tests for Zod schemas covering POST /api/v1/knowledge-base/search/global
+ * request/response validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SearchModeSchema,
+  GlobalKbSearchRequestSchema,
+  GlobalKbSearchResultSchema,
+  GlobalKbSearchResponseSchema,
+  type GlobalKbSearchRequest,
+  type GlobalKbSearchResponse,
+} from '../kb-globale.schemas';
+
+describe('KB Globale Schemas', () => {
+  const validResult = {
+    chunkId: 'doc-123_0',
+    docId: '550e8400-e29b-41d4-a716-446655440000',
+    docTitle: 'Azul Rulebook',
+    gameId: '550e8400-e29b-41d4-a716-446655440001',
+    gameName: 'Azul',
+    docType: 'base',
+    headingPath: 'Setup > Initial Tiles',
+    snippet: 'Place the starting tiles on the board.',
+    pageNumber: 3,
+    score: 0.95,
+  };
+
+  const validEnvelope = {
+    results: [validResult],
+    hasMore: false,
+    nextCursor: null,
+  };
+
+  // ──────────────────────────────────────────────────────────────────
+  // GlobalKbSearchResponseSchema tests
+  // ──────────────────────────────────────────────────────────────────
+
+  it('parses a full valid response', () => {
+    expect(() => GlobalKbSearchResponseSchema.parse(validEnvelope)).not.toThrow();
+  });
+
+  it('parses with hasMore + cursor', () => {
+    const envelope = {
+      results: [validResult],
+      hasMore: true,
+      nextCursor: 'opaque-cursor-string-abc123',
+    };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).not.toThrow();
+  });
+
+  it('result accepts headingPath=null and pageNumber=null', () => {
+    const result = {
+      ...validResult,
+      headingPath: null,
+      pageNumber: null,
+    };
+    const envelope = { results: [result], hasMore: false, nextCursor: null };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).not.toThrow();
+  });
+
+  it('rejects unknown fields in envelope', () => {
+    const invalid = { ...validEnvelope, totalCount: 0 };
+    expect(() => GlobalKbSearchResponseSchema.parse(invalid)).toThrow();
+  });
+
+  it('rejects malformed docId UUID', () => {
+    const result = { ...validResult, docId: 'not-a-uuid' };
+    const envelope = { results: [result], hasMore: false, nextCursor: null };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).toThrow();
+  });
+
+  it('rejects malformed gameId UUID', () => {
+    const result = { ...validResult, gameId: 'invalid-uuid' };
+    const envelope = { results: [result], hasMore: false, nextCursor: null };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).toThrow();
+  });
+
+  it('accepts empty snippet', () => {
+    const result = { ...validResult, snippet: '' };
+    const envelope = { results: [result], hasMore: false, nextCursor: null };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).not.toThrow();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // GlobalKbSearchRequestSchema tests
+  // ──────────────────────────────────────────────────────────────────
+
+  it('request: rejects query=""', () => {
+    const req = { query: '' };
+    expect(() => GlobalKbSearchRequestSchema.parse(req)).toThrow();
+  });
+
+  it('request: accepts minimal { query: "azul" }', () => {
+    const req = { query: 'azul' };
+    expect(() => GlobalKbSearchRequestSchema.parse(req)).not.toThrow();
+  });
+
+  it('request: accepts all optional fields', () => {
+    const req = {
+      query: 'azul rules',
+      limit: 50,
+      cursor: 'next-page-cursor',
+      mode: 'Semantic' as const,
+    };
+    expect(() => GlobalKbSearchRequestSchema.parse(req)).not.toThrow();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // SearchModeSchema tests
+  // ──────────────────────────────────────────────────────────────────
+
+  it("SearchModeSchema: accepts 'Semantic'", () => {
+    expect(() => SearchModeSchema.parse('Semantic')).not.toThrow();
+  });
+
+  it("SearchModeSchema: rejects 'Keyword'", () => {
+    expect(() => SearchModeSchema.parse('Keyword')).toThrow();
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // Type-level inference tests
+  // ──────────────────────────────────────────────────────────────────
+
+  it('type-level: GlobalKbSearchResponse infers correct shape', () => {
+    const response: GlobalKbSearchResponse = validEnvelope;
+    expect(response.results[0].chunkId).toBe('doc-123_0');
+    expect(response.hasMore).toBe(false);
+  });
+
+  it('type-level: GlobalKbSearchRequest infers correct shape', () => {
+    const request: GlobalKbSearchRequest = { query: 'test' };
+    expect(request.query).toBe('test');
+  });
+});

--- a/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
@@ -1,0 +1,65 @@
+/**
+ * KB Globale Schemas (Issue #1482 Task 0)
+ *
+ * Zod schemas for the cross-game global KB search endpoint
+ * (BE Phase 1 #1661): POST /api/v1/knowledge-base/search/global.
+ *
+ * Matches `GlobalKbSearchResultDto` from
+ * apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/GlobalKbSearchResultDto.cs.
+ */
+
+import { z } from 'zod';
+
+/**
+ * SearchMode enum for the search request.
+ * Currently only "Semantic" is supported in v1.
+ * Will be extended when BE adds Keyword or other search modes.
+ * @see apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Enums/SearchMode.cs
+ */
+export const SearchModeSchema = z.enum(['Semantic']);
+
+export type SearchMode = z.infer<typeof SearchModeSchema>;
+
+/**
+ * GlobalKbSearchResultDto — a single enriched result from cross-game KB search.
+ * Mirrors the BE DTO fields 1:1 with camelCase transformation.
+ */
+export const GlobalKbSearchResultSchema = z.object({
+  chunkId: z.string(),
+  docId: z.string().uuid(),
+  docTitle: z.string(),
+  gameId: z.string().uuid(),
+  gameName: z.string(),
+  docType: z.string(),
+  headingPath: z.string().nullable(),
+  snippet: z.string(),
+  pageNumber: z.number().int().nullable(),
+  score: z.number(),
+});
+
+export type GlobalKbSearchResult = z.infer<typeof GlobalKbSearchResultSchema>;
+
+/**
+ * GlobalKbSearchRequest — the POST /knowledge-base/search/global request body.
+ */
+export const GlobalKbSearchRequestSchema = z.object({
+  query: z.string().min(1, 'Query must not be empty'),
+  limit: z.number().int().positive().optional(),
+  cursor: z.string().nullable().optional(),
+  mode: SearchModeSchema.optional(),
+});
+
+export type GlobalKbSearchRequest = z.infer<typeof GlobalKbSearchRequestSchema>;
+
+/**
+ * GlobalKbSearchResponse envelope — the complete response from /knowledge-base/search/global.
+ */
+export const GlobalKbSearchResponseSchema = z
+  .object({
+    results: z.array(GlobalKbSearchResultSchema),
+    hasMore: z.boolean(),
+    nextCursor: z.string().nullable(),
+  })
+  .strict();
+
+export type GlobalKbSearchResponse = z.infer<typeof GlobalKbSearchResponseSchema>;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3883,6 +3883,39 @@
         "cancel": "Cancel",
         "back": "← Back"
       }
+    },
+    "kbGlobale": {
+      "hero": {
+        "placeholder": "Search across all games' KB…",
+        "submit": "Search",
+        "clear": "Clear",
+        "modeLabel": "Search mode",
+        "modeOptions": {
+          "Semantic": "Semantic"
+        }
+      },
+      "home": {
+        "heading": "Recent documents",
+        "empty": {
+          "title": "No documents yet",
+          "description": "Upload a PDF from your library to get started.",
+          "cta": "Go to library"
+        },
+        "errorTitle": "Could not load documents",
+        "errorDescription": "An error occurred. Please try again shortly.",
+        "retry": "Retry"
+      },
+      "results": {
+        "loadMore": "Load more",
+        "loadingMore": "Loading…",
+        "empty": {
+          "title": "No results",
+          "description": "Try different search terms or check your spelling."
+        },
+        "errorTitle": "Search error",
+        "errorDescription": "Search failed. Please try again shortly.",
+        "retry": "Retry"
+      }
     }
   }
 }

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3936,6 +3936,39 @@
         "cancel": "Annulla",
         "back": "← Indietro"
       }
+    },
+    "kbGlobale": {
+      "hero": {
+        "placeholder": "Cerca nella knowledge base…",
+        "submit": "Cerca",
+        "clear": "Cancella",
+        "modeLabel": "Modalità di ricerca",
+        "modeOptions": {
+          "Semantic": "Semantica"
+        }
+      },
+      "home": {
+        "heading": "Documenti recenti",
+        "empty": {
+          "title": "Nessun documento ancora",
+          "description": "Carica un PDF dalla libreria per iniziare.",
+          "cta": "Vai alla libreria"
+        },
+        "errorTitle": "Impossibile caricare i documenti",
+        "errorDescription": "Si è verificato un errore. Riprova tra qualche istante.",
+        "retry": "Riprova"
+      },
+      "results": {
+        "loadMore": "Carica altri",
+        "loadingMore": "Caricamento…",
+        "empty": {
+          "title": "Nessun risultato",
+          "description": "Prova con termini diversi o controlla l'ortografia."
+        },
+        "errorTitle": "Errore nella ricerca",
+        "errorDescription": "La ricerca non è riuscita. Riprova tra qualche istante.",
+        "retry": "Riprova"
+      }
     }
   }
 }

--- a/audits/2026-05-12-token-violations.md
+++ b/audits/2026-05-12-token-violations.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Date** | 2026-05-28 |
+| **Date** | 2026-05-30 |
 | **Generator** | `pnpm lint:tokens` (DS-2) |
 | **Spec** | [`2026-05-12-token-canonicalization.md`](../docs/for-developers/specs/2026-05-12-token-canonicalization.md) |
 | **Rule** | `local/no-hardcoded-color-utility` |

--- a/docs/for-developers/frontend/contracts/kb-globale-hooks.md
+++ b/docs/for-developers/frontend/contracts/kb-globale-hooks.md
@@ -218,12 +218,21 @@ All pure presentational, labels-injected, DS-15 tokens, `data-slot`, jest-axe pe
 |---|---|---|---|---|
 | Q1 | **Does a cross-game KB search FE endpoint exist?** | BE | ✅ **RESOLVED** by #1661 PR-1 (`POST /api/v1/knowledge-base/search/global`, response = `GlobalKbSearchResponseDto` mirroring §5 above; cursor pagination + hasMore). | (unblocked) |
 | Q2 | **Does a kb-ask SSE endpoint exist** (`POST /api/v1/kb/ask`) or only agent-chat? | BE | ✅ **RESOLVED** by #1661 PR-2 — `POST /api/v1/knowledge-base/ask/global` emitting `RagStreamingEvent` (mirrors `useAgentChatStream` wire format). Body: `{ query: string, language?: string, topK?: number }`. RBAC-filtered (public ∪ owned ∪ all-for-admin). | `useKbAskStream` (Interactions — now UNBLOCKED) |
-| Q3 | **CitationPill click behavior**: nav viewer to chunk, open modal, or highlight? Recommend: deep-link `?docId=&chunkId=` + scroll. | Design | open | Drawer + viewer integration |
+| Q3 | **CitationPill click behavior**: nav viewer to chunk, open modal, or highlight? Recommend: deep-link `?docId=&chunkId=` + scroll. | Design | 🟡 **DEFERRED to Phase 2** (decision at Interactions dispatch — recommendation stands: deep-link + scroll) | Drawer + viewer integration |
 | Q4 | **RBAC for global search**: private games included? Only shared/community? Only user's library? | Product/BE | ✅ **RESOLVED** by #1661 PR-1: accessible = `SharedGame.IsRagPublic` ∪ `UserLibraryEntry.OwnershipDeclaredAt != null` (user-owned library), excludes other users' private games. Admin/SuperAdmin → all non-deleted. | (unblocked) |
-| Q5 | **Editor scope**: edit doc content (chunks) or only metadata (title/type/tags/lang)? Recommend metadata-only v1. | Product | open | `KbEditorDesktop` + `useUpdateKbDocMeta` |
-| Q6 | **Filter facets** beyond docType/game/language? (tags? date?) | Design | open | `FilterAccordion` |
+| Q5 | **Editor scope**: edit doc content (chunks) or only metadata (title/type/tags/lang)? Recommend metadata-only v1. | Product/BE | 🚧 **BE-BLOCKED** — `PATCH /kb-docs/{id}` endpoint does NOT exist (verified 2026-05-29). Opened **#1687** (metadata-only v1, mirrors recommendation). `KbEditorDesktop` (#8) **DROPPED from Phase 2 v1** until #1687 lands. | `KbEditorDesktop` deferred |
+| Q6 | **Filter facets** beyond docType/game/language? (tags? date?) | Design/BE | 🚧 **BE-BLOCKED** — see D-B below. Opened **#1686** for server-side facets. `FilterAccordion` (#4) **DEFERRED from Foundation** until #1686 lands. | `FilterAccordion` deferred |
 
-**Foundation (Phase 1) is now UNBLOCKED** (Q1 ✅ + Q4 ✅). **Interactions (Phase 2) is now UNBLOCKED for Q2** (Q2 ✅ by #1661 PR-2 — `POST /api/v1/knowledge-base/ask/global`). Remaining open: Q3 (CitationPill click behavior) + Q5 (Editor scope).
+### Divergences vs shipped BE (verified 2026-05-29 against #1661 merge)
+
+| # | Divergence | Decision | Impact |
+|---|---|---|---|
+| **D-A** | `ask/global` request body is `{ Query, Language?, TopK? }` — **no `gameId`** (purely cross-game). Contract §3 ipotised `scope?: { gameId? }`. | `useKbAskStream.ask(query, opts?: { language?: string; topK?: number })`. Default `language='it'`. Phase 2. | hook signature change |
+| **D-B** | `search/global` body is `{ Query, Limit, Cursor, Mode, MinScore }` — **no facet params** (docType / gameId / language). `FilterAccordion` (#4) has no BE backing. | **DEFER FilterAccordion** from Foundation v1 → BE follow-up **#1686** (server-side facets). Foundation drops from 6 → 5 components. | Foundation scope ↓ |
+| **D-C** | `search/global` accepts `Mode: SearchMode?` + `MinScore: double?` not in contract §5. | **Expose `Mode` as `SearchMode` segmented control in `HeroSearch`** (Semantic default — backed UI replaces the deferred facet panel). `MinScore` stays internal default (not exposed). | new Foundation UI |
+
+**Foundation (Phase 1) UNBLOCKED** (Q1 ✅ + Q4 ✅ + D-A/D-B/D-C resolved + D-B routed to #1686). **5-component scope congelato** — see §11 below.
+**Interactions (Phase 2) PARTIALLY UNBLOCKED**: viewer + AI drawer + CitationPill UNBLOCKED (Q2 ✅, Q3 deferred-with-default). `KbEditorDesktop` BLOCKED on #1687.
 
 ## §8. Bundle budget
 
@@ -264,14 +273,59 @@ useGlobalKbSearch:
 
 ## §10. Acceptance criteria (for the eventual impl PRs)
 
-- [ ] Q1–Q6 resolved (this contract surfaces them; resolution may need BE issues)
-- [ ] Foundation PR: 5 components + `useGlobalKbSearch` + schemas + route shell + tests
-- [ ] Interactions PR: 5 components + `useKbAskStream` + lazy-split + tests
+- [ ] Q1–Q6 resolved (this contract surfaces them; resolution may need BE issues — Q5/Q6 routed to #1687/#1686)
+- [ ] Foundation PR: **5** components (was 6, FilterAccordion deferred per D-B) + `useGlobalKbSearch` + schemas + route shell + tests
+- [ ] Interactions PR: **4** components (was 5, KbEditorDesktop deferred per Q5/#1687) + `useKbAskStream` + lazy-split + tests
 - [ ] AI drawer 4-state FSM matches mockup; SSE mirrors `useAgentChatStream`
 - [ ] Citations reuse `streaming.schemas.ts`; viewer deep-link via `chunkId`
 - [ ] Bundle ≤ +150 KB (Interactions all lazy)
 - [ ] DS-15 + jest-axe per component
 - [ ] Matrix 10 rows pending → done; route summary updated
+
+## §11. Spec-panel decisions — 2026-05-29 (Wiegers/Fowler/Nygard/Adzic)
+
+Discussion-mode review of this contract against the BE actually shipped by #1661 (PRs #1672 + #1677). Goal: freeze Foundation scope, route deferred work to BE follow-up issues, eliminate hand-wavy components.
+
+### Frozen Foundation scope (Phase 1 — 5 components, all backed)
+
+| # | Component | Hook / data | BE backing | Notes |
+|---|---|---|---|---|
+| 1 | `HeroSearch` | local state + URL push | — | + `SearchMode` segmented control (D-C — Semantic default) |
+| 2 | `KbHomeDesktop` | `useUserKbDocs` (#1588, already in tree post-#1645) | `GET /api/v1/kb-docs?sortBy=recent&state=ready` ✅ | landing — recent docs cross-game, no new "status" hook (mirror simplification) |
+| 3 | `KbSearchResultsDesktop` | `useGlobalKbSearch` (greenfield) | `POST /api/v1/knowledge-base/search/global` ✅ | cursor pagination + `hasMore` "Load more"; no `totalCount` (Nygard D6 — too expensive cross-game) |
+| 4 | ~~`FilterAccordion`~~ | — | ❌ (deferred to #1686) | **DROPPED** from Foundation v1 — facets need server-side backing |
+| 5 | `KbEmptyState` | — | — | `no-query` (landing CTA) vs `no-results` (search returned 0) |
+| — | `useGlobalKbSearch` | greenfield | `POST /api/v1/knowledge-base/search/global` | debounced 250ms, cursor pagination, accepts `query + mode` (no facets in v1) |
+| — | `kb-globale.schemas.ts` | greenfield | mirrors `GlobalKbSearchResponseDto` + `GlobalKbSearchResultDto` (10 fields) | `Results / HasMore / NextCursor`; result fields match BE 1:1 |
+
+**Route**: create `apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx` (greenfield). URL SSOT: `?q=&mode=` only (no `docType / game / lang` until #1686).
+
+### Phase 2 Interactions (deferred to a separate dispatch)
+
+- **IN**: `KbDocViewerDesktop`, `KbDocViewerMobile`, `DrawerShell` (4 AI states), `CitationPill`, `useKbAskStream`.
+- **OUT** until #1687: `KbEditorDesktop`, `useUpdateKbDocMeta`.
+- **Q3 default at dispatch**: CitationPill click → URL push `?docId=&chunkId=` + viewer scroll.
+
+### Open questions retired by this session
+
+- **Q3** → deferred (decision at Phase 2 dispatch, default = deep-link).
+- **Q5** → BE-blocked, **#1687**.
+- **Q6** → BE-blocked, **#1686**.
+- **D-A / D-B / D-C** → resolved above.
+
+### Bundle re-budget
+
+- Foundation: ~40 KB (was ~50; one less component, no facet logic).
+- Interactions v1: ~80 KB (was ~100; editor deferred).
+- Umbrella stays ≤ +150 KB.
+
+### Impl-readiness checklist (for the writing-plans handoff)
+
+- [x] All Foundation components have verified BE backing
+- [x] Zod schemas match the shipped DTO field-by-field
+- [x] Greenfield items isolated (`useGlobalKbSearch`, `kb-globale.schemas.ts`, route shell, 5 components)
+- [x] Reuse claims verified (`useUserKbDocs`, `streaming.schemas.ts`, `KbChunkSummary` not needed in Foundation)
+- [x] BE follow-up issues filed and linked (#1686, #1687)
 
 ---
 

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -414,34 +414,38 @@ the PR review.
 | `sp4-kb-hub.jsx` | `RaptorPanel` | `apps/web/src/components/features/kb-hub/RaptorPanel.tsx` | `/library/[gameId]/kb` | done | #1481 | T A V | — |
 | `sp4-kb-hub.jsx` | `DeleteDialog` | `apps/web/src/components/features/kb-hub/DeleteDialog.tsx` | `/library/[gameId]/kb` | done | #1481 | T A M V | — |
 
-### KB globale — `/knowledge-base/global` (F1b) — 10 components — **Tier L** ✅ Phase 0.5 contract delivered (#1482)
+### KB globale — `/knowledge-base/global` (F1b) — 10 components — **Tier L** ✅ Phase 0.5 contract delivered (#1482) / **Phase 1 Foundation DONE** (PR #1688)
 
 > Mockup delivered post 2026-05-10 as `sp4-kb-globale.jsx`. Global search,
 > doc viewer (desktop + mobile), inline editor, and AI drawer (4-state FSM:
 > idle/streaming/completed/error).
 > **Phase 0.5 sub-hook contract DELIVERED** (#1482): [`contracts/kb-globale-hooks.md`](contracts/kb-globale-hooks.md).
+> **Phase 1 Foundation DELIVERED** (PR #1688): `useGlobalKbSearch` hook + 5 components
+> (HeroSearch, KbHomeDesktop, KbSearchResultsDesktop, KbEmptyState, route shell + orchestrator)
+> + Zod schemas + i18n catalogs + matrix + bundle budget.
 > Route decided: `/knowledge-base/global` (canonical). Dispatch is 2-phase
-> (Foundation: search/home/results/filters/empty + `useGlobalKbSearch`;
+> (Foundation: search/home/results/filters/empty + `useGlobalKbSearch` ✅ DONE;
 > Interactions: viewer/editor/AI-drawer + `useKbAskStream` mirroring
 > `useAgentChatStream`, all lazy-split). Reuse verified: `streaming.schemas.ts`
 > (CitationSchema + StreamingEventType), `kb-chunks.schemas.ts`, `useKbDocDetail`,
-> `useKbChunksList`. Greenfield: `useGlobalKbSearch` + `useKbAskStream`.
-> **6 open questions** (BE cross-game search + kb-ask SSE endpoints, citation
-> click, RBAC, editor scope, facets) must resolve before impl dispatch — see
-> contract §7. Components remain `pending` until Foundation/Interactions PRs land.
+> `useKbChunksList`, `useUserKbDocs`. Greenfield: `useGlobalKbSearch` + `useKbAskStream`.
+> **Remaining open questions** (BE cross-game search scope, kb-ask SSE, RBAC, editor scope, facets)
+> must resolve before Interactions dispatch — see contract §7 + follow-up issues #1686 / #1687.
+> FilterAccordion, viewers, editor, drawer deferred to Phase 2.
 
 | Mockup | Component | Path | Route | Status | PR | AC | audit_pr |
 |--------|-----------|------|-------|--------|----|----|----------|
-| `sp4-kb-globale.jsx` | `HeroSearch` | `apps/web/src/components/features/kb-globale/HeroSearch.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `KbHomeDesktop` | `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `KbSearchResultsDesktop` | `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `KbDocViewerDesktop` | `apps/web/src/components/features/kb-globale/KbDocViewerDesktop.tsx` | `/knowledge-base/global` | pending | — | T A M V | — |
-| `sp4-kb-globale.jsx` | `KbDocViewerMobile` | `apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx` | `/knowledge-base/global` | pending | — | T A M V | — |
-| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `DrawerShell` (+ `DrawerIdle` / `DrawerStreaming` / `DrawerCompleted` / `DrawerError` states) | `apps/web/src/components/features/kb-globale/Drawer*.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `CitationPill` | `apps/web/src/components/features/kb-globale/CitationPill.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
-| `sp4-kb-globale.jsx` | `KbEmptyState` | `apps/web/src/components/features/kb-globale/KbEmptyState.tsx` | `/knowledge-base/global` | pending | — | T A V | — |
+| `sp4-kb-globale.jsx` | `HeroSearch` | `apps/web/src/components/features/kb-globale/HeroSearch.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
+| `sp4-kb-globale.jsx` | `KbHomeDesktop` | `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
+| `sp4-kb-globale.jsx` | `KbSearchResultsDesktop` | `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
+| `sp4-kb-globale.jsx` | `FilterAccordion` | `apps/web/src/components/features/kb-globale/FilterAccordion.tsx` | `/knowledge-base/global` | pending | — | T A V | #1686 deferred |
+| `sp4-kb-globale.jsx` | `KbDocViewerDesktop` | `apps/web/src/components/features/kb-globale/KbDocViewerDesktop.tsx` | `/knowledge-base/global` | pending | — | T A M V | #1687 deferred |
+| `sp4-kb-globale.jsx` | `KbDocViewerMobile` | `apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx` | `/knowledge-base/global` | pending | — | T A M V | #1687 deferred |
+| `sp4-kb-globale.jsx` | `KbEditorDesktop` | `apps/web/src/components/features/kb-globale/KbEditorDesktop.tsx` | `/knowledge-base/global` | pending | — | T A V | #1687 deferred |
+| `sp4-kb-globale.jsx` | `DrawerShell` (+ `DrawerIdle` / `DrawerStreaming` / `DrawerCompleted` / `DrawerError` states) | `apps/web/src/components/features/kb-globale/Drawer*.tsx` | `/knowledge-base/global` | pending | — | T A V | Phase 2 deferred |
+| `sp4-kb-globale.jsx` | `CitationPill` | `apps/web/src/components/features/kb-globale/CitationPill.tsx` | `/knowledge-base/global` | pending | — | T A V | Phase 2 deferred |
+| `sp4-kb-globale.jsx` | `KbEmptyState` | `apps/web/src/components/features/kb-globale/KbEmptyState.tsx` | `/knowledge-base/global` | done | #1688 | T A V | — |
+| — | Route shell + orchestrator | `apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx` + `_components/KbGlobaleView.tsx` | `/knowledge-base/global` | done | #1688 | — | — |
 
 ## SP6 — Nanolith libro-game (Iter 1.B / Iter 4) — 2 components
 

--- a/docs/superpowers/plans/2026-05-29-kb-globale-foundation.md
+++ b/docs/superpowers/plans/2026-05-29-kb-globale-foundation.md
@@ -1,0 +1,385 @@
+# Plan — `/knowledge-base/global` Phase 1 Foundation (Issue #1482)
+
+> **Pipeline**: `/sc:spec-panel` (2026-05-29) → this plan → `subagent-driven-development`.
+> **Branch**: `feature/issue-1482-foundation` (parent: `main-dev`).
+> **Worktree**: `.claude/worktrees/issue-1482-foundation` (origin/main-dev fresh, post-#1681).
+> **Contract**: [`docs/for-developers/frontend/contracts/kb-globale-hooks.md`](../../for-developers/frontend/contracts/kb-globale-hooks.md) §11 (scope congelato).
+> **BE follow-up issues**: #1686 (server-side facets — unblocks FilterAccordion), #1687 (PATCH metadata — unblocks editor).
+
+## Scope (frozen)
+
+5 componenti + 1 hook + Zod schemas + route shell + integration tests + matrix update. **Tier M effettivo** (ridotto dal Tier L del contract perché FilterAccordion + editor sono deferred).
+
+**Estimated effort**: ~6–8h subagent time. **One PR**: `feat(kb-globale): #1482 Phase 1 Foundation`.
+
+## Reuse vs greenfield (verified P74)
+
+| Item | Verdict | Path |
+|---|---|---|
+| `useUserKbDocs(state='ready', sortBy='recent')` | ✅ REUSE (post #1645) | `apps/web/src/hooks/queries/useUserKbDocs.ts` |
+| `UserKbDocDto` + `KbDocsListResponse` Zod | ✅ REUSE | `apps/web/src/lib/api/schemas/kb-docs.schemas.ts` |
+| `kbDocsClient.listUserKbDocs(...)` | ✅ REUSE | `apps/web/src/lib/api/clients/kbDocsClient.ts` |
+| `useGlobalKbSearch` | ❌ GREENFIELD | `apps/web/src/hooks/queries/useGlobalKbSearch.ts` |
+| `kbClient.searchGlobal(req)` | ❌ GREENFIELD | extend `apps/web/src/lib/api/clients/kbDocsClient.ts` (or new `kbGlobaleClient.ts`) |
+| `kb-globale.schemas.ts` | ❌ GREENFIELD | `apps/web/src/lib/api/schemas/kb-globale.schemas.ts` |
+| 5 components | ❌ GREENFIELD | `apps/web/src/components/features/kb-globale/*` |
+| Route shell | ❌ GREENFIELD | `apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx` + `_components/KbGlobaleView.tsx` |
+
+## BE contract recap (verified against origin/main-dev `1111e4dc5`)
+
+```http
+POST /api/v1/knowledge-base/search/global
+Body: { Query: string, Limit?: int=20, Cursor?: string|null, Mode?: SearchMode|null, MinScore?: double|null }
+Resp: {
+  Results: [{
+    ChunkId: string,
+    DocId: Guid,
+    DocTitle: string,
+    GameId: Guid,
+    GameName: string,
+    DocType: string,
+    HeadingPath: string|null,
+    Snippet: string,
+    PageNumber: int|null,
+    Score: float
+  }],
+  HasMore: bool,
+  NextCursor: string|null
+}
+```
+
+`SearchMode` enum: at least `Semantic` (default). FE exposes only `Semantic` in v1; other modes TBD via Q6 follow-up if surfaced.
+
+## Tasks (TDD red→green, sequential dispatch)
+
+> **Subagent dispatch convention**: model hint follows P120 (mix-on-complexity). Each task = one subagent invocation in `feature-dev:code-architect` or `coder` agent, depending on layering. RED→GREEN→commit per task.
+
+### Task 0 — Zod schemas + client method (haiku · ~30min)
+
+**Files**:
+- NEW `apps/web/src/lib/api/schemas/kb-globale.schemas.ts`
+- EDIT `apps/web/src/lib/api/clients/kbDocsClient.ts` (or NEW `kbGlobaleClient.ts` if cleaner) — add `searchGlobal(req): Promise<GlobalKbSearchResponse>`
+- NEW `apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts`
+
+**Schema spec** (mirrors §11 of contract):
+
+```ts
+export const SearchModeSchema = z.enum(['Semantic']); // expand as BE adds modes
+export const GlobalKbSearchRequestSchema = z.object({
+  query: z.string().min(1),
+  limit: z.number().int().positive().optional(),
+  cursor: z.string().nullable().optional(),
+  mode: SearchModeSchema.optional(),
+});
+export const GlobalKbSearchResultSchema = z.object({
+  chunkId: z.string(),
+  docId: z.string().uuid(),
+  docTitle: z.string(),
+  gameId: z.string().uuid(),
+  gameName: z.string(),
+  docType: z.string(),
+  headingPath: z.string().nullable(),
+  snippet: z.string(),
+  pageNumber: z.number().int().nullable(),
+  score: z.number(),
+});
+export const GlobalKbSearchResponseSchema = z.object({
+  results: z.array(GlobalKbSearchResultSchema),
+  hasMore: z.boolean(),
+  nextCursor: z.string().nullable(),
+}).strict();
+```
+
+**AC (Task 0)**:
+- [ ] Schema match shipped BE DTO 1:1 (Results/HasMore/NextCursor field names; result has 10 fields)
+- [ ] `searchGlobal({query, limit?, cursor?, mode?})` resolves to parsed response (HttpClient + Zod validation via existing client infra)
+- [ ] Unit tests: valid request roundtrip, optional fields default, rejects unknown fields (`.strict()`), rejects bad enum, rejects malformed UUID/score
+- [ ] `pnpm typecheck` + `pnpm lint` clean
+
+**Depends on**: nothing.
+
+### Task 1 — `useGlobalKbSearch` hook (sonnet · ~1h)
+
+**Files**:
+- NEW `apps/web/src/hooks/queries/useGlobalKbSearch.ts`
+- NEW `apps/web/src/hooks/queries/__tests__/useGlobalKbSearch.test.tsx`
+
+**Hook spec**:
+
+```ts
+export interface UseGlobalKbSearchOptions {
+  query: string;
+  mode?: SearchMode;
+  debounceMs?: number; // default 250
+  enabled?: boolean;   // default !!query
+}
+export interface UseGlobalKbSearchResult {
+  data: { results: readonly GlobalKbSearchResult[]; hasMore: boolean } | undefined;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  error: Error | null;
+  fetchNextPage: () => void; // appends cursor page
+  resetCursor: () => void;   // on query/mode change
+}
+export function useGlobalKbSearch(opts: UseGlobalKbSearchOptions): UseGlobalKbSearchResult;
+```
+
+**Implementation hints**:
+- Use `useInfiniteQuery` from React Query keyed on `['kb-globale', 'search', { query, mode }]`.
+- `getNextPageParam: lastPage => lastPage.hasMore ? lastPage.nextCursor : undefined`.
+- Debounce query string before key change (250ms default). Reuse existing debounce primitive in tree if any; otherwise inline `useDebouncedValue` (small, no new dep).
+- `enabled = !!query && query.length >= 2` to avoid 1-char noise (Wiegers: testable threshold).
+- `staleTime: 5 * 60 * 1000` (search results valid 5min, mirrors useUserKbDocs).
+
+**AC (Task 1)**:
+- [ ] Query `""` → `enabled=false`, no fetch, `data=undefined`
+- [ ] Query change → cursor reset, refetch (no leak from previous query into `data.results`)
+- [ ] `fetchNextPage()` appends next page; `hasMore` aggregates last page only
+- [ ] Mode change behaves like query change (full reset)
+- [ ] Error from client surfaces as `error`, no thrown
+- [ ] Debounce: rapid typing fires only the final request (use vi.useFakeTimers)
+- [ ] Unit tests cover: 7 scenarios above + mocked client via `vi.mock('@/lib/api')` pattern
+
+**Depends on**: Task 0.
+
+### Task 2 — `HeroSearch` component + `SearchMode` toggle (haiku · ~45min)
+
+**Files**:
+- NEW `apps/web/src/components/features/kb-globale/HeroSearch.tsx`
+- NEW `apps/web/src/components/features/kb-globale/__tests__/HeroSearch.test.tsx`
+
+**Props**:
+
+```ts
+interface HeroSearchProps {
+  initialQuery?: string;
+  initialMode?: SearchMode;
+  onSubmit: (q: string, mode: SearchMode) => void; // pushes to URL
+  onClear?: () => void;
+  labels: {
+    placeholder: string;
+    submit: string;
+    modeLabel: string;
+    modeOptions: Record<SearchMode, string>;
+  };
+}
+```
+
+**Rendering**: large hero with text input + segmented control for `mode` (Semantic default) + submit button (or Enter key). Clear button when value present. DS-15 tokens (`bg-card`, `text-foreground`, `border-border`, `bg-entity-game` for accent if alignment with KB theme — verify against mockup `sp4-kb-globale.html`).
+
+**AC (Task 2)**:
+- [ ] Render input with placeholder from labels
+- [ ] Segmented control reflects mode, calls onSubmit with current value on Enter/click submit
+- [ ] Clear button (×) when value non-empty, calls onClear and clears input
+- [ ] Labels-injected (no hardcoded strings — i18n consumer wires them)
+- [ ] `jest-axe` test passes (no a11y violations: input has label, buttons have accessible names)
+- [ ] No-token violations: `pnpm lint:tokens`
+
+**Depends on**: Task 0 (schema types).
+
+### Task 3 — `KbEmptyState` (haiku · ~30min)
+
+**Files**:
+- NEW `apps/web/src/components/features/kb-globale/KbEmptyState.tsx`
+- NEW `apps/web/src/components/features/kb-globale/__tests__/KbEmptyState.test.tsx`
+
+**Props**:
+
+```ts
+type KbEmptyKind = 'no-query' | 'no-results';
+interface KbEmptyStateProps {
+  kind: KbEmptyKind;
+  labels: { title: string; description: string; cta?: string };
+  onCtaClick?: () => void;
+}
+```
+
+**Rendering**: discriminated render per `kind`. `no-query` is landing CTA "Start searching across all your games". `no-results` is "No matches for «query» — try a different mode or simpler terms".
+
+**AC (Task 3)**:
+- [ ] Renders title + description per kind
+- [ ] CTA button rendered when `cta` label provided, calls onCtaClick
+- [ ] jest-axe clean (role="status" or descriptive heading hierarchy)
+- [ ] DS-15 tokens
+
+**Depends on**: nothing.
+
+### Task 4 — `KbHomeDesktop` landing (sonnet · ~1h)
+
+**Files**:
+- NEW `apps/web/src/components/features/kb-globale/KbHomeDesktop.tsx`
+- NEW `apps/web/src/components/features/kb-globale/__tests__/KbHomeDesktop.test.tsx`
+
+**Spec**: rendered when URL has no `?q=`. Shows recent KB docs cross-game (via `useUserKbDocs({state: 'ready', sortBy: 'recent', pageSize: 12})` reuse — post-#1645 API).
+
+**Props**:
+
+```ts
+interface KbHomeDesktopProps {
+  // hook results passed in (testability — facility orchestrator-level mocking)
+  recentDocs: UserKbDoc[];
+  isLoading: boolean;
+  error: Error | null;
+  labels: { /* heading, empty CTA, doc card aria, ... */ };
+  onDocClick?: (docId: string) => void; // Phase 2 viewer; in Foundation = TBD/optional
+}
+```
+
+Inline doc card list (12 items max, 3-col grid desktop). Loading state = 12 skeleton cards. Error → inline error banner. Empty → `<KbEmptyState kind="no-query" />`.
+
+**AC (Task 4)**:
+- [ ] Renders 12 doc cards with title + gameName + processedAt-as-updatedAt
+- [ ] Loading shows 12 skeletons (data-testid)
+- [ ] Error renders error banner (Nygard: no swallowed errors)
+- [ ] Empty (`recentDocs.length === 0 && !isLoading && !error`) renders KbEmptyState
+- [ ] No waterfall: hook is consumed by orchestrator (Task 6), KbHomeDesktop is pure
+- [ ] jest-axe + DS-15
+
+**Depends on**: Task 3 (KbEmptyState).
+
+### Task 5 — `KbSearchResultsDesktop` + load-more (sonnet · ~1.5h)
+
+**Files**:
+- NEW `apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx`
+- NEW `apps/web/src/components/features/kb-globale/__tests__/KbSearchResultsDesktop.test.tsx`
+
+**Props**:
+
+```ts
+interface KbSearchResultsDesktopProps {
+  results: readonly GlobalKbSearchResult[];
+  hasMore: boolean;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  error: Error | null;
+  onLoadMore: () => void;
+  onResultClick?: (r: GlobalKbSearchResult) => void; // Phase 2 viewer; in Foundation: TBD
+  labels: { /* loadMore, loadingMore, empty, error, headerCount, ... */ };
+}
+```
+
+Result row layout (per mockup `sp4-kb-globale-search.html` — verify exact layout when implementing):
+- `gameName · docTitle · DocType pill · pageNumber?`
+- `Snippet` (highlight match if feasible — Phase 2 nice-to-have, **NOT** Foundation AC)
+- `headingPath` line if non-null
+- score badge (small, muted)
+
+Load-more button at bottom when `hasMore`. Disabled + spinner when `isFetchingNextPage`. Empty → `KbEmptyState kind="no-results"`.
+
+**AC (Task 5)**:
+- [ ] Renders N results with all 10 fields visible (score visible but muted)
+- [ ] `hasMore=true` → load-more button rendered + clickable
+- [ ] `isFetchingNextPage=true` → button disabled with spinner label
+- [ ] `results=[]` + `!isLoading` + `!error` → KbEmptyState kind="no-results"
+- [ ] `error` → error banner, no result list
+- [ ] No infinite-scroll auto-trigger in v1 (explicit click — Nygard: predictability)
+- [ ] jest-axe + DS-15
+
+**Depends on**: Task 0 (schema types), Task 3 (KbEmptyState).
+
+### Task 6 — Route shell + orchestrator (sonnet · ~1.5h)
+
+**Files**:
+- NEW `apps/web/src/app/(authenticated)/knowledge-base/global/page.tsx` (server component thin wrapper)
+- NEW `apps/web/src/app/(authenticated)/knowledge-base/global/_components/KbGlobaleView.tsx` (client orchestrator)
+- NEW `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.test.tsx`
+
+**Server page** (Next.js App Router):
+
+```tsx
+// page.tsx
+import { Suspense } from 'react';
+import { KbGlobaleView } from './_components/KbGlobaleView';
+
+export default function Page() {
+  return (
+    <Suspense fallback={<KbGlobaleSkeleton />}>
+      <KbGlobaleView />
+    </Suspense>
+  );
+}
+```
+
+**Orchestrator** (URL SSOT):
+- Read `searchParams` (or `useSearchParams` client-side): `q`, `mode`.
+- If `!q` → render `<KbHomeDesktop>` (consume `useUserKbDocs(...)`).
+- If `q` → render `<KbSearchResultsDesktop>` (consume `useGlobalKbSearch({query: q, mode})`).
+- Render `<HeroSearch initialQuery={q} initialMode={mode} onSubmit={pushUrl} onClear={clearUrl}>` always on top.
+- `pushUrl(q, mode)` uses `useRouter().push` or `useSearchParams.set` — match existing pattern in `/discover` route.
+
+**AC (Task 6)**:
+- [ ] Route renders at `/knowledge-base/global` (HTTP 200, no SSR error)
+- [ ] `?q=azul` → results view; `?q=&mode=Semantic` → home (empty q)
+- [ ] HeroSearch submit pushes URL (test via mock `useRouter` or `URLSearchParams` assertion)
+- [ ] Home vs Results branch is testable via setup (mock useSearchParams)
+- [ ] No double-fetch: orchestrator decides which hook fires per URL state (no `enabled: true` for both)
+- [ ] jest-axe clean
+
+**Depends on**: Tasks 1, 2, 4, 5.
+
+### Task 7 — Integration test (MSW) (sonnet · ~1h)
+
+**Files**:
+- NEW `apps/web/src/app/(authenticated)/knowledge-base/global/_components/__tests__/KbGlobaleView.integration.test.tsx`
+
+**Scenarios** (MSW-mocked `POST /api/v1/knowledge-base/search/global` + `GET /api/v1/kb-docs`):
+1. Land on `/knowledge-base/global` with no `q` → home renders 12 recent docs.
+2. Type "azul" + submit → URL changes to `?q=azul`, results render N rows.
+3. Click "Load more" → next page appended (cursor passed correctly).
+4. Mode toggle to Semantic (default already) → no-op refetch (already-fetched data reused).
+5. Server returns 500 → error banner visible, no crash.
+6. Query "" via clear → back to home view.
+
+**AC (Task 7)**:
+- [ ] 6 scenarios covered, all pass
+- [ ] MSW handlers assert request shape (Zod-validated body)
+- [ ] No `act()` warnings, no console errors
+
+**Depends on**: Task 6.
+
+### Task 8 — Matrix + bundle budget + i18n (haiku · ~30min)
+
+**Files**:
+- EDIT `docs/for-developers/frontend/v2-migration-matrix.md` — add 5 rows for kb-globale components + 1 row for route, status `done`, link PR.
+- EDIT (if exists) `apps/web/.bundle-budgets.json` — add entry for `/knowledge-base/global` with budget ~+40 KB (Foundation).
+- EDIT `apps/web/src/i18n/messages/it.json` + `en.json` — add labels for HeroSearch, KbEmptyState, KbHomeDesktop, KbSearchResultsDesktop (key namespace `pages.kbGlobale.*`).
+- EDIT `docs/for-developers/audits/2026-05-22-mockup-gaps.md` (if entry exists for kb-globale) — flip to closed.
+
+**AC (Task 8)**:
+- [ ] Matrix shows 6 rows under "kb-globale" with `Status=done`, `PR=#<this PR>`
+- [ ] Bundle budget entry added (or skipped if file absent — document in PR body)
+- [ ] i18n keys present in both `it.json` and `en.json`, used by Tasks 2-5 (no untranslated leaf strings)
+
+**Depends on**: Task 7 (closes the loop).
+
+## Final review checklist (pre-PR)
+
+- [ ] `pnpm typecheck` (worktree) clean
+- [ ] `pnpm lint` clean
+- [ ] `pnpm lint:tokens` clean
+- [ ] `pnpm test -- kb-globale useGlobalKbSearch kb-globale.schemas` — all green
+- [ ] `superpowers:code-reviewer` agent final pass (APPROVED or APPROVED_WITH_NOTES)
+- [ ] Branch is `feature/issue-1482-foundation` ← parent `main-dev`
+- [ ] Commit messages follow conventional commits (`feat(kb-globale): #1482 ...`)
+
+## PR
+
+- **Title**: `feat(kb-globale): #1482 Phase 1 Foundation — search + landing + 5 components`
+- **Base**: `main-dev`
+- **Body must contain**:
+  - `Refs #1482` (NOT `Closes` — Phase 2 still pending)
+  - Link to contract §11
+  - Link to BE follow-up issues #1686 / #1687 (in "Deferred" section)
+  - Test counts (BE+FE)
+  - Bundle delta vs baseline (target ≤ +40 KB)
+
+## Out of scope (explicit — for reviewer clarity)
+
+- `FilterAccordion` (component #4) — deferred to #1686
+- `KbDocViewerDesktop` / `KbDocViewerMobile` — Phase 2
+- `KbEditorDesktop` — deferred to #1687
+- `DrawerShell` + AI ask + `useKbAskStream` — Phase 2
+- `CitationPill` — Phase 2
+- Mobile-specific KB home/search variants — Phase 2 (mobile drawer pattern)
+- Snippet highlighting / match-highlight — Phase 2 nice-to-have
+- Infinite scroll — v1 keeps explicit "Load more" (Nygard predictability)


### PR DESCRIPTION
**Status**: DRAFT — currently only contract update + Foundation plan have landed. Tasks 0-8 will be added as subagent-driven TDD commits.

Refs #1482 — implementation Phase 1 Foundation of `/knowledge-base/global` (Tier-L → Tier-M effective after spec-panel scope freeze).

## Pipeline

1. ✅ Spec-panel review 2026-05-29 (Wiegers/Fowler/Nygard/Adzic) on the Phase 0.5 contract vs BE shipped by #1661.
2. ✅ Contract updated: §7 Q1-Q6 status refresh + new divergences table (D-A/D-B/D-C) + §11 frozen scope.
3. ✅ Foundation plan written (`docs/superpowers/plans/2026-05-29-kb-globale-foundation.md`) — 9 TDD tasks.
4. 🔄 Subagent-driven dispatch: Task 0 (schemas) → Task 8 (matrix/budget/i18n).

## Scope (frozen, 5 components)

| # | Component | Hook / data | BE backing |
|---|---|---|---|
| 1 | `HeroSearch` (+ SearchMode toggle) | local state | n/a (UI) |
| 2 | `KbHomeDesktop` | `useUserKbDocs` (REUSE post-#1645) | `GET /api/v1/kb-docs` ✅ |
| 3 | `KbSearchResultsDesktop` (+ Load more) | `useGlobalKbSearch` (greenfield) | `POST /api/v1/knowledge-base/search/global` ✅ |
| 4 | ~~`FilterAccordion`~~ | — | ❌ DEFERRED → #1686 |
| 5 | `KbEmptyState` | — | n/a |
| — | `useGlobalKbSearch` + `kb-globale.schemas.ts` | greenfield | aligned 1:1 to shipped DTO |
| — | Route shell `/knowledge-base/global` | URL SSOT `?q=&mode=` | — |

## Deferred work (out of scope)

- `FilterAccordion` (server-side facets) → BE issue **#1686**
- `KbEditorDesktop` + `useUpdateKbDocMeta` → BE issue **#1687**
- `KbDocViewer{Desktop,Mobile}` / `DrawerShell` (AI ask FSM) / `CitationPill` / `useKbAskStream` → Phase 2 Interactions (separate dispatch after Foundation merges)

## BE contract recap (verified against `origin/main-dev@1111e4dc5`)

```
POST /api/v1/knowledge-base/search/global
  Body:  { Query, Limit?, Cursor?, Mode?, MinScore? }
  Resp:  { Results[], HasMore, NextCursor }  // GlobalKbSearchResponseDto / GlobalKbSearchResultDto
```

`MinScore` not exposed in v1 (internal default). `Mode` exposed as segmented control (only `Semantic` in enum at write time; expandable as BE adds modes).

## Test plan

Per Foundation plan §Final review checklist:
- BE: n/a (FE-only PR)
- FE: schemas unit + hook unit + 5 component unit + integration MSW + jest-axe per component
- `pnpm typecheck && pnpm lint && pnpm lint:tokens` clean
- Bundle delta ≤ +40 KB target