### PR TITLE
fix(dice): #1691 rejection sampling eliminates Math.Abs overflow + modulo bias

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs
@@ -138,16 +138,40 @@ public class DiceRoll
     /// </summary>
     private static int[] RollDice(int count, int sides)
     {
-        var results = new int[count];
         using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-        var buffer = new byte[4];
+        return RollDiceCore(count, sides, rng);
+    }
+
+    /// <summary>
+    /// Pure rolling logic exposed for deterministic testing.
+    /// Uses rejection sampling to produce a uniform distribution over [1, sides] with
+    /// zero modulo bias and no <c>Math.Abs(int.MinValue)</c> overflow (issue #1691).
+    /// </summary>
+    /// <param name="count">Number of dice to roll (must be ≥ 0).</param>
+    /// <param name="sides">Number of sides per die (must be ≥ 1).</param>
+    /// <param name="rng">Source of randomness. Must produce 4-byte fills via <see cref="System.Security.Cryptography.RandomNumberGenerator.GetBytes(byte[])"/>.</param>
+    /// <returns>Array of <paramref name="count"/> integers, each in <c>[1, sides]</c>.</returns>
+    internal static int[] RollDiceCore(int count, int sides, System.Security.Cryptography.RandomNumberGenerator rng)
+    {
+        // Largest multiple of `sides` that fits in [0, uint.MaxValue]. Values ≥ limit are
+        // rejected and re-sampled to eliminate modulo bias. Rejection probability is
+        // (uint.MaxValue + 1 - limit) / (uint.MaxValue + 1) ≤ (sides - 1) / 2^32 ≈ 10⁻⁹
+        // for standard dice (d4..d100) → performance impact negligible.
+        var limit = (uint.MaxValue / (uint)sides) * (uint)sides;
+
+        var results = new int[count];
+        Span<byte> buffer = stackalloc byte[4];
 
         for (int i = 0; i < count; i++)
         {
-            rng.GetBytes(buffer);
-            // Convert to positive integer and map to 1-sides range
-            var value = Math.Abs(BitConverter.ToInt32(buffer, 0));
-            results[i] = (value % sides) + 1;
+            uint value;
+            do
+            {
+                rng.GetBytes(buffer);
+                value = BitConverter.ToUInt32(buffer);
+            } while (value >= limit);
+
+            results[i] = (int)(value % (uint)sides) + 1;
         }
 
         return results;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollRejectionSamplingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollRejectionSamplingTests.cs
@@ -1,0 +1,131 @@
+using System.Security.Cryptography;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
+
+/// <summary>
+/// Issue #1691: regression coverage for the rejection-sampling implementation of
+/// <see cref="DiceRoll.RollDiceCore"/>.
+///
+/// <para>
+/// These tests do NOT replace <see cref="DiceRollFairnessTests"/> (chi-square statistical
+/// fairness). They cover deterministic edge cases the statistical tests cannot:
+/// <list type="bullet">
+///   <item>The pre-#1691 code used <c>Math.Abs(BitConverter.ToInt32(...))</c>, which
+///   throws on <c>int.MinValue</c> (~1 / 2³² of inputs) → latent prod crash.</item>
+///   <item>The pre-#1691 code used <c>value % sides</c>, introducing modulo bias for
+///   any <c>sides</c> that does not divide 2³¹ evenly.</item>
+/// </list>
+/// </para>
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "1691")]
+public sealed class DiceRollRejectionSamplingTests
+{
+    /// <summary>
+    /// Deterministic RNG that emits a pre-baked sequence of 4-byte values. Each call to
+    /// <see cref="GetBytes(byte[])"/> writes the next <see cref="uint"/> in little-endian.
+    /// When the sequence is exhausted it cycles. Cycling lets us test the rejection-sampling
+    /// loop by following a "rejected" value with an "accepted" one.
+    /// </summary>
+    private sealed class SequenceRng : RandomNumberGenerator
+    {
+        private readonly uint[] _values;
+        private int _index;
+
+        public SequenceRng(params uint[] values)
+        {
+            if (values is null || values.Length == 0)
+            {
+                throw new ArgumentException("Sequence must contain at least one value", nameof(values));
+            }
+            _values = values;
+        }
+
+        public override void GetBytes(byte[] data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            if (data.Length != 4)
+            {
+                throw new InvalidOperationException($"SequenceRng only supports 4-byte fills (got {data.Length})");
+            }
+            var value = _values[_index];
+            _index = (_index + 1) % _values.Length;
+            BitConverter.TryWriteBytes(data.AsSpan(), value);
+        }
+
+        public override void GetBytes(Span<byte> data)
+        {
+            if (data.Length != 4)
+            {
+                throw new InvalidOperationException($"SequenceRng only supports 4-byte fills (got {data.Length})");
+            }
+            var value = _values[_index];
+            _index = (_index + 1) % _values.Length;
+            BitConverter.TryWriteBytes(data, value);
+        }
+    }
+
+    /// <summary>
+    /// The pre-#1691 implementation did <c>Math.Abs(BitConverter.ToInt32(...))</c>; the byte
+    /// sequence <c>{0x00, 0x00, 0x00, 0x80}</c> decodes to <see cref="int.MinValue"/>, and
+    /// <c>Math.Abs(int.MinValue)</c> overflows. The new implementation reads the same bytes as
+    /// <see cref="uint"/> (= 2_147_483_648) and rejection-samples — no exception is ever thrown.
+    /// </summary>
+    [Fact]
+    public void RollDiceCore_BytesEncodeIntMinValue_DoesNotThrow_AndStaysInRange()
+    {
+        // 2_147_483_648 = 0x80000000 — the bit pattern of int.MinValue.
+        var rng = new SequenceRng(0x80000000u);
+
+        var result = DiceRoll.RollDiceCore(count: 1, sides: 6, rng: rng);
+
+        result.Should().HaveCount(1);
+        result[0].Should().BeInRange(1, 6);
+    }
+
+    /// <summary>
+    /// Exercises the rejection loop. A value equal to (or above) the largest multiple of
+    /// <c>sides</c> ≤ <see cref="uint.MaxValue"/> must be rejected; the next value in the
+    /// sequence is used instead. For sides=6, limit = (2³² / 6) * 6 = 4_294_967_292 →
+    /// values 4_294_967_292..4_294_967_295 are rejected.
+    /// </summary>
+    [Fact]
+    public void RollDiceCore_ValueAtRejectionThreshold_IsResampled()
+    {
+        // First value 4_294_967_292 is the smallest rejected sample for sides=6.
+        // Second value 0 is accepted → 0 % 6 + 1 = 1.
+        var rng = new SequenceRng(4_294_967_292u, 0u);
+
+        var result = DiceRoll.RollDiceCore(count: 1, sides: 6, rng: rng);
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be(1, "the rejected first sample is replaced by the accepted second sample (0 % 6 + 1 = 1)");
+    }
+
+    /// <summary>
+    /// Stress test: 1_000_000 rolls across every standard die size never throw and never
+    /// produce out-of-range values. Acceptance criterion DICE-CRASH-01 in issue #1691.
+    /// </summary>
+    [Theory]
+    [InlineData(4)]
+    [InlineData(6)]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(12)]
+    [InlineData(20)]
+    [InlineData(100)]
+    public void RollDiceCore_OneMillionRolls_AllInRangeAndNoThrow(int sides)
+    {
+        using var rng = RandomNumberGenerator.Create();
+
+        var result = DiceRoll.RollDiceCore(count: 1_000_000, sides: sides, rng: rng);
+
+        result.Should().HaveCount(1_000_000);
+        result.Should().OnlyContain(r => r >= 1 && r <= sides);
+    }
+}


