### PR TITLE
feat(kb): #1686 server-side facets per /knowledge-base/search/global

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQuery.cs
@@ -22,6 +22,21 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GlobalKbSearch;
 /// <param name="MinScore">Minimum hybrid score; results below threshold are discarded.</param>
 /// <param name="UserId">Authenticated user ID (for RBAC resolution).</param>
 /// <param name="Role">Authenticated user role (for RBAC resolution).</param>
+/// <param name="DocType">
+/// Optional facet (Issue #1686, D-1/D-7): list of document types from the allowlist
+/// <c>{ "base", "expansion", "errata", "homerule" }</c> (case-insensitive). When null
+/// or empty, no filter is applied (legacy behaviour, D-3). Hard cap of 10 elements.
+/// </param>
+/// <param name="GameId">
+/// Optional facet (Issue #1686, D-5): single SharedGame.Id to narrow results to.
+/// When provided AND ∈ accessibleGameIds, the search runs only on that game.
+/// When provided AND ∉ accessibleGameIds, returns 200 empty (no info leak).
+/// </param>
+/// <param name="Language">
+/// Optional facet (Issue #1686, D-2): ISO 639-1 code from the allowlist
+/// <c>{ "en", "it", "de", "fr", "es" }</c> (case-insensitive). When null, no
+/// language filter is applied.
+/// </param>
 internal sealed record GlobalKbSearchQuery(
     string Query,
     int Limit,
@@ -29,4 +44,7 @@ internal sealed record GlobalKbSearchQuery(
     SearchMode Mode,
     double MinScore,
     Guid UserId,
-    UserRole Role) : IQuery<GlobalKbSearchResponseDto>;
+    UserRole Role,
+    IReadOnlyList<string>? DocType = null,
+    Guid? GameId = null,
+    string? Language = null) : IQuery<GlobalKbSearchResponseDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
@@ -73,7 +73,14 @@ internal sealed class GlobalKbSearchQueryHandler
         // 3. Search: probe with Limit+1 to detect hasMore (EC-4)
         var probeLimit = query.Limit + 1;
         var rawResults = await _multiGameSearch
-            .SearchAsync(query.Query, accessibleGameIds, probeLimit, query.Mode, query.MinScore, cancellationToken)
+            .SearchAsync(
+                query: query.Query,
+                gameIds: accessibleGameIds,
+                limit: probeLimit,
+                mode: query.Mode,
+                minScore: query.MinScore,
+                documentIds: null, // Issue #1686 Task 4: facets push-down lands in Task 6
+                cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         // 4. Apply cursor filter (keyset pagination: skip items before the cursor position)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
@@ -62,6 +62,23 @@ internal sealed class GlobalKbSearchQueryHandler
             return new GlobalKbSearchResponseDto(Array.Empty<GlobalKbSearchResultDto>(), false, null);
         }
 
+        // Issue #1686 D-5: GameId facet intersects with RBAC.
+        // When provided AND ∉ accessibleGameIds → 200 empty (NOT 403, avoid info leak).
+        // When provided AND ∈ accessibleGameIds → narrow search to that game only.
+        if (query.GameId.HasValue)
+        {
+            if (!accessibleGameIds.Contains(query.GameId.Value))
+            {
+                _logger.LogDebug(
+                    "[GlobalKbSearch] UserId={UserId} requested GameId={GameId} not in accessible set — returning empty (D-5)",
+                    query.UserId, query.GameId.Value);
+                return new GlobalKbSearchResponseDto(Array.Empty<GlobalKbSearchResultDto>(), false, null);
+            }
+
+            // Narrow the accessible set to exactly the requested game.
+            accessibleGameIds = new[] { query.GameId.Value };
+        }
+
         // 2. Decode cursor (best-effort; invalid cursor → start from beginning)
         var cursorScore = double.MaxValue;
         var cursorChunkId = string.Empty;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs
@@ -79,6 +79,31 @@ internal sealed class GlobalKbSearchQueryHandler
             accessibleGameIds = new[] { query.GameId.Value };
         }
 
+        // Issue #1686 D-4: push-down DocType + Language facets BEFORE vector search.
+        // When ANY of these is set, compute an allowlist of PdfDocument.Id values via a
+        // single EF query filtered by (SharedGameId ∈ accessibleGameIds) AND (DocumentType IN docTypes)
+        // AND (Language == language). Forwarded to IMultiGameHybridSearchService.SearchAsync
+        // as the documentIds parameter, which each per-game hybrid search uses to restrict its hits.
+        IReadOnlyList<Guid>? facetDocumentIds = null;
+        var hasDocTypeFacet = query.DocType is { Count: > 0 };
+        var hasLanguageFacet = !string.IsNullOrWhiteSpace(query.Language);
+
+        if (hasDocTypeFacet || hasLanguageFacet)
+        {
+            facetDocumentIds = await BuildFacetDocumentIdsAsync(
+                accessibleGameIds, query.DocType, query.Language, cancellationToken)
+                .ConfigureAwait(false);
+
+            // D-11: empty documentIds → short-circuit to 200 empty (no wasted RPC).
+            if (facetDocumentIds.Count == 0)
+            {
+                _logger.LogDebug(
+                    "[GlobalKbSearch] UserId={UserId} facets matched zero documents — returning empty (D-11)",
+                    query.UserId);
+                return new GlobalKbSearchResponseDto(Array.Empty<GlobalKbSearchResultDto>(), false, null);
+            }
+        }
+
         // 2. Decode cursor (best-effort; invalid cursor → start from beginning)
         var cursorScore = double.MaxValue;
         var cursorChunkId = string.Empty;
@@ -96,7 +121,7 @@ internal sealed class GlobalKbSearchQueryHandler
                 limit: probeLimit,
                 mode: query.Mode,
                 minScore: query.MinScore,
-                documentIds: null, // Issue #1686 Task 4: facets push-down lands in Task 6
+                documentIds: facetDocumentIds, // Issue #1686 D-4: push-down allowlist (null when no facets)
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
@@ -183,6 +208,76 @@ internal sealed class GlobalKbSearchQueryHandler
     }
 
     // ─── Private helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Issue #1686 D-4: computes the document allowlist for the push-down facet filter.
+    /// Single EF query against <c>PdfDocuments</c> filtered by
+    /// <c>SharedGameId ∈ accessibleGameIds</c> AND (when provided)
+    /// <c>DocumentType ∈ docType</c> AND <c>Language == language</c>.
+    /// Values are normalised to lower-case before comparison (D-8).
+    /// </summary>
+    /// <param name="accessibleGameIds">RBAC-resolved game set (post D-5 intersection).</param>
+    /// <param name="docType">Optional list of doc types (case-insensitive). Null/empty = no filter.</param>
+    /// <param name="language">Optional ISO 639-1 language code (case-insensitive). Null = no filter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of matching <c>PdfDocument.Id</c> values (may be empty).</returns>
+    private async Task<IReadOnlyList<Guid>> BuildFacetDocumentIdsAsync(
+        IReadOnlyList<Guid> accessibleGameIds,
+        IReadOnlyList<string>? docType,
+        string? language,
+        CancellationToken cancellationToken)
+    {
+        // Materialise normalised filter values once. The entity already stores DocumentType
+        // and Language in lower-case (see PdfDocumentEntity defaults: "base", "en", …), and the
+        // validator's allowlist match is case-insensitive. So we normalise user input to
+        // lower-case in-memory and compare to entity values WITHOUT EF-side ToLower() — keeping
+        // the SQL provider-agnostic (CA1311-safe).
+        List<string>? docTypesLower = null;
+        if (docType is { Count: > 0 })
+        {
+            docTypesLower = docType
+                .Where(d => !string.IsNullOrWhiteSpace(d))
+                .Select(d => d.Trim().ToLowerInvariant())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            // After dedup, the list might be empty if all entries were whitespace; treat as no filter.
+            if (docTypesLower.Count == 0)
+            {
+                docTypesLower = null;
+            }
+        }
+
+        string? languageLower = null;
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            languageLower = language.Trim().ToLowerInvariant();
+        }
+
+        // Composable query: start with the RBAC invariant, then conditionally narrow.
+        var q = _db.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.SharedGameId.HasValue && accessibleGameIds.Contains(p.SharedGameId.Value));
+
+        if (docTypesLower != null)
+        {
+            // EF translates Contains() → SQL IN (...). Entity values are already lower-case.
+            q = q.Where(p => docTypesLower.Contains(p.DocumentType));
+        }
+
+        if (languageLower != null)
+        {
+            // Entity stores ISO 639-1 in lower-case already.
+            q = q.Where(p => p.Language == languageLower);
+        }
+
+        var ids = await q
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return ids;
+    }
 
     /// <summary>
     /// Executes a single EF query that joins VectorDocument → PdfDocument → SharedGame

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryValidator.cs
@@ -27,6 +27,17 @@ internal sealed class GlobalKbSearchQueryValidator : AbstractValidator<GlobalKbS
             "base", "expansion", "errata", "homerule"
         };
 
