### PR TITLE
fix(admin-kb): #1665 reset KB feedback page to 1 on filter/gameId change

### DIFF
--- a/apps/web/src/components/admin/knowledge-base/__tests__/kb-feedback-panel.test.tsx
+++ b/apps/web/src/components/admin/knowledge-base/__tests__/kb-feedback-panel.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * KbFeedbackPanel — Issue #1665 regression coverage.
+ *
+ * Bug: switching the outcome filter (or the gameId prop) used to keep the
+ * stale `page` value, so a user paged past page 1 would land on an empty
+ * page after filtering. Fix resets `page` to 1 in both cases.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetAdminKbFeedback = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    knowledgeBase: {
+      getAdminKbFeedback: (...args: unknown[]) => mockGetAdminKbFeedback(...args),
+    },
+  },
+}));
+
+import { KbFeedbackPanel } from '../kb-feedback-panel';
+
+const GAME_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const GAME_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+function pageOfLastCall(): number | undefined {
+  const last = mockGetAdminKbFeedback.mock.calls.at(-1);
+  return last?.[1]?.page as number | undefined;
+}
+
+function outcomeOfLastCall(): string | undefined {
+  const last = mockGetAdminKbFeedback.mock.calls.at(-1);
+  return last?.[1]?.outcome as string | undefined;
+}
+
+describe('KbFeedbackPanel — #1665 page reset on filter change', () => {
+  beforeEach(() => {
+    mockGetAdminKbFeedback.mockReset();
+    mockGetAdminKbFeedback.mockResolvedValue({
+      items: Array.from({ length: 20 }, (_, i) => ({
+        id: `fb-${i}`,
+        messageId: `msg-${String(i).padStart(8, '0')}`,
+        outcome: 'helpful' as const,
+        comment: null,
+        createdAt: '2026-05-30T12:00:00Z',
+      })),
+      total: 80,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it('resets page to 1 when the outcome filter changes', async () => {
+    const user = userEvent.setup();
+    render(<KbFeedbackPanel gameId={GAME_A} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(mockGetAdminKbFeedback).toHaveBeenCalled());
+
+    // Walk to page 3 — re-find between clicks because re-render can swap refs.
+    await user.click(await screen.findByRole('button', { name: /succ/i }));
+    await waitFor(() => expect(pageOfLastCall()).toBe(2));
+    await user.click(await screen.findByRole('button', { name: /succ/i }));
+    await waitFor(() => expect(pageOfLastCall()).toBe(3));
+
+    // Open the filter and pick "Utili"
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: /^utili$/i }));
+
+    // Bug: would fetch with page=3. Fix: page resets to 1.
+    await waitFor(() => {
+      expect(outcomeOfLastCall()).toBe('helpful');
+      expect(pageOfLastCall()).toBe(1);
+    });
+  });
+
+  it('resets page to 1 when the gameId prop changes', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<KbFeedbackPanel gameId={GAME_A} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(mockGetAdminKbFeedback).toHaveBeenCalled());
+
+    const next = await screen.findByRole('button', { name: /succ/i });
+    await user.click(next);
+    await waitFor(() => expect(pageOfLastCall()).toBe(2));
+
+    rerender(<KbFeedbackPanel gameId={GAME_B} />);
+
+    await waitFor(() => {
+      const lastCall = mockGetAdminKbFeedback.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe(GAME_B);
+      expect(pageOfLastCall()).toBe(1);
+    });
+  });
+});

--- a/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { MessageSquare, ThumbsDown, ThumbsUp } from 'lucide-react';
@@ -19,15 +19,24 @@ interface Props {
   gameId: string;
 }
 
+const OUTCOME_ALL = 'all';
+
 export function KbFeedbackPanel({ gameId }: Props) {
-  const [outcomeFilter, setOutcomeFilter] = useState<string>('');
+  const [outcomeFilter, setOutcomeFilter] = useState<string>(OUTCOME_ALL);
   const [page, setPage] = useState(1);
+
+  // #1665: changing the gameId prop while paged past page 1 used to leave
+  // `page` stale and surface an empty page. Reset whenever gameId changes.
+  useEffect(() => {
+    setPage(1);
+  }, [gameId]);
 
   const { data, isLoading } = useQuery({
     queryKey: ['admin-kb-feedback', gameId, outcomeFilter, page],
     queryFn: () =>
       api.knowledgeBase.getAdminKbFeedback(gameId, {
-        outcome: outcomeFilter ? (outcomeFilter as 'helpful' | 'not_helpful') : undefined,
+        outcome:
+          outcomeFilter === OUTCOME_ALL ? undefined : (outcomeFilter as 'helpful' | 'not_helpful'),
         page,
         pageSize: 20,
       }),
@@ -37,12 +46,19 @@ export function KbFeedbackPanel({ gameId }: Props) {
     <section className="rounded-[10px] border border-border/60 bg-card overflow-hidden">
       {/* Panel header: filter + meta */}
       <div className="flex items-center gap-2.5 border-b border-border/60 bg-background px-3.5 py-2.5">
-        <Select value={outcomeFilter} onValueChange={setOutcomeFilter}>
+        <Select
+          value={outcomeFilter}
+          onValueChange={value => {
+            setOutcomeFilter(value);
+            // #1665: reset to page 1 so the filtered set is not paged past its end.
+            setPage(1);
+          }}
+        >
           <SelectTrigger className="h-7 w-36 text-[11px] font-quicksand font-bold bg-card border-border/60">
             <SelectValue placeholder="Tutti" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">Tutti</SelectItem>
+            <SelectItem value={OUTCOME_ALL}>Tutti</SelectItem>
             <SelectItem value="helpful">Utili</SelectItem>
             <SelectItem value="not_helpful">Non utili</SelectItem>
           </SelectContent>


### PR DESCRIPTION
## Summary

- Fix `KbFeedbackPanel` not resetting `page` to 1 when the outcome filter changes — user paged past page 1 landed on the empty state after switching filter.
- Same reset applied when the `gameId` prop changes.
- Side fix: replace `<SelectItem value="">` with sentinel `value="all"` (Radix forbids empty strings), unlocking the panel under jsdom so regression tests can mount it.

## Test plan

- [x] `pnpm vitest run src/components/admin/knowledge-base/__tests__/kb-feedback-panel.test.tsx` → 2/2 green
- [x] `pnpm vitest run src/components/admin/knowledge-base` → 150/150 green (no regressions in 21 sibling test files)
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm eslint apps/web/src/components/admin/knowledge-base/kb-feedback-panel.tsx` → 0 warnings
- [ ] Manual smoke: open `/admin/knowledge-base/feedback`, page past 1, switch filter, observe page-1 results (not empty state)

## Refs

- Closes #1665
- Discovered during #1664 (F3-FU-3 KB tool-pages re-skin) — pre-existing bug, tracked then, fixed now
- Pattern: matches existing `value="all"` sentinel used in `users/invitations`, `knowledge-base/vectors`, `knowledge-base/documents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)