### PR TITLE
test(a11y): #1715 PauseOverlay ESC — assert a11y contract not strict DOM detach

### DIFF
--- a/apps/web/e2e/a11y/session-live.spec.ts
+++ b/apps/web/e2e/a11y/session-live.spec.ts
@@ -267,13 +267,29 @@ test.describe('Session live — accessibility @a11y', () => {
   // Reliability note: We click inside the dialog before pressing ESC to ensure
   // keyboard events land on the element with the onKeyDown handler.
 
-  // Skipped 2026-05-30 (PR #1700 release CI #3): even with 15s timeout the
-  // PauseOverlay never detaches after ESC + URL replace under CI load. The
-  // dialog is mounted via Portal/Suspense and the URL→state→unmount round-trip
-  // appears to race the test assertion. Pre-existing on main-staging (not a
-  // release regression). Follow-up: investigate dialog cleanup pattern or
-  // assert on `display:none` / aria-hidden state instead of DOM detachment.
-  test.fixme('PauseOverlay ESC closes dialog — URL drops ?dialog=pause', async ({ page }) => {
+  // Re-enabled 2026-05-31 (issue #1715): test was skipped via `test.fixme()` in
+  // PR #1711 because the strict `state: 'detached'` assertion raced the
+  // React.lazy + Suspense unmount under CI load. The flow is:
+  //   ESC keydown → onClose() → router.replace() → ?dialog=pause removed
+  //     → React re-render → Suspense child unmounts → DOM node removed
+  //
+  // Under CI scheduler pressure step 3→5 can take >15s, even though the URL
+  // mutation (step 2) and the user-visible dismissal (focus restore + dialog
+  // hidden) complete promptly. Investigation in #1715 confirmed the production
+  // semantics are correct — ESC is captured, the handler is called synchronously,
+  // focus is restored on unmount via PauseOverlay's `useEffect` cleanup. The
+  // race is purely test-side timing of strict DOM detach vs. observable a11y
+  // contract.
+  //
+  // Fix strategy: assert on the user-visible a11y contract (URL drops the
+  // dialog param + dialog is no longer visible to AT users) instead of the
+  // stricter "DOM node detached" condition. Playwright's `toBeHidden()` auto-
+  // retries and passes when the element is detached OR visually hidden, which
+  // matches the WCAG 2.1.1 promise: ESC dismisses the dialog from the user's
+  // perspective. Detach itself still happens — we just don't gate the test on
+  // the exact reconciliation tick. Pattern parallels round-2 flake fixes in
+  // PR #1711 (game-night-create numeric parsing over regex match).
+  test('PauseOverlay ESC closes dialog — URL drops ?dialog=pause', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await seedAuth(page);
     await page.goto(`/sessions/${FIXTURE_SESSION_ID}/live?fixture=host&dialog=pause`, {
@@ -290,16 +306,21 @@ test.describe('Session live — accessibility @a11y', () => {
     // Press ESC — triggers onClose() → router.replace removes ?dialog=pause
     await page.keyboard.press('Escape');
 
-    // Dialog must detach from DOM (URL navigation causes React re-render).
-    // Bumped 5s → 15s 2026-05-30 (PR #1700 release CI flake): same headroom
-    // used elsewhere in this spec for dialog mount/unmount under CI load.
-    await page.waitForSelector('[data-slot="pause-overlay"]', {
-      state: 'detached',
-      timeout: 15_000,
-    });
+    // PRIMARY a11y contract: URL must drop ?dialog=pause synchronously.
+    // This proves the ESC handler fired AND router.replace committed — i.e.
+    // the dismiss state is the source of truth and AT users navigating by URL
+    // will see the dialog as closed. `expect.poll` auto-retries with default
+    // 5s timeout (sufficient: router.replace is sub-second under CI).
+    await expect.poll(() => page.url(), { timeout: 5_000 }).not.toContain('dialog=pause');
 
-    // URL must no longer contain ?dialog=pause (URL SSOT verified)
-    expect(page.url()).not.toContain('dialog=pause');
+    // SECONDARY a11y contract: dialog must be invisible to AT users.
+    // `toBeHidden()` passes for any of: detached, display:none, visibility:hidden,
+    // zero size, off-screen, or aria-hidden ancestor. This matches the user-
+    // visible dismissal contract without racing React.lazy + Suspense's
+    // reconciliation tick (which is the root cause of the original flake).
+    // 15s timeout: same headroom used elsewhere in this spec for dialog
+    // lifecycle assertions under CI load.
+    await expect(page.locator('[data-slot="pause-overlay"]')).toBeHidden({ timeout: 15_000 });
   });
 
   // ── EndgameDialog ESC DISABLED — intentional deviation ─────────────────────


### PR DESCRIPTION
## Summary

Re-enables the `PauseOverlay ESC closes dialog — URL drops ?dialog=pause` a11y test that was skipped via `test.fixme()` in PR #1711. The test now asserts on the **observable a11y contract** (URL committed + dialog hidden) rather than the **strict DOM contract** (DOM node detached), which eliminates the React.lazy + Suspense reconciliation race without weakening the WCAG 2.1.1 guarantee.

## Investigation

Read the PauseOverlay component (`apps/web/src/components/features/session-live/PauseOverlay.tsx`) and the orchestrator (`SessionLiveView.tsx`):

- Mounted via `React.lazy()` + `<Suspense fallback={null}>`, **not** via React Portal — but the lazy-loaded child still goes through Suspense's coordinated unmount path
- `onKeyDown` ESC handler calls `e.preventDefault()` then `onClose()` synchronously (no `useTransition` / `useDeferredValue`)
- `onClose` resolves to `handleDialogChange('none')` → `router.replace(...)` (Next.js App Router)
- `useEffect` cleanup restores focus to the previously-focused element on unmount

The ESC handler itself is correct and synchronous. The race is entirely in steps 3-5 of the chain:

```
ESC keydown → onClose() → router.replace()              [synchronous]
   → ?dialog=pause removed                              [sub-second]
     → React re-render
       → Suspense child unmounts
         → DOM node removed                             [racy under CI load]
```

Under CI scheduler pressure the React reconciliation tick can overrun the 15s `waitForSelector(state: 'detached')` timeout, even though the URL is already committed and the user can no longer interact with the dialog.

## Fix path chosen: test-only

**Rejected**: production fix. The ESC handler is synchronous, the URL replace is committed, focus is restored on cleanup — there is no real a11y bug. Forcing the unmount via `flushSync` would add complexity without user-visible benefit.

**Chosen**: assert on the user-visible a11y contract:

1. `expect.poll(() => page.url()).not.toContain('dialog=pause')` — proves `onClose` fired and `router.replace` committed (URL SSOT is the actual dismiss-state source of truth)
2. `expect(locator).toBeHidden({ timeout: 15_000 })` — proves dialog is invisible to AT users. Playwright's `toBeHidden()` passes for detached OR hidden (display:none / visibility:hidden / zero size / aria-hidden ancestor) and auto-retries, so it tolerates the reconciliation tick without weakening the contract

DOM detach **still happens** in production — the test just no longer gates on the exact tick. A broken ESC handler (handler removed, URL doesn't update) would still fail the test.

## What changed

- `apps/web/e2e/a11y/session-live.spec.ts`:
  - Removed `test.fixme()` — test now runs
  - Replaced `waitForSelector(state: 'detached')` with `expect.poll(url)` + `toBeHidden(locator)`
  - Updated the comment block to reference #1715 and document the new assertion contract

Pattern parallels round-2 flake fix in PR #1711 (game-night-create — `transitionDuration` numeric parsing over regex match).

## Test plan

- [x] `pnpm exec tsc --noEmit -p .` → 0 errors
- [x] `pnpm test src/components/features/session-live/__tests__/PauseOverlay.test.tsx` → 16/16 pass (no regression in component contract)
- [x] `pnpm exec playwright test e2e/a11y/session-live.spec.ts --list` → test is enumerated (no longer skipped)
- [ ] Full a11y E2E suite — deferred to release CI on this PR (per task brief, suite is 5-10 min)

## Out of scope

- Other PauseOverlay tests (focus trap, ARIA contract) — already passing
- EndgameDialog ESC-disabled behavior (intentional WCAG deviation, untouched)
- Token/CSS variable migration (DS-16)

Closes #1715

🤖 Generated with [Claude Code](https://claude.com/claude-code)