### PR TITLE
feat(mockups): SP8 library mobile + libro-game companion

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -6,7 +6,7 @@
 >
 > **Audience**: developers looking for "which mockup file do I need for route X?".
 >
-> **Last updated**: 2026-05-23. Keep in sync with
+> **Last updated**: 2026-05-30. Keep in sync with
 > [`docs/for-developers/frontend/v2-migration-matrix.md`](../docs/for-developers/frontend/v2-migration-matrix.md)
 > Route Index section.
 
@@ -78,6 +78,7 @@
 | `sp4-kb-detail.html` | page-mock | `/knowledge-base/[id]` (deferred — G4 v3 pivot) |
 | `sp4-kb-hub.html` | page-mock | `/knowledge-base` |
 | `sp4-library-desktop.html` | page-mock | `/library` (Wave B.3 done) |
+| `sp4-library-mobile.html` | page-mock | `/library` (mobile <768px variant, SP8 brief 2026-05-30, IA semplificata 3 tab + overflow) |
 | `sp4-player-detail.html` | page-mock | `/players/[id]`, `/players/[id]/{achievements,games,sessions,stats}` |
 | `sp4-players-index.html` | page-mock | `/players` |
 | `sp4-session-live-parts.jsx` | component-mock | Sub-components of `/sessions/[id]/live` Foundation sub-PR |