+    /// <summary>
+    /// Allowlist for the <see cref="GlobalKbSearchQuery.Language"/> facet (D-2).
+    /// Mirrors <c>PdfDocumentEntity.Language</c> supported ISO 639-1 codes.
+    /// Comparison is case-insensitive (D-8).
+    /// </summary>
+    internal static readonly HashSet<string> AllowedLanguages =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "en", "it", "de", "fr", "es"
+        };
+
     public GlobalKbSearchQueryValidator()
     {
         RuleFor(x => x.Query)
@@ -59,6 +70,14 @@ internal sealed class GlobalKbSearchQueryValidator : AbstractValidator<GlobalKbS
             .WithMessage(
                 $"DocType must be one of: {string.Join(", ", AllowedDocTypes)}.")
             .When(x => x.DocType != null);
+
+        // Issue #1686 — Language facet validation (D-2, D-8, D-12).
+        // When non-null, must be in the allowlist (case-insensitive). Null is "no filter" (D-3).
+        RuleFor(x => x.Language)
+            .Must(IsAllowedLanguage)
+            .WithMessage(
+                $"Language must be one of: {string.Join(", ", AllowedLanguages)}.")
+            .When(x => x.Language != null);
     }
 
     /// <summary>
@@ -73,5 +92,20 @@ internal sealed class GlobalKbSearchQueryValidator : AbstractValidator<GlobalKbS
         }
 
         return AllowedDocTypes.Contains(value.Trim());
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="value"/> (after trimming) is in the
+    /// <see cref="AllowedLanguages"/> allowlist. Case-insensitive (D-8).
+    /// Empty / whitespace returns <c>false</c> (D-12 actionable error).
+    /// </summary>
+    private static bool IsAllowedLanguage(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return AllowedLanguages.Contains(value.Trim());
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryValidator.cs
@@ -6,11 +6,26 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.GlobalKbSearch;
 /// Validates <see cref="GlobalKbSearchQuery"/> before the handler runs.
 /// Registered via FluentValidation pipeline behaviour (same pattern as EstimateAgentCostQueryValidator).
 /// Issue #1661: cross-game KB search (Task 4).
+/// Issue #1686: facet validation (DocType allowlist, Language allowlist, list-length cap).
 /// </summary>
 internal sealed class GlobalKbSearchQueryValidator : AbstractValidator<GlobalKbSearchQuery>
 {
     /// <summary>Hard cap on results per page (EC-7 — avoids excessive cross-game load).</summary>
     internal const int HardCapLimit = 50;
+
+    /// <summary>Maximum number of elements in the DocType facet list (D-7).</summary>
+    internal const int DocTypeListCap = 10;
+
+    /// <summary>
+    /// Allowlist for the <see cref="GlobalKbSearchQuery.DocType"/> facet (D-1).
+    /// Mirrors <c>PdfDocumentEntity.DocumentType</c> defaults: base, expansion, errata, homerule.
+    /// Comparison is case-insensitive — the HashSet was built with <see cref="StringComparer.OrdinalIgnoreCase"/>.
+    /// </summary>
+    internal static readonly HashSet<string> AllowedDocTypes =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "base", "expansion", "errata", "homerule"
+        };
 
     public GlobalKbSearchQueryValidator()
     {
@@ -29,5 +44,34 @@ internal sealed class GlobalKbSearchQueryValidator : AbstractValidator<GlobalKbS
         RuleFor(x => x.UserId)
             .NotEqual(Guid.Empty)
             .WithMessage("UserId must be a valid GUID.");
+
+        // Issue #1686 — DocType facet validation (D-1, D-7, D-8, D-12).
+        // List-level cap (D-7): when non-null, max 10 entries.
+        RuleFor(x => x.DocType)
+            .Must(list => list == null || list.Count <= DocTypeListCap)
+            .WithMessage($"DocType must contain at most {DocTypeListCap} entries.");
+
+        // Per-element allowlist (D-1, D-8). RuleForEach runs only when list is non-null.
+        RuleForEach(x => x.DocType)
+            .NotEmpty()
+            .WithMessage("DocType entries must not be empty or whitespace.")
+            .Must(IsAllowedDocType)
+            .WithMessage(
+                $"DocType must be one of: {string.Join(", ", AllowedDocTypes)}.")
+            .When(x => x.DocType != null);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="value"/> (after trimming) is in the
+    /// <see cref="AllowedDocTypes"/> allowlist. Case-insensitive (D-8).
+    /// </summary>
+    private static bool IsAllowedDocType(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return AllowedDocTypes.Contains(value.Trim());
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IMultiGameHybridSearchService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IMultiGameHybridSearchService.cs
@@ -30,6 +30,12 @@ internal interface IMultiGameHybridSearchService
     /// <param name="limit">Maximum number of results to return (hard cap, EC-7).</param>
     /// <param name="mode">Search mode forwarded to each per-game call.</param>
     /// <param name="minScore">Minimum hybrid score; results below this threshold are discarded.</param>
+    /// <param name="documentIds">
+    /// Optional document allowlist (Issue #1686, D-4). When non-null, each per-game search
+    /// restricts its hit set to <c>PdfDocumentEntity.Id</c> values in this list. Forwarded to
+    /// <see cref="IHybridSearchService.SearchAsync"/>'s <c>documentIds</c> parameter.
+    /// When null, no document filter is applied (legacy behaviour, D-3).
+    /// </param>
     /// <param name="cancellationToken">Propagated to all parallel per-game calls (EC-3 resource safety).</param>
     /// <returns>
     /// Ranked list of <see cref="MultiGameSearchResultItem"/> ordered by
@@ -41,6 +47,7 @@ internal interface IMultiGameHybridSearchService
         int limit,
         SearchMode mode = SearchMode.Hybrid,
         double minScore = 0.0,
+        IReadOnlyList<Guid>? documentIds = null,
         CancellationToken cancellationToken = default);
 }
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
@@ -39,6 +39,7 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
         int limit,
         SearchMode mode = SearchMode.Hybrid,
         double minScore = 0.0,
+        IReadOnlyList<Guid>? documentIds = null,
         CancellationToken cancellationToken = default)
     {
         // EC-1: no accessible games → return empty immediately
@@ -46,8 +47,12 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
             return Array.Empty<MultiGameSearchResultItem>();
 
         _logger.LogInformation(
-            "MultiGameHybridSearch: query='{Query}', gameCount={GameCount}, limit={Limit}, mode={Mode}, minScore={MinScore}",
-            query, gameIds.Count, limit, mode, minScore);
+            "MultiGameHybridSearch: query='{Query}', gameCount={GameCount}, limit={Limit}, mode={Mode}, minScore={MinScore}, documentIdsCount={DocCount}",
+            query, gameIds.Count, limit, mode, minScore, documentIds?.Count);
+
+        // Convert IReadOnlyList → List once (interface requires List<Guid>? on the per-game service).
+        // Materialise outside the per-game loop so all parallel calls share the same instance.
+        var documentIdsList = documentIds is null ? null : new List<Guid>(documentIds);
 
         // Step 1: Launch parallel per-game searches.
         // We request 'limit' results per game so each game contributes enough candidates
@@ -56,7 +61,7 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
         var perGameLimit = Math.Min(Math.Max(limit, 1), 50);
 
         var tasks = gameIds
-            .Select(gameId => SearchGameSafeAsync(query, gameId, perGameLimit, mode, cancellationToken))
+            .Select(gameId => SearchGameSafeAsync(query, gameId, perGameLimit, mode, documentIdsList, cancellationToken))
             .ToList();
 
         // Task.WhenAll guarantees parallel execution (all tasks start before any is awaited).
@@ -102,12 +107,15 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
     /// <summary>
     /// Issues a single-game search, catching and logging any exception so that
     /// one failing game does not abort the entire cross-game query (EC-2 resilience).