### PR DESCRIPTION
Closes #1691.

## What changed

`DiceRoll.RollDice` (`apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs`) had two latent bugs identified by the spec-panel review on 2026-05-30:

1. **CRASH** — `Math.Abs(BitConverter.ToInt32(buffer, 0))` on a buffer encoding `int.MinValue` (probability 1 / 2³² per roll) overflows. Latent prod crash every 10-50 days of exercise.
2. **BIAS** — `(value % sides) + 1` introduces modulo bias whenever `sides` does not evenly divide 2³¹. ~5e-8 skew per face on d20, ~5e-7 on d100.

Both are fixed by a single rejection-sampling implementation in `RollDiceCore`.

## Implementation

- `RandomNumberGenerator` is read as `uint` via `BitConverter.ToUInt32` — no `Math.Abs`, no overflow.
- Rejection sampling: discard values ≥ `(uint.MaxValue / sides) * sides`, resample. Rejection probability ≤ (sides − 1) / 2³² ≈ 10⁻⁹ for standard dice → performance impact negligible.
- Extracted `internal static RollDiceCore(int count, int sides, RandomNumberGenerator rng)` for deterministic testing with a `SequenceRng` test double. The existing private `RollDice(count, sides)` now just creates a cryptographic RNG and delegates.
- `Span<byte> stackalloc` buffer eliminates the per-call heap allocation.

## Tests (12 PASS in 465ms total)

**`DiceRollRejectionSamplingTests` (new)**:
- `RollDiceCore_BytesEncodeIntMinValue_DoesNotThrow_AndStaysInRange` — deterministic regression for the crash. Pre-#1691 code would have thrown.
- `RollDiceCore_ValueAtRejectionThreshold_IsResampled` — exercises the rejection loop with a `SequenceRng(4_294_967_292, 0)`.
- `RollDiceCore_OneMillionRolls_AllInRangeAndNoThrow` `[Theory]` for sides ∈ {4,6,8,10,12,20,100} — 7M rolls total, all in range, no throw. Satisfies acceptance criterion DICE-CRASH-01.

**`DiceRollFairnessTests` (existing)**: unchanged. Still passes — the rejection-sampling distribution is strictly more uniform than the previous biased one.

## Out of scope

- #1692 — move chi-square to nightly suite (low-urgency follow-up).
- #1693 — inject `IRandomNumberGenerator` as singleton (design refactor).

## Validation note

Per CLAUDE.md, the PR CI runs `Backend Fast` (build + unit), not the integration suite — Backend Fast green will validate that nothing breaks build/unit. The new tests are unit (`Category=Unit`), so they will execute in the PR CI lane.

Refs: spec-panel discussion 2026-05-30 (#1691 / #1692 / #1693), memory `rolldice-chisquare-flaky.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)