@@ -137,7 +138,7 @@
 | `librogame-runthrough-game-onboarding.html` | page-mock | `/library/[gameId]` (libro variant — prereq gate, gap-coverage 2026-05-12, PR #1056) |
 | `librogame-runthrough-glossary-editor.html` | component-mock | Glossary editor (mirror of sp6 jsx) |
 | `librogame-runthrough-library-search.html` | component-mock | In-library search overlay (not page-level) |
-| `librogame-runthrough-play-session.html` | page-mock | `/library/[gameId]/play/[campaignId]` |
+| `librogame-runthrough-play-session.html` | page-mock | `/library/[gameId]/play/[campaignId]` (4 stati v1 congelati + 3 stati SP8 companion: state-05 diary, state-06 paragrafi-drawer, state-07 end-campaign, brief 2026-05-30; jsx twin nuovo con 3 lab interattivi) |
 | `librogame-runthrough-quota-credits.html` | component-mock | Quota/credits overlay (global) |
 | `librogame-runthrough-resume-picker.html` | page-mock | `/library/[gameId]/play` |
 | `librogame-runthrough-session-end.html` | page-mock | `/sessions/live/[sessionId]` (end-state) |

--- a/admin-mockups/briefs/SP8-libro-game-companion.md
+++ b/admin-mockups/briefs/SP8-libro-game-companion.md
@@ -1,0 +1,336 @@
+# SP8 Libro Game Companion — Brief Claude Design (Play-Session extension, 1 mockup esteso)
+
+> **Preambolo obbligatorio**: leggi `admin-mockups/briefs/_common.md` prima di iniziare.
+> Questo brief **estende** il mockup esistente `librogame-runthrough-play-session.html` (serie nanolith-runthrough, persona Aaron) con **3 nuovi stati** per completare le 6 functions v1 del **companion model**. NON è un mockup greenfield: i 4 stati esistenti restano intatti.
+
+## Stato programma
+
+| SP | PR | Stato | Audience |
+|----|----|-------|----------|
+| SP3 public-secondary | merged | ✅ | nuovi visitatori |
+| SP4 entity-desktop | merged | ✅ | utenti autenticati |
+| SP5 admin-tools | merged | ✅ | admin/power-user |
+| SP6 libro-game MVP + nanolith Iter 1 | merged | ✅ | casual gamer (Sara) + dogfood (Aaron) |
+| SP7 game-night | merged | ✅ | host/player serate |
+| **SP8 libro-game companion** | **(questo brief)** | ⏳ in design | **Aaron libro-game enthusiast** |
+
+**SP8 = estensione companion, NON nuova feature.** La play-session libro-game (`librogame-runthrough-play-session.html`, 49KB, 4 stati: story/encounter/chat/glossary) copre già 3/6 functions v1 del companion. Mancano **diary**, **paragrafi visitati**, **end-campaign**. Questo brief le aggiunge come 3 nuovi stati nello stesso file.
+
+## Persona target & contesto d'uso
+
+**Aaron, libro-game enthusiast** (`badsworm@gmail.com`), già definito in SP6 Cap.2. Gioca campagne libro-game (Tainted Grail, ISS Vanguard) **con amici al tavolo**, smartphone in mano come **companion** — NON game manager.
+
+**Companion model (vincolo architetturale chiave)**:
+> L'app NON gestisce il gioco. È un companion che (1) risponde alle domande sulle regole, (2) traduce le pagine su richiesta, (3) salva lo stato della partita. "Con amici" è scenografico — Aaron è l'unico utente loggato, gli amici giocano fisicamente. NO multi-player coordination, NO invite/join libro-game, NO sync stato fra player.
+
+**Setup tavolo**: salotto, luce media, manuale fisico EN aperto, telefono single-device, WiFi instabile è la norma.
+
+### 6 functions companion v1 (gerarchia confermata)
+
+| # | Function | Gerarchia | Stato mockup |
+|---|----------|-----------|--------------|
+| 1 | Chat regole (agente) | **PRIMARY** | ✅ esiste (`state-03-chat-overlay`) |
+| 2 | Translate pagina (foto) | **PRIMARY** | ✅ esiste (photo action in `state-01-story`) |
+| 3 | Save/resume stato | **MENU** (auto-background) | ✅ implicito (paragrafo corrente persistito) |
+| 4 | **Note/diary utente** | **SECONDARY** | ❌ **questo brief — state-05** |
+| 5 | **Lista paragrafi visitati** | **SECONDARY** | ❌ **questo brief — state-06** |
+| 8 | **End campaign / mark complete** | **MENU** | ❌ **questo brief — state-07** |
+
+"Altre funzioni verranno aggiunte in futuro" → v1 si congela a queste 6.
+
+## Scope SP8 — esattamente 3 nuovi stati (1 mockup esteso)
+
+| # | Stato (anchor id) | UI pattern | Function v1 |
+|---|-------------------|------------|-------------|
+| 1 | `state-05-diary-tab` | 5a tab (mobile) / colonna laterale (desktop) | #4 Note/diary |
+| 2 | `state-06-paragrafi-drawer` | Drawer slide-up dalla session header | #5 Paragrafi visitati |
+| 3 | `state-07-end-campaign` | Kebab menu → dialog 3-vie → post-close screen | #8 End campaign |
+
+**File target**: estendere `admin-mockups/design_files/librogame-runthrough-play-session.{html,jsx}` (il `.jsx` oggi MANCA — crearlo per gli stati interattivi). NON rigenerare i 4 stati esistenti.
+
+**Sequence di consegna**: state-05 (diary, più ricco) → state-06 (paragrafi drawer) → state-07 (end-campaign).
+
+## Componenti già stabili — NON ridisegnare
+
+Il mockup li **istanzia**, non li clona:
+
+| Componente | Path codice | Riuso in SP8 |
+|------------|-------------|--------------|
+| Session header + tab system | `librogame-runthrough-play-session.html` (esistente) | base da estendere: +1 tab Diary, +icon history, +kebab |
+| `MeepleCard` | `apps/web/src/components/ui/data-display/meeple-card/` | entry diary cards |
+| `EntityChip` / `EntityPip` | `apps/web/src/components/ui/data-display/entity-chip/` | ogni cross-reference (§ paragrafo, glossary) |
+| `Drawer` (cascadeNavigationStore) | `apps/web/src/stores/cascadeNavigationStore.ts` | state-06 (bottom-sheet mobile / side-panel desktop) |
+| `Dialog` / modal primitive | `03-drawer-variants.html` pattern | confirmation jump-back + end-campaign 3-vie |
+| `Tabs` animated underline | wave 1 SP4 | tab system esteso (5a tab Diary) |
+
+**Greenfield emergenti** (da implementare poi in `apps/web/src/components/ui/v2/libro-game/`):
+- `DiaryMarkdownEditor` (textarea markdown + toolbar B/I/U/📌/🔗 + live preview)
+- `VisitedParagraphsDrawer` + `JumpConfirmDialog`
+- `EndCampaignDialog` (3-vie) + `PostCloseSummary`
+
+### `entityHsl` helper inline (palette 9 entity)
+
+```js
+const ENTITY_HSL = {
+  game:    '25 95% 45%',  player:  '262 83% 58%',  session: '240 60% 55%',
+  agent:   '38 92% 50%',  kb:      '174 60% 40%',   chat:    '220 80% 55%',
+  event:   '350 89% 60%', toolkit: '142 70% 45%',   tool:    '195 80% 50%',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(${ENTITY_HSL[entity]} / ${alpha})` : `hsl(${ENTITY_HSL[entity]})`;
+```
+
+## Mapping companion concept → entity color
+
+| Concept SP8 | Entity | Razionale |
+|-------------|--------|-----------|
+| Sessione di gioco attiva | `session` (🎯 indigo) | la play-session è session-themed (coerente col mockup esistente) |
+| Nota diary | `session` base + `player` (👤 viola) accent | le note sono contenuto utente dentro la sessione |
+| Paragrafo visitato | `kb` (📄 teal) | i paragrafi sono KB chunks (coerente SP6 mapping) |
+| Paragrafo corrente (anchor) | `session` (🎯) | il "dove sono ora" è stato di sessione |
+| End: Completata | `toolkit` (🧰 green = success semantico) | conclusione positiva |
+| End: Archivia | `session` (🎯) | pausa neutra |
+| End: Abbandona | `event` (🎉 rose = danger semantico) | azione distruttiva-soft |
+| Export PDF | `kb` (📄) | il riassunto è un documento |
+
+## Vincolo dati (GitGuardian gate)
+
+❌ **VIETATO**: UUID-like, bearer (`sk_...`, `eyJ...`), hex ≥32 char.
+✅ **OK**: ID short (`gb-tainted-grail`, `diary-12`, `camp-avalon-1`, `§147`).
+
+### Dati realistici da usare
+
+- **Gamebook**: Tainted Grail: The Fall of Avalon (EN, Awaken Realms, §-numbered)
+- **Campagna**: "La grotta dei Goblin", Cap 4, paragrafo corrente §214
+- **Player names** (gruppo Aaron): Marco, Giulia, Davide, Luca
+- **Glossario realistico**: Niamh, Spada di Avalon (Sword of Avalon), Pietra Spettrale (Wraithstone), Korak (NPC)
+- **Paragrafi**: §134, §189, §198, §214 (newest-first nella history)
+- **Note diary esempio**: "Goblin liberati senza combattere — bonus reputazione +2", "NPC Korak mi deve un favore, citato a §134", "Tesoro nella grotta non preso, tornare dopo §340"
+
+---
+
+## state-05 — Diary tab (`state-05-diary-tab`)
+
+**Function**: #4 Note/diary utente.
+**Pattern mobile**: 5a tab nel tab system esistente (Story · Encounter · Chat · Glossary · **Diary**). Scroll-x se 5 tab non entrano in 375px.
+**Pattern desktop**: nuova entry "Diary" nella left context panel (380px) + content area destra.
+
+### Content model (decisioni Socratiche)
+
+- **Free-form markdown** (no struttura predefinita)
+- **Text-only v1** — NO foto inline (le foto restano nel flow translate; photo-in-diary = v2)
+- **Auto-pin paragrafo corrente** — ogni entry ha metadata `§numero + timestamp`
+- **Newest-first timeline**
+- **Timestamp ibrido** — relativo <24h (`5 min fa`, `ieri 21:34`), assoluto oltre (`12 mag 21:34`)
+- **Save model**: **draft locale continuo + commit esplicito**. Ogni keystroke → draft in localStorage (zero perdita su crash/offline). Tap "Salva" → commit + entry in lista.
+- **Edit-after-save** consentito
+
+### Layout — lista (default)
+
+- CTA primario top: "+ Nuova nota" (entity=session color)
+- Entry card per nota:
+  - Header: `📌 §214 · 21:34` (badge paragrafo entity=kb + timestamp mono)
+  - Body: testo markdown reso (truncate 3 righe + "espandi")
+  - Actions: ✏️ Modifica · 🗑️ Elimina
+- Newest-first
+
+### Layout — editor (tap "+ Nuova nota" → full-screen mobile / inline-expand desktop)
+
+- Top bar: `← Annulla` · "Nota §214" · `Salva` (disabled se < 1 char committable)
+- Markdown toolbar: B / I / U / 📌 (link paragrafo) / 🔗
+- Textarea autofocus (markdown)
+- Live preview sotto (throttled 200ms)
+- Indicator "Bozza salvata" discreto (conferma draft locale attivo)
+
+### Stati richiesti
+
+- **Default** (3 note newest-first: §214, §198, §134 con testi realistici)
+- **Editor pristine** (textarea vuota, Salva disabled, "Bozza" indicator)
+- **Editor typed** (~150 char markdown + live preview)
+- **Empty** (illustrazione + "Nessuna nota ancora" + CTA "Scrivi la prima")
+- **Loading** (skeleton 2 entry)
+- **Error save** (banner "Errore salvataggio — riprova" + retry + autosave-local fallback indicator)
+- **Offline** (banner "Offline — la nota sarà salvata al ritorno online" + queue indicator)
+- **Light + dark**
+- **Mobile 375px + desktop 1440px**
+
+### Deviazioni accettate
+
+- Live preview markdown = render statico nel mockup (no parser reale)
+- Draft-local indicator = visual placeholder (vero impl usa localStorage/IndexedDB)
+
+---
+
+## state-06 — Paragrafi visitati drawer (`state-06-paragrafi-drawer`)
+
+**Function**: #5 Lista paragrafi visitati.
+**Trigger mobile**: tap icon 🕰 history nella session header (a fianco di `§214 · Cap 4`).
+**Trigger desktop**: tap breadcrumb-history nella left context panel → drawer slide-in da sinistra.
+**Pattern**: Drawer bottom-sheet 75% height (mobile) / side-panel (desktop). Canonico `03-drawer-variants.html`.
+
+### Layout drawer
+
+- Drag handle top (mobile) + "Paragrafi visitati" + close X
+- Search box: "Cerca per numero o testo…" — **scope: solo §numero/chapter v1** (NON full-text: l'app ha il testo completo SOLO per paragrafi tradotti → full-text sarebbe asimmetrico, rimandato v2)
+- Top sticky: paragrafo **corrente** highlighted (`§214 (ora) · Cap 4`, entity=session)
+- Lista **newest-first** (most-recently-visited):
+  - `§198 · 22 min fa · Cap 4` + snippet "Entri nel corridoio…" + CTA `→ [vai qui]`
+  - `§189 · 1h fa · Cap 4`
+  - `§134 · 2h fa · Cap 3`
+
+### Jump-back confirmation dialog (tap `[vai qui]`)
+
+- Title "Tornare al §189?"
+- Body "Perderai la posizione corrente §214. Il §214 resterà comunque visitato nella history."
+- CTA: `[Annulla]` · `[Sì, torna]`
+- Side effects post-confirm: save-state → §189; §214 resta in history (no cancellazione); drawer chiude; story tab → §189
+
+### Stati richiesti
+
+- **Default** (4 paragrafi newest-first + corrente highlighted)
+- **Confirmation dialog** (jump-back §189)
+- **Empty** (solo §1 visitato — single entry + tip "Continua a leggere per popolare la history")
+- **Loading** (skeleton 3 entry)
+- **Error** (banner "Impossibile caricare la history" + retry)
+- **Offline** (history cached read-only; `[vai qui]` disabled con tooltip "Disponibile online")
+- **Light + dark**
+- **Mobile + desktop**
+
+### Deviazioni accettate
+
+- Search = filtro client-side su numero/chapter (no full-text backend nel mockup)
+
+---
+
+## state-07 — End campaign (`state-07-end-campaign`)
+
+**Function**: #8 End campaign / mark complete.
+**Trigger mobile**: tap kebab `⋮` in alto-dx session header.
+**Trigger desktop**: CTA "Chiudi campagna" nel footer della left context panel.
+
+### Kebab menu
+
+```
+Impostazioni sessione
+─────────────────────
+📦 Esporta dati
+🏁 Chiudi campagna   ← target
+⚙️ Preferenze
+```
+
+### Dialog 3-vie soft (tap "🏁 Chiudi campagna")
+
+3 opzioni card-selezionabili:
+- **✅ Completata** (entity=toolkit/success): "Ho finito la storia." → side effects: lock paragrafi (read-only history) + **server-side PDF generation** (async endpoint) + resume-picker → "Completate"
+- **📥 Archivia** (entity=session): "Chiudo per ora, posso riaprire." → side effects: resume-picker → "Archiviate" con CTA "Riapri" (no lock, no PDF)
+- **❌ Abbandona** (entity=event/danger): "Chiudo definitivamente. Posso riaprire con un **singolo confirm**." → side effects: lock paragrafi + resume-picker → "Abbandonate"
+
+> **Nota Socratica**: il reopen di Abbandona usa **single confirm** (NON doppio): riaprire è non-distruttivo, friction proporzionata al rischio nullo.
+
+### Post-close summary screen (dopo conferma)
+
+Solo per **Completata** mostra CTA PDF. Riassunto:
+- `✅ Campagna chiusa` · "La grotta dei Goblin"
+- Status: Completata · Durata: 3h 24m · Paragrafi visitati: 47 · Note diary: 12 · Foto translate: 8 · Chat regola: 15
+- CTA primario (solo Completata): `📄 Scarica PDF riassunto` (entity=kb) — trigger server-side generation
+- CTA `🏠 Torna alla libreria` → `/library`
+
+### Stati richiesti
+
+- **Kebab menu aperto**
+- **Dialog 3-vie** (3 card selezionabili)
+- **Loading** (state transition BE — spinner overlay "Chiudendo…")
+- **Error** (banner "Impossibile chiudere — riprova" + retry + "Forza chiusura locale" opzione)
+- **Offline** (conferma marcata "pending sync" con badge)
+- **Post-close Completata** (summary + CTA PDF)
+- **Post-close Archivia** (summary senza PDF, con "Riapri")
+- **Light + dark**
+- **Mobile + desktop**
+
+### Deviazioni accettate
+
+- PDF generation = CTA placeholder (vero impl chiama endpoint BE async — vedi nota implementazione)
+- Confetti/celebration su Completata = opzionale, rispetta `prefers-reduced-motion`
+
+---
+
+## IA aggiornata (post-extension)
+
+**Mobile tab system**: `Story · Encounter · Chat · Glossary · Diary` (5 tab, scroll-x se serve) + session header con `🕰 history` + `⋮ kebab`.
+
+**Desktop split-view**: left context panel (380px) lista 5 tab + secondary actions (History drawer, End campaign) · right content flex.
+
+---
+
+## Definition of Done (per gli stati SP8)
+
+### Token & visual
+- [ ] Solo CSS variables da `tokens.css` (zero hex hardcoded)
+- [ ] `entityHsl(entity, alpha?)` inline per i 9 entity color
+- [ ] Light + dark entrambi (`<html data-theme="dark">`)
+- [ ] Mobile 375px + desktop 1440px entrambi
+
+### Componenti
+- [ ] EntityChip/Pip per ogni reference (§ paragrafo=kb, glossary, ecc.)
+- [ ] Drawer (state-06) usa pattern canonico bottom-sheet/side-panel
+- [ ] Tab system esteso NON ridisegna i 4 stati esistenti
+- [ ] Dialog 3-vie (state-07) usa `role="alertdialog"`
+
+### Stati
+- [ ] Default + Empty + Loading (skeleton) + Error per state-05 e state-06
+- [ ] Offline state per tutti e 3 (companion = WiFi instabile)
+- [ ] state-07: kebab + dialog + loading + error + 2 post-close variants
+
+### A11y
+- [ ] Markdown editor: `role="textbox"`, `aria-multiline`, `aria-label`
+- [ ] Drawer: `role="dialog"`, `aria-modal`, focus-trap, ESC-to-close
+- [ ] Dialog 3-vie: `role="alertdialog"`, focus su prima azione, ESC=Annulla
+- [ ] Kebab: `role="menu"`, arrow-key nav
+- [ ] `prefers-reduced-motion`: disabilita slide/bounce drawer + confetti
+
+### Dati
+- [ ] Testo UI in italiano
+- [ ] Tainted Grail + "La grotta dei Goblin" + glossario realistico (Niamh, Korak)
+- [ ] Player names italiani · note diary realistiche
+- [ ] NO UUID-like, NO bearer-pattern
+
+---
+
+## File di riferimento da allegare in chat Claude Design
+
+Quando apri la sessione Claude Design (no repo access), allega:
+
+**Obbligatori (preambolo)**:
+1. `admin-mockups/briefs/_common.md` — preambolo design system
+2. `admin-mockups/briefs/SP8-libro-game-companion.md` — questo brief
+3. `admin-mockups/design_files/tokens.css` — design tokens
+4. `admin-mockups/design_files/components.css` — classi base
+5. `admin-mockups/design_files/data.js` — dati finti (**NON rigenerarlo** — read-only, è shared)
+
+**Base da estendere (CRITICO)**:
+6. `admin-mockups/design_files/librogame-runthrough-play-session.html` — il mockup esistente (4 stati) da estendere con i 3 nuovi. NON rigenerare i 4 esistenti.
+
+**Reference visivi 1:1 prod**:
+7. `admin-mockups/design_files/librogame-runthrough-translate-viewer.html` — pattern reading-mode + Aaron persona
+8. `admin-mockups/design_files/03-drawer-variants.html` — drawer canonico (state-06)
+9. `admin-mockups/design_files/sp4-session-summary.jsx` — pattern summary/diary timeline (state-07 post-close)
+
+## Risposta attesa nel thread Claude Design
+
+1. Conferma scope SP8 (3 nuovi stati, estensione NON greenfield, companion model Aaron, persona single-user)
+2. **Una risposta = uno stato** (state-05 → state-06 → state-07)
+3. File completo HTML + JSX (crea il `.jsx` mancante)
+4. Path salvataggio: `admin-mockups/design_files/librogame-runthrough-play-session.{html,jsx}` (esteso)
+5. Note finali: deviazioni flaggate + nuovi componenti v2 emersi + stati Socratici coperti
+
+## Note finali per Claude Design
+
+**Tono UI**: warm, casual, paritario (gruppo italiano informale "tu/voi"). Aaron è enthusiast, non power-user tecnico.
+
+**Microcopy hint**:
+- Diary empty: "Nessuna nota ancora — scrivi quello che vuoi ricordare"
+- Jump-back confirm: "Perderai la posizione corrente" (non "navigation state reset")
+- End completata: "Hai finito la storia!" (celebrativo, non "campaign status: completed")
+- Offline diary: "La nota sarà salvata appena torni online" (rassicurante, no "sync queue pending")
+
+**Vincolo non-functional**: lettura distante 1.5m al tavolo → body text ≥ 18pt nelle aree di lettura (coerente play-session esistente).

--- a/admin-mockups/briefs/SP8-mobile-parity.md
+++ b/admin-mockups/briefs/SP8-mobile-parity.md
@@ -1,0 +1,237 @@
+# SP8 Mobile Parity — Brief Claude Design: Library Mobile (1 mockup greenfield)
+
+> **Preambolo obbligatorio**: leggi `admin-mockups/briefs/_common.md` prima di iniziare.
+> Questo brief introduce la **variante mobile-first** del route `/library`. Il mockup desktop `sp4-library-desktop.html` esiste (SP4, PR #574) ma è **desktop-only** (zero `@media`/`phone`/`375px`). SP8 colma il gap mobile.
+
+## Stato programma
+
+| SP | PR | Stato | Audience |
+|----|----|-------|----------|
+| SP4 entity-desktop (library) | merged #574 | ✅ desktop | utenti autenticati |
+| **SP8 mobile-parity (library)** | **(questo brief)** | ⏳ in design | **utente mobile-first** |
+
+**SP8 = mobile parity, NON nuova feature.** `/library` ha già il content model definito (LibraryHero + LibraryTabs + LibraryHybridGrid + BulkSelectionBar + RecentActivityRail). Questo brief produce la **variante mobile 375px-first** con IA semplificata, riusando lo stesso content model.
+
+## Persona target & contesto d'uso
+
+**Utente autenticato su smartphone** (Aaron/Sara family). Apre l'app durante una serata di gioco o in mobilità per consultare/aprire rapidamente un'entità della sua libreria.
+
+**Trigger reale** (dal flow companion): *"con lo smartphone seleziona il gioco dalla libreria"* → la library mobile è lo **step #1** del flow companion libro-game. Senza variante mobile-first, lo step è scoperto.
+
+**Contesto**: one-hand use, schermo piccolo, possibili momenti offline, navigazione veloce.
+
+## Scope SP8 — esattamente 1 mockup
+
+| # | File | Route | Pattern | Audience |
+|---|------|-------|---------|----------|
+| A | `sp4-library-mobile.{html,jsx}` | `/library` (mobile <768px) | Hero compatto + tab semplificate + grid 1-col + bulk long-press | Library mobile |
+
+**Naming**: `sp4-library-mobile` (resta scope SP4-entity in naming, è la variante mobile del `sp4-library-desktop` esistente — coerente con convenzione `_common.md`).
+
+## IA semplificata (decisione di design)
+
+Mobile NON è il desktop reflowed. IA prioritizzata 80/20:
+
+- **3 tab primarie top**: Games + Sessions + Chat (high-frequency)
+- **Overflow "Più"** (kebab/menu): Agents + KB (low-frequency)
+- **Hero compatto** (no full-width gradient desktop)
+- **Bulk-select via long-press** (no top-sticky checkbox)
+- **Recent activity** = sezione "Recente" sotto la griglia (NON rail sticky)
+
+**Trade-off accettato**: 2 tap per Agents/KB invece di 1. Razionale: mobile real-estate + frequency-of-use.
+
+**Out of scope**: ridisegno bottom-nav globale dell'app (decisione IA cross-route separata).
+
+## Componenti già stabili — NON ridisegnare
+
+| Componente | Path codice | Adattamento mobile |
+|------------|-------------|---------------------|
+| `MeepleCard` | `apps/web/src/components/ui/data-display/meeple-card/` | `variant="list"` 1-col (esistente) |
+| `LibraryTabs` | `apps/web/src/components/features/library/LibraryTabs.tsx` | + `overflowItems` prop (Agents/KB) |
+| `LibraryHybridGrid` | `apps/web/src/components/features/library/LibraryHybridGrid.tsx` | forza `columns=1` mobile |
+| `BulkSelectionBar` | `apps/web/src/components/features/library/BulkSelectionBar.tsx` | variant FAB + bottom-sheet (no top-sticky) |
+| `RecentActivityRail` | `apps/web/src/components/features/library/RecentActivityRail.tsx` | render come sezione, drop `position:sticky` |
+| `AdvancedFiltersDrawer` | `apps/web/src/components/features/library/AdvancedFiltersDrawer.tsx` | anchor=bottom, 80vh, swipe-down dismiss |
+| `MobileBottomBar` | `apps/web/src/components/layout/` | shell mobile (5-tab nav) |
+
+**Greenfield emergenti** (poi in `apps/web/src/components/ui/v2/library/`):
+- Hero compatto mobile (sostituto di `LibraryHeroDesktop`, ~64-96px)
+- `useLongPress` hook primitive
+- Bottom-sheet bulk-actions panel
+
+### `entityHsl` helper inline
+
+```js
+const ENTITY_HSL = {
+  game:    '25 95% 45%',  player:  '262 83% 58%',  session: '240 60% 55%',
+  agent:   '38 92% 50%',  kb:      '174 60% 40%',   chat:    '220 80% 55%',
+  event:   '350 89% 60%', toolkit: '142 70% 45%',   tool:    '195 80% 50%',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(${ENTITY_HSL[entity]} / ${alpha})` : `hsl(${ENTITY_HSL[entity]})`;
+```
+
+## Vincolo dati (GitGuardian gate)
+
+❌ UUID-like, bearer, hex ≥32 char.
+✅ ID short (`g-catan`, `g-wingspan`, `p-marco`, `sess-sat-3`).
+
+### Dati realistici da usare
+
+- **Giochi**: Azul, I Coloni di Catan, Wingspan, Brass: Birmingham, Carcassonne, 7 Wonders (da `data.js`)
+- **Player names**: Marco, Giulia, Davide, Luca
+- **Recent activity**: "Hai aperto Catan 2h fa", "Sessione Wingspan in corso", "Chat con Maestro Catan"
+
+---
+
+## A — Library Mobile (`sp4-library-mobile`)
+
+**File**: `sp4-library-mobile.{html,jsx}`
+**Route**: `/library` (breakpoint mobile <768px)
+**Pattern**: Hero compatto + tab semplificate + grid 1-col + sezione recente. Variante mobile-first di `sp4-library-desktop.html`.
+
+### Header (sticky)
+
+```
+┌─────────────────────────────────┐
+│  [Logo]  La mia libreria   ☰    │  ← hero compatto (no gradient full)
+├─────────────────────────────────┤
+│ ▸ Games   Sessions   Chat   …   │  ← 3 tab + "…" overflow
+├─────────────────────────────────┤
+│ 🔍 Cerca…              [filtri] │  ← search (scope=tab) + filter chip
+└─────────────────────────────────┘
+```
+
+- Tab attiva: count badge (es. "Games 47"), highlight `entityHsl('game')`
+- Overflow "…" → menu: Agents · KB (con dot indicator se nuove entries)
+- `[filtri]` → apre `AdvancedFiltersDrawer` bottom-sheet 80vh
+
+### Body — grid + sezione recente
+
+```
+┌─────────────────────────────────┐
+│ Filtri attivi: [×Tutti]         │
+├─────────────────────────────────┤
+│ ┌────┐ Azul · Plan B · 2017     │  ← MeepleCard variant="list"
+│ │img │ ★ 7.8 · 2-4 giocatori    │     entity="game"
+│ └────┘                           │
+├─────────────────────────────────┤
+│ ┌────┐ I Coloni di Catan        │
+│ └────┘ ...                       │
+├─────────────────────────────────┤
+│   [carica altri · 12 di 47]     │  ← infinite scroll
+├─────────────────────────────────┤
+│ ──── Recente ────                │  ← sezione (non sticky)
+│ Hai aperto Catan 2h fa  →        │
+│ Sessione Wingspan in corso →     │
+└─────────────────────────────────┘
+```
+
+- MeepleCard `variant="list"` (image 64-80px left)
+- Infinite scroll page-size 12
+- Sezione "Recente": max 3-5 cross-entity items (riusa `RecentActivityRail` data hook)
+- Filter chips attivi sopra lista, tap rimuove
+
+### Bulk-select (long-press 500ms)
+
+```
+┌─────────────────────────────────┐
+│  ← Annulla   3 selezionati   ⋮  │  ← top bar sostituisce header
+├─────────────────────────────────┤
+│ ▣ Azul                          │  ← checkbox visibili
+│ ▢ I Coloni di Catan             │
+│ ▣ Brass: Birmingham             │
+└─────────────────────────────────┘
+                              [⋮ FAB] ← bottom-right
+                  actions: Archivia · Tag · Esporta (bottom-sheet)
+```
+
+### Stati richiesti (Lisa-5 per tab Games, 1-2 esempi per altre)
+
+- **Default** (tab Games, 8+ card list + sezione recente)
+- **Empty** (illustrazione entity-themed + "Nessun gioco ancora" + CTA "Aggiungi gioco" → `/library/add` + secondario "Scopri shared" → `/shared-games`)
+- **Loading** (skeleton 3 card + hero/tab visibili, NO spinner)
+- **Error** (banner "Impossibile caricare la libreria" + retry + "Mostra cache" se disponibile — riusa pattern GamebookErrorBanner)
+- **Permission denied** (per shared library privata: "Non hai accesso" + "Chiedi un invito")
+- **Offline** (top banner "Modalità offline — dati cache potrebbero essere obsoleti" + tab read-only)
+- **Bulk-select mode** (3 selezionati + FAB bottom-sheet actions)
+- **Overflow "Più" aperto** (menu Agents/KB)
+- **AdvancedFiltersDrawer** (bottom-sheet 80vh aperto)
+- **Filtered empty** ("Nessun risultato per questi filtri" + "Resetta filtri")
+- **Light + dark**
+- **Mobile 375px + tablet 768px** (verifica reflow al breakpoint)
+
+### Deviazioni accettate
+
+- Long-press feedback (haptic + scale) = visual placeholder, rispetta `prefers-reduced-motion`
+- Infinite scroll = mockup mostra stato finale + 1 intermedio (12/47)
+- Sezione "Recente" = stessa data del RecentActivityRail desktop, layout diverso (no sticky)
+
+---
+
+## Definition of Done
+
+### Token & visual
+- [ ] Solo CSS variables da `tokens.css` (zero hex hardcoded)
+- [ ] `entityHsl` inline per 9 entity color
+- [ ] Light + dark entrambi
+- [ ] Mobile 375px (canonical) + tablet 768px
+
+### Componenti
+- [ ] EntityChip/Pip per ogni reference
+- [ ] MeepleCard `variant="list"` riusato (NON ridisegnare)
+- [ ] LibraryTabs esteso con overflow (non nuovo componente)
+- [ ] BulkSelectionBar variant mobile FAB
+
+### Stati
+- [ ] Default + Empty + Loading + Error per tab Games
+- [ ] Permission + Offline + Filtered-empty
+- [ ] Bulk-select mode + overflow menu + filters drawer
+
+### A11y
+- [ ] `role="tablist"`, `aria-selected`, `aria-label` su kebab "Più"
+- [ ] Touch target ≥44×44px
+- [ ] `prefers-reduced-motion`: long-press feedback + tab transition + bottom-sheet
+- [ ] Live-region per skeleton→content
+
+### Dati
+- [ ] Testo UI italiano
+- [ ] Giochi reali da data.js · player names italiani
+- [ ] NO UUID-like, NO bearer-pattern
+
+---
+
+## File di riferimento da allegare in chat Claude Design
+
+**Obbligatori (preambolo)**:
+1. `admin-mockups/briefs/_common.md` — preambolo design system
+2. `admin-mockups/briefs/SP8-mobile-parity.md` — questo brief
+3. `admin-mockups/design_files/tokens.css` — design tokens
+4. `admin-mockups/design_files/components.css` — classi base
+5. `admin-mockups/design_files/data.js` — dati finti (**NON rigenerarlo** — read-only, shared)
+
+**Base content-model (CRITICO)**:
+6. `admin-mockups/design_files/sp4-library-desktop.html` — il desktop esistente: stesso content model, da adattare a mobile. NON è la versione finale mobile.
+
+**Reference visivi 1:1 prod**:
+7. `admin-mockups/design_files/mobile-app.jsx` — full mobile shell (BottomBar, drawer physics, connection pips)
+8. `admin-mockups/design_files/02-desktop-patterns.html` — pattern desktop (per il fallback ≥768px)
+9. `admin-mockups/design_files/03-drawer-variants.html` — bottom-sheet drawer (filters + bulk actions)
+
+## Risposta attesa nel thread Claude Design
+
+1. Conferma scope SP8 mobile-parity (1 mockup, IA semplificata 3+overflow, mobile-first)
+2. Genera il mockup completo (HTML + JSX)
+3. Path salvataggio: `admin-mockups/design_files/sp4-library-mobile.{html,jsx}`
+4. Note finali: deviazioni flaggate + nuovi componenti v2 emersi + stati coperti
+
+## Note finali per Claude Design
+
+**Tono UI**: warm, casual, italiano informale.
+
+**Microcopy hint**:
+- Empty: "Nessun gioco ancora — aggiungi il primo!"
+- Offline: "Sei offline — alcuni dati potrebbero non essere aggiornati"
+- Bulk: "3 selezionati" (azione chiara, no "items in selection state")
+
+**Mobile-first è canonical**: 375px è il target primario, tablet 768px è adaptation. Desktop ≥1024px → fallback a `sp4-library-desktop.html`.

--- a/admin-mockups/design_files/librogame-runthrough-play-session.html
+++ b/admin-mockups/design_files/librogame-runthrough-play-session.html
@@ -589,6 +589,1024 @@
     </div>
   </section>
 
+  <!-- ─── state-05-diary-tab ─── -->
+  <!-- SP8 · Function #4 Note/diary utente. Append-only: i 4 stati sopra restano congelati.
+       Tab system esteso (+ Diary = 4a tab). Tutti i classi nuove sono prefissate .dy- per evitare collisioni.
+       Mapping: entry = session base + player accent · §badge = kb · CTA nuova nota = session.
+       Dati: Tainted Grail "La grotta dei Goblin", Cap 4, §214 corrente. NB: gli stati congelati usano §289/Eldoria
+       (vedi nota deviazione) — i nuovi stati usano i dati canonici del brief SP8 (§214, glossario Niamh/Korak). -->
+  <style id="sp8-diary-styles">
+    /* tab esteso: con 4 tab restiamo entro 375px; scroll-x di sicurezza se servisse */
+    .tabs.dy-scroll { overflow-x: auto; scrollbar-width: none; }
+    .tabs.dy-scroll::-webkit-scrollbar { display: none; }
+    .tabs.dy-scroll .tab { flex: 1 0 auto; min-width: 84px; }
+    .tab[aria-selected="true"].dy-diary { color: hsl(var(--c-session)); }
+
+    /* CTA nuova nota (entity=session) */
+    .dy-newcta { width: 100%; padding: var(--s-3); border-radius: var(--r-md); background: hsl(var(--c-session)); color: #fff; border: 0; font-family: var(--f-display); font-size: var(--fs-md); font-weight: var(--fw-bold); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: var(--s-2); box-shadow: 0 4px 14px hsl(var(--c-session) / 0.28); margin-bottom: var(--s-4); }
+    .dy-newcta:hover { transform: translateY(-1px); }
+
+    /* timeline note (newest-first) */
+    .dy-timeline { display: flex; flex-direction: column; gap: var(--s-3); }
+    .dy-entry { position: relative; border: 1px solid var(--border-light); border-left: 3px solid hsl(var(--c-player) / 0.55); border-radius: var(--r-lg); background: var(--bg-card); padding: var(--s-3) var(--s-4); }
+    .dy-entry .dy-meta { display: flex; align-items: center; gap: var(--s-2); margin-bottom: var(--s-2); flex-wrap: wrap; }
+    .dy-pin { display: inline-flex; align-items: center; gap: 4px; padding: 2px var(--s-2); border-radius: var(--r-pill); background: hsl(var(--c-kb) / 0.14); color: hsl(var(--c-kb)); font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-bold); }
+    .dy-time { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); }
+    .dy-body { font-family: var(--f-body); font-size: 18px; line-height: var(--lh-snug); color: var(--text); margin: 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+    .dy-body.dy-full { -webkit-line-clamp: unset; }
+    .dy-body strong { font-weight: var(--fw-bold); }
+    .dy-body .dy-ref { color: hsl(var(--c-kb)); font-family: var(--f-mono); font-weight: var(--fw-semi); background: hsl(var(--c-kb) / 0.1); padding: 0 4px; border-radius: var(--r-xs); }
+    .dy-expand { background: none; border: 0; color: hsl(var(--c-session)); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); cursor: pointer; padding: 2px 0; margin-top: 2px; }
+    .dy-acts { display: flex; gap: var(--s-3); margin-top: var(--s-3); padding-top: var(--s-2); border-top: 1px solid var(--border-light); }
+    .dy-act { display: inline-flex; align-items: center; gap: 4px; background: none; border: 0; color: var(--text-muted); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); cursor: pointer; }
+    .dy-act:hover { color: var(--text-sec); }
+    .dy-act.dy-del:hover { color: hsl(var(--c-event)); }
+
+    /* editor full-screen (mobile) */
+    .dy-editor { position: absolute; inset: 0; z-index: var(--z-drawer); background: var(--bg); display: flex; flex-direction: column; }
+    .dy-ed-top { display: flex; align-items: center; gap: var(--s-2); padding: var(--s-3); border-bottom: 1px solid var(--border-light); background: var(--bg-card); flex-shrink: 0; }
+    .dy-ed-top .dy-cancel { background: none; border: 0; color: var(--text-sec); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); cursor: pointer; }
+    .dy-ed-top .dy-ed-ti { flex: 1; text-align: center; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); color: var(--text); }
+    .dy-ed-top .dy-save { background: hsl(var(--c-session)); color: #fff; border: 0; border-radius: var(--r-pill); padding: var(--s-1) var(--s-4); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); cursor: pointer; }
+    .dy-ed-top .dy-save:disabled { background: var(--bg-muted); color: var(--text-muted); cursor: not-allowed; }
+    .dy-toolbar { display: flex; align-items: center; gap: var(--s-1); padding: var(--s-2) var(--s-3); border-bottom: 1px solid var(--border-light); background: var(--bg-card); flex-shrink: 0; }
+    .dy-tool { width: 32px; height: 32px; border-radius: var(--r-sm); background: var(--bg-muted); border: 1px solid var(--border-light); color: var(--text-sec); font-family: var(--f-mono); font-size: var(--fs-sm); font-weight: var(--fw-bold); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
+    .dy-tool:hover { border-color: hsl(var(--c-session) / 0.4); }
+    .dy-tool.dy-pintool { color: hsl(var(--c-kb)); }
+    .dy-toolbar .dy-draft { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); }
+    .dy-toolbar .dy-draft .dot { width: 7px; height: 7px; border-radius: 50%; background: hsl(var(--c-toolkit)); }
+    .dy-textarea { width: 100%; flex: 0 0 auto; min-height: 120px; border: 0; outline: 0; resize: none; background: transparent; padding: var(--s-4); font-family: var(--f-body); font-size: 18px; line-height: var(--lh-relax); color: var(--text); }
+    .dy-textarea::placeholder { color: var(--text-muted); }
+    .dy-preview { border-top: 1px dashed var(--border); margin: 0 var(--s-4); padding: var(--s-3) 0; flex: 1; overflow-y: auto; }
+    .dy-preview .dy-pv-lbl { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: var(--s-2); }
+    .dy-preview .dy-body { display: block; -webkit-line-clamp: unset; }
+
+    /* empty / banners / skeleton */
+    .dy-empty { text-align: center; padding: var(--s-9) var(--s-5); display: flex; flex-direction: column; align-items: center; gap: var(--s-3); }
+    .dy-empty .dy-ill { width: 76px; height: 76px; border-radius: var(--r-2xl); background: hsl(var(--c-session) / 0.12); display: flex; align-items: center; justify-content: center; font-size: 38px; }
+    .dy-empty h3 { font-family: var(--f-display); font-size: var(--fs-xl); color: var(--text); }
+    .dy-empty p { color: var(--text-sec); font-size: var(--fs-md); margin: 0; max-width: 240px; }
+    .dy-banner { display: flex; align-items: flex-start; gap: var(--s-2); padding: var(--s-3); border-radius: var(--r-md); margin-bottom: var(--s-3); font-size: var(--fs-sm); line-height: var(--lh-snug); }
+    .dy-banner .dy-bic { flex-shrink: 0; font-size: var(--fs-lg); }
+    .dy-banner .dy-btx { flex: 1; }
+    .dy-banner .dy-btx strong { display: block; font-family: var(--f-display); font-weight: var(--fw-bold); margin-bottom: 2px; }
+    .dy-banner .dy-btx .dy-sub { color: var(--text-sec); font-size: var(--fs-xs); }
+    .dy-banner .dy-retry { background: none; border: 1px solid currentColor; border-radius: var(--r-pill); padding: 3px var(--s-3); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-xs); cursor: pointer; align-self: center; }
+    .dy-banner.err { background: hsl(var(--c-event) / 0.1); border: 1px solid hsl(var(--c-event) / 0.3); color: hsl(var(--c-event)); }
+    .dy-banner.off { background: hsl(var(--c-tool) / 0.1); border: 1px solid hsl(var(--c-tool) / 0.3); color: hsl(var(--c-tool)); }
+    .dy-banner .dy-btx, .dy-banner .dy-sub { color: var(--text-sec); }
+    .dy-localsave { display: inline-flex; align-items: center; gap: 5px; font-family: var(--f-mono); font-size: var(--fs-xs); color: hsl(var(--c-toolkit)); margin-top: 4px; }
+    .dy-localsave .dot { width: 7px; height: 7px; border-radius: 50%; background: hsl(var(--c-toolkit)); }
+    .dy-skel { border: 1px solid var(--border-light); border-radius: var(--r-lg); background: var(--bg-card); padding: var(--s-3) var(--s-4); margin-bottom: var(--s-3); }
+    .dy-skel .ln { height: 12px; border-radius: var(--r-pill); background: var(--bg-muted); margin-bottom: var(--s-2); }
+    .dy-shimmer { background: linear-gradient(90deg, var(--bg-muted) 25%, var(--bg-hover) 37%, var(--bg-muted) 63%); background-size: 400% 100%; animation: dyShimmer 1.4s ease infinite; }
+    @keyframes dyShimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
+    @media (prefers-reduced-motion: reduce) { .dy-shimmer { animation: none; } }
+
+    /* desktop diary: nav entry nella left panel + content */
+    .dy-navitem { display: flex; align-items: center; gap: var(--s-2); width: 100%; padding: var(--s-2) var(--s-3); border-radius: var(--r-md); background: none; border: 0; color: var(--text-sec); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); cursor: pointer; text-align: left; }
+    .dy-navitem .em { width: 18px; text-align: center; }
+    .dy-navitem .cnt { margin-left: auto; font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); }
+    .dy-navitem[aria-selected="true"] { background: hsl(var(--c-session) / 0.12); color: hsl(var(--c-session)); }
+    .dy-navitem[aria-selected="true"] .cnt { color: hsl(var(--c-session)); }
+    .dy-d-foot { margin-top: auto; padding-top: var(--s-3); border-top: 1px solid var(--border-light); }
+    .dy-endbtn { width: 100%; padding: var(--s-2) var(--s-3); border-radius: var(--r-md); background: var(--bg); border: 1px solid var(--border); color: var(--text-sec); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-sm); cursor: pointer; }
+
+    /* lab controls (interactive section, sotto la gallery statica) */
+    .dy-lab-bar { display: flex; flex-wrap: wrap; align-items: center; gap: var(--s-2); margin-bottom: var(--s-6); }
+    .dy-lab-bar .grp { display: inline-flex; align-items: center; gap: 4px; padding: 4px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--r-pill); }
+    .dy-lab-bar .grp .lbl { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); padding: 0 var(--s-2); text-transform: uppercase; letter-spacing: 0.06em; }
+    .dy-seg { padding: var(--s-1) var(--s-3); border-radius: var(--r-pill); background: transparent; border: 0; color: var(--text-sec); font-family: var(--f-display); font-weight: var(--fw-semi); font-size: var(--fs-xs); cursor: pointer; }
+    .dy-seg.on { background: hsl(var(--c-session)); color: #fff; }
+  </style>
+
+  <section class="state-section" aria-labelledby="s5">
+    <span class="label">Stato 05 · Diary Tab<span class="cmp">PlaySessionShell · DiaryView (v2)</span></span>
+    <h2 id="s5">Note diary §214 — markdown editor + timeline newest-first</h2>
+    <p class="desc">Function #4 companion. Aaron annota la partita al §214 Cap 4. Nuova 4a tab <strong>Diary</strong> nel tab system (Story · Encounter · Glossario · Diary). Note free-form markdown, text-only, auto-pin del paragrafo corrente (📌 §214), salvataggio draft-local continuo + commit esplicito. Gallery statica: tutti gli stati (default · editor pristine · editor typed · empty · loading · error save · offline). Versione interattiva nella sezione "Diary Lab" più in basso.</p>
+
+    <div class="frames">
+
+      <!-- Mobile · default (3 note newest-first) -->
+      <div class="phone" role="region" aria-label="Mobile · diary default">
+        <span class="frame-label">Mobile · default</span>
+        <div class="phone-sbar"><span>22:36</span><span>📶 🔋 58%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips">
+          <span class="manapip kb"><span class="badge">47</span></span>
+          <span class="manapip chat"><span class="badge">15</span></span>
+          <span class="manapip session"><span class="badge">1</span></span>
+          <span class="manapip toolkit"><span class="badge">12</span></span>
+          <span class="lbl-mini">· Cap 4 · note 12</span>
+        </div>
+        <div class="tabs dy-scroll" role="tablist">
+          <button class="tab" role="tab" aria-selected="false"><span class="em">📖</span>Story</button>
+          <button class="tab" role="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button>
+          <button class="tab" role="tab" aria-selected="false"><span class="em">📚</span>Glossario</button>
+          <button class="tab dy-diary" role="tab" aria-selected="true"><span class="em">📓</span>Diary</button>
+        </div>
+        <div class="content">
+          <button class="dy-newcta">＋ Nuova nota</button>
+          <div class="dy-timeline">
+            <div class="dy-entry">
+              <div class="dy-meta"><span class="dy-pin">📌 §214</span><span class="dy-time">5 min fa</span></div>
+              <p class="dy-body">Goblin liberati senza combattere — bonus reputazione <strong>+2</strong>. Niamh sembra fidarsi di più del gruppo adesso.</p>
+              <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+            </div>
+            <div class="dy-entry">
+              <div class="dy-meta"><span class="dy-pin">📌 §198</span><span class="dy-time">ieri 21:34</span></div>
+              <p class="dy-body">NPC <strong>Korak</strong> mi deve un favore, citato a <span class="dy-ref">§134</span>. Da rigiocare se serve un passaggio sicuro.</p>
+              <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+            </div>
+            <div class="dy-entry">
+              <div class="dy-meta"><span class="dy-pin">📌 §134</span><span class="dy-time">12 mag 21:34</span></div>
+              <p class="dy-body">Tesoro nella grotta non preso, tornare dopo <span class="dy-ref">§340</span>. La Spada di Avalon è ancora là.</p>
+              <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · editor pristine -->
+      <div class="phone" role="region" aria-label="Mobile · diary editor pristine">
+        <span class="frame-label">Mobile · editor pristine</span>
+        <div class="phone-sbar"><span>22:37</span><span>📶 🔋 58%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content" style="padding: 0; position: relative;">
+          <div class="dy-editor" role="dialog" aria-label="Nuova nota §214">
+            <div class="dy-ed-top"><button class="dy-cancel">← Annulla</button><span class="dy-ed-ti">Nota §214</span><button class="dy-save" disabled>Salva</button></div>
+            <div class="dy-toolbar">
+              <button class="dy-tool" aria-label="Grassetto">B</button>
+              <button class="dy-tool" style="font-style: italic;" aria-label="Corsivo">I</button>
+              <button class="dy-tool" style="text-decoration: underline;" aria-label="Sottolineato">U</button>
+              <button class="dy-tool dy-pintool" aria-label="Collega paragrafo">📌</button>
+              <button class="dy-tool" aria-label="Link">🔗</button>
+              <span class="dy-draft"><span class="dot"></span>Bozza salvata</span>
+            </div>
+            <textarea class="dy-textarea" placeholder="Scrivi quello che vuoi ricordare… (markdown)" aria-label="Testo nota" aria-multiline="true"></textarea>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · editor typed + live preview -->
+      <div class="phone" role="region" aria-label="Mobile · diary editor typed">
+        <span class="frame-label">Mobile · editor typed</span>
+        <div class="phone-sbar"><span>22:38</span><span>📶 🔋 57%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content" style="padding: 0; position: relative;">
+          <div class="dy-editor" role="dialog" aria-label="Nuova nota §214">
+            <div class="dy-ed-top"><button class="dy-cancel">← Annulla</button><span class="dy-ed-ti">Nota §214</span><button class="dy-save">Salva</button></div>
+            <div class="dy-toolbar">
+              <button class="dy-tool" aria-label="Grassetto">B</button>
+              <button class="dy-tool" style="font-style: italic;" aria-label="Corsivo">I</button>
+              <button class="dy-tool" style="text-decoration: underline;" aria-label="Sottolineato">U</button>
+              <button class="dy-tool dy-pintool" aria-label="Collega paragrafo">📌</button>
+              <button class="dy-tool" aria-label="Link">🔗</button>
+              <span class="dy-draft"><span class="dot"></span>Bozza salvata</span>
+            </div>
+            <textarea class="dy-textarea" aria-label="Testo nota" aria-multiline="true">Combattuto i 2 Goblin a §214. **Korak** è caduto al secondo turno — Giulia ha usato la Pietra Spettrale per finirlo. Loot: 14 oro, vedi §340.</textarea>
+            <div class="dy-preview">
+              <div class="dy-pv-lbl">Anteprima</div>
+              <p class="dy-body">Combattuto i 2 Goblin a <span class="dy-ref">§214</span>. <strong>Korak</strong> è caduto al secondo turno — Giulia ha usato la Pietra Spettrale per finirlo. Loot: 14 oro, vedi <span class="dy-ref">§340</span>.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · empty -->
+      <div class="phone" role="region" aria-label="Mobile · diary empty">
+        <span class="frame-label">Mobile · empty</span>
+        <div class="phone-sbar"><span>22:40</span><span>📶 🔋 57%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span><span class="lbl-mini">· note 0</span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content">
+          <div class="dy-empty">
+            <div class="dy-ill">📓</div>
+            <h3>Nessuna nota ancora</h3>
+            <p>Scrivi quello che vuoi ricordare — scelte, NPC, tesori lasciati indietro.</p>
+            <button class="dy-newcta" style="margin-bottom: 0; max-width: 220px;">✍️ Scrivi la prima</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · loading -->
+      <div class="phone" role="region" aria-label="Mobile · diary loading">
+        <span class="frame-label">Mobile · loading</span>
+        <div class="phone-sbar"><span>22:41</span><span>📶 🔋 56%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content" aria-busy="true">
+          <button class="dy-newcta" style="opacity: 0.5;">＋ Nuova nota</button>
+          <div class="dy-skel"><div class="ln dy-shimmer" style="width: 35%;"></div><div class="ln dy-shimmer" style="width: 90%;"></div><div class="ln dy-shimmer" style="width: 70%; margin-bottom: 0;"></div></div>
+          <div class="dy-skel"><div class="ln dy-shimmer" style="width: 35%;"></div><div class="ln dy-shimmer" style="width: 80%;"></div><div class="ln dy-shimmer" style="width: 55%; margin-bottom: 0;"></div></div>
+        </div>
+      </div>
+
+      <!-- Mobile · error save -->
+      <div class="phone" role="region" aria-label="Mobile · diary error save">
+        <span class="frame-label">Mobile · error save</span>
+        <div class="phone-sbar"><span>22:42</span><span>📶 🔋 56%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content">
+          <div class="dy-banner err" role="alert">
+            <span class="dy-bic">⚠️</span>
+            <div class="dy-btx"><strong style="color: hsl(var(--c-event));">Errore salvataggio — riprova</strong><span class="dy-sub">La nota non è arrivata al server.</span><span class="dy-localsave"><span class="dot"></span>Salvata in locale · nessuna perdita</span></div>
+            <button class="dy-retry">↻ Riprova</button>
+          </div>
+          <div class="dy-timeline">
+            <div class="dy-entry">
+              <div class="dy-meta"><span class="dy-pin">📌 §214</span><span class="dy-time">ora · non sincr.</span></div>
+              <p class="dy-body">Combattuto i 2 Goblin a §214. <strong>Korak</strong> è caduto al secondo turno — loot 14 oro.</p>
+              <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · offline -->
+      <div class="phone" role="region" aria-label="Mobile · diary offline">
+        <span class="frame-label">Mobile · offline</span>
+        <div class="phone-sbar"><span>22:44</span><span>✈️ 🔋 55%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
+        <div class="content">
+          <div class="dy-banner off" role="status">
+            <span class="dy-bic">📴</span>
+            <div class="dy-btx"><strong style="color: hsl(var(--c-tool));">Offline</strong><span class="dy-sub">La nota sarà salvata appena torni online.</span><span class="dy-localsave" style="color: hsl(var(--c-tool));"><span class="dot" style="background: hsl(var(--c-tool));"></span>1 in coda</span></div>
+          </div>
+          <button class="dy-newcta">＋ Nuova nota</button>
+          <div class="dy-timeline">
+            <div class="dy-entry">
+              <div class="dy-meta"><span class="dy-pin">📌 §214</span><span class="dy-time">5 min fa</span></div>
+              <p class="dy-body">Goblin liberati senza combattere — bonus reputazione <strong>+2</strong>. Niamh si fida di più.</p>
+              <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · diary default (left context panel + content) -->
+      <div class="desktop" role="region" aria-label="Desktop · diary default">
+        <span class="frame-label">Desktop · 1440px (scaled)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary</span></div>
+        <div class="d-body">
+          <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
+            <div class="side-card" style="margin-bottom: var(--s-2);">
+              <h4>Campagna</h4>
+              <div class="row"><span class="k">Nome</span><span class="v">Grotta Goblin</span></div>
+              <div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div>
+            </div>
+            <nav aria-label="Sezioni sessione" style="display: flex; flex-direction: column; gap: 2px; margin-bottom: var(--s-3);">
+              <button class="dy-navitem"><span class="em">📖</span>Story<span class="cnt">§214</span></button>
+              <button class="dy-navitem"><span class="em">⚔️</span>Encounter<span class="cnt">—</span></button>
+              <button class="dy-navitem"><span class="em">📚</span>Glossario<span class="cnt">12</span></button>
+              <button class="dy-navitem" aria-selected="true"><span class="em">📓</span>Diary<span class="cnt">12</span></button>
+            </nav>
+            <div class="dy-d-foot"><button class="dy-endbtn">🏁 Chiudi campagna</button></div>
+          </aside>
+          <div class="d-main">
+            <button class="dy-newcta" style="max-width: 200px;">＋ Nuova nota</button>
+            <div class="dy-timeline">
+              <div class="dy-entry">
+                <div class="dy-meta"><span class="dy-pin">📌 §214</span><span class="dy-time">5 min fa</span></div>
+                <p class="dy-body dy-full">Goblin liberati senza combattere — bonus reputazione <strong>+2</strong>. Niamh sembra fidarsi di più del gruppo adesso.</p>
+                <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+              </div>
+              <div class="dy-entry">
+                <div class="dy-meta"><span class="dy-pin">📌 §198</span><span class="dy-time">ieri 21:34</span></div>
+                <p class="dy-body dy-full">NPC <strong>Korak</strong> mi deve un favore, citato a <span class="dy-ref">§134</span>. Da rigiocare se serve un passaggio sicuro.</p>
+                <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+              </div>
+              <div class="dy-entry">
+                <div class="dy-meta"><span class="dy-pin">📌 §134</span><span class="dy-time">12 mag 21:34</span></div>
+                <p class="dy-body dy-full">Tesoro nella grotta non preso, tornare dopo <span class="dy-ref">§340</span>. La Spada di Avalon è ancora là.</p>
+                <div class="dy-acts"><button class="dy-act">✏️ Modifica</button><button class="dy-act dy-del">🗑️ Elimina</button></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · editor inline-expand -->
+      <div class="desktop" role="region" aria-label="Desktop · diary editor">
+        <span class="frame-label">Desktop · editor inline-expand</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary&edit=new</span></div>
+        <div class="d-body">
+          <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
+            <nav aria-label="Sezioni sessione" style="display: flex; flex-direction: column; gap: 2px;">
+              <button class="dy-navitem"><span class="em">📖</span>Story<span class="cnt">§214</span></button>
+              <button class="dy-navitem"><span class="em">⚔️</span>Encounter<span class="cnt">—</span></button>
+              <button class="dy-navitem"><span class="em">📚</span>Glossario<span class="cnt">12</span></button>
+              <button class="dy-navitem" aria-selected="true"><span class="em">📓</span>Diary<span class="cnt">12</span></button>
+            </nav>
+          </aside>
+          <div class="d-main">
+            <div class="dy-editor" style="position: relative; inset: auto; border: 1px solid var(--border); border-radius: var(--r-lg); overflow: hidden; height: 100%;">
+              <div class="dy-ed-top"><button class="dy-cancel">← Annulla</button><span class="dy-ed-ti">Nota §214</span><button class="dy-save">Salva</button></div>
+              <div class="dy-toolbar">
+                <button class="dy-tool" aria-label="Grassetto">B</button>
+                <button class="dy-tool" style="font-style: italic;" aria-label="Corsivo">I</button>
+                <button class="dy-tool" style="text-decoration: underline;" aria-label="Sottolineato">U</button>
+                <button class="dy-tool dy-pintool" aria-label="Collega paragrafo">📌</button>
+                <button class="dy-tool" aria-label="Link">🔗</button>
+                <span class="dy-draft"><span class="dot"></span>Bozza salvata</span>
+              </div>
+              <textarea class="dy-textarea" aria-label="Testo nota" aria-multiline="true">Combattuto i 2 Goblin a §214. **Korak** è caduto al secondo turno — Giulia ha usato la Pietra Spettrale per finirlo. Loot: 14 oro, vedi §340.</textarea>
+              <div class="dy-preview">
+                <div class="dy-pv-lbl">Anteprima live</div>
+                <p class="dy-body">Combattuto i 2 Goblin a <span class="dy-ref">§214</span>. <strong>Korak</strong> è caduto al secondo turno — Giulia ha usato la Pietra Spettrale per finirlo. Loot: 14 oro, vedi <span class="dy-ref">§340</span>.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ─── state-05 · DIARY LAB (interattivo, carica librogame-runthrough-play-session.jsx) ─── -->
+  <section class="state-section" aria-labelledby="s5lab">
+    <span class="label">Stato 05 · Diary Lab (interattivo)<span class="cmp">React · Babel standalone</span></span>
+    <h2 id="s5lab">Diary interattivo — scrivi, salva, cambia stato</h2>
+    <p class="desc">Versione runnable di state-05. Cambia stato dal selettore; "＋ Nuova nota" apre l'editor (typing → live preview + Salva attivo + bozza locale). Tema controllato dal bottone 🌗 in alto. Sorgente: <code>librogame-runthrough-play-session.jsx</code>.</p>
+    <div id="diary-lab-root"></div>
+  </section>
+
+  <!-- ─── state-06-paragrafi-drawer ─── -->
+  <!-- SP8 · Function #5 Lista paragrafi visitati. Append-only. Drawer canonico:
+       bottom-sheet 75% (mobile, da 03-drawer-variants V1) / side-panel slide-from-left (desktop).
+       Trigger mobile: 🕰 history nella session-h. Trigger desktop: voce "History" left panel.
+       Classi nuove prefissate .hy- . Search scope v1 = solo §numero/capitolo (full-text rimandato:
+       l'app ha il testo completo SOLO per paragrafi tradotti → vedi nota deviazione).
+       Jump-back: §214 resta in history (no cancellazione), save-state → target, drawer chiude. -->
+  <style id="sp8-history-styles">
+    /* 🕰 history trigger nella session header */
+    .session-h .hy-trigger { width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--c-session) / 0.12); border: 0; font-size: 14px; cursor: pointer; color: hsl(var(--c-session)); display: inline-flex; align-items: center; justify-content: center; }
+
+    /* scrim + bottom-sheet (mobile) */
+    .hy-scrim { position: absolute; inset: 0; z-index: var(--z-drawer); background: rgba(0,0,0,0.4); display: flex; flex-direction: column; justify-content: flex-end; }
+    .hy-sheet { height: 75%; background: var(--bg-card); border-radius: var(--r-2xl) var(--r-2xl) 0 0; box-shadow: 0 -10px 30px rgba(0,0,0,0.25); display: flex; flex-direction: column; overflow: hidden; animation: hySlideUp var(--dur-md, 0.32s) var(--ease-out); }
+    @keyframes hySlideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+    .hy-drag { width: 40px; height: 4px; border-radius: var(--r-pill); background: var(--border-strong); margin: var(--s-2) auto 0; flex-shrink: 0; }
+    .hy-head { display: flex; align-items: center; gap: var(--s-2); padding: var(--s-3) var(--s-4); flex-shrink: 0; }
+    .hy-head .hy-title { flex: 1; font-family: var(--f-display); font-size: var(--fs-md); font-weight: var(--fw-bold); color: var(--text); }
+    .hy-head .hy-x { width: 30px; height: 30px; border-radius: 50%; background: var(--bg-muted); border: 0; font-size: 13px; color: var(--text-sec); cursor: pointer; }
+
+    /* search (scope §numero/capitolo) */
+    .hy-search { padding: 0 var(--s-4) var(--s-2); flex-shrink: 0; }
+    .hy-search .hy-field { display: flex; align-items: center; gap: var(--s-2); padding: var(--s-2) var(--s-3); border: 1px solid var(--border); border-radius: var(--r-md); background: var(--bg); }
+    .hy-search .hy-field .ic { color: var(--text-muted); font-size: var(--fs-sm); }
+    .hy-search .hy-field input { flex: 1; border: 0; outline: 0; background: transparent; font-family: var(--f-body); font-size: var(--fs-md); color: var(--text); }
+    .hy-search .hy-field input::placeholder { color: var(--text-muted); }
+    .hy-search .hy-scope { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin-top: 4px; padding-left: 2px; }
+
+    /* current paragraph sticky (entity=session) */
+    .hy-current { margin: 0 var(--s-4) var(--s-3); padding: var(--s-3); border-radius: var(--r-md); background: hsl(var(--c-session) / 0.1); border: 1px solid hsl(var(--c-session) / 0.3); display: flex; align-items: center; gap: var(--s-2); flex-shrink: 0; }
+    .hy-current .hy-now-pin { display: inline-flex; align-items: center; gap: 4px; padding: 3px var(--s-2); border-radius: var(--r-pill); background: hsl(var(--c-session)); color: #fff; font-family: var(--f-mono); font-size: var(--fs-sm); font-weight: var(--fw-bold); }
+    .hy-current .hy-now-meta { font-family: var(--f-mono); font-size: var(--fs-xs); color: hsl(var(--c-session)); font-weight: var(--fw-semi); }
+    .hy-current .hy-now-tag { margin-left: auto; font-family: var(--f-mono); font-size: var(--fs-xs); color: hsl(var(--c-session)); text-transform: uppercase; letter-spacing: 0.05em; }
+
+    /* list newest-first */
+    .hy-list { flex: 1; overflow-y: auto; padding: 0 var(--s-4) var(--s-4); display: flex; flex-direction: column; gap: var(--s-2); }
+    .hy-row { border: 1px solid var(--border-light); border-radius: var(--r-lg); background: var(--bg); padding: var(--s-3); display: flex; flex-direction: column; gap: var(--s-2); }
+    .hy-row .hy-r-top { display: flex; align-items: center; gap: var(--s-2); }
+    .hy-row .hy-para { display: inline-flex; align-items: center; gap: 4px; padding: 2px var(--s-2); border-radius: var(--r-pill); background: hsl(var(--c-kb) / 0.14); color: hsl(var(--c-kb)); font-family: var(--f-mono); font-size: var(--fs-sm); font-weight: var(--fw-bold); }
+    .hy-row .hy-when { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); }
+    .hy-row .hy-chap { margin-left: auto; font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-sec); padding: 1px var(--s-2); background: var(--bg-muted); border-radius: var(--r-sm); }
+    .hy-row .hy-snip { font-family: var(--f-body); font-size: 18px; line-height: var(--lh-snug); color: var(--text-sec); margin: 0; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+    .hy-row .hy-goto { align-self: flex-start; padding: var(--s-1) var(--s-3); border-radius: var(--r-pill); background: hsl(var(--c-session)); color: #fff; border: 0; font-family: var(--f-display); font-size: var(--fs-sm); font-weight: var(--fw-bold); cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+    .hy-row .hy-goto:hover { transform: translateY(-1px); }
+    .hy-row .hy-goto:disabled { background: var(--bg-muted); color: var(--text-muted); cursor: not-allowed; }
+    .hy-row .hy-goto-wrap { position: relative; align-self: flex-start; }
+    .hy-row .hy-tip { position: absolute; bottom: calc(100% + 6px); left: 0; white-space: nowrap; padding: 3px var(--s-2); border-radius: var(--r-sm); background: var(--text); color: var(--bg); font-family: var(--f-mono); font-size: var(--fs-xs); opacity: 0; pointer-events: none; transition: opacity var(--dur-sm) var(--ease-out); }
+    .hy-row .hy-goto-wrap:hover .hy-tip, .hy-row.hy-show-tip .hy-tip { opacity: 1; }
+
+    /* empty / loading / banners */
+    .hy-empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--s-3); padding: var(--s-7) var(--s-5); text-align: center; }
+    .hy-empty .hy-ill { width: 72px; height: 72px; border-radius: var(--r-2xl); background: hsl(var(--c-kb) / 0.12); display: flex; align-items: center; justify-content: center; font-size: 36px; }
+    .hy-empty h3 { font-family: var(--f-display); font-size: var(--fs-lg); color: var(--text); margin: 0; }
+    .hy-empty p { color: var(--text-sec); font-size: var(--fs-md); margin: 0; max-width: 230px; }
+    .hy-skel { border: 1px solid var(--border-light); border-radius: var(--r-lg); background: var(--bg); padding: var(--s-3); }
+    .hy-skel .ln { height: 12px; border-radius: var(--r-pill); background: var(--bg-muted); margin-bottom: var(--s-2); }
+    .hy-banner { display: flex; align-items: flex-start; gap: var(--s-2); margin: 0 var(--s-4) var(--s-3); padding: var(--s-3); border-radius: var(--r-md); font-size: var(--fs-sm); line-height: var(--lh-snug); flex-shrink: 0; }
+    .hy-banner .hy-bic { flex-shrink: 0; font-size: var(--fs-lg); }
+    .hy-banner .hy-btx { flex: 1; }
+    .hy-banner .hy-btx strong { display: block; font-family: var(--f-display); font-weight: var(--fw-bold); margin-bottom: 2px; }
+    .hy-banner .hy-btx .hy-sub { color: var(--text-sec); font-size: var(--fs-xs); }
+    .hy-banner .hy-retry { background: none; border: 1px solid currentColor; border-radius: var(--r-pill); padding: 3px var(--s-3); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-xs); cursor: pointer; align-self: center; }
+    .hy-banner.err { background: hsl(var(--c-event) / 0.1); border: 1px solid hsl(var(--c-event) / 0.3); color: hsl(var(--c-event)); }
+    .hy-banner.off { background: hsl(var(--c-tool) / 0.1); border: 1px solid hsl(var(--c-tool) / 0.3); color: hsl(var(--c-tool)); }
+
+    /* jump-back confirmation (alertdialog) */
+    .hy-confirm-scrim { position: absolute; inset: 0; z-index: calc(var(--z-drawer) + 5); background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; padding: var(--s-5); }
+    .hy-confirm { width: 100%; max-width: 320px; background: var(--bg-card); border-radius: var(--r-xl); box-shadow: var(--shadow-lg); padding: var(--s-5); animation: hyPop var(--dur-md, 0.28s) var(--ease-out); }
+    @keyframes hyPop { from { transform: scale(0.94); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+    .hy-confirm .hy-c-icon { width: 44px; height: 44px; border-radius: var(--r-lg); background: hsl(var(--c-session) / 0.14); display: flex; align-items: center; justify-content: center; font-size: 22px; margin-bottom: var(--s-3); }
+    .hy-confirm h3 { font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-bold); color: var(--text); margin: 0 0 var(--s-2); }
+    .hy-confirm p { font-family: var(--f-body); font-size: var(--fs-md); line-height: var(--lh-snug); color: var(--text-sec); margin: 0 0 var(--s-4); }
+    .hy-confirm p .hy-ref { color: hsl(var(--c-kb)); font-family: var(--f-mono); font-weight: var(--fw-semi); }
+    .hy-confirm .hy-c-acts { display: flex; gap: var(--s-2); }
+    .hy-confirm .hy-c-acts button { flex: 1; padding: var(--s-3); border-radius: var(--r-md); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); cursor: pointer; }
+    .hy-confirm .hy-c-cancel { background: var(--bg-muted); border: 1px solid var(--border); color: var(--text-sec); }
+    .hy-confirm .hy-c-go { background: hsl(var(--c-session)); border: 0; color: #fff; }
+    .hy-confirm .hy-c-go:hover { transform: translateY(-1px); }
+
+    /* desktop side-panel (slide from left) */
+    .hy-side-host { position: absolute; inset: 0; z-index: var(--z-drawer); display: flex; }
+    .hy-side-scrim { flex: 1; background: rgba(0,0,0,0.35); }
+    .hy-side { width: 380px; max-width: 70%; background: var(--bg-card); border-right: 1px solid var(--border); box-shadow: 10px 0 30px rgba(0,0,0,0.18); display: flex; flex-direction: column; order: -1; animation: hySlideRight var(--dur-md, 0.32s) var(--ease-out); }
+    @keyframes hySlideRight { from { transform: translateX(-100%); } to { transform: translateX(0); } }
+    /* desktop left-panel "History" secondary action */
+    .dy-navitem.hy-secondary { color: hsl(var(--c-kb)); }
+    .dy-navitem.hy-secondary[aria-selected="true"] { background: hsl(var(--c-kb) / 0.12); color: hsl(var(--c-kb)); }
+
+    @media (prefers-reduced-motion: reduce) {
+      .hy-sheet, .hy-side, .hy-confirm { animation: none; }
+    }
+  </style>
+
+  <section class="state-section" aria-labelledby="s6">
+    <span class="label">Stato 06 · Paragrafi Drawer<span class="cmp">PlaySessionShell · VisitedParagraphsDrawer</span></span>
+    <h2 id="s6">History paragrafi visitati — drawer + jump-back confirm</h2>
+    <p class="desc">Function #5. Aaron tocca 🕰 nella header per rivedere dove è stato. Bottom-sheet 75% (mobile, pattern canonico <code>03-drawer-variants</code> V1) / side-panel da sinistra (desktop). Paragrafo corrente §214 in sticky top (entity=session), lista newest-first con snippet + <strong>[→ vai qui]</strong>. Tap jump-back apre conferma <code>role="alertdialog"</code>: §214 resta in history, nessuna cancellazione. Search v1 = solo §numero/capitolo. Stati: default · confirm · empty · loading · error · offline (history cached, [vai qui] disabilitato).</p>
+
+    <div class="frames">
+
+      <!-- Mobile · default (drawer open, current + 3 entries) -->
+      <div class="phone" role="region" aria-label="Mobile · history default">
+        <span class="frame-label">Mobile · default</span>
+        <div class="phone-sbar"><span>22:46</span><span>📶 🔋 55%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span><span class="lbl-mini">· Cap 4</span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="filter: blur(1px); opacity: 0.5;"><div class="para-card"><div class="num-row"><span class="num">§214</span><span class="chap">Cap 4</span></div><p class="text">La grotta si apre davanti a te…</p></div></div>
+        <div class="hy-scrim" role="dialog" aria-modal="true" aria-label="Paragrafi visitati">
+          <div class="hy-sheet">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x" aria-label="Chiudi">✕</button></div>
+            <div class="hy-search"><div class="hy-field"><span class="ic">🔍</span><input placeholder="Cerca per numero o capitolo…" aria-label="Cerca paragrafo"/></div><div class="hy-scope">Cerca per §numero o capitolo</div></div>
+            <div class="hy-current"><span class="hy-now-pin">📍 §214</span><span class="hy-now-meta">Cap 4</span><span class="hy-now-tag">ora</span></div>
+            <div class="hy-list">
+              <div class="hy-row">
+                <div class="hy-r-top"><span class="hy-para">§198</span><span class="hy-when">22 min fa</span><span class="hy-chap">Cap 4</span></div>
+                <p class="hy-snip">Entri nel corridoio buio, una corrente d'aria spegne la torcia. In fondo senti un raschiare metallico.</p>
+                <button class="hy-goto">→ vai qui</button>
+              </div>
+              <div class="hy-row">
+                <div class="hy-r-top"><span class="hy-para">§189</span><span class="hy-when">1h fa</span><span class="hy-chap">Cap 4</span></div>
+                <p class="hy-snip">Il ponte di corda oscilla sul precipizio. Niamh ti fa cenno di aspettare prima di attraversare.</p>
+                <button class="hy-goto">→ vai qui</button>
+              </div>
+              <div class="hy-row">
+                <div class="hy-r-top"><span class="hy-para">§134</span><span class="hy-when">2h fa</span><span class="hy-chap">Cap 3</span></div>
+                <p class="hy-snip">Korak ti porge la mano: "Ti devo un favore. Cercami quando avrai bisogno di passare il valico."</p>
+                <button class="hy-goto">→ vai qui</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · jump-back confirm -->
+      <div class="phone" role="region" aria-label="Mobile · history jump-back confirm">
+        <span class="frame-label">Mobile · jump-back confirm</span>
+        <div class="phone-sbar"><span>22:47</span><span>📶 🔋 55%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="filter: blur(1px); opacity: 0.4;"></div>
+        <div class="hy-scrim" style="background: rgba(0,0,0,0.5);" aria-hidden="true">
+          <div class="hy-sheet" style="filter: blur(1px);">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div>
+          </div>
+        </div>
+        <div class="hy-confirm-scrim" role="alertdialog" aria-modal="true" aria-labelledby="hyc-ti" aria-describedby="hyc-bd">
+          <div class="hy-confirm">
+            <div class="hy-c-icon">↩️</div>
+            <h3 id="hyc-ti">Tornare al §189?</h3>
+            <p id="hyc-bd">Perderai la posizione corrente <span class="hy-ref">§214</span>. Il §214 resterà comunque visitato nella history.</p>
+            <div class="hy-c-acts"><button class="hy-c-cancel">Annulla</button><button class="hy-c-go" autofocus>Sì, torna</button></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · empty (only §1) -->
+      <div class="phone" role="region" aria-label="Mobile · history empty">
+        <span class="frame-label">Mobile · empty</span>
+        <div class="phone-sbar"><span>20:02</span><span>📶 🔋 88%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§1</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="header-pips"><span class="manapip session"><span class="badge">1</span></span><span class="lbl-mini">· Cap 1</span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
+        <div class="hy-scrim" role="dialog" aria-modal="true" aria-label="Paragrafi visitati">
+          <div class="hy-sheet">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div>
+            <div class="hy-current"><span class="hy-now-pin">📍 §1</span><span class="hy-now-meta">Cap 1</span><span class="hy-now-tag">ora</span></div>
+            <div class="hy-empty">
+              <div class="hy-ill">🧭</div>
+              <h3>Sei appena partito</h3>
+              <p>Continua a leggere per popolare la history dei paragrafi visitati.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · loading -->
+      <div class="phone" role="region" aria-label="Mobile · history loading">
+        <span class="frame-label">Mobile · loading</span>
+        <div class="phone-sbar"><span>22:48</span><span>📶 🔋 54%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
+        <div class="hy-scrim" role="dialog" aria-modal="true" aria-busy="true" aria-label="Paragrafi visitati">
+          <div class="hy-sheet">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div>
+            <div class="hy-current"><span class="hy-now-pin">📍 §214</span><span class="hy-now-meta">Cap 4</span><span class="hy-now-tag">ora</span></div>
+            <div class="hy-list">
+              <div class="hy-skel"><div class="ln dy-shimmer" style="width: 45%;"></div><div class="ln dy-shimmer" style="width: 95%;"></div><div class="ln dy-shimmer" style="width: 30%; margin-bottom: 0;"></div></div>
+              <div class="hy-skel"><div class="ln dy-shimmer" style="width: 45%;"></div><div class="ln dy-shimmer" style="width: 80%;"></div><div class="ln dy-shimmer" style="width: 30%; margin-bottom: 0;"></div></div>
+              <div class="hy-skel"><div class="ln dy-shimmer" style="width: 45%;"></div><div class="ln dy-shimmer" style="width: 70%;"></div><div class="ln dy-shimmer" style="width: 30%; margin-bottom: 0;"></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · error -->
+      <div class="phone" role="region" aria-label="Mobile · history error">
+        <span class="frame-label">Mobile · error</span>
+        <div class="phone-sbar"><span>22:49</span><span>📶 🔋 54%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
+        <div class="hy-scrim" role="dialog" aria-modal="true" aria-label="Paragrafi visitati">
+          <div class="hy-sheet">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div>
+            <div class="hy-banner err" role="alert">
+              <span class="hy-bic">⚠️</span>
+              <div class="hy-btx"><strong style="color: hsl(var(--c-event));">Impossibile caricare la history</strong><span class="hy-sub">Controlla la connessione e riprova.</span></div>
+              <button class="hy-retry">↻ Riprova</button>
+            </div>
+            <div class="hy-current" style="opacity: 0.55;"><span class="hy-now-pin">📍 §214</span><span class="hy-now-meta">Cap 4</span><span class="hy-now-tag">ora</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · offline (cached read-only, [vai qui] disabled + tip) -->
+      <div class="phone" role="region" aria-label="Mobile · history offline">
+        <span class="frame-label">Mobile · offline</span>
+        <div class="phone-sbar"><span>22:51</span><span>✈️ 🔋 53%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
+        <div class="hy-scrim" role="dialog" aria-modal="true" aria-label="Paragrafi visitati">
+          <div class="hy-sheet">
+            <div class="hy-drag"></div>
+            <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div>
+            <div class="hy-banner off" role="status">
+              <span class="hy-bic">📴</span>
+              <div class="hy-btx"><strong style="color: hsl(var(--c-tool));">Offline — history in sola lettura</strong><span class="hy-sub">Il salto sarà disponibile quando torni online.</span></div>
+            </div>
+            <div class="hy-current"><span class="hy-now-pin">📍 §214</span><span class="hy-now-meta">Cap 4</span><span class="hy-now-tag">ora</span></div>
+            <div class="hy-list">
+              <div class="hy-row hy-show-tip">
+                <div class="hy-r-top"><span class="hy-para">§198</span><span class="hy-when">22 min fa</span><span class="hy-chap">Cap 4</span></div>
+                <p class="hy-snip">Entri nel corridoio buio, una corrente d'aria spegne la torcia.</p>
+                <div class="hy-goto-wrap"><span class="hy-tip">Disponibile online</span><button class="hy-goto" disabled>→ vai qui</button></div>
+              </div>
+              <div class="hy-row">
+                <div class="hy-r-top"><span class="hy-para">§189</span><span class="hy-when">1h fa</span><span class="hy-chap">Cap 4</span></div>
+                <p class="hy-snip">Il ponte di corda oscilla sul precipizio.</p>
+                <div class="hy-goto-wrap"><button class="hy-goto" disabled>→ vai qui</button></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · default (side-panel from left) -->
+      <div class="desktop" role="region" aria-label="Desktop · history default">
+        <span class="frame-label">Desktop · 1440px (scaled)</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?history=open</span></div>
+        <div class="d-body" style="position: relative;">
+          <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
+            <div class="side-card" style="margin-bottom: var(--s-2);"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div>
+            <nav aria-label="Sezioni sessione" style="display: flex; flex-direction: column; gap: 2px;">
+              <button class="dy-navitem"><span class="em">📖</span>Story<span class="cnt">§214</span></button>
+              <button class="dy-navitem"><span class="em">⚔️</span>Encounter<span class="cnt">—</span></button>
+              <button class="dy-navitem"><span class="em">📚</span>Glossario<span class="cnt">12</span></button>
+              <button class="dy-navitem"><span class="em">📓</span>Diary<span class="cnt">12</span></button>
+              <button class="dy-navitem hy-secondary" aria-selected="true"><span class="em">🕰</span>History<span class="cnt">47</span></button>
+            </nav>
+          </aside>
+          <div class="d-main" aria-hidden="true" style="opacity: 0.5;"><div class="para-card"><div class="num-row"><span class="num">§214</span><span class="chap">Cap 4</span></div><p class="text">La grotta si apre davanti a te, l'aria sa di muschio e metallo…</p></div></div>
+          <div class="hy-side-host">
+            <div class="hy-side">
+              <div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x" aria-label="Chiudi">✕</button></div>
+              <div class="hy-search"><div class="hy-field"><span class="ic">🔍</span><input placeholder="Cerca per numero o capitolo…"/></div><div class="hy-scope">Cerca per §numero o capitolo</div></div>
+              <div class="hy-current"><span class="hy-now-pin">📍 §214</span><span class="hy-now-meta">Cap 4</span><span class="hy-now-tag">ora</span></div>
+              <div class="hy-list">
+                <div class="hy-row">
+                  <div class="hy-r-top"><span class="hy-para">§198</span><span class="hy-when">22 min fa</span><span class="hy-chap">Cap 4</span></div>
+                  <p class="hy-snip">Entri nel corridoio buio, una corrente d'aria spegne la torcia. In fondo senti un raschiare metallico.</p>
+                  <button class="hy-goto">→ vai qui</button>
+                </div>
+                <div class="hy-row">
+                  <div class="hy-r-top"><span class="hy-para">§189</span><span class="hy-when">1h fa</span><span class="hy-chap">Cap 4</span></div>
+                  <p class="hy-snip">Il ponte di corda oscilla sul precipizio. Niamh ti fa cenno di aspettare.</p>
+                  <button class="hy-goto">→ vai qui</button>
+                </div>
+                <div class="hy-row">
+                  <div class="hy-r-top"><span class="hy-para">§134</span><span class="hy-when">2h fa</span><span class="hy-chap">Cap 3</span></div>
+                  <p class="hy-snip">Korak ti porge la mano: "Ti devo un favore."</p>
+                  <button class="hy-goto">→ vai qui</button>
+                </div>
+              </div>
+            </div>
+            <div class="hy-side-scrim"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · jump-back confirm -->
+      <div class="desktop" role="region" aria-label="Desktop · history confirm">
+        <span class="frame-label">Desktop · jump-back confirm</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?history=open&jump=189</span></div>
+        <div class="d-body" style="position: relative;">
+          <aside class="d-side" style="width: 260px;"><div class="side-card"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div></aside>
+          <div class="d-main" aria-hidden="true" style="opacity: 0.4;"></div>
+          <div class="hy-side-host"><div class="hy-side" style="filter: blur(1px);"><div class="hy-head"><span class="hy-title">🕰 Paragrafi visitati</span><button class="hy-x">✕</button></div></div><div class="hy-side-scrim"></div></div>
+          <div class="hy-confirm-scrim" role="alertdialog" aria-modal="true" aria-labelledby="hyc2-ti" aria-describedby="hyc2-bd">
+            <div class="hy-confirm">
+              <div class="hy-c-icon">↩️</div>
+              <h3 id="hyc2-ti">Tornare al §189?</h3>
+              <p id="hyc2-bd">Perderai la posizione corrente <span class="hy-ref">§214</span>. Il §214 resterà comunque visitato nella history.</p>
+              <div class="hy-c-acts"><button class="hy-c-cancel">Annulla</button><button class="hy-c-go" autofocus>Sì, torna</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ─── state-06 · HISTORY LAB (interattivo) ─── -->
+  <section class="state-section" aria-labelledby="s6lab">
+    <span class="label">Stato 06 · History Lab (interattivo)<span class="cmp">React · Babel standalone</span></span>
+    <h2 id="s6lab">History interattiva — apri drawer, cerca, salta indietro</h2>
+    <p class="desc">Versione runnable di state-06. 🕰 apre il drawer; la search filtra per §numero/capitolo client-side; <strong>[→ vai qui]</strong> apre la conferma jump-back (Sì → §214 resta in history, drawer chiude, story va al target). Stato dal selettore. Sorgente: <code>librogame-runthrough-play-session.jsx</code>.</p>
+    <div id="history-lab-root"></div>
+  </section>
+
+  <!-- ─── state-07-end-campaign ─── -->
+  <!-- SP8 · Function #8 End campaign / mark complete. Append-only. Classi nuove .ec- .
+       Trigger mobile: kebab ⋮ session-h. Trigger desktop: "Chiudi campagna" left-panel footer.
+       Dialog 3-vie SOFT (Completata / Archivia / Abbandona) → side effects differenziati.
+       Nota Socratica: reopen Abbandona = SINGLE confirm (riaprire è non-distruttivo).
+       Post-close: PDF CTA SOLO per Completata (server-side gen async, placeholder qui). -->
+  <style id="sp8-endcampaign-styles">
+    /* kebab menu (role=menu) */
+    .ec-kebab { position: absolute; top: 56px; right: var(--s-3); z-index: calc(var(--z-drawer) + 2); min-width: 210px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--r-lg); box-shadow: var(--shadow-lg); padding: var(--s-2); animation: ecPop var(--dur-sm, 0.18s) var(--ease-out); transform-origin: top right; }
+    @keyframes ecPop { from { transform: scale(0.92); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+    .ec-kebab .ec-k-lbl { font-family: var(--f-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); padding: var(--s-2) var(--s-2) 4px; font-weight: var(--fw-bold); }
+    .ec-kebab .ec-k-div { height: 1px; background: var(--border-light); margin: 4px var(--s-2); }
+    .ec-kitem { display: flex; align-items: center; gap: var(--s-2); width: 100%; min-height: 44px; padding: var(--s-2); border-radius: var(--r-md); border: 0; background: transparent; cursor: pointer; text-align: left; font-family: var(--f-display); font-size: var(--fs-md); font-weight: var(--fw-semi); color: var(--text); }
+    .ec-kitem:hover { background: var(--bg-hover); }
+    .ec-kitem .ic { width: 30px; text-align: center; font-size: 16px; }
+    .ec-kitem.ec-target { color: hsl(var(--c-session)); font-weight: var(--fw-bold); }
+    .ec-kitem.ec-target:hover { background: hsl(var(--c-session) / 0.1); }
+
+    /* 3-vie dialog */
+    .ec-scrim { position: absolute; inset: 0; z-index: var(--z-drawer); background: rgba(0,0,0,0.5); display: flex; align-items: flex-end; }
+    .ec-scrim.ec-center { align-items: center; justify-content: center; padding: var(--s-5); }
+    .ec-dialog { width: 100%; background: var(--bg-card); border-radius: var(--r-2xl) var(--r-2xl) 0 0; box-shadow: var(--shadow-lg); padding: var(--s-4) var(--s-4) var(--s-5); display: flex; flex-direction: column; animation: ecSlideUp var(--dur-md, 0.3s) var(--ease-out); max-height: 92%; overflow-y: auto; }
+    .ec-scrim.ec-center .ec-dialog { max-width: 420px; border-radius: var(--r-2xl); animation: ecPop var(--dur-md, 0.28s) var(--ease-out); }
+    @keyframes ecSlideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+    .ec-grab { width: 40px; height: 4px; border-radius: var(--r-pill); background: var(--border-strong); margin: 0 auto var(--s-3); flex-shrink: 0; }
+    .ec-dialog h3 { font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-bold); color: var(--text); margin: 0 0 var(--s-1); }
+    .ec-dialog .ec-d-sub { font-family: var(--f-body); font-size: var(--fs-md); color: var(--text-sec); margin: 0 0 var(--s-4); line-height: var(--lh-snug); }
+
+    .ec-choices { display: flex; flex-direction: column; gap: var(--s-2); margin-bottom: var(--s-4); }
+    .ec-choice { display: flex; align-items: flex-start; gap: var(--s-3); padding: var(--s-3); border-radius: var(--r-lg); border: 1.5px solid var(--border); background: var(--bg); cursor: pointer; text-align: left; transition: border-color var(--dur-sm) var(--ease-out), background var(--dur-sm) var(--ease-out); }
+    .ec-choice:hover { border-color: hsl(var(--e) / 0.5); }
+    .ec-choice[aria-pressed="true"] { border-color: hsl(var(--e)); background: hsl(var(--e) / 0.08); }
+    .ec-choice .ec-c-ic { width: 42px; height: 42px; border-radius: var(--r-md); flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 20px; background: hsl(var(--e) / 0.15); color: hsl(var(--e)); }
+    .ec-choice .ec-c-tx { flex: 1; min-width: 0; }
+    .ec-choice .ec-c-tx .ec-c-ti { font-family: var(--f-display); font-size: var(--fs-md); font-weight: var(--fw-bold); color: var(--text); display: flex; align-items: center; gap: var(--s-2); }
+    .ec-choice .ec-c-tx .ec-c-ds { font-family: var(--f-body); font-size: var(--fs-sm); color: var(--text-sec); margin-top: 2px; line-height: var(--lh-snug); }
+    .ec-choice .ec-c-radio { width: 22px; height: 22px; border-radius: 50%; border: 2px solid var(--border-strong); flex-shrink: 0; align-self: center; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 12px; }
+    .ec-choice[aria-pressed="true"] .ec-c-radio { background: hsl(var(--e)); border-color: hsl(var(--e)); }
+    .ec-choice .ec-c-note { display: inline-block; margin-top: var(--s-2); padding: 2px var(--s-2); border-radius: var(--r-sm); background: hsl(var(--e) / 0.12); color: hsl(var(--e)); font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-semi); }
+
+    .ec-d-acts { display: flex; gap: var(--s-2); }
+    .ec-d-acts button { flex: 1; min-height: 48px; border-radius: var(--r-md); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); cursor: pointer; }
+    .ec-d-cancel { background: var(--bg-muted); border: 1px solid var(--border); color: var(--text-sec); flex: 0 0 auto !important; padding: 0 var(--s-5); }
+    .ec-d-confirm { background: hsl(var(--e, var(--c-session))); border: 0; color: #fff; }
+    .ec-d-confirm:disabled { background: var(--bg-muted); color: var(--text-muted); cursor: not-allowed; }
+    .ec-d-confirm:not(:disabled):hover { transform: translateY(-1px); }
+
+    /* loading overlay (BE state transition) */
+    .ec-loading { position: absolute; inset: 0; z-index: calc(var(--z-drawer) + 4); background: var(--glass-bg); backdrop-filter: blur(8px); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--s-3); }
+    .ec-spinner { width: 46px; height: 46px; border-radius: 50%; border: 4px solid hsl(var(--c-session) / 0.2); border-top-color: hsl(var(--c-session)); animation: ecSpin 0.8s linear infinite; }
+    @keyframes ecSpin { to { transform: rotate(360deg); } }
+    .ec-loading .ec-l-tx { font-family: var(--f-display); font-size: var(--fs-md); font-weight: var(--fw-bold); color: var(--text); }
+    .ec-loading .ec-l-sub { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); }
+
+    /* error banner */
+    .ec-error { margin: var(--s-4); padding: var(--s-4); border-radius: var(--r-lg); border: 1px solid hsl(var(--c-event) / 0.35); background: hsl(var(--c-event) / 0.08); }
+    .ec-error .ec-e-top { display: flex; gap: var(--s-2); align-items: flex-start; }
+    .ec-error .ec-e-ic { font-size: 22px; flex-shrink: 0; }
+    .ec-error h4 { font-family: var(--f-display); font-size: var(--fs-md); color: hsl(var(--c-event)); margin: 0 0 2px; }
+    .ec-error p { font-size: var(--fs-sm); color: var(--text-sec); line-height: var(--lh-snug); margin: 0; }
+    .ec-error .ec-e-acts { display: flex; gap: var(--s-2); margin-top: var(--s-3); }
+    .ec-error .ec-e-acts button { min-height: 40px; padding: 0 var(--s-4); border-radius: var(--r-sm); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); cursor: pointer; }
+    .ec-error .ec-e-retry { background: hsl(var(--c-event)); color: #fff; border: 0; }
+    .ec-error .ec-e-force { background: transparent; border: 1px solid var(--border-strong); color: var(--text-sec); }
+
+    /* post-close summary */
+    .ec-summary { display: flex; flex-direction: column; align-items: center; text-align: center; padding: var(--s-6) var(--s-5) var(--s-5); flex: 1; overflow-y: auto; }
+    .ec-summary .ec-s-badge { width: 76px; height: 76px; border-radius: var(--r-2xl); display: flex; align-items: center; justify-content: center; font-size: 40px; margin-bottom: var(--s-4); }
+    .ec-summary.ec-done .ec-s-badge { background: hsl(var(--c-toolkit) / 0.15); }
+    .ec-summary.ec-arch .ec-s-badge { background: hsl(var(--c-session) / 0.15); }
+    .ec-summary .ec-s-kick { font-family: var(--f-mono); font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: 0.1em; font-weight: var(--fw-bold); }
+    .ec-summary.ec-done .ec-s-kick { color: hsl(var(--c-toolkit)); }
+    .ec-summary.ec-arch .ec-s-kick { color: hsl(var(--c-session)); }
+    .ec-summary h2 { font-family: var(--f-display); font-size: var(--fs-2xl); font-weight: var(--fw-bold); color: var(--text); margin: var(--s-1) 0 var(--s-2); }
+    .ec-summary .ec-s-camp { font-family: var(--f-body); font-size: var(--fs-md); color: var(--text-sec); margin: 0 0 var(--s-5); }
+    .ec-stats { display: grid; grid-template-columns: 1fr 1fr; gap: var(--s-2); width: 100%; margin-bottom: var(--s-5); }
+    .ec-stat { padding: var(--s-3); border-radius: var(--r-md); background: var(--bg); border: 1px solid var(--border-light); text-align: left; }
+    .ec-stat .ec-st-v { font-family: var(--f-display); font-size: var(--fs-xl); font-weight: var(--fw-ext); color: var(--text); }
+    .ec-stat .ec-st-k { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin-top: 2px; }
+    .ec-stat.ec-wide { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; }
+    .ec-stat.ec-wide .ec-st-v { font-size: var(--fs-md); }
+    .ec-cta-col { display: flex; flex-direction: column; gap: var(--s-2); width: 100%; }
+    .ec-btn-pdf { min-height: 50px; border-radius: var(--r-md); background: hsl(var(--c-kb)); color: #fff; border: 0; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: var(--s-2); box-shadow: 0 4px 14px hsl(var(--c-kb) / 0.28); }
+    .ec-btn-pdf:hover { transform: translateY(-1px); }
+    .ec-btn-reopen { min-height: 48px; border-radius: var(--r-md); background: hsl(var(--c-session) / 0.12); color: hsl(var(--c-session)); border: 1px solid hsl(var(--c-session) / 0.3); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: var(--s-2); }
+    .ec-btn-lib { min-height: 48px; border-radius: var(--r-md); background: transparent; color: var(--text-sec); border: 1px solid var(--border-strong); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: var(--s-2); }
+    .ec-pdf-note { font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted); margin-top: var(--s-1); }
+    .ec-pending { display: inline-flex; align-items: center; gap: 5px; margin-top: var(--s-2); padding: 3px var(--s-3); border-radius: var(--r-pill); background: hsl(var(--c-tool) / 0.12); color: hsl(var(--c-tool)); font-family: var(--f-mono); font-size: var(--fs-xs); font-weight: var(--fw-bold); }
+    .ec-pending .dot { width: 7px; height: 7px; border-radius: 50%; background: hsl(var(--c-tool)); }
+
+    /* confetti (reduced-motion safe) */
+    .ec-confetti { position: absolute; inset: 0; pointer-events: none; overflow: hidden; z-index: 1; }
+    .ec-confetti i { position: absolute; top: -10px; width: 8px; height: 8px; border-radius: 1px; animation: ecFall 2.6s var(--ease-out) forwards; }
+    @keyframes ecFall { to { transform: translateY(720px) rotate(540deg); opacity: 0; } }
+    @media (prefers-reduced-motion: reduce) {
+      .ec-kebab, .ec-dialog, .ec-summary { animation: none; }
+      .ec-spinner { animation: ecSpin 1.6s linear infinite; }
+      .ec-confetti { display: none; }
+    }
+  </style>
+
+  <section class="state-section" aria-labelledby="s7">
+    <span class="label">Stato 07 · End Campaign<span class="cmp">PlaySessionShell · EndCampaignFlow</span></span>
+    <h2 id="s7">Chiudi campagna — kebab → dialog 3-vie → summary</h2>
+    <p class="desc">Function #8. Kebab ⋮ (mobile) / "Chiudi campagna" left-panel (desktop) → dialog 3-vie soft: <strong>✅ Completata</strong> (toolkit, lock + PDF server-side + "Completate") · <strong>📥 Archivia</strong> (session, no lock/PDF, "Riapri") · <strong>❌ Abbandona</strong> (event, lock, reopen <em>single-confirm</em>). Post-close summary con stats; CTA PDF <strong>solo</strong> per Completata. Stati: kebab · dialog · loading · error (+forza chiusura locale) · offline (pending sync) · post-close Completata · post-close Archivia. Light+dark, mobile+desktop.</p>
+
+    <div class="frames">
+
+      <!-- Mobile · kebab aperto -->
+      <div class="phone" role="region" aria-label="Mobile · kebab menu">
+        <span class="frame-label">Mobile · kebab menu</span>
+        <div class="phone-sbar"><span>23:02</span><span>📶 🔋 50%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione" aria-expanded="true">⋮</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.45;"><div class="para-card"><div class="num-row"><span class="num">§214</span><span class="chap">Cap 4</span></div><p class="text">La grotta si apre davanti a te…</p></div></div>
+        <div class="ec-kebab" role="menu" aria-label="Impostazioni sessione">
+          <div class="ec-k-lbl">Impostazioni sessione</div>
+          <button class="ec-kitem" role="menuitem"><span class="ic">📦</span>Esporta dati</button>
+          <div class="ec-k-div"></div>
+          <button class="ec-kitem ec-target" role="menuitem"><span class="ic">🏁</span>Chiudi campagna</button>
+          <button class="ec-kitem" role="menuitem"><span class="ic">⚙️</span>Preferenze</button>
+        </div>
+      </div>
+
+      <!-- Mobile · dialog 3-vie -->
+      <div class="phone" role="region" aria-label="Mobile · dialog 3-vie">
+        <span class="frame-label">Mobile · dialog 3-vie</span>
+        <div class="phone-sbar"><span>23:03</span><span>📶 🔋 50%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.3;"></div>
+        <div class="ec-scrim" role="alertdialog" aria-modal="true" aria-labelledby="ec-d1-ti">
+          <div class="ec-dialog">
+            <div class="ec-grab"></div>
+            <h3 id="ec-d1-ti">Come vuoi chiudere?</h3>
+            <p class="ec-d-sub">"La grotta dei Goblin" · Cap 4 · §214</p>
+            <div class="ec-choices">
+              <button class="ec-choice" style="--e: var(--c-toolkit);" aria-pressed="true">
+                <span class="ec-c-ic">✅</span>
+                <span class="ec-c-tx"><span class="ec-c-ti">Completata</span><span class="ec-c-ds">Ho finito la storia. Genero il PDF riassunto.</span></span>
+                <span class="ec-c-radio">✓</span>
+              </button>
+              <button class="ec-choice" style="--e: var(--c-session);" aria-pressed="false">
+                <span class="ec-c-ic">📥</span>
+                <span class="ec-c-tx"><span class="ec-c-ti">Archivia</span><span class="ec-c-ds">Chiudo per ora, posso riaprire quando voglio.</span></span>
+                <span class="ec-c-radio"></span>
+              </button>
+              <button class="ec-choice" style="--e: var(--c-event);" aria-pressed="false">
+                <span class="ec-c-ic">❌</span>
+                <span class="ec-c-tx"><span class="ec-c-ti">Abbandona</span><span class="ec-c-ds">Chiudo definitivamente.</span><span class="ec-c-note">Riapri con un solo tap</span></span>
+                <span class="ec-c-radio"></span>
+              </button>
+            </div>
+            <div class="ec-d-acts"><button class="ec-d-cancel">Annulla</button><button class="ec-d-confirm" style="--e: var(--c-toolkit);">Completa campagna</button></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · loading -->
+      <div class="phone" role="region" aria-label="Mobile · closing loading">
+        <span class="frame-label">Mobile · loading</span>
+        <div class="phone-sbar"><span>23:03</span><span>📶 🔋 49%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content" aria-hidden="true" style="opacity: 0.3;"></div>
+        <div class="ec-loading" role="status" aria-live="polite">
+          <div class="ec-spinner"></div>
+          <span class="ec-l-tx">Chiudendo la campagna…</span>
+          <span class="ec-l-sub">Genero il riassunto e blocco i paragrafi</span>
+        </div>
+      </div>
+
+      <!-- Mobile · error -->
+      <div class="phone" role="region" aria-label="Mobile · close error">
+        <span class="frame-label">Mobile · error</span>
+        <div class="phone-sbar"><span>23:04</span><span>📶 🔋 49%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content">
+          <div class="ec-error" role="alert">
+            <div class="ec-e-top"><span class="ec-e-ic">⚠️</span><div><h4>Impossibile chiudere — riprova</h4><p>Il server non ha risposto. La tua partita è al sicuro, niente è andato perso.</p></div></div>
+            <div class="ec-e-acts"><button class="ec-e-retry">↻ Riprova</button><button class="ec-e-force">Forza chiusura locale</button></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · offline (pending sync) -->
+      <div class="phone" role="region" aria-label="Mobile · close offline">
+        <span class="frame-label">Mobile · offline (pending sync)</span>
+        <div class="phone-sbar"><span>23:06</span><span>✈️ 🔋 48%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span><button class="menu">⋮</button></div>
+        <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
+        <div class="tabs"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
+        <div class="content">
+          <div class="ec-summary ec-arch">
+            <div class="ec-s-badge">📥</div>
+            <span class="ec-s-kick">Archiviata · in coda</span>
+            <h2>Chiusura segnata</h2>
+            <p class="ec-s-camp">"La grotta dei Goblin"</p>
+            <span class="ec-pending"><span class="dot"></span>Pending sync · si completa online</span>
+            <div class="ec-cta-col" style="margin-top: var(--s-5);">
+              <button class="ec-btn-lib">🏠 Torna alla libreria</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · post-close Completata -->
+      <div class="phone" role="region" aria-label="Mobile · post-close completata">
+        <span class="frame-label">Mobile · post-close · Completata</span>
+        <div class="phone-sbar"><span>23:04</span><span>📶 🔋 49%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span></div>
+        <div class="content" style="padding: 0;">
+          <div class="ec-confetti" aria-hidden="true">
+            <i style="left: 12%; background: hsl(var(--c-toolkit)); animation-delay: 0s;"></i>
+            <i style="left: 28%; background: hsl(var(--c-session)); animation-delay: 0.2s;"></i>
+            <i style="left: 46%; background: hsl(var(--c-kb)); animation-delay: 0.1s;"></i>
+            <i style="left: 64%; background: hsl(var(--c-game)); animation-delay: 0.35s;"></i>
+            <i style="left: 82%; background: hsl(var(--c-chat)); animation-delay: 0.15s;"></i>
+          </div>
+          <div class="ec-summary ec-done">
+            <div class="ec-s-badge">🏆</div>
+            <span class="ec-s-kick">Completata</span>
+            <h2>Hai finito la storia!</h2>
+            <p class="ec-s-camp">"La grotta dei Goblin" · Tainted Grail</p>
+            <div class="ec-stats">
+              <div class="ec-stat"><div class="ec-st-v">3h 24m</div><div class="ec-st-k">Durata</div></div>
+              <div class="ec-stat"><div class="ec-st-v">47</div><div class="ec-st-k">Paragrafi visitati</div></div>
+              <div class="ec-stat"><div class="ec-st-v">12</div><div class="ec-st-k">Note diary</div></div>
+              <div class="ec-stat"><div class="ec-st-v">8</div><div class="ec-st-k">Foto translate</div></div>
+              <div class="ec-stat ec-wide"><span class="ec-st-k" style="margin: 0;">Chat regola</span><span class="ec-st-v">15</span></div>
+            </div>
+            <div class="ec-cta-col">
+              <button class="ec-btn-pdf">📄 Scarica PDF riassunto</button>
+              <span class="ec-pdf-note">Il PDF viene generato sul server · ~10s</span>
+              <button class="ec-btn-lib">🏠 Torna alla libreria</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile · post-close Archivia -->
+      <div class="phone" role="region" aria-label="Mobile · post-close archivia">
+        <span class="frame-label">Mobile · post-close · Archivia</span>
+        <div class="phone-sbar"><span>23:05</span><span>📶 🔋 49%</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span></div>
+        <div class="content" style="padding: 0;">
+          <div class="ec-summary ec-arch">
+            <div class="ec-s-badge">📥</div>
+            <span class="ec-s-kick">Archiviata</span>
+            <h2>Campagna messa via</h2>
+            <p class="ec-s-camp">"La grotta dei Goblin" · la riprendi quando vuoi</p>
+            <div class="ec-stats">
+              <div class="ec-stat"><div class="ec-st-v">3h 24m</div><div class="ec-st-k">Giocato finora</div></div>
+              <div class="ec-stat"><div class="ec-st-v">§214</div><div class="ec-st-k">Ultimo paragrafo</div></div>
+              <div class="ec-stat"><div class="ec-st-v">47</div><div class="ec-st-k">Paragrafi visitati</div></div>
+              <div class="ec-stat"><div class="ec-st-v">12</div><div class="ec-st-k">Note diary</div></div>
+            </div>
+            <div class="ec-cta-col">
+              <button class="ec-btn-reopen">▶️ Riapri campagna</button>
+              <button class="ec-btn-lib">🏠 Torna alla libreria</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · dialog 3-vie -->
+      <div class="desktop" role="region" aria-label="Desktop · dialog 3-vie">
+        <span class="frame-label">Desktop · dialog 3-vie</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?close=1</span></div>
+        <div class="d-body" style="position: relative;">
+          <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
+            <div class="side-card" style="margin-bottom: var(--s-2);"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div>
+            <nav style="display: flex; flex-direction: column; gap: 2px;"><button class="dy-navitem"><span class="em">📖</span>Story<span class="cnt">§214</span></button><button class="dy-navitem"><span class="em">📓</span>Diary<span class="cnt">12</span></button><button class="dy-navitem"><span class="em">🕰</span>History<span class="cnt">47</span></button></nav>
+            <div class="dy-d-foot"><button class="dy-endbtn" style="background: hsl(var(--c-session) / 0.12); color: hsl(var(--c-session)); border-color: hsl(var(--c-session) / 0.3);">🏁 Chiudi campagna</button></div>
+          </aside>
+          <div class="d-main" aria-hidden="true" style="opacity: 0.4;"></div>
+          <div class="ec-scrim ec-center" role="alertdialog" aria-modal="true" aria-labelledby="ec-d2-ti">
+            <div class="ec-dialog">
+              <h3 id="ec-d2-ti">Come vuoi chiudere?</h3>
+              <p class="ec-d-sub">"La grotta dei Goblin" · Cap 4 · §214</p>
+              <div class="ec-choices">
+                <button class="ec-choice" style="--e: var(--c-toolkit);" aria-pressed="true"><span class="ec-c-ic">✅</span><span class="ec-c-tx"><span class="ec-c-ti">Completata</span><span class="ec-c-ds">Ho finito la storia. Genero il PDF riassunto.</span></span><span class="ec-c-radio">✓</span></button>
+                <button class="ec-choice" style="--e: var(--c-session);" aria-pressed="false"><span class="ec-c-ic">📥</span><span class="ec-c-tx"><span class="ec-c-ti">Archivia</span><span class="ec-c-ds">Chiudo per ora, posso riaprire quando voglio.</span></span><span class="ec-c-radio"></span></button>
+                <button class="ec-choice" style="--e: var(--c-event);" aria-pressed="false"><span class="ec-c-ic">❌</span><span class="ec-c-tx"><span class="ec-c-ti">Abbandona</span><span class="ec-c-ds">Chiudo definitivamente.</span><span class="ec-c-note">Riapri con un solo tap</span></span><span class="ec-c-radio"></span></button>
+              </div>
+              <div class="ec-d-acts"><button class="ec-d-cancel">Annulla</button><button class="ec-d-confirm" style="--e: var(--c-toolkit);">Completa campagna</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop · post-close Completata -->
+      <div class="desktop" role="region" aria-label="Desktop · post-close completata">
+        <span class="frame-label">Desktop · post-close · Completata</span>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1/summary</span></div>
+        <div class="d-body" style="justify-content: center; align-items: center; position: relative;">
+          <div class="ec-confetti" aria-hidden="true"><i style="left: 20%; background: hsl(var(--c-toolkit));"></i><i style="left: 40%; background: hsl(var(--c-session)); animation-delay: 0.2s;"></i><i style="left: 60%; background: hsl(var(--c-kb)); animation-delay: 0.1s;"></i><i style="left: 78%; background: hsl(var(--c-game)); animation-delay: 0.3s;"></i></div>
+          <div class="ec-summary ec-done" style="max-width: 460px; overflow: visible;">
+            <div class="ec-s-badge">🏆</div>
+            <span class="ec-s-kick">Completata</span>
+            <h2>Hai finito la storia!</h2>
+            <p class="ec-s-camp">"La grotta dei Goblin" · Tainted Grail</p>
+            <div class="ec-stats" style="grid-template-columns: repeat(3, 1fr);">
+              <div class="ec-stat"><div class="ec-st-v">3h 24m</div><div class="ec-st-k">Durata</div></div>
+              <div class="ec-stat"><div class="ec-st-v">47</div><div class="ec-st-k">Paragrafi</div></div>
+              <div class="ec-stat"><div class="ec-st-v">12</div><div class="ec-st-k">Note diary</div></div>
+              <div class="ec-stat"><div class="ec-st-v">8</div><div class="ec-st-k">Foto translate</div></div>
+              <div class="ec-stat"><div class="ec-st-v">15</div><div class="ec-st-k">Chat regola</div></div>
+              <div class="ec-stat"><div class="ec-st-v">100%</div><div class="ec-st-k">Storia</div></div>
+            </div>
+            <div class="ec-cta-col" style="flex-direction: row;">
+              <button class="ec-btn-pdf" style="flex: 1;">📄 Scarica PDF riassunto</button>
+              <button class="ec-btn-lib" style="flex: 1;">🏠 Libreria</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ─── state-07 · END CAMPAIGN LAB (interattivo) ─── -->
+  <section class="state-section" aria-labelledby="s7lab">
+    <span class="label">Stato 07 · End Campaign Lab (interattivo)<span class="cmp">React · Babel standalone</span></span>
+    <h2 id="s7lab">Flusso chiusura — kebab → scegli → conferma → summary</h2>
+    <p class="desc">Versione runnable di state-07. Apri il kebab ⋮ → "Chiudi campagna" → scegli una delle 3 vie (il CTA e l'accent cambiano) → conferma: parte il loading e arriva il summary corretto (PDF solo per Completata, Riapri per Archivia/Abbandona). Il selettore "Esito server" forza loading/error/offline alla conferma. Sorgente: <code>librogame-runthrough-play-session.jsx</code>.</p>
+    <div id="endcampaign-lab-root"></div>
+  </section>
+
 </main>
 
 <!-- DEMO-NAV flow links: other librogame screens reachable from this shell -->
@@ -613,5 +1631,11 @@
     r.dataset.theme = r.dataset.theme === 'dark' ? 'light' : 'dark';
   });
 </script>