+    /// The <paramref name="documentIds"/> allowlist (Issue #1686) restricts the per-game
+    /// hit set to a subset of PDF documents; <c>null</c> = no document filter.
     /// </summary>
     private async Task<(Guid GameId, List<HybridSearchResult> Results)> SearchGameSafeAsync(
         string query,
         Guid gameId,
         int limit,
         SearchMode mode,
+        List<Guid>? documentIds,
         CancellationToken cancellationToken)
     {
         try
@@ -117,7 +125,7 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
                 gameId,
                 mode,
                 limit,
-                documentIds: null,
+                documentIds: documentIds,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return (gameId, results);

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -125,7 +125,10 @@ internal static class KnowledgeBaseEndpoints
             Mode: request.Mode ?? SearchMode.Hybrid,
             MinScore: request.MinScore ?? 0.0,
             UserId: userId,
-            Role: userRole);
+            Role: userRole,
+            DocType: request.DocType,
+            GameId: request.GameId,
+            Language: request.Language);
 
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
@@ -1410,13 +1413,36 @@ internal sealed record SearchKbChunksRequest(string Query, int? Skip, int? Take)
 /// <summary>
 /// Request body for POST /api/v1/knowledge-base/search/global (cross-game search, Issue #1661).
 /// User/Role are NOT in the request — they are resolved from the authenticated session.
+/// Issue #1686 added optional facet fields (DocType, GameId, Language).
 /// </summary>
+/// <param name="Query">Natural-language search query (required, max 500 chars).</param>
+/// <param name="Limit">Max results per page (default 20, hard cap 50).</param>
+/// <param name="Cursor">Opaque pagination cursor from a previous response.</param>
+/// <param name="Mode">Search mode (Hybrid by default).</param>
+/// <param name="MinScore">Minimum hybrid score; results below threshold are discarded.</param>
+/// <param name="DocType">
+/// Optional facet (Issue #1686, D-6): list of canonical <c>DocumentCategory</c> values from the allowlist
+/// <c>{ "Rulebook", "Expansion", "Errata", "QuickStart", "Reference", "PlayerAid", "Other" }</c>
+/// (case-insensitive). Hard cap of 10 elements. Null or empty = no filter (D-3 byte-identical legacy).
+/// </param>
+/// <param name="GameId">
+/// Optional facet (Issue #1686, D-5): single SharedGame.Id to narrow results to.
+/// When provided AND accessible, search runs only on that game.
+/// When provided AND NOT accessible, returns 200 empty (no info leak).
+/// </param>
+/// <param name="Language">
+/// Optional facet (Issue #1686, D-2): ISO 639-1 code from the allowlist
+/// <c>{ "en", "it", "de", "fr", "es" }</c> (case-insensitive). Null = no filter.
+/// </param>
 internal sealed record GlobalKbSearchRequest(
     string Query,
     int Limit = 20,
     string? Cursor = null,
     SearchMode? Mode = null,
-    double? MinScore = null);
+    double? MinScore = null,
+    IReadOnlyList<string>? DocType = null,
+    Guid? GameId = null,
+    string? Language = null);
 
 /// <summary>
 /// Request body for POST /api/v1/knowledge-base/ask/global (cross-game SSE ask, Issue #1661 PR-2).

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/CrossGameStreamQaQueryHandlerTests.cs
@@ -72,6 +72,7 @@ public sealed class CrossGameStreamQaQueryHandlerTests
         await _searchService.DidNotReceive().SearchAsync(
             Arg.Any<string>(), Arg.Any<IReadOnlyList<Guid>>(),
             Arg.Any<int>(), Arg.Any<SearchMode>(), Arg.Any<double>(),
+            Arg.Any<IReadOnlyList<Guid>?>(),
             Arg.Any<CancellationToken>());
 
         // Complete event answer text should indicate no context
@@ -186,6 +187,7 @@ public sealed class CrossGameStreamQaQueryHandlerTests
         _searchService
             .SearchAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<Guid>>(),
                          Arg.Any<int>(), Arg.Any<SearchMode>(), Arg.Any<double>(),
+                         Arg.Any<IReadOnlyList<Guid>?>(),
                          Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("Vector store unavailable"));
 
@@ -256,6 +258,7 @@ public sealed class CrossGameStreamQaQueryHandlerTests
         _searchService
             .SearchAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<Guid>>(),
                          Arg.Any<int>(), Arg.Any<SearchMode>(), Arg.Any<double>(),
+                         Arg.Any<IReadOnlyList<Guid>?>(),
                          Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<MultiGameSearchResultItem>)new[]
             {
@@ -277,6 +280,7 @@ public sealed class CrossGameStreamQaQueryHandlerTests
             Arg.Is<IReadOnlyList<Guid>>(ids =>
                 ids.Count == 1 && ids.Contains(GameId1) && !ids.Contains(GameId2)),
             Arg.Any<int>(), Arg.Any<SearchMode>(), Arg.Any<double>(),
+            Arg.Any<IReadOnlyList<Guid>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -291,6 +295,7 @@ public sealed class CrossGameStreamQaQueryHandlerTests
         _searchService
             .SearchAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<Guid>>(),
                          Arg.Any<int>(), Arg.Any<SearchMode>(), Arg.Any<double>(),
+                         Arg.Any<IReadOnlyList<Guid>?>(),
                          Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<MultiGameSearchResultItem>)new[]
             {

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
@@ -83,6 +83,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 It.IsAny<int>(),
                 SearchMode.Hybrid,
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem>());
 
@@ -101,6 +102,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 It.IsAny<int>(),
                 SearchMode.Hybrid,
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -157,7 +159,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         _searchMock
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
-                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem> { searchResult });
 
         var query = BuildQuery(userId, "test", limit: 10);
@@ -196,7 +198,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         _searchMock
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
-                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem> { orphanResult });
 
         var query = BuildQuery(userId, "test", limit: 10);
@@ -259,6 +261,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 limit + 1, // handler must call with limit+1
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(searchResults);
 
@@ -310,7 +313,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         _searchMock
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
-                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem>
             {
                 BuildSearchResult(gameId, pdfId.ToString(), pdfId.ToString(), chunkIndex: 0, score: 0.8f)
@@ -371,7 +374,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         _searchMock
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), limit + 1,
-                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var query = BuildQuery(userId, "test", limit: limit);
@@ -415,6 +418,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 It.IsAny<int>(),
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem>());
 
@@ -432,6 +436,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 It.IsAny<int>(),
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
 
