### PR TITLE
feat(admin-kb): #1655 F3-FU-6 KbSubNav count badges

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs
@@ -40,4 +40,13 @@ internal interface IProcessingJobRepository : IRepository<ProcessingJob, Guid>
     /// Issue #5455: Concurrency control.
     /// </summary>
     Task<int> CountProcessingAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Count jobs whose status is in the supplied set.
+    /// Returns 0 if the set is empty.
+    /// Issue #1655: KbSubNav count badges.
+    /// </summary>
+    Task<int> CountByStatusesAsync(
+        IReadOnlyList<JobStatus> statuses,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
@@ -187,7 +187,8 @@ internal class ProcessingJobRepository : RepositoryBase, IProcessingJobRepositor
         IReadOnlyList<JobStatus> statuses,
         CancellationToken cancellationToken = default)
     {
-        if (statuses is null || statuses.Count == 0)
+        ArgumentNullException.ThrowIfNull(statuses);
+        if (statuses.Count == 0)
             return 0;
 
         var statusStrings = statuses.Select(s => s.ToString()).ToArray();

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs
@@ -183,6 +183,21 @@ internal class ProcessingJobRepository : RepositoryBase, IProcessingJobRepositor
             .ConfigureAwait(false);
     }
 
+    public async Task<int> CountByStatusesAsync(
+        IReadOnlyList<JobStatus> statuses,
+        CancellationToken cancellationToken = default)
+    {
+        if (statuses is null || statuses.Count == 0)
+            return 0;
+
+        var statusStrings = statuses.Select(s => s.ToString()).ToArray();
+        return await DbContext.ProcessingJobs
+            .AsNoTracking()
+            .Where(j => statusStrings.Contains(j.Status))
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private static ProcessingJob MapToDomain(ProcessingJobEntity entity)
     {
         var steps = entity.Steps

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Counts displayed as badges on the admin KbSubNav.
+/// Issue #1655 (F3-FU-6).
+/// </summary>
+public sealed record KbNavCountsDto(
+    int ProcessingQueue,
+    int Feedback7d,
+    DateTimeOffset AsOf
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs
@@ -7,4 +7,4 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
 /// Returns counts for KbSubNav badges: active processing jobs + feedback last 7 days.
 /// Issue #1655 (F3-FU-6).
 /// </summary>
-public sealed record GetKbNavCountsQuery() : IRequest<KbNavCountsDto>;
+internal sealed record GetKbNavCountsQuery() : IRequest<KbNavCountsDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+/// <summary>
+/// Returns counts for KbSubNav badges: active processing jobs + feedback last 7 days.
+/// Issue #1655 (F3-FU-6).
+/// </summary>
+public sealed record GetKbNavCountsQuery() : IRequest<KbNavCountsDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+internal sealed class GetKbNavCountsQueryHandler
+    : IRequestHandler<GetKbNavCountsQuery, KbNavCountsDto>
+{
+    private static readonly JobStatus[] ActiveStatuses =
+        [JobStatus.Queued, JobStatus.Processing, JobStatus.Failed];
+
+    private static readonly TimeSpan FeedbackWindow = TimeSpan.FromDays(7);
+
+    private readonly IProcessingJobRepository _jobs;
+    private readonly IKbUserFeedbackRepository _feedback;
+    private readonly TimeProvider _clock;
+
+    public GetKbNavCountsQueryHandler(
+        IProcessingJobRepository jobs,
+        IKbUserFeedbackRepository feedback,
+        TimeProvider clock)
+    {
+        _jobs = jobs;
+        _feedback = feedback;
+        _clock = clock;
+    }
+
+    public async Task<KbNavCountsDto> Handle(GetKbNavCountsQuery request, CancellationToken cancellationToken)
+    {
+        var asOf = _clock.GetUtcNow();
+        var since = asOf.UtcDateTime - FeedbackWindow;
+
+        var queueTask = _jobs.CountByStatusesAsync(ActiveStatuses, cancellationToken);
+        var feedbackTask = _feedback.CountSinceAsync(since, cancellationToken);
+
+        await Task.WhenAll(queueTask, feedbackTask).ConfigureAwait(false);
+
+        return new KbNavCountsDto(
+            ProcessingQueue: await queueTask.ConfigureAwait(false),
+            Feedback7d: await feedbackTask.ConfigureAwait(false),
+            AsOf: asOf);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
@@ -23,9 +23,9 @@ internal sealed class GetKbNavCountsQueryHandler
         IKbUserFeedbackRepository feedback,
         TimeProvider clock)
     {
-        _jobs = jobs;
-        _feedback = feedback;
-        _clock = clock;
+        _jobs = jobs ?? throw new ArgumentNullException(nameof(jobs));
+        _feedback = feedback ?? throw new ArgumentNullException(nameof(feedback));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
     public async Task<KbNavCountsDto> Handle(GetKbNavCountsQuery request, CancellationToken cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs
@@ -13,4 +13,10 @@ internal interface IKbUserFeedbackRepository
     Task<int> CountByGameIdAsync(
         Guid gameId, string? outcomeFilter, DateTime? fromDate,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Count feedback rows whose CreatedAt is on or after the given moment.
+    /// Issue #1655: KbSubNav count badges.
+    /// </summary>
+    Task<int> CountSinceAsync(DateTime since, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs
@@ -46,4 +46,12 @@ internal sealed class KbUserFeedbackRepository : IKbUserFeedbackRepository
             query = query.Where(f => f.CreatedAt >= fromDate.Value);
         return query.CountAsync(cancellationToken);
     }
+
+    public Task<int> CountSinceAsync(DateTime since, CancellationToken cancellationToken = default)
+    {
+        return _db.KbUserFeedbacks
+            .AsNoTracking()
+            .Where(f => f.CreatedAt >= since)
+            .CountAsync(cancellationToken);
+    }
 }

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -42,7 +42,7 @@ internal static class AdminKnowledgeBaseEndpoints
         })
         .WithName("GetKbNavCounts")
         .WithSummary("Counts for KbSubNav badges (active queue + feedback last 7d).")
-        .Produces<KbNavCountsDto>(200);
+        .Produces<KbNavCountsDto>(StatusCodes.Status200OK);
 
         // POST /api/v1/admin/kb/vector-search — semantic search over pgvector embeddings
         kbGroup.MapPost("/vector-search", async (

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.ExportDocumentChunks;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGamesWithoutKb;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchDocumentChunks;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Filters;
@@ -32,6 +33,16 @@ internal static class AdminKnowledgeBaseEndpoints
         })
         .WithName("GetVectorStats")
         .WithSummary("Get pgvector statistics grouped by game");
+
+        // GET /api/v1/admin/kb/nav-counts — Issue #1655 F3-FU-6
+        kbGroup.MapGet("/nav-counts", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var counts = await mediator.Send(new GetKbNavCountsQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(counts);
+        })
+        .WithName("GetKbNavCounts")
+        .WithSummary("Counts for KbSubNav badges (active queue + feedback last 7d).")
+        .Produces<KbNavCountsDto>(200);
 
         // POST /api/v1/admin/kb/vector-search — semantic search over pgvector embeddings
         kbGroup.MapPost("/vector-search", async (

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs
@@ -1,11 +1,9 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
 using Api.Infrastructure.Entities.DocumentProcessing;
-using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
-using NSubstitute;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
@@ -19,9 +17,12 @@ public sealed class ProcessingJobRepositoryCountByStatusesTests
 
     private static ProcessingJobRepository CreateRepo(out Api.Infrastructure.MeepleAiDbContext db)
     {
-        db = TestDbContextFactory.CreateInMemoryDbContext();
-        var collector = Substitute.For<IDomainEventCollector>();
-        return new ProcessingJobRepository(db, collector);
+        // Read-only tests: use the factory's shared Moq collector so the same instance is wired
+        // into both MeepleAiDbContext and the repository — see PhotoBatchUploadRepositoryIntegrationTests
+        // for the write-path (Testcontainers) pattern.
+        var collector = TestDbContextFactory.CreateMockEventCollector();
+        db = TestDbContextFactory.CreateInMemoryDbContextWithCollector(collector);
+        return new ProcessingJobRepository(db, collector.Object);
     }
 
     private static ProcessingJobEntity NewJob(JobStatus status) => new()
@@ -91,5 +92,16 @@ public sealed class ProcessingJobRepositoryCountByStatusesTests
         var count = await repo.CountByStatusesAsync(new[] { JobStatus.Failed }, Ct);
 
         count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_NullStatuses_ThrowsArgumentNullException()
+    {
+        var repo = CreateRepo(out _);
+
+        Func<Task> act = () => repo.CountByStatusesAsync(null!, Ct);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("statuses");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs
@@ -1,0 +1,95 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1655")]
+public sealed class ProcessingJobRepositoryCountByStatusesTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static ProcessingJobRepository CreateRepo(out Api.Infrastructure.MeepleAiDbContext db)
+    {
+        db = TestDbContextFactory.CreateInMemoryDbContext();
+        var collector = Substitute.For<IDomainEventCollector>();
+        return new ProcessingJobRepository(db, collector);
+    }
+
+    private static ProcessingJobEntity NewJob(JobStatus status) => new()
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = Guid.NewGuid(),
+        UserId = Guid.NewGuid(),
+        Status = status.ToString(),
+        Priority = 0,
+        CreatedAt = DateTimeOffset.UtcNow,
+    };
+
+    [Fact]
+    public async Task CountByStatusesAsync_NoMatches_ReturnsZero()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(NewJob(JobStatus.Completed), NewJob(JobStatus.Cancelled));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(
+            new[] { JobStatus.Queued, JobStatus.Processing, JobStatus.Failed }, Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_MultipleStatuses_CountsAcrossAll()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(
+            NewJob(JobStatus.Queued),
+            NewJob(JobStatus.Queued),
+            NewJob(JobStatus.Processing),
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Completed),     // not counted
+            NewJob(JobStatus.Cancelled));    // not counted
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(
+            new[] { JobStatus.Queued, JobStatus.Processing, JobStatus.Failed }, Ct);
+
+        count.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_EmptyStatusList_ReturnsZero()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.Add(NewJob(JobStatus.Queued));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(Array.Empty<JobStatus>(), Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_SingleStatus_CountsOnlyThatStatus()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Queued));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(new[] { JobStatus.Failed }, Ct);
+
+        count.Should().Be(2);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
@@ -119,4 +119,20 @@ public sealed class GetKbNavCountsQueryHandlerTests
 
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    [Theory]
+    [InlineData("jobs")]
+    [InlineData("feedback")]
+    [InlineData("clock")]
+    public void Constructor_NullDependency_ThrowsArgumentNullException(string paramName)
+    {
+        Action act = paramName switch
+        {
+            "jobs"     => () => new GetKbNavCountsQueryHandler(null!, _feedback, _clock),
+            "feedback" => () => new GetKbNavCountsQueryHandler(_jobs, null!, _clock),
+            "clock"    => () => new GetKbNavCountsQueryHandler(_jobs, _feedback, null!),
+            _          => throw new InvalidOperationException()
+        };
+        act.Should().Throw<ArgumentNullException>().WithParameterName(paramName);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
@@ -1,0 +1,122 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class GetKbNavCountsQueryHandlerTests
+{
+    private readonly IProcessingJobRepository _jobs = Substitute.For<IProcessingJobRepository>();
+    private readonly IKbUserFeedbackRepository _feedback = Substitute.For<IKbUserFeedbackRepository>();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 5, 30, 12, 0, 0, TimeSpan.Zero));
+    private readonly GetKbNavCountsQueryHandler _sut;
+
+    public GetKbNavCountsQueryHandlerTests()
+    {
+        _sut = new GetKbNavCountsQueryHandler(_jobs, _feedback, _clock);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCountsFromBothRepositories()
+    {
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns(7);
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(23);
+
+        var result = await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.ProcessingQueue.Should().Be(7);
+        result.Feedback7d.Should().Be(23);
+        result.AsOf.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task Handle_PassesActiveStatusesToProcessingRepo()
+    {
+        await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        await _jobs.Received(1).CountByStatusesAsync(
+            Arg.Is<IReadOnlyList<JobStatus>>(s =>
+                s.Count == 3 &&
+                s.Contains(JobStatus.Queued) &&
+                s.Contains(JobStatus.Processing) &&
+                s.Contains(JobStatus.Failed)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PassesNowMinus7DaysToFeedbackRepo()
+    {
+        await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        var expectedSince = _clock.GetUtcNow().UtcDateTime.AddDays(-7);
+        await _feedback.Received(1).CountSinceAsync(
+            Arg.Is<DateTime>(d => Math.Abs((d - expectedSince).TotalMilliseconds) < 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RunsCountQueriesInParallel()
+    {
+        var queueTcs = new TaskCompletionSource<int>();
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns(queueTcs.Task);
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var task = _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        // Give the scheduler a chance to enter both awaits
+        await Task.Yield();
+
+        // If the handler called repos sequentially it would still be on the first await
+        // and the feedback call would never have happened.
+        await _feedback.Received(1).CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+
+        queueTcs.SetResult(1);
+        var result = await task;
+
+        result.ProcessingQueue.Should().Be(1);
+        result.Feedback7d.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesProcessingRepoException()
+    {
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new InvalidOperationException("boom"));
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var act = () => _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new OperationCanceledException(cts.Token));
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new OperationCanceledException(cts.Token));
+
+        var act = () => _sut.Handle(new GetKbNavCountsQuery(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/GetKbNavCountsQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/GetKbNavCountsQueryHandlerIntegrationTests.cs
@@ -1,0 +1,183 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="GetKbNavCountsQueryHandler"/> against a real PostgreSQL
+/// database via Testcontainers. Validates that the EF Core SQL translation of
+/// <c>CountByStatusesAsync</c> (IN clause) and <c>CountSinceAsync</c> (WHERE &gt;= clause)
+/// produces the correct aggregate counts end-to-end.
+/// Issue #1655 (F3-FU-6 KbSubNav count badges).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class GetKbNavCountsQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _dbName = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+    public GetKbNavCountsQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _dbName = $"test_kbnav_counts_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_dbName);
+
+        var mockMediator = TestDbContextFactory.CreateMockMediator();
+        var mockEventCollector = TestDbContextFactory.CreateMockEventCollector();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString, o => o.UseVector())
+            .EnableSensitiveDataLogging()
+            .EnableDetailedErrors()
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(options, mockMediator.Object, mockEventCollector.Object);
+        await _dbContext.Database.MigrateAsync(Token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_dbName);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Handle_RealPostgres_CountsActiveJobsAndRecentFeedback()
+    {
+        // Arrange ----------------------------------------------------------------
+        var now = DateTime.UtcNow;
+        var clock = new FakeTimeProvider(new DateTimeOffset(now, TimeSpan.Zero));
+
+        // Seed a user and a PDF document required by ProcessingJobEntity FK constraints.
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(CreateUser(userId));
+
+        // One PDF document shared across all seeded jobs.
+        var pdfId = Guid.NewGuid();
+        _dbContext.PdfDocuments.Add(CreatePdfDocument(pdfId, userId));
+
+        await _dbContext.SaveChangesAsync(Token);
+
+        // Seed jobs:
+        //   Active (counted):   Queued ×2 + Processing ×1 + Failed ×1 → 4
+        //   Excluded:           Completed ×3 + Cancelled ×1             → 4
+        _dbContext.ProcessingJobs.AddRange(
+            MakeJob(pdfId, userId, JobStatus.Queued, now),
+            MakeJob(pdfId, userId, JobStatus.Queued, now),
+            MakeJob(pdfId, userId, JobStatus.Processing, now),
+            MakeJob(pdfId, userId, JobStatus.Failed, now),
+            MakeJob(pdfId, userId, JobStatus.Completed, now),
+            MakeJob(pdfId, userId, JobStatus.Completed, now),
+            MakeJob(pdfId, userId, JobStatus.Completed, now),
+            MakeJob(pdfId, userId, JobStatus.Cancelled, now));
+
+        // Seed feedback:
+        //   Within 7 days (counted):   offsets 0,1,3,5,6 → 5
+        //   Older (excluded):          offsets 10,30     → 2
+        var withinWindow = new[] { 0, 1, 3, 5, 6 };
+        var outsideWindow = new[] { 10, 30 };
+        foreach (var dayOffset in withinWindow)
+            _dbContext.KbUserFeedbacks.Add(MakeFeedback(now.AddDays(-dayOffset)));
+        foreach (var dayOffset in outsideWindow)
+            _dbContext.KbUserFeedbacks.Add(MakeFeedback(now.AddDays(-dayOffset)));
+
+        await _dbContext.SaveChangesAsync(Token);
+
+        // Build repositories from the same DbContext used to seed.
+        var mockEventCollector = TestDbContextFactory.CreateMockEventCollector();
+        var jobsRepo = new ProcessingJobRepository(_dbContext, mockEventCollector.Object);
+        var fbRepo = new KbUserFeedbackRepository(_dbContext);
+        var sut = new GetKbNavCountsQueryHandler(jobsRepo, fbRepo, clock);
+
+        // Act --------------------------------------------------------------------
+        var result = await sut.Handle(new GetKbNavCountsQuery(), Token);
+
+        // Assert -----------------------------------------------------------------
+        result.ProcessingQueue.Should().Be(4,
+            "Queued ×2 + Processing ×1 + Failed ×1 are the three active statuses");
+        result.Feedback7d.Should().Be(5,
+            "five feedback records fall within the 7-day window");
+        result.AsOf.Should().Be(clock.GetUtcNow(),
+            "AsOf must be the clock's current UTC time");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static UserEntity CreateUser(Guid userId) => new()
+    {
+        Id = userId,
+        Email = $"kbnav-test-{userId:N}@test.local",
+        DisplayName = "KbNavCounts Test User",
+        PasswordHash = "hashed",
+        Role = "User",
+        Tier = "free",
+        CreatedAt = DateTime.UtcNow,
+        IsTwoFactorEnabled = false,
+    };
+
+    private static PdfDocumentEntity CreatePdfDocument(Guid pdfId, Guid userId) => new()
+    {
+        Id = pdfId,
+        FileName = "test-rulebook.pdf",
+        FilePath = "/test/test-rulebook.pdf",
+        FileSizeBytes = 1024,
+        UploadedByUserId = userId,
+        UploadedAt = DateTime.UtcNow,
+        ProcessingState = "Ready",
+    };
+
+    private static ProcessingJobEntity MakeJob(
+        Guid pdfDocumentId, Guid userId, JobStatus status, DateTime createdAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = pdfDocumentId,
+        UserId = userId,
+        Status = status.ToString(),
+        Priority = 0,
+        CreatedAt = new DateTimeOffset(createdAt, TimeSpan.Zero),
+    };
+
+    private static KbUserFeedback MakeFeedback(DateTime createdAt)
+    {
+        var feedback = KbUserFeedback.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            chatSessionId: Guid.NewGuid(),
+            messageId: Guid.NewGuid(),
+            outcome: "helpful",
+            comment: null);
+
+        // Override the private CreatedAt set by KbUserFeedback.Create() to a
+        // deterministic test timestamp, enabling precise window-boundary assertions.
+        typeof(KbUserFeedback)
+            .GetProperty(nameof(KbUserFeedback.CreatedAt))!
+            .SetValue(feedback, createdAt);
+
+        return feedback;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/GetKbNavCountsQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/GetKbNavCountsQueryHandlerIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCo
 /// produces the correct aggregate counts end-to-end.
 /// Issue #1655 (F3-FU-6 KbSubNav count badges).
 /// </summary>
-[Collection("Integration-GroupD")]
+[Collection("Integration-GroupA")]
 [Trait("Category", TestCategories.Integration)]
 [Trait("BoundedContext", "KnowledgeBase")]
 [Trait("Issue", "1655")]
@@ -49,7 +49,7 @@ public sealed class GetKbNavCountsQueryHandlerIntegrationTests : IAsyncLifetime
         var mockEventCollector = TestDbContextFactory.CreateMockEventCollector();
 
         var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
-            .UseNpgsql(connectionString, o => o.UseVector())
+            .UseNpgsql(connectionString, o => o.UseVector()) // Issue #3547: UseVector() required by MeepleAiDbContext model
             .EnableSensitiveDataLogging()
             .EnableDetailedErrors()
             .Options;
@@ -60,8 +60,9 @@ public sealed class GetKbNavCountsQueryHandlerIntegrationTests : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        await _dbContext.DisposeAsync();
         await _fixture.DropIsolatedDatabaseAsync(_dbName);
+        if (_dbContext is not null)
+            await _dbContext.DisposeAsync();
     }
 
     [Fact(Timeout = 30_000)]
@@ -97,6 +98,7 @@ public sealed class GetKbNavCountsQueryHandlerIntegrationTests : IAsyncLifetime
         // Seed feedback:
         //   Within 7 days (counted):   offsets 0,1,3,5,6 → 5
         //   Older (excluded):          offsets 10,30     → 2
+        // Day-offset 7 omitted to avoid boundary ambiguity in `WHERE CreatedAt >= since`
         var withinWindow = new[] { 0, 1, 3, 5, 6 };
         var outsideWindow = new[] { 10, 30 };
         foreach (var dayOffset in withinWindow)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminKbNavCountsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminKbNavCountsEndpointIntegrationTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Endpoints;
+
+/// <summary>
+/// HTTP-layer integration tests for GET /api/v1/admin/kb/nav-counts.
+/// Verifies 401 (anonymous), 403 (editor), and 200 (superadmin) scenarios.
+/// Issue #1655 — F3-FU-6 KbSubNav count badges.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class AdminKbNavCountsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _anonClient = null!;
+    private HttpClient _editorClient = null!;
+    private HttpClient _adminClient = null!;
+    private string _editorToken = null!;
+    private string _adminToken = null!;
+
+    public AdminKbNavCountsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"kbnav_endpoint_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_, _adminToken) = await TestSessionHelper.CreateSuperAdminSessionAsync(db);
+        (_, _editorToken) = await TestSessionHelper.CreateEditorSessionAsync(db);
+
+        _anonClient = _factory.CreateClient();
+        _editorClient = _factory.CreateClient();
+        _adminClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _anonClient?.Dispose();
+        _editorClient?.Dispose();
+        _adminClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private static HttpRequestMessage NewRequest(string token) =>
+        TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            "/api/v1/admin/kb/nav-counts",
+            token);
+
+    [Fact(Timeout = 90_000)]
+    public async Task Get_WithoutSession_Returns401()
+    {
+        var response = await _anonClient.GetAsync("/api/v1/admin/kb/nav-counts");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Get_WithEditorSession_Returns403()
+    {
+        var response = await _editorClient.SendAsync(NewRequest(_editorToken));
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Get_WithAdminSession_Returns200WithDto()
+    {
+        var response = await _adminClient.SendAsync(NewRequest(_adminToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<KbNavCountsDto>();
+
+        dto.Should().NotBeNull();
+        dto!.ProcessingQueue.Should().BeGreaterThanOrEqualTo(0);
+        dto.Feedback7d.Should().BeGreaterThanOrEqualTo(0);
+        dto.AsOf.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(-1));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepositoryCountSinceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepositoryCountSinceTests.cs
@@ -1,0 +1,84 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class KbUserFeedbackRepositoryCountSinceTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static KbUserFeedback MakeFeedback(DateTime createdAt)
+    {
+        var fb = KbUserFeedback.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            chatSessionId: Guid.NewGuid(),
+            messageId: Guid.NewGuid(),
+            outcome: "helpful",
+            comment: null);
+        var prop = typeof(KbUserFeedback).GetProperty(nameof(KbUserFeedback.CreatedAt))!;
+        prop.SetValue(fb, createdAt);
+        return fb;
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_NoFeedback_ReturnsZero()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var repo = new KbUserFeedbackRepository(db);
+
+        var count = await repo.CountSinceAsync(DateTime.UtcNow.AddDays(-7), Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_IncludesFeedbackOnAndAfterSince()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var now = DateTime.UtcNow;
+        var since = now.AddDays(-7);
+
+        db.KbUserFeedbacks.AddRange(
+            MakeFeedback(now),                          // within window
+            MakeFeedback(now.AddDays(-3)),              // within window
+            MakeFeedback(since),                        // exactly at boundary -> included
+            MakeFeedback(now.AddDays(-10)),             // before window
+            MakeFeedback(now.AddDays(-30)));            // before window
+        await db.SaveChangesAsync(Ct);
+
+        var repo = new KbUserFeedbackRepository(db);
+        var count = await repo.CountSinceAsync(since, Ct);
+
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_AllOutcomesCount()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var now = DateTime.UtcNow;
+
+        var helpful = MakeFeedback(now.AddDays(-1));
+        var notHelpful = KbUserFeedback.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            "not_helpful", null);
+        typeof(KbUserFeedback).GetProperty(nameof(KbUserFeedback.CreatedAt))!
+            .SetValue(notHelpful, now.AddDays(-2));
+
+        db.KbUserFeedbacks.AddRange(helpful, notHelpful);
+        await db.SaveChangesAsync(Ct);
+
+        var repo = new KbUserFeedbackRepository(db);
+        var count = await repo.CountSinceAsync(now.AddDays(-7), Ct);
+
+        count.Should().Be(2);
+    }
+}

--- a/apps/api/tests/Api.Tests/TestHelpers/TestDbContextFactory.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/TestDbContextFactory.cs
@@ -42,6 +42,30 @@ public static class TestDbContextFactory
     }
 
     /// <summary>
+    /// Creates an InMemory DbContext wired to a caller-supplied collector instance.
+    /// Use when the same collector must be shared with a repository under test so that
+    /// SaveChangesAsync and the repository operate on the exact same mock object.
+    /// </summary>
+    public static MeepleAiDbContext CreateInMemoryDbContextWithCollector(
+        Mock<IDomainEventCollector> collector,
+        string? databaseName = null)
+    {
+        var dbName = databaseName ?? Guid.NewGuid().ToString();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .ConfigureWarnings(warnings =>
+            {
+                warnings.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning);
+                warnings.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning);
+            })
+            .Options;
+
+        var mockMediator = new Mock<IMediator>();
+        return new MeepleAiDbContext(options, mockMediator.Object, collector.Object);
+    }
+
+    /// <summary>
     /// Creates a mock IDomainEventCollector that returns empty event list.
     /// Issue #2430: Prevents NullReferenceException in SaveChangesAsync.
     /// </summary>

--- a/apps/web/e2e/admin-kb-navcounts.spec.ts
+++ b/apps/web/e2e/admin-kb-navcounts.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Admin KB SubNav count badges smoke test — F3-FU-6 #1655 Task 11
+ *
+ * Verifies that navigating to /admin/knowledge-base renders both
+ * kb-nav-badge-queue and kb-nav-badge-feedback with valid numeric content
+ * (or "99+" if capped, or "—" on backend error).
+ *
+ * Does NOT assert exact counts (those are flaky against a live backend).
+ *
+ * ── Auth context ──────────────────────────────────────────────────────────
+ * This test requires real admin access to /admin/knowledge-base.
+ *
+ * Known limitation (issue #1655 follow-up):
+ *   The v1 plaintext role cookie (meepleai_user_role) that proxy.ts used to
+ *   resolve admin role in E2E tests was sunset on 2026-05-13. Since then,
+ *   proxy.ts resolves the role only from the backend-validated session cache
+ *   (isSessionCookieValid → /auth/me → cacheSessionValidation). However,
+ *   when PLAYWRIGHT_AUTH_BYPASS=true is set in the webServer environment
+ *   (see playwright.config.ts), proxy.ts skips isSessionCookieValid entirely,
+ *   so the cache is never populated and isAdmin always evaluates to false.
+ *
+ *   As a result, ALL admin E2E tests that use PLAYWRIGHT_AUTH_BYPASS + mock
+ *   auth helpers (AdminHelper, seedAuthSession) are currently broken for
+ *   /admin/** routes in dev/CI environments. This is a systemic issue tracked
+ *   separately from this task.
+ *
+ *   This test uses real credentials and a pre-flight check: if the server
+ *   redirects away from /admin after real login (indicating bypass-broken-role),
+ *   it skips gracefully instead of failing with a confusing error.
+ *
+ * ── Nav-counts ────────────────────────────────────────────────────────────
+ * The nav-counts endpoint is mocked so the badge counts are deterministic
+ * regardless of live processing-queue or feedback state.
+ *
+ * ── Credentials ───────────────────────────────────────────────────────────
+ * PLAYWRIGHT_ADMIN_EMAIL / PLAYWRIGHT_ADMIN_PASSWORD env vars.
+ * Falls back to ADMIN_EMAIL / ADMIN_PASSWORD (from .env.test) then to the
+ * local dev seeded admin (admin@meepleai.app).
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const adminEmail =
+  process.env.PLAYWRIGHT_ADMIN_EMAIL || process.env.ADMIN_EMAIL || 'admin@meepleai.app';
+const adminPassword =
+  process.env.PLAYWRIGHT_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD || '5ZwHNfXqTkRfTQG5bFr5MAPh';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Log in via the backend API. Playwright's shared cookie jar automatically
+ * carries the response cookies (including the `secure`-flagged session cookie,
+ * which Chrome DevTools Protocol allows on localhost over HTTP) into subsequent
+ * browser page navigations.
+ *
+ * Returns the raw session cookie value for diagnostic use, or null on failure.
+ */
+async function loginViaBackendApi(page: Page): Promise<boolean> {
+  const response = await page.request.post(`${apiBase}/api/v1/auth/login`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: { email: adminEmail, password: adminPassword },
+  });
+
+  if (!response.ok()) {
+    console.error(
+      `[admin-kb-navcounts] Backend login failed: HTTP ${response.status()} — ` +
+        `check PLAYWRIGHT_ADMIN_EMAIL / PLAYWRIGHT_ADMIN_PASSWORD env vars`
+    );
+    return false;
+  }
+
+  console.log(`[admin-kb-navcounts] API login OK for ${adminEmail}`);
+  return true;
+}
+
+/**
+ * Pre-flight: navigate to /admin and check whether the proxy lets us in.
+ *
+ * With PLAYWRIGHT_AUTH_BYPASS=true active in the dev server and the v1 role
+ * cookie path expired (2026-05-13), the proxy cannot resolve the admin role
+ * and redirects /admin → / → /library. In that case this function returns
+ * false and the test skips gracefully.
+ *
+ * Returns true only if the browser actually lands on /admin or /admin/**.
+ */
+async function canAccessAdmin(page: Page): Promise<boolean> {
+  await page.goto('/admin');
+  await page.waitForLoadState('domcontentloaded');
+  const isOnAdmin = page.url().includes('/admin');
+  if (!isOnAdmin) {
+    console.warn(
+      `[admin-kb-navcounts] /admin redirected to ${page.url()}. ` +
+        'This is the known PLAYWRIGHT_AUTH_BYPASS + v1-sunset issue (#1655 follow-up). ' +
+        'Skipping test.'
+    );
+  }
+  return isOnAdmin;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Admin KB SubNav count badges (#1655)', () => {
+  test.beforeEach(async ({ page }) => {
+    // 1. Mock the nav-counts endpoint BEFORE navigation so the mock is active
+    //    from the first fetch. Returns non-zero counts for a clear numeric display.
+    await page.route(`${apiBase}/api/v1/admin/kb/nav-counts`, async route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          processingQueue: 3,
+          feedback7d: 12,
+          asOf: new Date().toISOString(),
+        }),
+      })
+    );
+
+    // 2. Log in via real credentials so the browser context holds a valid session.
+    const loggedIn = await loginViaBackendApi(page);
+    test.skip(!loggedIn, 'Skipping: backend login failed — check credentials or API availability');
+  });
+
+  test('shows queue and feedback badges with numeric content', async ({ page }) => {
+    // Pre-flight: verify admin access is actually granted.
+    // Skips gracefully when PLAYWRIGHT_AUTH_BYPASS + v1 sunset blocks admin role.
+    const adminAccessible = await canAccessAdmin(page);
+    test.skip(
+      !adminAccessible,
+      'Skipping: /admin not accessible — PLAYWRIGHT_AUTH_BYPASS active + v1 role cookie sunset ' +
+        '(2026-05-13). Admin E2E tests require proxy.ts role bypass support to be updated. ' +
+        'See #1655 follow-up.'
+    );
+
+    await page.goto('/admin/knowledge-base');
+
+    // Guard: confirm we're on the admin KB page.
+    await expect(page).toHaveURL(/\/admin\/knowledge-base/, { timeout: 10_000 });
+
+    // Wait for the skeleton to resolve into the real badge.
+    // KbCountBadge renders data-testid="kb-nav-badge-queue-loading" while
+    // loading=true; after the first fetch resolves it switches to
+    // data-testid="kb-nav-badge-queue" with the numeric display.
+    const queueBadge = page.getByTestId('kb-nav-badge-queue');
+    const feedbackBadge = page.getByTestId('kb-nav-badge-feedback');
+
+    await expect(queueBadge).toBeVisible({ timeout: 10_000 });
+    await expect(feedbackBadge).toBeVisible({ timeout: 10_000 });
+
+    // Content must be: digits with optional "+", or em-dash "—" on error.
+    await expect(queueBadge).toHaveText(/^\d+\+?$|^—$/, { timeout: 10_000 });
+    await expect(feedbackBadge).toHaveText(/^\d+\+?$|^—$/, { timeout: 10_000 });
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { JSX } from 'react';
+
+interface KbCountBadgeProps {
+  readonly count: number | undefined;
+  readonly loading: boolean;
+  readonly tooltip?: string;
+  readonly testId?: string;
+}
+
+export function KbCountBadge({ count, loading, tooltip, testId }: KbCountBadgeProps): JSX.Element {
+  if (loading && count === undefined) {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid={testId ? `${testId}-loading` : undefined}
+        className="ml-1.5 inline-block h-4 w-6 rounded-full bg-muted animate-pulse"
+      />
+    );
+  }
+
+  const safe = count ?? 0;
+  const display = safe > 99 ? '99+' : safe.toString();
+  const isActive = safe > 0;
+
+  return (
+    <span
+      aria-label={`${safe} elementi`}
+      title={tooltip}
+      data-testid={testId}
+      className={[
+        'ml-1.5 inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1.5 rounded-full',
+        'text-[10px] font-bold tabular-nums leading-none',
+        isActive
+          ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+          : 'bg-muted text-muted-foreground',
+      ].join(' ')}
+    >
+      {display}
+    </span>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
@@ -5,11 +5,18 @@ import type { JSX } from 'react';
 interface KbCountBadgeProps {
   readonly count: number | undefined;
   readonly loading: boolean;
+  readonly isError?: boolean;
   readonly tooltip?: string;
   readonly testId?: string;
 }
 
-export function KbCountBadge({ count, loading, tooltip, testId }: KbCountBadgeProps): JSX.Element {
+export function KbCountBadge({
+  count,
+  loading,
+  isError,
+  tooltip,
+  testId,
+}: KbCountBadgeProps): JSX.Element {
   if (loading && count === undefined) {
     return (
       <span
@@ -17,6 +24,23 @@ export function KbCountBadge({ count, loading, tooltip, testId }: KbCountBadgePr
         data-testid={testId ? `${testId}-loading` : undefined}
         className="ml-1.5 inline-block h-4 w-6 rounded-full bg-muted animate-pulse"
       />
+    );
+  }
+
+  if (isError && count === undefined) {
+    return (
+      <span
+        aria-label="conteggio non disponibile"
+        title={tooltip}
+        data-testid={testId}
+        className={[
+          'ml-1.5 inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1.5 rounded-full',
+          'text-[10px] font-bold leading-none',
+          'bg-muted text-muted-foreground',
+        ].join(' ')}
+      >
+        —
+      </span>
     );
   }
 

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx
@@ -26,7 +26,7 @@ export function KbCountBadge({ count, loading, tooltip, testId }: KbCountBadgePr
 
   return (
     <span
-      aria-label={`${safe} elementi`}
+      aria-hidden="true"
       title={tooltip}
       data-testid={testId}
       className={[

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx
@@ -50,7 +50,7 @@ function isActive(tabHref: string, pathname: string): boolean {
  */
 export function KbSubNav() {
   const pathname = usePathname();
-  const { queue, feedback, loading } = useKbNavCounts();
+  const { queue, feedback, loading, isError } = useKbNavCounts();
 
   return (
     <nav
@@ -79,6 +79,7 @@ export function KbSubNav() {
                   <KbCountBadge
                     count={count}
                     loading={loading}
+                    isError={isError}
                     tooltip={TOOLTIPS[tab.kind]}
                     testId={`kb-nav-badge-${tab.kind}`}
                   />

--- a/apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx
@@ -4,23 +4,35 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import { useKbNavCounts } from '@/hooks/admin/useKbNavCounts';
+
+import { KbCountBadge } from './KbCountBadge';
+
 const KB_BASE = '/admin/knowledge-base';
+
+type KbTabKind = 'queue' | 'feedback';
 
 interface KbTab {
   readonly label: string;
   readonly href: string;
+  readonly kind?: KbTabKind;
 }
 
 const TABS: ReadonlyArray<KbTab> = [
   { label: 'Explorer', href: KB_BASE },
   { label: 'Vector Collections', href: `${KB_BASE}/vectors` },
-  { label: 'Processing Queue', href: `${KB_BASE}/queue` },
+  { label: 'Processing Queue', href: `${KB_BASE}/queue`, kind: 'queue' },
   { label: 'RAG Pipeline', href: `${KB_BASE}/pipeline` },
   { label: 'Embedding', href: `${KB_BASE}/embedding` },
-  { label: 'Feedback', href: `${KB_BASE}/feedback` },
+  { label: 'Feedback', href: `${KB_BASE}/feedback`, kind: 'feedback' },
   { label: 'Settings', href: `${KB_BASE}/settings` },
   { label: 'Snapshots', href: `${KB_BASE}/snapshots` },
 ];
+
+const TOOLTIPS: Record<KbTabKind, string> = {
+  queue: 'Job attivi (queued, in elaborazione o falliti)',
+  feedback: 'Feedback ricevuti negli ultimi 7 giorni',
+};
 
 function isActive(tabHref: string, pathname: string): boolean {
   // Explorer is active ONLY on exact /admin/knowledge-base (otherwise it
@@ -32,14 +44,13 @@ function isActive(tabHref: string, pathname: string): boolean {
 /**
  * KB sub-nav: 8 tab-link a route reali. La sezione attiva è derivata dal
  * pathname corrente (App Router). Vive dentro `knowledge-base/layout.tsx` e
- * wrappa Explorer + le 7 tool-page esistenti (vectors, queue, pipeline,
- * embedding, feedback, settings, snapshots).
+ * wrappa Explorer + le 7 tool-page esistenti.
  *
- * Pattern visivo SP5: `.admin-tabs` orizzontale; bordo bottom token-tinted
- * sull'attivo. Niente badge count in F3.1 (deferred a follow-up).
+ * Issue #1655: wired count badges on Processing Queue + Feedback tabs.
  */
 export function KbSubNav() {
   const pathname = usePathname();
+  const { queue, feedback, loading } = useKbNavCounts();
 
   return (
     <nav
@@ -49,6 +60,8 @@ export function KbSubNav() {
       <ul className="flex gap-1 min-w-max">
         {TABS.map(tab => {
           const active = isActive(tab.href, pathname);
+          const count =
+            tab.kind === 'queue' ? queue : tab.kind === 'feedback' ? feedback : undefined;
           return (
             <li key={tab.href}>
               <Link
@@ -62,6 +75,14 @@ export function KbSubNav() {
                 ].join(' ')}
               >
                 {tab.label}
+                {tab.kind && (
+                  <KbCountBadge
+                    count={count}
+                    loading={loading}
+                    tooltip={TOOLTIPS[tab.kind]}
+                    testId={`kb-nav-badge-${tab.kind}`}
+                  />
+                )}
               </Link>
             </li>
           );

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { KbCountBadge } from '../KbCountBadge';
+
+describe('KbCountBadge', () => {
+  it('renders a loading skeleton when loading and count is undefined', () => {
+    const { container } = render(<KbCountBadge count={undefined} loading={true} testId="badge" />);
+    expect(container.querySelector('[data-testid="badge-loading"]')).toBeInTheDocument();
+  });
+
+  it('renders 0 with muted style when count is 0', () => {
+    render(<KbCountBadge count={0} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('0');
+    expect(badge.className).toContain('bg-muted');
+  });
+
+  it('renders 23 with amber style when count is greater than 0', () => {
+    render(<KbCountBadge count={23} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('23');
+    expect(badge.className).toContain('bg-amber-500/15');
+  });
+
+  it('renders "99+" when count exceeds 99', () => {
+    render(<KbCountBadge count={150} loading={false} testId="badge" />);
+    expect(screen.getByTestId('badge')).toHaveTextContent('99+');
+  });
+
+  it('falls back to 0 with muted style when count is undefined and not loading', () => {
+    render(<KbCountBadge count={undefined} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('0');
+    expect(badge.className).toContain('bg-muted');
+  });
+
+  it('applies the title attribute from the tooltip prop', () => {
+    render(<KbCountBadge count={1} loading={false} tooltip="hello" testId="badge" />);
+    expect(screen.getByTestId('badge')).toHaveAttribute('title', 'hello');
+  });
+
+  it('omits data-testid when not provided', () => {
+    const { container } = render(<KbCountBadge count={1} loading={false} />);
+    expect(container.querySelector('[data-testid]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
@@ -44,4 +44,12 @@ describe('KbCountBadge', () => {
     const { container } = render(<KbCountBadge count={1} loading={false} />);
     expect(container.querySelector('[data-testid]')).toBeNull();
   });
+
+  it('renders em-dash with muted style when isError is true and count is undefined', () => {
+    render(<KbCountBadge count={undefined} loading={false} isError={true} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('—');
+    expect(badge).toHaveAttribute('aria-label', 'conteggio non disponibile');
+    expect(badge.className).toContain('bg-muted');
+  });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
@@ -9,6 +9,11 @@ vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
 }));
 
+const mockUseKbNavCounts = vi.fn();
+vi.mock('@/hooks/admin/useKbNavCounts', () => ({
+  useKbNavCounts: () => mockUseKbNavCounts(),
+}));
+
 const TABS = [
   { label: 'Explorer', href: '/admin/knowledge-base' },
   { label: 'Vector Collections', href: '/admin/knowledge-base/vectors' },
@@ -21,7 +26,15 @@ const TABS = [
 ];
 
 describe('KbSubNav', () => {
-  beforeEach(() => mockPathname.mockReset());
+  beforeEach(() => {
+    mockPathname.mockReset();
+    mockUseKbNavCounts.mockReset().mockReturnValue({
+      queue: undefined,
+      feedback: undefined,
+      loading: false,
+      isError: false,
+    });
+  });
 
   it('renders all 8 KB tabs with correct hrefs', () => {
     mockPathname.mockReturnValue('/admin/knowledge-base');
@@ -82,5 +95,45 @@ describe('KbSubNav', () => {
     for (const tab of TABS) {
       expect(screen.getByRole('link', { name: tab.label })).not.toHaveAttribute('aria-current');
     }
+  });
+
+  it('renders queue badge with count from hook', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 7, feedback: 23, loading: false, isError: false });
+    render(<KbSubNav />);
+    expect(screen.getByTestId('kb-nav-badge-queue')).toHaveTextContent('7');
+  });
+
+  it('renders feedback badge with count from hook', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 7, feedback: 23, loading: false, isError: false });
+    render(<KbSubNav />);
+    expect(screen.getByTestId('kb-nav-badge-feedback')).toHaveTextContent('23');
+  });
+
+  it('does NOT render badges on non-counted tabs', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 5, feedback: 5, loading: false, isError: false });
+    render(<KbSubNav />);
+    // 8 tabs total but only 2 with badges
+    const badges = screen.queryAllByTestId(/^kb-nav-badge-/);
+    expect(badges).toHaveLength(2);
+  });
+
+  it('renders skeleton when loading and counts are undefined', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({
+      queue: undefined,
+      feedback: undefined,
+      loading: true,
+      isError: false,
+    });
+    const { container } = render(<KbSubNav />);
+    expect(
+      container.querySelector('[data-testid="kb-nav-badge-queue-loading"]')
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="kb-nav-badge-feedback-loading"]')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
@@ -136,4 +136,17 @@ describe('KbSubNav', () => {
       container.querySelector('[data-testid="kb-nav-badge-feedback-loading"]')
     ).toBeInTheDocument();
   });
+
+  it('renders em-dash badges when hook reports error', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({
+      queue: undefined,
+      feedback: undefined,
+      loading: false,
+      isError: true,
+    });
+    render(<KbSubNav />);
+    expect(screen.getByTestId('kb-nav-badge-queue')).toHaveTextContent('—');
+    expect(screen.getByTestId('kb-nav-badge-feedback')).toHaveTextContent('—');
+  });
 });

--- a/apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.tsx
+++ b/apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useKbNavCounts } from '../useKbNavCounts';
+import { fetchKbNavCounts } from '@/lib/api/admin-kb-nav-counts';
+
+vi.mock('@/lib/api/admin-kb-nav-counts', () => ({
+  fetchKbNavCounts: vi.fn(),
+}));
+
+const mockedFetchKbNavCounts = vi.mocked(fetchKbNavCounts);
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useKbNavCounts', () => {
+  beforeEach(() => {
+    mockedFetchKbNavCounts.mockReset();
+  });
+
+  it('returns queue and feedback from a successful fetch', async () => {
+    mockedFetchKbNavCounts.mockResolvedValueOnce({
+      processingQueue: 7,
+      feedback7d: 23,
+      asOf: '2026-05-30T12:00:00Z',
+    });
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.queue).toBe(7);
+    expect(result.current.feedback).toBe(23);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('exposes loading=true and undefined values before first settle', () => {
+    mockedFetchKbNavCounts.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper: makeWrapper() });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.queue).toBeUndefined();
+    expect(result.current.feedback).toBeUndefined();
+  });
+
+  it('sets isError=true when the fetch throws', async () => {
+    mockedFetchKbNavCounts.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.queue).toBeUndefined();
+    expect(result.current.feedback).toBeUndefined();
+  });
+});

--- a/apps/web/src/hooks/admin/useKbNavCounts.ts
+++ b/apps/web/src/hooks/admin/useKbNavCounts.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin KB SubNav Counts hook (Issue #1655 Task 8)
+ *
+ * Polls GET /api/v1/admin/kb/nav-counts every 30 s and exposes
+ * the badge counts for the KbSubNav tabs.
+ */
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { fetchKbNavCounts } from '@/lib/api/admin-kb-nav-counts';
+
+export interface KbNavCounts {
+  readonly queue: number | undefined;
+  readonly feedback: number | undefined;
+  readonly loading: boolean;
+  readonly isError: boolean;
+}
+
+export function useKbNavCounts(): KbNavCounts {
+  const query = useQuery({
+    queryKey: ['admin', 'kb', 'nav-counts'] as const,
+    queryFn: ({ signal }) => fetchKbNavCounts({ signal }),
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 15_000,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    queue: query.data?.processingQueue,
+    feedback: query.data?.feedback7d,
+    loading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/apps/web/src/lib/api/admin-kb-nav-counts.ts
+++ b/apps/web/src/lib/api/admin-kb-nav-counts.ts
@@ -1,0 +1,29 @@
+/**
+ * Admin KB SubNav Counts API client (Issue #1655 Task 7)
+ *
+ * Fetches badge counts for the KbSubNav tabs:
+ * - processingQueue: documents currently pending/processing
+ * - feedback7d: RAG feedback items from the last 7 days
+ *
+ * Endpoint: GET /api/v1/admin/kb/nav-counts
+ */
+
+import { apiClient } from '@/lib/api/client';
+import {
+  KbNavCountsDtoSchema,
+  type KbNavCountsDto,
+} from '@/lib/api/schemas/admin-knowledge-base.schemas';
+
+export type { KbNavCountsDto };
+
+/**
+ * GET /api/v1/admin/kb/nav-counts
+ * Returns badge counts for the KB sub-navigation tabs.
+ */
+export async function fetchKbNavCounts(options?: {
+  signal?: AbortSignal;
+}): Promise<KbNavCountsDto | null> {
+  return apiClient.get<KbNavCountsDto>('/api/v1/admin/kb/nav-counts', KbNavCountsDtoSchema, {
+    signal: options?.signal,
+  });
+}

--- a/apps/web/src/lib/api/schemas/admin-knowledge-base.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-knowledge-base.schemas.ts
@@ -392,3 +392,13 @@ export type KbSnapshotInfo = z.infer<typeof KbSnapshotInfoSchema>;
 export type KbSnapshotList = z.infer<typeof KbSnapshotListSchema>;
 export type KbExportResult = z.infer<typeof KbExportResultSchema>;
 export type KbImportResult = z.infer<typeof KbImportResultSchema>;
+
+// ─── KB SubNav Counts (Issue #1655) ──────────────────────────────────────────
+
+export const KbNavCountsDtoSchema = z.object({
+  processingQueue: z.number().int().nonnegative(),
+  feedback7d: z.number().int().nonnegative(),
+  asOf: z.string(),
+});
+
+export type KbNavCountsDto = z.infer<typeof KbNavCountsDtoSchema>;

--- a/docs/superpowers/plans/2026-05-30-f3-fu-6-kbsubnav-count-badges.md
+++ b/docs/superpowers/plans/2026-05-30-f3-fu-6-kbsubnav-count-badges.md
@@ -1,0 +1,1629 @@
+# F3-FU-6 KbSubNav Count Badges — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add wired count badges to the `KbSubNav` for the "Processing Queue" and "Feedback" tabs in the admin Knowledge Base section, fed by a single polled endpoint.
+
+**Architecture:** New `GET /api/v1/admin/kb/nav-counts` endpoint returns 2 counts: active jobs (`Queued+Processing+Failed`) + feedback last 7 days. React Query polling (30s + window-focus refetch). New `KbCountBadge` component rendered next to label of those 2 tabs only.
+
+**Tech Stack:** .NET 9 MediatR + EF Core + Postgres; Next.js + React Query + Tailwind; xUnit + NSubstitute + FluentAssertions + Testcontainers; Vitest + Testing Library + Playwright.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-30-f3-fu-6-kbsubnav-count-badges-design.md`
+
+**Branch:** `feature/issue-1655-kbsubnav-count-badges` (already created, parent `main-dev`)
+
+**Issue:** [#1655](https://github.com/meepleAi-app/meepleai-monorepo/issues/1655) — P3
+
+---
+
+## Task 1: Add `CountByStatusesAsync` to `IProcessingJobRepository`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs`
+- Test (new): `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs`
+
+Context: `Status` column is stored as a **string** in DB (see existing `CountByStatusAsync` impl at line 97 of `ProcessingJobRepository.cs` — uses `status.ToString()` for comparison). The new method accepts a list of `JobStatus` enum values and uses `Contains` on serialized strings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1655")]
+public sealed class ProcessingJobRepositoryCountByStatusesTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static ProcessingJobRepository CreateRepo(out Api.Infrastructure.MeepleAiDbContext db)
+    {
+        db = TestDbContextFactory.CreateInMemoryDbContext();
+        var collector = Substitute.For<IDomainEventCollector>();
+        return new ProcessingJobRepository(db, collector);
+    }
+
+    private static ProcessingJobEntity NewJob(JobStatus status) => new()
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = Guid.NewGuid(),
+        Status = status.ToString(),
+        Priority = 0,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        EnqueuedBy = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public async Task CountByStatusesAsync_NoMatches_ReturnsZero()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(NewJob(JobStatus.Completed), NewJob(JobStatus.Cancelled));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(
+            new[] { JobStatus.Queued, JobStatus.Processing, JobStatus.Failed }, Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_MultipleStatuses_CountsAcrossAll()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(
+            NewJob(JobStatus.Queued),
+            NewJob(JobStatus.Queued),
+            NewJob(JobStatus.Processing),
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Completed),     // not counted
+            NewJob(JobStatus.Cancelled));    // not counted
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(
+            new[] { JobStatus.Queued, JobStatus.Processing, JobStatus.Failed }, Ct);
+
+        count.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_EmptyStatusList_ReturnsZero()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.Add(NewJob(JobStatus.Queued));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(Array.Empty<JobStatus>(), Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountByStatusesAsync_SingleStatus_CountsOnlyThatStatus()
+    {
+        var repo = CreateRepo(out var db);
+        db.ProcessingJobs.AddRange(
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Failed),
+            NewJob(JobStatus.Queued));
+        await db.SaveChangesAsync(Ct);
+
+        var count = await repo.CountByStatusesAsync(new[] { JobStatus.Failed }, Ct);
+
+        count.Should().Be(2);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run from `apps/api`:
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ProcessingJobRepositoryCountByStatusesTests"
+```
+
+Expected: build error `'IProcessingJobRepository' does not contain a definition for 'CountByStatusesAsync'`.
+
+- [ ] **Step 3: Add the method to the interface**
+
+In `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs`, add **before** the closing brace:
+
+```csharp
+    /// <summary>
+    /// Count jobs whose status is in the supplied set.
+    /// Returns 0 if the set is empty.
+    /// Issue #1655: KbSubNav count badges.
+    /// </summary>
+    Task<int> CountByStatusesAsync(
+        IReadOnlyList<JobStatus> statuses,
+        CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 4: Implement the method**
+
+In `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs`, add right after the existing `CountByStatusAsync` (around line 103):
+
+```csharp
+    public async Task<int> CountByStatusesAsync(
+        IReadOnlyList<JobStatus> statuses,
+        CancellationToken cancellationToken = default)
+    {
+        if (statuses is null || statuses.Count == 0)
+            return 0;
+
+        var statusStrings = statuses.Select(s => s.ToString()).ToArray();
+        return await DbContext.ProcessingJobs
+            .AsNoTracking()
+            .Where(j => statusStrings.Contains(j.Status))
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ProcessingJobRepositoryCountByStatusesTests"
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs \
+        apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepositoryCountByStatusesTests.cs
+git commit -m "feat(processing-queue): #1655 add CountByStatusesAsync repository method"
+```
+
+---
+
+## Task 2: Add `CountSinceAsync` to `IKbUserFeedbackRepository`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs`
+- Test (new): `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepositoryCountSinceTests.cs`
+
+Context: `KbUserFeedback.CreatedAt` is `DateTime` (not `DateTimeOffset`); existing methods on this repository accept `DateTime?`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepositoryCountSinceTests.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class KbUserFeedbackRepositoryCountSinceTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static KbUserFeedback MakeFeedback(DateTime createdAt)
+    {
+        // Domain factory sets CreatedAt = DateTime.UtcNow; we set it via reflection
+        // for deterministic test scenarios (no public setter).
+        var fb = KbUserFeedback.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            chatSessionId: Guid.NewGuid(),
+            messageId: Guid.NewGuid(),
+            outcome: "helpful",
+            comment: null);
+        var prop = typeof(KbUserFeedback).GetProperty(nameof(KbUserFeedback.CreatedAt))!;
+        prop.SetValue(fb, createdAt);
+        return fb;
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_NoFeedback_ReturnsZero()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var repo = new KbUserFeedbackRepository(db);
+
+        var count = await repo.CountSinceAsync(DateTime.UtcNow.AddDays(-7), Ct);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_IncludesFeedbackOnAndAfterSince()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var now = DateTime.UtcNow;
+        var since = now.AddDays(-7);
+
+        db.KbUserFeedbacks.AddRange(
+            MakeFeedback(now),                          // within window
+            MakeFeedback(now.AddDays(-3)),              // within window
+            MakeFeedback(since),                        // exactly at boundary -> included
+            MakeFeedback(now.AddDays(-10)),             // before window
+            MakeFeedback(now.AddDays(-30)));            // before window
+        await db.SaveChangesAsync(Ct);
+
+        var repo = new KbUserFeedbackRepository(db);
+        var count = await repo.CountSinceAsync(since, Ct);
+
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CountSinceAsync_AllOutcomesCount()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var now = DateTime.UtcNow;
+
+        var helpful = MakeFeedback(now.AddDays(-1));
+        var notHelpful = KbUserFeedback.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            "not_helpful", null);
+        typeof(KbUserFeedback).GetProperty(nameof(KbUserFeedback.CreatedAt))!
+            .SetValue(notHelpful, now.AddDays(-2));
+
+        db.KbUserFeedbacks.AddRange(helpful, notHelpful);
+        await db.SaveChangesAsync(Ct);
+
+        var repo = new KbUserFeedbackRepository(db);
+        var count = await repo.CountSinceAsync(now.AddDays(-7), Ct);
+
+        count.Should().Be(2);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~KbUserFeedbackRepositoryCountSinceTests"
+```
+
+Expected: build error `'IKbUserFeedbackRepository' does not contain a definition for 'CountSinceAsync'`.
+
+- [ ] **Step 3: Add the method to the interface**
+
+In `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs`, add before the closing brace:
+
+```csharp
+    /// <summary>
+    /// Count feedback rows whose CreatedAt is on or after the given moment.
+    /// Issue #1655: KbSubNav count badges.
+    /// </summary>
+    Task<int> CountSinceAsync(DateTime since, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 4: Implement the method**
+
+In `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs`, add right after `CountByGameIdAsync` (around line 48):
+
+```csharp
+    public Task<int> CountSinceAsync(DateTime since, CancellationToken cancellationToken = default)
+    {
+        return _db.KbUserFeedbacks
+            .AsNoTracking()
+            .Where(f => f.CreatedAt >= since)
+            .CountAsync(cancellationToken);
+    }
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~KbUserFeedbackRepositoryCountSinceTests"
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs \
+        apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepositoryCountSinceTests.cs
+git commit -m "feat(kb): #1655 add CountSinceAsync repository method"
+```
+
+---
+
+## Task 3: Create `KbNavCountsDto`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs`
+
+No test needed for a pure data record. It will be validated indirectly via Task 4 (handler) and Task 6 (endpoint).
+
+- [ ] **Step 1: Create the DTO**
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Counts displayed as badges on the admin KbSubNav.
+/// Issue #1655 (F3-FU-6).
+/// </summary>
+public sealed record KbNavCountsDto(
+    int ProcessingQueue,
+    int Feedback7d,
+    DateTimeOffset AsOf
+);
+```
+
+- [ ] **Step 2: Verify the project builds**
+
+```bash
+dotnet build apps/api/src/Api/Api.csproj
+```
+
+Expected: build succeeded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs
+git commit -m "feat(kb): #1655 add KbNavCountsDto"
+```
+
+---
+
+## Task 4: Create `GetKbNavCountsQuery` + Handler (unit-tested)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs`
+- Test (new): `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class GetKbNavCountsQueryHandlerTests
+{
+    private readonly IProcessingJobRepository _jobs = Substitute.For<IProcessingJobRepository>();
+    private readonly IKbUserFeedbackRepository _feedback = Substitute.For<IKbUserFeedbackRepository>();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 5, 30, 12, 0, 0, TimeSpan.Zero));
+    private readonly GetKbNavCountsQueryHandler _sut;
+
+    public GetKbNavCountsQueryHandlerTests()
+    {
+        _sut = new GetKbNavCountsQueryHandler(_jobs, _feedback, _clock);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCountsFromBothRepositories()
+    {
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns(7);
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(23);
+
+        var result = await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.ProcessingQueue.Should().Be(7);
+        result.Feedback7d.Should().Be(23);
+        result.AsOf.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public async Task Handle_PassesActiveStatusesToProcessingRepo()
+    {
+        await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        await _jobs.Received(1).CountByStatusesAsync(
+            Arg.Is<IReadOnlyList<JobStatus>>(s =>
+                s.Count == 3 &&
+                s.Contains(JobStatus.Queued) &&
+                s.Contains(JobStatus.Processing) &&
+                s.Contains(JobStatus.Failed)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PassesNowMinus7DaysToFeedbackRepo()
+    {
+        await _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        var expectedSince = _clock.GetUtcNow().UtcDateTime.AddDays(-7);
+        await _feedback.Received(1).CountSinceAsync(
+            Arg.Is<DateTime>(d => Math.Abs((d - expectedSince).TotalMilliseconds) < 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RunsCountQueriesInParallel()
+    {
+        var queueTcs = new TaskCompletionSource<int>();
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns(queueTcs.Task);
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var task = _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        // Give the scheduler a chance to enter both awaits
+        await Task.Yield();
+
+        // If the handler called repos sequentially it would still be on the first await
+        // and the feedback call would never have happened.
+        await _feedback.Received(1).CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+
+        queueTcs.SetResult(1);
+        var result = await task;
+
+        result.ProcessingQueue.Should().Be(1);
+        result.Feedback7d.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesProcessingRepoException()
+    {
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new InvalidOperationException("boom"));
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var act = () => _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("boom");
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new OperationCanceledException(cts.Token));
+        _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new OperationCanceledException(cts.Token));
+
+        var act = () => _sut.Handle(new GetKbNavCountsQuery(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetKbNavCountsQueryHandlerTests"
+```
+
+Expected: build error — query/handler don't exist.
+
+- [ ] **Step 3: Create the query**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+/// <summary>
+/// Returns counts for KbSubNav badges: active processing jobs + feedback last 7 days.
+/// Issue #1655 (F3-FU-6).
+/// </summary>
+public sealed record GetKbNavCountsQuery() : IRequest<KbNavCountsDto>;
+```
+
+- [ ] **Step 4: Create the handler**
+
+Create `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+
+internal sealed class GetKbNavCountsQueryHandler
+    : IRequestHandler<GetKbNavCountsQuery, KbNavCountsDto>
+{
+    private static readonly JobStatus[] ActiveStatuses =
+        [JobStatus.Queued, JobStatus.Processing, JobStatus.Failed];
+
+    private static readonly TimeSpan FeedbackWindow = TimeSpan.FromDays(7);
+
+    private readonly IProcessingJobRepository _jobs;
+    private readonly IKbUserFeedbackRepository _feedback;
+    private readonly TimeProvider _clock;
+
+    public GetKbNavCountsQueryHandler(
+        IProcessingJobRepository jobs,
+        IKbUserFeedbackRepository feedback,
+        TimeProvider clock)
+    {
+        _jobs = jobs;
+        _feedback = feedback;
+        _clock = clock;
+    }
+
+    public async Task<KbNavCountsDto> Handle(GetKbNavCountsQuery request, CancellationToken cancellationToken)
+    {
+        var asOf = _clock.GetUtcNow();
+        var since = asOf.UtcDateTime - FeedbackWindow;
+
+        var queueTask = _jobs.CountByStatusesAsync(ActiveStatuses, cancellationToken);
+        var feedbackTask = _feedback.CountSinceAsync(since, cancellationToken);
+
+        await Task.WhenAll(queueTask, feedbackTask).ConfigureAwait(false);
+
+        return new KbNavCountsDto(
+            ProcessingQueue: await queueTask.ConfigureAwait(false),
+            Feedback7d: await feedbackTask.ConfigureAwait(false),
+            AsOf: asOf);
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetKbNavCountsQueryHandlerTests"
+```
+
+Expected: 6 passed.
+
+If `Microsoft.Extensions.Time.Testing` is not referenced by `Api.Tests.csproj`, add it via `<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />` (verify exact version against `Directory.Packages.props`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/ \
+        apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/
+git commit -m "feat(kb): #1655 add GetKbNavCountsQuery + handler"
+```
+
+---
+
+## Task 5: Integration test the handler against real Postgres
+
+**Files:**
+- Test (new): `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/GetKbNavCountsQueryHandlerIntegrationTests.cs`
+
+This test wires the handler against a real Postgres via Testcontainers (rule: "acceptance tests must exercise real pipeline").
+
+- [ ] **Step 1: Write the failing test**
+
+Create the file:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts.Integration;
+
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class GetKbNavCountsQueryHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private MeepleAiDbContext _db = null!;
+
+    public GetKbNavCountsQueryHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"kbnav_counts_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+        _db = new MeepleAiDbContext(options);
+        await _db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _db?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Handle_RealPostgres_CountsActiveJobsAndRecentFeedback()
+    {
+        // Seed jobs: 2 Queued + 1 Processing + 1 Failed = 4 active; 3 Completed + 1 Cancelled = excluded
+        var now = DateTime.UtcNow;
+        var jobs = new[]
+        {
+            NewJob(JobStatus.Queued, now), NewJob(JobStatus.Queued, now),
+            NewJob(JobStatus.Processing, now),
+            NewJob(JobStatus.Failed, now),
+            NewJob(JobStatus.Completed, now), NewJob(JobStatus.Completed, now), NewJob(JobStatus.Completed, now),
+            NewJob(JobStatus.Cancelled, now),
+        };
+        _db.ProcessingJobs.AddRange(jobs);
+
+        // Seed feedback: 5 within 7d + 2 older
+        var clock = new FakeTimeProvider(new DateTimeOffset(now, TimeSpan.Zero));
+        foreach (var minus in new[] { 0, 1, 3, 5, 6 })
+            _db.KbUserFeedbacks.Add(MakeFeedback(now.AddDays(-minus)));
+        foreach (var minus in new[] { 10, 30 })
+            _db.KbUserFeedbacks.Add(MakeFeedback(now.AddDays(-minus)));
+
+        await _db.SaveChangesAsync();
+
+        var collector = Substitute.For<IDomainEventCollector>();
+        var jobsRepo = new ProcessingJobRepository(_db, collector);
+        var fbRepo = new KbUserFeedbackRepository(_db);
+        var sut = new GetKbNavCountsQueryHandler(jobsRepo, fbRepo, clock);
+
+        var result = await sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
+
+        result.ProcessingQueue.Should().Be(4);
+        result.Feedback7d.Should().Be(5);
+        result.AsOf.Should().Be(clock.GetUtcNow());
+    }
+
+    private static ProcessingJobEntity NewJob(JobStatus status, DateTime nowUtc) => new()
+    {
+        Id = Guid.NewGuid(),
+        PdfDocumentId = Guid.NewGuid(),
+        Status = status.ToString(),
+        Priority = 0,
+        CreatedAt = new DateTimeOffset(nowUtc, TimeSpan.Zero),
+        UpdatedAt = new DateTimeOffset(nowUtc, TimeSpan.Zero),
+        EnqueuedBy = Guid.NewGuid(),
+    };
+
+    private static KbUserFeedback MakeFeedback(DateTime createdAt)
+    {
+        var fb = KbUserFeedback.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
+            "helpful", null);
+        typeof(KbUserFeedback).GetProperty(nameof(KbUserFeedback.CreatedAt))!
+            .SetValue(fb, createdAt);
+        return fb;
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Requires Docker running. From `apps/api`:
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetKbNavCountsQueryHandlerIntegrationTests"
+```
+
+Expected: 1 passed (Testcontainers spins up Postgres, runs migrations, seeds, asserts).
+
+If the test class file location does not compile due to project structure (e.g., test project does not auto-discover subfolders), verify against an existing `Integration/` test under `apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/Integration/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/Integration/
+git commit -m "test(kb): #1655 add integration test for GetKbNavCountsQueryHandler"
+```
+
+---
+
+## Task 6: Add endpoint + HTTP integration tests (401/403/200)
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`
+- Test (new): `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminKbNavCountsEndpointIntegrationTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the test file:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Endpoints;
+
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1655")]
+public sealed class AdminKbNavCountsEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _anonClient = null!;
+    private HttpClient _editorClient = null!;
+    private HttpClient _adminClient = null!;
+    private string _editorToken = null!;
+    private string _adminToken = null!;
+
+    public AdminKbNavCountsEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"kbnav_endpoint_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_, _adminToken) = await TestSessionHelper.CreateSuperAdminSessionAsync(db);
+        (_, _editorToken) = await TestSessionHelper.CreateEditorSessionAsync(db);
+
+        _anonClient = _factory.CreateClient();
+        _editorClient = _factory.CreateClient();
+        _adminClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _anonClient?.Dispose();
+        _editorClient?.Dispose();
+        _adminClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private static HttpRequestMessage NewRequest(string token)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, "/api/v1/admin/kb/nav-counts");
+        req.Headers.Add("Cookie", $"meepleai_session={token}");
+        return req;
+    }
+
+    [Fact]
+    public async Task Get_WithoutSession_Returns401()
+    {
+        var response = await _anonClient.GetAsync("/api/v1/admin/kb/nav-counts");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WithEditorSession_Returns403()
+    {
+        var response = await _editorClient.SendAsync(NewRequest(_editorToken));
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_WithAdminSession_Returns200WithDto()
+    {
+        var response = await _adminClient.SendAsync(NewRequest(_adminToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<KbNavCountsDto>();
+
+        dto.Should().NotBeNull();
+        dto!.ProcessingQueue.Should().BeGreaterThanOrEqualTo(0);
+        dto.Feedback7d.Should().BeGreaterThanOrEqualTo(0);
+        dto.AsOf.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(-1));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminKbNavCountsEndpointIntegrationTests"
+```
+
+Expected: tests fail with 404 (endpoint not registered).
+
+- [ ] **Step 3: Add the endpoint**
+
+In `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs`, add to the `using` block at top:
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbNavCounts;
+```
+
+Then add the endpoint inside `MapAdminKnowledgeBaseEndpoints`, right after the existing `/vector-stats` mapping (around line 35):
+
+```csharp
+        // GET /api/v1/admin/kb/nav-counts — Issue #1655 F3-FU-6
+        kbGroup.MapGet("/nav-counts", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var counts = await mediator.Send(new GetKbNavCountsQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(counts);
+        })
+        .WithName("GetKbNavCounts")
+        .WithSummary("Counts for KbSubNav badges (active queue + feedback last 7d).")
+        .Produces<KbNavCountsDto>(200);
+```
+
+Also add `using Api.BoundedContexts.KnowledgeBase.Application.DTOs;` if not already present (for `KbNavCountsDto`).
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminKbNavCountsEndpointIntegrationTests"
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Run full Api.Tests suite to confirm no regression**
+
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~AdminKnowledgeBaseEndpoints|FullyQualifiedName~KbSubNav|FullyQualifiedName~Issue\"1655\""
+```
+
+Expected: zero failures across the touched areas.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Endpoints/AdminKbNavCountsEndpointIntegrationTests.cs
+git commit -m "feat(admin-kb): #1655 GET /api/v1/admin/kb/nav-counts endpoint"
+```
+
+---
+
+## Task 7: Frontend API client — add `getNavCounts`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/admin-knowledge-base.ts` (or whichever file currently exports `api.adminKnowledgeBase.*`)
+
+Context: before editing, locate the existing client. Run:
+```bash
+grep -rn "adminKnowledgeBase" apps/web/src/lib --include="*.ts"
+```
+Use the file that already exports the `adminKnowledgeBase` object. If none exists, create `apps/web/src/lib/api/admin-knowledge-base.ts` and ensure it is re-exported from `apps/web/src/lib/api/index.ts` (or `api.ts`).
+
+- [ ] **Step 1: Inspect existing client shape**
+
+```bash
+grep -A 5 "adminKnowledgeBase" apps/web/src/lib/api/*.ts | head -40
+```
+
+Identify the existing file, its export style (named object vs. namespace), and the helper used for fetches (`apiFetch`, `fetchJson`, etc.).
+
+- [ ] **Step 2: Add the type + method**
+
+In the located file, add the type definition near the other DTO interfaces:
+
+```ts
+export interface KbNavCountsDto {
+  processingQueue: number;
+  feedback7d: number;
+  asOf: string;
+}
+```
+
+And add the method into the `adminKnowledgeBase` export object (use whichever fetch helper the file already uses — example with a generic `apiFetch`):
+
+```ts
+getNavCounts: ({ signal }: { signal?: AbortSignal } = {}) =>
+  apiFetch<KbNavCountsDto>('/api/v1/admin/kb/nav-counts', { signal }),
+```
+
+If a different convention is used in the file (e.g., axios-style or a `request()` helper with method+body), match that style.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/api/
+git commit -m "feat(api-client): #1655 add adminKnowledgeBase.getNavCounts"
+```
+
+---
+
+## Task 8: Create `useKbNavCounts` hook with tests
+
+**Files:**
+- Create: `apps/web/src/hooks/admin/useKbNavCounts.ts`
+- Test (new): `apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.ts`
+
+Pre-check: confirm `apps/web/src/hooks/admin/` exists. If not, create the dir.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+
+import { useKbNavCounts } from '../useKbNavCounts';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    adminKnowledgeBase: {
+      getNavCounts: vi.fn(),
+    },
+  },
+}));
+
+const getNavCounts = vi.mocked(api.adminKnowledgeBase.getNavCounts);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useKbNavCounts', () => {
+  beforeEach(() => {
+    getNavCounts.mockReset();
+  });
+
+  it('returns queue and feedback from a successful fetch', async () => {
+    getNavCounts.mockResolvedValueOnce({
+      processingQueue: 7,
+      feedback7d: 23,
+      asOf: '2026-05-30T12:00:00Z',
+    });
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.queue).toBe(7);
+    expect(result.current.feedback).toBe(23);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('exposes loading=true and undefined values before first settle', () => {
+    getNavCounts.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.queue).toBeUndefined();
+    expect(result.current.feedback).toBeUndefined();
+  });
+
+  it('sets isError=true when the fetch throws', async () => {
+    getNavCounts.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useKbNavCounts(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.queue).toBeUndefined();
+    expect(result.current.feedback).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd apps/web && pnpm test src/hooks/admin/__tests__/useKbNavCounts.test.ts
+```
+
+Expected: error — `useKbNavCounts` not found.
+
+- [ ] **Step 3: Create the hook**
+
+Create `apps/web/src/hooks/admin/useKbNavCounts.ts`:
+
+```ts
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+
+export interface KbNavCounts {
+  readonly queue: number | undefined;
+  readonly feedback: number | undefined;
+  readonly loading: boolean;
+  readonly isError: boolean;
+}
+
+export function useKbNavCounts(): KbNavCounts {
+  const query = useQuery({
+    queryKey: ['admin', 'kb', 'nav-counts'] as const,
+    queryFn: ({ signal }) => api.adminKnowledgeBase.getNavCounts({ signal }),
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 15_000,
+    retry: 1,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    queue: query.data?.processingQueue,
+    feedback: query.data?.feedback7d,
+    loading: query.isLoading,
+    isError: query.isError,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+cd apps/web && pnpm test src/hooks/admin/__tests__/useKbNavCounts.test.ts
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/admin/
+git commit -m "feat(admin-kb): #1655 add useKbNavCounts hook"
+```
+
+---
+
+## Task 9: Create `KbCountBadge` component with tests
+
+**Files:**
+- Create: `apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx`
+- Test (new): `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { KbCountBadge } from '../KbCountBadge';
+
+describe('KbCountBadge', () => {
+  it('renders a loading skeleton when loading and count is undefined', () => {
+    const { container } = render(
+      <KbCountBadge count={undefined} loading={true} testId="badge" />
+    );
+    expect(container.querySelector('[data-testid="badge-loading"]')).toBeInTheDocument();
+  });
+
+  it('renders 0 with muted style when count is 0', () => {
+    render(<KbCountBadge count={0} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('0');
+    expect(badge.className).toContain('bg-muted');
+  });
+
+  it('renders 23 with amber style when count is greater than 0', () => {
+    render(<KbCountBadge count={23} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('23');
+    expect(badge.className).toContain('bg-amber-500/15');
+  });
+
+  it('renders "99+" when count exceeds 99', () => {
+    render(<KbCountBadge count={150} loading={false} testId="badge" />);
+    expect(screen.getByTestId('badge')).toHaveTextContent('99+');
+  });
+
+  it('falls back to 0 with muted style when count is undefined and not loading', () => {
+    render(<KbCountBadge count={undefined} loading={false} testId="badge" />);
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveTextContent('0');
+    expect(badge.className).toContain('bg-muted');
+  });
+
+  it('applies the title attribute from the tooltip prop', () => {
+    render(
+      <KbCountBadge count={1} loading={false} tooltip="hello" testId="badge" />
+    );
+    expect(screen.getByTestId('badge')).toHaveAttribute('title', 'hello');
+  });
+
+  it('omits data-testid when not provided', () => {
+    const { container } = render(<KbCountBadge count={1} loading={false} />);
+    expect(container.querySelector('[data-testid]')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd apps/web && pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
+```
+
+Expected: import error — module not found.
+
+- [ ] **Step 3: Create the component**
+
+Create `apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx`:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: amber accent (admin convention, DS-13c scope deferred to DS-16) */
+'use client';
+
+import type { JSX } from 'react';
+
+interface KbCountBadgeProps {
+  readonly count: number | undefined;
+  readonly loading: boolean;
+  readonly tooltip?: string;
+  readonly testId?: string;
+}
+
+export function KbCountBadge({
+  count,
+  loading,
+  tooltip,
+  testId,
+}: KbCountBadgeProps): JSX.Element {
+  if (loading && count === undefined) {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid={testId ? `${testId}-loading` : undefined}
+        className="ml-1.5 inline-block h-4 w-6 rounded-full bg-muted animate-pulse"
+      />
+    );
+  }
+
+  const safe = count ?? 0;
+  const display = safe > 99 ? '99+' : safe.toString();
+  const isActive = safe > 0;
+
+  return (
+    <span
+      aria-label={`${safe} elementi`}
+      title={tooltip}
+      data-testid={testId}
+      className={[
+        'ml-1.5 inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1.5 rounded-full',
+        'text-[10px] font-bold tabular-nums leading-none',
+        isActive
+          ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+          : 'bg-muted text-muted-foreground',
+      ].join(' ')}
+    >
+      {display}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+cd apps/web && pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx
+git commit -m "feat(admin-kb): #1655 add KbCountBadge component"
+```
+
+---
+
+## Task 10: Wire `KbCountBadge` into `KbSubNav` + extend existing tests
+
+**Files:**
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx`
+- Modify: `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx`
+
+- [ ] **Step 1: Extend the test file**
+
+Open `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx` and **add at the top** of the imports:
+
+```tsx
+import { vi } from 'vitest';
+```
+(if not already imported, which it already is)
+
+Then add the hook mock right after the `next/navigation` mock:
+
+```tsx
+const mockUseKbNavCounts = vi.fn();
+vi.mock('@/hooks/admin/useKbNavCounts', () => ({
+  useKbNavCounts: () => mockUseKbNavCounts(),
+}));
+```
+
+And in `beforeEach`, reset both mocks and set a default:
+
+```tsx
+beforeEach(() => {
+  mockPathname.mockReset();
+  mockUseKbNavCounts.mockReset().mockReturnValue({
+    queue: undefined,
+    feedback: undefined,
+    loading: false,
+    isError: false,
+  });
+});
+```
+
+Add 4 new tests at the bottom of the `describe('KbSubNav', ...)` block:
+
+```tsx
+  it('renders queue badge with count from hook', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 7, feedback: 23, loading: false, isError: false });
+    render(<KbSubNav />);
+    expect(screen.getByTestId('kb-nav-badge-queue')).toHaveTextContent('7');
+  });
+
+  it('renders feedback badge with count from hook', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 7, feedback: 23, loading: false, isError: false });
+    render(<KbSubNav />);
+    expect(screen.getByTestId('kb-nav-badge-feedback')).toHaveTextContent('23');
+  });
+
+  it('does NOT render badges on non-counted tabs', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: 5, feedback: 5, loading: false, isError: false });
+    render(<KbSubNav />);
+    // 8 tabs total but only 2 with badges
+    const badges = screen.queryAllByTestId(/^kb-nav-badge-/);
+    expect(badges).toHaveLength(2);
+  });
+
+  it('renders skeleton when loading and counts are undefined', () => {
+    mockPathname.mockReturnValue('/admin/knowledge-base');
+    mockUseKbNavCounts.mockReturnValue({ queue: undefined, feedback: undefined, loading: true, isError: false });
+    const { container } = render(<KbSubNav />);
+    expect(container.querySelector('[data-testid="kb-nav-badge-queue-loading"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="kb-nav-badge-feedback-loading"]')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests to confirm new ones fail**
+
+```bash
+cd apps/web && pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
+```
+
+Expected: original 7 tests pass; 4 new ones fail (badges not rendered).
+
+- [ ] **Step 3: Modify `KbSubNav.tsx` to wire the badges**
+
+Replace the **entire body** of `apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx` with:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: amber accent + zinc dark palette (admin convention, DS-13c scope deferred to DS-16) */
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { KbCountBadge } from './KbCountBadge';
+import { useKbNavCounts } from '@/hooks/admin/useKbNavCounts';
+
+const KB_BASE = '/admin/knowledge-base';
+
+type KbTabKind = 'queue' | 'feedback';
+
+interface KbTab {
+  readonly label: string;
+  readonly href: string;
+  readonly kind?: KbTabKind;
+}
+
+const TABS: ReadonlyArray<KbTab> = [
+  { label: 'Explorer', href: KB_BASE },
+  { label: 'Vector Collections', href: `${KB_BASE}/vectors` },
+  { label: 'Processing Queue', href: `${KB_BASE}/queue`, kind: 'queue' },
+  { label: 'RAG Pipeline', href: `${KB_BASE}/pipeline` },
+  { label: 'Embedding', href: `${KB_BASE}/embedding` },
+  { label: 'Feedback', href: `${KB_BASE}/feedback`, kind: 'feedback' },
+  { label: 'Settings', href: `${KB_BASE}/settings` },
+  { label: 'Snapshots', href: `${KB_BASE}/snapshots` },
+];
+
+const TOOLTIPS: Record<KbTabKind, string> = {
+  queue: 'Job attivi (queued, in elaborazione o falliti)',
+  feedback: 'Feedback ricevuti negli ultimi 7 giorni',
+};
+
+function isActive(tabHref: string, pathname: string): boolean {
+  if (tabHref === KB_BASE) return pathname === KB_BASE;
+  return pathname === tabHref || pathname.startsWith(`${tabHref}/`);
+}
+
+/**
+ * KB sub-nav: 8 tab-link a route reali. La sezione attiva è derivata dal
+ * pathname corrente (App Router). Vive dentro `knowledge-base/layout.tsx` e
+ * wrappa Explorer + le 7 tool-page esistenti.
+ *
+ * Issue #1655: wired count badges on Processing Queue + Feedback tabs.
+ */
+export function KbSubNav() {
+  const pathname = usePathname();
+  const { queue, feedback, loading } = useKbNavCounts();
+
+  return (
+    <nav
+      aria-label="Knowledge Base sezioni"
+      className="border-b border-border/60 dark:border-zinc-700/60 -mx-6 px-6 mb-6 overflow-x-auto"
+    >
+      <ul className="flex gap-1 min-w-max">
+        {TABS.map(tab => {
+          const active = isActive(tab.href, pathname);
+          const count = tab.kind === 'queue' ? queue : tab.kind === 'feedback' ? feedback : undefined;
+          return (
+            <li key={tab.href}>
+              <Link
+                href={tab.href}
+                aria-current={active ? 'page' : undefined}
+                className={[
+                  'inline-flex items-center px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+                  active
+                    ? 'border-amber-500 text-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border',
+                ].join(' ')}
+              >
+                {tab.label}
+                {tab.kind && (
+                  <KbCountBadge
+                    count={count}
+                    loading={loading}
+                    tooltip={TOOLTIPS[tab.kind]}
+                    testId={`kb-nav-badge-${tab.kind}`}
+                  />
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 4: Run all KbSubNav tests to confirm everything passes**
+
+```bash
+cd apps/web && pnpm test src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
+```
+
+Expected: 11 passed (7 original + 4 new).
+
+- [ ] **Step 5: Run the admin KB suite to check for regressions**
+
+```bash
+cd apps/web && pnpm test src/components/admin/knowledge-base
+```
+
+Expected: zero failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx \
+        apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx
+git commit -m "feat(admin-kb): #1655 wire count badges into KbSubNav"
+```
+
+---
+
+## Task 11: E2E smoke test (Playwright)
+
+**Files:**
+- Test (new): `apps/web/e2e/admin-kb-navcounts.spec.ts`
+
+- [ ] **Step 1: Inspect an existing admin Playwright spec for auth pattern**
+
+```bash
+ls apps/web/e2e/ | grep -i admin
+```
+
+Read one of the existing admin E2E specs to learn how `superadmin` login is performed (often via fixtures or storage state). Match the pattern.
+
+- [ ] **Step 2: Write the smoke spec**
+
+Create `apps/web/e2e/admin-kb-navcounts.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('admin KB sub-nav count badges (#1655)', () => {
+  test('shows queue and feedback badges with numeric content', async ({ page }) => {
+    // NOTE: replace this with the project's existing superadmin login helper.
+    // Search for previous admin specs (e.g., apps/web/e2e/admin-*.spec.ts) for the canonical pattern.
+    await page.goto('/admin/knowledge-base');
+
+    const queueBadge = page.getByTestId('kb-nav-badge-queue');
+    const feedbackBadge = page.getByTestId('kb-nav-badge-feedback');
+
+    await expect(queueBadge).toBeVisible();
+    await expect(feedbackBadge).toBeVisible();
+
+    // Numeric or "99+" or em-dash on error
+    await expect(queueBadge).toHaveText(/^\d+\+?$|^—$/);
+    await expect(feedbackBadge).toHaveText(/^\d+\+?$|^—$/);
+  });
+});
+```
+
+If a project-specific superadmin auth fixture exists (e.g., `loginAsSuperAdmin(page)` exported from `apps/web/e2e/fixtures/auth.ts`), import it and call it before `page.goto`.
+
+- [ ] **Step 3: Run the spec**
+
+```bash
+cd apps/web && pnpm test:e2e admin-kb-navcounts
+```
+
+Expected: 1 passed. If the test cannot authenticate, look at the most recently merged admin E2E spec for the canonical login flow and copy it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/admin-kb-navcounts.spec.ts
+git commit -m "test(admin-kb): #1655 e2e smoke for KbSubNav count badges"
+```
+
+---
+
+## Task 12: Push branch + open PR to `main-dev`
+
+- [ ] **Step 1: Run full backend + frontend tests one last time**
+
+Backend (from `apps/api`):
+```bash
+dotnet test tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~Issue\"1655\"|FullyQualifiedName~AdminKnowledgeBase|FullyQualifiedName~KbSubNav|FullyQualifiedName~GetKbNavCounts|FullyQualifiedName~ProcessingJobRepository|FullyQualifiedName~KbUserFeedbackRepository"
+```
+
+Frontend (from `apps/web`):
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: all passing, zero lint errors.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/issue-1655-kbsubnav-count-badges
+```
+
+- [ ] **Step 3: Open the PR to `main-dev`** (NOT `main`!)
+
+```bash
+gh pr create --base main-dev --title "feat(admin-kb): #1655 F3-FU-6 KbSubNav count badges (Queue/Feedback)" --body "$(cat <<'EOF'
+## Summary
+Closes #1655 (F3-FU-6). Adds wired count badges to the admin Knowledge Base sub-nav for the **Processing Queue** and **Feedback** tabs.
+
+- **Queue badge**: count of jobs in `Queued + Processing + Failed`
+- **Feedback badge**: count of feedback rows with `created_at >= NOW() - 7 days`
+- Single endpoint `GET /api/v1/admin/kb/nav-counts` polled every 30s + on window focus via React Query
+- Visual: pill badge — amber when `> 0`, muted when `0`, `99+` cap, tooltip explains the metric
+
+Closes the last open follow-up of the F3 KB Explorer cluster (PR #1649). 5/6 follow-up already merged (#1650, #1651, #1652, #1653, #1654/#1697).
+
+## Test plan
+- [x] Unit tests: `CountByStatusesAsync` repo (4), `CountSinceAsync` repo (3), `GetKbNavCountsQueryHandler` (6)
+- [x] Integration test: handler against Postgres via Testcontainers
+- [x] Integration tests: endpoint (401 anon, 403 editor, 200 admin)
+- [x] Frontend unit: `KbCountBadge` (7), `useKbNavCounts` (3), `KbSubNav` (11 = 7 existing + 4 new)
+- [x] E2E smoke: badges visible with numeric content on `/admin/knowledge-base`
+- [x] No regressions on existing KbSubNav tests
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Capture the PR URL**
+
+Return the PR URL printed by `gh pr create` so the user can review.
+
+- [ ] **Step 5: After PR merge — local cleanup**
+
+(Do NOT run before the PR is merged.) Per CLAUDE.md branch hygiene rule:
+```bash
+git checkout main-dev && git pull && git branch -D feature/issue-1655-kbsubnav-count-badges
+```
+
+The remote branch is auto-deleted on merge per repo policy.
+
+---
+
+## Self-Review Notes (post-write)
+
+**Spec coverage check** against `docs/superpowers/specs/2026-05-30-f3-fu-6-kbsubnav-count-badges-design.md`:
+
+| Spec section | Task |
+|---|---|
+| DTO `KbNavCountsDto` | Task 3 |
+| Query + Handler | Task 4 |
+| Repository extensions | Task 1, Task 2 |
+| Endpoint registration | Task 6 |
+| API client `getNavCounts` | Task 7 |
+| Hook `useKbNavCounts` | Task 8 |
+| Component `KbCountBadge` | Task 9 |
+| Wiring into `KbSubNav` | Task 10 |
+| Error handling (fail-fast BE) | Tasks 4–6 (covered by tests) |
+| Error handling (FE keepPreviousData) | Task 8 |
+| 6 unit handler tests | Task 4 |
+| Integration handler test | Task 5 |
+| 3 endpoint integration tests | Task 6 |
+| 7 KbCountBadge tests | Task 9 |
+| 3 useKbNavCounts tests | Task 8 |
+| 4 extra KbSubNav tests | Task 10 |
+| 1 E2E smoke | Task 11 |
+
+**Placeholder scan**: no `TBD`, `TODO`, `implement later`. Two notes ("verify file path X" and "match the project's auth helper") describe **how to locate** existing infrastructure that the engineer must discover — these are not work placeholders, they are exploration directives.
+
+**Type consistency**: `KbNavCountsDto` properties `ProcessingQueue/Feedback7d/AsOf` (BE) → `processingQueue/feedback7d/asOf` (FE) — System.Text.Json camelCase serialization handles this; FE interface matches. `useKbNavCounts` returns `queue/feedback/loading/isError` (renamed for ergonomics); component prop `count` matches in both consumer call sites.
+
+**Branch hygiene**: branch was created from `main-dev` in the brainstorming phase (commit `590c04646`); spec already committed there. All tasks commit incrementally to the same branch.

--- a/docs/superpowers/specs/2026-05-30-f3-fu-6-kbsubnav-count-badges-design.md
+++ b/docs/superpowers/specs/2026-05-30-f3-fu-6-kbsubnav-count-badges-design.md
@@ -1,0 +1,487 @@
+# F3-FU-6 — KbSubNav Count Badges (Queue / Feedback)
+
+- **Issue**: [#1655](https://github.com/meepleAi-app/meepleai-monorepo/issues/1655)
+- **Cluster**: F3 KB Explorer follow-up (chiusura — 5/6 già fatte)
+- **Priority**: P3
+- **Branch parent**: `main-dev`
+- **Date**: 2026-05-30
+
+---
+
+## Background
+
+PR #1649 ha consegnato l'admin Knowledge Base Explorer con `KbSubNav` (8 tab orizzontali). Il commento nel codice di `KbSubNav.tsx` diceva esplicitamente:
+
+> *"Niente badge count in F3.1 (deferred a follow-up)."*
+
+Questa spec definisce quel follow-up, limitato ai tab **Processing Queue** e **Feedback** (gli unici menzionati nel titolo dell'issue). Gli altri 6 tab restano senza badge.
+
+## Goal
+
+Mostrare, accanto al label dei tab *Processing Queue* e *Feedback* del sub-nav `KbSubNav`, un badge numerico che riflette in tempo "quasi reale" la quantità di lavoro/attività pertinente, così che il superadmin sappia at-a-glance se c'è qualcosa che richiede attenzione senza aprire le tab.
+
+## Non-goal
+
+- Badge sugli altri 6 tab (Explorer, Vector Collections, RAG Pipeline, Embedding, Settings, Snapshots).
+- Notifiche push / toast su nuovo elemento.
+- Drill-down dal badge (resta semplice indicatore numerico).
+- SSE/WebSocket real-time push (polling ogni 30s è sufficiente).
+- Persistenza "letto/non letto" per feedback (no read model dedicato).
+
+## Semantica dei conteggi
+
+| Tab | Cosa conta | Query |
+|---|---|---|
+| Processing Queue | Job che richiedono attenzione | `COUNT(processing_jobs) WHERE status IN (Queued, Processing, Failed)` |
+| Feedback | Attività feedback ultima settimana | `COUNT(kb_user_feedback) WHERE created_at >= NOW() - INTERVAL '7 days'` |
+
+**Note**:
+- *Queue*: include `Failed` perché ammette retry manuale (azione admin). Esclude `Completed`, `Cancelled` (no azione richiesta).
+- *Feedback*: count **non monotono** — vecchi feedback escono dalla finestra mobile. Documentato in tooltip nativo (`title`) sul badge: *"Feedback ricevuti negli ultimi 7 giorni"*.
+
+## Architettura
+
+```
+KbSubNav (client)
+   └── useKbNavCounts() → React Query (poll 30s + refetchOnWindowFocus)
+            │
+            ▼
+   GET /api/v1/admin/kb/nav-counts
+            │  MediatR
+            ▼
+   GetKbNavCountsQueryHandler
+       ├── IProcessingJobRepository.CountByStatusesAsync([Queued, Processing, Failed])
+       └── IKbUserFeedbackRepository.CountSinceAsync(now - 7d)
+           (eseguite in parallelo via Task.WhenAll)
+            │
+            ▼
+   KbNavCountsDto { ProcessingQueue, Feedback7d, AsOf }
+```
+
+**Bounded Context placement**: la query vive in `KnowledgeBase.Application.Queries.GetKbNavCounts` perché è una vista *navigation-purpose* del BC KB, anche se aggrega dati da `DocumentProcessing`. Il cross-BC read avviene tramite interfaccia repository — niente entity sharing.
+
+## Backend
+
+### DTO
+
+`apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+public sealed record KbNavCountsDto(
+    int ProcessingQueue,
+    int Feedback7d,
+    DateTimeOffset AsOf
+);
+```
+
+### Query + Handler
+
+`apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/`:
+
+```csharp
+public sealed record GetKbNavCountsQuery() : IRequest<KbNavCountsDto>;
+
+internal sealed class GetKbNavCountsQueryHandler
+    : IRequestHandler<GetKbNavCountsQuery, KbNavCountsDto>
+{
+    private static readonly ProcessingJobStatus[] ActiveStatuses =
+        [ProcessingJobStatus.Queued, ProcessingJobStatus.Processing, ProcessingJobStatus.Failed];
+
+    private static readonly TimeSpan FeedbackWindow = TimeSpan.FromDays(7);
+
+    private readonly IProcessingJobRepository _jobs;
+    private readonly IKbUserFeedbackRepository _feedback;
+    private readonly TimeProvider _clock;
+
+    public GetKbNavCountsQueryHandler(
+        IProcessingJobRepository jobs,
+        IKbUserFeedbackRepository feedback,
+        TimeProvider clock)
+    {
+        _jobs = jobs;
+        _feedback = feedback;
+        _clock = clock;
+    }
+
+    public async Task<KbNavCountsDto> Handle(GetKbNavCountsQuery _, CancellationToken ct)
+    {
+        var asOf = _clock.GetUtcNow();
+        var since = asOf - FeedbackWindow;
+
+        var queueTask = _jobs.CountByStatusesAsync(ActiveStatuses, ct);
+        var feedbackTask = _feedback.CountSinceAsync(since, ct);
+
+        await Task.WhenAll(queueTask, feedbackTask).ConfigureAwait(false);
+
+        return new KbNavCountsDto(
+            ProcessingQueue: await queueTask.ConfigureAwait(false),
+            Feedback7d: await feedbackTask.ConfigureAwait(false),
+            AsOf: asOf);
+    }
+}
+```
+
+### Repository extensions (NO migration)
+
+`IProcessingJobRepository`:
+```csharp
+Task<int> CountByStatusesAsync(
+    IReadOnlyList<ProcessingJobStatus> statuses,
+    CancellationToken cancellationToken);
+```
+Impl: `_dbContext.ProcessingJobs.AsNoTracking().Where(j => statuses.Contains(j.Status)).CountAsync(ct)`.
+
+`IKbUserFeedbackRepository`:
+```csharp
+Task<int> CountSinceAsync(DateTimeOffset since, CancellationToken cancellationToken);
+```
+Impl: `_dbContext.KbUserFeedbacks.AsNoTracking().Where(f => f.CreatedAt >= since).CountAsync(ct)`.
+
+Entrambi sono `COUNT(*)`. Riusano indici esistenti su `status` e `created_at`. Nessuna migration richiesta.
+
+### Endpoint
+
+In `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs` (estendere file esistente):
+
+```csharp
+kbGroup.MapGet("/nav-counts", async (IMediator mediator, CancellationToken ct) =>
+{
+    var counts = await mediator.Send(new GetKbNavCountsQuery(), ct).ConfigureAwait(false);
+    return Results.Ok(counts);
+})
+.WithName("GetKbNavCounts")
+.WithSummary("Counts for KbSubNav badges (queue active + feedback last 7d).")
+.Produces<KbNavCountsDto>(200);
+```
+
+Sotto `RequireAdminSessionFilter` come gli altri endpoint del group → 401/403 automatici.
+
+### DI registration
+
+Handler auto-discovered da MediatR assembly scan. Repository methods aggiunti a implementazioni esistenti — nessuna nuova DI binding.
+
+## Frontend
+
+### Componente badge
+
+`apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx`:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin KB explorer: amber accent (admin convention) */
+'use client';
+
+interface KbCountBadgeProps {
+  readonly count: number | undefined;
+  readonly loading: boolean;
+  readonly tooltip?: string;
+  readonly testId?: string;
+}
+
+export function KbCountBadge({ count, loading, tooltip, testId }: KbCountBadgeProps): JSX.Element {
+  if (loading && count === undefined) {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid={testId ? `${testId}-loading` : undefined}
+        className="ml-1.5 inline-block h-4 w-6 rounded-full bg-muted animate-pulse"
+      />
+    );
+  }
+
+  const safe = count ?? 0;
+  const display = safe > 99 ? '99+' : safe;
+  const isActive = safe > 0;
+
+  return (
+    <span
+      aria-label={`${safe} elementi`}
+      title={tooltip}
+      data-testid={testId}
+      className={[
+        'ml-1.5 inline-flex items-center justify-center min-w-[1.5rem] h-4 px-1.5 rounded-full',
+        'text-[10px] font-bold tabular-nums leading-none',
+        isActive
+          ? 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+          : 'bg-muted text-muted-foreground',
+      ].join(' ')}
+    >
+      {display}
+    </span>
+  );
+}
+```
+
+### Hook
+
+`apps/web/src/hooks/admin/useKbNavCounts.ts`:
+
+```ts
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface KbNavCounts {
+  queue: number | undefined;
+  feedback: number | undefined;
+  loading: boolean;
+  isError: boolean;
+}
+
+export function useKbNavCounts(): KbNavCounts {
+  const query = useQuery({
+    queryKey: ['admin', 'kb', 'nav-counts'] as const,
+    queryFn: ({ signal }) => api.adminKnowledgeBase.getNavCounts({ signal }),
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 15_000,
+    retry: 1,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    queue: query.data?.processingQueue,
+    feedback: query.data?.feedback7d,
+    loading: query.isLoading,
+    isError: query.isError,
+  };
+}
+```
+
+### API client
+
+In `apps/web/src/lib/api/admin-knowledge-base.ts` (estendere modulo esistente):
+
+```ts
+export interface KbNavCountsDto {
+  processingQueue: number;
+  feedback7d: number;
+  asOf: string;
+}
+
+// ...esistente
+getNavCounts: ({ signal }: { signal?: AbortSignal } = {}) =>
+  apiFetch<KbNavCountsDto>('/api/v1/admin/kb/nav-counts', { signal }),
+```
+
+### Modifica `KbSubNav.tsx`
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { KbCountBadge } from './KbCountBadge';
+import { useKbNavCounts } from '@/hooks/admin/useKbNavCounts';
+
+const KB_BASE = '/admin/knowledge-base';
+
+interface KbTab {
+  readonly label: string;
+  readonly href: string;
+  readonly kind?: 'queue' | 'feedback';
+}
+
+const TABS: ReadonlyArray<KbTab> = [
+  { label: 'Explorer', href: KB_BASE },
+  { label: 'Vector Collections', href: `${KB_BASE}/vectors` },
+  { label: 'Processing Queue', href: `${KB_BASE}/queue`, kind: 'queue' },
+  { label: 'RAG Pipeline', href: `${KB_BASE}/pipeline` },
+  { label: 'Embedding', href: `${KB_BASE}/embedding` },
+  { label: 'Feedback', href: `${KB_BASE}/feedback`, kind: 'feedback' },
+  { label: 'Settings', href: `${KB_BASE}/settings` },
+  { label: 'Snapshots', href: `${KB_BASE}/snapshots` },
+];
+
+const TOOLTIPS: Record<NonNullable<KbTab['kind']>, string> = {
+  queue: 'Job attivi (queued, in elaborazione o falliti)',
+  feedback: 'Feedback ricevuti negli ultimi 7 giorni',
+};
+
+export function KbSubNav() {
+  const pathname = usePathname();
+  const { queue, feedback, loading } = useKbNavCounts();
+
+  return (
+    <nav
+      aria-label="Knowledge Base sezioni"
+      className="border-b border-border/60 dark:border-zinc-700/60 -mx-6 px-6 mb-6 overflow-x-auto"
+    >
+      <ul className="flex gap-1 min-w-max">
+        {TABS.map(tab => {
+          const active = isActive(tab.href, pathname);
+          const count = tab.kind === 'queue' ? queue : tab.kind === 'feedback' ? feedback : undefined;
+          return (
+            <li key={tab.href}>
+              <Link
+                href={tab.href}
+                aria-current={active ? 'page' : undefined}
+                className={/* invariato */}
+              >
+                {tab.label}
+                {tab.kind && (
+                  <KbCountBadge
+                    count={count}
+                    loading={loading}
+                    tooltip={TOOLTIPS[tab.kind]}
+                    testId={`kb-nav-badge-${tab.kind}`}
+                  />
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+```
+
+`isActive` resta identico.
+
+## Error handling
+
+| Caso | Comportamento |
+|---|---|
+| Errore di rete / 5xx | React Query `isError = true`. Badge → `—` con `aria-label="conteggio non disponibile"`, tinta `muted`. Tab restano clickabili. |
+| 401 / 403 | Gestito dal layer API esistente (redirect login). Hook non aggiunge logica. |
+| Backend handler — una delle due COUNT fallisce | `Task.WhenAll` propaga la prima eccezione → 5xx. Fail-fast. FE mostra `—` per entrambi i badge. |
+| Loading iniziale | Skeleton (`bg-muted animate-pulse`) larghezza fissa per evitare layout shift. |
+| `count === 0` autentico | Pill grigia "0" — distinto da loading. |
+| Polling concurrent / cambio tab | `placeholderData: keepPreviousData` evita flicker; KbSubNav vive in `layout.tsx` → l'hook persiste. |
+| Cancellation | `signal` propagato a `fetch` e CT a EF Core; React Query auto-aborta su unmount o keyChange. |
+
+## Testing
+
+### Backend — Unit (handler con mocks)
+
+`tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs`:
+
+1. `Handle_returns_counts_from_both_repositories` — happy path, asserisce DTO + `AsOf` da `FakeTimeProvider`.
+2. `Handle_passes_active_statuses_to_processing_repo` — verifica array esatto `[Queued, Processing, Failed]`.
+3. `Handle_uses_now_minus_7_days_for_feedback` — `FakeTimeProvider.SetUtcNow`, asserisce `since`.
+4. `Handle_runs_count_queries_in_parallel` — uno dei mock blocca con `TaskCompletionSource`, l'altro deve essere già stato chiamato.
+5. `Handle_propagates_processing_repo_exception` — fail-fast.
+6. `Handle_propagates_cancellation_token` — `OperationCanceledException` su CT pre-cancellato.
+
+### Backend — Integration (Testcontainers Postgres)
+
+`tests/Api.Tests/Integration/BoundedContexts/KnowledgeBase/GetKbNavCountsQueryHandlerIntegrationTests.cs`:
+
+Seed:
+- 2 job `Queued`, 1 `Processing`, 1 `Failed`, 3 `Completed`, 1 `Cancelled` → expected `ProcessingQueue = 4`
+- 5 feedback `CreatedAt = now - 1..6 days`, 2 feedback `CreatedAt = now - 10 days` → expected `Feedback7d = 5`
+
+Esegue handler reale contro DB reale → asserisce DTO esatto. **Rispetta la regola "acceptance tests must exercise real pipeline"** (memory `feedback_acceptance_tests_must_exercise_real_pipeline.md`).
+
+### Backend — Endpoint integration (HTTP)
+
+In `tests/Api.Tests/Routing/AdminKnowledgeBaseEndpointsTests.cs` (estendere file esistente):
+
+1. `Get_nav_counts_without_session_returns_401`
+2. `Get_nav_counts_with_user_session_returns_403`
+3. `Get_nav_counts_with_admin_session_returns_200_with_dto`
+
+### Frontend — Unit `KbCountBadge`
+
+`apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx`:
+
+1. `renders skeleton during loading when count is undefined`
+2. `renders 0 pill with muted style when count is 0`
+3. `renders 23 pill with amber style when count > 0`
+4. `renders "99+" when count > 99`
+5. `falls back to 0 when count is undefined after loading`
+6. `applies title attribute from tooltip prop`
+7. `applies data-testid when testId provided`
+
+### Frontend — Unit `useKbNavCounts`
+
+`apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.ts`:
+
+Mock `api.adminKnowledgeBase.getNavCounts`:
+1. `returns queue and feedback from successful fetch`
+2. `loading is true before first settle`
+3. `isError is true when fetch throws`
+4. `configures refetchInterval=30000 and refetchOnWindowFocus=true` (verificato osservando le opzioni passate a `useQuery` via spy)
+
+### Frontend — Estensione `KbSubNav.test.tsx`
+
+Mock `useKbNavCounts` con `vi.mock('@/hooks/admin/useKbNavCounts')`:
+
+- Preserva i 7 test esistenti (regressione zero — i mock di default ritornano `{ queue: undefined, feedback: undefined, loading: false, isError: false }` per non interferire).
+- Aggiunge:
+  1. `renders queue badge with count from hook`
+  2. `renders feedback badge with count from hook`
+  3. `does NOT render badge on non-counted tabs` (Explorer, Vectors, Pipeline, Embedding, Settings, Snapshots)
+  4. `renders skeleton during initial loading`
+
+### E2E (Playwright)
+
+`apps/web/e2e/admin-kb-navcounts.spec.ts`:
+
+1 smoke test: superadmin login → naviga `/admin/knowledge-base` → asserisce presenza badge `data-testid="kb-nav-badge-queue"` e `kb-nav-badge-feedback` con contenuto numerico (regex `/^\d+\+?$|^—$/`). Nessun assert sul valore esatto (sarebbe flaky).
+
+### Coverage attesa
+
+- Handler: 100% line, 100% branch (6 test coprono tutti i path)
+- Badge: 100% (4 stati x 2 dimensioni assert)
+- Hook: ≥ 90%
+- `KbSubNav` patch: ≥ 95%
+- Zero regressioni sui 7 test esistenti di `KbSubNav.test.tsx`
+
+## Performance
+
+- 2 query `COUNT(*)` con indice esistente, parallelizzate. Stima: < 5ms ciascuna su dataset realistico (10k job, 5k feedback).
+- Polling 30s × N admin connessi: trascurabile (1 admin tipico → 2 query/min).
+- Nessuna cache server-side (aggiunge staleness senza beneficio).
+- Nessun SSE/WebSocket overhead.
+
+## Security
+
+- Endpoint sotto `RequireAdminSessionFilter` come gli altri del group.
+- Nessun dato sensibile esposto (solo conteggi aggregati).
+- Nessun parametro user-controlled → niente SQL injection surface.
+
+## Rollout
+
+- No feature flag necessario: P3, scope frontend additivo, fallback safe (badge non si rompe se endpoint non c'è → `isError` → `—`).
+- Deploy senza dipendenze: backend prima (endpoint disponibile), frontend dopo (lo consuma).
+
+## File touched
+
+**Nuovi (10)**:
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/KbNavCountsDto.cs`
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQuery.cs`
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs`
+- `apps/web/src/components/admin/knowledge-base/explorer/KbCountBadge.tsx`
+- `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbCountBadge.test.tsx`
+- `apps/web/src/hooks/admin/useKbNavCounts.ts`
+- `apps/web/src/hooks/admin/__tests__/useKbNavCounts.test.ts`
+- `tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs`
+- `tests/Api.Tests/Integration/BoundedContexts/KnowledgeBase/GetKbNavCountsQueryHandlerIntegrationTests.cs`
+- `apps/web/e2e/admin-kb-navcounts.spec.ts`
+
+**Modificati (9)**:
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IKbUserFeedbackRepository.cs` (+1 method)
+- `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/KbUserFeedbackRepository.cs` (+impl)
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IProcessingJobRepository.cs` (+1 method)
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/ProcessingJobRepository.cs` (+impl)
+- `apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs` (+endpoint)
+- `apps/web/src/lib/api/admin-knowledge-base.ts` (+method + tipo)
+- `apps/web/src/components/admin/knowledge-base/explorer/KbSubNav.tsx` (+hook, +badge, +kind)
+- `apps/web/src/components/admin/knowledge-base/explorer/__tests__/KbSubNav.test.tsx` (+mock, +4 test)
+- `tests/Api.Tests/Routing/AdminKnowledgeBaseEndpointsTests.cs` (+3 test)
+
+## Acceptance criteria
+
+1. Endpoint `GET /api/v1/admin/kb/nav-counts` ritorna 200 + DTO valido per session admin; 401/403 altrimenti.
+2. Tab "Processing Queue" mostra badge con conteggio aggiornato di job in `Queued + Processing + Failed`.
+3. Tab "Feedback" mostra badge con conteggio aggiornato di feedback creati nelle ultime 7 giorni.
+4. Badge sempre presenti su quelle 2 tab (anche con `0`, stile muted); amber quando `> 0`; `99+` quando `> 99`.
+5. Aggiornamento automatico ogni 30s + refresh su window focus.
+6. Errore di rete → badge `—` invece di crash; tab restano usable.
+7. Skeleton durante loading iniziale (no layout shift).
+8. Tooltip nativo (`title`) descrive cosa conta ciascun badge.
+9. 7 test esistenti di `KbSubNav` continuano a passare.
+10. Coverage handler 100%, badge 100%, hook ≥ 90%.


### PR DESCRIPTION
## Summary

Implements F3-FU-6 (#1655): live count badges on the **Processing Queue** and **Feedback** tabs of the Admin KB sub-nav.

- **Backend** – `CountByStatusesAsync` + `CountSinceAsync` repository extensions; `KbNavCountsDto`; `GetKbNavCountsQuery` + handler; `GET /api/v1/admin/kb/nav-counts` endpoint (Admin-only, 200/401/403)
- **Frontend** – `fetchKbNavCounts` API client; `useKbNavCounts` SWR/React-Query hook (30 s polling, 15 s stale-time); `KbCountBadge` component (skeleton → numeric, `99+` cap, `—` on error); wired into `KbSubNav` for `kind='queue'` and `kind='feedback'` tabs
- **Tests** – 6 unit tests (handler) + 1 integration test (real Postgres via Testcontainers) + 3 HTTP tests (401/403/200); 3 hook unit tests; 7 KbCountBadge unit tests; 9 KbSubNav unit tests (badge count, loading skeleton, non-badge tabs); 1 E2E smoke test (graceful skip when PLAYWRIGHT_AUTH_BYPASS + v1-sunset blocks admin role)

## Test plan

- [x] `dotnet test --filter "KbNavCounts"` — all unit + integration tests pass
- [x] `pnpm test` — 30 FE unit tests pass (KbSubNav + KbCountBadge + useKbNavCounts)
- [x] `pnpm test:e2e -- --grep "Admin KB SubNav"` — 1 SKIPPED (graceful: known systemic admin auth issue since proxy.ts v1-sunset 2026-05-13; documented in spec header + skip message; will run green once proxy bypass is updated for admin role)
- [x] FE build passes (`pnpm build` — pre-push hook)
- [x] BE build passes (`dotnet build` — pre-push hook)

## Known concern

The E2E smoke (`admin-kb-navcounts.spec.ts`) skips in all dev/CI environments where `PLAYWRIGHT_AUTH_BYPASS=true` is active. This is a **pre-existing systemic issue** (all admin E2E tests broken since 2026-05-13): `proxy.ts` v1 role cookie sunset makes admin role resolution impossible in bypass mode. The test is structurally correct and will run green once `proxy.ts` is updated to support admin role bypass. Tracked separately from this task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)