+
+<!-- ─── SP8 interactive lab loaders (append-only, below freeze line) ─── -->
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="librogame-runthrough-play-session.jsx"></script>
 </body>
 </html>

--- a/admin-mockups/design_files/librogame-runthrough-play-session.jsx
+++ b/admin-mockups/design_files/librogame-runthrough-play-session.jsx
@@ -1,0 +1,873 @@
+/* ════════════════════════════════════════════════════════════════
+   librogame-runthrough-play-session.jsx
+   Schermata : Librogame Play Session Shell — interattivo (SP8 companion)
+   Route     : /library/librogame/play/{campaignId}
+   Descrizione: versione runnable Babel-standalone delle estensioni SP8.
+                Monta nel #diary-lab-root in fondo a
+                librogame-runthrough-play-session.html (la gallery statica
+                sopra resta la fonte di verità pixel-perfect; questo lab è la
+                controparte cliccabile).
+   Brief      : SP8-libro-game-companion. Persona Aaron, companion model
+                single-user. NON ridisegna i 4 stati congelati.
+   Stato      : ⏳ state-05 Diary (questa risposta).
+                state-06 Paragrafi drawer + state-07 End campaign verranno
+                APPESI in coda a questo file nelle risposte 2 e 3.
+   Dati       : inline (data.js è read-only). Tainted Grail · "La grotta dei
+                Goblin" · Cap 4 · §214 · glossario Niamh/Korak/Pietra Spettrale.
+   ════════════════════════════════════════════════════════════════ */
+
+const { useState, useEffect, useRef, useCallback } = React;
+
+/* ─── entityHsl helper inline (palette 9 entity, da brief) ─── */
+const ENTITY_HSL = {
+  game:    '25 95% 45%',  player:  '262 83% 58%',  session: '240 60% 55%',
+  agent:   '38 92% 50%',  kb:      '174 60% 40%',   chat:    '220 80% 55%',
+  event:   '350 89% 60%', toolkit: '142 70% 45%',   tool:    '195 80% 50%',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(${ENTITY_HSL[entity]} / ${alpha})` : `hsl(${ENTITY_HSL[entity]})`;
+/* in dark mode i token entity cambiano: per coerenza tema usiamo le CSS var live */
+const eVar = (entity, alpha) =>
+  alpha != null ? `hsl(var(--c-${entity}) / ${alpha})` : `hsl(var(--c-${entity}))`;
+
+/* ─── paragrafo corrente della sessione (auto-pin) ─── */
+const CURRENT_PARA = '§214';
+
+/* ─── note seed per ciascuno stato (inline, NON da data.js) ─── */
+const SEED_DEFAULT = [
+  { id: 'diary-12', para: '§214', time: '5 min fa',     text: 'Goblin liberati senza combattere — bonus reputazione **+2**. Niamh sembra fidarsi di più del gruppo adesso.' },
+  { id: 'diary-11', para: '§198', time: 'ieri 21:34',   text: 'NPC **Korak** mi deve un favore, citato a §134. Da rigiocare se serve un passaggio sicuro.' },
+  { id: 'diary-09', para: '§134', time: '12 mag 21:34', text: 'Tesoro nella grotta non preso, tornare dopo §340. La **Spada di Avalon** è ancora là.' },
+];
+const SEED_OFFLINE = [
+  { id: 'diary-12', para: '§214', time: '5 min fa', text: 'Goblin liberati senza combattere — bonus reputazione **+2**. Niamh si fida di più.' },
+];
+const SEED_ERROR = [
+  { id: 'diary-draft', para: '§214', time: 'ora · non sincr.', text: 'Combattuto i 2 Goblin a §214. **Korak** è caduto al secondo turno — loot 14 oro.', unsynced: true },
+];
+
+const seedFor = (st) =>
+  st === 'empty' ? [] :
+  st === 'offline' ? SEED_OFFLINE.map(n => ({ ...n })) :
+  st === 'error' ? SEED_ERROR.map(n => ({ ...n })) :
+  SEED_DEFAULT.map(n => ({ ...n }));
+
+/* ─── render markdown statico: **bold** + §NNN ref chip ─── */
+function renderMarkdown(text) {
+  const out = [];
+  // split su **bold**
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  parts.forEach((part, i) => {
+    if (/^\*\*[^*]+\*\*$/.test(part)) {
+      out.push(<strong key={'b' + i}>{part.slice(2, -2)}</strong>);
+      return;
+    }
+    // dentro al testo normale, evidenzia §NNN
+    const segs = part.split(/(§\d+)/g);
+    segs.forEach((seg, j) => {
+      if (/^§\d+$/.test(seg)) out.push(<span key={'r' + i + '_' + j} className="dy-ref">{seg}</span>);
+      else if (seg) out.push(<React.Fragment key={'t' + i + '_' + j}>{seg}</React.Fragment>);
+    });
+  });
+  return out;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   useDiary — stato condiviso fra frame mobile e desktop
+   ════════════════════════════════════════════════════════════════ */
+function useDiary(lisaState) {
+  const [notes, setNotes] = useState(() => seedFor(lisaState));
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [expanded, setExpanded] = useState(() => new Set());
+
+  // reset quando cambia lo stato del lab
+  useEffect(() => {
+    setNotes(seedFor(lisaState));
+    setEditorOpen(false); setDraft(''); setEditingId(null); setExpanded(new Set());
+  }, [lisaState]);
+
+  const openNew = () => { setEditingId(null); setDraft(''); setEditorOpen(true); };
+  const openEdit = (n) => { setEditingId(n.id); setDraft(n.text); setEditorOpen(true); };
+  const cancel = () => { setEditorOpen(false); setDraft(''); setEditingId(null); };
+  const canSave = draft.trim().length > 0;
+  const save = () => {
+    if (!canSave) return;
+    if (editingId) {
+      setNotes(ns => ns.map(n => n.id === editingId ? { ...n, text: draft.trim(), time: 'ora · modificata' } : n));
+    } else {
+      const id = 'diary-' + Math.random().toString(36).slice(2, 7);
+      setNotes(ns => [{ id, para: CURRENT_PARA, time: 'ora', text: draft.trim() }, ...ns]);
+    }
+    cancel();
+  };
+  const del = (id) => setNotes(ns => ns.filter(n => n.id !== id));
+  const toggleExpand = (id) => setExpanded(s => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  return { notes, editorOpen, draft, setDraft, editingId, canSave, expanded,
+           openNew, openEdit, cancel, save, del, toggleExpand };
+}
+
+/* ─── singola entry ─── */
+function DiaryEntry({ n, expanded, onExpand, onEdit, onDelete, desktop }) {
+  const long = n.text.length > 90;
+  const isOpen = desktop || expanded;
+  return (
+    <div className="dy-entry">
+      <div className="dy-meta">
+        <span className="dy-pin">📌 {n.para}</span>
+        <span className="dy-time">{n.time}</span>
+        {n.unsynced && <span className="dy-localsave"><span className="dot"></span>locale</span>}
+      </div>
+      <p className={`dy-body${isOpen ? ' dy-full' : ''}`}>{renderMarkdown(n.text)}</p>
+      {long && !desktop && (
+        <button className="dy-expand" onClick={() => onExpand(n.id)}>{expanded ? 'comprimi' : 'espandi'}</button>
+      )}
+      <div className="dy-acts">
+        <button className="dy-act" onClick={() => onEdit(n)}>✏️ Modifica</button>
+        <button className="dy-act dy-del" onClick={() => onDelete(n.id)}>🗑️ Elimina</button>
+      </div>
+    </div>
+  );
+}
+
+/* ─── editor markdown (condiviso) ─── */
+function DiaryEditor({ d, desktop }) {
+  const taRef = useRef(null);
+  useEffect(() => { if (taRef.current) taRef.current.focus(); }, []);
+  const insert = (wrap) => {
+    const ta = taRef.current; if (!ta) return;
+    const s = ta.selectionStart, e = ta.selectionEnd;
+    const sel = d.draft.slice(s, e) || '';
+    const next = d.draft.slice(0, s) + wrap + sel + wrap + d.draft.slice(e);
+    d.setDraft(next);
+    requestAnimationFrame(() => { ta.focus(); ta.selectionStart = ta.selectionEnd = s + wrap.length + sel.length; });
+  };
+  const insertPara = () => {
+    const ta = taRef.current; if (!ta) return;
+    const s = ta.selectionStart;
+    const next = d.draft.slice(0, s) + CURRENT_PARA + d.draft.slice(s);
+    d.setDraft(next);
+    requestAnimationFrame(() => { ta.focus(); ta.selectionStart = ta.selectionEnd = s + CURRENT_PARA.length; });
+  };
+  const editorStyle = desktop
+    ? { position: 'relative', inset: 'auto', border: '1px solid var(--border)', borderRadius: 'var(--r-lg)', overflow: 'hidden', height: '100%' }
+    : null;
+  return (
+    <div className="dy-editor" style={editorStyle} role="dialog" aria-label={`${d.editingId ? 'Modifica' : 'Nuova'} nota ${CURRENT_PARA}`}>
+      <div className="dy-ed-top">
+        <button className="dy-cancel" onClick={d.cancel}>← Annulla</button>
+        <span className="dy-ed-ti">Nota {CURRENT_PARA}</span>
+        <button className="dy-save" disabled={!d.canSave} onClick={d.save}>Salva</button>
+      </div>
+      <div className="dy-toolbar">
+        <button className="dy-tool" aria-label="Grassetto" onClick={() => insert('**')}>B</button>
+        <button className="dy-tool" style={{ fontStyle: 'italic' }} aria-label="Corsivo" onClick={() => insert('*')}>I</button>
+        <button className="dy-tool" style={{ textDecoration: 'underline' }} aria-label="Sottolineato" onClick={() => insert('__')}>U</button>
+        <button className="dy-tool dy-pintool" aria-label="Collega paragrafo" onClick={insertPara}>📌</button>
+        <button className="dy-tool" aria-label="Link" onClick={() => insert('[]')}>🔗</button>
+        <span className="dy-draft"><span className="dot"></span>Bozza salvata</span>
+      </div>
+      <textarea ref={taRef} className="dy-textarea" aria-label="Testo nota" aria-multiline="true"
+        placeholder="Scrivi quello che vuoi ricordare… (markdown)"
+        value={d.draft} onChange={(e) => d.setDraft(e.target.value)} />
+      {d.draft.trim().length > 0 && (
+        <div className="dy-preview">
+          <div className="dy-pv-lbl">Anteprima live</div>
+          <p className="dy-body">{renderMarkdown(d.draft)}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── skeleton loading ─── */
+function DiarySkeleton() {
+  return (
+    <React.Fragment>
+      <div className="dy-skel"><div className="ln dy-shimmer" style={{ width: '35%' }}></div><div className="ln dy-shimmer" style={{ width: '90%' }}></div><div className="ln dy-shimmer" style={{ width: '70%', marginBottom: 0 }}></div></div>
+      <div className="dy-skel"><div className="ln dy-shimmer" style={{ width: '35%' }}></div><div className="ln dy-shimmer" style={{ width: '80%' }}></div><div className="ln dy-shimmer" style={{ width: '55%', marginBottom: 0 }}></div></div>
+    </React.Fragment>
+  );
+}
+
+/* ─── corpo diary (lista o editor) condiviso mobile/desktop ─── */
+function DiaryBody({ d, lisaState, desktop }) {
+  if (lisaState === 'loading') {
+    return (
+      <div aria-busy="true">
+        <button className="dy-newcta" style={{ opacity: 0.5, maxWidth: desktop ? 200 : undefined }} disabled>＋ Nuova nota</button>
+        <DiarySkeleton />
+      </div>
+    );
+  }
+  if (d.editorOpen) return <DiaryEditor d={d} desktop={desktop} />;
+  if (lisaState === 'empty' || d.notes.length === 0) {
+    return (
+      <div className="dy-empty">
+        <div className="dy-ill">📓</div>
+        <h3>Nessuna nota ancora</h3>
+        <p>Scrivi quello che vuoi ricordare — scelte, NPC, tesori lasciati indietro.</p>
+        <button className="dy-newcta" style={{ marginBottom: 0, maxWidth: 220 }} onClick={d.openNew}>✍️ Scrivi la prima</button>
+      </div>
+    );
+  }
+  return (
+    <React.Fragment>
+      {lisaState === 'error' && (
+        <div className="dy-banner err" role="alert">
+          <span className="dy-bic">⚠️</span>
+          <div className="dy-btx">
+            <strong style={{ color: eVar('event') }}>Errore salvataggio — riprova</strong>
+            <span className="dy-sub">La nota non è arrivata al server.</span>
+            <span className="dy-localsave"><span className="dot"></span>Salvata in locale · nessuna perdita</span>
+          </div>
+          <button className="dy-retry">↻ Riprova</button>
+        </div>
+      )}
+      {lisaState === 'offline' && (
+        <div className="dy-banner off" role="status">
+          <span className="dy-bic">📴</span>
+          <div className="dy-btx">
+            <strong style={{ color: eVar('tool') }}>Offline</strong>
+            <span className="dy-sub">La nota sarà salvata appena torni online.</span>
+            <span className="dy-localsave" style={{ color: eVar('tool') }}><span className="dot" style={{ background: eVar('tool') }}></span>1 in coda</span>
+          </div>
+        </div>
+      )}
+      <button className="dy-newcta" style={{ maxWidth: desktop ? 200 : undefined }} onClick={d.openNew}>＋ Nuova nota</button>
+      <div className="dy-timeline">
+        {d.notes.map(n => (
+          <DiaryEntry key={n.id} n={n} desktop={desktop}
+            expanded={d.expanded.has(n.id)} onExpand={d.toggleExpand}
+            onEdit={d.openEdit} onDelete={d.del} />
+        ))}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ─── shell mobile (375px) ─── */
+function PhoneFrame({ d, lisaState }) {
+  const offline = lisaState === 'offline';
+  const noteCount = lisaState === 'empty' ? 0 : 12;
+  return (
+    <div className="phone" role="region" aria-label="Mobile · diary interattivo">
+      <span className="frame-label">Mobile · 375px</span>
+      <div className="phone-sbar"><span>22:36</span><span>{offline ? '✈️' : '📶'} 🔋 58%</span></div>
+      <div className="session-h">
+        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">{CURRENT_PARA}</span></span>
+        <button className="menu" aria-label="Menu sessione">⋯</button>
+      </div>
+      <div className="header-pips">
+        <span className="manapip kb"><span className="badge">47</span></span>
+        <span className="manapip chat"><span className="badge">15</span></span>
+        <span className="manapip session"><span className="badge">1</span></span>
+        <span className="manapip toolkit"><span className="badge">12</span></span>
+        <span className="lbl-mini">· Cap 4 · note {noteCount}</span>
+      </div>
+      <div className="tabs dy-scroll" role="tablist">
+        <button className="tab" role="tab" aria-selected="false"><span className="em">📖</span>Story</button>
+        <button className="tab" role="tab" aria-selected="false"><span className="em">⚔️</span>Encounter</button>
+        <button className="tab" role="tab" aria-selected="false"><span className="em">📚</span>Glossario</button>
+        <button className="tab dy-diary" role="tab" aria-selected="true"><span className="em">📓</span>Diary</button>
+      </div>
+      <div className="content" style={d.editorOpen ? { padding: 0, position: 'relative' } : { position: 'relative' }}>
+        <DiaryBody d={d} lisaState={lisaState} desktop={false} />
+      </div>
+    </div>
+  );
+}
+
+/* ─── shell desktop (split-view) ─── */
+function DesktopFrame({ d, lisaState }) {
+  return (
+    <div className="desktop" role="region" aria-label="Desktop · diary interattivo">
+      <span className="frame-label">Desktop · 1440px (scaled)</span>
+      <div className="titlebar">
+        <span className="dot r"></span><span className="dot y"></span><span className="dot g"></span>
+        <span className="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary</span>
+      </div>
+      <div className="d-body">
+        <aside className="d-side" style={{ width: 260, display: 'flex', flexDirection: 'column' }}>
+          <div className="side-card" style={{ marginBottom: 'var(--s-2)' }}>
+            <h4>Campagna</h4>
+            <div className="row"><span className="k">Nome</span><span className="v">Grotta Goblin</span></div>
+            <div className="row"><span className="k">Capitolo</span><span className="v">4 · {CURRENT_PARA}</span></div>
+          </div>
+          <nav aria-label="Sezioni sessione" style={{ display: 'flex', flexDirection: 'column', gap: 2, marginBottom: 'var(--s-3)' }}>
+            <button className="dy-navitem"><span className="em">📖</span>Story<span className="cnt">{CURRENT_PARA}</span></button>
+            <button className="dy-navitem"><span className="em">⚔️</span>Encounter<span className="cnt">—</span></button>
+            <button className="dy-navitem"><span className="em">📚</span>Glossario<span className="cnt">12</span></button>
+            <button className="dy-navitem" aria-selected="true"><span className="em">📓</span>Diary<span className="cnt">{lisaState === 'empty' ? 0 : 12}</span></button>
+          </nav>
+          <div className="dy-d-foot"><button className="dy-endbtn">🏁 Chiudi campagna</button></div>
+        </aside>
+        <div className="d-main">
+          <DiaryBody d={d} lisaState={lisaState} desktop={true} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   DiaryLab — selettore stato + frame mobile/desktop in sync
+   ════════════════════════════════════════════════════════════════ */
+const LISA_STATES = [
+  { id: 'default', lb: 'Default' },
+  { id: 'empty',   lb: 'Vuoto' },
+  { id: 'loading', lb: 'Loading' },
+  { id: 'error',   lb: 'Errore save' },
+  { id: 'offline', lb: 'Offline' },
+];
+
+function DiaryLab() {
+  const [lisaState, setLisaState] = useState('default');
+  const d = useDiary(lisaState);
+  return (
+    <div>
+      <div className="dy-lab-bar" role="toolbar" aria-label="Stato diary">
+        <div className="grp">
+          <span className="lbl">Stato</span>
+          {LISA_STATES.map(s => (
+            <button key={s.id} className={`dy-seg${lisaState === s.id ? ' on' : ''}`}
+              aria-pressed={lisaState === s.id} onClick={() => setLisaState(s.id)}>{s.lb}</button>
+          ))}
+        </div>
+      </div>
+      <div className="frames">
+        <PhoneFrame d={d} lisaState={lisaState} />
+        <DesktopFrame d={d} lisaState={lisaState} />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('diary-lab-root')).render(<DiaryLab />);
+
+/* ════════════════════════════════════════════════════════════════
+   state-06 — Paragrafi visitati drawer (APPEND)
+   Function #5. Drawer canonico bottom-sheet (mobile) / side-panel (desktop).
+   Jump-back con conferma alertdialog. Search v1 = §numero/capitolo client-side.
+   ════════════════════════════════════════════════════════════════ */
+
+const HISTORY_SEED = [
+  { para: '§198', n: 198, when: '22 min fa', chap: 'Cap 4', snip: "Entri nel corridoio buio, una corrente d'aria spegne la torcia. In fondo senti un raschiare metallico." },
+  { para: '§189', n: 189, when: '1h fa',     chap: 'Cap 4', snip: 'Il ponte di corda oscilla sul precipizio. Niamh ti fa cenno di aspettare prima di attraversare.' },
+  { para: '§134', n: 134, when: '2h fa',     chap: 'Cap 3', snip: 'Korak ti porge la mano: "Ti devo un favore. Cercami quando avrai bisogno di passare il valico."' },
+];
+
+const HIST_STATES = [
+  { id: 'default', lb: 'Default' },
+  { id: 'empty',   lb: 'Vuoto' },
+  { id: 'loading', lb: 'Loading' },
+  { id: 'error',   lb: 'Errore' },
+  { id: 'offline', lb: 'Offline' },
+];
+
+/* hook condiviso mobile/desktop */
+function useHistory(histState) {
+  const [open, setOpen] = useState(true);
+  const [query, setQuery] = useState('');
+  const [confirmTarget, setConfirmTarget] = useState(null); // entry o null
+  const [currentPara, setCurrentPara] = useState('§214');
+  const [toast, setToast] = useState(null);
+
+  useEffect(() => {
+    setOpen(true); setQuery(''); setConfirmTarget(null); setCurrentPara('§214'); setToast(null);
+  }, [histState]);
+
+  const rows = histState === 'empty' ? [] : HISTORY_SEED;
+  const filtered = rows.filter(r => {
+    const q = query.trim().toLowerCase().replace(/^§/, '');
+    if (!q) return true;
+    return String(r.n).includes(q) || r.chap.toLowerCase().includes(q) || ('cap ' + r.chap).includes(q);
+  });
+
+  const askJump = (entry) => setConfirmTarget(entry);
+  const cancelJump = () => setConfirmTarget(null);
+  const doJump = () => {
+    const prev = currentPara;
+    setCurrentPara(confirmTarget.para);
+    setToast(`Tornato a ${confirmTarget.para} · ${prev} resta in history`);
+    setConfirmTarget(null);
+    setOpen(false);
+    setTimeout(() => setToast(null), 2600);
+  };
+
+  return { open, setOpen, query, setQuery, confirmTarget, askJump, cancelJump, doJump,
+           currentPara, rows, filtered, toast, histState };
+}
+
+/* riga history */
+function HistoryRow({ r, disabled, onJump }) {
+  return (
+    <div className="hy-row">
+      <div className="hy-r-top">
+        <span className="hy-para">{r.para}</span>
+        <span className="hy-when">{r.when}</span>
+        <span className="hy-chap">{r.chap}</span>
+      </div>
+      <p className="hy-snip">{r.snip}</p>
+      {disabled ? (
+        <div className="hy-goto-wrap"><span className="hy-tip">Disponibile online</span><button className="hy-goto" disabled>→ vai qui</button></div>
+      ) : (
+        <button className="hy-goto" onClick={() => onJump(r)}>→ vai qui</button>
+      )}
+    </div>
+  );
+}
+
+/* corpo drawer condiviso */
+function HistoryBody({ h, desktop }) {
+  const offline = h.histState === 'offline';
+  return (
+    <React.Fragment>
+      <div className="hy-head">
+        <span className="hy-title">🕰 Paragrafi visitati</span>
+        <button className="hy-x" aria-label="Chiudi" onClick={() => h.setOpen(false)}>✕</button>
+      </div>
+
+      {h.histState !== 'empty' && h.histState !== 'error' && (
+        <div className="hy-search">
+          <div className="hy-field">
+            <span className="ic">🔍</span>
+            <input placeholder="Cerca per numero o capitolo…" aria-label="Cerca paragrafo"
+              value={h.query} onChange={(e) => h.setQuery(e.target.value)} />
+          </div>
+          <div className="hy-scope">Cerca per §numero o capitolo</div>
+        </div>
+      )}
+
+      {h.histState === 'error' && (
+        <div className="hy-banner err" role="alert">
+          <span className="hy-bic">⚠️</span>
+          <div className="hy-btx"><strong style={{ color: eVar('event') }}>Impossibile caricare la history</strong><span className="hy-sub">Controlla la connessione e riprova.</span></div>
+          <button className="hy-retry">↻ Riprova</button>
+        </div>
+      )}
+      {offline && (
+        <div className="hy-banner off" role="status">
+          <span className="hy-bic">📴</span>
+          <div className="hy-btx"><strong style={{ color: eVar('tool') }}>Offline — history in sola lettura</strong><span className="hy-sub">Il salto sarà disponibile quando torni online.</span></div>
+        </div>
+      )}
+
+      <div className="hy-current" style={h.histState === 'error' ? { opacity: 0.55 } : null}>
+        <span className="hy-now-pin">📍 {h.currentPara}</span>
+        <span className="hy-now-meta">Cap 4</span>
+        <span className="hy-now-tag">ora</span>
+      </div>
+
+      {h.histState === 'loading' ? (
+        <div className="hy-list">
+          {[95, 80, 70].map((w, i) => (
+            <div className="hy-skel" key={i}><div className="ln dy-shimmer" style={{ width: '45%' }}></div><div className="ln dy-shimmer" style={{ width: w + '%' }}></div><div className="ln dy-shimmer" style={{ width: '30%', marginBottom: 0 }}></div></div>
+          ))}
+        </div>
+      ) : h.histState === 'empty' ? (
+        <div className="hy-empty">
+          <div className="hy-ill">🧭</div>
+          <h3>Sei appena partito</h3>
+          <p>Continua a leggere per popolare la history dei paragrafi visitati.</p>
+        </div>
+      ) : h.histState === 'error' ? null : (
+        <div className="hy-list">
+          {h.filtered.length === 0 ? (
+            <div className="hy-empty" style={{ padding: 'var(--s-6)' }}>
+              <div className="hy-ill" style={{ width: 56, height: 56, fontSize: 28 }}>🔍</div>
+              <p>Nessun paragrafo per "{h.query}"</p>
+            </div>
+          ) : h.filtered.map(r => (
+            <HistoryRow key={r.para} r={r} disabled={offline} onJump={h.askJump} />
+          ))}
+        </div>
+      )}
+    </React.Fragment>
+  );
+}
+
+/* conferma jump-back (alertdialog) */
+function JumpConfirm({ h }) {
+  const goRef = useRef(null);
+  useEffect(() => { if (goRef.current) goRef.current.focus(); }, []);
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') h.cancelJump(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+  return (
+    <div className="hy-confirm-scrim" role="alertdialog" aria-modal="true" aria-labelledby="hyl-ti" aria-describedby="hyl-bd" onClick={(e) => { if (e.target === e.currentTarget) h.cancelJump(); }}>
+      <div className="hy-confirm">
+        <div className="hy-c-icon">↩️</div>
+        <h3 id="hyl-ti">Tornare al {h.confirmTarget.para}?</h3>
+        <p id="hyl-bd">Perderai la posizione corrente <span className="hy-ref">{h.currentPara}</span>. Il {h.currentPara} resterà comunque visitato nella history.</p>
+        <div className="hy-c-acts">
+          <button className="hy-c-cancel" onClick={h.cancelJump}>Annulla</button>
+          <button className="hy-c-go" ref={goRef} onClick={h.doJump}>Sì, torna</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* toast jump-confirmato (story → target) */
+function HistoryToast({ text }) {
+  return (
+    <div style={{ position: 'absolute', left: '50%', bottom: 'var(--s-5)', transform: 'translateX(-50%)', zIndex: 60, background: eVar('session'), color: '#fff', padding: 'var(--s-2) var(--s-4)', borderRadius: 'var(--r-pill)', fontFamily: 'var(--f-display)', fontWeight: 'var(--fw-bold)', fontSize: 'var(--fs-sm)', boxShadow: 'var(--shadow-lg)', maxWidth: '86%', textAlign: 'center' }} role="status">
+      ✓ {text}
+    </div>
+  );
+}
+
+/* shell mobile history */
+function HistoryPhone({ h }) {
+  const offline = h.histState === 'offline';
+  return (
+    <div className="phone" role="region" aria-label="Mobile · history interattiva">
+      <span className="frame-label">Mobile · 375px</span>
+      <div className="phone-sbar"><span>22:46</span><span>{offline ? '✈️' : '📶'} 🔋 55%</span></div>
+      <div className="session-h">
+        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">{h.currentPara}</span></span>
+        <button className="hy-trigger" aria-label="Paragrafi visitati" aria-expanded={h.open} onClick={() => h.setOpen(true)}>🕰</button>
+      </div>
+      <div className="header-pips"><span className="manapip kb"><span className="badge">47</span></span><span className="manapip session"><span className="badge">1</span></span><span className="manapip toolkit"><span className="badge">12</span></span><span className="lbl-mini">· Cap 4</span></div>
+      <div className="tabs"><button className="tab" aria-selected="true"><span className="em">📖</span>Story</button><button className="tab" aria-selected="false"><span className="em">⚔️</span>Encounter</button><button className="tab" aria-selected="false"><span className="em">📚</span>Glossario</button></div>
+      <div className="content">
+        <div className="para-card"><div className="num-row"><span className="num">{h.currentPara}</span><span className="chap">Cap 4</span></div><p className="text">La grotta si apre davanti a te, l'aria sa di muschio e metallo. Da qualche parte gocciola dell'acqua.</p></div>
+        {!h.open && (
+          <p style={{ textAlign: 'center', color: 'var(--text-muted)', fontFamily: 'var(--f-mono)', fontSize: 'var(--fs-xs)', marginTop: 'var(--s-5)' }}>Tocca 🕰 in alto per riaprire la history</p>
+        )}
+      </div>
+      {h.open && (
+        <div className="hy-scrim" role="dialog" aria-modal="true" aria-label="Paragrafi visitati" onClick={(e) => { if (e.target === e.currentTarget) h.setOpen(false); }}>
+          <div className="hy-sheet">
+            <div className="hy-drag"></div>
+            <HistoryBody h={h} desktop={false} />
+          </div>
+        </div>
+      )}
+      {h.confirmTarget && <JumpConfirm h={h} />}
+      {h.toast && <HistoryToast text={h.toast} />}
+    </div>
+  );
+}
+
+/* shell desktop history */
+function HistoryDesktop({ h }) {
+  return (
+    <div className="desktop" role="region" aria-label="Desktop · history interattiva">
+      <span className="frame-label">Desktop · 1440px (scaled)</span>
+      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-avalon-1?history={h.open ? 'open' : 'closed'}</span></div>
+      <div className="d-body" style={{ position: 'relative' }}>
+        <aside className="d-side" style={{ width: 260, display: 'flex', flexDirection: 'column' }}>
+          <div className="side-card" style={{ marginBottom: 'var(--s-2)' }}><h4>Campagna</h4><div className="row"><span className="k">Capitolo</span><span className="v">4 · {h.currentPara}</span></div></div>
+          <nav aria-label="Sezioni sessione" style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <button className="dy-navitem"><span className="em">📖</span>Story<span className="cnt">{h.currentPara}</span></button>
+            <button className="dy-navitem"><span className="em">⚔️</span>Encounter<span className="cnt">—</span></button>
+            <button className="dy-navitem"><span className="em">📚</span>Glossario<span className="cnt">12</span></button>
+            <button className="dy-navitem"><span className="em">📓</span>Diary<span className="cnt">12</span></button>
+            <button className="dy-navitem hy-secondary" aria-selected={h.open} onClick={() => h.setOpen(true)}><span className="em">🕰</span>History<span className="cnt">47</span></button>
+          </nav>
+        </aside>
+        <div className="d-main"><div className="para-card"><div className="num-row"><span className="num">{h.currentPara}</span><span className="chap">Cap 4</span></div><p className="text">La grotta si apre davanti a te, l'aria sa di muschio e metallo. Da qualche parte gocciola dell'acqua.</p></div></div>
+        {h.open && (
+          <div className="hy-side-host">
+            <div className="hy-side"><HistoryBody h={h} desktop={true} /></div>
+            <div className="hy-side-scrim" onClick={() => h.setOpen(false)}></div>
+          </div>
+        )}
+        {h.confirmTarget && <JumpConfirm h={h} />}
+        {h.toast && <HistoryToast text={h.toast} />}
+      </div>
+    </div>
+  );
+}
+
+function HistoryLab() {
+  const [histState, setHistState] = useState('default');
+  const h = useHistory(histState);
+  return (
+    <div>
+      <div className="dy-lab-bar" role="toolbar" aria-label="Stato history">
+        <div className="grp">
+          <span className="lbl">Stato</span>
+          {HIST_STATES.map(s => (
+            <button key={s.id} className={`dy-seg${histState === s.id ? ' on' : ''}`}
+              aria-pressed={histState === s.id} onClick={() => setHistState(s.id)}>{s.lb}</button>
+          ))}
+        </div>
+      </div>
+      <div className="frames">
+        <HistoryPhone h={h} />
+        <HistoryDesktop h={h} />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('history-lab-root')).render(<HistoryLab />);
+
+/* ════════════════════════════════════════════════════════════════
+   state-07 — End campaign (APPEND)
+   Function #8. Kebab → dialog 3-vie soft → loading → summary.
+   PDF CTA solo Completata. Reopen Abbandona = single-confirm (non-distruttivo).
+   ════════════════════════════════════════════════════════════════ */
+
+const CLOSE_OPTIONS = [
+  { id: 'done',     e: 'toolkit', ic: '✅', ti: 'Completata', ds: 'Ho finito la storia. Genero il PDF riassunto.', cta: 'Completa campagna' },
+  { id: 'archive',  e: 'session', ic: '📥', ti: 'Archivia',   ds: 'Chiudo per ora, posso riaprire quando voglio.',  cta: 'Archivia campagna' },
+  { id: 'abandon',  e: 'event',   ic: '❌', ti: 'Abbandona',  ds: 'Chiudo definitivamente.', note: 'Riapri con un solo tap', cta: 'Abbandona campagna' },
+];
+
+const CAMP_STATS = [
+  { v: '3h 24m', k: 'Durata' },
+  { v: '47', k: 'Paragrafi visitati' },
+  { v: '12', k: 'Note diary' },
+  { v: '8', k: 'Foto translate' },
+];
+
+const SERVER_OUTCOMES = [
+  { id: 'ok',      lb: 'Successo' },
+  { id: 'error',   lb: 'Errore' },
+  { id: 'offline', lb: 'Offline' },
+];
+
+function Confetti() {
+  const cols = ['toolkit', 'session', 'kb', 'game', 'chat'];
+  return (
+    <div className="ec-confetti" aria-hidden="true">
+      {Array.from({ length: 14 }).map((_, i) => (
+        <i key={i} style={{ left: (5 + i * 6.5) + '%', background: eVar(cols[i % cols.length]), animationDelay: (i % 5) * 0.12 + 's' }}></i>
+      ))}
+    </div>
+  );
+}
+
+function CloseSummary({ outcomeId, server, onReopen, onLib, onRetry, onForce }) {
+  const opt = CLOSE_OPTIONS.find(o => o.id === outcomeId);
+  const isDone = outcomeId === 'done';
+  const isArchive = outcomeId === 'archive';
+  const kind = isDone ? 'ec-done' : 'ec-arch';
+
+  if (server === 'error') {
+    return (
+      <div className="ec-error" role="alert" style={{ margin: 'var(--s-4)' }}>
+        <div className="ec-e-top"><span className="ec-e-ic">⚠️</span><div><h4>Impossibile chiudere — riprova</h4><p>Il server non ha risposto. La tua partita è al sicuro, niente è andato perso.</p></div></div>
+        <div className="ec-e-acts"><button className="ec-e-retry" onClick={onRetry}>↻ Riprova</button><button className="ec-e-force" onClick={onForce}>Forza chiusura locale</button></div>
+      </div>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      {isDone && server === 'ok' && <Confetti />}
+      <div className={`ec-summary ${kind}`} style={{ position: 'relative', zIndex: 2 }}>
+        <div className="ec-s-badge">{isDone ? '🏆' : '📥'}</div>
+        <span className="ec-s-kick">{isDone ? 'Completata' : (server === 'offline' ? 'Archiviata · in coda' : (isArchive ? 'Archiviata' : 'Abbandonata'))}</span>
+        <h2>{isDone ? 'Hai finito la storia!' : (isArchive ? 'Campagna messa via' : 'Campagna chiusa')}</h2>
+        <p className="ec-s-camp">"La grotta dei Goblin"{isDone ? ' · Tainted Grail' : ' · la riprendi quando vuoi'}</p>
+        {server === 'offline' && <span className="ec-pending"><span className="dot"></span>Pending sync · si completa online</span>}
+        {server !== 'offline' && (
+          <div className="ec-stats">
+            {CAMP_STATS.map(s => (
+              <div className="ec-stat" key={s.k}><div className="ec-st-v">{s.v}</div><div className="ec-st-k">{s.k}</div></div>
+            ))}
+            <div className="ec-stat ec-wide"><span className="ec-st-k" style={{ margin: 0 }}>Chat regola</span><span className="ec-st-v">15</span></div>
+          </div>
+        )}
+        <div className="ec-cta-col" style={{ marginTop: server === 'offline' ? 'var(--s-5)' : 0 }}>
+          {isDone && server === 'ok' && (
+            <React.Fragment>
+              <button className="ec-btn-pdf">📄 Scarica PDF riassunto</button>
+              <span className="ec-pdf-note">Il PDF viene generato sul server · ~10s</span>
+            </React.Fragment>
+          )}
+          {!isDone && server === 'ok' && (
+            <button className="ec-btn-reopen" onClick={onReopen}>▶️ Riapri campagna</button>
+          )}
+          <button className="ec-btn-lib" onClick={onLib}>🏠 Torna alla libreria</button>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* dialog 3-vie */
+function CloseDialog({ centered, selected, onSelect, onCancel, onConfirm }) {
+  const dRef = useRef(null);
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onCancel(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+  const opt = CLOSE_OPTIONS.find(o => o.id === selected);
+  return (
+    <div className={`ec-scrim${centered ? ' ec-center' : ''}`} role="alertdialog" aria-modal="true" aria-labelledby="ecl-ti" onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+      <div className="ec-dialog" ref={dRef}>
+        {!centered && <div className="ec-grab"></div>}
+        <h3 id="ecl-ti">Come vuoi chiudere?</h3>
+        <p className="ec-d-sub">"La grotta dei Goblin" · Cap 4 · §214</p>
+        <div className="ec-choices" role="radiogroup" aria-label="Modalità di chiusura">
+          {CLOSE_OPTIONS.map(o => (
+            <button key={o.id} className="ec-choice" style={{ '--e': `var(--c-${o.e})` }}
+              role="radio" aria-checked={selected === o.id} aria-pressed={selected === o.id}
+              onClick={() => onSelect(o.id)}>
+              <span className="ec-c-ic">{o.ic}</span>
+              <span className="ec-c-tx">
+                <span className="ec-c-ti">{o.ti}</span>
+                <span className="ec-c-ds">{o.ds}</span>
+                {o.note && <span className="ec-c-note">{o.note}</span>}
+              </span>
+              <span className="ec-c-radio">{selected === o.id ? '✓' : ''}</span>
+            </button>
+          ))}
+        </div>
+        <div className="ec-d-acts">
+          <button className="ec-d-cancel" onClick={onCancel}>Annulla</button>
+          <button className="ec-d-confirm" style={{ '--e': `var(--c-${opt ? opt.e : 'session'})` }} disabled={!selected} onClick={onConfirm}>
+            {opt ? opt.cta : 'Conferma'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function useEndCampaign(server) {
+  const [phase, setPhase] = useState('idle'); // idle | kebab | dialog | loading | summary
+  const [selected, setSelected] = useState('done');
+  const [outcome, setOutcome] = useState(null);
+
+  useEffect(() => { setPhase('idle'); setSelected('done'); setOutcome(null); }, [server]);
+
+  const confirm = () => {
+    setPhase('loading');
+    setTimeout(() => {
+      setOutcome(selected);
+      setPhase('summary');
+    }, server === 'ok' ? 1100 : 900);
+  };
+  const retry = () => { setPhase('loading'); setTimeout(() => setPhase('summary'), 1000); };
+  const reset = () => { setPhase('idle'); setOutcome(null); };
+
+  return { phase, setPhase, selected, setSelected, outcome, confirm, retry, reset };
+}
+
+function KebabMenu({ onClose }) {
+  return (
+    <div className="ec-kebab" role="menu" aria-label="Impostazioni sessione">
+      <div className="ec-k-lbl">Impostazioni sessione</div>
+      <button className="ec-kitem" role="menuitem">📦<span style={{ marginLeft: 6 }}>Esporta dati</span></button>
+      <div className="ec-k-div"></div>
+      <button className="ec-kitem ec-target" role="menuitem" onClick={onClose}>🏁<span style={{ marginLeft: 6 }}>Chiudi campagna</span></button>
+      <button className="ec-kitem" role="menuitem">⚙️<span style={{ marginLeft: 6 }}>Preferenze</span></button>
+    </div>
+  );
+}
+
+function EndPhone({ ec, server }) {
+  // error/offline: dopo loading mostriamo summary che internamente rende error/pending
+  const showSummary = ec.phase === 'summary';
+  return (
+    <div className="phone" role="region" aria-label="Mobile · end campaign interattivo">
+      <span className="frame-label">Mobile · 375px</span>
+      <div className="phone-sbar"><span>23:02</span><span>{server === 'offline' ? '✈️' : '📶'} 🔋 50%</span></div>
+      <div className="session-h">
+        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">§214</span></span>
+        {!showSummary && <button className="menu" aria-label="Menu sessione" aria-expanded={ec.phase === 'kebab'} onClick={() => ec.setPhase(ec.phase === 'kebab' ? 'idle' : 'kebab')}>⋮</button>}
+      </div>
+      {!showSummary && (
+        <React.Fragment>
+          <div className="header-pips"><span className="manapip kb"><span className="badge">47</span></span><span className="manapip session"><span className="badge">1</span></span><span className="manapip toolkit"><span className="badge">12</span></span></div>
+          <div className="tabs"><button className="tab" aria-selected="true"><span className="em">📖</span>Story</button><button className="tab" aria-selected="false"><span className="em">⚔️</span>Encounter</button><button className="tab" aria-selected="false"><span className="em">📚</span>Glossario</button></div>
+        </React.Fragment>
+      )}
+      <div className="content" style={showSummary ? { padding: 0, position: 'relative' } : { position: 'relative' }}>
+        {!showSummary && ec.phase !== 'dialog' && (
+          <div className="para-card"><div className="num-row"><span className="num">§214</span><span className="chap">Cap 4</span></div><p className="text">La grotta si apre davanti a te, l'aria sa di muschio e metallo. Da qualche parte gocciola dell'acqua.</p></div>
+        )}
+        {showSummary && (
+          <CloseSummary outcomeId={ec.outcome} server={server}
+            onReopen={ec.reset} onLib={ec.reset} onRetry={ec.retry} onForce={() => { /* forza locale */ ec.reset(); }} />
+        )}
+      </div>
+      {ec.phase === 'kebab' && <KebabMenu onClose={() => ec.setPhase('dialog')} />}
+      {ec.phase === 'dialog' && (
+        <CloseDialog selected={ec.selected} onSelect={ec.setSelected} onCancel={() => ec.setPhase('idle')} onConfirm={ec.confirm} />
+      )}
+      {ec.phase === 'loading' && (
+        <div className="ec-loading" role="status" aria-live="polite">
+          <div className="ec-spinner"></div>
+          <span className="ec-l-tx">Chiudendo la campagna…</span>
+          <span className="ec-l-sub">{ec.selected === 'done' ? 'Genero il riassunto e blocco i paragrafi' : 'Salvo lo stato della sessione'}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EndDesktop({ ec, server }) {
+  const showSummary = ec.phase === 'summary';
+  return (
+    <div className="desktop" role="region" aria-label="Desktop · end campaign interattivo">
+      <span className="frame-label">Desktop · 1440px (scaled)</span>
+      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-avalon-1{showSummary ? '/summary' : '?close=' + (ec.phase === 'dialog' ? '1' : '0')}</span></div>
+      <div className="d-body" style={{ position: 'relative', justifyContent: showSummary ? 'center' : undefined, alignItems: showSummary ? 'center' : undefined }}>
+        {!showSummary && (
+          <React.Fragment>
+            <aside className="d-side" style={{ width: 260, display: 'flex', flexDirection: 'column' }}>
+              <div className="side-card" style={{ marginBottom: 'var(--s-2)' }}><h4>Campagna</h4><div className="row"><span className="k">Capitolo</span><span className="v">4 · §214</span></div></div>
+              <nav style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <button className="dy-navitem"><span className="em">📖</span>Story<span className="cnt">§214</span></button>
+                <button className="dy-navitem"><span className="em">📓</span>Diary<span className="cnt">12</span></button>
+                <button className="dy-navitem"><span className="em">🕰</span>History<span className="cnt">47</span></button>
+              </nav>
+              <div className="dy-d-foot"><button className="dy-endbtn" style={{ background: eVar('session', 0.12), color: eVar('session'), borderColor: eVar('session', 0.3) }} onClick={() => ec.setPhase('dialog')}>🏁 Chiudi campagna</button></div>
+            </aside>
+            <div className="d-main"><div className="para-card"><div className="num-row"><span className="num">§214</span><span className="chap">Cap 4</span></div><p className="text">La grotta si apre davanti a te, l'aria sa di muschio e metallo. Da qualche parte gocciola dell'acqua.</p></div></div>
+          </React.Fragment>
+        )}
+        {showSummary && (
+          <div style={{ width: '100%', maxWidth: 480, position: 'relative' }}>
+            <CloseSummary outcomeId={ec.outcome} server={server}
+              onReopen={ec.reset} onLib={ec.reset} onRetry={ec.retry} onForce={ec.reset} />
+          </div>
+        )}
+        {ec.phase === 'dialog' && (
+          <CloseDialog centered selected={ec.selected} onSelect={ec.setSelected} onCancel={() => ec.setPhase('idle')} onConfirm={ec.confirm} />
+        )}
+        {ec.phase === 'loading' && (
+          <div className="ec-loading" role="status" aria-live="polite"><div className="ec-spinner"></div><span className="ec-l-tx">Chiudendo la campagna…</span><span className="ec-l-sub">{ec.selected === 'done' ? 'Genero il riassunto e blocco i paragrafi' : 'Salvo lo stato della sessione'}</span></div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EndCampaignLab() {
+  const [server, setServer] = useState('ok');
+  const ec = useEndCampaign(server);
+  return (
+    <div>
+      <div className="dy-lab-bar" role="toolbar" aria-label="Esito server alla conferma">
+        <div className="grp">
+          <span className="lbl">Esito server</span>
+          {SERVER_OUTCOMES.map(s => (
+            <button key={s.id} className={`dy-seg${server === s.id ? ' on' : ''}`}
+              aria-pressed={server === s.id} onClick={() => setServer(s.id)}>{s.lb}</button>
+          ))}
+        </div>
+        <button className="dy-seg" style={{ border: '1px solid var(--border)' }} onClick={ec.reset}>↺ Reset flow</button>
+      </div>
+      <div className="frames">
+        <EndPhone ec={ec} server={server} />
+        <EndDesktop ec={ec} server={server} />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('endcampaign-lab-root')).render(<EndCampaignLab />);

--- a/admin-mockups/design_files/sp4-library-mobile.html
+++ b/admin-mockups/design_files/sp4-library-mobile.html
@@ -1,0 +1,521 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>SP8 mobile-parity · Library mobile — /library</title>
+<!--
+  @route /library  (mobile <768px)
+  @scope sp4-library-mobile  (variante mobile-first di sp4-library-desktop.html)
+  @brief SP8-mobile-parity
+  @status in-design
+  Variante mobile-first del route /library: hero compatto + tab semplificate
+  (Games/Sessions/Chat + overflow Agents/KB) + grid 1-col MeepleCard list +
+  sezione Recente + bulk-select long-press + filters bottom-sheet 80vh.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700;800&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+<style>
+  /* ════════════════════════════════════════════════
+     SP8 Library Mobile — preview shell + component CSS
+     Tutti i valori da tokens.css. Nessun hex hardcoded.
+     ════════════════════════════════════════════════ */
+
+  body { min-height: 100vh; }
+
+  /* ─── Preview stage ─── */
+  .lab {
+    min-height: 100vh;
+    padding: var(--s-7) var(--s-5) var(--s-10);
+    display: flex; flex-direction: column; align-items: center;
+  }
+  .lab-head { max-width: 900px; text-align: center; margin-bottom: var(--s-5); }
+  .lab-head .kick {
+    font-family: var(--f-mono); font-size: var(--fs-xs);
+    text-transform: uppercase; letter-spacing: .12em; font-weight: 700;
+    color: hsl(var(--c-game));
+  }
+  .lab-head h1 { font-size: var(--fs-3xl); margin: var(--s-2) 0; }
+  .lab-head p { color: var(--text-sec); font-size: var(--fs-md); max-width: 640px; margin: 0 auto; line-height: var(--lh-snug); }
+
+  /* ─── Control bar ─── */
+  .controls {
+    position: sticky; top: var(--s-4); z-index: var(--z-nav);
+    display: flex; flex-wrap: wrap; gap: var(--s-2);
+    align-items: center; justify-content: center;
+    padding: var(--s-3) var(--s-4);
+    background: var(--glass-bg); backdrop-filter: blur(16px);
+    border: 1px solid var(--border); border-radius: var(--r-pill);
+    box-shadow: var(--shadow-md);
+    margin-bottom: var(--s-7);
+  }
+  .ctl-grp { display: flex; gap: 4px; align-items: center; }
+  .ctl-grp + .ctl-grp { border-left: 1px solid var(--border); padding-left: var(--s-2); }
+  .ctl-lbl {
+    font-family: var(--f-mono); font-size: 9px; text-transform: uppercase;
+    letter-spacing: .08em; color: var(--text-muted); font-weight: 700;
+    margin-right: 2px;
+  }
+  .seg {
+    padding: 6px 11px; border-radius: var(--r-pill); border: 1px solid transparent;
+    background: transparent; color: var(--text-sec);
+    font-family: var(--f-display); font-weight: 700; font-size: var(--fs-xs);
+    cursor: pointer; white-space: nowrap; transition: all var(--dur-sm) var(--ease-out);
+  }
+  .seg:hover { background: var(--bg-hover); color: var(--text); }
+  .seg.on { background: hsl(var(--c-game)); color: #fff; }
+  .seg.on.theme { background: var(--text); color: var(--bg); }
+
+  /* ─── Device frames ─── */
+  .stage-frames {
+    display: flex; gap: var(--s-9); align-items: flex-start;
+    justify-content: center; flex-wrap: wrap; width: 100%;
+  }
+  .frame-col { display: flex; flex-direction: column; align-items: center; gap: var(--s-3); }
+  .frame-tag {
+    font-family: var(--f-mono); font-size: var(--fs-xs); color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: .08em; font-weight: 700;
+  }
+  .frame-tag b { color: hsl(var(--c-game)); }
+
+  .device {
+    background: #1a1a1a; border-radius: 52px; padding: 12px;
+    box-shadow: 0 40px 90px rgba(90,60,20,.22), 0 0 0 2px #000;
+    flex-shrink: 0;
+  }
+  [data-theme="dark"] .device { box-shadow: 0 40px 90px rgba(0,0,0,.65), 0 0 0 2px #000; }
+  .device.tablet { border-radius: 40px; padding: 14px; }
+  .screen {
+    width: 375px; height: 760px; border-radius: 40px; overflow: hidden;
+    background: var(--bg); position: relative;
+    display: flex; flex-direction: column;
+  }
+  .device.tablet .screen { width: 768px; height: 760px; border-radius: 28px; }
+
+  /* status bar */
+  .sbar {
+    height: 30px; flex-shrink: 0; display: flex; align-items: center;
+    justify-content: space-between; padding: 8px 24px 0;
+    font-size: var(--fs-sm); font-weight: var(--fw-bold); color: var(--text);
+  }
+  .sbar .ind { display: flex; gap: 5px; font-size: var(--fs-xs); }
+
+  /* the actual app viewport */
+  .screen { color: var(--text); }
+  .app { flex: 1; min-height: 0; display: flex; flex-direction: column; position: relative; overflow: hidden; color: var(--text); }
+  .app-scroll { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; }
+  .app-scroll::-webkit-scrollbar { width: 0; }
+
+  /* ════════════ HEADER (compact hero) ════════════ */
+  .lh-header {
+    position: sticky; top: 0; z-index: var(--z-sticky);
+    background: var(--glass-bg); backdrop-filter: blur(18px);
+    border-bottom: 1px solid var(--border);
+  }
+  .lh-bar {
+    display: flex; align-items: center; gap: var(--s-3);
+    padding: var(--s-3) var(--s-4) var(--s-2);
+  }
+  .lh-mark {
+    width: 34px; height: 34px; border-radius: var(--r-md); flex-shrink: 0;
+    background: linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)));
+    color: #fff; display: flex; align-items: center; justify-content: center;
+    font-family: var(--f-display); font-weight: var(--fw-ext); font-size: var(--fs-lg);
+    box-shadow: var(--shadow-xs);
+  }
+  .lh-titles { flex: 1; min-width: 0; }
+  .lh-titles .t { font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-xl); line-height: 1.1; color: var(--text); }
+  .lh-titles .s { font-size: var(--fs-xs); color: var(--text-muted); margin-top: 1px; }
+  .lh-icon {
+    width: 44px; height: 44px; border-radius: var(--r-md); flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    background: transparent; border: none; color: var(--text-sec); font-size: 20px;
+    position: relative; transition: background var(--dur-sm) var(--ease-out);
+  }
+  .lh-icon:hover { background: var(--bg-hover); }
+  .lh-icon .ndot {
+    position: absolute; top: 9px; right: 9px; width: 8px; height: 8px;
+    border-radius: 50%; background: hsl(var(--c-event));
+    box-shadow: 0 0 0 2px var(--bg-card);
+  }
+
+  /* ── Tabs ── */
+  .lh-tabs {
+    display: flex; align-items: stretch; gap: 2px;
+    padding: 0 var(--s-3); position: relative;
+  }
+  .lh-tab {
+    appearance: none; border: none; background: transparent; cursor: pointer;
+    padding: 10px 12px 12px; min-height: 44px;
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-base);
+    color: var(--text-muted); border-bottom: 2.5px solid transparent;
+    transition: color var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out);
+    white-space: nowrap;
+  }
+  .lh-tab[aria-selected="true"] { color: hsl(var(--e, var(--c-game))); border-bottom-color: hsl(var(--e, var(--c-game))); }
+  .lh-tab .cnt {
+    font-family: var(--f-display); font-size: 10px; font-weight: var(--fw-ext);
+    padding: 1px 6px; border-radius: var(--r-pill); background: var(--bg-muted); color: var(--text-muted);
+  }
+  .lh-tab[aria-selected="true"] .cnt { background: hsl(var(--e, var(--c-game))); color: #fff; }
+  .lh-more {
+    margin-left: auto; appearance: none; border: none; background: transparent; cursor: pointer;
+    min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center;
+    gap: 3px; color: var(--text-muted); font-size: 22px; position: relative;
+    border-bottom: 2.5px solid transparent; transition: color var(--dur-sm);
+  }
+  .lh-more:hover { color: var(--text); }
+  .lh-more.active-overflow { color: hsl(var(--c-agent)); border-bottom-color: hsl(var(--c-agent)); }
+  .lh-more .ndot {
+    position: absolute; top: 10px; right: 8px; width: 7px; height: 7px; border-radius: 50%;
+    background: hsl(var(--c-agent)); box-shadow: 0 0 0 2px var(--glass-bg);
+  }
+
+  /* ── Search + filter row ── */
+  .lh-search { display: flex; gap: var(--s-2); padding: var(--s-2) var(--s-4) var(--s-3); }
+  .lh-search .field {
+    flex: 1; position: relative; display: flex; align-items: center;
+  }
+  .lh-search .field .ic { position: absolute; left: 11px; font-size: 14px; opacity: .55; pointer-events: none; }
+  .lh-search input {
+    width: 100%; height: 40px; padding: 0 12px 0 34px;
+    border-radius: var(--r-md); border: 1.5px solid var(--border);
+    background: var(--bg-card); color: var(--text);
+    font-family: var(--f-body); font-size: var(--fs-base); outline: none;
+    transition: border-color var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm) var(--ease-out);
+  }
+  .lh-search input:focus { border-color: hsl(var(--c-game) / .6); box-shadow: 0 0 0 3px hsl(var(--c-game) / .14); }
+  .lh-filter {
+    min-width: 44px; height: 40px; padding: 0 12px; flex-shrink: 0;
+    display: inline-flex; align-items: center; gap: 6px;
+    border-radius: var(--r-md); border: 1.5px solid var(--border);
+    background: var(--bg-card); color: var(--text-sec);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    cursor: pointer; transition: all var(--dur-sm) var(--ease-out);
+  }
+  .lh-filter:hover { border-color: var(--border-strong); }
+  .lh-filter.has-active { border-color: hsl(var(--c-game) / .5); color: hsl(var(--c-game)); background: hsl(var(--c-game) / .08); }
+  .lh-filter .badge {
+    font-size: 9px; font-weight: var(--fw-ext); padding: 0 5px; border-radius: var(--r-pill);
+    background: hsl(var(--c-game)); color: #fff;
+  }
+
+  /* ════════════ BODY ════════════ */
+  .lh-body { padding: var(--s-2) 0 var(--s-9); }
+
+  /* active filter chips */
+  .filterchips { display: flex; gap: 6px; flex-wrap: wrap; padding: var(--s-2) var(--s-4) var(--s-3); }
+  .filterchips .lbl { font-size: var(--fs-xs); color: var(--text-muted); font-family: var(--f-mono); align-self: center; text-transform: uppercase; letter-spacing: .06em; }
+  .fchip {
+    display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+    padding: 5px 8px 5px 10px; border-radius: var(--r-pill);
+    background: hsl(var(--c-game) / .12); color: hsl(var(--c-game));
+    border: 1px solid hsl(var(--c-game) / .25);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-xs);
+  }
+  .fchip .x { font-size: 12px; opacity: .8; line-height: 1; }
+  .fchip:hover { background: hsl(var(--c-game) / .18); }
+
+  /* ── MeepleCard list variant ── */
+  .mlist { display: flex; flex-direction: column; gap: var(--s-2); padding: 0 var(--s-4); }
+  .device.tablet .mlist { display: grid; grid-template-columns: 1fr 1fr; gap: var(--s-3); }
+
+  .mcard {
+    --e: var(--c-game);
+    display: flex; align-items: stretch; gap: var(--s-3);
+    padding: var(--s-2); border-radius: var(--r-lg);
+    background: var(--bg-card); border: 1px solid var(--border);
+    box-shadow: var(--shadow-xs); cursor: pointer; position: relative;
+    user-select: none; -webkit-user-select: none; -webkit-tap-highlight-color: transparent;
+    transition: transform var(--dur-sm) var(--ease-out), box-shadow var(--dur-sm) var(--ease-out),
+                border-color var(--dur-sm) var(--ease-out);
+  }
+  .mcard:active { transform: scale(.985); }
+  .mcard.lp-arming { transform: scale(.96); box-shadow: 0 0 0 2px hsl(var(--e) / .4), var(--shadow-sm); }
+  .mcard.selected { border-color: hsl(var(--e) / .55); background: hsl(var(--e) / .06); }
+  .mcard .cov {
+    width: 68px; height: 68px; flex-shrink: 0; border-radius: var(--r-md);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 30px; color: rgba(255,255,255,.92); text-shadow: 0 2px 6px rgba(0,0,0,.25);
+    overflow: hidden; position: relative;
+  }
+  .device.tablet .mcard .cov { width: 64px; height: 64px; }
+  .mcard .body { flex: 1; min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 3px; padding: 2px 0; }
+  .mcard .title-row { display: flex; align-items: center; gap: 6px; }
+  .mcard .ti {
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md);
+    line-height: 1.15; color: var(--text);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .mcard .sub { font-size: var(--fs-xs); color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mcard .meta { display: flex; align-items: center; gap: var(--s-2); margin-top: 2px; flex-wrap: wrap; }
+  .mcard .meta .mi { display: inline-flex; align-items: center; gap: 3px; font-size: var(--fs-xs); color: var(--text-sec); font-weight: var(--fw-semi); }
+  .mcard .meta .star { color: hsl(var(--c-warning)); }
+  .mcard .chevron { align-self: center; color: var(--text-muted); font-size: 16px; flex-shrink: 0; padding-right: 4px; }
+
+  /* entity chip (badge pill) */
+  .e-chip2 {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 1px 7px; border-radius: var(--r-sm);
+    background: hsl(var(--e) / .14); color: hsl(var(--e));
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: 10px;
+    text-transform: uppercase; letter-spacing: .03em; flex-shrink: 0;
+  }
+
+  /* bulk checkbox */
+  .mcard .check {
+    align-self: center; width: 24px; height: 24px; flex-shrink: 0; margin-left: 2px;
+    border-radius: var(--r-sm); border: 2px solid var(--border-strong);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 14px; transition: all var(--dur-sm) var(--ease-out);
+  }
+  .mcard.selected .check { background: hsl(var(--e)); border-color: hsl(var(--e)); }
+
+  /* load more */
+  .loadmore { padding: var(--s-4) var(--s-4) var(--s-3); }
+  .device.tablet .loadmore { grid-column: 1 / -1; }
+  .loadmore button {
+    width: 100%; padding: 12px; min-height: 44px; border-radius: var(--r-md);
+    border: 1.5px dashed var(--border-strong); background: transparent; color: var(--text-sec);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    transition: all var(--dur-sm) var(--ease-out);
+  }
+  .loadmore button:hover { border-color: hsl(var(--c-game) / .5); color: hsl(var(--c-game)); background: hsl(var(--c-game) / .05); }
+  .loadmore .done { text-align: center; font-size: var(--fs-xs); color: var(--text-muted); font-family: var(--f-mono); }
+
+  /* ── Recente section ── */
+  .recent { margin-top: var(--s-5); padding: 0 var(--s-4); }
+  .device.tablet .recent { grid-column: 1 / -1; }
+  .recent .rdiv {
+    display: flex; align-items: center; gap: var(--s-3); margin-bottom: var(--s-3);
+  }
+  .recent .rdiv .ln { flex: 1; height: 1px; background: var(--border); }
+  .recent .rdiv .tx {
+    font-family: var(--f-mono); font-size: var(--fs-xs); text-transform: uppercase;
+    letter-spacing: .1em; color: var(--text-muted); font-weight: 700;
+  }
+  .recent .rrow {
+    display: flex; align-items: center; gap: var(--s-3);
+    padding: 10px var(--s-2); border-radius: var(--r-md); cursor: pointer; min-height: 44px;
+    transition: background var(--dur-sm) var(--ease-out);
+  }
+  .recent .rrow:hover { background: var(--bg-hover); }
+  .recent .rrow .ric {
+    width: 34px; height: 34px; flex-shrink: 0; border-radius: var(--r-sm);
+    display: flex; align-items: center; justify-content: center; font-size: 16px;
+    background: hsl(var(--e) / .15); color: hsl(var(--e));
+  }
+  .recent .rrow .rtx { flex: 1; min-width: 0; font-size: var(--fs-sm); line-height: 1.35; color: var(--text-sec); }
+  .recent .rrow .rtx b { color: var(--text); font-weight: var(--fw-bold); }
+  .recent .rrow .rtx .ent { color: hsl(var(--e)); font-weight: var(--fw-bold); }
+  .recent .rrow .rtx .when { display: block; font-size: 10px; color: var(--text-muted); margin-top: 1px; font-family: var(--f-mono); }
+  .recent .rrow .rar { color: var(--text-muted); font-size: 15px; flex-shrink: 0; }
+
+  /* ════════════ STATES ════════════ */
+  /* skeleton */
+  .sk { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--r-lg); padding: var(--s-2); display: flex; gap: var(--s-3); align-items: center; }
+  .sk .skcov { width: 68px; height: 68px; border-radius: var(--r-md); flex-shrink: 0; }
+  .sk .skbody { flex: 1; display: flex; flex-direction: column; gap: 7px; }
+  .sk .skln { height: 11px; border-radius: var(--r-pill); }
+  .shimmer { position: relative; overflow: hidden; background: var(--bg-muted); }
+  .shimmer::after {
+    content: ''; position: absolute; inset: 0; transform: translateX(-100%);
+    background: linear-gradient(90deg, transparent, hsl(var(--c-game) / .08), transparent);
+    animation: shim 1.4s var(--ease-in-out) infinite;
+  }
+  @keyframes shim { 100% { transform: translateX(100%); } }
+
+  /* empty / permission / filtered-empty illustration */
+  .estate { padding: var(--s-8) var(--s-6); text-align: center; display: flex; flex-direction: column; align-items: center; }
+  .estate .ill {
+    width: 108px; height: 108px; border-radius: var(--r-2xl); margin-bottom: var(--s-5);
+    display: flex; align-items: center; justify-content: center; font-size: 50px; position: relative;
+    background: hsl(var(--e, var(--c-game)) / .1);
+  }
+  .estate .ill::before {
+    content: ''; position: absolute; inset: -8px; border-radius: var(--r-2xl);
+    border: 2px dashed hsl(var(--e, var(--c-game)) / .25);
+  }
+  .estate h3 { font-family: var(--f-display); font-size: var(--fs-xl); margin-bottom: var(--s-2); color: var(--text); }
+  .estate p { color: var(--text-sec); font-size: var(--fs-base); line-height: var(--lh-snug); max-width: 280px; margin: 0 auto var(--s-5); }
+  .estate .acts { display: flex; flex-direction: column; gap: var(--s-2); width: 100%; max-width: 260px; }
+  .btn-pri, .btn-sec {
+    min-height: 46px; padding: 0 var(--s-5); border-radius: var(--r-md);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-base);
+    cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    transition: all var(--dur-sm) var(--ease-out); border: 1.5px solid transparent;
+  }
+  .btn-pri { background: hsl(var(--e, var(--c-game))); color: #fff; box-shadow: var(--shadow-sm); }
+  .btn-pri:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+  .btn-sec { background: transparent; border-color: var(--border-strong); color: var(--text-sec); }
+  .btn-sec:hover { border-color: hsl(var(--e, var(--c-game)) / .5); color: hsl(var(--e, var(--c-game))); }
+
+  /* error banner (GamebookErrorBanner pattern) */
+  .ebanner {
+    margin: var(--s-3) var(--s-4); padding: var(--s-4);
+    border-radius: var(--r-lg); border: 1px solid hsl(var(--c-danger) / .35);
+    background: hsl(var(--c-danger) / .08);
+    display: flex; gap: var(--s-3); align-items: flex-start;
+  }
+  .ebanner .eic { font-size: 22px; flex-shrink: 0; line-height: 1.2; }
+  .ebanner .ebody { flex: 1; }
+  .ebanner .ebody h4 { font-family: var(--f-display); font-size: var(--fs-base); color: hsl(var(--c-danger)); margin-bottom: 3px; }
+  .ebanner .ebody p { font-size: var(--fs-sm); color: var(--text-sec); line-height: var(--lh-snug); }
+  .ebanner .eacts { display: flex; gap: var(--s-2); margin-top: var(--s-3); }
+  .ebanner .eacts button {
+    min-height: 38px; padding: 0 14px; border-radius: var(--r-sm);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); cursor: pointer;
+    border: 1.5px solid transparent; transition: all var(--dur-sm);
+  }
+  .ebanner .eacts .retry { background: hsl(var(--c-danger)); color: #fff; }
+  .ebanner .eacts .retry:hover { transform: translateY(-1px); }
+  .ebanner .eacts .cache { background: transparent; border-color: var(--border-strong); color: var(--text-sec); }
+
+  /* offline top banner */
+  .offbar {
+    display: flex; align-items: center; gap: var(--s-2);
+    padding: 9px var(--s-4); background: hsl(var(--c-warning) / .14);
+    border-bottom: 1px solid hsl(var(--c-warning) / .3);
+    font-size: var(--fs-sm); color: var(--text); font-weight: var(--fw-semi);
+  }
+  .offbar .od { width: 8px; height: 8px; border-radius: 50%; background: hsl(var(--c-warning)); flex-shrink: 0; }
+
+  /* ════════════ BULK MODE ════════════ */
+  .bulkbar {
+    display: flex; align-items: center; gap: var(--s-2);
+    padding: var(--s-3) var(--s-3) var(--s-3) var(--s-2);
+    background: hsl(var(--c-game)); color: #fff;
+    position: sticky; top: 0; z-index: var(--z-nav);
+    animation: bulkin var(--dur-md) var(--ease-spring);
+  }
+  @keyframes bulkin { from { transform: translateY(-100%); } to { transform: translateY(0); } }
+  .bulkbar button.bb-x { appearance: none; border: none; background: transparent; color: #fff; cursor: pointer; min-width: 44px; min-height: 44px; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); display: inline-flex; align-items: center; gap: 6px; }
+  .bulkbar .bb-count { flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-lg); }
+  .bulkbar .bb-kebab { appearance: none; border: none; background: rgba(255,255,255,.18); color: #fff; cursor: pointer; width: 40px; height: 40px; border-radius: var(--r-md); font-size: 20px; }
+
+  /* FAB */
+  .fab {
+    position: absolute; right: var(--s-5); bottom: var(--s-5); z-index: var(--z-overlay);
+    width: 58px; height: 58px; border-radius: var(--r-pill); border: none;
+    background: hsl(var(--c-game)); color: #fff; font-size: 24px; cursor: pointer;
+    box-shadow: var(--shadow-lg); display: flex; align-items: center; justify-content: center;
+    animation: fabin var(--dur-md) var(--ease-spring);
+  }
+  @keyframes fabin { from { transform: scale(0); } to { transform: scale(1); } }
+  .fab:hover { transform: translateY(-2px); }
+
+  /* ════════════ BOTTOM SHEET (drawer V1 / filters / bulk actions) ════════════ */
+  .overlay {
+    position: absolute; inset: 0; z-index: var(--z-overlay);
+    background: rgba(0,0,0,.42); opacity: 0; pointer-events: none;
+    transition: opacity var(--dur-md) var(--ease-out);
+  }
+  .overlay.open { opacity: 1; pointer-events: auto; }
+  .sheet {
+    position: absolute; left: 0; right: 0; bottom: 0; z-index: var(--z-drawer);
+    background: var(--bg-card); border-radius: var(--r-2xl) var(--r-2xl) 0 0;
+    box-shadow: var(--shadow-drawer); display: flex; flex-direction: column;
+    transform: translateY(100%); transition: transform var(--dur-md) var(--ease-spring);
+    max-height: 88%;
+  }
+  .sheet.open { transform: translateY(0); }
+  .sheet.tall { height: 80%; }
+  .sheet .grab { width: 40px; height: 4px; border-radius: 2px; background: var(--border-strong); margin: 10px auto 4px; flex-shrink: 0; cursor: grab; }
+  .sheet .sh-head { display: flex; align-items: center; gap: var(--s-2); padding: var(--s-2) var(--s-5) var(--s-3); border-bottom: 1px solid var(--border); }
+  .sheet .sh-head h3 { flex: 1; font-family: var(--f-display); font-size: var(--fs-lg); color: var(--text); }
+  .sheet .sh-head .reset { appearance: none; border: none; background: transparent; color: hsl(var(--c-game)); font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); cursor: pointer; padding: 8px; min-height: 40px; }
+  .sheet .sh-body { flex: 1; overflow-y: auto; padding: var(--s-4) var(--s-5); }
+  .sheet .sh-foot { padding: var(--s-3) var(--s-5) var(--s-5); border-top: 1px solid var(--border); display: flex; gap: var(--s-2); }
+  .sheet .sh-foot .btn-pri, .sheet .sh-foot .btn-sec { flex: 1; }
+
+  /* filter groups */
+  .fgroup { margin-bottom: var(--s-5); }
+  .fgroup .fg-lbl { font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: .04em; color: var(--text-sec); margin-bottom: var(--s-2); }
+  .fopts { display: flex; flex-wrap: wrap; gap: var(--s-2); }
+  .fopt {
+    padding: 8px 14px; min-height: 40px; border-radius: var(--r-pill); cursor: pointer;
+    border: 1.5px solid var(--border); background: var(--bg); color: var(--text-sec);
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);
+    display: inline-flex; align-items: center; gap: 6px; transition: all var(--dur-sm) var(--ease-out);
+  }
+  .fopt[aria-pressed="true"] { border-color: hsl(var(--c-game) / .55); background: hsl(var(--c-game) / .12); color: hsl(var(--c-game)); }
+
+  /* bulk actions list */
+  .bulkacts { display: flex; flex-direction: column; gap: 2px; }
+  .bulkact {
+    display: flex; align-items: center; gap: var(--s-3); width: 100%;
+    padding: var(--s-3) var(--s-2); min-height: 52px; border-radius: var(--r-md);
+    appearance: none; border: none; background: transparent; cursor: pointer; text-align: left;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-md); color: var(--text);
+    transition: background var(--dur-sm) var(--ease-out);
+  }
+  .bulkact:hover { background: var(--bg-hover); }
+  .bulkact.danger { color: hsl(var(--c-danger)); }
+  .bulkact .bi {
+    width: 38px; height: 38px; border-radius: var(--r-md); flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center; font-size: 18px;
+    background: hsl(var(--e, var(--c-game)) / .14); color: hsl(var(--e, var(--c-game)));
+  }
+  .bulkact .bsub { font-size: var(--fs-xs); color: var(--text-muted); font-weight: var(--fw-reg); margin-top: 1px; }
+
+  /* overflow menu (popover) */
+  .ovmenu {
+    position: absolute; top: 96px; right: var(--s-3); z-index: var(--z-modal);
+    min-width: 180px; background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: var(--r-lg); box-shadow: var(--shadow-lg); padding: var(--s-2);
+    transform-origin: top right; animation: pop var(--dur-sm) var(--ease-spring);
+  }
+  @keyframes pop { from { transform: scale(.9); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+  .ovmenu .ov-lbl { font-family: var(--f-mono); font-size: 9px; text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); padding: var(--s-2) var(--s-2) 4px; font-weight: 700; }
+  .ovitem {
+    display: flex; align-items: center; gap: var(--s-3); width: 100%; min-height: 46px;
+    padding: 8px var(--s-2); border-radius: var(--r-md); appearance: none; border: none;
+    background: transparent; cursor: pointer; text-align: left;
+    font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-base); color: var(--text);
+  }
+  .ovitem:hover { background: var(--bg-hover); }
+  .ovitem .ovic { width: 32px; height: 32px; border-radius: var(--r-sm); display: flex; align-items: center; justify-content: center; font-size: 16px; background: hsl(var(--e) / .15); color: hsl(var(--e)); flex-shrink: 0; }
+  .ovitem .ovcnt { margin-left: auto; font-size: var(--fs-xs); color: var(--text-muted); font-weight: var(--fw-bold); }
+  .ovitem .ovdot { width: 7px; height: 7px; border-radius: 50%; background: hsl(var(--e)); margin-left: 6px; }
+
+  /* toast */
+  .toast {
+    position: absolute; left: 50%; bottom: var(--s-6); transform: translateX(-50%) translateY(20px);
+    z-index: var(--z-toast); padding: 11px 18px; border-radius: var(--r-pill);
+    background: var(--text); color: var(--bg); font-family: var(--f-display); font-weight: var(--fw-bold);
+    font-size: var(--fs-sm); box-shadow: var(--shadow-lg); opacity: 0; pointer-events: none;
+    transition: all var(--dur-md) var(--ease-spring); white-space: nowrap;
+  }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
+  /* focus ring */
+  .app :focus-visible { outline: 2px solid hsl(var(--c-game)); outline-offset: 2px; border-radius: var(--r-xs); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sheet, .overlay, .fab, .bulkbar, .ovmenu, .toast, .mcard, .shimmer::after { transition: none !important; animation: none !important; }
+    .shimmer::after { display: none; }
+  }
+
+  @media (max-width: 900px) {
+    .stage-frames { gap: var(--s-6); }
+    .device.tablet { display: none; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="data.js"></script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script type="text/babel" src="sp4-library-mobile.jsx"></script>
+</body>
+</html>

--- a/admin-mockups/design_files/sp4-library-mobile.jsx
+++ b/admin-mockups/design_files/sp4-library-mobile.jsx
@@ -1,0 +1,731 @@
+/* ════════════════════════════════════════════════════════════════
+   sp4-library-mobile.jsx
+   Schermata : Library Mobile (variante mobile-first di sp4-library-desktop)
+   Route     : /library  (breakpoint mobile <768px; tablet 768px adaptation)
+   Descrizione: Hero compatto + tab semplificate (Games/Sessions/Chat +
+                overflow Agents/KB) + grid 1-col MeepleCard list + sezione
+                Recente + bulk-select via long-press + filters bottom-sheet.
+   Brief      : SP8-mobile-parity. Content model riusato da SP4 desktop.
+   ════════════════════════════════════════════════════════════════ */
+
+const { useState, useEffect, useRef, useCallback } = React;
+
+/* ─── entityHsl helper (inline, da brief) ─── */
+const ENTITY_HSL = {
+  game:    '25 95% 45%',  player:  '262 83% 58%',  session: '240 60% 55%',
+  agent:   '38 92% 50%',  kb:      '174 60% 40%',   chat:    '220 80% 55%',
+  event:   '350 89% 60%', toolkit: '142 70% 45%',   tool:    '195 80% 50%',
+};
+const entityHsl = (entity, alpha) =>
+  alpha != null ? `hsl(${ENTITY_HSL[entity]} / ${alpha})` : `hsl(${ENTITY_HSL[entity]})`;
+
+/* In dark mode i token entity cambiano: usiamo le CSS var live per coerenza. */
+const eVar = (entity, alpha) =>
+  alpha != null ? `hsl(var(--c-${entity}) / ${alpha})` : `hsl(var(--c-${entity}))`;
+
+/* ─── Tab config (IA semplificata 3 + overflow) ─── */
+const PRIMARY_TABS = [
+  { id: 'game',    label: 'Games',    em: '🎲', count: 47 },
+  { id: 'session', label: 'Sessions', em: '🎯', count: DS.sessions.length },
+  { id: 'chat',    label: 'Chat',     em: '💬', count: DS.chats.length },
+];
+const OVERFLOW_TABS = [
+  { id: 'agent', label: 'Agents', em: '🤖', count: DS.agents.length, hasNew: true },
+  { id: 'kb',    label: 'KB',     em: '📄', count: DS.kbs.length,     hasNew: false },
+];
+const ALL_TABS = [...PRIMARY_TABS, ...OVERFLOW_TABS];
+
+/* lista per tab */
+const listFor = (tab) => ({
+  game: DS.games, session: DS.sessions, chat: DS.chats, agent: DS.agents, kb: DS.kbs,
+}[tab] || []);
+
+/* ─── shape di una MeepleCard list ─── */
+function cardData(item) {
+  switch (item.type) {
+    case 'game': return {
+      cover: item.cover, em: item.coverEmoji, ti: item.title,
+      sub: `${item.publisher} · ${item.year}`,
+      metas: [
+        { cls: 'star', ic: '★', txt: item.rating },
+        { ic: '👥', txt: `${item.players} giocatori` },
+      ],
+      badge: item.badge,
+    };
+    case 'session': return {
+      cover: item.cover, em: item.coverEmoji, ti: item.title, sub: item.subtitle,
+      metas: [ { ic: '👥', txt: `${item.playerIds.length} giocatori` }, { ic: '📊', txt: `Turno ${item.turn}` } ],
+      badge: item.badge,
+    };
+    case 'chat': return {
+      cover: DS.color('chat'), em: '💬', ti: item.title, sub: item.subtitle,
+      metas: [ { ic: '💬', txt: `${item.msgCount} msg` }, { ic: '🕒', txt: item.lastAt } ],
+      badge: item.badge,
+    };
+    case 'agent': return {
+      cover: item.cover, em: item.coverEmoji, ti: item.title, sub: item.subtitle,
+      metas: [ { ic: '💬', txt: `${item.invocations} inv` }, { ic: '⚡', txt: item.avgLatency } ],
+      badge: item.badge,
+    };
+    case 'kb': return {
+      cover: item.cover, em: item.coverEmoji, ti: item.title, sub: item.subtitle,
+      metas: [ { ic: '📄', txt: `${item.pages} pag` }, { ic: '💾', txt: item.size } ],
+      badge: item.badge,
+    };
+    default: return { cover: item.cover, em: '📦', ti: item.title, sub: item.subtitle || '', metas: [], badge: item.badge };
+  }
+}
+
+/* ─── connessioni (versione compatta da mobile-app.jsx) ─── */
+function connectionsOf(e) {
+  const out = [];
+  const push = (type, items) => { if (items.length) out.push({ type, count: items.length, first: items[0] }); };
+  if (e.type === 'game') {
+    push('agent', DS.agents.filter(a => a.gameId === e.id));
+    push('kb', DS.kbs.filter(k => k.gameId === e.id));
+    push('chat', DS.chats.filter(c => c.gameId === e.id));
+    push('session', DS.sessions.filter(s => s.gameId === e.id));
+    push('toolkit', DS.toolkits.filter(t => t.gameId === e.id));
+  } else if (e.type === 'session') {
+    if (e.gameId) push('game', [DS.byId[e.gameId]].filter(Boolean));
+    push('player', (e.playerIds || []).map(id => DS.byId[id]).filter(Boolean));
+  } else if (e.type === 'chat') {
+    if (e.agentId) push('agent', [DS.byId[e.agentId]].filter(Boolean));
+    if (e.gameId) push('game', [DS.byId[e.gameId]].filter(Boolean));
+  } else if (e.type === 'agent') {
+    if (e.gameId) push('game', [DS.byId[e.gameId]].filter(Boolean));
+    push('kb', DS.kbs.filter(k => k.gameId === e.gameId));
+    push('chat', DS.chats.filter(c => c.agentId === e.id));
+  } else if (e.type === 'kb') {
+    if (e.gameId) push('game', [DS.byId[e.gameId]].filter(Boolean));
+    push('agent', DS.agents.filter(a => a.gameId === e.gameId));
+  }
+  return out;
+}
+
+/* ─── Recente (cross-entity, stessa data del RecentActivityRail) ─── */
+const RECENTS = [
+  { type: 'game',    ref: 'g-catan',     pre: 'Hai aperto', ent: 'I Coloni di Catan', when: '2 ore fa' },
+  { type: 'session', ref: 's-azul-live', pre: 'Sessione',   ent: 'Serata Azul in corso', when: 'ora · Turno 3/5' },
+  { type: 'chat',    ref: 'c-catan-strat', pre: 'Chat con', ent: 'Catan Coach', when: 'Ieri' },
+  { type: 'kb',      ref: 'kb-wingspan', pre: 'Indicizzato', ent: 'wingspan-rules.pdf', when: '2 giorni fa' },
+];
+
+/* ════════════════════════════════════════════════════════════════
+   useLongPress — primitive greenfield (500ms)
+   ════════════════════════════════════════════════════════════════ */
+function useLongPress(onLongPress, ms = 500) {
+  const timer = useRef(null);
+  const fired = useRef(false);
+  const [arming, setArming] = useState(null);
+
+  const start = (id) => (e) => {
+    if (e.button === 2) return;          // ignora tasto destro
+    fired.current = false;
+    setArming(id);
+    timer.current = setTimeout(() => {
+      fired.current = true;
+      setArming(null);
+      onLongPress(id);
+    }, ms);
+  };
+  const cancel = () => { clearTimeout(timer.current); setArming(null); };
+  const consume = () => { const f = fired.current; fired.current = false; return f; };
+  useEffect(() => () => clearTimeout(timer.current), []);
+  return { arming, start, cancel, consume };
+}
+
+/* ════════════════════════════════════════════════════════════════
+   MeepleCard — variant="list"
+   ════════════════════════════════════════════════════════════════ */
+function MeepleCard({ item, bulkMode, selected, arming, bind, onTap }) {
+  const d = cardData(item);
+  return (
+    <div
+      className={`mcard${selected ? ' selected' : ''}${arming ? ' lp-arming' : ''}`}
+      style={{ '--e': `var(--c-${item.type})` }}
+      role="button" tabIndex={0}
+      aria-pressed={bulkMode ? selected : undefined}
+      aria-label={`${d.ti}${bulkMode ? (selected ? ' · selezionato' : ' · non selezionato') : ''}`}
+      onMouseDown={bind.start(item.id)} onMouseUp={bind.cancel} onMouseLeave={bind.cancel}
+      onTouchStart={bind.start(item.id)} onTouchEnd={bind.cancel} onTouchMove={bind.cancel}
+      onContextMenu={(e) => e.preventDefault()}
+      onClick={() => onTap(item)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTap(item); } }}
+    >
+      <div className="cov" style={{ background: d.cover }}>{d.em}</div>
+      <div className="body">
+        <div className="title-row">
+          <span className="ti">{d.ti}</span>
+          {d.badge && <span className="e-chip2">{d.badge}</span>}
+        </div>
+        <div className="sub">{d.sub}</div>
+        <div className="meta">
+          {d.metas.map((m, i) => (
+            <span key={i} className={`mi${m.cls ? ' ' + m.cls : ''}`}><span>{m.ic}</span>{m.txt}</span>
+          ))}
+        </div>
+      </div>
+      {bulkMode
+        ? <div className="check">{selected ? '✓' : ''}</div>
+        : <span className="chevron" aria-hidden="true">›</span>}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Skeleton card (loading)
+   ════════════════════════════════════════════════════════════════ */
+function SkeletonCard() {
+  return (
+    <div className="sk">
+      <div className="skcov shimmer"></div>
+      <div className="skbody">
+        <div className="skln shimmer" style={{ width: '62%', height: 13 }}></div>
+        <div className="skln shimmer" style={{ width: '40%' }}></div>
+        <div className="skln shimmer" style={{ width: '78%' }}></div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Recente section
+   ════════════════════════════════════════════════════════════════ */
+function RecentSection({ onOpen }) {
+  return (
+    <div className="recent">
+      <div className="rdiv"><span className="ln"></span><span className="tx">Recente</span><span className="ln"></span></div>
+      {RECENTS.map((r, i) => {
+        const ref = DS.byId[r.ref];
+        return (
+          <div key={i} className="rrow" style={{ '--e': `var(--c-${r.type})` }}
+            role="button" tabIndex={0}
+            onClick={() => ref && onOpen(ref)}
+            onKeyDown={(e) => { if (e.key === 'Enter') ref && onOpen(ref); }}>
+            <div className="ric">{DS.EC[r.type].em}</div>
+            <div className="rtx">
+              {r.pre} <span className="ent">{r.ent}</span>
+              <span className="when">{r.when}</span>
+            </div>
+            <span className="rar" aria-hidden="true">→</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Detail bottom-sheet (drawer V1 canonico — compatto)
+   ════════════════════════════════════════════════════════════════ */
+function DetailSheet({ entity, onClose, onOpen }) {
+  const open = !!entity;
+  const e = entity;
+  const conns = e ? connectionsOf(e) : [];
+  return (
+    <React.Fragment>
+      <div className={`overlay${open ? ' open' : ''}`} onClick={onClose}></div>
+      <div className={`sheet${open ? ' open' : ''}`} role="dialog" aria-modal="true"
+        aria-label={e ? e.title : 'Dettaglio'} style={e ? { '--e': `var(--c-${e.type})` } : null}>
+        <div className="grab"></div>
+        {e && (
+          <React.Fragment>
+            <div className="sh-head">
+              <div className="cov" style={{ width: 36, height: 36, borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, color: '#fff', background: e.cover || eVar(e.type) }}>{e.coverEmoji || DS.EC[e.type].em}</div>
+              <h3>{e.title}</h3>
+              <button className="lh-icon" aria-label="Chiudi" onClick={onClose} style={{ width: 40, height: 40 }}>✕</button>
+            </div>
+            <div className="sh-body">
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 16 }}>
+                {conns.map(c => (
+                  <button key={c.type} className="fopt" onClick={() => c.first && onOpen(c.first)}
+                    style={{ borderColor: eVar(c.type, .4), background: eVar(c.type, .1), color: eVar(c.type) }}>
+                    <span>{DS.EC[c.type].em}</span>{c.count} {DS.EC[c.type].lb}
+                  </button>
+                ))}
+              </div>
+              <div className="fgroup">
+                <div className="fg-lbl">Apri in /library</div>
+                <p style={{ fontSize: 13, color: 'var(--text-sec)', lineHeight: 1.55, margin: 0 }}>
+                  Su mobile il tap apre il drawer entità a tutta scheda (bottom-sheet tabbed canonico). Le pip sopra sono <strong style={{ color: 'var(--text)' }}>EntityPip</strong> tappabili che sostituiscono l'entità in vista.
+                </p>
+              </div>
+            </div>
+            <div className="sh-foot">
+              <button className="btn-pri" style={{ '--e': `var(--c-${e.type})` }} onClick={onClose}>Apri scheda</button>
+              <button className="btn-sec" onClick={onClose}>Chiudi</button>
+            </div>
+          </React.Fragment>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Filters bottom-sheet 80vh (AdvancedFiltersDrawer, anchor=bottom)
+   ════════════════════════════════════════════════════════════════ */
+const FILTER_GROUPS = [
+  { key: 'sort', label: 'Ordina per', opts: ['Recenti', 'A → Z', 'Rating', 'Più giocati'] },
+  { key: 'status', label: 'Stato', opts: ['Posseduti', 'Wishlist', 'Preferiti'] },
+  { key: 'players', label: 'Giocatori', opts: ['2', '3–4', '5+'] },
+  { key: 'weight', label: 'Complessità', opts: ['Leggero', 'Medio', 'Pesante'] },
+];
+function FiltersSheet({ open, draft, onToggle, onReset, onApply, onClose }) {
+  return (
+    <React.Fragment>
+      <div className={`overlay${open ? ' open' : ''}`} onClick={onClose}></div>
+      <div className={`sheet tall${open ? ' open' : ''}`} role="dialog" aria-modal="true" aria-label="Filtri avanzati">
+        <div className="grab"></div>
+        <div className="sh-head">
+          <h3>Filtri</h3>
+          <button className="reset" onClick={onReset}>Resetta</button>
+        </div>
+        <div className="sh-body">
+          {FILTER_GROUPS.map(g => (
+            <div className="fgroup" key={g.key}>
+              <div className="fg-lbl">{g.label}</div>
+              <div className="fopts">
+                {g.opts.map(o => {
+                  const on = (draft[g.key] || []).includes(o);
+                  return (
+                    <button key={o} className="fopt" aria-pressed={on}
+                      onClick={() => onToggle(g.key, o)}>
+                      {on && <span aria-hidden="true">✓</span>}{o}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="sh-foot">
+          <button className="btn-sec" onClick={onClose}>Annulla</button>
+          <button className="btn-pri" onClick={onApply}>Applica filtri</button>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Bulk actions bottom-sheet (FAB → Archivia / Tag / Esporta)
+   ════════════════════════════════════════════════════════════════ */
+function BulkActionsSheet({ open, count, onClose, onAction }) {
+  const acts = [
+    { id: 'archive', em: '📦', e: 'toolkit', lb: 'Archivia', sub: `Sposta ${count} in archivio` },
+    { id: 'tag', em: '🏷️', e: 'player', lb: 'Aggiungi tag', sub: 'Etichetta la selezione' },
+    { id: 'export', em: '📤', e: 'chat', lb: 'Esporta', sub: 'Condividi o esporta lista' },
+    { id: 'remove', em: '🗑️', e: 'event', lb: 'Rimuovi dalla libreria', sub: null, danger: true },
+  ];
+  return (
+    <React.Fragment>
+      <div className={`overlay${open ? ' open' : ''}`} onClick={onClose}></div>
+      <div className={`sheet${open ? ' open' : ''}`} role="dialog" aria-modal="true" aria-label="Azioni selezione">
+        <div className="grab"></div>
+        <div className="sh-head"><h3>{count} selezionati</h3>
+          <button className="lh-icon" aria-label="Chiudi" onClick={onClose} style={{ width: 40, height: 40 }}>✕</button></div>
+        <div className="sh-body">
+          <div className="bulkacts">
+            {acts.map(a => (
+              <button key={a.id} className={`bulkact${a.danger ? ' danger' : ''}`} style={{ '--e': `var(--c-${a.e})` }}
+                onClick={() => onAction(a.lb)}>
+                <span className="bi">{a.em}</span>
+                <span>{a.lb}{a.sub && <span className="bsub">{a.sub}</span>}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   LibraryMobile — schermata principale
+   ════════════════════════════════════════════════════════════════ */
+function LibraryMobile({ condition, isTablet }) {
+  const [tab, setTab] = useState('game');
+  const [query, setQuery] = useState('');
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [filterDraft, setFilterDraft] = useState({});
+  const [activeFilters, setActiveFilters] = useState(
+    condition === 'filtered' ? [{ key: 'weight', label: 'Pesante' }, { key: 'players', label: '5+' }] : []
+  );
+  const [visible, setVisible] = useState(6);
+  const [bulkMode, setBulkMode] = useState(false);
+  const [selected, setSelected] = useState(() => new Set());
+  const [bulkSheet, setBulkSheet] = useState(false);
+  const [detail, setDetail] = useState(null);
+  const [toast, setToast] = useState('');
+  const toastTimer = useRef(null);
+
+  const offline = condition === 'offline';
+  const readOnly = offline;
+
+  const showToast = (msg) => {
+    setToast(msg);
+    clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(''), 2200);
+  };
+
+  const enterBulk = (id) => {
+    if (readOnly) { showToast('Non disponibile offline'); return; }
+    setBulkMode(true);
+    setSelected(new Set([id]));
+  };
+  const lp = useLongPress(enterBulk, 500);
+
+  const exitBulk = () => { setBulkMode(false); setSelected(new Set()); setBulkSheet(false); };
+
+  const onTapCard = (item) => {
+    if (lp.consume()) return;            // long-press ha già agito
+    if (bulkMode) {
+      setSelected(prev => {
+        const n = new Set(prev);
+        n.has(item.id) ? n.delete(item.id) : n.add(item.id);
+        if (n.size === 0) setBulkMode(false);
+        return n;
+      });
+      return;
+    }
+    setDetail(item);
+  };
+
+  const switchTab = (id) => { setTab(id); setVisible(6); setQuery(''); setOverflowOpen(false); };
+
+  // filtra lista per query
+  const base = listFor(tab);
+  const filtered = query
+    ? base.filter(e => e.title.toLowerCase().includes(query.toLowerCase()))
+    : base;
+  const shown = filtered.slice(0, visible);
+  const hasMore = visible < filtered.length;
+
+  const toggleDraft = (key, opt) => setFilterDraft(prev => {
+    const cur = new Set(prev[key] || []);
+    cur.has(opt) ? cur.delete(opt) : cur.add(opt);
+    return { ...prev, [key]: [...cur] };
+  });
+  const applyFilters = () => {
+    const next = [];
+    Object.entries(filterDraft).forEach(([k, arr]) => arr.forEach(label => next.push({ key: k, label })));
+    setActiveFilters(next);
+    setFiltersOpen(false);
+    showToast(next.length ? `${next.length} filtri applicati` : 'Filtri rimossi');
+  };
+  const removeFilter = (idx) => setActiveFilters(prev => prev.filter((_, i) => i !== idx));
+  const resetFiltersToZero = () => { setActiveFilters([]); setFilterDraft({}); };
+
+  const activeTabMeta = ALL_TABS.find(t => t.id === tab);
+
+  /* ── derived: la lista è "vuota da filtro"? ── */
+  const filteredEmpty = condition === 'filtered';
+
+  /* tabs da mostrare: tablet mostra tutte e 5, mobile 3 + overflow */
+  const tabsToShow = isTablet ? ALL_TABS : PRIMARY_TABS;
+
+  return (
+    <div className="app">
+      {offline && (
+        <div className="offbar" role="status">
+          <span className="od"></span>Sei offline — alcuni dati potrebbero non essere aggiornati
+        </div>
+      )}
+
+      {/* ─── HEADER (bulk bar sostituisce header quando attivo) ─── */}
+      {bulkMode ? (
+        <div className="bulkbar">
+          <button className="bb-x" onClick={exitBulk}>← Annulla</button>
+          <span className="bb-count">{selected.size} selezionat{selected.size === 1 ? 'o' : 'i'}</span>
+          <button className="bb-kebab" aria-label="Azioni sulla selezione" onClick={() => setBulkSheet(true)}>⋮</button>
+        </div>
+      ) : (
+        <header className="lh-header">
+          <div className="lh-bar">
+            <div className="lh-mark">M</div>
+            <div className="lh-titles">
+              <div className="t">{condition === 'permission' ? 'Libreria di Sara' : 'La mia libreria'}</div>
+              <div className="s">
+                {condition === 'permission' ? 'Condivisa · privata' : `${activeTabMeta.count} ${activeTabMeta.label.toLowerCase()}`}
+              </div>
+            </div>
+            <button className="lh-icon" aria-label="Menu libreria">☰</button>
+          </div>
+
+          {condition !== 'permission' && (
+            <React.Fragment>
+              <div className="lh-tabs" role="tablist" aria-label="Categorie libreria">
+                {tabsToShow.map(t => (
+                  <button key={t.id} className="lh-tab" role="tab"
+                    aria-selected={tab === t.id}
+                    style={{ '--e': `var(--c-${t.id})` }}
+                    onClick={() => switchTab(t.id)}>
+                    {t.label}<span className="cnt">{t.count}</span>
+                  </button>
+                ))}
+                {!isTablet && (
+                  <button className={`lh-more${overflowOpen ? ' active-overflow' : ''}`}
+                    aria-label="Più categorie: Agents e KB" aria-haspopup="menu" aria-expanded={overflowOpen}
+                    onClick={() => setOverflowOpen(o => !o)}>
+                    ⋯{OVERFLOW_TABS.some(t => t.hasNew) && <span className="ndot"></span>}
+                  </button>
+                )}
+              </div>
+
+              <div className="lh-search">
+                <div className="field">
+                  <span className="ic" aria-hidden="true">🔍</span>
+                  <input value={query} onChange={e => { setQuery(e.target.value); setVisible(6); }}
+                    placeholder={`Cerca in ${activeTabMeta.label}…`} aria-label={`Cerca in ${activeTabMeta.label}`} />
+                </div>
+                <button className={`lh-filter${activeFilters.length ? ' has-active' : ''}`}
+                  aria-label="Filtri avanzati" onClick={() => !readOnly && setFiltersOpen(true)}>
+                  <span aria-hidden="true">⛃</span>Filtri
+                  {activeFilters.length > 0 && <span className="badge">{activeFilters.length}</span>}
+                </button>
+              </div>
+            </React.Fragment>
+          )}
+        </header>
+      )}
+
+      {/* ─── BODY ─── */}
+      <div className="app-scroll">
+        {/* LOADING */}
+        {condition === 'loading' && (
+          <div className="lh-body" aria-live="polite" aria-busy="true">
+            <span className="sr-only">Caricamento libreria…</span>
+            <div className="mlist">
+              <SkeletonCard /><SkeletonCard /><SkeletonCard />
+            </div>
+          </div>
+        )}
+
+        {/* ERROR */}
+        {condition === 'error' && (
+          <div className="lh-body">
+            <div className="ebanner" role="alert">
+              <span className="eic">⚠️</span>
+              <div className="ebody">
+                <h4>Impossibile caricare la libreria</h4>
+                <p>Si è verificato un errore di rete. Riprova o consulta i dati in cache.</p>
+                <div className="eacts">
+                  <button className="retry" onClick={() => showToast('Nuovo tentativo…')}>↻ Riprova</button>
+                  <button className="cache" onClick={() => showToast('Mostro dati in cache')}>Mostra cache</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* PERMISSION DENIED */}
+        {condition === 'permission' && (
+          <div className="estate" style={{ '--e': 'var(--c-player)' }}>
+            <div className="ill">🔒</div>
+            <h3>Non hai accesso</h3>
+            <p>La libreria di Sara T. è privata. Chiedi un invito per consultare i suoi giochi e le sessioni.</p>
+            <div className="acts">
+              <button className="btn-pri" style={{ '--e': 'var(--c-player)' }} onClick={() => showToast('Richiesta inviata a Sara T.')}>✉️ Chiedi un invito</button>
+              <button className="btn-sec" onClick={() => showToast('Torna alla tua libreria')}>Torna alla mia libreria</button>
+            </div>
+          </div>
+        )}
+
+        {/* EMPTY (collezione vuota) */}
+        {condition === 'empty' && (
+          <div className="estate" style={{ '--e': 'var(--c-game)' }}>
+            <div className="ill">🎲</div>
+            <h3>Nessun gioco ancora</h3>
+            <p>Aggiungi il primo! La tua libreria raccoglie giochi, sessioni e chat in un unico posto.</p>
+            <div className="acts">
+              <button className="btn-pri" onClick={() => showToast('Vai a /library/add')}>＋ Aggiungi gioco</button>
+              <button className="btn-sec" onClick={() => showToast('Vai a /shared-games')}>🔎 Scopri shared</button>
+            </div>
+          </div>
+        )}
+
+        {/* FILTERED EMPTY */}
+        {filteredEmpty && (
+          <div className="lh-body">
+            <div className="filterchips">
+              <span className="lbl">Filtri attivi</span>
+              {activeFilters.map((f, i) => (
+                <button key={i} className="fchip" onClick={() => removeFilter(i)}>
+                  {f.label}<span className="x" aria-hidden="true">✕</span>
+                </button>
+              ))}
+            </div>
+            <div className="estate" style={{ '--e': 'var(--c-game)', paddingTop: 24 }}>
+              <div className="ill">🔍</div>
+              <h3>Nessun risultato</h3>
+              <p>Nessun gioco corrisponde a questi filtri. Prova a rimuoverne qualcuno.</p>
+              <div className="acts">
+                <button className="btn-pri" onClick={resetFiltersToZero}>Resetta filtri</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* DEFAULT + OFFLINE (lista normale) */}
+        {(condition === 'default' || condition === 'offline') && (
+          <div className="lh-body">
+            {activeFilters.length > 0 && (
+              <div className="filterchips">
+                <span className="lbl">Filtri</span>
+                {activeFilters.map((f, i) => (
+                  <button key={i} className="fchip" onClick={() => removeFilter(i)}>
+                    {f.label}<span className="x" aria-hidden="true">✕</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {shown.length === 0 ? (
+              <div className="estate" style={{ '--e': `var(--c-${tab})`, paddingTop: 24 }}>
+                <div className="ill">🔍</div>
+                <h3>Nessun risultato</h3>
+                <p>Nessun elemento per «{query}». Prova un altro termine.</p>
+              </div>
+            ) : (
+              <div className="mlist">
+                {shown.map(item => (
+                  <MeepleCard key={item.id} item={item}
+                    bulkMode={bulkMode} selected={selected.has(item.id)}
+                    arming={lp.arming === item.id} bind={lp} onTap={onTapCard} />
+                ))}
+                {hasMore ? (
+                  <div className="loadmore">
+                    <button onClick={() => setVisible(v => v + 6)}>
+                      ↓ Carica altri · {shown.length} di {activeTabMeta.count}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="loadmore">
+                    <div className="done">{filtered.length} di {activeTabMeta.count} caricati</div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Sezione Recente: solo tab Games, no bulk, no ricerca attiva */}
+            {tab === 'game' && !bulkMode && !query && <RecentSection onOpen={setDetail} />}
+          </div>
+        )}
+      </div>
+
+      {/* ─── FAB (bulk mode) ─── */}
+      {bulkMode && (
+        <button className="fab" aria-label="Azioni sulla selezione" onClick={() => setBulkSheet(true)}>⋮</button>
+      )}
+
+      {/* ─── Overflow menu (Agents / KB) ─── */}
+      {overflowOpen && !isTablet && (
+        <React.Fragment>
+          <div className="overlay open" style={{ background: 'transparent' }} onClick={() => setOverflowOpen(false)}></div>
+          <div className="ovmenu" role="menu" aria-label="Più categorie">
+            <div className="ov-lbl">Più categorie</div>
+            {OVERFLOW_TABS.map(t => (
+              <button key={t.id} className="ovitem" role="menuitem" style={{ '--e': `var(--c-${t.id})` }}
+                onClick={() => switchTab(t.id)}>
+                <span className="ovic">{t.em}</span>{t.label}
+                {t.hasNew && <span className="ovdot" title="Nuove entries"></span>}
+                <span className="ovcnt">{t.count}</span>
+              </button>
+            ))}
+          </div>
+        </React.Fragment>
+      )}
+
+      {/* ─── Sheets & toast ─── */}
+      <FiltersSheet open={filtersOpen} draft={filterDraft}
+        onToggle={toggleDraft} onReset={() => setFilterDraft({})}
+        onApply={applyFilters} onClose={() => setFiltersOpen(false)} />
+      <BulkActionsSheet open={bulkSheet} count={selected.size}
+        onClose={() => setBulkSheet(false)}
+        onAction={(lb) => { setBulkSheet(false); exitBulk(); showToast(`${lb} · ${selected.size} elementi`); }} />
+      <DetailSheet entity={detail} onClose={() => setDetail(null)} onOpen={setDetail} />
+
+      <div className={`toast${toast ? ' show' : ''}`} role="status">{toast}</div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Device frame
+   ════════════════════════════════════════════════════════════════ */
+function Device({ tablet, condition, label }) {
+  return (
+    <div className="frame-col">
+      <div className="frame-tag">{label} · <b>{tablet ? '768px tablet' : '375px mobile'}</b></div>
+      <div className={`device${tablet ? ' tablet' : ''}`}>
+        <div className="screen">
+          <div className="sbar">
+            <span>14:32</span>
+            <div className="ind"><span>📶</span><span>🔋</span></div>
+          </div>
+          <LibraryMobile condition={condition} isTablet={tablet} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Root — control bar (tema + stato) e frames mobile + tablet
+   ════════════════════════════════════════════════════════════════ */
+const STATES = [
+  { id: 'default', lb: 'Default' },
+  { id: 'empty', lb: 'Vuoto' },
+  { id: 'loading', lb: 'Loading' },
+  { id: 'error', lb: 'Errore' },
+  { id: 'permission', lb: 'Permesso' },
+  { id: 'offline', lb: 'Offline' },
+  { id: 'filtered', lb: 'Filtrato' },
+];
+
+function Root() {
+  const [theme, setTheme] = useState(() => localStorage.getItem('mai-theme') || 'light');
+  const [condition, setCondition] = useState('default');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('mai-theme', theme);
+  }, [theme]);
+
+  return (
+    <div className="lab">
+      <div className="lab-head">
+        <div className="kick">SP8 · Mobile Parity</div>
+        <h1>Library <span style={{ color: 'hsl(var(--c-game))' }}>mobile</span></h1>
+        <p>Variante mobile-first di <code>/library</code>. IA semplificata: 3 tab + overflow. Lo stato <strong>Default</strong> è interattivo — tab, ricerca, long-press 500ms per selezione multipla, menu ⋯, filtri 80vh.</p>
+      </div>
+
+      <div className="controls" role="toolbar" aria-label="Controlli anteprima">
+        <div className="ctl-grp">
+          <span className="ctl-lbl">Stato</span>
+          {STATES.map(s => (
+            <button key={s.id} className={`seg${condition === s.id ? ' on' : ''}`}
+              aria-pressed={condition === s.id} onClick={() => setCondition(s.id)}>{s.lb}</button>
+          ))}
+        </div>
+        <div className="ctl-grp">
+          <span className="ctl-lbl">Tema</span>
+          {['light', 'dark'].map(t => (
+            <button key={t} className={`seg theme${theme === t ? ' on' : ''}`}
+              aria-pressed={theme === t} onClick={() => setTheme(t)}>{t === 'light' ? '☀︎ Light' : '☾ Dark'}</button>
+          ))}
+        </div>
+      </div>
+
+      <div className="stage-frames">
+        <Device key={'m' + condition} tablet={false} condition={condition} label="Mobile" />
+        <Device key={'t' + condition} tablet={true} condition={condition} label="Tablet" />
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Root />);

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -660,7 +660,7 @@ instead.
 
 | Route | Mockup | Note |
 |-------|--------|------|
-| `/library` | `sp4-library-desktop.html` | Tier S done (PR #574/635/638) |
+| `/library` | `sp4-library-desktop.html` + `sp4-library-mobile.html` | Tier S done (PR #574/635/638); mobile variant SP8 brief 2026-05-30 (IA semplificata 3 tab + overflow Più=Agents/KB) |
 | `/library/wishlist` | — | gap |
 | `/library/playlists` · `/[id]` · `/shared/[token]` | — | **gap critico** (US-attiva) |
 | `/library/private` · `/add` · `/[id]` | `sp4-add-game-pdf-dedup.html` + `sp4-upload-wizard-extended.html` [partial] | — |
@@ -669,7 +669,7 @@ instead.
 | `/library/[gameId]` | `sp4-game-detail.html` + `librogame-runthrough-game-detail.html` + `librogame-runthrough-game-onboarding.html` | IA closes #871 (PR #1037); onboarding gap-coverage 2026-05-12 (pending Stage-2); libro variant audit #1551 → **0% drift** (see [libro-detail-gap-report.md](../../../admin-mockups/design_handoff/libro-detail-gap-report.md)) |
 | `/library/[gameId]/agent` | `sp4-agent-detail.html` + `sp4-game-chat-tab.html` | — |
 | `/library/[gameId]/play` | `librogame-runthrough-resume-picker.html` + `sp6-libro-game-resume-state.html` | Libro-game |
-| `/library/[gameId]/play/[campaignId]` | `librogame-runthrough-play-session.html` + `sp6-libro-game-index.html` | — |
+| `/library/[gameId]/play/[campaignId]` | `librogame-runthrough-play-session.html` + `sp6-libro-game-index.html` | 4 stati v1 congelati + 3 stati SP8 companion (state-05 diary, state-06 paragrafi-drawer, state-07 end-campaign) brief 2026-05-30; nuovo jsx twin con 3 lab interattivi; deviazione narrativa dati documentata (nuovi stati riferiscono §214/Tainted Grail/Niamh, congelati §289/Eldoria/Voidstone) |
 | `/library/[gameId]/play/[campaignId]/translate` | `librogame-runthrough-translate-viewer.html` + `sp6-libro-game-photo-upload.html` | Tier S done (PR #790) |
 | `/library/[gameId]/play/[campaignId]/encounter` | `librogame-runthrough-encounter-cheatsheet.html` | Tier S done (PR #1525, parse-centric MVP; state D deferred) |
 | `/library/[gameId]/toolbox` · `/toolkit` · `/toolkit/[sessionId]` | `sp4-toolkit-detail.html` ↻ | — |


### PR DESCRIPTION
## Summary

- 2 nuovi brief SP* canonici (`SP8-mobile-parity.md` + `SP8-libro-game-companion.md`) in `admin-mockups/briefs/` estendendo `_common.md` — prodotti via spec-panel socratic con 6 open questions risolte (foto inline diary / PDF generation / reopen friction / save model / timestamp format / search scope)
- 2 mockup generati su Claude Design web: **sp4-library-mobile** (greenfield mobile-first variant `/library`, IA semplificata 3 tab + overflow "Più") e **librogame-runthrough-play-session** esteso con 3 nuovi stati companion (diary tab / paragrafi-drawer / end-campaign) — i 4 stati v1 congelati intatti, JSX twin creato ex-novo con 3 lab interattivi runnable
- Bookkeeping aggiornato: `MOCKUPS_INDEX.md` + `v2-migration-matrix.md`

## Deviazioni accettate documentate

- **Narrative data**: nuovi stati SP8 usano §214/Tainted Grail/Niamh, congelati §289/Eldoria/Voidstone — 2 archi narrativi coesistono per design, allineamento dati deferred
- **IA tab system**: Diary diventa 4a tab (non 5a come da brief) — il shell ha Chat come overlay non tab, 4 tab in 375px senza scroll è meglio UX
- **Hex eccezioni**: solo `#fff` su entity-color fill (contrast text pattern) + device-frame chrome — coerente con pattern degli altri mockup

## Test plan

- [ ] Open `admin-mockups/design_files/sp4-library-mobile.html` in browser → verify 3 primary tabs + overflow "Più" + bulk long-press + recent section + Lisa-5 states su Games tab
- [ ] Open `admin-mockups/design_files/librogame-runthrough-play-session.html` in browser → verify 4 stati v1 invariati + 3 stati SP8 + 3 lab interattivi (DiaryLab / HistoryLab / EndCampaignLab) runnable
- [ ] Light + dark theme entrambi via toggle 🌗
- [ ] `data.js` NON toccato (verifica timestamp pre-Claude Design)
- [ ] Pre-push hooks: ✅ già passati (build FE + backend verdi a push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)