@@ -444,6 +449,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
                 It.IsAny<int>(),
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -534,7 +540,7 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         _searchMock
             .Setup(s => s.SearchAsync(
                 It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
-                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SearchMode>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MultiGameSearchResultItem>
             {
                 BuildSearchResult(gameId, pdfId.ToString(), pdfId.ToString(), chunkIndex: 0, score: 0.8f)
@@ -551,6 +557,121 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         response.Results[0].HeadingPath.Should().BeNull();
     }
 
+    // ─── Issue #1686 Task 5: GameId facet intersects with RBAC ──────────────────
+
+    [Fact]
+    public async Task GameId_InAccessibleSet_NarrowsSearchToThatGameOnly()
+    {
+        // Arrange — accessible = [A, B, C]; request GameId = B → only B is searched
+        var userId = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+        var gameC = Guid.NewGuid();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameA, gameB, gameC });
+
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<Guid>>(),
+                It.IsAny<int>(),
+                It.IsAny<SearchMode>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        var query = BuildQuery(userId, "test", limit: 10, gameId: gameB);
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — search called with ONLY gameB (intersection of accessible and requested)
+        _searchMock.Verify(
+            s => s.SearchAsync(
+                It.IsAny<string>(),
+                It.Is<IReadOnlyList<Guid>>(ids => ids.Count == 1 && ids.Contains(gameB)),
+                It.IsAny<int>(),
+                It.IsAny<SearchMode>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GameId_NotInAccessibleSet_ReturnsEmpty_NoCallToSearch()
+    {
+        // Arrange — accessible = [A, B]; request GameId = rogueC → 200 empty, NOT 403
+        var userId = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+        var rogueC = Guid.NewGuid();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameA, gameB });
+
+        var query = BuildQuery(userId, "test", limit: 10, gameId: rogueC);
+        var sut = CreateSut();
+
+        // Act
+        var response = await sut.Handle(query, CancellationToken.None);
+
+        // Assert — empty response, search NEVER called (RBAC-safe: no info leak D-5)
+        response.Results.Should().BeEmpty();
+        response.HasMore.Should().BeFalse();
+        response.NextCursor.Should().BeNull();
+        _searchMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GameId_Null_KeepsAllAccessibleGames_BackwardCompatible()
+    {
+        // Arrange — accessible = [A, B]; gameId = null → search receives all accessible
+        var userId = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameA, gameB });
+
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<Guid>>(),
+                It.IsAny<int>(),
+                It.IsAny<SearchMode>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        // Default BuildQuery has gameId = null
+        var query = BuildQuery(userId, "test", limit: 10);
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — search receives both accessible games (legacy D-3 behaviour)
+        _searchMock.Verify(
+            s => s.SearchAsync(
+                It.IsAny<string>(),
+                It.Is<IReadOnlyList<Guid>>(ids =>
+                    ids.Count == 2 && ids.Contains(gameA) && ids.Contains(gameB)),
+                It.IsAny<int>(),
+                It.IsAny<SearchMode>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────────
 
     private static GlobalKbSearchQuery BuildQuery(
@@ -558,7 +679,10 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         string query,
         int limit = 10,
         string? cursor = null,
-        SearchMode mode = SearchMode.Hybrid) =>
+        SearchMode mode = SearchMode.Hybrid,
+        IReadOnlyList<string>? docType = null,
+        Guid? gameId = null,
+        string? language = null) =>
         new(
             Query: query,
             Limit: limit,
@@ -566,7 +690,10 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
             Mode: mode,
             MinScore: 0.0,
             UserId: userId,
-            Role: UserRole.User);
+            Role: UserRole.User,
+            DocType: docType,
+            GameId: gameId,
+            Language: language);
 
     private static MultiGameSearchResultItem BuildSearchResult(
         Guid gameId,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
@@ -864,6 +864,84 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
         capturedDocIds.Should().BeNull();
     }
 
+    // ─── Issue #1686 Task 7: empty documentIds short-circuit (D-11) ────────────
+
+    [Fact]
+    public async Task DocTypeFacet_MatchesZeroDocs_ShortCircuitsToEmpty_NoCallToSearch()
+    {
+        // Arrange — game has only "base" PDFs; request DocType=["errata"] → no matches
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = gameId, Title = "Empty Facet Game",
+            IsDeleted = false, IsRagPublic = true,
+            CreatedAt = DateTime.UtcNow, CreatedBy = Guid.NewGuid()
+        };
+        _db.SharedGames.Add(sharedGame);
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId, FileName = "b.pdf", FilePath = "/f/b",
+            UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en"
+        });
+        await _db.SaveChangesAsync();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        var query = BuildQuery(userId, "test", limit: 10, docType: new[] { "errata" });
+        var sut = CreateSut();
+
+        // Act
+        var response = await sut.Handle(query, CancellationToken.None);
+
+        // Assert — empty response, search NEVER called (D-11 short-circuit)
+        response.Results.Should().BeEmpty();
+        response.HasMore.Should().BeFalse();
+        response.NextCursor.Should().BeNull();
+        _searchMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LanguageFacet_MatchesZeroDocs_ShortCircuitsToEmpty()
+    {
+        // Arrange — game has only "en" PDFs; request Language="de" → no matches
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = gameId, Title = "Lang Empty Game",
+            IsDeleted = false, IsRagPublic = true,
+            CreatedAt = DateTime.UtcNow, CreatedBy = Guid.NewGuid()
+        };
+        _db.SharedGames.Add(sharedGame);
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId, FileName = "e.pdf", FilePath = "/f/e",
+            UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en"
+        });
+        await _db.SaveChangesAsync();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        var query = BuildQuery(userId, "test", limit: 10, language: "de");
+        var sut = CreateSut();
+
+        // Act
+        var response = await sut.Handle(query, CancellationToken.None);
+
+        // Assert — D-11 short-circuit
+        response.Results.Should().BeEmpty();
+        _searchMock.VerifyNoOtherCalls();
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────────
 
     private static GlobalKbSearchQuery BuildQuery(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs
@@ -672,6 +672,198 @@ public sealed class GlobalKbSearchQueryHandlerTests : IDisposable
             Times.Once);
     }
 
+    // ─── Issue #1686 Task 6: DocType + Language push-down via EF pre-filter ────
+
+    [Fact]
+    public async Task DocType_FacetFiltersPdfDocsBeforeSearch()
+    {
+        // Arrange — 3 PDFs in one game: 2 "base", 1 "expansion"; request DocType=["base"]
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var baseDoc1 = Guid.NewGuid();
+        var baseDoc2 = Guid.NewGuid();
+        var expansionDoc = Guid.NewGuid();
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = gameId, Title = "DocType Facet Game",
+            IsDeleted = false, IsRagPublic = true,
+            CreatedAt = DateTime.UtcNow, CreatedBy = Guid.NewGuid()
+        };
+        _db.SharedGames.Add(sharedGame);
+        _db.PdfDocuments.AddRange(
+            new PdfDocumentEntity { Id = baseDoc1, FileName = "b1.pdf", FilePath = "/f/b1", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = baseDoc2, FileName = "b2.pdf", FilePath = "/f/b2", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = expansionDoc, FileName = "e.pdf", FilePath = "/f/e", UploadedByUserId = userId, DocumentType = "expansion", SharedGameId = gameId, Language = "en" }
+        );
+        await _db.SaveChangesAsync();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        IReadOnlyList<Guid>? capturedDocIds = null;
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
+                It.IsAny<SearchMode>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, _, _, _, _, docIds, _) => capturedDocIds = docIds)
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        var query = BuildQuery(userId, "test", limit: 10, docType: new[] { "base" });
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — only the 2 "base" PDF IDs reached the search (NOT the expansion)
+        capturedDocIds.Should().NotBeNull();
+        capturedDocIds!.Should().HaveCount(2);
+        capturedDocIds.Should().Contain(baseDoc1).And.Contain(baseDoc2);
+        capturedDocIds.Should().NotContain(expansionDoc);
+    }
+
+    [Fact]
+    public async Task Language_FacetFiltersPdfDocsBeforeSearch()
+    {
+        // Arrange — 3 PDFs: 2 "en", 1 "it"; request Language="en"
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var enDoc1 = Guid.NewGuid();
+        var enDoc2 = Guid.NewGuid();
+        var itDoc = Guid.NewGuid();
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = gameId, Title = "Lang Facet Game",
+            IsDeleted = false, IsRagPublic = true,
+            CreatedAt = DateTime.UtcNow, CreatedBy = Guid.NewGuid()
+        };
+        _db.SharedGames.Add(sharedGame);
+        _db.PdfDocuments.AddRange(
+            new PdfDocumentEntity { Id = enDoc1, FileName = "e1.pdf", FilePath = "/f/e1", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = enDoc2, FileName = "e2.pdf", FilePath = "/f/e2", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = itDoc, FileName = "i.pdf", FilePath = "/f/i", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "it" }
+        );
+        await _db.SaveChangesAsync();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        IReadOnlyList<Guid>? capturedDocIds = null;
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
+                It.IsAny<SearchMode>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, _, _, _, _, docIds, _) => capturedDocIds = docIds)
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        var query = BuildQuery(userId, "test", limit: 10, language: "en");
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — only the 2 "en" PDF IDs reached the search
+        capturedDocIds.Should().NotBeNull();
+        capturedDocIds!.Should().HaveCount(2);
+        capturedDocIds.Should().Contain(enDoc1).And.Contain(enDoc2);
+        capturedDocIds.Should().NotContain(itDoc);
+    }
+
+    [Fact]
+    public async Task DocTypeAndLanguage_BothFacetsAppliedAsAnd()
+    {
+        // Arrange — 4 PDFs: (base,en), (base,it), (expansion,en), (expansion,it)
+        // Request DocType=["base"] AND Language="en" → only first PDF survives
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var match = Guid.NewGuid();
+        var baseIt = Guid.NewGuid();
+        var expEn = Guid.NewGuid();
+        var expIt = Guid.NewGuid();
+
+        var sharedGame = new SharedGameEntity
+        {
+            Id = gameId, Title = "Combined Facet Game",
+            IsDeleted = false, IsRagPublic = true,
+            CreatedAt = DateTime.UtcNow, CreatedBy = Guid.NewGuid()
+        };
+        _db.SharedGames.Add(sharedGame);
+        _db.PdfDocuments.AddRange(
+            new PdfDocumentEntity { Id = match, FileName = "m.pdf", FilePath = "/f/m", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = baseIt, FileName = "bi.pdf", FilePath = "/f/bi", UploadedByUserId = userId, DocumentType = "base", SharedGameId = gameId, Language = "it" },
+            new PdfDocumentEntity { Id = expEn, FileName = "ee.pdf", FilePath = "/f/ee", UploadedByUserId = userId, DocumentType = "expansion", SharedGameId = gameId, Language = "en" },
+            new PdfDocumentEntity { Id = expIt, FileName = "ei.pdf", FilePath = "/f/ei", UploadedByUserId = userId, DocumentType = "expansion", SharedGameId = gameId, Language = "it" }
+        );
+        await _db.SaveChangesAsync();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        IReadOnlyList<Guid>? capturedDocIds = null;
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
+                It.IsAny<SearchMode>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, _, _, _, _, docIds, _) => capturedDocIds = docIds)
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        var query = BuildQuery(userId, "test", limit: 10, docType: new[] { "base" }, language: "en");
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — exactly one PDF matches both filters (D-4 AND semantics)
+        capturedDocIds.Should().NotBeNull();
+        capturedDocIds!.Should().ContainSingle().Which.Should().Be(match);
+    }
+
+    [Fact]
+    public async Task NoFacets_PassesNullDocumentIdsToSearch_BackwardCompatible()
+    {
+        // Arrange — when no facets are present, search receives documentIds=null (legacy D-3)
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _ragAccessMock
+            .Setup(s => s.GetAccessibleGameIdsAsync(userId, UserRole.User, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { gameId });
+
+        IReadOnlyList<Guid>? capturedDocIds = new[] { Guid.NewGuid() }; // sentinel - must be overwritten to null
+        _searchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<int>(),
+                It.IsAny<SearchMode>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, _, _, _, _, docIds, _) => capturedDocIds = docIds)
+            .ReturnsAsync(new List<MultiGameSearchResultItem>());
+
+        // Default BuildQuery has docType = null, language = null
+        var query = BuildQuery(userId, "test", limit: 10);
+        var sut = CreateSut();
+
+        // Act
+        await sut.Handle(query, CancellationToken.None);
+
+        // Assert — search received null documentIds (legacy path D-3)
+        capturedDocIds.Should().BeNull();
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────────
 
     private static GlobalKbSearchQuery BuildQuery(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryValidatorTests.cs
@@ -151,4 +151,72 @@ public sealed class GlobalKbSearchQueryValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Query");
     }
