### PR TITLE
fix(e2e): #1640 locale-agnostic games-tab selector (smoke + a11y)

### DIFF
--- a/apps/web/e2e/a11y/games-library.spec.ts
+++ b/apps/web/e2e/a11y/games-library.spec.ts
@@ -2,8 +2,10 @@
  * Accessibility tests — games tab of /library (Wave B.1, Issue #633, updated #1566).
  *
  * The games surface was previously at /games?tab=library and is now reached by
- * navigating to /library and clicking the "Giochi" tab (LibraryHub initializes
- * to the 'all' tab via useState and does NOT read ?tab= from the URL).
+ * navigating to /library and clicking the games tab (LibraryHub initializes
+ * to the 'all' tab via useState and does NOT read ?tab= from the URL). The tab
+ * is selected via `data-tab-key="games"` to remain locale-agnostic — the label
+ * is "Giochi" in IT and "Games" in EN; Playwright CI runs default to en-US.
  *
  * Combines:
  *   - axe-core WCAG 2.1 AA scan su default state (results grid populato)
@@ -47,7 +49,8 @@ async function gotoLibraryReady(page: Page, search = '', waitForGrid = true): Pr
   const url = search ? `/library?${search.replace(/^\?/, '')}` : '/library';
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 });
-  await page.getByRole('tab', { name: /giochi/i }).click();
+  // Locale-agnostic selector — see games.smoke.spec.ts (#1640) for rationale.
+  await page.locator('[role="tab"][data-tab-key="games"]').click();
   if (waitForGrid) {
     await page.waitForSelector('[data-slot="games-results-grid"]', { timeout: 30_000 });
   } else {

--- a/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
+++ b/apps/web/e2e/smoke-real-backend/games.smoke.spec.ts
@@ -26,9 +26,12 @@ test.describe('SMOKE — /games redirect + /library games tab (real backend)', (
     await applySessionToPage(page, cookieHeader);
     await page.goto('/library', { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 });
-    // LibraryHub does not read ?tab= from the URL; click the Giochi tab to reach
+    // LibraryHub does not read ?tab= from the URL; click the games tab to reach
     // the games surface (#1566 wired the Games* components into this tab).
-    await page.getByRole('tab', { name: /giochi/i }).click();
+    // Locale-agnostic selector: Playwright CI Chrome defaults to en-US which
+    // renders the label as "Games" (not "Giochi"), so we target data-tab-key
+    // exposed by LibraryTabs.tsx — same pattern as the unit suite (#1640).
+    await page.locator('[role="tab"][data-tab-key="games"]').click();
     // The smoke fixture user has 1 library entry → expect the grid; fall back to
     // empty-state if the fixture changes. Either proves the games branch mounted.
     await page.waitForSelector(


### PR DESCRIPTION
## Summary
- Replace `getByRole('tab', { name: /giochi/i })` with `[role="tab"][data-tab-key="games"]` in both the nightly smoke (`games.smoke.spec.ts`) and the a11y suite (`games-library.spec.ts`).
- Closes #1640.

## Root cause
The nightly `E2E Smoke Real Backend` has been red for 4 consecutive nights (2026-05-27 → 2026-05-30). The failing test was introduced on 2026-05-27 by commit `67b77a04a` and shipped with a locale-sensitive selector.

Playwright CI Chrome defaults to `en-US`. `IntlProvider` (in `providers.tsx`) calls `getBrowserLocale()` with no explicit locale override → normalises to `'en'` → the `pages.library.hubTabs.games` key resolves to **"Games"**, not "Giochi". The regex `/giochi/i` never matches; 10 s timeout × 3 retries × 1 worker = job failure.

The same defect was latent in `apps/web/e2e/a11y/games-library.spec.ts:50` — the visual-test fixture path masked it but the locator is equally fragile, so I'm preempting it.

## Why data-tab-key
- Already exposed by `LibraryTabs.tsx:88` as a stable test hook
- Already used by the unit suite (`LibraryHub.test.tsx:618,659`)
- Combines `role="tab"` (semantic) with `data-tab-key` (i18n-stable)
- Cheaper than forcing a Playwright `contextOptions.locale` override (which would mask other latent locale bugs across the e2e suite, e.g. `public-layout.spec.ts`)

## Test plan
- [x] eslint passes on both files
- [ ] CI: `Dev Async` + `Dev Fast` green on this PR
- [ ] Tonight's `E2E Smoke Real Backend (nightly)` run goes green (post-merge verification)

## Follow-up (not in this PR)
- `apps/web/e2e/public-layout.spec.ts` has 7 more `name: /giochi/i` occurrences targeting `link` roles. Those are not currently in the nightly smoke gate, but they will break if anyone runs that suite in CI. Worth a separate cleanup PR; not opening one now to keep this fix scoped to the active P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)