### PR TITLE
fix(auth): #1533 preserve 2FA backup codes across admin role/suspend

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
@@ -989,6 +989,19 @@ public sealed class User : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Restores backup codes without enabling 2FA. Internal hydration helper used by
+    /// UserRepository when the persistence row has codes but IsTwoFactorEnabled is false
+    /// (Issue #1533: stale rows or 2FA setup-in-progress window between TotpService.SetupAsync
+    /// and the first OTP confirmation). Decouples backup-code hydration from the 2FA-enabled
+    /// invariant so subsequent UpdateAsync calls preserve the persisted codes.
+    /// </summary>
+    internal void RestoreBackupCodesOnly(IEnumerable<BackupCode> backupCodes)
+    {
+        _backupCodes.Clear();
+        _backupCodes.AddRange(backupCodes);
+    }
+
+    /// <summary>
     /// Restores OAuth accounts from persistence layer.
     /// Internal method to avoid reflection in repository (S3011 compliance).
     /// Should only be called by UserRepository during entity materialization.

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
@@ -989,14 +989,23 @@ public sealed class User : AggregateRoot<Guid>
     }
 
     /// <summary>
-    /// Restores backup codes without enabling 2FA. Internal hydration helper used by
-    /// UserRepository when the persistence row has codes but IsTwoFactorEnabled is false
-    /// (Issue #1533: stale rows or 2FA setup-in-progress window between TotpService.SetupAsync
-    /// and the first OTP confirmation). Decouples backup-code hydration from the 2FA-enabled
-    /// invariant so subsequent UpdateAsync calls preserve the persisted codes.
+    /// Restores 2FA setup-in-progress state (TotpSecret and/or BackupCodes) without flipping
+    /// the IsTwoFactorEnabled flag. Internal hydration helper used by UserRepository when the
+    /// persistence row carries a TotpSecretEncrypted or BackupCode rows but IsTwoFactorEnabled
+    /// is still false (Issue #1533: stale rows or the setup window between TotpService.SetupAsync
+    /// and the first OTP confirmation).
+    ///
+    /// Both arguments are independently optional: pass <c>null</c> for an absent setup secret
+    /// and an empty collection for absent codes. Decoupling these from the IsTwoFactorEnabled
+    /// invariant ensures subsequent UpdateAsync calls preserve the setup secret and recovery
+    /// codes even when they reach the domain aggregate via a path that does not enable 2FA
+    /// (e.g. ChangeUserRoleCommand, SuspendUserCommand).
     /// </summary>
-    internal void RestoreBackupCodesOnly(IEnumerable<BackupCode> backupCodes)
+    internal void RestoreSetupInProgressState(TotpSecret? totpSecret, IEnumerable<BackupCode> backupCodes)
     {
+        ArgumentNullException.ThrowIfNull(backupCodes);
+
+        TotpSecret = totpSecret;
         _backupCodes.Clear();
         _backupCodes.AddRange(backupCodes);
     }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
@@ -200,21 +200,49 @@ public class UserRepository : RepositoryBase, IUserRepository
         existingUser.OnboardingSkipped = entity.OnboardingSkipped;
         existingUser.OnboardingCompletedAt = entity.OnboardingCompletedAt;
 
-        // Synchronize backup codes collection (delete old, add new)
-        // This ensures we don't duplicate codes on every update
-        existingUser.BackupCodes.Clear();
+        // Reconcile backup codes collection by CodeHash (Issue #1533).
+        // The previous Clear() + foreach Add pattern collided with the UNIQUE INDEX on
+        // CodeHash whenever hydrated domain codes were re-emitted (same hashes, new GUIDs)
+        // — the DELETE + INSERT batch tripped the unique constraint and surfaced as a
+        // DbUpdateConcurrencyException. Reconciling by hash also preserves the original
+        // BackupCode Ids and CreatedAt timestamps when no semantic change occurred,
+        // avoiding spurious audit churn on every UpdateAsync call.
+        var persistedByHash = existingUser.BackupCodes.ToDictionary(
+            bc => bc.CodeHash, StringComparer.Ordinal);
+        var domainHashes = entity.BackupCodes
+            .Select(bc => bc.HashedValue)
+            .ToHashSet(StringComparer.Ordinal);
 