+
+    // ─── Language: null passes ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task NullLanguage_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: null));
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ─── Language: allowlist values pass ─────────────────────────────────────
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("it")]
+    [InlineData("de")]
+    [InlineData("fr")]
+    [InlineData("es")]
+    public async Task LanguageAllowlistValue_Passes(string allowedCode)
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: allowedCode));
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LanguageMixedCase_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: "IT"));
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ─── Language: unknown / empty / whitespace fail ─────────────────────────
+
+    [Fact]
+    public async Task LanguageUnknown_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: "xx"));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "Language");
+        // D-12: error message enumerates allowed values
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage.Contains("en", StringComparison.OrdinalIgnoreCase) &&
+            e.ErrorMessage.Contains("it", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task LanguageEmptyString_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: string.Empty));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Language");
+    }
+
+    [Fact]
+    public async Task LanguageWhitespace_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(language: "   "));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Language");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryValidatorTests.cs
@@ -1,0 +1,154 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GlobalKbSearch;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GlobalKbSearchQueryValidator"/> — facet validation.
+/// Issue #1686 (Task 1+2): DocType (list) and Language (single string) allowlist enforcement.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GlobalKbSearchQueryValidatorTests
+{
+    private static readonly Guid AnyUserId = Guid.NewGuid();
+
+    private static GlobalKbSearchQuery BuildQuery(
+        IReadOnlyList<string>? docType = null,
+        Guid? gameId = null,
+        string? language = null,
+        string query = "test query",
+        int limit = 10) =>
+        new(
+            Query: query,
+            Limit: limit,
+            Cursor: null,
+            Mode: SearchMode.Hybrid,
+            MinScore: 0.0,
+            UserId: AnyUserId,
+            Role: UserRole.User,
+            DocType: docType,
+            GameId: gameId,
+            Language: language);
+
+    // ─── DocType: null and empty list treated as "no filter" ────────────────
+
+    [Fact]
+    public async Task NullDocType_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(docType: null));
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EmptyDocTypeList_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(docType: Array.Empty<string>()));
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ─── DocType: allowlist values pass ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("base")]
+    [InlineData("expansion")]
+    [InlineData("errata")]
+    [InlineData("homerule")]
+    public async Task DocTypeAllowlistValue_Passes(string allowedValue)
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(BuildQuery(docType: new[] { allowedValue }));
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DocTypeWithMixedCase_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(
+            BuildQuery(docType: new[] { "Base", "EXPANSION", "Errata" }));
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ─── DocType: unknown values fail with actionable message ────────────────
+
+    [Fact]
+    public async Task DocTypeWithUnknownValue_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(
+            BuildQuery(docType: new[] { "unknown-type" }));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName.Contains("DocType", StringComparison.Ordinal));
+        // D-12: error message enumerates allowed values
+        result.Errors.Should().Contain(e =>
+            e.ErrorMessage.Contains("base", StringComparison.OrdinalIgnoreCase) &&
+            e.ErrorMessage.Contains("expansion", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task DocTypeWithEmptyStringElement_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(
+            BuildQuery(docType: new[] { "base", string.Empty }));
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DocTypeWithWhitespaceElement_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(
+            BuildQuery(docType: new[] { "base", "   " }));
+        result.IsValid.Should().BeFalse();
+    }
+
+    // ─── DocType: hard cap on list length (D-7) ──────────────────────────────
+
+    [Fact]
+    public async Task DocTypeListAboveCap_FailsValidation()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        // Cap = 10; pass 11 identical valid values to exceed length while keeping each valid
+        var oversized = Enumerable.Repeat("base", 11).ToArray();
+
+        var result = await validator.ValidateAsync(BuildQuery(docType: oversized));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName.Contains("DocType", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DocTypeListAtCap_Passes()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        // Cap = 10; pass exactly 10 entries (allowlist has 4, repetitions are accepted by allowlist)
+        var atCap = Enumerable.Repeat("base", 10).ToArray();
+
+        var result = await validator.ValidateAsync(BuildQuery(docType: atCap));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ─── Combined: existing rules still apply alongside facets ───────────────
+
+    [Fact]
+    public async Task EmptyQueryWithValidDocType_StillFailsOnQuery()
+    {
+        var validator = new GlobalKbSearchQueryValidator();
+        var result = await validator.ValidateAsync(
+            BuildQuery(query: string.Empty, docType: new[] { "base" }));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Query");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
@@ -355,6 +355,76 @@ public class MultiGameHybridSearchServiceTests
     }
 
     // ---------------------------------------------------------------------------
+    // Issue #1686 — documentIds parameter is forwarded to each per-game IHybridSearchService call
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DocumentIds_PassedThrough_ToPerGameSearch()
+    {
+        // Arrange
+        var gameId1 = Guid.NewGuid();
+        var gameId2 = Guid.NewGuid();
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        var documentIds = new List<Guid> { docA, docB };
+
+        // Setup with explicit documentIds match — both per-game calls receive the same allowlist
+        _hybridSearchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(),
+                It.IsAny<SearchMode>(), It.IsAny<int>(),
+                It.Is<List<Guid>?>(d => d != null && d.SequenceEqual(documentIds)),
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>());
+
+        var sut = CreateSut();
+
+        // Act — call with documentIds allowlist
+        await sut.SearchAsync(
+            "test",
+            new[] { gameId1, gameId2 },
+            limit: 10,
+            mode: SearchMode.Hybrid,
+            minScore: 0.0,
+            documentIds: documentIds,
+            cancellationToken: CancellationToken.None);
+
+        // Assert — each game received the same documentIds allowlist
+        _hybridSearchMock.Verify(
+            s => s.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(),
+                It.IsAny<SearchMode>(), It.IsAny<int>(),
+                It.Is<List<Guid>?>(d => d != null && d.Count == 2 && d.Contains(docA) && d.Contains(docB)),
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task DocumentIds_Null_ForwardedAsNull_BackwardCompatible()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        SetupHybridSearchForGame(gameId, count: 1, baseScore: 0.8f);
+
+        var sut = CreateSut();
+
+        // Act — call WITHOUT documentIds (legacy path, default null)
+        await sut.SearchAsync("test", new[] { gameId }, limit: 10);
+
+        // Assert — per-game search receives documentIds=null (preserves legacy behaviour, D-3)
+        _hybridSearchMock.Verify(
+            s => s.SearchAsync(
+                It.IsAny<string>(), gameId,
+                It.IsAny<SearchMode>(), It.IsAny<int>(),
+                null,  // explicit null — backward-compatible default
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ---------------------------------------------------------------------------
     // Helper methods
     // ---------------------------------------------------------------------------
 

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbAskStreamEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbAskStreamEndpointTests.cs
@@ -475,15 +475,17 @@ public sealed class GlobalKbAskStreamEndpointTests : IAsyncLifetime
                 It.IsAny<int>(),
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, CancellationToken>(
-                (_, gameIds, _, _, _, _) => _capturedSearchGameIds.Add(gameIds))
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, gameIds, _, _, _, _, _) => _capturedSearchGameIds.Add(gameIds))
             .ReturnsAsync((
                 string _,
                 IReadOnlyList<Guid> gameIds,
                 int limit,
                 SearchMode mode,
                 double _,
+                IReadOnlyList<Guid>? _,
                 CancellationToken _) =>
             {
                 var results = new List<MultiGameSearchResultItem>();

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
@@ -287,6 +287,118 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
         }
     }
 
+    // ── Issue #1686: facet validation + push-down end-to-end ────────────────
+
+    /// <summary>
+    /// Issue #1686 — request with unknown DocType value → 422 UnprocessableEntity
+    /// (validator allowlist enforced + middleware maps FluentValidation to 422).
+    /// </summary>
+    [Fact]
+    public async Task Returns_422_when_DocType_unknown()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            Endpoint,
+            _aliceToken,
+            new { Query = "rules", Limit = 5, DocType = new[] { "banana" } });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    /// <summary>
+    /// Issue #1686 — request with unknown Language → 422 UnprocessableEntity.
+    /// </summary>
+    [Fact]
+    public async Task Returns_422_when_Language_unknown()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            Endpoint,
+            _aliceToken,
+            new { Query = "rules", Limit = 5, Language = "xx" });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    /// <summary>
+    /// Issue #1686 — request with DocType list above the 10-element cap → 422.
+    /// </summary>
+    [Fact]
+    public async Task Returns_422_when_DocType_list_above_cap()
+    {
+        var oversized = Enumerable.Repeat("base", 11).ToArray();
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            Endpoint,
+            _aliceToken,
+            new { Query = "rules", Limit = 5, DocType = oversized });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    /// <summary>
+    /// Issue #1686 D-5 — requesting a GameId not in accessible set returns 200 empty
+    /// (NOT 403 — avoids info leak).
+    /// </summary>
+    [Fact]
+    public async Task GameId_OfPrivateUnowned_Returns_200_Empty()
+    {
+        // Alice does NOT own gameBobOwned. RBAC sees public + gameAliceOwned, NOT gameBobOwned.
+        // Requesting GameId = gameBobOwned must return 200 empty per D-5.
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            Endpoint,
+            _aliceToken,
+            new { Query = "rules", Limit = 5, GameId = _gameBobOwnedId });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<GlobalKbSearchResponseDto>(
+            TestCancellationToken);
+
+        payload.Should().NotBeNull();
+        payload!.Results.Should().BeEmpty();
+        payload.HasMore.Should().BeFalse();
+        payload.NextCursor.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Issue #1686 D-5 — requesting a GameId IS accessible narrows the search.
+    /// We verify via the capturedGameIds bag that only the requested GameId
+    /// was passed to the vector search layer.
+    /// </summary>
+    [Fact]
+    public async Task GameId_OfAccessibleGame_NarrowsSearchToThatGame()
+    {
+        _capturedGameIds.Clear();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            Endpoint,
+            _aliceToken,
+            new { Query = "rules", Limit = 5, GameId = _gameAliceOwnedId });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Each capture must contain ONLY the requested game (search invoked with [gameAliceOwned] singleton).
+        _capturedGameIds.Should().NotBeEmpty();
+        _capturedGameIds.Should().AllSatisfy(ids =>
+        {
+            ids.Should().ContainSingle();
+            ids.Should().Contain(_gameAliceOwnedId);
+        });
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs
@@ -444,9 +444,10 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
                 It.IsAny<int>(),
                 It.IsAny<SearchMode>(),
                 It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, CancellationToken>(
-                (_, gameIds, _, _, _, _) =>
+            .Callback<string, IReadOnlyList<Guid>, int, SearchMode, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, gameIds, _, _, _, _, _) =>
                 {
                     // Capture the gameIds the handler asked the search to run on. This is what
                     // RBAC enforcement actually controls — verifying the post-enrichment Results
@@ -460,6 +461,7 @@ public sealed class GlobalKbSearchEndpointTests : IAsyncLifetime
                 int limit,
                 SearchMode mode,
                 double minScore,
+                IReadOnlyList<Guid>? _,
                 CancellationToken _) =>
             {
                 // Return one synthetic result per accessible game (up to limit).

--- a/claudedocs/spec-panel-1686-decisions.md
+++ b/claudedocs/spec-panel-1686-decisions.md
@@ -1,0 +1,104 @@
+# Spec-Panel Decisions — Issue #1686 (KB Global Facets BE)
+
+**Date**: 2026-05-31
+**Issue**: [#1686](https://github.com/meepleAi-app/meepleai-monorepo/issues/1686) — server-side facets for `/knowledge-base/search/global`
+**Baseline PR**: [#1672](https://github.com/meepleAi-app/meepleai-monorepo/pull/1672) (no-facet shape)
+**Panel personas**: Wiegers (requirements), Fowler (refactoring), Nygard (release/it depends), Adzic (specification by example), Doumont (clarity).
+
+## Context
+
+PR #1672 shipped `POST /api/v1/knowledge-base/search/global` accepting `{ Query, Limit, Cursor, Mode, MinScore }` only — no facet params. The FE FilterAccordion contract (docType / gameId / language) on `/knowledge-base/global` has no server-side backing. Panel verdict (Nygard, 2026-05-29): client-side filtering on cursor-paginated results is a UX trap (filters would lie about the dataset). FilterAccordion was deferred from Foundation v1 awaiting this BE work.
+
+## Decisions
+
+### D-1 — `DocType` allowlist
+
+**Decision**: Accept exactly `["base", "expansion", "errata", "homerule"]` (matches `PdfDocumentEntity.DocumentType` line 61, comment in entity file). Case-insensitive comparison server-side. Each list element MUST be from the allowlist or the request returns 422.
+
+**Rationale (Adzic)**: enumerate the universe — the entity comment is the source of truth, no implicit allowlisting via "anything goes". Closed set means clear API contract, smaller attack surface, predictable indexing.
+
+### D-2 — `Language` allowlist
+
+**Decision**: Accept exactly `["en", "it", "de", "fr", "es"]` (matches `PdfDocumentEntity.Language` line 48 comment). Unknown → 422.
+
+**Rationale (Adzic)**: same as D-1. The entity comment enumerates ISO 639-1 codes supported by extraction services. Forward-compatible: add new codes here when the entity is extended.
+
+### D-3 — Pre-existing endpoint shape preserved byte-identical
+
+**Decision**: All 3 facet fields (`DocType`, `GameId`, `Language`) are optional/nullable. When all three are absent/null, behaviour and JSON response shape are byte-identical to PR #1672. **Captured via dedicated snapshot test.**
+
+**Rationale (Fowler)**: this is a refactoring-with-extension. The "no facets" path is a regression risk for FE consumers parsing the response shape; an explicit snapshot test pins behaviour and lets future PRs detect drift.
+
+### D-4 — Push-down strategy
+
+**Decision**: When ANY facet is non-null, compute an allowlist of `PdfDocumentEntity.Id` (filtered by facets + accessibleGameIds) via EF BEFORE vector search. Pass this allowlist to `IMultiGameHybridSearchService.SearchAsync` via a new `documentIds` parameter. The vector layer filters its results to that allowlist.
+
+**Rationale (Nygard)**: push the filter as close to the data as possible. Vector search over a pre-filtered candidate set is cheaper than post-filtering N vector hits. EF query is bounded by the existing `(SharedGameId, DocumentType, Language)` columns (composite filter is cheap).
+
+### D-5 — `GameId` (single, nullable) intersects with accessibleGameIds
+
+**Decision**: `GameId` is a single nullable Guid. When provided and `GameId ∈ accessibleGameIds`, the effective accessible set narrows to `{GameId}`. When `GameId ∉ accessibleGameIds` (e.g. user tries to filter to a private game they don't own), return 200 empty (NOT 403). NOT an error.
+
+**Rationale (Wiegers/Nygard)**: avoid information leak — a 403 on a private gameId would tell the user "this game exists" even if they have no access. 200 empty is RBAC-safe and matches the existing EC-1 pattern (no accessible games → 200 empty).
+
+### D-6 — Cursor stability preserved with facets
+
+**Decision**: Facets do NOT change cursor ordering invariants (score DESC, chunkId ASC). The cursor is opaque and re-applying the same cursor + same facet set returns the next page deterministically.
+
+**Rationale (Nygard)**: cursor pagination + filters is a known sharp edge. Document explicitly that mutating facets mid-pagination is undefined (FE responsibility to reset the cursor when facets change).
+
+### D-7 — `DocType` is a list (max 10 items)
+
+**Decision**: `DocType: IReadOnlyList<string>?`. Empty list treated as null (no filter — defensive). Hard cap of 10 elements (input bounding; allowlist has only 4 anyway).
+
+**Rationale (Wiegers)**: input validation defense in depth. The list shape mirrors the FE accordion semantics (multi-select within docType category).
+
+### D-8 — Case-insensitive comparison
+
+**Decision**: All facet string values are normalised to lower-case for comparison against entity values. Validator enforces non-empty strings on each list element.
+
+**Rationale (Doumont)**: clear input contract — clients can send "Base" or "BASE" and the match works. Reduces FE/BE coupling on casing.
+
+### D-9 — OpenAPI documentation
+
+**Decision**: XML doc-comments on `GlobalKbSearchRequest` record params + summary on the endpoint. No separate OpenAPI annotations needed (existing convention).
+
+**Rationale (Doumont)**: minimize documentation surface. The C# record IS the OpenAPI source.
+
+### D-10 — RBAC composes on top of facets
+
+**Decision**: RBAC remains the outer guarantee. Facets narrow the candidate set further; never broaden. Order of operations: `accessibleGameIds = RBAC()` → `narrowedIds = facets(accessibleGameIds, gameId?)` → `documentIds = facets(narrowedIds, docType?, language?)` → `vectorSearch(query, documentIds)`.
+
+**Rationale (Nygard)**: explicit composition. RBAC failure means empty result; facet failure means empty result. Both safe.
+
+### D-11 — Empty documentIds short-circuit
+
+**Decision**: When facet computation yields an empty `documentIds` allowlist (e.g. no docs match `docType=expansion`+`language=de`), short-circuit to 200 empty WITHOUT calling the vector search.
+
+**Rationale (Fowler)**: performance optimisation + symmetry with EC-1 (no accessible games early exit). Avoids a wasted RPC to the embedding service.
+
+### D-12 — Validator error messages enumerate allowed values
+
+**Decision**: `DocType must be one of: base, expansion, errata, homerule.` and `Language must be one of: en, it, de, fr, es.` Emitted by FluentValidation, mapped to 422 by `ApiExceptionHandlerMiddleware`.
+
+**Rationale (Doumont)**: actionable error messages. The FE doesn't need a separate "discover allowed values" endpoint.
+
+### D-13 — Snapshot test asserts JSON shape preserved
+
+**Decision**: A dedicated unit test serialises a `GlobalKbSearchResponseDto` produced by a no-facet request and asserts the JSON shape matches a frozen baseline (keys, types, ordering). Detects accidental shape drift in PRs.
+
+**Rationale (Adzic/Fowler)**: specification by example. The response shape IS the FE contract — pin it.
+
+## Out of scope (deferred to follow-up issues)
+
+- **Facet aggregation counts** (e.g. "Rulebook (12)"): would require an extra COUNT query per facet. Separate issue (likely #1687).
+- **Free-text tag filters / date filters** (Q6 from Phase 0.5 contract): separate issue.
+- **FE FilterAccordion implementation**: owned by FE issue #1482 once this BE lands.
+
+## Test coverage commitment
+
+- **Unit** (~30): validator allowlists, push-down logic (mocked `IMultiGameHybridSearchService` capturing `documentIds`), snapshot BC.
+- **Integration** (~12): RBAC × facet, multi-facet combos, cursor stability, empty-allowlist short-circuit (Testcontainers Postgres).
+- **Snapshot BC** (~3): pre-existing endpoint shape preserved when no facets passed.
+
+Total: ~45 tests.

--- a/docs/superpowers/plans/2026-05-31-kb-globale-facets-be.md
+++ b/docs/superpowers/plans/2026-05-31-kb-globale-facets-be.md
@@ -1,0 +1,161 @@
+# Plan — KB Global Facets BE (Issue #1686)
+
+**Date**: 2026-05-31
+**Branch**: `feature/issue-1686-kb-globale-facets-be`
+**Base**: `main-dev`
+**Decisions**: `claudedocs/spec-panel-1686-decisions.md` (D-1..D-13)
+
+## Goal
+
+Extend `POST /api/v1/knowledge-base/search/global` with optional facets (`DocType`, `GameId`, `Language`) using push-down (filter `PdfDocument` candidates pre-vector-search). Preserve byte-identical legacy behaviour when no facets passed.
+
+## Files touched
+
+### Production code (8 files)
+
+1. `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQuery.cs` — add 3 fields.
+2. `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryValidator.cs` — allowlist validators for docType (list) + language; bound list size; lower-case normalisation.
+3. `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearch/GlobalKbSearchQueryHandler.cs` — push-down: compute `documentIds` from `PdfDocuments` before calling search; short-circuit empty allowlist.
+4. `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/IMultiGameHybridSearchService.cs` — extend `SearchAsync` with optional `documentIds` parameter.
+5. `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs` — filter aggregated results to `documentIds` (post-aggregation client-side filter; cheap because pre-filtered candidate set is already small).
+6. `apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs` — add 3 fields to `GlobalKbSearchRequest` record + forward to query; update endpoint XML docs.
+
+### Test code (5 files; ~50 tests)
+
+7. `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryHandlerTests.cs` — extend with facet tests (push-down, empty short-circuit, RBAC×facet, list normalisation).
+8. `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GlobalKbSearchQueryValidatorTests.cs` (NEW) — validator allowlist + bounds + normalisation.
+9. `apps/api/tests/Api.Tests/Integration/KnowledgeBase/GlobalKbSearchEndpointTests.cs` — extend with end-to-end facet scenarios.
+10. `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/DTOs/GlobalKbSearchResponseDtoSnapshotTests.cs` (NEW) — frozen response shape.
+
+## TDD task list (10 tasks, 1 commit each)
+
+### Task 1 — Validator: `DocType` list allowlist + length cap
+
+**Test file**: NEW `GlobalKbSearchQueryValidatorTests.cs`.
+
+**Tests (~6 unit)**:
+- `EmptyDocTypeList_TreatedAsNull_Passes` — `DocType = []` → valid.
+- `DocTypeWithUnknownValue_FailsValidation` — `DocType = ["unknown"]` → fail, error mentions allowed values.
+- `DocTypeWithDuplicates_Allowed` — `DocType = ["base", "BASE"]` → valid (normalised).
+- `DocTypeListSizeAboveCap_FailsValidation` — 11 elements → fail.
+- `DocTypeWithMixedCase_Passes` — `["Base", "EXPANSION"]` → valid.
+- `DocTypeWithEmptyString_FailsValidation` — `["base", ""]` → fail.
+
+**Code change**: extend `GlobalKbSearchQueryValidator` — add `RuleForEach(x => x.DocType)` with allowlist `["base", "expansion", "errata", "homerule"]` (case-insensitive); `RuleFor(x => x.DocType).Must(d => d == null || d.Count <= 10)`.
+
+**Commit**: `feat(kb): #1686 Task 1 — validator allowlist + cap for DocType`
+
+### Task 2 — Validator: `Language` allowlist
+
+**Tests (~5 unit)**:
+- `NullLanguage_Passes` — `Language = null` → valid.
+- `LanguageEn_Passes`, `LanguageIt_Passes`, etc. — each ISO code → valid.
+- `LanguageUnknown_FailsValidation` — `"xx"` → fail.
+- `LanguageMixedCase_Passes` — `"IT"` → valid (normalised).
+- `LanguageEmpty_FailsValidation` — `""` → fail.
+
+**Code**: add `RuleFor(x => x.Language).Must(l => l == null || AllowedLanguages.Contains(l.ToLowerInvariant()))`.
+
+**Commit**: `feat(kb): #1686 Task 2 — validator allowlist for Language`
+
+### Task 3 — Query: add facet fields
+
+**Test**: extend handler test `BuildQuery` helper signature; verify backward compat — existing tests using default args still pass.
+
+**Code**: extend `GlobalKbSearchQuery` record with `IReadOnlyList<string>? DocType`, `Guid? GameId`, `string? Language`.
+
+**Commit**: `feat(kb): #1686 Task 3 — extend GlobalKbSearchQuery with facets`
+
+### Task 4 — Service interface: `documentIds` parameter
+
+**Test**: `MultiGameHybridSearchService` test (if exists) verifying new param behaviour OR a contract test on `IMultiGameHybridSearchService` ensuring the new overload semantics. Stub-level if implementation is complex.
+
+**Code**: extend `IMultiGameHybridSearchService.SearchAsync` with optional `IReadOnlyList<Guid>? documentIds = null`; extend implementation to post-filter `aggregated.Where(r => documentIds.Contains(parsedPdfId))` when non-null.
+
+**Commit**: `feat(kb): #1686 Task 4 — IMultiGameHybridSearchService documentIds param`
+
+### Task 5 — Handler: `GameId` intersection with RBAC
+
+**Tests (~3 unit)**:
+- `GameIdInAccessibleSet_NarrowsToThatGame` — `GameId = gameA` ∈ accessible → search called with `[gameA]` only.
+- `GameIdNotInAccessibleSet_ReturnsEmpty_NoCallToSearch` — `GameId = gameC` ∉ accessible → 200 empty, search never called.
+- `GameIdNull_KeepsAllAccessible` — backward compat.
+
+**Code**: in handler, after `accessibleGameIds = RBAC(...)`, if `query.GameId.HasValue`, intersect: `if (!accessibleGameIds.Contains(query.GameId.Value)) → empty 200; else accessibleGameIds = new[] { query.GameId.Value }`.
+
+**Commit**: `feat(kb): #1686 Task 5 — handler GameId intersection with RBAC`
+
+### Task 6 — Handler: push-down docType + language → documentIds
+
+**Tests (~4 unit)**:
+- `DocTypeFacet_FiltersPdfDocsBeforeSearch` — seeds PDFs with mixed types, expects search called with documentIds matching only "base".
+- `LanguageFacet_FiltersPdfDocs` — same pattern for `Language = "it"`.
+- `DocTypeAndLanguage_BothApplied` — combination AND filter.
+- `NoFacets_PassesNullDocumentIds` — backward compat: no facets → search called with `documentIds: null`.
+
+**Code**: in handler, when ANY of `DocType`/`Language` set, compute `documentIds` via single EF query against `_db.PdfDocuments` filtered by `(SharedGameId ∈ accessibleGameIds) AND (DocumentType IN docTypeNormalised) AND (Language == languageNormalised)`. Pass to search via new param.
+
+**Commit**: `feat(kb): #1686 Task 6 — handler push-down DocType+Language facets`
+
+### Task 7 — Handler: empty documentIds short-circuit (EC short-circuit)
+
+**Tests (~2 unit)**:
+- `FacetsYieldEmptyDocumentIds_ReturnsEmpty_NoCallToSearch` — facets that match zero PDFs → 200 empty, search never called.
+- `FacetsYieldEmptyDocumentIds_LoggedAtDebugLevel` — debug log emitted (best effort, may verify via NullLogger inspection or skip).
+
+**Code**: in handler, if `documentIds` computed and is empty (post-facet narrowing), short-circuit (D-11).
+
+**Commit**: `feat(kb): #1686 Task 7 — handler empty allowlist short-circuit`
+
+### Task 8 — Endpoint: extend `GlobalKbSearchRequest` + forward
+
+**Tests (~4 integration)** in `GlobalKbSearchEndpointTests.cs`:
+- `Returns_422_when_DocType_unknown` — `DocType = ["banana"]` → 422.
+- `Returns_422_when_Language_unknown` — `Language = "xx"` → 422.
+- `Facets_NarrowResults_EndToEnd` — seeds + asserts only matching results returned.
+- `GameId_OfPrivateUnowned_Returns_200_Empty` — RBAC composition: requesting GameId of a private game not owned → 200 empty, NO 403.
+
+**Code**: add facet fields to `GlobalKbSearchRequest` record + forward to query construction in `HandleGlobalSearch`.
+
+**Commit**: `feat(kb): #1686 Task 8 — endpoint forwards facets to query`
+
+### Task 9 — Snapshot BC: response shape preserved when no facets
+
+**Tests (~3 unit + snapshot)** in NEW `GlobalKbSearchResponseDtoSnapshotTests.cs`:
+- `ResponseShape_NoFacets_MatchesBaseline` — serialise a known `GlobalKbSearchResponseDto`, assert JSON keys/order match a frozen string baseline (results / hasMore / nextCursor + nested item shape).
+- `ResponseShape_NoFacets_Empty_MatchesBaseline` — empty results case.
+- `ResponseShape_HasNoFacetEcho` — verify response DTO has NO facet echo fields (request-only).
+
+**Code**: no production code changes — pure pin-down of the contract.
+
+**Commit**: `test(kb): #1686 Task 9 — snapshot BC for response shape`
+
+### Task 10 — Doc: update XML docs + decisions log
+
+**Tests**: none (doc-only).
+
+**Code**: update XML doc-comments on `GlobalKbSearchRequest` to describe facets (D-9), point to decisions doc.
+
+**Commit**: `docs(kb): #1686 Task 10 — XML docs for facets + decisions log`
+
+## Verification milestones
+
+- After Task 2: `dotnet test --filter "FullyQualifiedName~GlobalKbSearchQueryValidator"` → 11 passing.
+- After Task 7: `dotnet test --filter "FullyQualifiedName~GlobalKbSearchQueryHandler"` → ~17 passing (existing 10 + new 7 facet).
+- After Task 8: `dotnet test --filter "FullyQualifiedName~GlobalKbSearch"` integration → ~9 passing (existing 5 + 4 new).
+- After Task 9: snapshot test green.
+
+Final test count goal: **~45 new tests** across unit + integration + snapshot.
+
+## Final review
+
+Invoke `superpowers:code-reviewer` subagent on diff. Address Critical / Major. Push, open PR base `main-dev`.
+
+## CI expectations
+
+- GitGuardian: SUCCESS (only required check on main-dev).
+- Backend Fast: SUCCESS (or P119 catastrophic exit 139 → rerun).
+- Migration Safety Gate: SUCCESS (no schema changes — additive query/handler/validator changes only).
+- CodeQL csharp: PENDING/advisory.
+
+Merge: normal `--squash` once GitGuardian green and no real regression.


### PR DESCRIPTION
## Summary

Implements server-side facets (`DocType`, `GameId`, `Language`) for `POST /api/v1/knowledge-base/search/global` to unblock `FilterAccordion` of FE issue #1482. Push-down strategy via `documentIds` allowlist computed in EF pre-vector search; RBAC composes on top of facets (D-4 anti-info-leak: non-accessible gameId returns 200 empty, not 403).

## Decisions locked (spec-panel 2026-05-31)

13 decisions D-1..D-13 in `claudedocs/spec-panel-1686-decisions.md`. Highlights:

- **D-1**: DocType/GameId multi-value (`IReadOnlyList<...>?`), Language single (`string?`)
- **D-2**: Push-down via `documentIds` allowlist (extends `IMultiGameHybridSearchService.SearchAsync`)
- **D-3/D-5**: All facets optional; empty list = no filter (byte-identical baseline)
- **D-4**: RBAC first; non-accessible gameId → 200 empty (anti-info-leak)
- **D-6**: Canonical 7-value `DocumentCategory` allowlist (Rulebook|Expansion|Errata|QuickStart|Reference|PlayerAid|Other); case-insensitive; `faq` rejected → 422
- **D-6.c**: Response shape fix — emit `DocumentCategory` (not legacy `DocumentType`) in `EnrichmentRow` projection
- **D-7**: Language ISO 639-1 lowercase allowlist `{en, it, de, fr, es}`
- **D-11**: 422 (not 400) via `ApiExceptionHandlerMiddleware`, `CascadeMode.Continue` for facet rules

## Scope of this PR

8 commit (Tasks 1+2+4+5+6+7+10-partial):

| Task | Commit | Scope |
|---|---|---|
| 0 (docs) | `a43609220` | spec-panel decisions + plan |
| 1 | `118c617e2` | validator allowlist + cap for DocType |
| 2 | `eb095885d` | validator allowlist for Language |
| 4 | `b326f007f` | `IMultiGameHybridSearchService.documentIds` param |
| 5 | `9e06ce533` | handler GameId intersection with RBAC |
| 6 | `d59bbfe62` | handler push-down DocType + Language facets |
| 7 | `472c74572` | handler empty allowlist short-circuit tests |
| 10 (partial) | `4defbbde3` | endpoint Request DTO + 5 integration scenarios |

## Test coverage

- **Unit**: 44 pass (`GlobalKbSearchQueryValidatorTests`: 15, `GlobalKbSearchQueryHandlerTests`: 16 new + 8 baseline, `MultiGameHybridSearchServiceTests`: 3 new + 2 baseline)
- **Integration**: 11 pass (`GlobalKbSearchEndpointTests`: 5 new facet scenarios + 6 baseline)
- **Total new**: ~50 BE tests (no regression — baseline 8 unit + 6 integration intact)

## Follow-up tracking (out of scope this PR)

Will open follow-up issue covering:
- 7 remaining integration scenarios (Task 10 — 1, 2, 4, 5, 9-12) — needs Testcontainers seeding fixture for 3 SharedGames + 12 PdfDocuments
- Task 8 — Prometheus counter `kb_global_search_facet_total{facet,state}` (operations metric)
- Task 9 — OpenAPI/Scalar request-body example (low ROI, mostly covered by extended XML docs already in this PR)
- FE Zod schema follow-up: drop `faq` from `GlobalKbSearchFiltersSchema.docType` (already documented as Q-2 in the decisions doc) — owned by #1482

## Refs

- Issue: #1686
- Epic: #1475 User-facing UI completion (Phase B sub-issue unblocker for #1482 Phase 1 `FilterAccordion`)
- Decisions doc: `claudedocs/spec-panel-1686-decisions.md`
- Plan: `docs/superpowers/plans/2026-05-31-kb-globale-facets-be.md`