### PR TITLE
feat(library): #1714 useLibrary visual-test fixture hatch — re-activates 4 a11y tests

### DIFF
--- a/apps/web/e2e/a11y/games-library.spec.ts
+++ b/apps/web/e2e/a11y/games-library.spec.ts
@@ -59,15 +59,10 @@ async function gotoLibraryReady(page: Page, search = '', waitForGrid = true): Pr
 }
 
 test.describe('Games library — accessibility @a11y', () => {
-  // Skipped 2026-05-30 (PR #1700 release CI): `useLibrary` does NOT have a
-  // VISUAL_TEST_FIXTURE short-circuit, so without backend data the games tab
-  // lands in `gamesEffectiveKind = 'empty'` (renders GamesEmptyState, not
-  // GamesResultsGrid). Was masked previously because `Frontend - A11y E2E`
-  // runs only on PRs to main-staging (not main-dev via Dev Fast) — first run
-  // surfacing this was the release PR. Follow-up: add fixture short-circuit
-  // to useLibrary matching SessionSummaryView pattern, or mock API in spec.
-  test.fixme('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
-    await gotoLibraryReady(page);
+  // Re-activated 2026-05-30 via #1714: useLibrary now short-circuits to a
+  // 12-entry fixture when STATE_OVERRIDE_ENABLED && ?fixture=default.
+  test('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
+    await gotoLibraryReady(page, 'fixture=default');
     // Default state expects results grid populato — wait for first card.
     await expect(page.locator('[data-slot="games-results-grid-link"]').first()).toBeVisible();
 
@@ -106,15 +101,13 @@ test.describe('Games library — accessibility @a11y', () => {
     expect(results.violations).toEqual([]);
   });
 
-  // Skipped 2026-05-30 (PR #1700 release CI): same root cause as the test
-  // above — `useLibrary` lacks fixture short-circuit, so the grid is empty
-  // and the `games-results-grid-link` locator never resolves.
-  test.fixme('prefers-reduced-motion: card hover transitions collapse to sub-ms', async ({ page }) => {
+  // Re-activated 2026-05-30 via #1714: same fix as the test above.
+  test('prefers-reduced-motion: card hover transitions collapse to sub-ms', async ({ page }) => {
     // Emulate reduced-motion BEFORE goto so the global CSS rule
     // (globals.css:388-396) applies on first paint. Without this the
     // GridCard `transition-all duration-[350ms]` runs full hover animation.
     await page.emulateMedia({ reducedMotion: 'reduce' });
-    await gotoLibraryReady(page);
+    await gotoLibraryReady(page, 'fixture=default');
     await expect(page.locator('[data-slot="games-results-grid-link"]').first()).toBeVisible();
 
     // Inspect computed transition-duration on the GridCard element (first child

--- a/apps/web/e2e/a11y/library.spec.ts
+++ b/apps/web/e2e/a11y/library.spec.ts
@@ -41,13 +41,12 @@ async function gotoLibraryReady(page: Page, search = ''): Promise<void> {
 }
 
 test.describe('Library desktop — accessibility @a11y', () => {
-  // Skipped 2026-05-30 (PR #1700 release CI): `useLibrary` does NOT have a
-  // VISUAL_TEST_FIXTURE short-circuit, so without backend data the hub lands
-  // in empty/loading state — LibraryHybridGrid is not rendered. Same pattern
-  // as games-library.spec. Follow-up: add fixture short-circuit to useLibrary
-  // matching SessionSummaryView pattern, or mock /api/v1/library in spec.
-  test.fixme('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
-    await gotoLibraryReady(page);
+  // Re-activated 2026-05-30 via #1714: useLibrary now has a VISUAL_TEST_FIXTURE
+  // short-circuit (parseLibraryStateOverride). Append `?fixture=default` to
+  // force the populated state (mirrors PR #1709 cluster-1 pattern for
+  // session-summary.spec.ts).
+  test('axe-core: no WCAG 2.1 AA violations on default state', async ({ page }) => {
+    await gotoLibraryReady(page, '?fixture=default');
     // Default state expects LibraryHybridGrid populato — wait for first card.
     await expect(page.locator('[data-slot="library-grid-card"]').first()).toBeVisible();
 
@@ -86,15 +85,13 @@ test.describe('Library desktop — accessibility @a11y', () => {
     expect(results.violations).toEqual([]);
   });
 
-  // Skipped 2026-05-30 (PR #1700 release CI): same root cause as the test
-  // above — `useLibrary` lacks fixture short-circuit, so library-grid-card
-  // never renders.
-  test.fixme('prefers-reduced-motion: card hover transitions collapse to sub-ms', async ({ page }) => {
+  // Re-activated 2026-05-30 via #1714: same fix as the test above.
+  test('prefers-reduced-motion: card hover transitions collapse to sub-ms', async ({ page }) => {
     // Emulate reduced-motion BEFORE goto so the global CSS rule
     // (globals.css:388-396) applies on first paint. Without this the
     // GridCard `transition-all duration-[350ms]` runs full hover animation.
     await page.emulateMedia({ reducedMotion: 'reduce' });
-    await gotoLibraryReady(page);
+    await gotoLibraryReady(page, '?fixture=default');
     await expect(page.locator('[data-slot="library-grid-card"]').first()).toBeVisible();
 
     // Inspect computed transition-duration on the GridCard element. Under

--- a/apps/web/src/hooks/queries/useLibrary.ts
+++ b/apps/web/src/hooks/queries/useLibrary.ts
@@ -16,6 +16,11 @@ import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { api } from '@/lib/api';
 import { fetchUserGamebooks } from '@/lib/api/gamebooks-list';
 import type { LibraryActivityItem } from '@/lib/api/schemas/library-activity.schemas';
+import {
+  libraryFixtures,
+  parseLibraryStateOverride,
+  STATE_OVERRIDE_ENABLED,
+} from '@/lib/library/visual-test-fixture';
 import type {
   PaginatedLibraryResponse,
   UserLibraryStats,
@@ -66,6 +71,15 @@ export const libraryKeys = {
  * @param params - Optional filtering and pagination parameters
  * @param enabled - Whether to run the query (default: true)
  * @returns UseQueryResult with paginated library data
+ *
+ * Visual-test fixture hatch (issue #1714): when `STATE_OVERRIDE_ENABLED` and
+ * the URL carries `?fixture=default|empty`, the queryFn returns the matching
+ * fixture instead of hitting `/api/v1/library`. Production builds without
+ * `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1` constant-fold the gate to
+ * `false`, so the fixture data is dead-code-eliminated.
+ *
+ * Reads `?fixture=` lazily from `window.location.search` inside the queryFn
+ * so the override survives route param changes without triggering a refetch.
  */
 export function useLibrary(
   params?: GetUserLibraryParams,
@@ -74,6 +88,12 @@ export function useLibrary(
   return useQuery({
     queryKey: libraryKeys.list(params),
     queryFn: async (): Promise<PaginatedLibraryResponse> => {
+      if (STATE_OVERRIDE_ENABLED && typeof window !== 'undefined') {
+        const override = parseLibraryStateOverride(new URLSearchParams(window.location.search));
+        if (override !== null) {
+          return libraryFixtures[override];
+        }
+      }
       return api.library.getLibrary(params);
     },
     enabled,

--- a/apps/web/src/lib/library/__tests__/visual-test-fixture.test.ts
+++ b/apps/web/src/lib/library/__tests__/visual-test-fixture.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for `library/visual-test-fixture` URL-override hatch (issue #1714).
+ *
+ * Covers the `parseLibraryStateOverride` + `libraryFixtures` additions made
+ * in PR follow-up #1700. The existing `tryLoadVisualTestFixture` /
+ * `IS_VISUAL_TEST_BUILD` constant are NOT re-tested here — those were
+ * shipped in Wave B.3 (PR #638) and have not changed.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  libraryFixtureKindSchema,
+  libraryFixtures,
+  parseLibraryStateOverride,
+  STATE_OVERRIDE_ENABLED,
+} from '../visual-test-fixture';
+
+describe('STATE_OVERRIDE_ENABLED', () => {
+  it('is true in the unit-test environment (NODE_ENV !== "production")', () => {
+    // Vitest sets NODE_ENV=test by default. The constant is computed at
+    // module-load time so a single boolean read is sufficient.
+    expect(STATE_OVERRIDE_ENABLED).toBe(true);
+  });
+});
+
+describe('libraryFixtureKindSchema', () => {
+  it('accepts "default"', () => {
+    expect(libraryFixtureKindSchema.safeParse('default').success).toBe(true);
+  });
+
+  it('accepts "empty"', () => {
+    expect(libraryFixtureKindSchema.safeParse('empty').success).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(libraryFixtureKindSchema.safeParse('loading').success).toBe(false);
+    expect(libraryFixtureKindSchema.safeParse('filtered-empty').success).toBe(false);
+    expect(libraryFixtureKindSchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('libraryFixtures', () => {
+  it('has the 2 expected kinds', () => {
+    expect(Object.keys(libraryFixtures).sort()).toEqual(['default', 'empty']);
+  });
+
+  it('default has >= 3 entries (covers grid 3-col layout + reduced-motion hover)', () => {
+    expect(libraryFixtures.default.items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('default totalCount matches items.length', () => {
+    expect(libraryFixtures.default.totalCount).toBe(libraryFixtures.default.items.length);
+  });
+
+  it('default has totalPages=1 (single page response)', () => {
+    expect(libraryFixtures.default.totalPages).toBe(1);
+    expect(libraryFixtures.default.hasNextPage).toBe(false);
+    expect(libraryFixtures.default.hasPreviousPage).toBe(false);
+  });
+
+  it('empty has zero entries', () => {
+    expect(libraryFixtures.empty.items).toHaveLength(0);
+    expect(libraryFixtures.empty.totalCount).toBe(0);
+    expect(libraryFixtures.empty.totalPages).toBe(0);
+  });
+
+  it('default entries provide all fields MeepleCard grid render needs', () => {
+    for (const entry of libraryFixtures.default.items) {
+      expect(entry.gameId).toEqual(expect.any(String));
+      expect(entry.gameTitle).toEqual(expect.any(String));
+      expect(entry.gameTitle.length).toBeGreaterThan(0);
+      // gameImageUrl + gamePublisher MAY be null but the field must exist.
+      expect(entry).toHaveProperty('gameImageUrl');
+      expect(entry).toHaveProperty('gamePublisher');
+      expect(entry).toHaveProperty('currentState');
+      expect(entry.addedAt).toEqual(expect.any(String));
+    }
+  });
+});
+
+describe('parseLibraryStateOverride', () => {
+  it('returns null when input is null/undefined', () => {
+    expect(parseLibraryStateOverride(null)).toBeNull();
+    expect(parseLibraryStateOverride(undefined)).toBeNull();
+  });
+
+  it('returns null when input is empty string', () => {
+    expect(parseLibraryStateOverride('')).toBeNull();
+  });
+
+  it('parses raw string "default"', () => {
+    expect(parseLibraryStateOverride('default')).toBe('default');
+  });
+
+  it('parses raw string "empty"', () => {
+    expect(parseLibraryStateOverride('empty')).toBe('empty');
+  });
+
+  it('returns null on unknown string', () => {
+    expect(parseLibraryStateOverride('loading')).toBeNull();
+    expect(parseLibraryStateOverride('garbage')).toBeNull();
+  });
+
+  it('extracts the fixture key from a URLSearchParams', () => {
+    const params = new URLSearchParams('fixture=default&other=ignored');
+    expect(parseLibraryStateOverride(params)).toBe('default');
+  });
+
+  it('returns null when URLSearchParams has no `fixture` key', () => {
+    const params = new URLSearchParams('state=filtered-empty');
+    expect(parseLibraryStateOverride(params)).toBeNull();
+  });
+
+  it('respects empty URLSearchParams', () => {
+    expect(parseLibraryStateOverride(new URLSearchParams())).toBeNull();
+  });
+});

--- a/apps/web/src/lib/library/visual-test-fixture.ts
+++ b/apps/web/src/lib/library/visual-test-fixture.ts
@@ -28,7 +28,9 @@
  *   - `apps/web/e2e/v2-states/library.spec.ts` (Commit 4)
  */
 
-import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
+import { z } from 'zod';
+
+import type { PaginatedLibraryResponse, UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
 
 /**
  * Deterministic UUIDv4-shaped sentinel encoding issue #574 in the last group
@@ -253,4 +255,87 @@ export function tryLoadVisualTestFixture(
   if (!IS_VISUAL_TEST_BUILD) return null;
   if (state === 'empty') return [];
   return FIXTURE_DEFAULT;
+}
+
+// ---------------------------------------------------------------------------
+// `?fixture=` URL override hatch — issue #1714 (PR #1700 follow-up)
+// ---------------------------------------------------------------------------
+//
+// The `tryLoadVisualTestFixture` above is gated by `IS_VISUAL_TEST_BUILD`
+// only (i.e. CI a11y build). Local dev + e2e Playwright runs that don't
+// rebuild with the env var (e.g. `pnpm dev`) cannot reach the fixture
+// without this hatch. Mirrors `parseStateOverride` in
+// `apps/web/src/lib/sessions-summary/visual-test-fixture.ts`.
+//
+// The hatch enables `?fixture=default|empty` on the /library route so the
+// 4 a11y E2E tests skipped by PR #1711 can re-activate:
+//   - apps/web/e2e/a11y/library.spec.ts (default + reduced-motion)
+//   - apps/web/e2e/a11y/games-library.spec.ts (default + reduced-motion)
+
+/**
+ * Build-time gating for the `?fixture=` URL override hatch.
+ *
+ * Allowing fixture overrides in production would expose a UI manipulation
+ * surface (a real user could append `?fixture=default` and see fake data).
+ * The hatch is enabled only when IS_VISUAL_TEST_BUILD=true OR
+ * NODE_ENV !== 'production' (development/test environments).
+ */
+export const STATE_OVERRIDE_ENABLED =
+  IS_VISUAL_TEST_BUILD || process.env.NODE_ENV !== 'production';
+
+export const libraryFixtureKindSchema = z.enum(['default', 'empty']);
+export type LibraryFixtureKind = z.infer<typeof libraryFixtureKindSchema>;
+
+/**
+ * Wraps the fixture entries into a `PaginatedLibraryResponse` shape so
+ * `useLibrary` can substitute it for the real TanStack Query result without
+ * any caller-side adaptation.
+ */
+function wrapAsResponse(entries: readonly UserLibraryEntry[]): PaginatedLibraryResponse {
+  return {
+    items: [...entries],
+    page: 1,
+    pageSize: 50,
+    totalCount: entries.length,
+    totalPages: entries.length === 0 ? 0 : 1,
+    hasNextPage: false,
+    hasPreviousPage: false,
+  };
+}
+
+/**
+ * Single source of truth for the 2 library fixture URL-override variants.
+ * Keyed by `LibraryFixtureKind` — same discriminant as the existing
+ * `LibraryFixtureState` (`'default' | 'empty'`).
+ */
+export const libraryFixtures: Readonly<Record<LibraryFixtureKind, PaginatedLibraryResponse>> = {
+  default: wrapAsResponse(FIXTURE_DEFAULT),
+  empty: wrapAsResponse([]),
+};
+
+/**
+ * Parses the `?fixture=` URL search param into a `LibraryFixtureKind`.
+ *
+ * Returns `null` when:
+ *   - `STATE_OVERRIDE_ENABLED` is false (production builds without the env var)
+ *   - The param is missing, empty, or not a recognized fixture kind
+ *
+ * Accepts either a `URLSearchParams`, a plain string (the param value), or
+ * `null`/`undefined` for ergonomic call sites.
+ */
+export function parseLibraryStateOverride(
+  searchParam: string | URLSearchParams | null | undefined
+): LibraryFixtureKind | null {
+  if (!STATE_OVERRIDE_ENABLED) return null;
+  let raw: string | null;
+  if (searchParam == null) {
+    raw = null;
+  } else if (typeof searchParam === 'string') {
+    raw = searchParam;
+  } else {
+    raw = searchParam.get('fixture');
+  }
+  if (!raw) return null;
+  const parsed = libraryFixtureKindSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }


### PR DESCRIPTION
Closes #1714.

## Summary

Adds a `?fixture=default|empty` URL-override hatch to `useLibrary`, mirroring the pattern already used by `SessionSummaryView` (PR #1709 cluster-1). Re-activates 4 a11y E2E tests skipped by PR #1711 without per-spec API mocking.

## Why not just `IS_VISUAL_TEST_BUILD`?

The existing `tryLoadVisualTestFixture` gates on `IS_VISUAL_TEST_BUILD` only — that's the CI a11y build artifact flag (set in `ci.yml:216` for `build-frontend-a11y`). It can't be reached at runtime from a URL param because the build constant is folded.

The new hatch uses `STATE_OVERRIDE_ENABLED = IS_VISUAL_TEST_BUILD || NODE_ENV !== 'production'` so:
- ✅ Production builds: dead-code-eliminated (no user-visible URL hatch)
- ✅ CI a11y builds: enabled (existing artifact, no rebuild needed)
- ✅ Local dev (`pnpm dev`): enabled (developers can scan `?fixture=default` for local a11y triage)

Same pattern as `apps/web/src/lib/sessions-summary/visual-test-fixture.ts:72`.

## Changes

| File | Purpose |
|---|---|
| `apps/web/src/lib/library/visual-test-fixture.ts` | Append `STATE_OVERRIDE_ENABLED`, `libraryFixtureKindSchema`, `libraryFixtures` Record, `parseLibraryStateOverride` |
| `apps/web/src/lib/library/__tests__/visual-test-fixture.test.ts` | New — 18 unit tests |
| `apps/web/src/hooks/queries/useLibrary.ts` | Wire the hatch into the queryFn (lazy read of `window.location.search`) |
| `apps/web/e2e/a11y/library.spec.ts` | Re-activate 2 tests with `?fixture=default` |
| `apps/web/e2e/a11y/games-library.spec.ts` | Re-activate 2 tests with `fixture=default` |

## Test plan

- [x] 18/18 new fixture unit tests pass
- [x] 121/121 library + useLibrary tests pass total (no regressions)
- [x] Typecheck clean
- [ ] CI Dev Fast green on this PR
- [ ] On release PR (when ci.yml runs): `Frontend - A11y E2E` exercises the 4 re-activated tests and reports 0 violations (or surfaces real a11y debt on `/library` route which we fix in a follow-up)
- [ ] Bundle Size CI check passes — `/library` delta < 2 KB (issue R-1.2)

## Acceptance criteria (issue #1714)

- [x] useLibrary hook updated with fixture short-circuit (production-gated)
- [x] visual-test-fixture.ts extended with libraryFixtures Record + parseLibraryStateOverride
- [x] 4 test.fixme() converted to test()
- [ ] Bundle size delta < 2 KB (CI on this PR will verify)
- [x] Unit tests for parseLibraryStateOverride
- [ ] Documentation in dev guide (deferred — pattern matches SessionSummaryView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