-        foreach (var backupCode in entity.BackupCodes)
+        foreach (var persisted in existingUser.BackupCodes.ToList())
         {
-            existingUser.BackupCodes.Add(new Api.Infrastructure.Entities.UserBackupCodeEntity
+            if (!domainHashes.Contains(persisted.CodeHash))
             {
-                Id = Guid.NewGuid(),
-                UserId = entity.Id,
-                CodeHash = backupCode.HashedValue,
-                IsUsed = backupCode.IsUsed,
-                UsedAt = backupCode.UsedAt,
-                CreatedAt = DateTime.UtcNow
-            });
+                existingUser.BackupCodes.Remove(persisted);
+            }
+        }
+
+        foreach (var domainCode in entity.BackupCodes)
+        {
+            if (persistedByHash.TryGetValue(domainCode.HashedValue, out var existing))
+            {
+                if (existing.IsUsed != domainCode.IsUsed || existing.UsedAt != domainCode.UsedAt)
+                {
+                    existing.IsUsed = domainCode.IsUsed;
+                    existing.UsedAt = domainCode.UsedAt;
+                }
+            }
+            else
+            {
+                existingUser.BackupCodes.Add(new Api.Infrastructure.Entities.UserBackupCodeEntity
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = entity.Id,
+                    CodeHash = domainCode.HashedValue,
+                    IsUsed = domainCode.IsUsed,
+                    UsedAt = domainCode.UsedAt,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
         }
 
         await Task.CompletedTask.ConfigureAwait(false);
@@ -295,18 +323,25 @@ public class UserRepository : RepositoryBase, IUserRepository
             entity.DataRetentionDays);
 
         // S3011 fix: Use internal hydration methods instead of reflection
-        // Reconstruct 2FA state
+        // Reconstruct 2FA state + backup codes.
+        // Issue #1533: BackupCode hydration is intentionally DECOUPLED from the 2FA-enabled
+        // invariant. A user can have persisted codes without IsTwoFactorEnabled=true during the
+        // setup window (TotpService.SetupAsync persists secret + codes, the flag flips only on
+        // first OTP confirmation) or in stale states. Without this hydration the next
+        // UpdateAsync issued by an admin command (ChangeUserRoleCommand / SuspendUserCommand)
+        // would wipe the persisted codes via Clear()+Add(empty).
+        var backupCodes = entity.BackupCodes
+            .Select(bc => BackupCode.FromHashed(bc.CodeHash, bc.IsUsed, bc.UsedAt))
+            .ToList();
+
         if (entity.IsTwoFactorEnabled && !string.IsNullOrEmpty(entity.TotpSecretEncrypted))
         {
             var totpSecret = TotpSecret.FromEncrypted(entity.TotpSecretEncrypted);
-
-            // Convert backup codes from persistence to domain
-            var backupCodes = entity.BackupCodes
-                .Select(bc => BackupCode.FromHashed(bc.CodeHash, bc.IsUsed, bc.UsedAt))
-                .ToList();
-
-            // Use internal method instead of reflection (S3011 compliance)
             user.Restore2FAState(totpSecret, entity.IsTwoFactorEnabled, entity.TwoFactorEnabledAt, backupCodes);
+        }
+        else if (backupCodes.Count > 0)
+        {
+            user.RestoreBackupCodesOnly(backupCodes);
         }
 
         // Reconstruct OAuth accounts collection

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
@@ -324,24 +324,29 @@ public class UserRepository : RepositoryBase, IUserRepository
 
         // S3011 fix: Use internal hydration methods instead of reflection
         // Reconstruct 2FA state + backup codes.
-        // Issue #1533: BackupCode hydration is intentionally DECOUPLED from the 2FA-enabled
-        // invariant. A user can have persisted codes without IsTwoFactorEnabled=true during the
-        // setup window (TotpService.SetupAsync persists secret + codes, the flag flips only on
-        // first OTP confirmation) or in stale states. Without this hydration the next
-        // UpdateAsync issued by an admin command (ChangeUserRoleCommand / SuspendUserCommand)
-        // would wipe the persisted codes via Clear()+Add(empty).
+        // Issue #1533: TotpSecret AND BackupCode hydration are intentionally DECOUPLED from
+        // the IsTwoFactorEnabled invariant. A user can have a persisted setup secret + codes
+        // without IsTwoFactorEnabled=true during the enrollment window (TotpService.SetupAsync
+        // persists both, but the flag flips only on first OTP confirmation) or in stale states.
+        // Without this hydration:
+        //   - empty domain.BackupCodes → UpdateAsync's reconciliation removes all persisted codes
+        //   - null  domain.TotpSecret  → UpdateAsync's scalar copy nulls TotpSecretEncrypted
+        // Either side-effect breaks enrollment when an admin command (ChangeUserRoleCommand /
+        // SuspendUserCommand) runs through UpdateAsync mid-flight.
         var backupCodes = entity.BackupCodes
             .Select(bc => BackupCode.FromHashed(bc.CodeHash, bc.IsUsed, bc.UsedAt))
             .ToList();
+        var totpSecret = string.IsNullOrEmpty(entity.TotpSecretEncrypted)
+            ? null
+            : TotpSecret.FromEncrypted(entity.TotpSecretEncrypted);
 
-        if (entity.IsTwoFactorEnabled && !string.IsNullOrEmpty(entity.TotpSecretEncrypted))
+        if (entity.IsTwoFactorEnabled && totpSecret is not null)
         {
-            var totpSecret = TotpSecret.FromEncrypted(entity.TotpSecretEncrypted);
             user.Restore2FAState(totpSecret, entity.IsTwoFactorEnabled, entity.TwoFactorEnabledAt, backupCodes);
         }
-        else if (backupCodes.Count > 0)
+        else if (totpSecret is not null || backupCodes.Count > 0)
         {
-            user.RestoreBackupCodesOnly(backupCodes);
+            user.RestoreSetupInProgressState(totpSecret, backupCodes);
         }
 
         // Reconstruct OAuth accounts collection

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/Integration/SuspendUserCommandHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/Integration/SuspendUserCommandHandlerIntegrationTests.cs
@@ -145,4 +145,56 @@ public sealed class SuspendUserCommandHandlerIntegrationTests : IAsyncLifetime
         suspendedUser.Should().NotBeNull();
         suspendedUser!.IsSuspended.Should().BeTrue();
     }
