### PR TITLE
refactor(dice): #1693 shared RandomNumberGenerator singleton + optional rng parameter

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/DiceRoll.cs
@@ -81,12 +81,19 @@ public class DiceRoll
     /// <param name="participantId">Participant performing the roll.</param>
     /// <param name="formula">Dice formula (e.g., "2d6+3").</param>
     /// <param name="label">Optional label for the roll.</param>
+    /// <param name="rng">
+    /// Optional source of randomness. When <c>null</c> (default) the process-wide
+    /// cryptographic singleton is used. Tests can pass a deterministic
+    /// <see cref="System.Security.Cryptography.RandomNumberGenerator"/> to assert
+    /// exact roll outcomes (issue #1693).
+    /// </param>
     /// <returns>New DiceRoll instance with results.</returns>
     public static DiceRoll Create(
         Guid sessionId,
         Guid participantId,
         string formula,
-        string? label = null)
+        string? label = null,
+        System.Security.Cryptography.RandomNumberGenerator? rng = null)
     {
         if (sessionId == Guid.Empty)
             throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
@@ -98,7 +105,7 @@ public class DiceRoll
             throw new ArgumentException("Formula cannot be empty.", nameof(formula));
 
         var parsed = DiceFormulaParser.Parse(formula);
-        var rolls = RollDice(parsed.Count, parsed.Sides);
+        var rolls = RollDiceCore(parsed.Count, parsed.Sides, rng ?? SharedRng);
         var total = rolls.Sum() + parsed.Modifier;
 
         return new DiceRoll
@@ -134,13 +141,12 @@ public class DiceRoll
     }
 
     /// <summary>
-    /// Rolls dice using cryptographic RNG for fairness.
+    /// Process-wide cryptographic RNG. <see cref="System.Security.Cryptography.RandomNumberGenerator"/>
+    /// is thread-safe in .NET 6+, so a single shared instance avoids the per-roll allocation +
+    /// kernel handle acquisition cost of <c>RandomNumberGenerator.Create()</c> (issue #1693).
     /// </summary>
-    private static int[] RollDice(int count, int sides)
-    {
-        using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
-        return RollDiceCore(count, sides, rng);
-    }
+    private static readonly System.Security.Cryptography.RandomNumberGenerator SharedRng
+        = System.Security.Cryptography.RandomNumberGenerator.Create();
 
     /// <summary>
     /// Pure rolling logic exposed for deterministic testing.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollRejectionSamplingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/DiceRollRejectionSamplingTests.cs
@@ -128,4 +128,25 @@ public sealed class DiceRollRejectionSamplingTests
         result.Should().HaveCount(1_000_000);
         result.Should().OnlyContain(r => r >= 1 && r <= sides);
     }
+
+    /// <summary>
+    /// Issue #1693: <see cref="DiceRoll.Create"/> accepts an optional
+    /// <see cref="RandomNumberGenerator"/> parameter so tests can assert exact roll
+    /// outcomes without going through chi-square goodness-of-fit. Passing a
+    /// <see cref="SequenceRng"/> that emits 0 then 5 (encoded as uint) produces a 2d6
+    /// rolling [1, 6] before the modifier — fully deterministic.
+    /// </summary>
+    [Fact]
+    public void Create_WithInjectedRng_ProducesDeterministicRoll()
+    {
+        // For sides=6: value=0 → 0 % 6 + 1 = 1; value=5 → 5 % 6 + 1 = 6.
+        var rng = new SequenceRng(0u, 5u);
+        var sessionId = Guid.Parse("aaaaaaaa-0000-4000-8000-aaaaaaaaaaaa");
+        var participantId = Guid.Parse("bbbbbbbb-0000-4000-8000-bbbbbbbbbbbb");
+
+        var diceRoll = DiceRoll.Create(sessionId, participantId, "2d6", label: null, rng: rng);
+
+        diceRoll.GetRolls().Should().Equal(1, 6);
+        diceRoll.Total.Should().Be(7); // 1 + 6 + 0 (no modifier)
+    }
 }


### PR DESCRIPTION
Closes #1693. Builds on PR #1694 (#1691).

## What changed (2 micro-improvements)

1. **Static singleton `SharedRng`** replaces per-call `RandomNumberGenerator.Create()`. `RandomNumberGenerator` is thread-safe in .NET 6+, so a process-wide instance avoids the per-roll allocation + kernel handle acquisition cost (~10-50µs on Windows). Negligible in absolute terms but addresses Fowler's design concern from the spec-panel.

2. **Optional `RandomNumberGenerator? rng = null` parameter on `DiceRoll.Create`**. Default `null` keeps backward compatibility — the 20+ existing call sites are unchanged and use the singleton. Test code can now inject a deterministic RNG and assert exact roll outcomes WITHOUT chi-square statistical assertions.

## Why a parameter and not full DI?

Full DI would require injecting `IRandomNumberGenerator` through `RollDiceCommandHandler` → `DiceRoll.Create`. With 20+ call sites already taking `(sessionId, participantId, formula, label?)` as parameters, an additional optional parameter is the strictly minimal change. The public surface already accepts everything it needs; we don't need an abstraction layer.

## Tests (32 PASS in 549ms)

**New**: `Create_WithInjectedRng_ProducesDeterministicRoll` — uses `SequenceRng(0u, 5u)` to assert 2d6 = [1, 6], total = 7. This is the deterministic test path the spec-panel review (Fowler) flagged as previously impossible.

**Existing (all unchanged, still green)**: 12 rejection-sampling + 3 chi-square fairness + 16 DiceRollTests legacy.

## Out of scope

- #1691 — MERGED in PR #1694 (rejection sampling).
- #1692 — CLOSED as won't-fix (chi-square move to nightly; resampling already in place).

Refs: spec-panel discussion 2026-05-30 (Fowler), PR #1694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)