### PR TITLE
fix(a11y): #1700 step4 library — use inert to exclude dimmed subtree from axe scan

### DIFF
--- a/apps/web/src/components/features/game-night-create/GameCandidatesPicker.tsx
+++ b/apps/web/src/components/features/game-night-create/GameCandidatesPicker.tsx
@@ -79,7 +79,12 @@ export function GameCandidatesPicker({
 
       <div
         data-slot="game-night-create-step4-library"
-        aria-hidden={decideAtGroup}
+        // `inert` removes the subtree from the accessibility tree AND from
+        // axe's color-contrast scan (#1700 release CI), unlike aria-hidden
+        // alone. Without this, the opacity-50 dimming on already-muted text
+        // dropped contrast below WCAG AA 4.5:1 even though the subtree is
+        // visually marked as inactive.
+        {...(decideAtGroup ? { inert: true } : {})}
         className={decideAtGroup ? 'opacity-50 pointer-events-none' : ''}
       >
         <p className="text-sm font-medium text-foreground">{labels.libraryHeader}</p>


### PR DESCRIPTION
## Summary

Resolves the residual axe AA color-contrast violation on `/game-nights/new` wizard `step4-decide-group` fixture, surfaced by PR #1700 release CI re-run on 2026-05-30 (after #1705 fixed the `--primary` violations).

Wrong assumption was that `aria-hidden={decideAtGroup}` would also exclude the dimmed subtree from axe color-contrast checks. It doesn't — axe visits hidden subtrees and computes effective rendered contrast on them.

The dimmed muted-foreground text (#928d88) and selected-count text (#aea69f) on cream (#f7f3ee) with 50% opacity layer measured ~2.3-3:1 vs AA threshold 4.5:1.

## Fix

Use the HTML5 `inert` attribute which:
- Removes the subtree from the accessibility tree (same as aria-hidden)
- Blocks all interaction events (replaces pointer-events-none)
- AND signals to axe-core that contrast checks should skip the subtree

React 19 supports `inert` as a boolean attribute directly.

## Test plan

- [ ] CI Dev Fast green on this PR
- [ ] After merge: re-FF PR #1700 release branch, expect `Frontend - A11y E2E` to report **0 axe violations** (Scenario A or C if flakes remain — flakes not addressed here)

## Out of scope

- 13 Playwright infra flakes on the a11y suite (timeout / locator / assertion errors). Pre-existing, not axe-related. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