+
+    // Issue #1533 — admin commands must not wipe persisted 2FA backup codes when
+    // 2FA is mid-setup (TotpSecret set, IsTwoFactorEnabled=false) or in a stale state.
+    [Fact]
+    public async Task Handle_SuspendingUserMid2FASetup_PreservesBackupCodes()
+    {
+        // Arrange — user with persisted backup codes but IsTwoFactorEnabled=false
+        // (mimics TotpService.SetupAsync run, no OTP confirmation yet).
+        var userId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var user = new User(
+            userId,
+            new Email("midsetup@s.test"),
+            "Mid Setup User",
+            PasswordHash.Create("hashedPwd1234"),
+            Role.User
+        );
+
+        await _userRepository.AddAsync(user, CancellationToken.None);
+        await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+        // Set TotpSecretEncrypted directly on persistence row + seed 6 codes.
+        // IsTwoFactorEnabled stays false on purpose (setup-in-progress window).
+        var persistedRow = await _dbContext.Users.FirstAsync(u => u.Id == userId);
+        persistedRow.TotpSecretEncrypted = "fake_setup_secret_pending_confirmation";
+
+        for (var i = 0; i < 6; i++)
+        {
+            _dbContext.UserBackupCodes.Add(new Api.Infrastructure.Entities.UserBackupCodeEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CodeHash = $"midsetup-hash-{i}-{Guid.NewGuid():N}",
+                IsUsed = false,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var command = new SuspendUserCommand(userId.ToString(), requesterId, "Admin action during 2FA setup");
+
+        // Act
+        await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — codes still present so the user can resume enrollment.
+        var codeCount = await _dbContext.UserBackupCodes
+            .AsNoTracking()
+            .CountAsync(c => c.UserId == userId);
+        codeCount.Should().Be(6,
+            because: "SuspendUserCommand MUST NOT wipe persisted backup codes during 2FA setup (#1533)");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/Integration/SuspendUserCommandHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/Integration/SuspendUserCommandHandlerIntegrationTests.cs
@@ -188,7 +188,12 @@ public sealed class SuspendUserCommandHandlerIntegrationTests : IAsyncLifetime
         var command = new SuspendUserCommand(userId.ToString(), requesterId, "Admin action during 2FA setup");
 
         // Act
-        await _handler.Handle(command, TestContext.Current.CancellationToken);
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — suspension actually executed (guard against silent no-op masking the
+        // backup-code assertion below).
+        result.IsSuspended.Should().BeTrue(
+            because: "the suspension must actually execute, otherwise the codes-preserved assertion is meaningless");
 
         // Assert — codes still present so the user can resume enrollment.
         var codeCount = await _dbContext.UserBackupCodes
@@ -196,5 +201,14 @@ public sealed class SuspendUserCommandHandlerIntegrationTests : IAsyncLifetime
             .CountAsync(c => c.UserId == userId);
         codeCount.Should().Be(6,
             because: "SuspendUserCommand MUST NOT wipe persisted backup codes during 2FA setup (#1533)");
+
+        // Assert — TotpSecret survives so the user can resume enrollment (#1533 follow-up).
+        var persistedAfter = await _dbContext.Users
+            .AsNoTracking()
+            .FirstAsync(u => u.Id == userId);
+        persistedAfter.TotpSecretEncrypted.Should().Be("fake_setup_secret_pending_confirmation",
+            because: "the TOTP setup secret must survive admin commands during enrollment");
+        persistedAfter.IsTwoFactorEnabled.Should().BeFalse(
+            because: "the enrollment is still in-progress — the flag must NOT flip until first OTP confirmation");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/Authentication/UserRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/UserRepositoryIntegrationTests.cs
@@ -634,6 +634,17 @@ public sealed class UserRepositoryIntegrationTests : IAsyncLifetime
             .CountAsync(c => c.UserId == TestUserId1, TestCancellationToken))
             .Should().Be(8,
                 because: "admin actions during 2FA setup window MUST NOT wipe backup codes (#1533)");
+
+        // Assert — TotpSecret survives the round-trip. Without TotpSecret hydration in
+        // MapToDomain, the next UpdateAsync would null TotpSecretEncrypted via the scalar
+        // copy `existingUser.TotpSecretEncrypted = entity.TotpSecret?.EncryptedValue`,
+        // leaving the user with codes but no way to complete enrollment (#1533 follow-up).
+        var persistedAfter = await _dbContext.Users.AsNoTracking()
+            .FirstAsync(u => u.Id == TestUserId1, TestCancellationToken);
+        persistedAfter.TotpSecretEncrypted.Should().Be("fake_setup_secret_not_yet_confirmed",
+            because: "the TOTP setup secret must survive admin commands during enrollment");
+        persistedAfter.IsTwoFactorEnabled.Should().BeFalse(
+            because: "enrollment is still in-progress — the flag must NOT flip until first OTP confirmation");
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/Integration/Authentication/UserRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/UserRepositoryIntegrationTests.cs
@@ -530,6 +530,112 @@ public sealed class UserRepositoryIntegrationTests : IAsyncLifetime
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #1533 — UpdateAsync must NOT wipe backup codes when caller did not
+    // intend to mutate them. Two reproducible scenarios:
+    //   B. Stale codes: 2FA fully disabled but codes still in DB.
+    //   C. Setup in-progress: TotpSecretEncrypted set but IsTwoFactorEnabled=false
+    //      (the window between TotpService setup and the first OTP confirmation).
+    // Both states are real-life occurrences (Scenario C affects every user during
+    // 2FA enrollment). Before the fix, MapToDomain hydrated BackupCodes only when
+    // both flags were set, so domain.BackupCodes arrived empty and UpdateAsync's
+    // Clear()+Add(empty) wiped the persisted rows.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_RoleChangeOnUserWithBackupCodesNo2FA_ShouldPreserveBackupCodes()
+    {
+        // Arrange — Scenario B: user with backup codes seeded directly, 2FA disabled.
+        await CleanDatabaseAsync();
+        var user = CreateTestUser(TestUserId1, "stale-codes@test.com");
+        await _repository!.AddAsync(user, TestCancellationToken);
+        await _unitOfWork!.SaveChangesAsync(TestCancellationToken);
+
+        for (var i = 0; i < 5; i++)
+        {
+            _dbContext!.UserBackupCodes.Add(new Api.Infrastructure.Entities.UserBackupCodeEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestUserId1,
+                CodeHash = $"stale-hash-{i}-{Guid.NewGuid():N}",
+                IsUsed = false,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        await _dbContext!.SaveChangesAsync(TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+
+        (await _dbContext.UserBackupCodes.AsNoTracking()
+            .CountAsync(c => c.UserId == TestUserId1, TestCancellationToken))
+            .Should().Be(5, because: "the seeding step must succeed before the act");
+
+        // Act — same pathway ChangeUserRoleCommandHandler uses: load + mutate scalar + UpdateAsync.
+        await ExecuteInScopeAsync(async (repo, uow) =>
+        {
+            var loaded = await repo.GetByIdAsync(TestUserId1, TestCancellationToken);
+            loaded!.UpdateRole(Role.Editor);
+            await repo.UpdateAsync(loaded, TestCancellationToken);
+            await uow.SaveChangesAsync(TestCancellationToken);
+            return true;
+        });
+
+        // Assert — codes still present (regression guard for #1533).
+        (await _dbContext.UserBackupCodes.AsNoTracking()
+            .CountAsync(c => c.UserId == TestUserId1, TestCancellationToken))
+            .Should().Be(5,
+                because: "scalar mutations (role change) MUST NOT wipe persisted backup codes (#1533)");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SuspensionOnUserMid2FASetup_ShouldPreserveBackupCodes()
+    {
+        // Arrange — Scenario C: 2FA setup-in-progress (TotpSecret set, IsTwoFactorEnabled=false).
+        // This is the realistic enrollment window: TotpService.SetupAsync persists the secret
+        // + plaintext-hashed backup codes, but IsTwoFactorEnabled flips only on the first
+        // successful OTP verification.
+        await CleanDatabaseAsync();
+        var user = CreateTestUser(TestUserId1, "midsetup@test.com");
+        await _repository!.AddAsync(user, TestCancellationToken);
+        await _unitOfWork!.SaveChangesAsync(TestCancellationToken);
+
+        // Directly set TotpSecretEncrypted on the persistence row to mimic setup-mid-state.
+        var persistedUser = await _dbContext!.Users
+            .AsTracking()
+            .FirstAsync(u => u.Id == TestUserId1, TestCancellationToken);
+        persistedUser.TotpSecretEncrypted = "fake_setup_secret_not_yet_confirmed";
+        // IsTwoFactorEnabled remains false intentionally.
+
+        for (var i = 0; i < 8; i++)
+        {
+            _dbContext.UserBackupCodes.Add(new Api.Infrastructure.Entities.UserBackupCodeEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = TestUserId1,
+                CodeHash = $"setup-hash-{i}-{Guid.NewGuid():N}",
+                IsUsed = false,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+
+        // Act — admin suspends the user during the enrollment window.
+        await ExecuteInScopeAsync(async (repo, uow) =>
+        {
+            var loaded = await repo.GetByIdAsync(TestUserId1, TestCancellationToken);
+            loaded!.Suspend("admin action mid-2FA-setup");
+            await repo.UpdateAsync(loaded, TestCancellationToken);
+            await uow.SaveChangesAsync(TestCancellationToken);
+            return true;
+        });
+
+        // Assert — codes still present so the user can resume enrollment after un-suspension.
+        (await _dbContext.UserBackupCodes.AsNoTracking()
+            .CountAsync(c => c.UserId == TestUserId1, TestCancellationToken))
+            .Should().Be(8,
+                because: "admin actions during 2FA setup window MUST NOT wipe backup codes (#1533)");
+    }
+
     #endregion
 
     #region DeleteAsync Tests


### PR DESCRIPTION
## Summary

Fixes #1533 — admin commands (`ChangeUserRoleCommand`, `SuspendUserCommand`) were silently wiping persisted 2FA backup codes through `UserRepository.UpdateAsync`.

Two reproducible scenarios (both confirmed live on `main-dev @ 118cf72a8` via a RED test that fails before this PR):
- **B. Stale codes**: rows present in DB, `IsTwoFactorEnabled=false`.
- **C. 2FA setup mid-flight**: `TotpSecretEncrypted` set + codes persisted, but `IsTwoFactorEnabled` stays `false` until the first OTP confirmation. **Affects every user during enrollment** — the window between `TotpService.SetupAsync` and `Enable2FACommandHandler.Handle`.

Root cause: `MapToDomain` only hydrated `BackupCodes` when **both** `IsTwoFactorEnabled=true` AND `TotpSecretEncrypted` were set. In Scenarios B/C the domain `User` arrived with an empty `BackupCodes` collection, and `UpdateAsync`'s `Clear() + Add(empty)` silently DELETEd every persisted code whenever any admin command hit the repo.

## Fix

Three layered changes:

1. **Domain** (`User.cs`): new `internal RestoreBackupCodesOnly(IEnumerable<BackupCode>)` hydration helper. S3011-compliant (no reflection).

2. **Mapping** (`UserRepository.MapToDomain`): codes are hydrated whenever rows exist, decoupled from the 2FA-enabled flag. Restores into `Restore2FAState` when both flags are set, otherwise into `RestoreBackupCodesOnly` so the codes still reach the domain aggregate.

3. **Repository** (`UserRepository.UpdateAsync`): reconciles `BackupCodes` by `CodeHash` instead of `Clear() + foreach Add`. The old pattern, once hydration was re-emitting the same hashes, **also** collided with the UNIQUE INDEX on `CodeHash` — the DELETE + INSERT batch on identical hashes surfaced as a `DbUpdateConcurrencyException`. Reconciling by hash additionally preserves the original `BackupCode.Id` + `CreatedAt` when no semantic change occurred, avoiding spurious audit churn on every `UpdateAsync` call.

## Test plan

All Integration, Testcontainers Postgres:

- [x] **RED → GREEN**: `UpdateAsync_RoleChangeOnUserWithBackupCodesNo2FA_ShouldPreserveBackupCodes` (Scenario B). Fails on `main-dev` with `Expected 5 codes, found 0`; passes after fix.
- [x] **Scenario C**: `UpdateAsync_SuspensionOnUserMid2FASetup_ShouldPreserveBackupCodes`. Mimics the realistic 2FA setup window (TotpSecret set, IsTwoFactorEnabled=false, 8 codes seeded).
- [x] **End-to-end**: `Handle_SuspendingUserMid2FASetup_PreservesBackupCodes` in `SuspendUserCommandHandlerIntegrationTests` — exercises the full handler pathway via MediatR for Scenario C.
- [x] **Regression**: 44/44 pass in `UserRepositoryIntegrationTests` + `SuspendUserCommandHandlerIntegrationTests` (~4 min).
- [x] **Pre-existing failures unrelated**: 3 `TwoFactorSecurityPenetrationTests` (`BruteForce_InvalidBackupCodes_*`, `ReplayAttack_ReuseBackupCode_*`, `ReplayAttack_ConcurrentBackupCodeUse_*`) fail on `main-dev` baseline (verified by stashing the fix and re-running). They surface a separate `TotpService.ExecuteBackupCodeTransactionAsync` issue and are not caused by this PR.

## Why this matters

- Silent data loss: any admin role change or suspension on a user mid-enrollment wipes their recovery codes. If the user then loses their authenticator before completing setup or re-enrolling, they hit a hard lockout with no recovery path.
- No audit trail: the wipe happened at the repository level, invisible to the `[AtomicAudit]` interceptor on the command — compliance loses the deletion event entirely.
- Discovered during SP5 S1 (#1532) and held open while the 2FA cluster (#1622, #1626, #1627, #1628, #1656) closed out around it. This PR completes that cluster.

## Related

- Closes #1533
- Companion to SP5 S1 audit (#1532), SP5 S3 strict-mode cutover (#1597), and the 2FA setup/enroll fixes (#1622, #1626, #1627, #1656)

🤖 Generated with [Claude Code](https://claude.com/claude-code)