### PR TITLE
fix(a11y): add --c-session-text dark token for AA on ShareCard toggle

### DIFF
--- a/apps/web/src/components/features/session-summary/SessionShareCard.tsx
+++ b/apps/web/src/components/features/session-summary/SessionShareCard.tsx
@@ -186,7 +186,12 @@ export function SessionShareCard({
                 className={clsx(
                   'px-3 py-1 font-mono text-[10px] font-extrabold uppercase tracking-wide',
                   active
-                    ? 'bg-entity-session/14 text-entity-session'
+                    ? // PR #1721 follow-up: use --c-session-text (AA on dark bg) instead of
+                      // --c-session — the latter resolved to #7d86e8 on dark `--card +
+                      // --c-session/14` overlay (= ~#393a48) for a 3.85:1 contrast (axe AA
+                      // serious fail). The dedicated text token is darker on light themes
+                      // (same as --c-session) and lighter on dark themes (235 85% 85%).
+                      'bg-entity-session/14 text-[hsl(var(--c-session-text))]'
                     : 'bg-transparent text-muted-foreground hover:text-foreground'
                 )}
               >

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -45,6 +45,7 @@
   --c-game-text: 25 95% 32%;
   --c-kb-text:   174 60% 28%; /* Real-C-F: hsl(174 60% 28%) ≈ #1d7268 vs #f7f3ee = 4.95:1 ✅ — replaces hardcoded #4ecdc4 (1.75:1 fail) */
   --c-toolkit-text: 142 70% 24%; /* Real-C-E gamebook: hsl(142 70% 24%) ≈ #0f5d2b vs #e3f0e8 = ~5.6:1 ✅ — replaces text-entity-toolkit (4.16:1 fail on toolkit/12 bg) */
+  --c-session-text: 240 60% 35%; /* PR #1721 follow-up: light theme value = same as --c-session (already 12.22:1 AA on cream). Defined as a token so callers can use --c-session-text consistently across themes; dark theme overrides this to 235 85% 85% for AA on dark surfaces. */
 
   /* ─── Semantic Colors ─── */
   --c-success: 142 70% 45%;
@@ -211,6 +212,7 @@
   --c-game-text: 28 95% 70%;
   --c-kb-text:   174 60% 55%;
   --c-toolkit-text: 142 60% 72%; /* Real-C-E gamebook dark: lighter variant for AA on dark bg */
+  --c-session-text: 235 85% 85%; /* PR #1721 follow-up: lighter variant — hsl(235 85% 85%) ≈ #cdd1f9 hits AA ≥ 4.5:1 on dark `--card` + `--c-session/14` overlay (was --c-session 235 70% 70% ≈ #7d86e8 → 3.85:1 fail). Used by SessionShareCard theme toggle (line 189) and other components rendering text-entity-session text on dark surfaces. */
 
   color-scheme: dark;
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -550,6 +550,7 @@
   --c-game: 25 95% 38%;       /* 4.82:1 ✅ (#587, gate #601, then #807) */
   --c-game-text: 25 95% 32%;  /* 6.14:1 ✅ darker variant when used as text on light bg (#1094 Real-C-B, mirrors design-tokens-canonical.css:45) */
   --c-toolkit-text: 142 70% 24%;  /* ~5.6:1 ✅ darker variant for AA on light bg, paired with bg-entity-toolkit/12 (#1094 Real-C-E gamebook) */
+  --c-session-text: 240 60% 35%;  /* PR #1721 follow-up: light theme value = same as --c-session (already 12.22:1 AA on cream). Dark theme overrides to 235 85% 85% for AA on dark surfaces. */
   --c-player: 262 83% 45%;    /* 8.55:1 ✅ (#807: was L=58%) */
   --c-session: 240 60% 35%;   /* 12.22:1 ✅ (#807: was L=55%) */
   --c-agent: 38 92% 32%;      /* 4.87:1 ✅ (#807: was L=50%) */
@@ -708,6 +709,7 @@
   --c-game: 28 95% 58%;
   --c-game-text: 28 95% 70%;  /* 11.2:1 ✅ lighter variant for AA on dark bg (#1094 Real-C-B, mirrors design-tokens-canonical.css:199) */
   --c-toolkit-text: 142 60% 72%;  /* lighter variant for AA on dark bg (#1094 Real-C-E gamebook) */
+  --c-session-text: 235 85% 85%;  /* PR #1721 follow-up: lighter variant for AA on dark `--card` + `--c-session/14` overlay (was --c-session 235 70% 70% → 3.85:1 fail in SessionShareCard theme toggle). Mirrors design-tokens-canonical.css */
   --c-player: 262 75% 70%;
   --c-session: 235 70% 70%;
   --c-agent: 38 92% 62%;


### PR DESCRIPTION
## Summary

Resolves the dark-theme contrast bug flagged as out-of-scope follow-up in PR #1721 body. The dark-theme `--c-session: 235 70% 70%` (~ `#7d86e8`) on dark `--card` + 14% session overlay (= effective bg `#393a48`) produced a 3.85:1 contrast — axe AA serious fail surfaced during the #1700 release CI investigation on the SessionShareCard theme toggle.

## Pattern

Mirrors the existing `--c-game-text` / `--c-kb-text` / `--c-toolkit-text` tokens already in `design-tokens-canonical.css` (light = AA-safe darker shade, dark = AA-safe lighter shade). Adding `--c-session-text` completes the entity-text coverage matrix.

## Token values

| Theme | Value | Contrast on target bg |
|---|---|---|
| Light | `240 60% 35%` (= same as `--c-session`) | 12.22:1 on `#f7f3ee` cream ✅ |
| Dark  | `235 85% 85%` (~ `#cdd1f9`) | ≥ 4.5:1 on `#393a48` ✅ (was 3.85:1 fail) |

## Scope

Surgical:

| File | Change |
|---|---|
| `apps/web/src/styles/design-tokens-canonical.css` | Add `--c-session-text` in both `:root` (light) and dark theme blocks |
| `apps/web/src/styles/globals.css` | Mirror in the bridge layer (same pattern as `--c-game-text`) |
| `apps/web/src/components/features/session-summary/SessionShareCard.tsx` | Theme toggle radio (line 189) — switch from `text-entity-session` to `text-[hsl(var(--c-session-text))]` with inline rationale comment |

The 22 other components using `text-entity-session` are NOT changed here. Most render the indigo on light surfaces where the existing `--c-session: 240 60% 35%` is already 12:1 — no fix needed. A broader audit of dark-mode usage across those 22 components is a separate concern; file an issue if violations surface.

## Test plan

- [x] `pnpm exec tsc --noEmit -p .` — passes
- [x] `pnpm test SessionShareCard.test.tsx` — 15/15 (no behavior change)
- [x] Husky pre-commit + commitlint — passed
- [ ] CI Dev Fast green on this PR
- [ ] Next release PR's `Frontend - A11y E2E` exercises the ShareCard `?theme=dark` test end-to-end (already re-activated in PR #1721)

## Risks

Low — token addition is additive (no existing callers reference the new `--c-session-text` token name yet, except the single inline class change in SessionShareCard). The single inline class change is the only behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
