### PR TITLE
feat(admin-kb): #1654 F3-FU-5 Preview tab in KbDocDetailPanel

### DIFF
--- a/apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
+++ b/apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Admin KB Doc Preview tab smoke — F3-FU-5 T6 (#1654)
+ *
+ * Verifies that:
+ * 1. Landing on /admin/knowledge-base?doc={id}&tab=preview mounts the
+ *    `KbDocPreviewPanel` (which renders `PdfInlineViewer` with the admin
+ *    toolbar) and the toolbar shows Prev/Next + the page counter
+ *    "Pagina N / M".
+ * 2. Tab routing: clicking Preview from the overview view updates the URL
+ *    to include `tab=preview`; clicking Overview removes the param.
+ *
+ * Helper pattern: follows F3-FU-4 (`kb-doc-actions.spec.ts`, commit
+ * `23b17f6a5`) — `AdminHelper.setupAdminAuth(true)` + per-test route mocks.
+ * `seedKbDocFixture` (referenced in the plan template) does not exist; we
+ * mock the doc + chunks + PDF blob endpoints directly. Same approach as
+ * F3-FU-4's smoke for parity (visibility-only, no destructive actions).
+ *
+ * PDF blob source: `apps/web/e2e/test-data/pandemic_rulebook.pdf` (real
+ * 1-page PDF, 808 bytes). The assertion uses a loose regex that matches
+ * "Pagina N / M" for any M ≥ 1.
+ *
+ * Spec: docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md
+ * Plan: docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md (Task 6)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { expect, Page, test as base } from '@playwright/test';
+
+import { AdminHelper } from '../pages';
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const test = base.extend<{ adminPage: Page }>({
+  adminPage: async ({ page }: { page: Page }, use: (page: Page) => Promise<void>) => {
+    const adminHelper = new AdminHelper(page);
+    // Sets up /auth/me mock + catch-all /api/v1/admin/** stub.
+    // skip navigation = true (each test navigates explicitly).
+    await adminHelper.setupAdminAuth(true);
+    await use(page);
+  },
+});
+
+// ─── Mock data ───────────────────────────────────────────────────────────────
+
+const DOC_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const GAME_ID = 'gggggggg-hhhh-iiii-jjjj-kkkkkkkkkkkk';
+const FILE_NAME = 'catan-rulebook.pdf';
+
+const MOCK_GAMES = [
+  {
+    gameId: GAME_ID,
+    gameName: 'Catan',
+    totalChunks: 142,
+    docCount: 1,
+  },
+];
+
+const MOCK_GAME_DOCS = [
+  {
+    id: DOC_ID,
+    title: FILE_NAME,
+    status: 'indexed' as const,
+    pageCount: 24,
+    gameId: GAME_ID,
+  },
+];
+
+const MOCK_DOC_DETAIL = {
+  id: DOC_ID,
+  title: FILE_NAME,
+  gameId: GAME_ID,
+  gameName: 'Catan',
+  docType: 'rulebook',
+  uploadedAt: '2026-01-15T10:00:00Z',
+  processingStatus: 'ready' as const,
+  chunkCount: 142,
+  pageCount: 24,
+  language: 'it',
+};
+
+// Real PDF fixture (1 page, 808 bytes). The viewer asserts `Pagina N / M`
+// with M ≥ 1 — the exact page count is not load-bearing for the smoke.
+const PDF_FIXTURE_PATH = path.resolve(__dirname, '../test-data/pandemic_rulebook.pdf');
+
+// ─── Route setup helpers ─────────────────────────────────────────────────────
+
+/**
+ * Register KB explorer + PDF download route mocks BEFORE navigation.
+ * Order: specific routes first; the AdminHelper catch-all (registered by
+ * setupAdminAuth) covers anything else.
+ */
+async function setupKbMocks(page: Page) {
+  // 1. KB game-statuses list (KbExplorer queries this on mount)
+  await page.route(`${apiBase}/api/v1/admin/kb/games/`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: MOCK_GAMES }),
+    })
+  );
+
+  // 2. Game documents for the tree
+  await page.route(`${apiBase}/api/v1/knowledge-base/${GAME_ID}/documents`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_GAME_DOCS),
+    })
+  );
+
+  // 3. Doc detail hero (KbDocDetailPanel → useKbDocDetail)
+  await page.route(`${apiBase}/api/v1/kb-docs/${DOC_ID}`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_DOC_DETAIL),
+    })
+  );
+
+  // 4. Chunks list (KbDocDetailPanel → useKbChunksList) — empty pages
+  await page.route(`${apiBase}/api/v1/kb-docs/${DOC_ID}/chunks*`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], nextCursor: null }),
+    })
+  );
+
+  // 5. PDF blob download — returns the real test fixture PDF.
+  //    PdfInlineViewer calls fetch(downloadUrl, { credentials: 'include' })
+  //    and feeds the Blob to react-pdf's `<Document file={blob}>`.
+  const pdfBuffer = fs.readFileSync(PDF_FIXTURE_PATH);
+  await page.route(`${apiBase}/api/v1/pdfs/${DOC_ID}/download`, async route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/pdf',
+      body: pdfBuffer,
+    })
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('KB doc Preview tab (#1654)', () => {
+  test.beforeEach(async ({ adminPage: page }) => {
+    await setupKbMocks(page);
+  });
+
+  // ── Scenario 1: ?tab=preview mounts viewer with admin toolbar ────────────
+
+  test('admin opens ?tab=preview and sees the PDF viewer toolbar', async ({ adminPage: page }) => {
+    await page.goto(`/admin/knowledge-base?doc=${DOC_ID}&tab=preview`);
+
+    // Toolbar Prev / Next buttons render even before the PDF blob loads —
+    // they are part of the static toolbar in PdfInlineViewer.
+    const prevBtn = page.getByRole('button', { name: /prev/i });
+    const nextBtn = page.getByRole('button', { name: /next/i });
+    await expect(prevBtn).toBeVisible({ timeout: 15_000 });
+    await expect(nextBtn).toBeVisible();
+
+    // Page counter shows "Pagina N / M" once react-pdf calls onLoadSuccess.
+    // We assert a loose regex (M may vary if the fixture changes).
+    await expect(page.getByText(/Pagina\s+\d+\s*\/\s*\d+/i)).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── Scenario 2: Tab routing — Preview ↔ Overview ─────────────────────────
+
+  test('tab routing: Preview ↔ Overview updates URL param', async ({ adminPage: page }) => {
+    // Start on the overview view (default tab).
+    await page.goto(`/admin/knowledge-base?doc=${DOC_ID}`);
+
+    // Wait for the tab nav to mount.
+    const tabNav = page.getByRole('navigation', { name: /Sezione documento/i });
+    await expect(tabNav).toBeVisible({ timeout: 15_000 });
+
+    // Click Preview tab → URL gets `tab=preview` appended.
+    await tabNav.getByRole('link', { name: /preview/i }).click();
+    await expect(page).toHaveURL(new RegExp(`doc=${DOC_ID}&tab=preview`), { timeout: 10_000 });
+
+    // Click Overview tab → URL drops the `tab` param (overview is the default).
+    await tabNav.getByRole('link', { name: /overview/i }).click();
+    await expect(page).toHaveURL(new RegExp(`doc=${DOC_ID}(?!.*tab=)`), { timeout: 10_000 });
+  });
+});

--- a/apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
+++ b/apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
@@ -160,7 +160,7 @@ test.describe('KB doc Preview tab (#1654)', () => {
     const prevBtn = page.getByRole('button', { name: /prev/i });
     const nextBtn = page.getByRole('button', { name: /next/i });
     await expect(prevBtn).toBeVisible({ timeout: 15_000 });
-    await expect(nextBtn).toBeVisible();
+    await expect(nextBtn).toBeVisible({ timeout: 15_000 });
 
     // Page counter shows "Pagina N / M" once react-pdf calls onLoadSuccess.
     // We assert a loose regex (M may vary if the fixture changes).

--- a/apps/web/e2e/smoke-real-llm/game-night-happy-path.spec.ts
+++ b/apps/web/e2e/smoke-real-llm/game-night-happy-path.spec.ts
@@ -66,7 +66,7 @@ test.describe('SMOKE-REAL-LLM — game-night happy path (free tier)', () => {
     await expect(pdfTab).toHaveAttribute('aria-selected', 'true');
 
     const pdfBody = modal
-      .locator('[data-slot="citation-pdf-renderer"], [data-slot="citation-ownership-upsell"]')
+      .locator('[data-slot="pdf-inline-viewer"], [data-slot="citation-ownership-upsell"]')
       .first();
     await expect(pdfBody).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx
@@ -9,6 +9,7 @@ import { useKbDocDetail } from '@/hooks/queries/useKbDocDetail';
 import { KbDocActions } from './actions/KbDocActions';
 import { IngestionPanel } from './ingestion/IngestionPanel';
 import { KbDocDetailTabs, type KbDocTabKey } from './KbDocDetailTabs';
+import { KbDocPreviewPanel } from './preview/KbDocPreviewPanel';
 import { KbChunkSearch } from './search/KbChunkSearch';
 import { UsedByPanel } from './used-by/UsedByPanel';
 
@@ -59,6 +60,7 @@ export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelPro
     const tab = searchParams?.get('tab');
     if (tab === 'ingestion') return 'ingestion';
     if (tab === 'used-by') return 'used-by';
+    if (tab === 'preview') return 'preview';
     return 'overview';
   })();
 
@@ -112,6 +114,18 @@ export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelPro
         <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
           <KbDocDetailTabs docId={docId} activeTab={activeTab} />
           <UsedByPanel docId={docId} />
+        </div>
+      );
+    }
+
+    // The Preview tab is also independent of doc readiness — the download
+    // endpoint `/api/v1/pdfs/{id}/download` does NOT gate on processingStatus
+    // (T0 spike confirmed). Render the viewer for queued/processing/failed too.
+    if (activeTab === 'preview') {
+      return (
+        <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
+          <KbDocDetailTabs docId={docId} activeTab={activeTab} />
+          <KbDocPreviewPanel docId={docId} />
         </div>
       );
     }
@@ -185,6 +199,8 @@ export function KbDocDetailPanel({ docId, selectedDocMeta }: KbDocDetailPanelPro
       )}
 
       {activeTab === 'used-by' && <UsedByPanel docId={doc.id} />}
+
+      {activeTab === 'preview' && <KbDocPreviewPanel docId={doc.id} />}
 
       {activeTab === 'overview' && (
         <>

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 
-export type KbDocTabKey = 'overview' | 'ingestion' | 'used-by';
+export type KbDocTabKey = 'overview' | 'ingestion' | 'used-by' | 'preview';
 
 interface KbDocDetailTabsProps {
   readonly docId: string;
@@ -13,12 +13,13 @@ const TABS: ReadonlyArray<{ readonly key: KbDocTabKey; readonly label: string }>
   { key: 'overview', label: 'Overview' },
   { key: 'ingestion', label: 'Ingestion log' },
   { key: 'used-by', label: 'Used by' },
+  { key: 'preview', label: 'Preview' },
 ];
 
 /**
  * Inner tab nav for `KbDocDetailPanel`. URL-driven via `?tab=overview` (default)
- * | `?tab=ingestion` | `?tab=used-by`. Preserves `docId` in each link.
- * Issues #1650 (Ingestion log) + #1651 (Used by). Future follow-ups #1653/#1654.
+ * | `?tab=ingestion` | `?tab=used-by` | `?tab=preview`. Preserves `docId` in each link.
+ * Issues #1650 (Ingestion log) + #1651 (Used by) + #1654 (Preview).
  */
 export function KbDocDetailTabs({ docId, activeTab }: KbDocDetailTabsProps) {
   return (

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
@@ -77,6 +77,13 @@ vi.mock('../search/KbChunkSearch', () => ({
   ),
 }));
 
+// ── KbDocPreviewPanel mock (panel test doesn't exercise viewer internals) ─────
+vi.mock('../preview/KbDocPreviewPanel', () => ({
+  KbDocPreviewPanel: ({ docId }: { docId: string }) => (
+    <div data-testid="kb-doc-preview-panel-mock" data-doc-id={docId} />
+  ),
+}));
+
 // ── QueryClientProvider wrapper (needed for IngestionPanel tab) ───────────────
 function makeWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -286,6 +293,35 @@ describe('KbDocDetailPanel', () => {
     render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
     expect(screen.getByText(/in elaborazione/i)).toBeInTheDocument();
     expect(screen.queryByTestId('used-by-empty')).not.toBeInTheDocument();
+  });
+
+  it('renders KbDocPreviewPanel on ?tab=preview when doc is ready', () => {
+    mockSearchParams = new URLSearchParams('doc=doc-1&tab=preview');
+    mockUseKbDocDetail.mockReturnValue({ data: readyEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: { pages: [] }, hasNextPage: false });
+
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+
+    expect(screen.getByTestId('kb-doc-preview-panel-mock')).toHaveAttribute('data-doc-id', 'doc-1');
+    // chunks list NOT rendered when preview tab active
+    expect(screen.queryByText(/^Chunks$/)).not.toBeInTheDocument();
+  });
+
+  it('renders KbDocPreviewPanel on ?tab=preview when doc is locked (special-case)', () => {
+    mockSearchParams = new URLSearchParams('doc=doc-1&tab=preview');
+    mockUseKbDocDetail.mockReturnValue({ data: lockedEnvelope, isLoading: false });
+
+    render(
+      <KbDocDetailPanel
+        docId="doc-1"
+        selectedDocMeta={{ id: 'doc-1', title: 'X.pdf', gameId: null }}
+      />,
+      { wrapper: makeWrapper() }
+    );
+
+    expect(screen.getByTestId('kb-doc-preview-panel-mock')).toHaveAttribute('data-doc-id', 'doc-1');
+    // locked banner ("Documento in elaborazione") NOT rendered when preview tab active
+    expect(screen.queryByText(/Documento in elaborazione/i)).not.toBeInTheDocument();
   });
 
   // ── Part A: action-bar reachable for locked/failed docs ───────────────────────

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
@@ -12,11 +12,12 @@ vi.mock('next/navigation', async () => {
 });
 
 describe('KbDocDetailTabs', () => {
-  it('renders three tabs: Overview, Ingestion log, Used by', () => {
+  it('renders four tabs: Overview, Ingestion log, Used by, Preview', () => {
     render(<KbDocDetailTabs docId="abc" activeTab="overview" />);
     expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /ingestion log/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /used by/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /preview/i })).toBeInTheDocument();
   });
 
   it('Used by link sets ?tab=used-by and preserves doc param', () => {

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
@@ -47,4 +47,17 @@ describe('KbDocDetailTabs', () => {
     );
     expect(screen.getByRole('link', { name: /overview/i }).getAttribute('aria-current')).toBeNull();
   });
+
+  it('renders Preview tab and marks aria-current when active', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="preview" />);
+    const previewLink = screen.getByRole('link', { name: /preview/i });
+    expect(previewLink).toHaveAttribute('aria-current', 'page');
+    expect(previewLink).toHaveAttribute('href', '/admin/knowledge-base?doc=doc-1&tab=preview');
+  });
+
+  it('Overview link does NOT have tab param when activeTab=preview', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="preview" />);
+    const overviewLink = screen.getByRole('link', { name: /overview/i });
+    expect(overviewLink).toHaveAttribute('href', '/admin/knowledge-base?doc=doc-1');
+  });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx
@@ -2,7 +2,7 @@
 
 import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
 
-export interface KbDocPreviewPanelProps {
+interface KbDocPreviewPanelProps {
   /** Document UUID. Empty string → render null (panel-level guard). */
   readonly docId: string;
 }

--- a/apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
+
+export interface KbDocPreviewPanelProps {
+  /** Document UUID. Empty string → render null (panel-level guard). */
+  readonly docId: string;
+}
+
+/**
+ * KbDocPreviewPanel — admin variant of PdfInlineViewer.
+ * Renders the original PDF blob with the full admin toolbar
+ * (jump-to-page, zoom, open-in-tab, download). No anti-leak (admin context).
+ *
+ * Mounted by KbDocDetailPanel when activeTab === 'preview'.
+ *
+ * Issue #1654 F3-FU-5.
+ */
+export function KbDocPreviewPanel({ docId }: KbDocPreviewPanelProps) {
+  if (!docId) return null;
+  return (
+    <div className="p-4">
+      <PdfInlineViewer
+        documentId={docId}
+        features={{
+          download: true,
+          openInTab: true,
+          jumpToPage: true,
+          zoom: true,
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx
@@ -1,0 +1,42 @@
+// apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPdfInlineViewer = vi.fn();
+vi.mock('@/components/pdf/PdfInlineViewer', () => ({
+  PdfInlineViewer: (props: Record<string, unknown>) => {
+    mockPdfInlineViewer(props);
+    return <div data-testid="pdf-inline-viewer-mock" />;
+  },
+}));
+
+import { KbDocPreviewPanel } from '../KbDocPreviewPanel';
+
+describe('KbDocPreviewPanel', () => {
+  beforeEach(() => {
+    mockPdfInlineViewer.mockReset();
+  });
+
+  it('renders PdfInlineViewer with documentId from docId prop', () => {
+    render(<KbDocPreviewPanel docId="doc-abc" />);
+    expect(screen.getByTestId('pdf-inline-viewer-mock')).toBeInTheDocument();
+    expect(mockPdfInlineViewer).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'doc-abc' })
+    );
+  });
+
+  it('passes admin features { download, openInTab, jumpToPage, zoom } = true, antiLeak omitted', () => {
+    render(<KbDocPreviewPanel docId="doc-abc" />);
+    const props = mockPdfInlineViewer.mock.calls[0][0] as { features: Record<string, boolean> };
+    expect(props.features.download).toBe(true);
+    expect(props.features.openInTab).toBe(true);
+    expect(props.features.jumpToPage).toBe(true);
+    expect(props.features.zoom).toBe(true);
+    expect(props.features.antiLeak ?? false).toBe(false);
+  });
+
+  it('renders nothing when docId is empty string', () => {
+    const { container } = render(<KbDocPreviewPanel docId="" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+++ b/apps/web/src/components/features/game-chat/CitationPdfTab.tsx
@@ -5,38 +5,23 @@
  *   - isPublic=true → render PDF viewer immediato
  *   - altrimenti useCanViewPdf:
  *       loading → spinner
- *       canView=true → PDF viewer (Document+Page react-pdf)
+ *       canView=true → PDF viewer (PdfInlineViewer con antiLeak=true)
  *       canView=false OR isError → CitationOwnershipUpsell
  *
- * Anti-leak:
- *   - oncontextmenu disabled sul container PDF
- *   - NO download button
- *   - NO link al /api/v1/pdfs/{id}/download esposto al click
- *
- * Riusa il pattern fetch-blob di PdfViewerModal.tsx (apps/web/src/components/pdf/).
+ * Anti-leak gestito da PdfInlineViewer via features.antiLeak=true.
  *
  * Spec: docs/superpowers/specs/2026-05-10-citation-pdf-viewer-design.md §3.2 §4.2
+ * Shared viewer: docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md §4
  */
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ReactElement } from 'react';
-
-import { Document, Page, pdfjs } from 'react-pdf';
-import 'react-pdf/dist/Page/AnnotationLayer.css';
-import 'react-pdf/dist/Page/TextLayer.css';
 
 import clsx from 'clsx';
 
 import { CitationOwnershipUpsell } from '@/components/features/game-chat/CitationOwnershipUpsell';
+import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
 import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';
-import { api } from '@/lib/api';
-
-// pdfjs worker setup (mirror of PdfViewerModal.tsx:17-20)
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.mjs',
-  import.meta.url
-).toString();
 
 export interface CitationPdfTabProps {
   readonly documentId: string;
@@ -87,148 +72,12 @@ export function CitationPdfTab({
     return <CitationOwnershipUpsell gameId={gameId} className={className} />;
   }
 
-  return <PdfRenderer documentId={documentId} initialPage={initialPage} className={className} />;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// PdfRenderer — mirror of PdfViewerModal.tsx body, embedded inline (no Dialog),
-// no download button, oncontextmenu blocked
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface PdfRendererProps {
-  readonly documentId: string;
-  readonly initialPage: number;
-  readonly className?: string;
-}
-
-function PdfRenderer({ documentId, initialPage, className }: PdfRendererProps): ReactElement {
-  const [numPages, setNumPages] = useState<number>(0);
-  const [currentPage, setCurrentPage] = useState<number>(initialPage);
-  const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const onDocumentLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
-    setNumPages(numPages);
-  }, []);
-
-  // Fetch PDF as blob with credentials (mirror PdfViewerModal.tsx pattern)
-  useEffect(() => {
-    const pdfUrl = api.pdf.getPdfDownloadUrl(documentId);
-    const controller = new AbortController();
-
-    setLoading(true);
-    setLoadError(null);
-    setNumPages(0);
-    setCurrentPage(initialPage);
-    setPdfBlob(null);
-
-    fetch(pdfUrl, { credentials: 'include', signal: controller.signal })
-      .then(res => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-        return res.blob();
-      })
-      .then(blob => {
-        setPdfBlob(blob);
-        setLoading(false);
-      })
-      .catch(err => {
-        if (err.name !== 'AbortError') {
-          setLoadError(err.message);
-          setLoading(false);
-        }
-      });
-
-    return () => controller.abort();
-  }, [documentId, initialPage]);
-
-  const goPrev = () => setCurrentPage(p => Math.max(1, p - 1));
-  const goNext = () => setCurrentPage(p => Math.min(numPages, p + 1));
-
   return (
-    <div
-      ref={containerRef}
-      data-slot="citation-pdf-renderer"
-      className={clsx('flex flex-col gap-3', className)}
-    >
-      {/* Toolbar: prev/next + page info + anti-leak indicator */}
-      <div
-        className={clsx(
-          'flex items-center gap-2 rounded-md bg-muted px-3 py-2',
-          'font-mono text-xs flex-wrap'
-        )}
-      >
-        <button
-          type="button"
-          onClick={goPrev}
-          disabled={currentPage <= 1 || loading}
-          className={clsx(
-            'rounded-sm border border-border bg-card px-2 py-1',
-            'hover:bg-muted hover:border-[hsl(var(--c-kb))]',
-            'disabled:opacity-40 disabled:cursor-not-allowed'
-          )}
-        >
-          ← Prev
-        </button>
-        <span className="flex-1 text-center">
-          Pagina <strong>{currentPage}</strong> / {numPages || '?'}
-        </span>
-        <button
-          type="button"
-          onClick={goNext}
-          disabled={currentPage >= numPages || loading}
-          className={clsx(
-            'rounded-sm border border-border bg-card px-2 py-1',
-            'hover:bg-muted hover:border-[hsl(var(--c-kb))]',
-            'disabled:opacity-40 disabled:cursor-not-allowed'
-          )}
-        >
-          Next →
-        </button>
-        <span className="inline-flex items-center gap-1 text-[10px] text-[hsl(var(--c-success))]">
-          🔒 Solo visualizzazione
-        </span>
-      </div>
-
-      {/* PDF canvas — anti-leak: no right-click, no user-select */}
-      <div
-        onContextMenu={e => e.preventDefault()}
-        className={clsx(
-          'relative overflow-hidden rounded-md border border-border bg-card',
-          'select-none [&_canvas]:max-w-full',
-          'min-h-[400px]'
-        )}
-        style={{ aspectRatio: '210/297' }}
-      >
-        {loading && (
-          <div
-            role="status"
-            aria-label="Caricamento PDF"
-            className="absolute inset-0 flex items-center justify-center"
-          >
-            <div
-              aria-hidden="true"
-              className="h-10 w-10 rounded-full border-[3px] border-[hsl(var(--c-kb)/0.2)] border-t-[hsl(var(--c-kb))] motion-safe:animate-spin"
-            />
-          </div>
-        )}
-        {loadError && (
-          <div className="flex h-full items-center justify-center p-6 text-sm text-destructive">
-            Errore caricamento PDF: {loadError}
-          </div>
-        )}
-        {pdfBlob && (
-          <Document
-            file={pdfBlob}
-            onLoadSuccess={onDocumentLoadSuccess}
-            loading={null}
-            error={null}
-          >
-            <Page pageNumber={currentPage} renderAnnotationLayer={false} renderTextLayer={false} />
-          </Document>
-        )}
-      </div>
-    </div>
+    <PdfInlineViewer
+      documentId={documentId}
+      initialPage={initialPage}
+      features={{ antiLeak: true }}
+      className={className}
+    />
   );
 }

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -1,0 +1,296 @@
+/**
+ * PdfInlineViewer — shared inline PDF viewer with feature-flagged toolbar.
+ *
+ * Extracts the PdfRenderer interior of CitationPdfTab.tsx (apps/web/src/components/features/game-chat/)
+ * into a reusable shared component. Consumers control toolbar surface via `features` prop:
+ *   - antiLeak: contextmenu blocked + select-none + "🔒 Solo visualizzazione" badge
+ *   - download: <a download> button linking to /api/v1/pdfs/{id}/download
+ *   - openInTab: <a target="_blank" rel="noopener noreferrer"> button
+ *   - jumpToPage: numeric input with form submit, clamped [1, numPages]
+ *   - zoom: select with presets (50/100/150/fit-width) applied via Page.scale
+ *
+ * Worker setup: T0 spike (audits/2026-05-30-pdf-download-locked-spike.md) confirmed
+ * idempotent — multi-module assignment of the same workerSrc URL is safe, no singleton needed.
+ *
+ * Spec: docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md
+ * Plan: docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md (Task 1)
+ * Pattern source: apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+ */
+'use client';
+
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ChangeEvent,
+  type FormEvent,
+  type ReactElement,
+} from 'react';
+
+import clsx from 'clsx';
+import { Document, Page, pdfjs } from 'react-pdf';
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/Page/TextLayer.css';
+
+import { api } from '@/lib/api';
+
+// Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url
+).toString();
+
+export interface PdfInlineViewerFeatures {
+  readonly antiLeak?: boolean;
+  readonly download?: boolean;
+  readonly openInTab?: boolean;
+  readonly jumpToPage?: boolean;
+  readonly zoom?: boolean;
+}
+
+export interface PdfInlineViewerProps {
+  readonly documentId: string;
+  readonly initialPage?: number;
+  readonly defaultZoom?: 'fit-width' | number;
+  readonly features?: PdfInlineViewerFeatures;
+  readonly className?: string;
+}
+
+type ZoomState = 'fit-width' | number;
+
+// A4 portrait width at 72dpi ≈ 595 pt. Used as denominator for fit-width scale.
+const A4_WIDTH_PT = 595;
+const MIN_FIT_WIDTH_SCALE = 0.5;
+
+export function PdfInlineViewer({
+  documentId,
+  initialPage = 1,
+  defaultZoom = 'fit-width',
+  features = {},
+  className,
+}: PdfInlineViewerProps): ReactElement {
+  const [numPages, setNumPages] = useState<number>(0);
+  const [currentPage, setCurrentPage] = useState<number>(initialPage);
+  const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [zoom, setZoom] = useState<ZoomState>(defaultZoom);
+  const [containerWidth, setContainerWidth] = useState<number>(800);
+  const [jumpInput, setJumpInput] = useState<string>(String(initialPage));
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
+
+  const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
+    setNumPages(n);
+  }, []);
+
+  const onDocumentLoadError = useCallback((err: Error) => {
+    setLoadError(`PDF non leggibile: ${err.message}`);
+  }, []);
+
+  // Fetch blob with credentials. Mirror of CitationPdfTab fetch-blob lifecycle.
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setLoadError(null);
+    setNumPages(0);
+    setCurrentPage(initialPage);
+    setPdfBlob(null);
+    setJumpInput(String(initialPage));
+
+    fetch(downloadUrl, { credentials: 'include', signal: controller.signal })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        return res.blob();
+      })
+      .then(blob => {
+        setPdfBlob(blob);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (err.name !== 'AbortError') {
+          setLoadError(err.message);
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [downloadUrl, initialPage]);
+
+  // ResizeObserver for fit-width scale recompute.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const scale =
+    zoom === 'fit-width' ? Math.max(MIN_FIT_WIDTH_SCALE, containerWidth / A4_WIDTH_PT) : zoom / 100;
+
+  const goPrev = () => setCurrentPage(p => Math.max(1, p - 1));
+  const goNext = () => setCurrentPage(p => Math.min(numPages, p + 1));
+
+  const handleJumpSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const parsed = parseInt(jumpInput, 10);
+    if (Number.isNaN(parsed)) return;
+    const clamped = Math.max(1, Math.min(numPages || 1, parsed));
+    setCurrentPage(clamped);
+    setJumpInput(String(clamped));
+  };
+
+  const handleZoomChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    setZoom(v === 'fit-width' ? 'fit-width' : parseInt(v, 10));
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="pdf-inline-viewer"
+      className={clsx('flex flex-col gap-3', className)}
+    >
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs">
+        <button
+          type="button"
+          onClick={goPrev}
+          disabled={currentPage <= 1 || loading}
+          className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          ← Prev
+        </button>
+        <span className="px-2">
+          Pagina <strong>{currentPage}</strong> / {numPages || '?'}
+        </span>
+        <button
+          type="button"
+          onClick={goNext}
+          disabled={currentPage >= numPages || loading}
+          className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          Next →
+        </button>
+
+        {features.jumpToPage && (
+          <form onSubmit={handleJumpSubmit} className="flex items-center gap-1">
+            <label htmlFor="pdf-jump" className="text-muted-foreground">
+              Vai a pagina
+            </label>
+            <input
+              id="pdf-jump"
+              type="number"
+              role="spinbutton"
+              aria-label="Vai a pagina"
+              min={1}
+              max={numPages || undefined}
+              value={jumpInput}
+              onChange={e => setJumpInput(e.target.value)}
+              className="w-14 rounded-sm border border-border bg-card px-1 py-0.5 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+          </form>
+        )}
+
+        {features.zoom && (
+          <label className="flex items-center gap-1">
+            <span className="text-muted-foreground">Zoom</span>
+            <select
+              aria-label="Zoom"
+              value={zoom === 'fit-width' ? 'fit-width' : String(zoom)}
+              onChange={handleZoomChange}
+              className="rounded-sm border border-border bg-card px-1 py-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <option value="50">50%</option>
+              <option value="100">100%</option>
+              <option value="150">150%</option>
+              <option value="fit-width">fit-width</option>
+            </select>
+          </label>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          {features.openInTab && (
+            <a
+              href={downloadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Apri in tab"
+              className="inline-flex items-center rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              ↗ Apri in tab
+            </a>
+          )}
+          {features.download && (
+            <a
+              href={downloadUrl}
+              download
+              aria-label="Download"
+              className="inline-flex items-center rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              ⤓ Download
+            </a>
+          )}
+          {features.antiLeak && (
+            <span className="inline-flex items-center gap-1 text-[10px] text-[hsl(var(--c-success))]">
+              🔒 Solo visualizzazione
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div
+        data-testid="pdf-canvas-container"
+        onContextMenu={features.antiLeak ? e => e.preventDefault() : undefined}
+        className={clsx(
+          'relative overflow-hidden rounded-md border border-border bg-card',
+          features.antiLeak && 'select-none',
+          '[&_canvas]:max-w-full min-h-[400px]'
+        )}
+        style={{ aspectRatio: '210/297' }}
+      >
+        {loading && (
+          <div
+            role="status"
+            aria-label="Caricamento PDF"
+            className="absolute inset-0 flex items-center justify-center"
+          >
+            <div
+              aria-hidden="true"
+              className="h-10 w-10 rounded-full border-[3px] border-[hsl(var(--c-kb)/0.2)] border-t-[hsl(var(--c-kb))] motion-safe:animate-spin"
+            />
+          </div>
+        )}
+        {loadError && (
+          <div className="flex h-full items-center justify-center p-6 text-sm text-destructive">
+            Errore caricamento PDF: {loadError}
+          </div>
+        )}
+        {pdfBlob && !loadError && (
+          <Document
+            file={pdfBlob}
+            onLoadSuccess={onDocumentLoadSuccess}
+            onLoadError={onDocumentLoadError}
+            loading={null}
+            error={null}
+          >
+            <Page
+              pageNumber={currentPage}
+              scale={scale}
+              renderAnnotationLayer={false}
+              renderTextLayer={false}
+            />
+          </Document>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -135,6 +135,9 @@ export function PdfInlineViewer({
   const scale =
     zoom === 'fit-width' ? Math.max(MIN_FIT_WIDTH_SCALE, containerWidth / A4_WIDTH_PT) : zoom / 100;
 
+  // Spec FR-9: fetch failure → toolbar disabled (matches loading-state gating)
+  const controlsDisabled = loading || Boolean(loadError);
+
   const goPrev = () => setCurrentPage(p => Math.max(1, p - 1));
   const goNext = () => setCurrentPage(p => Math.min(numPages, p + 1));
 
@@ -163,7 +166,7 @@ export function PdfInlineViewer({
         <button
           type="button"
           onClick={goPrev}
-          disabled={currentPage <= 1 || loading}
+          disabled={currentPage <= 1 || controlsDisabled}
           className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           ← Prev
@@ -174,7 +177,7 @@ export function PdfInlineViewer({
         <button
           type="button"
           onClick={goNext}
-          disabled={currentPage >= numPages || loading}
+          disabled={currentPage >= numPages || controlsDisabled}
           className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           Next →
@@ -193,8 +196,9 @@ export function PdfInlineViewer({
               min={1}
               max={numPages || undefined}
               value={jumpInput}
+              disabled={controlsDisabled}
               onChange={e => setJumpInput(e.target.value)}
-              className="w-14 rounded-sm border border-border bg-card px-1 py-0.5 text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="w-14 rounded-sm border border-border bg-card px-1 py-0.5 text-center disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             />
           </form>
         )}
@@ -205,8 +209,9 @@ export function PdfInlineViewer({
             <select
               aria-label="Zoom"
               value={zoom === 'fit-width' ? 'fit-width' : String(zoom)}
+              disabled={controlsDisabled}
               onChange={handleZoomChange}
-              className="rounded-sm border border-border bg-card px-1 py-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="rounded-sm border border-border bg-card px-1 py-0.5 disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
               <option value="50">50%</option>
               <option value="100">100%</option>
@@ -217,7 +222,7 @@ export function PdfInlineViewer({
         )}
 
         <div className="ml-auto flex items-center gap-2">
-          {features.openInTab && (
+          {features.openInTab && !loadError && (
             <a
               href={downloadUrl}
               target="_blank"
@@ -228,7 +233,7 @@ export function PdfInlineViewer({
               ↗ Apri in tab
             </a>
           )}
-          {features.download && (
+          {features.download && !loadError && (
             <a
               href={downloadUrl}
               download

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -87,10 +87,10 @@ describe('PdfInlineViewer', () => {
 
   it('prev/next clamps to [1, numPages]', async () => {
     render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
-    await waitFor(() =>
-      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1')
-    );
-    // Prev at page 1 is disabled
+    // Wait for Document onLoadSuccess (mock fires via setTimeout 0) to populate numPages
+    // — Next button becomes enabled only when numPages > currentPage AND loading=false
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled());
+    // Prev at page 1 is still disabled (currentPage <= 1)
     expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
     // Next advances
     fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * PdfInlineViewer — shared inline PDF viewer with feature-flagged toolbar.
+ *
+ * Spec: docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md
+ * Plan: docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md (Task 1)
+ *
+ * Mock pattern source: apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('react-pdf', () => ({
+  Document: ({ children, onLoadSuccess }: any) => {
+    setTimeout(() => onLoadSuccess?.({ numPages: 5 }), 0);
+    return <div data-testid="pdf-document">{children}</div>;
+  },
+  Page: ({ pageNumber, scale }: { pageNumber: number; scale?: number }) => (
+    <div data-testid="pdf-page" data-page-number={pageNumber} data-scale={scale ?? 1}>
+      Page {pageNumber}
+    </div>
+  ),
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: { getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download` },
+  },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { PdfInlineViewer } from '../PdfInlineViewer';
+
+function mockBlobSuccess() {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    blob: () =>
+      Promise.resolve(
+        new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' })
+      ),
+  });
+}
+
+describe('PdfInlineViewer', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockBlobSuccess();
+  });
+
+  it('shows loading skeleton while fetching blob', () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<PdfInlineViewer documentId="doc-1" />);
+    expect(screen.getByRole('status', { name: /caricamento/i })).toBeInTheDocument();
+  });
+
+  it('renders Page at initialPage after fetch success', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={3} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '3');
+    });
+  });
+
+  it('shows error banner on fetch HTTP 500', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+    render(<PdfInlineViewer documentId="doc-1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/HTTP 500/i)).toBeInTheDocument();
+    });
+  });
+
+  it('ignores AbortError silently (no banner)', async () => {
+    mockFetch.mockImplementation((_: unknown, opts: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+    const { unmount } = render(<PdfInlineViewer documentId="doc-1" />);
+    unmount();
+    // no error banner expected; the test passes if no exception thrown
+  });
+
+  it('prev/next clamps to [1, numPages]', async () => {
+    render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1')
+    );
+    // Prev at page 1 is disabled
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+    // Next advances
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '2')
+    );
+  });
+
+  it('antiLeak=true prevents contextmenu + applies select-none', async () => {
+    render(<PdfInlineViewer documentId="doc-1" features={{ antiLeak: true }} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    const canvas = screen.getByTestId('pdf-canvas-container');
+    expect(canvas.className).toContain('select-none');
+    const ev = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    const prevented = !canvas.dispatchEvent(ev);
+    expect(prevented).toBe(true);
+  });
+
+  it('antiLeak=false (default) allows contextmenu, no select-none', async () => {
+    render(<PdfInlineViewer documentId="doc-1" />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    const canvas = screen.getByTestId('pdf-canvas-container');
+    expect(canvas.className).not.toContain('select-none');
+  });
+
+  it('features.download=true renders <a download> with download URL', async () => {
+    render(<PdfInlineViewer documentId="doc-1" features={{ download: true }} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    const a = screen.getByRole('link', { name: /download/i });
+    expect(a).toHaveAttribute('href', 'http://test/api/v1/pdfs/doc-1/download');
+    expect(a).toHaveAttribute('download');
+  });
+
+  it('features.openInTab=true renders <a target="_blank" rel="noopener noreferrer">', async () => {
+    render(<PdfInlineViewer documentId="doc-1" features={{ openInTab: true }} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    const a = screen.getByRole('link', { name: /apri in tab/i });
+    expect(a).toHaveAttribute('target', '_blank');
+    expect(a).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('features.jumpToPage=true clamps input to [1, numPages]', async () => {
+    render(<PdfInlineViewer documentId="doc-1" features={{ jumpToPage: true }} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    const input = screen.getByRole('spinbutton', { name: /vai a pagina/i });
+    fireEvent.change(input, { target: { value: '99' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '5')
+    );
+  });
+
+  it('features.jumpToPage=true ignores NaN input silently', async () => {
+    render(<PdfInlineViewer documentId="doc-1" features={{ jumpToPage: true }} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1')
+    );
+    const input = screen.getByRole('spinbutton', { name: /vai a pagina/i });
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.submit(input.closest('form')!);
+    // page should stay at 1 (NaN ignored)
+    await new Promise(r => setTimeout(r, 10));
+    expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1');
+  });
+
+  it('features.zoom=true switches preset → applies scale to Page', async () => {
+    render(<PdfInlineViewer documentId="doc-1" defaultZoom={100} features={{ zoom: true }} />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-scale', '1'));
+    const zoomSelect = screen.getByRole('combobox', { name: /zoom/i });
+    fireEvent.change(zoomSelect, { target: { value: '150' } });
+    await waitFor(() =>
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-scale', '1.5')
+    );
+  });
+
+  it('features.zoom=false (default) does not render zoom controls', async () => {
+    render(<PdfInlineViewer documentId="doc-1" />);
+    await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+    expect(screen.queryByRole('combobox', { name: /zoom/i })).not.toBeInTheDocument();
+  });
+});

--- a/audits/2026-05-30-pdf-download-locked-spike.md
+++ b/audits/2026-05-30-pdf-download-locked-spike.md
@@ -1,0 +1,72 @@
+# T0 Spike — PDF download endpoint vs doc states + pdfjs workerSrc multi-setup
+
+**Date:** 2026-05-30
+**Status:** decision
+**Scope:** outcome decisorio per T5 (locked branch) e T1 (workerSrc setup pattern)
+
+---
+
+## (a) Endpoint /api/v1/pdfs/{id}/download vs processingStatus
+
+**Handler location:**
+- Route definition: `apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs:61-65`
+- Handler method: `HandleDownloadPdf` at line 165
+- Query handler: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/DownloadPdfQueryHandler.cs`
+
+**Analysis of DownloadPdfQueryHandler.Handle (lines 43-101):**
+
+The handler executes three steps:
+
+1. **Step 1 (lines 43-56):** Fetches PDF metadata from DB — selects `Id`, `SharedGameId`, `PrivateGameId`, `FileName`, `FilePath`, `ContentType`, `UploadedByUserId`. **`processingStatus` / `ProcessingStatus` is not selected and not inspected.**
+
+2. **Step 2 (lines 64-76):** Authorization check — SharedGame PDFs (SharedGameId set, PrivateGameId null) are accessible to all authenticated users; private PDFs require owner or admin. **No status-based gate.**
+
+3. **Step 3 (lines 78-100):** Retrieves the blob from storage via `IBlobStorageService.RetrieveAsync`. Returns `null` (→ 404 at the routing layer) only if the blob is absent from storage. Returns 403 only via `UnauthorizedAccessException`.
+
+**Behavior on processingStatus:**
+
+| State | Behavior |
+|---|---|
+| `ready` | 200 with file blob (blob exists) |
+| `processing` / `queued` | 200 with file blob if blob is already in storage (upload succeeded before indexing); 404 if blob not yet uploaded |
+| `failed` | 200 with file blob if blob exists; 404 if blob upload also failed |
+
+The upload pipeline uploads the file to blob storage at the beginning of the processing workflow (before text extraction and indexing). Therefore in practice any doc with a non-null `FilePath` / non-missing blob will return 200 regardless of indexing status.
+
+**Decision: OK**
+
+The endpoint returns 200 + file blob for all docs where the file exists in storage, with no gate on `processingStatus`. T5 implements the locked branch as designed (preview available for `processing`/`queued`/`failed` states; FR-2 remains in scope).
+
+---
+
+## (b) pdfjs.GlobalWorkerOptions.workerSrc multi-setup
+
+**Current usage — 4 call sites in codebase:**
+
+| File | Line | Setup style |
+|---|---|---|
+| `apps/web/src/components/pdf/PdfPreview.tsx` | 16 | module-level (immediate) |
+| `apps/web/src/components/pdf/PdfViewerModal.tsx` | 17 | module-level (immediate) |
+| `apps/web/src/components/features/game-chat/CitationPdfTab.tsx` | 36 | module-level (immediate) |
+| `apps/web/src/components/chat-unified/PdfPageModal.tsx` | 20 | inside `dynamic()` import callback |
+
+**All 4 assignments set the identical value:**
+
+```ts
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+```
+
+**Behavior — idempotent:**
+
+`pdfjs.GlobalWorkerOptions.workerSrc` is a plain mutable string property on a singleton object shared across all modules in the same bundle. Each assignment resolves `new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString()` to the same webpack/Next.js bundled asset URL (the asset path is resolved at build time, not relative to the file's URL in production). Writing the same string value twice is a no-op. The existing pattern — 3 module-level assignments — already demonstrates this is safe: `PdfPreview`, `PdfViewerModal`, and `CitationPdfTab` all coexist without issue.
+
+There is no race condition or ordering constraint because:
+1. JavaScript module evaluation is synchronous.
+2. The worker is not spawned until `Document` mounts, which happens after all module-level code has run.
+
+**Decision: module-level setup in PdfInlineViewer**
+
+`PdfInlineViewer.tsx` can follow the existing pattern: module-level assignment at the top of the file (after `import { pdfjs } from 'react-pdf'`). CitationPdfTab keeps its current module-level setup unchanged (T2 removes it only if T2 consolidates the import, which is a separate decision). No singleton module `pdfjs-worker.ts` is needed.

--- a/docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md
+++ b/docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md
@@ -1,0 +1,1204 @@
+# SP5 Admin KB — F3-FU-5: Preview tab in KbDocDetailPanel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere un quarto tab `?tab=preview` a `KbDocDetailPanel` che renderizza inline il PDF originale del documento KB, estraendo il pattern `PdfRenderer` di `CitationPdfTab` in un componente shared `PdfInlineViewer` props-driven.
+
+**Architecture:** Refactor + nuovo componente in due passi indipendenti. (1) `PdfInlineViewer.tsx` net-new in `components/pdf/` con feature flags (antiLeak/download/openInTab/jumpToPage/zoom). (2) `CitationPdfTab` refactorato per consumarlo con `{antiLeak:true}` (output invariato → regression test passano). (3) `KbDocPreviewPanel.tsx` net-new in `explorer/preview/` consuma `PdfInlineViewer` con admin variant (toolbar full). `KbDocDetailTabs` + `KbDocDetailPanel` estesi per il nuovo tab; il viewer è disponibile sia su `ready` sia su `locked` (special-case come Used-by).
+
+**Tech Stack:** Next.js 16 App Router · React 19 · TypeScript · Tailwind 4 · react-pdf (già nel bundle) · pdfjs-dist · Vitest + React Testing Library · Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `audits/2026-05-30-pdf-download-locked-spike.md` | NEW | T0 spike report (download endpoint vs doc states + workerSrc multi-setup) |
+| `apps/web/src/components/pdf/PdfInlineViewer.tsx` | NEW | Shared component: fetch blob + Document+Page + toolbar feature-flagged + error banner |
+| `apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx` | NEW | Unit: feature-flag matrix + lifecycle + errors |
+| `apps/web/src/components/features/game-chat/CitationPdfTab.tsx` | MODIFY | Consumer di PdfInlineViewer con `{antiLeak:true}`. Strip PdfRenderer (righe ~94-234). |
+| `apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx` | MUST pass invariato | Regression gate: output e behavior esterni identici |
+| `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx` | MODIFY | `KbDocTabKey += 'preview'`, entry in `TABS` |
+| `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx` | MODIFY | Estendi matrice test con `activeTab='preview'` |
+| `apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx` | NEW | Wrapper admin variant: consuma PdfInlineViewer con toolbar full |
+| `apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx` | NEW | Unit: docId valido → viewer con admin flags · docId null → no-crash |
+| `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx` | MODIFY | `activeTab` discriminator + branch `preview` in ready & locked |
+| `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx` | MODIFY | Estendi matrice test: `?tab=preview` su ready + locked |
+| `apps/web/e2e/admin/kb-doc-preview-tab.spec.ts` | NEW | 2 smoke: viewer visibile + tab routing |
+
+---
+
+## Test mock strategy (riusa pattern CitationPdfTab.test.tsx)
+
+Per i test di `PdfInlineViewer` che richiedono `numPages > 0` (prev/next/jump-to-page) il mock globale di `vitest.setup.tsx` non basta (non chiama `onLoadSuccess`). Override locale (pattern da `CitationPdfTab.test.tsx:11-22`):
+
+```tsx
+vi.mock('react-pdf', () => ({
+  Document: ({ children, onLoadSuccess }: any) => {
+    setTimeout(() => onLoadSuccess?.({ numPages: 24 }), 0);
+    return <div data-testid="pdf-document">{children}</div>;
+  },
+  Page: ({ pageNumber, scale }: { pageNumber: number; scale?: number }) => (
+    <div data-testid="pdf-page" data-page-number={pageNumber} data-scale={scale}>
+      Page {pageNumber}
+    </div>
+  ),
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
+}));
+```
+
+E mock `fetch` globale per il blob:
+
+```tsx
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+mockFetch.mockResolvedValue({
+  ok: true,
+  blob: () => Promise.resolve(new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' })),
+});
+```
+
+E mock `api.pdf.getPdfDownloadUrl`:
+
+```tsx
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: { getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download` },
+  },
+}));
+```
+
+---
+
+## Task 0: T0 — Spike doc-only
+
+**Files:**
+- Create: `audits/2026-05-30-pdf-download-locked-spike.md`
+
+> **Tipo Task:** spike read-only. Doc-only. Outcome decisorio per T5 (locked branch) e T1 (workerSrc setup pattern).
+
+- [ ] **Step 1: Verifica (a) — endpoint download vs stato doc**
+
+  Strategia: read-only code review del handler backend dell'endpoint `/api/v1/pdfs/{id}/download`.
+
+  ```bash
+  cd D:/Repositories/meepleai-monorepo-dev
+  rg -n -l 'GetPdfDownload\|pdfs/.*/download' apps/api/src/Api -t cs
+  rg -n 'GetPdfDownload\|pdfs/.*download' apps/api/src/Api -t cs
+  ```
+
+  Expected: identifica il endpoint handler (probabilmente in `BoundedContexts/DocumentProcessing/...`). Apri il file e verifica se ci sono guard su `processingStatus`:
+  - Se il handler ritorna 200 per qualsiasi PDF con file blob presente (a prescindere da indexing status) → outcome OK, Q2 decisione "tutti gli stati" valida, T5 implementa il branch locked.
+  - Se il handler ritorna 4xx su stato non-`ready` → outcome BLOCCATO, T5 rimuove il branch locked (Preview viewer disponibile SOLO su ready, branch locked usa il banner standard come Overview/Ingestion); FR-2 rimosso dal test plan.
+
+- [ ] **Step 2: Verifica (b) — workerSrc multi-setup side effects**
+
+  Strategia: read della docs react-pdf + osservazione del codice esistente.
+
+  In CitationPdfTab.tsx:35-39 il workerSrc è settato a module-level (immediato all'import del file). Se PdfInlineViewer fa lo stesso, due chiamate `pdfjs.GlobalWorkerOptions.workerSrc = ...` accadono al primo import di entrambi i moduli.
+
+  Verifica con due approcci:
+  1. Repository search: `rg -n 'GlobalWorkerOptions' apps/web/src` — vedi quante volte è settato oggi.
+  2. Documentazione react-pdf: il setting è una proprietà mutabile su `pdfjs.GlobalWorkerOptions` — assegnare ripetutamente lo stesso valore è idempotent.
+
+  Outcome:
+  - Se idempotent (atteso) → `PdfInlineViewer.tsx` può fare il setup module-level, `CitationPdfTab` lo rimuove (T2). Ordine import non rilevante.
+  - Se NON idempotent → estrai il setup in un singleton module `apps/web/src/components/pdf/pdfjs-worker.ts` (eseguito una sola volta), `PdfInlineViewer` e `CitationPdfTab` lo importano.
+
+- [ ] **Step 3: Scrivi il report**
+
+  ```markdown
+  # T0 Spike — PDF download endpoint vs doc states + pdfjs workerSrc multi-setup
+
+  **Date:** 2026-05-30
+  **Status:** decision
+  **Scope:** outcome decisorio per T5 (locked branch) e T1 (workerSrc setup pattern)
+
+  ## (a) Endpoint /api/v1/pdfs/{id}/download vs processingStatus
+
+  **Handler location:** [file:line]
+
+  **Behavior on processingStatus:**
+  - `ready` → 200 con file blob
+  - `processing`/`queued` → [200 / 4xx]
+  - `failed` → [200 / 4xx]
+
+  **Decision:** [OK — T5 implementa locked branch | BLOCKED — T5 rimuove locked branch, FR-2 rimosso]
+
+  ## (b) pdfjs.GlobalWorkerOptions.workerSrc multi-setup
+
+  **Current usage:** [N posti in codebase]
+
+  **Behavior:** [idempotent / non-idempotent]
+
+  **Decision:** [module-level setup in PdfInlineViewer | singleton module pdfjs-worker.ts]
+  ```
+
+- [ ] **Step 4: Commit spike report**
+
+  ```bash
+  git add audits/2026-05-30-pdf-download-locked-spike.md
+  git commit -m "spike(admin-kb): #1654 T0 — endpoint download vs doc states + workerSrc multi-setup"
+  ```
+
+  > Se outcome (a) = BLOCKED → aggiorna la spec design § 7 stati + § 8 FR-2 + § 11 T5 con la nuova baseline prima di proseguire. Commit separato sul design doc se necessario.
+
+---
+
+## Task 1: `PdfInlineViewer` shared component (TDD)
+
+**Files:**
+- Create: `apps/web/src/components/pdf/PdfInlineViewer.tsx`
+- Create: `apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx`
+
+> Se T0 (b) ha indicato singleton module, crea anche `apps/web/src/components/pdf/pdfjs-worker.ts` prima di Step 4.
+
+- [ ] **Step 1: Crea il test file con setup mocks**
+
+  ```tsx
+  // apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+  import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+  vi.mock('react-pdf', () => ({
+    Document: ({ children, onLoadSuccess }: any) => {
+      setTimeout(() => onLoadSuccess?.({ numPages: 5 }), 0);
+      return <div data-testid="pdf-document">{children}</div>;
+    },
+    Page: ({ pageNumber, scale }: { pageNumber: number; scale?: number }) => (
+      <div data-testid="pdf-page" data-page-number={pageNumber} data-scale={scale ?? 1}>
+        Page {pageNumber}
+      </div>
+    ),
+    pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
+  }));
+
+  vi.mock('@/lib/api', () => ({
+    api: {
+      pdf: { getPdfDownloadUrl: (id: string) => `http://test/api/v1/pdfs/${id}/download` },
+    },
+  }));
+
+  const mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+
+  import { PdfInlineViewer } from '../PdfInlineViewer';
+
+  function mockBlobSuccess() {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob([new Uint8Array([0x25, 0x50, 0x44, 0x46])], { type: 'application/pdf' })),
+    });
+  }
+
+  describe('PdfInlineViewer', () => {
+    beforeEach(() => {
+      mockFetch.mockReset();
+      mockBlobSuccess();
+    });
+
+    it('shows loading skeleton while fetching blob', () => {
+      mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+      render(<PdfInlineViewer documentId="doc-1" />);
+      expect(screen.getByRole('status', { name: /caricamento/i })).toBeInTheDocument();
+    });
+
+    it('renders Page at initialPage after fetch success', async () => {
+      render(<PdfInlineViewer documentId="doc-1" initialPage={3} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '3');
+      });
+    });
+
+    it('shows error banner on fetch HTTP 500', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' });
+      render(<PdfInlineViewer documentId="doc-1" />);
+      await waitFor(() => {
+        expect(screen.getByText(/HTTP 500/i)).toBeInTheDocument();
+      });
+    });
+
+    it('ignores AbortError silently (no banner)', async () => {
+      mockFetch.mockImplementation((_, opts) => {
+        return new Promise((_, reject) => {
+          opts.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      });
+      const { unmount } = render(<PdfInlineViewer documentId="doc-1" />);
+      unmount();
+      // no error banner expected; the test passes if no exception thrown
+    });
+
+    it('prev/next clamps to [1, numPages]', async () => {
+      render(<PdfInlineViewer documentId="doc-1" initialPage={1} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1'));
+      // Prev at page 1 is disabled
+      expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+      // Next advances
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '2'));
+    });
+
+    it('antiLeak=true prevents contextmenu + applies select-none', async () => {
+      render(<PdfInlineViewer documentId="doc-1" features={{ antiLeak: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      const canvas = screen.getByTestId('pdf-canvas-container');
+      expect(canvas.className).toContain('select-none');
+      const ev = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+      const prevented = !canvas.dispatchEvent(ev);
+      expect(prevented).toBe(true);
+    });
+
+    it('antiLeak=false (default) allows contextmenu, no select-none', async () => {
+      render(<PdfInlineViewer documentId="doc-1" />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      const canvas = screen.getByTestId('pdf-canvas-container');
+      expect(canvas.className).not.toContain('select-none');
+    });
+
+    it('features.download=true renders <a download> with download URL', async () => {
+      render(<PdfInlineViewer documentId="doc-1" features={{ download: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      const a = screen.getByRole('link', { name: /download/i });
+      expect(a).toHaveAttribute('href', 'http://test/api/v1/pdfs/doc-1/download');
+      expect(a).toHaveAttribute('download');
+    });
+
+    it('features.openInTab=true renders <a target="_blank" rel="noopener noreferrer">', async () => {
+      render(<PdfInlineViewer documentId="doc-1" features={{ openInTab: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      const a = screen.getByRole('link', { name: /apri in tab/i });
+      expect(a).toHaveAttribute('target', '_blank');
+      expect(a).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('features.jumpToPage=true clamps input to [1, numPages]', async () => {
+      render(<PdfInlineViewer documentId="doc-1" features={{ jumpToPage: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      const input = screen.getByRole('spinbutton', { name: /vai a pagina/i });
+      fireEvent.change(input, { target: { value: '99' } });
+      fireEvent.submit(input.closest('form')!);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '5'));
+    });
+
+    it('features.jumpToPage=true ignores NaN input silently', async () => {
+      render(<PdfInlineViewer documentId="doc-1" features={{ jumpToPage: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1'));
+      const input = screen.getByRole('spinbutton', { name: /vai a pagina/i });
+      fireEvent.change(input, { target: { value: 'abc' } });
+      fireEvent.submit(input.closest('form')!);
+      // page should stay at 1 (NaN ignored)
+      await new Promise(r => setTimeout(r, 10));
+      expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-page-number', '1');
+    });
+
+    it('features.zoom=true switches preset → applies scale to Page', async () => {
+      render(<PdfInlineViewer documentId="doc-1" defaultZoom={100} features={{ zoom: true }} />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-scale', '1'));
+      const zoomSelect = screen.getByRole('combobox', { name: /zoom/i });
+      fireEvent.change(zoomSelect, { target: { value: '150' } });
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toHaveAttribute('data-scale', '1.5'));
+    });
+
+    it('features.zoom=false (default) does not render zoom controls', async () => {
+      render(<PdfInlineViewer documentId="doc-1" />);
+      await waitFor(() => expect(screen.getByTestId('pdf-page')).toBeInTheDocument());
+      expect(screen.queryByRole('combobox', { name: /zoom/i })).not.toBeInTheDocument();
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run test, confirm FAIL**
+
+  ```bash
+  cd apps/web
+  pnpm test pdf/__tests__/PdfInlineViewer.test.tsx 2>&1 | tail -20
+  ```
+
+  Expected: FAIL "Cannot find module '../PdfInlineViewer'".
+
+- [ ] **Step 3: Implementa `PdfInlineViewer`**
+
+  ```tsx
+  // apps/web/src/components/pdf/PdfInlineViewer.tsx
+  'use client';
+
+  import { useState, useEffect, useCallback, useRef, type ReactElement, type FormEvent } from 'react';
+  import { Document, Page, pdfjs } from 'react-pdf';
+  import 'react-pdf/dist/Page/AnnotationLayer.css';
+  import 'react-pdf/dist/Page/TextLayer.css';
+  import clsx from 'clsx';
+
+  import { api } from '@/lib/api';
+
+  // Worker setup (idempotent per T0 spike outcome).
+  // If T0 outcome = singleton module, replace this with: `import '@/components/pdf/pdfjs-worker'`.
+  pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    'pdfjs-dist/build/pdf.worker.min.mjs',
+    import.meta.url
+  ).toString();
+
+  export interface PdfInlineViewerFeatures {
+    readonly antiLeak?: boolean;
+    readonly download?: boolean;
+    readonly openInTab?: boolean;
+    readonly jumpToPage?: boolean;
+    readonly zoom?: boolean;
+  }
+
+  export interface PdfInlineViewerProps {
+    readonly documentId: string;
+    readonly initialPage?: number;
+    readonly defaultZoom?: 'fit-width' | number;
+    readonly features?: PdfInlineViewerFeatures;
+    readonly className?: string;
+  }
+
+  type ZoomState = 'fit-width' | number;
+
+  export function PdfInlineViewer({
+    documentId,
+    initialPage = 1,
+    defaultZoom = 'fit-width',
+    features = {},
+    className,
+  }: PdfInlineViewerProps): ReactElement {
+    const [numPages, setNumPages] = useState<number>(0);
+    const [currentPage, setCurrentPage] = useState<number>(initialPage);
+    const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [zoom, setZoom] = useState<ZoomState>(defaultZoom);
+    const [containerWidth, setContainerWidth] = useState<number>(800);
+    const [jumpInput, setJumpInput] = useState<string>(String(initialPage));
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
+
+    const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
+      setNumPages(n);
+    }, []);
+
+    const onDocumentLoadError = useCallback((err: Error) => {
+      setLoadError(`PDF non leggibile: ${err.message}`);
+    }, []);
+
+    // Fetch blob with credentials
+    useEffect(() => {
+      const controller = new AbortController();
+      setLoading(true);
+      setLoadError(null);
+      setNumPages(0);
+      setCurrentPage(initialPage);
+      setPdfBlob(null);
+      setJumpInput(String(initialPage));
+
+      fetch(downloadUrl, { credentials: 'include', signal: controller.signal })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+          return res.blob();
+        })
+        .then(blob => {
+          setPdfBlob(blob);
+          setLoading(false);
+        })
+        .catch((err: Error) => {
+          if (err.name !== 'AbortError') {
+            setLoadError(err.message);
+            setLoading(false);
+          }
+        });
+
+      return () => controller.abort();
+    }, [downloadUrl, initialPage]);
+
+    // ResizeObserver for fit-width
+    useEffect(() => {
+      if (!containerRef.current) return;
+      const el = containerRef.current;
+      const ro = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          setContainerWidth(entry.contentRect.width);
+        }
+      });
+      ro.observe(el);
+      return () => ro.disconnect();
+    }, []);
+
+    const scale =
+      zoom === 'fit-width' ? Math.max(0.5, containerWidth / 595) : zoom / 100;
+
+    const goPrev = () => setCurrentPage(p => Math.max(1, p - 1));
+    const goNext = () => setCurrentPage(p => Math.min(numPages, p + 1));
+
+    const handleJumpSubmit = (e: FormEvent) => {
+      e.preventDefault();
+      const parsed = parseInt(jumpInput, 10);
+      if (Number.isNaN(parsed)) return;
+      const clamped = Math.max(1, Math.min(numPages || 1, parsed));
+      setCurrentPage(clamped);
+      setJumpInput(String(clamped));
+    };
+
+    const handleZoomChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const v = e.target.value;
+      setZoom(v === 'fit-width' ? 'fit-width' : parseInt(v, 10));
+    };
+
+    return (
+      <div
+        ref={containerRef}
+        data-slot="pdf-inline-viewer"
+        className={clsx('flex flex-col gap-3', className)}
+      >
+        {/* Toolbar */}
+        <div className="flex flex-wrap items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-xs">
+          <button
+            type="button"
+            onClick={goPrev}
+            disabled={currentPage <= 1 || loading}
+            className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            ← Prev
+          </button>
+          <span className="px-2">
+            Pagina <strong>{currentPage}</strong> / {numPages || '?'}
+          </span>
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={currentPage >= numPages || loading}
+            className="rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            Next →
+          </button>
+
+          {features.jumpToPage && (
+            <form onSubmit={handleJumpSubmit} className="flex items-center gap-1">
+              <label htmlFor="pdf-jump" className="text-muted-foreground">Vai a pagina</label>
+              <input
+                id="pdf-jump"
+                type="number"
+                role="spinbutton"
+                aria-label="Vai a pagina"
+                min={1}
+                max={numPages || undefined}
+                value={jumpInput}
+                onChange={e => setJumpInput(e.target.value)}
+                className="w-14 rounded-sm border border-border bg-card px-1 py-0.5 text-center"
+              />
+            </form>
+          )}
+
+          {features.zoom && (
+            <label className="flex items-center gap-1">
+              <span className="text-muted-foreground">Zoom</span>
+              <select
+                aria-label="Zoom"
+                value={zoom === 'fit-width' ? 'fit-width' : String(zoom)}
+                onChange={handleZoomChange}
+                className="rounded-sm border border-border bg-card px-1 py-0.5"
+              >
+                <option value="50">50%</option>
+                <option value="100">100%</option>
+                <option value="150">150%</option>
+                <option value="fit-width">fit-width</option>
+              </select>
+            </label>
+          )}
+
+          <div className="ml-auto flex items-center gap-2">
+            {features.openInTab && (
+              <a
+                href={downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                ↗ Apri in tab
+              </a>
+            )}
+            {features.download && (
+              <a
+                href={downloadUrl}
+                download
+                className="inline-flex items-center rounded-sm border border-border bg-card px-2 py-1 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                ⤓ Download
+              </a>
+            )}
+            {features.antiLeak && (
+              <span className="inline-flex items-center gap-1 text-[10px] text-[hsl(var(--c-success))]">
+                🔒 Solo visualizzazione
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Canvas */}
+        <div
+          data-testid="pdf-canvas-container"
+          onContextMenu={features.antiLeak ? e => e.preventDefault() : undefined}
+          className={clsx(
+            'relative overflow-hidden rounded-md border border-border bg-card',
+            features.antiLeak && 'select-none',
+            '[&_canvas]:max-w-full min-h-[400px]'
+          )}
+          style={{ aspectRatio: '210/297' }}
+        >
+          {loading && (
+            <div
+              role="status"
+              aria-label="Caricamento PDF"
+              className="absolute inset-0 flex items-center justify-center"
+            >
+              <div
+                aria-hidden="true"
+                className="h-10 w-10 rounded-full border-[3px] border-[hsl(var(--c-kb)/0.2)] border-t-[hsl(var(--c-kb))] motion-safe:animate-spin"
+              />
+            </div>
+          )}
+          {loadError && (
+            <div className="flex h-full items-center justify-center p-6 text-sm text-destructive">
+              Errore caricamento PDF: {loadError}
+            </div>
+          )}
+          {pdfBlob && !loadError && (
+            <Document
+              file={pdfBlob}
+              onLoadSuccess={onDocumentLoadSuccess}
+              onLoadError={onDocumentLoadError}
+              loading={null}
+              error={null}
+            >
+              <Page
+                pageNumber={currentPage}
+                scale={scale}
+                renderAnnotationLayer={false}
+                renderTextLayer={false}
+              />
+            </Document>
+          )}
+        </div>
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Step 4: Run test, confirm PASS**
+
+  ```bash
+  cd apps/web
+  pnpm test pdf/__tests__/PdfInlineViewer.test.tsx 2>&1 | tail -20
+  ```
+
+  Expected: 13 PASS.
+
+- [ ] **Step 5: Run typecheck + lint**
+
+  ```bash
+  cd apps/web
+  pnpm typecheck 2>&1 | tail -10
+  pnpm lint pdf/PdfInlineViewer.tsx 2>&1 | tail -10
+  pnpm lint:tokens 2>&1 | tail -10
+  ```
+
+  Expected: 0 errori.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add apps/web/src/components/pdf/PdfInlineViewer.tsx \
+          apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx
+  git commit -m "feat(pdf): #1654 PdfInlineViewer shared component with feature-flagged toolbar"
+  ```
+
+---
+
+## Task 2: Refactor `CitationPdfTab` to consume `PdfInlineViewer`
+
+**Files:**
+- Modify: `apps/web/src/components/features/game-chat/CitationPdfTab.tsx`
+- Verify pass: `apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx`
+
+> Regression gate: il test esistente di CitationPdfTab DEVE passare invariato (zero modifiche al test file in questo task).
+
+- [ ] **Step 1: Run il test esistente come baseline**
+
+  ```bash
+  cd apps/web
+  pnpm test features/game-chat/__tests__/CitationPdfTab.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: tutti PASS (pre-refactor baseline).
+
+- [ ] **Step 2: Refactor `CitationPdfTab.tsx`**
+
+  Strip il `PdfRenderer` interno (righe ~94-234) e il setup `pdfjs.GlobalWorkerOptions.workerSrc` (righe 35-39). Il file diventa:
+
+  ```tsx
+  // apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+  /**
+   * CitationPdfTab — body del tab "PDF originale" del CitationModal v3.
+   *
+   * Logica:
+   *   - isPublic=true → render PDF viewer immediato
+   *   - altrimenti useCanViewPdf:
+   *       loading → spinner
+   *       canView=true → PDF viewer (PdfInlineViewer con antiLeak=true)
+   *       canView=false OR isError → CitationOwnershipUpsell
+   *
+   * Anti-leak gestito da PdfInlineViewer via features.antiLeak=true.
+   *
+   * Spec: docs/superpowers/specs/2026-05-10-citation-pdf-viewer-design.md §3.2 §4.2
+   * Shared viewer: docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md §4
+   */
+  'use client';
+
+  import type { ReactElement } from 'react';
+  import clsx from 'clsx';
+
+  import { CitationOwnershipUpsell } from '@/components/features/game-chat/CitationOwnershipUpsell';
+  import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
+  import { useCanViewPdf } from '@/hooks/queries/useCanViewPdf';
+
+  export interface CitationPdfTabProps {
+    readonly documentId: string;
+    readonly gameId?: string;
+    readonly initialPage: number;
+    readonly isPublic?: boolean;
+    readonly className?: string;
+  }
+
+  export function CitationPdfTab({
+    documentId,
+    gameId,
+    initialPage,
+    isPublic = false,
+    className,
+  }: CitationPdfTabProps): ReactElement {
+    const ownership = useCanViewPdf({
+      documentId,
+      gameId,
+      enabled: !isPublic,
+    });
+
+    const canRenderPdf = isPublic || ownership.canView;
+    const isCheckingOwnership = !isPublic && ownership.isLoading;
+    const showUpsell = !canRenderPdf && !isCheckingOwnership;
+
+    if (isCheckingOwnership) {
+      return (
+        <div
+          data-slot="citation-pdf-loading-ownership"
+          role="status"
+          aria-label="Caricamento"
+          className={clsx('flex flex-col items-center justify-center gap-3 p-9', className)}
+        >
+          <div
+            aria-hidden="true"
+            className={clsx(
+              'h-10 w-10 rounded-full border-[3px] border-[hsl(var(--c-kb)/0.2)]',
+              'border-t-[hsl(var(--c-kb))] motion-safe:animate-spin'
+            )}
+          />
+          <div className="font-mono text-xs text-muted-foreground">Verifica accesso al PDF…</div>
+        </div>
+      );
+    }
+
+    if (showUpsell) {
+      return <CitationOwnershipUpsell gameId={gameId} className={className} />;
+    }
+
+    return (
+      <PdfInlineViewer
+        documentId={documentId}
+        initialPage={initialPage}
+        features={{ antiLeak: true }}
+        className={className}
+      />
+    );
+  }
+  ```
+
+- [ ] **Step 3: Run il test esistente di CitationPdfTab — DEVE passare invariato**
+
+  ```bash
+  cd apps/web
+  pnpm test features/game-chat/__tests__/CitationPdfTab.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: identico baseline pre-refactor (tutti PASS).
+
+  > Se un test fallisce: STOP. Analizza la differenza (selector, behavior atteso, role/label). NON modificare il test. Aggiusta `PdfInlineViewer` se necessario (es. attributi a11y mancanti, data-testid divergente). Lo scope di questo task è "zero impact esterno".
+
+- [ ] **Step 4: Run il test di PdfInlineViewer (no regression)**
+
+  ```bash
+  pnpm test pdf/__tests__/PdfInlineViewer.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: 13/13 PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+  ```bash
+  pnpm typecheck 2>&1 | tail -5
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add apps/web/src/components/features/game-chat/CitationPdfTab.tsx
+  git commit -m "refactor(citation): #1654 consume PdfInlineViewer (antiLeak variant)"
+  ```
+
+---
+
+## Task 3: Aggiungi `'preview'` a `KbDocTabKey` + `TABS`
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx`
+
+- [ ] **Step 1: Estendi il test esistente**
+
+  Apri `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx`. Aggiungi (al describe esistente):
+
+  ```tsx
+  it('renders Preview tab and marks aria-current when active', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="preview" />);
+    const previewLink = screen.getByRole('link', { name: /preview/i });
+    expect(previewLink).toHaveAttribute('aria-current', 'page');
+    expect(previewLink).toHaveAttribute('href', '/admin/knowledge-base?doc=doc-1&tab=preview');
+  });
+
+  it('Overview link does NOT have tab param when activeTab=preview', () => {
+    render(<KbDocDetailTabs docId="doc-1" activeTab="preview" />);
+    const overviewLink = screen.getByRole('link', { name: /overview/i });
+    expect(overviewLink).toHaveAttribute('href', '/admin/knowledge-base?doc=doc-1');
+  });
+  ```
+
+- [ ] **Step 2: Run test, confirm FAIL**
+
+  ```bash
+  cd apps/web
+  pnpm test admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: 2 FAIL "no element with name /preview/i".
+
+- [ ] **Step 3: Estendi `KbDocTabKey` + `TABS`**
+
+  Apri `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`. Modifica:
+
+  ```tsx
+  // riga 5
+  export type KbDocTabKey = 'overview' | 'ingestion' | 'used-by' | 'preview';
+
+  // riga 12-16 → aggiungi entry 'preview'
+  const TABS: ReadonlyArray<{ readonly key: KbDocTabKey; readonly label: string }> = [
+    { key: 'overview', label: 'Overview' },
+    { key: 'ingestion', label: 'Ingestion log' },
+    { key: 'used-by', label: 'Used by' },
+    { key: 'preview', label: 'Preview' },
+  ];
+  ```
+
+  Aggiorna anche il jsdoc:
+
+  ```tsx
+  /**
+   * Inner tab nav for `KbDocDetailPanel`. URL-driven via `?tab=overview` (default)
+   * | `?tab=ingestion` | `?tab=used-by` | `?tab=preview`. Preserves `docId` in each link.
+   * Issues #1650 (Ingestion log) + #1651 (Used by) + #1654 (Preview).
+   */
+  ```
+
+- [ ] **Step 4: Run test, confirm PASS**
+
+  ```bash
+  pnpm test admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: tutti PASS (2 nuovi + esistenti).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx \
+          apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx
+  git commit -m "feat(admin-kb): #1654 add 'preview' to KbDocTabKey + TABS"
+  ```
+
+---
+
+## Task 4: `KbDocPreviewPanel` admin variant
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx`
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx`
+
+- [ ] **Step 1: Crea il test file**
+
+  ```tsx
+  // apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx
+  import { render, screen } from '@testing-library/react';
+  import { describe, it, expect, vi } from 'vitest';
+
+  const mockPdfInlineViewer = vi.fn();
+  vi.mock('@/components/pdf/PdfInlineViewer', () => ({
+    PdfInlineViewer: (props: Record<string, unknown>) => {
+      mockPdfInlineViewer(props);
+      return <div data-testid="pdf-inline-viewer-mock" />;
+    },
+  }));
+
+  import { KbDocPreviewPanel } from '../KbDocPreviewPanel';
+
+  describe('KbDocPreviewPanel', () => {
+    beforeEach(() => {
+      mockPdfInlineViewer.mockReset();
+    });
+
+    it('renders PdfInlineViewer with documentId from docId prop', () => {
+      render(<KbDocPreviewPanel docId="doc-abc" />);
+      expect(screen.getByTestId('pdf-inline-viewer-mock')).toBeInTheDocument();
+      expect(mockPdfInlineViewer).toHaveBeenCalledWith(
+        expect.objectContaining({ documentId: 'doc-abc' })
+      );
+    });
+
+    it('passes admin features { download, openInTab, jumpToPage, zoom } = true, antiLeak omitted', () => {
+      render(<KbDocPreviewPanel docId="doc-abc" />);
+      const props = mockPdfInlineViewer.mock.calls[0][0] as { features: Record<string, boolean> };
+      expect(props.features.download).toBe(true);
+      expect(props.features.openInTab).toBe(true);
+      expect(props.features.jumpToPage).toBe(true);
+      expect(props.features.zoom).toBe(true);
+      expect(props.features.antiLeak ?? false).toBe(false);
+    });
+
+    it('renders nothing when docId is empty string', () => {
+      const { container } = render(<KbDocPreviewPanel docId="" />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+  ```
+
+  Importa `beforeEach` se non già nel scope:
+
+  ```tsx
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+  ```
+
+- [ ] **Step 2: Run test, confirm FAIL**
+
+  ```bash
+  cd apps/web
+  pnpm test admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: FAIL "Cannot find module '../KbDocPreviewPanel'".
+
+- [ ] **Step 3: Implementa `KbDocPreviewPanel`**
+
+  ```tsx
+  // apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx
+  'use client';
+
+  import { PdfInlineViewer } from '@/components/pdf/PdfInlineViewer';
+
+  export interface KbDocPreviewPanelProps {
+    /** Document UUID. Empty string → render null (panel-level guard). */
+    readonly docId: string;
+  }
+
+  /**
+   * KbDocPreviewPanel — admin variant of PdfInlineViewer.
+   * Renders the original PDF blob with the full admin toolbar
+   * (jump-to-page, zoom, open-in-tab, download). No anti-leak (admin context).
+   *
+   * Mounted by KbDocDetailPanel when activeTab === 'preview'.
+   *
+   * Issue #1654 F3-FU-5.
+   */
+  export function KbDocPreviewPanel({ docId }: KbDocPreviewPanelProps) {
+    if (!docId) return null;
+    return (
+      <div className="p-4">
+        <PdfInlineViewer
+          documentId={docId}
+          features={{
+            download: true,
+            openInTab: true,
+            jumpToPage: true,
+            zoom: true,
+          }}
+        />
+      </div>
+    );
+  }
+  ```
+
+- [ ] **Step 4: Run test, confirm PASS**
+
+  ```bash
+  pnpm test admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add apps/web/src/components/admin/knowledge-base/explorer/preview/
+  git commit -m "feat(admin-kb): #1654 KbDocPreviewPanel admin variant of PdfInlineViewer"
+  ```
+
+---
+
+## Task 5: Branching in `KbDocDetailPanel` (ready + locked)
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx`
+
+> Se T0 (a) outcome = BLOCKED, skip Step 2 (locked branch test + impl) e relativo commit; FR-2 rimosso dal contratto.
+
+- [ ] **Step 1: Estendi il test esistente — `?tab=preview` su `ready`**
+
+  Apri `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx`. Aggiungi mock del nuovo panel (subito dopo i mock esistenti di `KbDocActions`/`KbChunkSearch`):
+
+  ```tsx
+  // ── KbDocPreviewPanel mock (panel test doesn't exercise viewer internals) ─────
+  vi.mock('../preview/KbDocPreviewPanel', () => ({
+    KbDocPreviewPanel: ({ docId }: { docId: string }) => (
+      <div data-testid="kb-doc-preview-panel-mock" data-doc-id={docId} />
+    ),
+  }));
+  ```
+
+  Aggiungi i test (nel describe esistente):
+
+  ```tsx
+  it('renders KbDocPreviewPanel on ?tab=preview when doc is ready', () => {
+    mockSearchParams = new URLSearchParams('doc=doc-1&tab=preview');
+    mockUseKbDocDetail.mockReturnValue({ data: readyEnvelope, isLoading: false });
+    mockUseKbChunksList.mockReturnValue({ data: { pages: [] }, hasNextPage: false });
+
+    render(<KbDocDetailPanel docId="doc-1" />, { wrapper: makeWrapper() });
+
+    expect(screen.getByTestId('kb-doc-preview-panel-mock')).toHaveAttribute('data-doc-id', 'doc-1');
+    // chunks list NOT rendered when preview tab active
+    expect(screen.queryByText(/^Chunks$/)).not.toBeInTheDocument();
+  });
+  ```
+
+- [ ] **Step 2: Estendi il test — `?tab=preview` su `locked` (SOLO se T0 (a) = OK)**
+
+  ```tsx
+  it('renders KbDocPreviewPanel on ?tab=preview when doc is locked (special-case)', () => {
+    mockSearchParams = new URLSearchParams('doc=doc-1&tab=preview');
+    mockUseKbDocDetail.mockReturnValue({ data: lockedEnvelope, isLoading: false });
+
+    render(<KbDocDetailPanel docId="doc-1" selectedDocMeta={{ id: 'doc-1', title: 'X.pdf', gameId: null }} />, { wrapper: makeWrapper() });
+
+    expect(screen.getByTestId('kb-doc-preview-panel-mock')).toHaveAttribute('data-doc-id', 'doc-1');
+    // locked banner ("Documento in elaborazione") NOT rendered when preview tab active
+    expect(screen.queryByText(/Documento in elaborazione/i)).not.toBeInTheDocument();
+  });
+  ```
+
+- [ ] **Step 3: Run test, confirm FAIL**
+
+  ```bash
+  cd apps/web
+  pnpm test admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: 1 o 2 FAIL (a seconda di T0).
+
+- [ ] **Step 4: Modifica `KbDocDetailPanel.tsx`**
+
+  Aggiorna `activeTab` discriminator (righe ~58-63):
+
+  ```tsx
+  const activeTab: KbDocTabKey = (() => {
+    const tab = searchParams?.get('tab');
+    if (tab === 'ingestion') return 'ingestion';
+    if (tab === 'used-by') return 'used-by';
+    if (tab === 'preview') return 'preview';
+    return 'overview';
+  })();
+  ```
+
+  Aggiungi import:
+
+  ```tsx
+  import { KbDocPreviewPanel } from './preview/KbDocPreviewPanel';
+  ```
+
+  **Locked branch — solo se T0 (a) = OK**. Aggiungi special-case PRIMA del fallback (analogo a `used-by` righe ~110-117):
+
+  ```tsx
+  if (activeTab === 'preview') {
+    return (
+      <div className="border border-border/60 dark:border-zinc-700/60 rounded-lg bg-card/80 dark:bg-zinc-900/80 overflow-hidden">
+        <KbDocDetailTabs docId={docId} activeTab={activeTab} />
+        <KbDocPreviewPanel docId={docId} />
+      </div>
+    );
+  }
+  ```
+
+  **Ready branch** — aggiungi nel render (dopo `{activeTab === 'used-by' && <UsedByPanel docId={doc.id} />}`):
+
+  ```tsx
+  {activeTab === 'preview' && <KbDocPreviewPanel docId={doc.id} />}
+  ```
+
+- [ ] **Step 5: Run test, confirm PASS**
+
+  ```bash
+  pnpm test admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx 2>&1 | tail -10
+  ```
+
+  Expected: tutti PASS.
+
+- [ ] **Step 6: Run suite admin completa per regression**
+
+  ```bash
+  pnpm test:admin-dashboard 2>&1 | tail -10
+  ```
+
+  Expected: 558+/558+ PASS (numero esatto può crescere coi nuovi test, ma 0 fail).
+
+- [ ] **Step 7: Run typecheck + lint**
+
+  ```bash
+  pnpm typecheck 2>&1 | tail -5
+  pnpm lint admin/knowledge-base/explorer/ 2>&1 | tail -5
+  pnpm lint:tokens 2>&1 | tail -5
+  ```
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx \
+          apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx
+  git commit -m "feat(admin-kb): #1654 wire Preview tab in KbDocDetailPanel (ready + locked)"
+  ```
+
+---
+
+## Task 6: E2E smoke + verification gate
+
+**Files:**
+- Create: `apps/web/e2e/admin/kb-doc-preview-tab.spec.ts`
+
+- [ ] **Step 1: Scrivi gli scenari smoke**
+
+  ```ts
+  // apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
+  import { test, expect } from '@playwright/test';
+  import { loginAsAdmin } from '../helpers/auth';
+  import { seedKbDocFixture } from '../helpers/kb-fixtures';
+
+  test.describe('KB doc Preview tab (#1654)', () => {
+    test('admin opens ?tab=preview and sees the PDF viewer toolbar', async ({ page }) => {
+      const { docId } = await seedKbDocFixture({ pageCount: 3 });
+      await loginAsAdmin(page);
+      await page.goto(`/admin/knowledge-base?doc=${docId}&tab=preview`);
+      // Toolbar visible
+      await expect(page.getByRole('button', { name: /prev/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: /next/i })).toBeVisible();
+      // Page counter "1 / 3"
+      await expect(page.getByText(/Pagina\s+1\s*\/\s*3/i)).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('tab routing: Preview ↔ Overview updates URL param', async ({ page }) => {
+      const { docId } = await seedKbDocFixture({ pageCount: 3 });
+      await loginAsAdmin(page);
+      await page.goto(`/admin/knowledge-base?doc=${docId}`); // overview default
+      await page.getByRole('link', { name: /preview/i }).click();
+      await expect(page).toHaveURL(new RegExp(`doc=${docId}&tab=preview`));
+      await page.getByRole('link', { name: /overview/i }).click();
+      await expect(page).toHaveURL(new RegExp(`doc=${docId}(?!&tab=)`));
+    });
+  });
+  ```
+
+  > Verifica preliminare: `apps/web/e2e/helpers/auth.ts` e `apps/web/e2e/helpers/kb-fixtures.ts` esistono? Run:
+  > ```bash
+  > find apps/web/e2e/helpers -name "*.ts" 2>&1
+  > ```
+  > Se mancano, riusa il pattern degli E2E esistenti per F3-FU-1/2/4: `apps/web/e2e/admin/kb-doc-actions.spec.ts` (output del commit #1653 `23b17f6a5`).
+
+- [ ] **Step 2: Run E2E smoke (opzionale local)**
+
+  ```bash
+  cd apps/web
+  pnpm test:e2e --grep "Preview tab"
+  ```
+
+  Expected: 2 PASS. (CI runner esegue automaticamente in PR.)
+
+- [ ] **Step 3: Gate finale — run ALL verification commands**
+
+  ```bash
+  cd apps/web
+  pnpm test pdf/__tests__/PdfInlineViewer.test.tsx
+  pnpm test admin/knowledge-base/explorer/__tests__/
+  pnpm test admin/knowledge-base/explorer/preview/__tests__/
+  pnpm test features/game-chat/__tests__/CitationPdfTab.test.tsx
+  pnpm test:admin-dashboard
+  pnpm typecheck
+  pnpm lint
+  pnpm lint:tokens
+  ```
+
+  Expected: tutti PASS, 0 typecheck error, 0 lint error, 0 token violation.
+
+- [ ] **Step 4: Commit E2E**
+
+  ```bash
+  git add apps/web/e2e/admin/kb-doc-preview-tab.spec.ts
+  git commit -m "test(admin-kb): #1654 E2E smoke for Preview tab"
+  ```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** spec § 5 (data flow) → Task 1 step 3 (fetch lifecycle + AbortController). Spec § 6 (error handling) → Task 1 step 1 test cases per HTTP 500, AbortError silente. Spec § 7 stati doc → Task 5 step 1+2 (`ready` + `locked`). Spec § 8 FR-1..FR-12 → Task 5 (FR-1, FR-2), Task 3 (FR-3), Task 1 (FR-4..FR-9), Task 2 (FR-10), Task 6 (FR-11, FR-12). Spec § 9 test plan → Task 1+4 (unit), Task 6 (E2E + gate). Spec § 11 phasing T0-T6 → Tasks 0-6 1:1.
+
+**2. Placeholder scan:** Nessun "TBD/TODO". Tutti gli step hanno codice concreto o comando esatto. T0 outcome decisorio esplicitato in T1 e T5 (no soggettività). I path file sono assoluti rispetto al repo root.
+
+**3. Type consistency:** `KbDocTabKey = 'overview' | 'ingestion' | 'used-by' | 'preview'` consistente in Task 3 (definition) + Task 5 (consumer discriminator). `PdfInlineViewerProps.features` shape costante: T1 (definition) + T2 (`{antiLeak: true}`) + T4 (`{download, openInTab, jumpToPage, zoom}`). `KbDocPreviewPanelProps.docId: string` costante in T4 + T5.
+
+**Note di rischio:**
+- **T0 spike (a) outcome BLOCKED**: T5 Step 2 e relativi test rimossi; aggiorna spec § 8 FR-2 e § 11 T5 prima di T1 per evitare drift. Commit di aggiornamento spec separato.
+- **T2 regression**: il test esistente di CitationPdfTab usa `setTimeout(() => onLoadSuccess?.({ numPages: 24 }), 0)` nel mock. PdfInlineViewer ha lo stesso pattern. Se un selettore esatto nel test ha cambiato (es. cerca `select-none` su un container che ora ha id diverso) → aggiusta `PdfInlineViewer` (non il test).
+- **E2E helper paths**: Step 1 di T6 assume `loginAsAdmin` + `seedKbDocFixture` esistenti. Se mancano (improbabile dato che F3-FU-1/2/4 hanno E2E smoke), riusa il pattern del commit `23b17f6a5`.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch fresh subagent per task, two-stage review (spec+quality) tra i task. Rate limit API permitting.
+
+**2. Inline Execution** — execute tasks in this session using `executing-plans`, batch con checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md
+++ b/docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md
@@ -1,0 +1,349 @@
+# SP5 Admin KB — F3-FU-5: Preview tab in KbDocDetailPanel (PDF viewer)
+
+> **Status**: design — review pending
+> **Issue**: [#1654](https://github.com/meepleAi-app/meepleai-monorepo/issues/1654) (P3, area/frontend)
+> **Parent**: SP5 admin console consolidation — wave F3-FU (post-#1649 KB Explorer)
+> **Spec parents**: `docs/superpowers/specs/2026-05-24-sp5-admin-console-consolidation-design.md` §5.A5 · `docs/superpowers/specs/2026-05-28-sp5-admin-kb-toolpages-reskin-design.md` (F3-FU sub-nav contract) · `docs/superpowers/specs/2026-05-10-citation-pdf-viewer-design.md` (PdfRenderer pattern reused)
+> **Predecessors in wave**: F3-FU-1 ingestion-log #1650 (PR #1668) · F3-FU-2 used-by #1651 (PR #1671) · F3-FU-4 doc actions + chunk similarity #1653 (commit `23b17f6a5`, PR #1679)
+
+## 1. Context & Goal
+
+Estendere `KbDocDetailPanel` con un quarto tab `?tab=preview` che renderizza inline il PDF originale del documento KB, eliminando il context-switch verso il download per ispezionare il contenuto. Operazione FE-only: riusa l'endpoint esistente `/api/v1/pdfs/{id}/download`.
+
+L'attuale wave F3-FU ha aggiunto a `KbDocDetailPanel` i tab Overview (default), Ingestion log, Used by, e (dentro Overview) action-bar + chunk similarity-search. Manca un'anteprima visuale del file sorgente — l'admin che vuole verificare il rendering, la qualità OCR, o controllare a quale pagina cade un chunk deve oggi scaricare il PDF o aprire una citation in altra parte dell'app. Il tab Preview chiude questo gap.
+
+## 2. Current state (evidence)
+
+- **Tab routing** in `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailTabs.tsx`: union `KbDocTabKey = 'overview' | 'ingestion' | 'used-by'`; array `TABS` consumato dalla nav; URL-driven via `?doc={id}&tab={key}` (overview = assenza param).
+- **Panel branching** in `apps/web/src/components/admin/knowledge-base/explorer/KbDocDetailPanel.tsx`: 4 stati (null/loading/locked/ready); su `locked` post-#1653 rende `KbDocDetailTabs + KbDocActions + banner` (Used-by è speciale: rende `UsedByPanel` invece del banner durante locked).
+- **PDF inline rendering pattern già nel codebase**: `apps/web/src/components/features/game-chat/CitationPdfTab.tsx` (post-PR di `2026-05-10-citation-pdf-viewer-design.md`) usa react-pdf (`Document` + `Page` + `pdfjs.GlobalWorkerOptions.workerSrc`), fetch del blob con credentials, prev/next pagination, anti-leak (no contextmenu, no download). Spec di riferimento citato nel header del file.
+- **Endpoint download** `api.pdf.getPdfDownloadUrl(docId)` già esposto e usato sia da `CitationPdfTab` (fetch blob) sia da `KbDocActions` (`<a href={...} download>`). Session-cookie auth.
+- **Bundle**: react-pdf + pdfjs worker già nel chunk admin (CitationPdfTab attivo nel game-chat sotto `(library)` route group). Per il tab admin sotto `(dashboard)` il viewer aggiunge zero deps; il bundle admin assorbe la stessa libreria.
+- **Test infra**: react-pdf mockato in `apps/web/vitest.setup.ts` (riusabile per nuovi test); `KbDocDetailPanel.test.tsx` + `KbDocDetailTabs.test.tsx` esistono come baseline.
+
+## 3. Scope
+
+### In scope (FU-5)
+
+1. Aggiungere `'preview'` a `KbDocTabKey` e a `TABS` in `KbDocDetailTabs.tsx`.
+2. Estrarre `PdfInlineViewer` (net-new shared component, `apps/web/src/components/pdf/PdfInlineViewer.tsx`) con props-driven feature flags. Pattern base = il `PdfRenderer` interno di `CitationPdfTab`.
+3. Refactor `CitationPdfTab.tsx` per consumare `PdfInlineViewer` con variant citation (`{ antiLeak: true }`). Output visuale + comportamento esterno invariati.
+4. Net-new `KbDocPreviewPanel` (`apps/web/src/components/admin/knowledge-base/explorer/preview/KbDocPreviewPanel.tsx`) che consuma `PdfInlineViewer` con variant admin (`{ download: true, openInTab: true, jumpToPage: true, zoom: true }`).
+5. Estendere il branching in `KbDocDetailPanel.tsx`:
+   - su `ready`: aggiungere `{activeTab === 'preview' && <KbDocPreviewPanel docId={doc.id} />}` accanto a Ingestion/Used-by/Overview.
+   - su `locked`: aggiungere lo stesso special-case di `used-by` per renderizzare il viewer (assunto: file blob disponibile anche su queued/processing/failed). **Verifica vincolante in T0 spike**: se l'endpoint non risponde su `locked`, il scope si restringe a "solo `ready`" (banner standard su locked per Preview come Overview/Ingestion) — la decisione Q2 utente diventa best-effort. Documentare il fallback in `audits/2026-05-30-pdf-download-locked-spike.md`.
+6. Toolbar admin: prev/next + page counter (esistente in CitationPdfTab) + jump-to-page input + zoom 50/100/150/fit-width (default fit-width) + open-in-tab + download.
+7. Error handling: 404/403/500 fetch errors, pdf.js parsing failure, PDF vuoto, AbortError ignorato, input invalido jump-to-page clampato.
+8. Test: unit `PdfInlineViewer` (feature-flag matrix), unit `KbDocPreviewPanel` (admin variant), update `KbDocDetailTabs.test.tsx` (`activeTab='preview'`), update `KbDocDetailPanel.test.tsx` (`?tab=preview` su ready + locked), regression `CitationPdfTab.test.tsx` (deve passare invariato), 2 E2E smoke.
+
+### Out of scope (deferred — track separately if needed)
+
+- ❌ Highlight chunks sovrapposti alla pagina (overlay rectangles).
+- ❌ Text-search dentro PDF (richiede pdf.js text-layer + UI dedicata).
+- ❌ Annotation rendering (`renderAnnotationLayer={false}` preservato).
+- ❌ Multi-page thumbnail grid.
+- ❌ Rotation controls.
+- ❌ Print button (open-in-tab + print nativo browser è escape-hatch).
+- ❌ Performance optimization per PDF >100 pagine (lazy page rendering).
+- ❌ Hero metadata enrichment (FileSizeBytes, OCR flag, indexer version) — tracked in spin-out #1676.
+- ❌ Visual regression test del viewer rendering (gate rimosso 2026-05-20, CLAUDE.md "Visual Gate REMOVED").
+- ❌ Modifiche backend (zero impact: endpoint download già esistente).
+
+## 4. Architecture & components
+
+```
+apps/web/src/components/pdf/
+  PdfInlineViewer.tsx                      [NEW — extracted shared component]
+  __tests__/PdfInlineViewer.test.tsx       [NEW]
+
+apps/web/src/components/features/game-chat/
+  CitationPdfTab.tsx                       [MODIFY — consumes PdfInlineViewer w/ citation variant]
+  __tests__/CitationPdfTab.test.tsx        [MUST pass invariato]
+
+apps/web/src/components/admin/knowledge-base/explorer/
+  KbDocDetailTabs.tsx                      [MODIFY — add 'preview' to KbDocTabKey + TABS entry]
+  KbDocDetailPanel.tsx                     [MODIFY — render <KbDocPreviewPanel> for preview tab in BOTH locked + ready branches]
+  __tests__/KbDocDetailTabs.test.tsx       [MODIFY — extend test matrix]
+  __tests__/KbDocDetailPanel.test.tsx      [MODIFY — extend test matrix]
+  preview/
+    KbDocPreviewPanel.tsx                  [NEW — admin variant of PdfInlineViewer]
+    __tests__/KbDocPreviewPanel.test.tsx   [NEW]
+
+apps/web/e2e/admin/
+  kb-doc-preview-tab.spec.ts               [NEW — 2 smoke scenarios]
+```
+
+### `PdfInlineViewer` interface (single source of truth)
+
+```typescript
+interface PdfInlineViewerProps {
+  readonly documentId: string;
+  readonly initialPage?: number;
+  readonly defaultZoom?: 'fit-width' | number;     // default: 'fit-width'
+  readonly features?: {
+    readonly antiLeak?: boolean;      // disable contextmenu + select-none; default false
+    readonly download?: boolean;      // show download button in toolbar; default false
+    readonly openInTab?: boolean;     // show open-in-tab anchor; default false
+    readonly jumpToPage?: boolean;    // show jump-to-page input; default false
+    readonly zoom?: boolean;          // show zoom controls; default false
+  };
+  readonly className?: string;
+}
+```
+
+- **Citation variant** (CitationPdfTab consumer): `features={{ antiLeak: true }}` — resto resta a default (false). Output visuale invariato → test esistenti passano.
+- **Admin Preview variant** (KbDocPreviewPanel consumer): `features={{ download: true, openInTab: true, jumpToPage: true, zoom: true }}` — toolbar full.
+
+### Boundary intenzionale
+
+- Ownership check (`useCanViewPdf`) + upsell (`CitationOwnershipUpsell`) restano in `CitationPdfTab`, NON scendono dentro `PdfInlineViewer`. Il viewer riceve solo "rendere o no" — separation of concerns.
+- `pdfjs.GlobalWorkerOptions.workerSrc` setup viene spostato dentro `PdfInlineViewer` (mount-time idempotent) → CitationPdfTab non lo dichiara più. Verifica in Task 0 spike: il worker setup multiplo causa problemi? (Risposta attesa: no, è idempotent — react-pdf detecta già-impostato.)
+
+## 5. Data flow
+
+### Fetch PDF blob (riuso pattern CitationPdfTab)
+
+```
+PdfInlineViewer mounts
+  → useEffect[documentId, initialPage]:
+      AbortController(); setLoading(true); setLoadError(null); setNumPages(0); setPdfBlob(null);
+      fetch(api.pdf.getPdfDownloadUrl(documentId), { credentials: 'include', signal })
+        .then(res => res.ok ? res.blob() : throw new Error(`HTTP ${res.status}: ${res.statusText}`))
+        .then(blob => setPdfBlob(blob); setLoading(false))
+        .catch(err => if (err.name !== 'AbortError') setLoadError(err.message); setLoading(false))
+  → cleanup: controller.abort() su unmount/depChange
+```
+
+### Lazy loading (admin variant)
+
+`KbDocPreviewPanel` montato solo quando `activeTab === 'preview'` (pattern analogo a `IngestionPanel`/`UsedByPanel`). Switch a Overview → unmount → controller.abort(). Costo di rete zero se l'utente non apre il tab.
+
+### State interno
+
+| State | Owner | Trigger |
+|-------|-------|---------|
+| `pdfBlob: Blob \| null` | viewer | fetch success |
+| `numPages: number` | viewer | onDocumentLoadSuccess |
+| `currentPage: number` | viewer | prev/next/jump-to-page |
+| `zoomLevel: number` | viewer | zoom buttons / fit-width recalc on resize |
+| `loadError: string \| null` | viewer | fetch failure / pdf.js error |
+| `loading: boolean` | viewer | true durante fetch o pdf parsing |
+
+### Toolbar interactions (admin variant)
+
+- **Prev/Next**: `setCurrentPage(p => clamp(p ± 1, 1, numPages))` — esistente in CitationPdfTab.
+- **Jump-to-page**: controlled input numerico (`type="number" min="1" max={numPages}`); on submit → `setCurrentPage(clamp(parseInt(input), 1, numPages))`; blur clampa silenziosamente input invalido (NaN → currentPage invariato).
+- **Zoom**: 4 preset (50% / 100% / 150% / fit-width) via dropdown o button group. `fit-width` = `ResizeObserver` sul container → calcola `scale = container.width / viewport.width` (passato a `<Page scale={...}>`). Default = `'fit-width'`.
+- **Open-in-tab**: `<a href={api.pdf.getPdfDownloadUrl(docId)} target="_blank" rel="noopener noreferrer">` — apre viewer browser-nativo in nuovo tab (preserva session cookie).
+- **Download**: stesso pattern di `KbDocActions` Download button: `<a href={...} download>` con session-cookie.
+
+### Integration con tab routing
+
+`KbDocDetailPanel.tsx` legge `searchParams.get('tab')` (pattern esistente, righe 57-63):
+
+```typescript
+const activeTab: KbDocTabKey = (() => {
+  const tab = searchParams?.get('tab');
+  if (tab === 'ingestion') return 'ingestion';
+  if (tab === 'used-by') return 'used-by';
+  if (tab === 'preview') return 'preview';     // NEW
+  return 'overview';
+})();
+```
+
+URL canonico: `/admin/knowledge-base?doc={uuid}&tab=preview`.
+
+## 6. Error handling
+
+| Failure | Where | Contromisura |
+|---------|-------|--------------|
+| `/api/v1/pdfs/{id}/download` 404 | fetch | `setLoadError("Documento non trovato")` → banner inline rosa nel viewer body. Toolbar disabilitata. |
+| 403 (auth scaduta) | fetch | `setLoadError("Sessione scaduta — ricarica la pagina")` + suggerimento refresh. |
+| 500 / network error | fetch | `setLoadError(err.message)` + retry button. |
+| pdf.js parsing failure | `<Document onLoadError>` | `setLoadError("PDF non leggibile")`. |
+| `numPages === 0` (PDF vuoto) | `<Document onLoadSuccess>` | banner "Documento vuoto" + toolbar nascosta. |
+| AbortError (tab-switch rapido) | fetch catch | ignorato (`err.name === 'AbortError'`) — pattern esistente in CitationPdfTab. |
+| File non ancora caricato (`locked` con upload incompleto) | fetch 423/404 | banner "File non ancora caricato — riprova al completamento upload". |
+| Browser senza pdf.js worker support | Document error | banner + fallback Open-in-tab CTA. |
+| Jump-to-page input invalido | onSubmit | clamp `[1, numPages]`, blur silenzioso, NaN ignorato. |
+| Zoom out-of-range | controls | preset disabilitati ai bordi (la lista è chiusa: 50/100/150/fit-width). |
+| `documentId` cambia mid-fetch | useEffect dep array | cleanup abort → nuovo fetch. |
+
+**Failure isolation**: errori nel viewer locali a `PdfInlineViewer` — torna a Overview ricarica doc detail invariato.
+
+**Telemetria**: nessun nuovo metric — gli errori di download sono già coperti da monitoring esistente su `/api/v1/pdfs/{id}/download` (PDF service-level).
+
+**Toast vs inline**: errori = banner inline (viewer occupa la viewport del pannello, errore già visibile). Toast solo per azioni utente discrete (es. download fallito da `<a download>` — ma in pratica `<a download>` non emette errori React-catchable, lo skip).
+
+## 7. UX & states
+
+### Tab nav
+
+`KbDocDetailTabs` rende 4 voci in ordine: **Overview · Ingestion log · Used by · Preview**. Tab attivo con `aria-current="page"` + bordo amber-500 (pattern esistente).
+
+### Stati del documento
+
+| Stato doc | Comportamento Preview tab |
+|-----------|----------------------------|
+| `null` (no doc selected) | placeholder "Seleziona documento" (esistente, fuori dal viewer) |
+| `loading` (detail fetch in corso) | skeleton (esistente, fuori dal viewer) |
+| `locked` queued/processing/failed | `KbDocDetailTabs` + slim hero + `KbDocActions` + `<KbDocPreviewPanel>` (file blob disponibile pre-indexing — da verificare in Task 0 spike) |
+| `ready` | `KbDocDetailTabs` + full hero + `<KbDocPreviewPanel>` |
+
+Su `locked`, il viewer rimpiazza il banner "in elaborazione" SOLO per il tab Preview (analogo al pattern Used-by). Per Overview e Ingestion il banner resta come oggi.
+
+### Viewer layout (admin variant)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⟵ Prev   Pagina 5 / 47   Next ⟶  │ [⌖ Vai a:  __5__]  │
+│                                    │ Zoom: [fit-width▾] │
+│                                    │ ↗ Apri in tab      │
+│                                    │ ⤓ Download         │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│                                                         │
+│            [ PDF page canvas, scaled ]                  │
+│                                                         │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+Layout responsive: toolbar `flex-wrap` su pannello stretto; canvas `aspect-ratio` A4 (210/297) come fallback durante loading (CitationPdfTab pattern).
+
+### Loading skeleton
+
+Durante fetch del blob: spinner centrato `border-[hsl(var(--c-kb))]` (pattern CitationPdfTab). Toolbar visibile ma controlli disabilitati.
+
+### Error banner
+
+Banner inline rosa nel viewer body: `border-rose-500/30 bg-rose-500/5 text-rose-700 dark:text-rose-300 rounded-lg p-4` + CTA retry se applicabile.
+
+## 8. Functional requirements (testable)
+
+| ID | Requirement | Verification |
+|----|-------------|--------------|
+| FR-1 | `?tab=preview` su `ready` doc → `<KbDocPreviewPanel>` rende; `<Overview chunks>` NON rende. | Unit `KbDocDetailPanel.test.tsx` |
+| FR-2 | `?tab=preview` su `locked` doc → `<KbDocPreviewPanel>` rende; banner "in elaborazione" NON rende (special-case come Used-by). | Unit `KbDocDetailPanel.test.tsx` |
+| FR-3 | `KbDocDetailTabs` mostra 4 voci nell'ordine `overview · ingestion · used-by · preview`; tab attivo ha `aria-current="page"`. | Unit `KbDocDetailTabs.test.tsx` |
+| FR-4 | `PdfInlineViewer` con `features.antiLeak=true` previene `contextmenu` (event default prevented) e applica `select-none` al container canvas. | Unit `PdfInlineViewer.test.tsx` |
+| FR-5 | `PdfInlineViewer` con `features.download=true` rende `<a href={api.pdf.getPdfDownloadUrl(docId)} download>` nella toolbar. | Unit `PdfInlineViewer.test.tsx` |
+| FR-6 | `PdfInlineViewer` con `features.openInTab=true` rende `<a target="_blank" rel="noopener noreferrer">` nella toolbar. | Unit `PdfInlineViewer.test.tsx` |
+| FR-7 | `PdfInlineViewer` con `features.jumpToPage=true` rende input numerico; submit clampato a `[1, numPages]`; NaN ignorato. | Unit `PdfInlineViewer.test.tsx` |
+| FR-8 | `PdfInlineViewer` con `features.zoom=true` rende preset 50/100/150/fit-width; switch ricalcola `scale` su Page. `defaultZoom='fit-width'` recalc su resize. | Unit `PdfInlineViewer.test.tsx` |
+| FR-9 | Fetch failure → banner inline rosa + toolbar disabilitata; AbortError ignorato silenziosamente. | Unit `PdfInlineViewer.test.tsx` |
+| FR-10 | `CitationPdfTab` post-refactor produce identico output e comportamento (test esistenti passano invariati). | Regression `CitationPdfTab.test.tsx` |
+| FR-11 | Tab `Preview` switch via click sub-nav aggiorna URL a `?doc={id}&tab=preview`; tornare a `Overview` rimuove il param. | E2E smoke `kb-doc-preview-tab.spec.ts` |
+| FR-12 | Toolbar admin visibile in viewport: prev/next + page counter `1 / N` + tutti i controlli admin. | E2E smoke `kb-doc-preview-tab.spec.ts` |
+
+## 9. Test plan
+
+### Layer 1 — Unit (Vitest + React Testing Library)
+
+- **`apps/web/src/components/pdf/__tests__/PdfInlineViewer.test.tsx`** (NEW)
+  - Loading skeleton durante fetch
+  - Render success con N pagine (mock react-pdf)
+  - Prev/Next clamp
+  - Jump-to-page valid + clamp + NaN ignore
+  - Zoom preset switching → ricalcola `scale`
+  - Fit-width recalc su window resize
+  - Errore fetch (HTTP 500) → banner inline; toolbar disabled
+  - Errore pdf.js → banner inline
+  - AbortController cleanup su unmount
+  - `features.antiLeak=true` → `onContextMenu` preventDefault + `select-none`
+  - `features.download=true` → `<a download>` rendered
+  - `features.openInTab=true` → `<a target="_blank" rel="noopener noreferrer">`
+  - `features.jumpToPage=false` → input non renderizzato
+  - `features.zoom=false` → controls non renderizzati
+
+- **`apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailTabs.test.tsx`** (MODIFY — extend matrix)
+  - Aggiungi voce `preview` nell'array di test; verifica `aria-current="page"` quando `activeTab='preview'`.
+
+- **`apps/web/src/components/admin/knowledge-base/explorer/preview/__tests__/KbDocPreviewPanel.test.tsx`** (NEW)
+  - Mount con `docId` valido → `PdfInlineViewer` rende con admin feature flags
+  - Verifica props passate: `{ download, openInTab, jumpToPage, zoom } = true`, `antiLeak = false (default)`
+  - `docId` null → componente non crash (early-return o `null`)
+
+- **`apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbDocDetailPanel.test.tsx`** (MODIFY — extend matrix)
+  - `?tab=preview` su `ready` doc → `KbDocPreviewPanel` rende, chunks list NON renderizzata
+  - `?tab=preview` su `locked` doc → viewer rende, banner "in elaborazione" NON renderizzato
+  - Slim hero + action-bar coesistono con viewer in locked
+
+- **`apps/web/src/components/features/game-chat/__tests__/CitationPdfTab.test.tsx`** (MUST keep passing invariato)
+  - Refactor a `PdfInlineViewer` invisible dall'esterno; ownership check + upsell + behavior invariati.
+
+### Layer 2 — E2E smoke (Playwright)
+
+- **`apps/web/e2e/admin/kb-doc-preview-tab.spec.ts`** (NEW)
+  - Scenario 1: Admin naviga `/admin/knowledge-base?doc={fixtureId}&tab=preview` → toolbar viewer visibile + page counter `1 / 3` (fixture PDF 3-page).
+  - Scenario 2: Tab routing — click `Preview` sub-nav → URL aggiornato a `?tab=preview`; click `Overview` → URL torna a `?doc={fixtureId}`.
+
+Mock react-pdf esistente in `apps/web/vitest.setup.ts` riusato per i nuovi unit test; E2E smoke usa fixture reale del backend admin.
+
+### Layer 3 — Verification gate (pre-PR)
+
+```bash
+cd apps/web
+pnpm test pdf/__tests__/PdfInlineViewer.test.tsx
+pnpm test admin/knowledge-base/explorer/__tests__/
+pnpm test:admin-dashboard              # suite admin 558+
+pnpm test features/game-chat           # regression CitationPdfTab
+pnpm typecheck
+pnpm lint
+pnpm lint:tokens
+```
+
+## 10. Non-functional & constraints
+
+### Hard constraints
+
+- **DDD/CQRS backend zero-touch**: riusa `/api/v1/pdfs/{id}/download` esistente. No migration, no nuovo handler, no nuovo DTO.
+- **Token canonicalization (DS-15)**: no neutral palette hardcoded (slate/gray/zinc/neutral/stone/white/black). Semantic tokens (`bg-card`, `border-border/60`, `text-muted-foreground`) + entity tokens già attivi in CitationPdfTab (`hsl(var(--c-kb))`, `hsl(var(--c-success))`).
+- **Eslint admin convention (DS-13c)**: `KbDocPreviewPanel.tsx` può portare il file-level disable `local/no-hardcoded-color-utility` per amber/zinc come gli altri file dell'explorer (`KbDocDetailPanel.tsx`). `PdfInlineViewer.tsx` evita la palette neutral → no disable necessario.
+- **A11y**: bare `<button>` → `type="button"` + `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` (convention #1664).
+- **Re-skin invariant CitationPdfTab**: output visuale + comportamento esterno identici dopo refactor — test esistenti come gate.
+
+### Soft constraints
+
+- **Bundle**: react-pdf + pdfjs worker già nel chunk admin via altro consumer; il nuovo viewer aggiunge zero deps.
+- **Network**: lazy fetch (solo quando tab attivo); AbortController su unmount.
+- **Memory**: blob revocato implicitamente quando `pdfBlob` viene sovrascritto (Blob garbage-collected da React state turnover).
+
+## 11. Phasing
+
+L'implementazione segue 6 task incrementali (TDD per ciascuno). I dettagli vivono nel plan associato.
+
+| Task | Focus | Files | Gate |
+|------|-------|-------|------|
+| T0 | Spike: (a) verifica che `/api/v1/pdfs/{id}/download` risponde 200 su doc `queued`/`processing`/`failed`; (b) verifica setup multiple di `pdfjs.GlobalWorkerOptions.workerSrc` non causa side-effect. **Outcome decisorio**: se (a) fallisce, T5 branching su `locked` resta come Overview/Ingestion (banner standard), test FR-2 rimosso; (b) deve passare prima di T1 (se fallisce, isolare il workerSrc setup a un singleton module). | doc-only `audits/2026-05-30-pdf-download-locked-spike.md` | report committed + (a) outcome riflesso in T5 implementation + (b) outcome riflesso in T1 module structure |
+| T1 | Estrai `PdfInlineViewer` (mirror PdfRenderer di CitationPdfTab, props-driven features, default toolbar minimal = solo prev/next + counter) | `components/pdf/PdfInlineViewer.tsx` + test | unit verdi |
+| T2 | Refactor `CitationPdfTab` per consumare `PdfInlineViewer` con `{antiLeak:true}` | `features/game-chat/CitationPdfTab.tsx` | regression test verdi |
+| T3 | Aggiungi `'preview'` a `KbDocTabKey` + `TABS` + test | `explorer/KbDocDetailTabs.tsx` + test | unit verdi |
+| T4 | Crea `KbDocPreviewPanel` (admin variant: full toolbar) | `explorer/preview/KbDocPreviewPanel.tsx` + test | unit verdi |
+| T5 | Branching in `KbDocDetailPanel` (ready + locked special-case) | `explorer/KbDocDetailPanel.tsx` + test | unit verdi |
+| T6 | E2E smoke (2 scenari) + verification gate completo | `e2e/admin/kb-doc-preview-tab.spec.ts` | typecheck + lint + tutte le suite verdi |
+
+Ordine forzato (dipendenze): T0 → T1 → T2 (CitationPdfTab regression gate prima di toccare la nuova feature) → T3 → T4 → T5 → T6.
+
+## 12. Open questions — status
+
+| ID | Question | Status |
+|----|----------|--------|
+| O-1 | `/api/v1/pdfs/{id}/download` risponde su doc in stato `queued`/`processing`/`failed`? | OPEN — T0 spike |
+| O-2 | `pdfjs.GlobalWorkerOptions.workerSrc` setup multiplo da `PdfInlineViewer` + `CitationPdfTab` pre-refactor causa side-effects? | OPEN — T0 spike. Spostare il setup dentro `PdfInlineViewer` mount-time mitiga (idempotent). |
+| O-3 | Zoom UI: dropdown preset o button-group (− 100% +)? | DEFERRED — implementatore sceglie il più ergonomico (entrambi accettabili dal design). |
+| O-4 | Fit-width: `ResizeObserver` sul container o `window.addEventListener('resize')`? | DEFERRED — `ResizeObserver` più preciso (container può cambiare width per ragioni non-window, es. drawer collapse). |
+| O-5 | Hero metadata enrichment (FileSize, OCR flag) nel viewer panel? | OUT-OF-SCOPE — tracked in spin-out #1676. |
+
+## Appendix — brainstorming provenance (2026-05-30)
+
+Design derivato da brainstorming session via `superpowers:brainstorming` skill. Decisioni chiave (Q1-Q4):
+
+- **Q1 Scope viewer**: `Full PDF (pattern CitationPdfTab)` — react-pdf con Document+Page+prev/next, riuso del pattern già nel codebase.
+- **Q2 Stati doc abilitati**: `Tutti gli stati (queued/processing/ready/failed)` — il file blob è disponibile pre-indexing, valore diagnostico anche su `failed`.
+- **Q3 Code reuse**: `Estrarre PdfInlineViewer condiviso (refactor)` — refactor pulito vs DRY-debt; rischio CitationPdfTab regression mitigato da test esistenti.
+- **Q4 Toolbar admin**: tutte le 4 opzioni selezionate (jump-to-page + zoom + open-in-tab + download).
+
+Visual companion skipped (decisioni concettuali, no materiale visivo SP5 di riferimento — F3-FU-5 è follow-up senza mockup).
+
+Panel sintetico applicato (Wiegers/Cockburn/Nygard/Fowler/Newman/Crispin) durante la scelta del task: Fowler "finisci una wave prima di aprirne un'altra" → conferma scope F3-FU residuo. Nygard sull'isolamento error → banner inline locale, no impact su altri tab.


### PR DESCRIPTION
## Summary

Closes #1654 (F3-FU-5). Adds a 4th `?tab=preview` tab to `KbDocDetailPanel` that renders the original PDF inline.

- Extracts shared `PdfInlineViewer` component (`apps/web/src/components/pdf/PdfInlineViewer.tsx`) with props-driven feature flags (antiLeak, download, openInTab, jumpToPage, zoom). Pattern source: existing `PdfRenderer` interior of `CitationPdfTab`.
- Refactors `CitationPdfTab` to consume `PdfInlineViewer` with `{antiLeak: true}` (regression-gated by 5/5 existing tests).
- New `KbDocPreviewPanel` (admin variant: full toolbar, no antiLeak).
- Wires Preview tab in `KbDocDetailPanel` on both `ready` AND `locked` states (T0 spike confirmed download endpoint works pre-indexing).

Backend: **zero change** (reuses `/api/v1/pdfs/{id}/download`).

## Architecture

Pattern: shared component + multiple consumers composing different feature subsets.

```
PdfInlineViewer (shared, props-driven feature flags)
  ├── CitationPdfTab consumer { antiLeak: true }
  └── KbDocPreviewPanel consumer { download, openInTab, jumpToPage, zoom }
```

## Test Plan

- [x] PdfInlineViewer: 13/13 unit (feature-flag matrix + lifecycle + errors)
- [x] KbDocPreviewPanel: 3/3 unit (admin variant props + null guard)
- [x] KbDocDetailTabs: 7/7 (5 existing + 2 new preview entries)
- [x] KbDocDetailPanel: 18/18 (16 existing + 2 new ready+locked)
- [x] CitationPdfTab regression: 5/5 (invariato)
- [x] Full admin-dashboard suite: 558/558 PASS
- [x] typecheck: 0 errors
- [x] lint: 0 errors (52 pre-existing warnings under baseline)
- [x] lint:tokens: 0 violations
- [ ] E2E smoke `kb-doc-preview-tab.spec.ts` (CI validates — local skipped per env port 3000)

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab-design.md`
- Plan: `docs/superpowers/plans/2026-05-30-sp5-admin-kb-f3-fu5-preview-tab.md`
- T0 spike report: `audits/2026-05-30-pdf-download-locked-spike.md`

## Notes

- `data-slot` contract changed: `citation-pdf-renderer` → `pdf-inline-viewer`. Smoke `e2e/smoke-real-llm/game-night-happy-path.spec.ts` updated accordingly.
- Toolbar gates input/select on `controlsDisabled = loading || !!loadError`; download/openInTab anchors render only when `!loadError` (clean UX on fetch failure, FR-9 compliance).
- Final holistic review catches in commit `fba846447` (smoke selector + FR-9 toolbar gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)