### PR TITLE
feat(kb-docs): #1687 PATCH /api/v1/kb-docs/{id} metadata

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -77,6 +77,18 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
     // Issue #5447: User-editable version label (e.g., "2nd Edition", "v1.3 Errata")
     public string? VersionLabel { get; private set; }
 
+    // Issue #1687: User-editable display title (distinct from immutable FileName).
+    // Null = fall back to FileName for FE display.
+    public string? Title { get; private set; }
+
+    // Issue #1687: User-curated tags. Read-only collection; mutated only via SetTags.
+    private readonly List<string> _tags = new();
+    public IReadOnlyList<string> Tags => _tags.AsReadOnly();
+
+    // Issue #1687: Audit columns recording the last user-driven metadata edit (D-3 last-write-wins).
+    public DateTime? UpdatedAt { get; private set; }
+    public Guid? UpdatedBy { get; private set; }
+
     // Issue #4219: Per-state timing tracking for metrics and ETA
     public DateTime? UploadingStartedAt { get; private set; }
     public DateTime? ExtractingStartedAt { get; private set; }
@@ -187,7 +199,11 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
         bool isActiveForRag = true,
         string? versionLabel = null,
         double? languageConfidence = null,
-        string? languageOverride = null)
+        string? languageOverride = null,
+        string? title = null,
+        IReadOnlyList<string>? tags = null,
+        DateTime? updatedAt = null,
+        Guid? updatedBy = null)
     {
         var document = new PdfDocument
         {
@@ -248,8 +264,18 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
 
             // E5-1: Language confidence and override
             LanguageConfidence = languageConfidence,
-            LanguageOverride = languageOverride
+            LanguageOverride = languageOverride,
+
+            // Issue #1687: editable metadata + audit columns
+            Title = title,
+            UpdatedAt = updatedAt,
+            UpdatedBy = updatedBy
         };
+
+        if (tags is { Count: > 0 })
+        {
+            document._tags.AddRange(tags);
+        }
 
         // Issue #4219: Calculate ETA after reconstitution
         document.UpdateETA();
@@ -602,6 +628,112 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
             UnlinkBaseDocument();
 
         SetVersionLabel(versionLabel);
+    }
+
+    // ── Issue #1687: editable metadata mutators (KbEditorDesktop PATCH endpoint) ──
+
+    /// <summary>
+    /// Sets the user-editable display title. Null, empty, or whitespace input clears the title.
+    /// Issue #1687 D-5: distinct from immutable FileName.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the editor id is empty, or the trimmed title exceeds 200 characters.</exception>
+    public void SetTitle(string? title, Guid editorId)
+    {
+        EnsureValidEditorId(editorId);
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            Title = null;
+        }
+        else
+        {
+            var trimmed = title.Trim();
+            if (trimmed.Length > 200)
+                throw new ArgumentException("Title cannot exceed 200 characters", nameof(title));
+
+            Title = trimmed;
+        }
+
+        StampAudit(editorId);
+    }
+
+    /// <summary>
+    /// Sets the user-curated tags. Normalizes (trim + lowercase + filter-empty + dedup + sort)
+    /// before storage so equality semantics are deterministic.
+    /// Issue #1687 D-8: max 20 tags / 50 chars each.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the editor id is empty, more than 20 tags are supplied, or any tag exceeds 50 chars after trim.</exception>
+    public void SetTags(IEnumerable<string> tags, Guid editorId)
+    {
+        ArgumentNullException.ThrowIfNull(tags);
+        EnsureValidEditorId(editorId);
+
+        var raw = tags.ToList();
+        if (raw.Count > 20)
+            throw new ArgumentException("Tags cannot contain more than 20 items", nameof(tags));
+
+        var normalized = new List<string>(raw.Count);
+        foreach (var tag in raw)
+        {
+            if (string.IsNullOrWhiteSpace(tag))
+                continue;
+
+            var trimmed = tag.Trim();
+            if (trimmed.Length > 50)
+                throw new ArgumentException("Each tag cannot exceed 50 characters", nameof(tags));
+
+            normalized.Add(trimmed.ToLowerInvariant());
+        }
+
+        var sorted = normalized
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal)
+            .ToList();
+
+        _tags.Clear();
+        _tags.AddRange(sorted);
+
+        StampAudit(editorId);
+    }
+
+    /// <summary>
+    /// Sets the document category without clobbering the base-document linkage or version label
+    /// (in contrast to <see cref="Reclassify"/> which is admin-grade and mutates all three).
+    /// Issue #1687 D-6 / Task 4 alt: SRP-narrow mutator for KbEditorDesktop.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the editor id is empty.</exception>
+    public void SetCategory(DocumentCategory category, Guid editorId)
+    {
+        EnsureValidEditorId(editorId);
+
+        DocumentCategory = category;
+        StampAudit(editorId);
+    }
+
+    /// <summary>
+    /// Editor-driven language override. Reuses the existing detection-pipeline path
+    /// (<see cref="OverrideLanguage"/>) and additionally records the audit columns.
+    /// Issue #1687 D-7: validator gates the whitelist before this call.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the editor id is empty.</exception>
+    public void OverrideLanguageByEditor(string? languageCode, Guid editorId)
+    {
+        EnsureValidEditorId(editorId);
+
+        OverrideLanguage(languageCode);
+        StampAudit(editorId);
+    }
+
+    private void StampAudit(Guid editorId)
+    {
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+        UpdatedBy = editorId;
+    }
+
+    private static void EnsureValidEditorId(Guid editorId)
+    {
+        if (editorId == Guid.Empty)
+            throw new ArgumentException("Editor id cannot be empty", nameof(editorId));
     }
 
     // Issue #2029: Update detected language after processing

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -736,6 +736,31 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
             throw new ArgumentException("Editor id cannot be empty", nameof(editorId));
     }
 
+    /// <summary>
+    /// Raises a <see cref="PdfMetadataChangedEvent"/> with the supplied change diff. Intended for the
+    /// <c>UpdateKbDocMetadataCommandHandler</c> only — it knows the cross-field diff (old/new tuples)
+    /// while individual aggregate mutators only see their own field.
+    /// Issue #1687 D-9 / Task 6.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="changes"/> is empty.</exception>
+    public void RaiseMetadataChangedEvent(IReadOnlyList<MetadataChange> changes, Guid editorId, string editorRole)
+    {
+        ArgumentNullException.ThrowIfNull(changes);
+        if (changes.Count == 0)
+            throw new ArgumentException("At least one change must be present to emit the metadata-changed event", nameof(changes));
+
+        EnsureValidEditorId(editorId);
+        if (string.IsNullOrWhiteSpace(editorRole))
+            throw new ArgumentException("Editor role must be non-empty", nameof(editorRole));
+
+        AddDomainEvent(new PdfMetadataChangedEvent(
+            AggregateId: Id,
+            UserId: editorId,
+            EditorRole: editorRole,
+            Changes: changes,
+            GameId: SharedGameId));
+    }
+
     // Issue #2029: Update detected language after processing
     public void UpdateLanguage(LanguageCode languageCode)
     {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/MetadataChange.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/MetadataChange.cs
@@ -1,0 +1,10 @@
+namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
+
+/// <summary>
+/// Single-field diff carried by <see cref="PdfMetadataChangedEvent"/> for audit and
+/// cache-invalidation consumers. Issue #1687 D-9.
+/// </summary>
+/// <param name="Field">Field name (camelCase: title, documentType, language, tags).</param>
+/// <param name="OldValue">Pre-edit value rendered as a string (null when previously unset).</param>
+/// <param name="NewValue">Post-edit value rendered as a string (null when explicitly cleared).</param>
+public sealed record MetadataChange(string Field, string? OldValue, string? NewValue);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfMetadataChangedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfMetadataChangedEvent.cs
@@ -1,0 +1,57 @@
+using Api.SharedKernel.Domain.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
+
+/// <summary>
+/// Raised by the <c>UpdateKbDocMetadataCommandHandler</c> when at least one editable
+/// metadata field on the <c>PdfDocument</c> aggregate actually changed. Issue #1687.
+///
+/// Registered in <see cref="Api.Infrastructure.DomainEventLog.EventTypeRegistry"/>
+/// with alias <c>"pdf.metadata.changed"</c>.
+///
+/// <para><b>Why <see cref="IDomainEvent"/> not <c>DomainEventBase</c>?</b>
+/// P116 from session memory: <c>record:IDomainEvent</c> preserves the record's
+/// immutability and value-based equality without inheriting the mutable
+/// <c>DomainEventBase</c> base class. The mapper convention (<c>Name.Replace("Event", "")</c>
+/// → AggregateType) still applies because it is reflection-based.</para>
+///
+/// <para><b>Mapper conventions (DomainEventLogMapper):</b>
+/// <list type="bullet">
+///   <item><c>AggregateId</c> → <c>domain_event_logs.aggregate_id</c> (reflection lookup)</item>
+///   <item><c>UserId</c> → <c>domain_event_logs.user_id</c> (reflection lookup)</item>
+///   <item>Class name minus "Event" suffix → <c>domain_event_logs.aggregate_type = "PdfMetadataChanged"</c></item>
+///   <item>Payload serialized with <c>JsonNamingPolicy.CamelCase</c></item>
+/// </list></para>
+///
+/// <para><b>D-12 deferred re-indexing:</b> <see cref="RequiresReindex"/> is a forward-compat
+/// hint computed from the change set (true when documentType or language changed). No consumer
+/// subscribes in v1; the property exists so a future opt-in re-indexing worker can pick up
+/// the signal without an event schema migration.</para>
+/// </summary>
+/// <param name="AggregateId">PDF document id. Reflected to <c>domain_event_logs.aggregate_id</c>.</param>
+/// <param name="UserId">The user who performed the edit. Reflected to <c>domain_event_logs.user_id</c>.</param>
+/// <param name="EditorRole">Editor's role at edit time — "Owner", "Admin", or "SuperAdmin".</param>
+/// <param name="Changes">List of changed fields with old/new value pairs. Never empty (handler skips emit when no real change).</param>
+/// <param name="GameId">The PDF's <c>SharedGameId</c> (null for orphaned / private-game docs). Used by the cache-invalidation handler.</param>
+public sealed record PdfMetadataChangedEvent(
+    Guid AggregateId,
+    Guid UserId,
+    string EditorRole,
+    IReadOnlyList<MetadataChange> Changes,
+    Guid? GameId) : IDomainEvent
+{
+    /// <summary>IDomainEvent contract — unique event instance id.</summary>
+    public Guid EventId { get; init; } = Guid.NewGuid();
+
+    /// <summary>IDomainEvent contract — emission timestamp (UTC).</summary>
+    public DateTime OccurredAt { get; init; } = TimeProvider.System.GetUtcNow().UtcDateTime;
+
+    /// <summary>
+    /// Computed flag indicating whether the change set requires the document to be re-indexed
+    /// in the RAG pipeline. True iff <see cref="Changes"/> contains a documentType or language edit.
+    /// D-12 forward-compat hint; no consumer subscribes in v1.
+    /// </summary>
+    public bool RequiresReindex => Changes.Any(c =>
+        string.Equals(c.Field, "documentType", StringComparison.Ordinal)
+        || string.Equals(c.Field, "language", StringComparison.Ordinal));
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -244,7 +244,11 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             isActiveForRag: entity.IsActiveForRag, // Issue #5446
             versionLabel: entity.VersionLabel, // Issue #5447
             languageConfidence: entity.LanguageConfidence, // E5-1
-            languageOverride: entity.LanguageOverride // E5-1
+            languageOverride: entity.LanguageOverride, // E5-1
+            title: entity.Title, // Issue #1687
+            tags: entity.Tags, // Issue #1687
+            updatedAt: entity.UpdatedAt, // Issue #1687
+            updatedBy: entity.UpdatedBy // Issue #1687
         );
     }
 
@@ -288,7 +292,11 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             IsActiveForRag = domain.IsActiveForRag, // Issue #5446
             VersionLabel = domain.VersionLabel, // Issue #5447
             LanguageConfidence = domain.LanguageConfidence, // E5-1
-            LanguageOverride = domain.LanguageOverride // E5-1
+            LanguageOverride = domain.LanguageOverride, // E5-1
+            Title = domain.Title, // Issue #1687
+            Tags = domain.Tags.ToList(), // Issue #1687
+            UpdatedAt = domain.UpdatedAt, // Issue #1687
+            UpdatedBy = domain.UpdatedBy // Issue #1687
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommand.cs
@@ -1,0 +1,28 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.ListUserKbDocs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+
+/// <summary>
+/// Command for <c>UpdateKbDocMetadataCommandHandler</c> — partial-update PATCH
+/// of editable PDF document metadata. Issue #1687.
+///
+/// JSON null on any field = no-op (D-4); explicit empty string clears <c>Title</c>;
+/// explicit empty array clears <c>Tags</c>. The validator gates each field with
+/// <c>.When(x => x.Field is not null)</c>.
+/// </summary>
+/// <param name="DocId">Target PDF id (route parameter).</param>
+/// <param name="EditorUserId">Authenticated caller's id (session principal).</param>
+/// <param name="EditorRole">Caller's role string ("Owner", "Admin", "SuperAdmin", "Editor", "User", …).</param>
+/// <param name="Title">New display title; null = no-op; empty/whitespace = clear.</param>
+/// <param name="DocumentType">DocumentCategory enum name (case-insensitive); null = no-op.</param>
+/// <param name="Language">ISO 639-1 code (whitelist via LanguageCode.IsSupported); null = no-op.</param>
+/// <param name="Tags">Replacement tag set; null = no-op; empty = clear; deduped+lowercased+sorted by aggregate.</param>
+internal sealed record UpdateKbDocMetadataCommand(
+    Guid DocId,
+    Guid EditorUserId,
+    string EditorRole,
+    string? Title,
+    string? DocumentType,
+    string? Language,
+    IReadOnlyList<string>? Tags) : ICommand<UserKbDocDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandHandler.cs
@@ -1,0 +1,201 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.ListUserKbDocs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+
+/// <summary>
+/// Handler for <see cref="UpdateKbDocMetadataCommand"/>. Issue #1687 Task 6.
+///
+/// Flow:
+/// <list type="number">
+/// <item>Load the <c>PdfDocument</c> aggregate via the repository.</item>
+/// <item>Authorize: owner OR Admin/SuperAdmin; everyone else gets <see cref="NotFoundException"/>
+///       (D-2 anti-info-leak — divergence from <c>HandleUpdateChatThreadTitle</c> which returns 403).</item>
+/// <item>For each non-null field on the command, compare current vs new (using the aggregate's normalization
+///       rules) and apply via the SRP-narrow mutator if different.</item>
+/// <item>If the change list is empty (idempotent no-op) skip persistence and event emission.</item>
+/// <item>Otherwise raise the <c>PdfMetadataChangedEvent</c> via the aggregate, save, and return the updated DTO.</item>
+/// </list>
+/// </summary>
+internal sealed class UpdateKbDocMetadataCommandHandler : ICommandHandler<UpdateKbDocMetadataCommand, UserKbDocDto>
+{
+    private readonly IPdfDocumentRepository _pdfRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UpdateKbDocMetadataCommandHandler> _logger;
+
+    public UpdateKbDocMetadataCommandHandler(
+        IPdfDocumentRepository pdfRepository,
+        ISharedGameRepository sharedGameRepository,
+        IUnitOfWork unitOfWork,
+        ILogger<UpdateKbDocMetadataCommandHandler> logger)
+    {
+        _pdfRepository = pdfRepository ?? throw new ArgumentNullException(nameof(pdfRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<UserKbDocDto> Handle(UpdateKbDocMetadataCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Step 1: load the aggregate.
+        var doc = await _pdfRepository.GetByIdAsync(command.DocId, cancellationToken).ConfigureAwait(false);
+        if (doc is null)
+        {
+            // D-2: never disambiguate "doesn't exist" from "can't see".
+            throw new NotFoundException("KbDocument", command.DocId.ToString());
+        }
+
+        // Step 2: authorize. D-1 RBAC + D-2 anti-info-leak.
+        var isOwner = doc.UploadedByUserId == command.EditorUserId;
+        var isAdmin = IsAdminRole(command.EditorRole);
+        if (!isOwner && !isAdmin)
+        {
+            _logger.LogWarning(
+                "User {EditorId} denied PATCH on KB doc {DocId} (owner: {OwnerId}, role: {Role})",
+                command.EditorUserId, command.DocId, doc.UploadedByUserId, command.EditorRole);
+            throw new NotFoundException("KbDocument", command.DocId.ToString());
+        }
+
+        // Step 3: snapshot pre-mutation state for accurate OldValue diff entries.
+        var preTitle = doc.Title;
+        var preCategory = doc.DocumentCategory;
+        var preLanguage = doc.LanguageOverride;
+        var preTags = doc.Tags.ToList();
+
+        // Step 4: diff & apply. Skip no-op writes (handler compares current vs new
+        // using the aggregate's canonicalization rules so "Same Title" emits no event).
+        var changes = new List<MetadataChange>();
+
+        if (command.Title is not null)
+        {
+            var newTitle = NormalizeTitle(command.Title);
+            if (!string.Equals(preTitle, newTitle, StringComparison.Ordinal))
+            {
+                doc.SetTitle(command.Title, command.EditorUserId);
+                changes.Add(new MetadataChange("title", preTitle, newTitle));
+            }
+        }
+
+        if (command.DocumentType is not null)
+        {
+            if (Enum.TryParse<DocumentCategory>(command.DocumentType, ignoreCase: true, out var parsedCategory)
+                && preCategory != parsedCategory)
+            {
+                doc.SetCategory(parsedCategory, command.EditorUserId);
+                changes.Add(new MetadataChange("documentType", preCategory.ToString(), parsedCategory.ToString()));
+            }
+        }
+
+        if (command.Language is not null)
+        {
+            var newLanguage = command.Language.Trim().ToLowerInvariant();
+            if (!string.Equals(preLanguage, newLanguage, StringComparison.Ordinal))
+            {
+                doc.OverrideLanguageByEditor(newLanguage, command.EditorUserId);
+                changes.Add(new MetadataChange("language", preLanguage, newLanguage));
+            }
+        }
+
+        if (command.Tags is not null)
+        {
+            var newTags = NormalizeTags(command.Tags);
+            if (!preTags.SequenceEqual(newTags, StringComparer.Ordinal))
+            {
+                doc.SetTags(command.Tags, command.EditorUserId);
+                changes.Add(new MetadataChange(
+                    "tags",
+                    OldValue: $"[{string.Join(",", preTags)}]",
+                    NewValue: $"[{string.Join(",", newTags)}]"));
+            }
+        }
+
+        // Step 5: idempotent no-op — return current DTO without persisting.
+        if (changes.Count == 0)
+        {
+            _logger.LogDebug(
+                "PATCH /kb-docs/{DocId} is a no-op for user {EditorId} — no changes detected",
+                command.DocId, command.EditorUserId);
+            return await BuildDtoAsync(doc, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Step 6: emit + persist.
+        doc.RaiseMetadataChangedEvent(changes, command.EditorUserId, ResolveEditorRoleLabel(isOwner, command.EditorRole));
+
+        await _pdfRepository.UpdateAsync(doc, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "PATCH /kb-docs/{DocId} updated by user {EditorId} (role: {Role}): {ChangeCount} field(s) changed",
+            command.DocId, command.EditorUserId, command.EditorRole, changes.Count);
+
+        return await BuildDtoAsync(doc, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string? NormalizeTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return null;
+        var trimmed = title.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static IReadOnlyList<string> NormalizeTags(IReadOnlyList<string> tags)
+    {
+        return tags
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Select(t => t.Trim().ToLowerInvariant())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static bool IsAdminRole(string role)
+    {
+        return string.Equals(role, "Admin", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(role, "SuperAdmin", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveEditorRoleLabel(bool isOwner, string requestedRole)
+    {
+        // Owner takes precedence even if the role string says Admin (the user owns the doc).
+        return isOwner ? "Owner" : requestedRole;
+    }
+
+    private async Task<UserKbDocDto> BuildDtoAsync(PdfDocument doc, CancellationToken cancellationToken)
+    {
+        string? gameName = null;
+        if (doc.SharedGameId is Guid gameId)
+        {
+            var names = await _sharedGameRepository
+                .GetNamesByIdsAsync(new[] { gameId }, cancellationToken)
+                .ConfigureAwait(false);
+            if (names.TryGetValue(gameId, out var resolved))
+                gameName = resolved;
+        }
+
+        return new UserKbDocDto(
+            Id: doc.Id,
+            GameId: doc.SharedGameId,
+            GameName: gameName,
+            FileName: doc.FileName.Value,
+            ProcessingState: doc.ProcessingState.ToString(),
+            PageCount: doc.PageCount,
+            ProcessedAt: doc.ProcessedAt,
+            UploadedAt: doc.UploadedAt,
+            UpdatedAt: doc.UpdatedAt ?? doc.ProcessedAt ?? doc.UploadedAt,
+            Title: doc.Title,
+            Tags: doc.Tags,
+            UpdatedBy: doc.UpdatedBy);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandValidator.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+
+/// <summary>
+/// FluentValidation rules for <see cref="UpdateKbDocMetadataCommand"/> (Issue #1687 Task 5).
+///
+/// Conditional gating per field via <c>.When(x => x.Field is not null)</c> implements
+/// the partial-update contract (D-4). Failures propagate as
+/// <see cref="FluentValidation.ValidationException"/> which the
+/// <c>ApiExceptionHandlerMiddleware</c> maps to HTTP 422.
+/// </summary>
+internal sealed class UpdateKbDocMetadataCommandValidator : AbstractValidator<UpdateKbDocMetadataCommand>
+{
+    private const int TitleMaxLength = 200;
+    private const int MaxTagCount = 20;
+    private const int MaxTagLength = 50;
+
+    public UpdateKbDocMetadataCommandValidator()
+    {
+        RuleFor(x => x.DocId)
+            .NotEmpty()
+            .WithMessage("DocId must not be empty.");
+
+        RuleFor(x => x.EditorUserId)
+            .NotEmpty()
+            .WithMessage("EditorUserId must not be empty.");
+
+        RuleFor(x => x.Title!)
+            .MaximumLength(TitleMaxLength)
+                .WithMessage($"Title must not exceed {TitleMaxLength} characters.")
+            .When(x => x.Title is not null);
+
+        RuleFor(x => x.DocumentType!)
+            .Must(BeValidDocumentCategory)
+                .WithMessage("DocumentType must be one of: Rulebook, Expansion, Errata, QuickStart, Reference, PlayerAid, Other (case-insensitive).")
+            .When(x => x.DocumentType is not null);
+
+        RuleFor(x => x.Language!)
+            .Must(LanguageCode.IsSupported)
+                .WithMessage("Language must be one of the supported ISO 639-1 codes (en, it, de, fr, es, pt, pl, nl, ja, zh).")
+            .When(x => x.Language is not null);
+
+        RuleFor(x => x.Tags)
+            .Must(t => t is null || t.Count <= MaxTagCount)
+                .WithMessage($"Tags must contain at most {MaxTagCount} items.");
+
+        RuleForEach(x => x.Tags!)
+            .Must(tag => !string.IsNullOrWhiteSpace(tag) && tag.Trim().Length <= MaxTagLength)
+                .WithMessage($"Each tag must be 1-{MaxTagLength} characters and non-empty.")
+            .When(x => x.Tags is not null);
+    }
+
+    private static bool BeValidDocumentCategory(string value)
+        => Enum.TryParse<DocumentCategory>(value, ignoreCase: true, out _);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/PdfMetadataChangedCacheInvalidationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/PdfMetadataChangedCacheInvalidationHandler.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Issue #1687 Task 8 — invalidates the <c>ListUserKbDocs</c> HybridCache page
+/// entries when a <see cref="PdfMetadataChangedEvent"/> is dispatched (D-10).
+///
+/// Tag pattern matches <c>ListUserKbDocsQueryHandler</c>'s cache writer at
+/// <c>tags: ["kb", "user-docs", $"user:{userId}"]</c>. Tag-based invalidation
+/// is O(1) per tag; we hit at most 3 tags per event.
+///
+/// On handler failure the cache stays stale until its 5min TTL — see the
+/// risk-mitigation table in the plan (low impact, bounded staleness).
+/// </summary>
+internal sealed class PdfMetadataChangedCacheInvalidationHandler
+    : INotificationHandler<PdfMetadataChangedEvent>
+{
+    private readonly IHybridCacheService _cache;
+    private readonly ILogger<PdfMetadataChangedCacheInvalidationHandler> _logger;
+
+    public PdfMetadataChangedCacheInvalidationHandler(
+        IHybridCacheService cache,
+        ILogger<PdfMetadataChangedCacheInvalidationHandler> logger)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(PdfMetadataChangedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        await _cache.RemoveByTagAsync($"user:{notification.UserId}", cancellationToken).ConfigureAwait(false);
+        await _cache.RemoveByTagAsync("user-docs", cancellationToken).ConfigureAwait(false);
+
+        if (notification.GameId is Guid gameId)
+        {
+            await _cache.RemoveByTagAsync($"game:{gameId}", cancellationToken).ConfigureAwait(false);
+        }
+
+        _logger.LogInformation(
+            "Invalidated kb-docs cache for user {UserId} doc {DocId} (gameId={GameId})",
+            notification.UserId, notification.AggregateId, notification.GameId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQuery.cs
@@ -42,7 +42,14 @@ public sealed record KbDocsListResponse(
 /// <param name="PageCount">Number of pages; null until extraction completes.</param>
 /// <param name="ProcessedAt">Timestamp of the most recent processing state transition; null for Pending docs that never started.</param>
 /// <param name="UploadedAt">Upload timestamp; always non-null. Used as the sort fallback when <paramref name="ProcessedAt"/> is null.</param>
-/// <param name="UpdatedAt">Explicit recency signal: ProcessedAt ?? UploadedAt. Mirrors the canonical sort key from the handler. Issue #1645.</param>
+/// <param name="UpdatedAt">
+///   Explicit recency signal: <c>doc.UpdatedAt ?? ProcessedAt ?? UploadedAt</c>. Issue #1687 D-13 promotes the
+///   metadata-edit timestamp to override the processing one, so a user-driven title change beats a stale
+///   pipeline transition for display purposes.
+/// </param>
+/// <param name="Title">User-editable display title (Issue #1687 D-5); null = fall back to FileName for display.</param>
+/// <param name="Tags">User-curated tag set (Issue #1687 D-8); deduped+lowercased+sorted. Empty when no tags.</param>
+/// <param name="UpdatedBy">Identifier of the last editor (Issue #1687 D-13); null when never edited.</param>
 public sealed record UserKbDocDto(
     Guid Id,
     Guid? GameId,
@@ -52,4 +59,7 @@ public sealed record UserKbDocDto(
     int? PageCount,
     DateTime? ProcessedAt,
     DateTime UploadedAt,
-    DateTime UpdatedAt);
+    DateTime UpdatedAt,
+    string? Title,
+    IReadOnlyList<string> Tags,
+    Guid? UpdatedBy);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/ListUserKbDocs/ListUserKbDocsQueryHandler.cs
@@ -119,7 +119,11 @@ internal sealed class ListUserKbDocsQueryHandler
                 p.ProcessingState,
                 p.PageCount,
                 p.ProcessedAt,
-                p.UploadedAt
+                p.UploadedAt,
+                p.Title,
+                p.Tags,
+                p.UpdatedAt,
+                p.UpdatedBy
             })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -148,7 +152,11 @@ internal sealed class ListUserKbDocsQueryHandler
             PageCount: r.PageCount,
             ProcessedAt: r.ProcessedAt,
             UploadedAt: r.UploadedAt,
-            UpdatedAt: r.ProcessedAt ?? r.UploadedAt)).ToList();
+            // Issue #1687 D-13: an explicit user edit beats the processing transition for display.
+            UpdatedAt: r.UpdatedAt ?? r.ProcessedAt ?? r.UploadedAt,
+            Title: r.Title,
+            Tags: r.Tags ?? new List<string>(),
+            UpdatedBy: r.UpdatedBy)).ToList();
 
         return new KbDocsListResponse(
             Items: items,

--- a/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
+++ b/apps/api/src/Api/Infrastructure/DomainEventLog/EventTypeRegistry.cs
@@ -57,6 +57,12 @@ public static class EventTypeRegistry
         // event was raised for SSE only, never into the MediatR pipeline, until BE-3).
         [typeof(SessionCreatedEvent)] = "session.created",
         [typeof(SessionFinalizedEvent)] = "session.finalized",
+
+        // Issue #1687 — durable log of user-driven KB-doc metadata edits.
+        // Without this entry the cache-invalidation handler still fires (MediatR
+        // in-memory) but the audit row is silently dropped. Tested explicitly in
+        // EventTypeRegistryTests.Registry_resolves_pdf_metadata_changed_alias.
+        [typeof(PdfMetadataChangedEvent)] = "pdf.metadata.changed",
     };
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
@@ -93,6 +93,16 @@ public class PdfDocumentEntity
     // Issue #5447: User-editable version label
     public string? VersionLabel { get; set; }
 
+    // Issue #1687: User-editable display title (distinct from immutable FileName).
+    public string? Title { get; set; }
+
+    // Issue #1687: User-curated tags (deduped + lowercased + sorted on write).
+    public List<string> Tags { get; set; } = new();
+
+    // Issue #1687: Audit columns set by metadata-edit handlers (last-write-wins per D-3).
+    public DateTime? UpdatedAt { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
     // Admin Wizard: Processing priority (Normal=0, Admin=10)
     public string ProcessingPriority { get; set; } = "Normal";
 

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/DocumentProcessing/PdfDocumentEntityConfiguration.cs
@@ -196,5 +196,34 @@ internal class PdfDocumentEntityConfiguration : IEntityTypeConfiguration<PdfDocu
         builder.HasIndex(e => new { e.UploadedByUserId, e.ProcessedAt })
             .IsDescending(false, true)
             .HasDatabaseName("ix_pdf_documents_uploaded_by_user_id_processed_at_desc");
+
+        // Issue #1687: User-editable display title (varchar(200) NULL).
+        builder.Property(e => e.Title)
+            .HasMaxLength(200)
+            .HasColumnName("title")
+            .IsRequired(false);
+
+        // Issue #1687: Tags stored as PG text[] for native array operators
+        // (@>, &&, ANY). Forward-compat with #1686 server-side facets.
+        builder.Property(e => e.Tags)
+            .HasColumnName("tags")
+            .HasColumnType("text[]")
+            .IsRequired()
+            .HasDefaultValueSql("'{}'::text[]");
+
+        // Issue #1687: Audit columns (last-write-wins per D-3, no RowVersion in v1).
+        builder.Property(e => e.UpdatedAt)
+            .HasColumnName("updated_at")
+            .IsRequired(false);
+
+        builder.Property(e => e.UpdatedBy)
+            .HasColumnName("updated_by")
+            .IsRequired(false);
+
+        // Issue #1687: GIN index on tags array for fast containment queries.
+        // Forward-compat with #1686 facets (?tags=strategy filter) — cheap to add now.
+        builder.HasIndex(e => e.Tags)
+            .HasDatabaseName("IX_pdf_documents_tags_gin")
+            .HasMethod("gin");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260531005633_AddPdfDocumentMetadataEditableFields.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260531005633_AddPdfDocumentMetadataEditableFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531005633_AddPdfDocumentMetadataEditableFields")]
+    partial class AddPdfDocumentMetadataEditableFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260531005633_AddPdfDocumentMetadataEditableFields.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260531005633_AddPdfDocumentMetadataEditableFields.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPdfDocumentMetadataEditableFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "tags",
+                table: "pdf_documents",
+                type: "text[]",
+                nullable: false,
+                defaultValueSql: "'{}'::text[]");
+
+            migrationBuilder.AddColumn<string>(
+                name: "title",
+                table: "pdf_documents",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_at",
+                table: "pdf_documents",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "updated_by",
+                table: "pdf_documents",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_pdf_documents_tags_gin",
+                table: "pdf_documents",
+                column: "tags")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_pdf_documents_tags_gin",
+                table: "pdf_documents");
+
+            migrationBuilder.DropColumn(
+                name: "tags",
+                table: "pdf_documents");
+
+            migrationBuilder.DropColumn(
+                name: "title",
+                table: "pdf_documents");
+
+            migrationBuilder.DropColumn(
+                name: "updated_at",
+                table: "pdf_documents");
+
+            migrationBuilder.DropColumn(
+                name: "updated_by",
+                table: "pdf_documents");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/KnowledgeBaseEndpoints.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.ContextEngineering.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.ContextEngineering.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 
+using Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.CrossGameStreamQa;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetGameDocuments;
@@ -1157,6 +1158,21 @@ internal static class KnowledgeBaseEndpoints
             .Produces<KbDocsListResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status422UnprocessableEntity);
+
+        // Issue #1687: partial-update PATCH for editable KB doc metadata (KbEditorDesktop).
+        group.MapPatch("/kb-docs/{id:guid}", HandleUpdateKbDocMetadata)
+            .WithName("UpdateKbDocMetadata")
+            .RequireSession()
+            .WithTags("KnowledgeBase")
+            .WithSummary("Update editable metadata (title, documentType, language, tags) for one KB document.")
+            .WithDescription(
+                "PATCH /api/v1/kb-docs/{id}. JSON null on any field = no-op (partial update); empty string clears Title; " +
+                "empty array clears Tags. Owner OR Admin/SuperAdmin only. Returns 404 (NOT 403) when the caller cannot " +
+                "see the doc — anti-info-leak per D-2 of the spec panel.")
+            .Produces<UserKbDocDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status422UnprocessableEntity);
     }
 
     private static async Task<IResult> HandleListUserKbDocs(
@@ -1186,6 +1202,44 @@ internal static class KnowledgeBaseEndpoints
             State: state);
 
         var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Issue #1687: handler for <c>PATCH /api/v1/kb-docs/{id}</c>. Editable metadata
+    /// (title / documentType / language / tags) — partial update via the
+    /// <see cref="UpdateKbDocMetadataCommand"/> + handler pipeline.
+    ///
+    /// Authorization is enforced inside the handler so 404 anti-info-leak (D-2)
+    /// is single-sourced. The endpoint only resolves the session principal and
+    /// the actor role string.
+    /// </summary>
+    private static async Task<IResult> HandleUpdateKbDocMetadata(
+        Guid id,
+        UpdateKbDocMetadataRequest req,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var session = context.Items[nameof(SessionStatusDto)] as SessionStatusDto;
+        if (session?.Principal?.Subject?.Id is not Guid userId
+            || userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var role = session.Principal!.EffectiveActor.Role ?? "User";
+
+        var command = new UpdateKbDocMetadataCommand(
+            DocId: id,
+            EditorUserId: userId,
+            EditorRole: role,
+            Title: req.Title,
+            DocumentType: req.DocumentType,
+            Language: req.Language,
+            Tags: req.Tags);
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 
@@ -1373,6 +1427,24 @@ internal record KnowledgeBaseSearchRequest(
 /// </summary>
 internal record UpdateChatThreadTitleRequest(
     string Title
+);
+
+/// <summary>
+/// Issue #1687: Request model for PATCH /api/v1/kb-docs/{id}. Each field is
+/// optional; JSON null means "no-op" (partial update / D-4). Empty string
+/// clears <see cref="Title"/>; empty array clears <see cref="Tags"/>.
+/// </summary>
+/// <param name="Title">User-editable display title; max 200 chars after trim.</param>
+/// <param name="DocumentType">Case-insensitive <c>DocumentCategory</c> enum value
+/// (Rulebook|Expansion|Errata|QuickStart|Reference|PlayerAid|Other).</param>
+/// <param name="Language">Case-insensitive ISO 639-1 code from the LanguageCode whitelist
+/// (en, it, de, fr, es, pt, pl, nl, ja, zh).</param>
+/// <param name="Tags">Replacement tag set; deduped+lowercased+sorted on persist; max 20 / 50 chars.</param>
+internal record UpdateKbDocMetadataRequest(
+    string? Title,
+    string? DocumentType,
+    string? Language,
+    IReadOnlyList<string>? Tags
 );
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentMetadataTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocumentMetadataTests.cs
@@ -1,0 +1,192 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Domain.Entities;
+
+/// <summary>
+/// Issue #1687 Task 2 — unit tests for the editable metadata mutators on
+/// <see cref="PdfDocument"/>. Each mutator validates input, records the
+/// audit columns (<c>UpdatedAt</c>, <c>UpdatedBy</c>), and (where the
+/// existing aggregate already had a setter) reuses the existing path.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PdfDocumentMetadataTests
+{
+    private static readonly Guid EditorId = Guid.Parse("c0ffee00-0000-4000-8000-000000000001");
+
+    // ── SetTitle ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetTitle_NullOrEmpty_ClearsTitle_UpdatesAudit()
+    {
+        var doc = CreateTestDocument();
+
+        doc.SetTitle(null, EditorId);
+        doc.Title.Should().BeNull("D-4 partial-update: explicit empty/null clears the value");
+        doc.UpdatedAt.Should().NotBeNull("audit must record the touch even when clearing");
+        doc.UpdatedBy.Should().Be(EditorId);
+
+        doc.SetTitle("   ", EditorId);
+        doc.Title.Should().BeNull("whitespace-only is treated as 'clear' to match the FluentValidation behavior");
+    }
+
+    [Fact]
+    public void SetTitle_ValidString_TrimsAndStores_UpdatesAudit()
+    {
+        var doc = CreateTestDocument();
+
+        doc.SetTitle("  Catan 5th Edition  ", EditorId);
+
+        doc.Title.Should().Be("Catan 5th Edition", "leading/trailing whitespace must be trimmed");
+        doc.UpdatedAt.Should().NotBeNull();
+        doc.UpdatedBy.Should().Be(EditorId);
+    }
+
+    [Fact]
+    public void SetTitle_Over200Chars_ThrowsArgumentException()
+    {
+        var doc = CreateTestDocument();
+        var tooLong = new string('a', 201);
+
+        Action act = () => doc.SetTitle(tooLong, EditorId);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*200*");
+    }
+
+    [Fact]
+    public void SetTitle_EmptyEditorId_ThrowsArgumentException()
+    {
+        var doc = CreateTestDocument();
+
+        Action act = () => doc.SetTitle("Some title", Guid.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    // ── SetTags ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetTags_EmptyEnumerable_ClearsTags_UpdatesAudit()
+    {
+        var doc = CreateTestDocument();
+        doc.SetTags(new[] { "strategy" }, EditorId);
+
+        doc.SetTags(Array.Empty<string>(), EditorId);
+
+        doc.Tags.Should().BeEmpty("explicit empty array means clear all tags (D-4)");
+        doc.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SetTags_Mixed_DedupedLowercasedSortedStored()
+    {
+        var doc = CreateTestDocument();
+
+        doc.SetTags(new[] { "Strategy", "family ", "strategy", " FAMILY", "Eurogame" }, EditorId);
+
+        doc.Tags.Should().HaveCount(3, "Strategy/strategy and FAMILY/family must dedupe after normalization");
+        doc.Tags.Should().BeInAscendingOrder(StringComparer.Ordinal,
+            "tags must be sorted invariantly so Set-comparisons are deterministic (D-8)");
+        doc.Tags.Should().BeEquivalentTo(new[] { "eurogame", "family", "strategy" });
+    }
+
+    [Fact]
+    public void SetTags_MoreThan20_ThrowsArgumentException()
+    {
+        var doc = CreateTestDocument();
+        var tooMany = Enumerable.Range(0, 21).Select(i => $"tag-{i}").ToArray();
+
+        Action act = () => doc.SetTags(tooMany, EditorId);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*20*");
+    }
+
+    [Fact]
+    public void SetTags_TagOver50Chars_ThrowsArgumentException()
+    {
+        var doc = CreateTestDocument();
+        var tooLongTag = new string('a', 51);
+
+        Action act = () => doc.SetTags(new[] { "ok", tooLongTag }, EditorId);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*50*");
+    }
+
+    [Fact]
+    public void SetTags_WhitespaceOnlyTagsFiltered()
+    {
+        var doc = CreateTestDocument();
+
+        doc.SetTags(new[] { "strategy", "  ", string.Empty, "family" }, EditorId);
+
+        doc.Tags.Should().HaveCount(2);
+        doc.Tags.Should().Contain("strategy");
+        doc.Tags.Should().Contain("family");
+    }
+
+    // ── SetCategory ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetCategory_ValidEnum_UpdatesAudit_DoesNotChangeBaseDocumentIdOrVersionLabel()
+    {
+        var doc = CreateTestDocument();
+        // Seed the legacy Reclassify state to detect that SetCategory does NOT mutate it.
+        doc.Reclassify(DocumentCategory.Errata, baseDocumentId: Guid.NewGuid(), versionLabel: "v1.3");
+        var seededBaseId = doc.BaseDocumentId;
+        var seededVersionLabel = doc.VersionLabel;
+
+        doc.SetCategory(DocumentCategory.QuickStart, EditorId);
+
+        doc.DocumentCategory.Should().Be(DocumentCategory.QuickStart);
+        doc.BaseDocumentId.Should().Be(seededBaseId,
+            "SetCategory is SRP-narrow and must NOT clobber the base-document link (D-6 / Task 4 alt)");
+        doc.VersionLabel.Should().Be(seededVersionLabel,
+            "SetCategory must NOT clobber the version label either");
+        doc.UpdatedAt.Should().NotBeNull();
+        doc.UpdatedBy.Should().Be(EditorId);
+    }
+
+    // ── OverrideLanguageByEditor ────────────────────────────────────────────────
+
+    [Fact]
+    public void OverrideLanguageByEditor_ValidISO6391_SetsLanguageOverride_UpdatesAudit()
+    {
+        var doc = CreateTestDocument();
+
+        doc.OverrideLanguageByEditor("it", EditorId);
+
+        doc.LanguageOverride.Should().Be("it", "reuses the existing pipeline path (line 634 OverrideLanguage)");
+        doc.UpdatedAt.Should().NotBeNull();
+        doc.UpdatedBy.Should().Be(EditorId);
+    }
+
+    [Fact]
+    public void OverrideLanguageByEditor_ClearsWhenWhitespace()
+    {
+        var doc = CreateTestDocument();
+        doc.OverrideLanguageByEditor("de", EditorId);
+
+        doc.OverrideLanguageByEditor("  ", EditorId);
+
+        doc.LanguageOverride.Should().BeNull();
+    }
+
+    private static PdfDocument CreateTestDocument()
+    {
+        return new PdfDocument(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            fileName: new FileName("test.pdf"),
+            filePath: "/uploads/test.pdf",
+            fileSize: new FileSize(1024),
+            uploadedByUserId: Guid.NewGuid());
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Events/PdfMetadataChangedEventTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Domain/Events/PdfMetadataChangedEventTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.SharedKernel.Domain.Interfaces;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Domain.Events;
+
+/// <summary>
+/// Issue #1687 Task 3 — unit tests for the new <see cref="PdfMetadataChangedEvent"/>.
+///
+/// The mapper conventions (P117) tested here are exactly the contract the
+/// existing DomainEventLogMapper consumes via reflection:
+/// 1. <c>typeof(Event).Name.Replace("Event", "")</c> == aggregate_type column value.
+/// 2. <c>JsonSerializer.Serialize(event, type, PropertyNamingPolicy.CamelCase)</c> ==
+///    payload_json column value.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "1687")]
+public class PdfMetadataChangedEventTests
+{
+    private static readonly Guid AggregateId = Guid.Parse("11111111-1111-4111-8111-111111111111");
+    private static readonly Guid EditorId = Guid.Parse("22222222-2222-4222-8222-222222222222");
+    private static readonly Guid GameId = Guid.Parse("33333333-3333-4333-8333-333333333333");
+
+    [Fact]
+    public void Event_implements_IDomainEvent()
+    {
+        var ev = CreateEvent();
+
+        ev.Should().BeAssignableTo<IDomainEvent>(
+            "P116: record:IDomainEvent (NOT DomainEventBase class) preserves immutability");
+        ev.EventId.Should().NotBe(Guid.Empty);
+        ev.OccurredAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public void AggregateType_via_mapper_convention_is_PdfMetadataChanged()
+    {
+        var typeName = typeof(PdfMetadataChangedEvent).Name;
+        var convention = typeName.EndsWith("Event", StringComparison.Ordinal)
+            ? typeName[..^"Event".Length]
+            : typeName;
+
+        convention.Should().Be("PdfMetadataChanged",
+            "P117 mapper convention: class name minus 'Event' suffix → aggregate_type column");
+    }
+
+    [Fact]
+    public void Payload_serializes_with_camelCase_keys()
+    {
+        var ev = new PdfMetadataChangedEvent(
+            AggregateId: AggregateId,
+            UserId: EditorId,
+            EditorRole: "Owner",
+            Changes: new[] { new MetadataChange("title", null, "Catan 5th Ed") },
+            GameId: GameId);
+
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var json = JsonSerializer.Serialize(ev, ev.GetType(), options);
+
+        using var doc = JsonDocument.Parse(json);
+        var keys = doc.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+        keys.Should().Contain("aggregateId");
+        keys.Should().Contain("userId");
+        keys.Should().Contain("editorRole");
+        keys.Should().Contain("changes");
+        keys.Should().Contain("gameId");
+        keys.Should().Contain("requiresReindex");
+        keys.Should().Contain("occurredAt");
+        keys.Should().Contain("eventId");
+
+        // Inner MetadataChange must also use camelCase
+        var firstChange = doc.RootElement.GetProperty("changes")[0];
+        firstChange.EnumerateObject().Select(p => p.Name).Should()
+            .Contain(new[] { "field", "oldValue", "newValue" });
+    }
+
+    [Fact]
+    public void RequiresReindex_isTrue_when_changes_contain_documentType()
+    {
+        var ev = new PdfMetadataChangedEvent(
+            AggregateId, EditorId, "Owner",
+            new[] { new MetadataChange("documentType", "Rulebook", "QuickStart") },
+            GameId);
+
+        ev.RequiresReindex.Should().BeTrue("category change affects RAG pipeline routing (D-12 hint)");
+    }
+
+    [Fact]
+    public void RequiresReindex_isTrue_when_changes_contain_language()
+    {
+        var ev = new PdfMetadataChangedEvent(
+            AggregateId, EditorId, "Admin",
+            new[] { new MetadataChange("language", "en", "it") },
+            GameId: null);
+
+        ev.RequiresReindex.Should().BeTrue("language change affects embedding model selection");
+    }
+
+    [Fact]
+    public void RequiresReindex_isFalse_when_changes_contain_only_title_or_tags()
+    {
+        var ev = new PdfMetadataChangedEvent(
+            AggregateId, EditorId, "Owner",
+            new[]
+            {
+                new MetadataChange("title", "Old", "New"),
+                new MetadataChange("tags", "[]", "[\"strategy\"]")
+            },
+            GameId);
+
+        ev.RequiresReindex.Should().BeFalse(
+            "title/tags do not impact RAG: D-12 defers re-indexing entirely");
+    }
+
+    [Fact]
+    public void AggregateId_property_exists_for_mapper_reflection()
+    {
+        // The DomainEventLogMapper reflects on the "AggregateId" property by name
+        // (see ExtractWellKnown). A rename would silently orphan log rows.
+        var prop = typeof(PdfMetadataChangedEvent).GetProperty("AggregateId");
+        prop.Should().NotBeNull();
+        prop!.PropertyType.Should().Be(typeof(Guid));
+    }
+
+    [Fact]
+    public void UserId_property_exists_for_mapper_reflection()
+    {
+        var prop = typeof(PdfMetadataChangedEvent).GetProperty("UserId");
+        prop.Should().NotBeNull();
+        prop!.PropertyType.Should().Be(typeof(Guid));
+    }
+
+    private static PdfMetadataChangedEvent CreateEvent()
+    {
+        return new PdfMetadataChangedEvent(
+            AggregateId: AggregateId,
+            UserId: EditorId,
+            EditorRole: "Owner",
+            Changes: Array.Empty<MetadataChange>(),
+            GameId: GameId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/UpdateKbDocMetadata/UpdateKbDocMetadataCommandValidatorTests.cs
@@ -1,0 +1,201 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+
+/// <summary>
+/// Issue #1687 Task 5 — validator unit tests for <see cref="UpdateKbDocMetadataCommand"/>.
+///
+/// Each field is gated by <c>.When(x => x.Field is not null)</c> so a JSON null
+/// (partial update) is a no-op at validation time (D-4). The handler downstream
+/// distinguishes "absent" (no-op) from "explicit empty" (clear) via the actual
+/// nullable string / empty-list semantics.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1687")]
+public class UpdateKbDocMetadataCommandValidatorTests
+{
+    private readonly UpdateKbDocMetadataCommandValidator _validator = new();
+
+    private static UpdateKbDocMetadataCommand Cmd(
+        Guid? docId = null,
+        Guid? editorId = null,
+        string editorRole = "Owner",
+        string? title = null,
+        string? documentType = null,
+        string? language = null,
+        IReadOnlyList<string>? tags = null) => new(
+            DocId: docId ?? Guid.NewGuid(),
+            EditorUserId: editorId ?? Guid.NewGuid(),
+            EditorRole: editorRole,
+            Title: title,
+            DocumentType: documentType,
+            Language: language,
+            Tags: tags);
+
+    [Fact]
+    public void DocId_Empty_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(docId: Guid.Empty));
+        result.ShouldHaveValidationErrorFor(c => c.DocId);
+    }
+
+    [Fact]
+    public void EditorUserId_Empty_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(editorId: Guid.Empty));
+        result.ShouldHaveValidationErrorFor(c => c.EditorUserId);
+    }
+
+    [Fact]
+    public void AllFieldsNull_Passes_NoOp()
+    {
+        var result = _validator.TestValidate(Cmd());
+        result.IsValid.Should().BeTrue("D-4: JSON null = no-op, valid command at validator level");
+    }
+
+    // ── Title ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Title_Null_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(title: null));
+        result.ShouldNotHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public void Title_Over200_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(title: new string('a', 201)));
+        result.ShouldHaveValidationErrorFor(c => c.Title);
+    }
+
+    [Fact]
+    public void Title_AllWhitespace_Passes()
+    {
+        // Handler interprets whitespace as "clear" (SetTitle("   ", ...) → Title=null).
+        // The validator does NOT reject because '<=200 chars' is satisfied.
+        var result = _validator.TestValidate(Cmd(title: "   "));
+        result.ShouldNotHaveValidationErrorFor(c => c.Title);
+    }
+
+    // ── DocumentType ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DocumentType_Null_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(documentType: null));
+        result.ShouldNotHaveValidationErrorFor(c => c.DocumentType);
+    }
+
+    [Fact]
+    public void DocumentType_NotInEnum_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(documentType: "FAQ"));
+        result.ShouldHaveValidationErrorFor(c => c.DocumentType);
+    }
+
+    [Fact]
+    public void DocumentType_GuideIsAlsoInvalid_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(documentType: "Guide"));
+        result.ShouldHaveValidationErrorFor(c => c.DocumentType);
+    }
+
+    [Fact]
+    public void DocumentType_CanonicalForm_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(documentType: "Rulebook"));
+        result.ShouldNotHaveValidationErrorFor(c => c.DocumentType);
+    }
+
+    [Fact]
+    public void DocumentType_CaseInsensitive_Passes()
+    {
+        // D-6: case-insensitive accept; handler canonicalizes to PascalCase form.
+        var result = _validator.TestValidate(Cmd(documentType: "rulebook"));
+        result.ShouldNotHaveValidationErrorFor(c => c.DocumentType);
+    }
+
+    // ── Language ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Language_Null_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(language: null));
+        result.ShouldNotHaveValidationErrorFor(c => c.Language);
+    }
+
+    [Fact]
+    public void Language_3Char_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(language: "eng"));
+        result.ShouldHaveValidationErrorFor(c => c.Language);
+    }
+
+    [Fact]
+    public void Language_NotInWhitelist_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(language: "ru"));
+        result.ShouldHaveValidationErrorFor(c => c.Language);
+    }
+
+    [Fact]
+    public void Language_CaseInsensitive_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(language: "IT"));
+        result.ShouldNotHaveValidationErrorFor(c => c.Language);
+    }
+
+    [Fact]
+    public void Language_Canonical_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(language: "en"));
+        result.ShouldNotHaveValidationErrorFor(c => c.Language);
+    }
+
+    // ── Tags ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Tags_Null_Passes()
+    {
+        var result = _validator.TestValidate(Cmd(tags: null));
+        result.ShouldNotHaveValidationErrorFor(c => c.Tags);
+    }
+
+    [Fact]
+    public void Tags_Empty_Passes()
+    {
+        // Explicit empty = clear all (D-4 / D-8); validator must accept.
+        var result = _validator.TestValidate(Cmd(tags: Array.Empty<string>()));
+        result.ShouldNotHaveValidationErrorFor(c => c.Tags);
+    }
+
+    [Fact]
+    public void Tags_21Items_Fails()
+    {
+        var tags = Enumerable.Range(0, 21).Select(i => $"tag-{i}").ToArray();
+        var result = _validator.TestValidate(Cmd(tags: tags));
+        result.ShouldHaveValidationErrorFor(c => c.Tags);
+    }
+
+    [Fact]
+    public void Tags_TagOver50_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(tags: new[] { "ok", new string('a', 51) }));
+        // The error attaches to the indexed element; ShouldHaveAnyValidationError
+        // is the safest assertion in FluentValidation's TestHelper.
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Tags_WhitespaceTag_Fails()
+    {
+        var result = _validator.TestValidate(Cmd(tags: new[] { "valid", "  " }));
+        result.IsValid.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/PdfMetadataChangedCacheInvalidationHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/PdfMetadataChangedCacheInvalidationHandlerTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Issue #1687 Task 8 — unit tests for the cache-invalidation handler that
+/// listens to <see cref="PdfMetadataChangedEvent"/> and removes the stale
+/// <c>ListUserKbDocs</c> page-cache entries by tag (D-10).
+///
+/// Tag pattern (matches the existing ListUserKbDocsQueryHandler):
+/// <c>["kb", "user-docs", $"user:{userId}"]</c>. The invalidation handler
+/// hits the user tag, the broad "user-docs" tag, and (when present) the
+/// game-scoped tag $"game:{gameId}" so any sibling cache key that tracks the
+/// game also gets dropped.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1687")]
+public sealed class PdfMetadataChangedCacheInvalidationHandlerTests
+{
+    private static readonly Guid DocId = Guid.Parse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    private static readonly Guid UserId = Guid.Parse("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+    private static readonly Guid GameId = Guid.Parse("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+
+    [Fact]
+    public async Task Handle_AlwaysInvalidates_user_userId_tag()
+    {
+        var cache = new Mock<IHybridCacheService>(MockBehavior.Strict);
+        cache.Setup(c => c.RemoveByTagAsync($"user:{UserId}", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        cache.Setup(c => c.RemoveByTagAsync("user-docs", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        // No GameId → game tag is NOT invoked.
+
+        var handler = NewHandler(cache.Object);
+
+        await handler.Handle(MakeEvent(gameId: null), CancellationToken.None);
+
+        cache.Verify(c => c.RemoveByTagAsync($"user:{UserId}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AlwaysInvalidates_user_docs_tag()
+    {
+        var cache = new Mock<IHybridCacheService>(MockBehavior.Strict);
+        cache.Setup(c => c.RemoveByTagAsync($"user:{UserId}", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        cache.Setup(c => c.RemoveByTagAsync("user-docs", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = NewHandler(cache.Object);
+
+        await handler.Handle(MakeEvent(gameId: null), CancellationToken.None);
+
+        cache.Verify(c => c.RemoveByTagAsync("user-docs", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithGameId_AlsoInvalidates_game_gameId_tag()
+    {
+        var cache = new Mock<IHybridCacheService>(MockBehavior.Strict);
+        cache.Setup(c => c.RemoveByTagAsync($"user:{UserId}", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        cache.Setup(c => c.RemoveByTagAsync("user-docs", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        cache.Setup(c => c.RemoveByTagAsync($"game:{GameId}", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = NewHandler(cache.Object);
+
+        await handler.Handle(MakeEvent(gameId: GameId), CancellationToken.None);
+
+        cache.Verify(c => c.RemoveByTagAsync($"game:{GameId}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoGameId_DoesNotInvalidate_game_tag()
+    {
+        var cache = new Mock<IHybridCacheService>(MockBehavior.Strict);
+        cache.Setup(c => c.RemoveByTagAsync($"user:{UserId}", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        cache.Setup(c => c.RemoveByTagAsync("user-docs", It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var handler = NewHandler(cache.Object);
+
+        await handler.Handle(MakeEvent(gameId: null), CancellationToken.None);
+
+        cache.Verify(c => c.RemoveByTagAsync(It.Is<string>(s => s.StartsWith("game:")), It.IsAny<CancellationToken>()),
+            Times.Never, "no game tag invalidation when GameId is null");
+    }
+
+    [Fact]
+    public async Task Handle_NullEvent_ThrowsArgumentNullException()
+    {
+        var handler = NewHandler(Mock.Of<IHybridCacheService>());
+        Func<Task> act = async () => await handler.Handle(null!, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static PdfMetadataChangedEvent MakeEvent(Guid? gameId)
+    {
+        return new PdfMetadataChangedEvent(
+            AggregateId: DocId,
+            UserId: UserId,
+            EditorRole: "Owner",
+            Changes: new[] { new MetadataChange("title", null, "X") },
+            GameId: gameId);
+    }
+
+    private static PdfMetadataChangedCacheInvalidationHandler NewHandler(IHybridCacheService cache)
+        => new(cache, NullLogger<PdfMetadataChangedCacheInvalidationHandler>.Instance);
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/DomainEventLog/EventTypeRegistryTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/DomainEventLog/EventTypeRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.Infrastructure.DomainEventLog;
 using Api.SharedKernel.Domain.Interfaces;
 using Api.Tests.Constants;
@@ -93,5 +94,24 @@ public sealed class EventTypeRegistryTests
     {
         public Guid EventId { get; } = Guid.NewGuid();
         public DateTime OccurredAt { get; } = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Issue #1687 Task 4 — the metadata-change event must be registered for
+    /// durable persistence. Without this entry the audit-log handler (D-11)
+    /// never sees the event because the mapper returns null.
+    /// </summary>
+    [Fact]
+    [Trait("Issue", "1687")]
+    public void Registry_resolves_pdf_metadata_changed_alias()
+    {
+        var ev = new PdfMetadataChangedEvent(
+            AggregateId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(),
+            EditorRole: "Owner",
+            Changes: Array.Empty<MetadataChange>(),
+            GameId: null);
+
+        EventTypeRegistry.TryResolve(ev).Should().Be("pdf.metadata.changed");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ListUserKbDocsQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/ListUserKbDocsQueryHandlerIntegrationTests.cs
@@ -359,4 +359,37 @@ public sealed class ListUserKbDocsQueryHandlerIntegrationTests : IAsyncLifetime
         dto.UpdatedAt.Should().BeCloseTo(uploadTime, TimeSpan.FromMilliseconds(1),
             "UpdatedAt should equal UploadedAt when ProcessedAt is null");
     }
+
+    // ─── Issue #1687 Task 10: Title/Tags/UpdatedBy in DTO + UpdatedAt override ─
+
+    [Fact(Timeout = 30000)]
+    public async Task Handle_DocWithTitleAndTags_ReturnsThemInDto()
+    {
+        await SeedUserAsync(UserA);
+        var game = await SeedGameAsync("Catan");
+        var uploadTime = DateTime.UtcNow.AddDays(-5);
+        var processTime = DateTime.UtcNow.AddDays(-3);
+        var editTime = DateTime.UtcNow.AddHours(-1);
+
+        var editorId = Guid.NewGuid();
+        var doc = NewDoc(UserA, game.Id, "Ready", "catan-rulebook.pdf", uploadTime, processTime);
+        doc.Title = "Catan 5th Edition";
+        doc.Tags = new List<string> { "family", "strategy" };
+        doc.UpdatedAt = editTime;
+        doc.UpdatedBy = editorId;
+
+        _dbContext!.PdfDocuments.Add(doc);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var result = await _handler!.Handle(new ListUserKbDocsQuery(UserA), TestCancellationToken);
+
+        result.Items.Should().HaveCount(1);
+        var dto = result.Items.Single();
+        dto.Title.Should().Be("Catan 5th Edition", "Issue #1687 D-5");
+        dto.Tags.Should().BeEquivalentTo(new[] { "family", "strategy" }, "Issue #1687 D-8");
+        dto.UpdatedBy.Should().Be(editorId, "Issue #1687 D-13");
+        // D-13 override: an explicit edit beats ProcessedAt for display recency.
+        dto.UpdatedAt.Should().BeCloseTo(editTime, TimeSpan.FromMilliseconds(1),
+            "UpdatedAt = doc.UpdatedAt when an edit happened post-processing");
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/UpdateKbDocMetadataCommandHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/UpdateKbDocMetadataCommandHandlerIntegrationTests.cs
@@ -1,0 +1,348 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands.UpdateKbDocMetadata;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Issue #1687 Task 6 — integration tests for <c>UpdateKbDocMetadataCommandHandler</c>.
+/// Asserts the authorization branch (D-2 anti-info-leak 404), the no-op idempotency
+/// path, and the actual persistence + domain-event emission.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1687")]
+public sealed class UpdateKbDocMetadataCommandHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IMediator? _mediator;
+    private ServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UpdateKbDocMetadataCommandHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_update_kb_doc_metadata_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(500, TestCancellationToken);
+            }
+        }
+
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext is not null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedUserAsync(Guid? userId = null)
+    {
+        var id = userId ?? Guid.NewGuid();
+        _dbContext!.Users.Add(new UserEntity
+        {
+            Id = id,
+            Email = $"u-{id:N}@test.local",
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<Guid> SeedSharedGameAsync(string title = "Catan")
+    {
+        var id = Guid.NewGuid();
+        _dbContext!.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            Description = string.Empty,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1, // Approved
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<Guid> SeedPdfDocumentAsync(Guid ownerId, Guid sharedGameId, string fileName = "rulebook.pdf")
+    {
+        var id = Guid.NewGuid();
+        _dbContext!.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = fileName,
+            FilePath = $"/tmp/{fileName}",
+            FileSizeBytes = 2048,
+            ContentType = "application/pdf",
+            UploadedByUserId = ownerId,
+            UploadedAt = DateTime.UtcNow.AddDays(-1),
+            SharedGameId = sharedGameId,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow.AddHours(-12),
+            Tags = new List<string>()
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+        return id;
+    }
+
+    private async Task<int> CountEventLogsAsync(Guid aggregateId)
+    {
+        return await _dbContext!.Set<Api.Infrastructure.Entities.DomainEventLog.DomainEventLogEntity>()
+            .CountAsync(e => e.AggregateId == aggregateId, TestCancellationToken);
+    }
+
+    // ─── AC1: Owner sets all fields → 200, persists, event payload ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_AsOwner_AllFieldsSet_PersistsChanges_EmitsEvent_WithChangesPayload()
+    {
+        var ownerId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: docId,
+            EditorUserId: ownerId,
+            EditorRole: "User",
+            Title: "Catan 5th Edition",
+            DocumentType: "Rulebook",
+            Language: "it",
+            Tags: new[] { "Strategy", "family" });
+
+        var dto = await _mediator!.Send(cmd, TestCancellationToken);
+
+        dto.Title.Should().Be("Catan 5th Edition");
+        dto.Tags.Should().BeEquivalentTo(new[] { "family", "strategy" }, "D-8 dedup+lowercase+sort");
+        dto.UpdatedBy.Should().Be(ownerId);
+
+        // Reload to confirm persistence.
+        _dbContext!.ChangeTracker.Clear();
+        var persisted = await _dbContext.PdfDocuments.AsNoTracking()
+            .SingleAsync(p => p.Id == docId, TestCancellationToken);
+        persisted.Title.Should().Be("Catan 5th Edition");
+        persisted.Tags.Should().BeEquivalentTo(new[] { "family", "strategy" });
+        persisted.UpdatedAt.Should().NotBeNull();
+        persisted.UpdatedBy.Should().Be(ownerId);
+
+        // One row in domain_event_logs.
+        (await CountEventLogsAsync(docId)).Should().Be(1, "EventTypeRegistry registration writes one log row per emission");
+    }
+
+    // ─── AC2: Admin patches another user's doc → editor_role=Admin in event ────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_AsAdmin_OnOtherUsersDoc_PersistsChanges_EmitsEvent_WithEditorRoleAdmin()
+    {
+        var ownerId = await SeedUserAsync();
+        var adminId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: docId,
+            EditorUserId: adminId,
+            EditorRole: "Admin",
+            Title: null,
+            DocumentType: null,
+            Language: null,
+            Tags: new[] { "moderated" });
+
+        var dto = await _mediator!.Send(cmd, TestCancellationToken);
+
+        dto.UpdatedBy.Should().Be(adminId, "the admin id is recorded as the editor (D-1)");
+        dto.Tags.Should().Contain("moderated");
+
+        (await CountEventLogsAsync(docId)).Should().Be(1);
+    }
+
+    // ─── AC3: Non-owner non-admin → 404 NotFound (D-2 anti-info-leak) ─────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_AsNonOwnerNonAdmin_ThrowsNotFoundException()
+    {
+        var ownerId = await SeedUserAsync();
+        var strangerId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: docId,
+            EditorUserId: strangerId,
+            EditorRole: "User",
+            Title: "Cannot do this",
+            DocumentType: null,
+            Language: null,
+            Tags: null);
+
+        Func<Task> act = async () => await _mediator!.Send(cmd, TestCancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>(
+            "D-2: a non-owner non-admin caller must get 404 (anti-info-leak), NOT 403");
+
+        // No state change.
+        _dbContext!.ChangeTracker.Clear();
+        var persisted = await _dbContext.PdfDocuments.AsNoTracking()
+            .SingleAsync(p => p.Id == docId, TestCancellationToken);
+        persisted.Title.Should().BeNull("no mutation on denied access");
+        (await CountEventLogsAsync(docId)).Should().Be(0, "no event emitted on denied access");
+    }
+
+    // ─── Doc does not exist → 404 ──────────────────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_DocIdDoesNotExist_ThrowsNotFoundException()
+    {
+        var editorId = await SeedUserAsync();
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: Guid.NewGuid(),
+            EditorUserId: editorId,
+            EditorRole: "Admin",
+            Title: "Anything",
+            DocumentType: null,
+            Language: null,
+            Tags: null);
+
+        Func<Task> act = async () => await _mediator!.Send(cmd, TestCancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // ─── AllFieldsNull → no-op (no event, no audit bump) ──────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_AllFieldsNull_NoChange_NoEvent_NoAuditBump()
+    {
+        var ownerId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: docId,
+            EditorUserId: ownerId,
+            EditorRole: "User",
+            Title: null,
+            DocumentType: null,
+            Language: null,
+            Tags: null);
+
+        var dto = await _mediator!.Send(cmd, TestCancellationToken);
+
+        // The DTO is returned but no audit was set and no event row exists.
+        dto.UpdatedBy.Should().BeNull();
+        (await CountEventLogsAsync(docId)).Should().Be(0, "no real change → no event (idempotent no-op)");
+    }
+
+    // ─── OnlyTitle → exactly one MetadataChange ─────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_OnlyTitle_OnlyOneChangeRecorded()
+    {
+        var ownerId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        var cmd = new UpdateKbDocMetadataCommand(
+            DocId: docId,
+            EditorUserId: ownerId,
+            EditorRole: "User",
+            Title: "New Title",
+            DocumentType: null,
+            Language: null,
+            Tags: null);
+
+        var dto = await _mediator!.Send(cmd, TestCancellationToken);
+
+        dto.Title.Should().Be("New Title");
+        (await CountEventLogsAsync(docId)).Should().Be(1, "title change emits exactly one event row");
+    }
+
+    // ─── Setting same value → no event (real diff check) ───────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Handle_SameTitleValue_NoEventEmitted()
+    {
+        var ownerId = await SeedUserAsync();
+        var gameId = await SeedSharedGameAsync();
+        var docId = await SeedPdfDocumentAsync(ownerId, gameId);
+
+        // First edit sets the title.
+        await _mediator!.Send(new UpdateKbDocMetadataCommand(
+            docId, ownerId, "User", "Same Title", null, null, null), TestCancellationToken);
+        (await CountEventLogsAsync(docId)).Should().Be(1);
+
+        // Second edit with the SAME title must NOT emit a second event.
+        await _mediator!.Send(new UpdateKbDocMetadataCommand(
+            docId, ownerId, "User", "Same Title", null, null, null), TestCancellationToken);
+        (await CountEventLogsAsync(docId)).Should().Be(1,
+            "no real diff → no event (the handler compares old vs new before emit)");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/KnowledgeBase/UpdateKbDocMetadataEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/KnowledgeBase/UpdateKbDocMetadataEndpointIntegrationTests.cs
@@ -1,0 +1,331 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.ListUserKbDocs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.KnowledgeBase;
+
+/// <summary>
+/// Issue #1687 Task 9 — HTTP-level integration tests for
+/// <c>PATCH /api/v1/kb-docs/{id}</c>. Covers the 8 G/W/T scenarios from D-16
+/// of the spec panel:
+/// 1. Owner sets title only → 200 + DTO + 1 event row.
+/// 2. Admin patches another user's tags → 200 + event with admin id.
+/// 3. Non-owner non-admin → 404 (D-2 anti-info-leak), no state change, no event.
+/// 4. Unauthenticated → 401.
+/// 5. Invalid documentType ("FAQ") → 422, no event.
+/// 6. All fields null → 200, no change, no event, audit unchanged.
+/// 7. 21 tags → 422, no event.
+/// 8. Cached list → PATCH → fresh GET returns updated data (cache invalidation).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "1687")]
+public sealed class UpdateKbDocMetadataEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UpdateKbDocMetadataEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"test_patch_kb_docs_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync(TestCancellationToken);
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_factory is not null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedSharedGameAsync(MeepleAiDbContext db, string title)
+    {
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title);
+        return gameId;
+    }
+
+    private async Task<Guid> SeedPdfDocumentAsync(
+        MeepleAiDbContext db,
+        Guid ownerId,
+        Guid sharedGameId,
+        string fileName = "rulebook.pdf",
+        string? title = null,
+        List<string>? tags = null)
+    {
+        var id = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = fileName,
+            FilePath = $"/tmp/{fileName}",
+            FileSizeBytes = 2048,
+            ContentType = "application/pdf",
+            UploadedByUserId = ownerId,
+            UploadedAt = DateTime.UtcNow.AddDays(-1),
+            SharedGameId = sharedGameId,
+            ProcessingState = "Ready",
+            ProcessedAt = DateTime.UtcNow.AddHours(-12),
+            Title = title,
+            Tags = tags ?? new List<string>()
+        });
+        await db.SaveChangesAsync(TestCancellationToken);
+        return id;
+    }
+
+    private async Task<int> CountEventLogsAsync(MeepleAiDbContext db, Guid aggregateId)
+    {
+        return await db.Set<Api.Infrastructure.Entities.DomainEventLog.DomainEventLogEntity>()
+            .CountAsync(e => e.AggregateId == aggregateId, TestCancellationToken);
+    }
+
+    // ─── AC1: Owner patches title → 200 + DTO + event ─────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC1_Owner_PatchesTitle_Returns200_PersistsDtoUpdatesAuditEmitsEvent()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (ownerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken,
+            new { title = "Catan 5th Edition" });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<UserKbDocDto>(TestCancellationToken);
+        dto.Should().NotBeNull();
+        dto!.Title.Should().Be("Catan 5th Edition");
+        dto.UpdatedBy.Should().Be(ownerId);
+        (await CountEventLogsAsync(db, docId)).Should().Be(1);
+    }
+
+    // ─── AC2: Admin patches another user's tags → 200 + event ──────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC2_Admin_PatchesTagsOnOtherDoc_Returns200_EditorRoleAdminInPayload()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (ownerId, _) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var (adminId, adminToken) = await TestSessionHelper.CreateAdminSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            adminToken,
+            new { tags = new[] { "Moderated" } });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<UserKbDocDto>(TestCancellationToken);
+        dto!.UpdatedBy.Should().Be(adminId, "the admin id is recorded as editor (D-1)");
+        dto.Tags.Should().BeEquivalentTo(new[] { "moderated" }, "D-8 lowercases on persist");
+
+        (await CountEventLogsAsync(db, docId)).Should().Be(1);
+    }
+
+    // ─── AC3: Non-owner non-admin → 404 (D-2 anti-info-leak) ──────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC3_NonOwnerNonAdmin_Patches_Returns404_NoMutationNoEvent()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var (ownerId, _) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var (_, strangerToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            strangerToken,
+            new { title = "Should not work" });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "D-2: never reveal existence of inaccessible docs (no 403)");
+
+        // No state change.
+        db.ChangeTracker.Clear();
+        var persisted = await db.PdfDocuments.AsNoTracking()
+            .SingleAsync(p => p.Id == docId, TestCancellationToken);
+        persisted.Title.Should().BeNull("no mutation on denied access");
+        (await CountEventLogsAsync(db, docId)).Should().Be(0);
+    }
+
+    // ─── AC4: Unauthenticated → 401 ─────────────────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC4_Unauthenticated_Patches_Returns401()
+    {
+        var docId = Guid.NewGuid();
+
+        var response = await _client.PatchAsJsonAsync(
+            $"/api/v1/kb-docs/{docId}",
+            new { title = "Anything" },
+            TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─── AC5: Invalid documentType ("FAQ") → 422 ────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC5_InvalidDocumentType_FAQ_Returns422_NoEvent()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (ownerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken,
+            new { documentType = "FAQ" });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity,
+            "FluentValidation rejects → ApiExceptionHandlerMiddleware returns 422 (NOT 400)");
+        (await CountEventLogsAsync(db, docId)).Should().Be(0);
+    }
+
+    // ─── AC6: All fields null → 200 + no event + audit unchanged ────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC6_AllFieldsNull_Returns200_NoEvent_AuditUnchanged()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (ownerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken,
+            new { title = (string?)null, documentType = (string?)null, language = (string?)null, tags = (string[]?)null });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "all-null body is a no-op, NOT a validation error");
+        (await CountEventLogsAsync(db, docId)).Should().Be(0);
+
+        db.ChangeTracker.Clear();
+        var persisted = await db.PdfDocuments.AsNoTracking()
+            .SingleAsync(p => p.Id == docId, TestCancellationToken);
+        persisted.UpdatedAt.Should().BeNull("audit unchanged on no-op");
+        persisted.UpdatedBy.Should().BeNull();
+    }
+
+    // ─── AC7: 21 tags → 422 ─────────────────────────────────────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC7_TwentyOneTags_Returns422_NoEvent()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (ownerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId);
+
+        var tags = Enumerable.Range(0, 21).Select(i => $"tag-{i}").ToArray();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken,
+            new { tags });
+
+        var response = await _client.SendAsync(request, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await CountEventLogsAsync(db, docId)).Should().Be(0);
+    }
+
+    // ─── AC8: Cached list → PATCH → fresh GET shows update ─────────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task AC8_CachedListThenPatch_GetReturnsFreshData()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (ownerId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(db, cancellationToken: TestCancellationToken);
+        var gameId = await SeedSharedGameAsync(db, "Catan");
+        var docId = await SeedPdfDocumentAsync(db, ownerId, gameId, title: "Original Title");
+
+        // 1. Warm the cache.
+        var firstGet = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/kb-docs", sessionToken);
+        var firstResp = await _client.SendAsync(firstGet, TestCancellationToken);
+        firstResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstPayload = await firstResp.Content.ReadFromJsonAsync<KbDocsListResponse>(TestCancellationToken);
+        firstPayload!.Items.Single().Title.Should().Be("Original Title");
+
+        // 2. PATCH the title.
+        var patch = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Patch,
+            $"/api/v1/kb-docs/{docId}",
+            sessionToken,
+            new { title = "Updated Title" });
+        (await _client.SendAsync(patch, TestCancellationToken)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // 3. Fresh GET — must reflect the update (proves cache invalidation handler wired).
+        var secondGet = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/kb-docs", sessionToken);
+        var secondResp = await _client.SendAsync(secondGet, TestCancellationToken);
+        var secondPayload = await secondResp.Content.ReadFromJsonAsync<KbDocsListResponse>(TestCancellationToken);
+        secondPayload!.Items.Single().Title.Should().Be("Updated Title",
+            "PdfMetadataChangedCacheInvalidationHandler removes the user:{userId} tag so the next GET re-runs the query");
+    }
+}


### PR DESCRIPTION
## Summary

Implements `PATCH /api/v1/kb-docs/{id}` for user-scoped KB doc metadata editing (`title`, `documentType`, `language`, `tags`). Unblocks FE component `KbEditorDesktop` of issue #1482 Phase 2 Interactions. Emits `PdfMetadataChangedEvent` for cache invalidation + future re-index hook.

## Decisions locked (spec-panel 2026-05-31)

16 decisions D-1..D-16 in `claudedocs/spec-panel-1687-decisions.md`. Highlights:

- **D-1** RBAC: owner (`UploadedByUserId == callerId`) + Admin/SuperAdmin only; no "Curator" (role does not exist in `UserRole` enum)
- **D-2** Anti-info-leak: **404 (not 403)** when caller cannot see the doc — diverging from `HandleUpdateChatThreadTitle` template
- **D-3** Concurrency: LWW with `UpdatedAt`/`UpdatedBy` audit columns; **no `RowVersion`** in v1 (deferred)
- **D-4** Partial update: JSON `null` = no-op, `""`/`[]` = clear; FluentValidation `.When(x => x.Field is not null)`
- **D-5** New `Title` column on `PdfDocumentEntity` (distinct from immutable `FileName`)
- **D-6** Request `documentType` maps to existing `DocumentCategory` enum (7 values) — issue body's `FAQ|Guide` deferred
- **D-7** `language` validates against existing `LanguageCode` whitelist (10 codes)
- **D-8** Tags: greenfield `text[] NOT NULL DEFAULT '{}'`; max 20 / 50 chars; deduped+lowercased+sorted on write; GIN index forward-compat with #1686
- **D-9** `PdfMetadataChangedEvent` as `record:IDomainEvent` (P116); lives in `DocumentProcessing/Domain/Events`; AggregateType=`"PdfMetadataChanged"` (P117 mapper convention)
- **D-10** Cache invalidation: tags `user:{userId}`, `user-docs`, optional `game:{gameId}` — matches `ListUserKbDocsQueryHandler` cache-write tags exactly
- **D-11** Audit log via `EventTypeRegistry` `[typeof(PdfMetadataChangedEvent)] = "pdf.metadata.changed"`
- **D-12** Re-indexing **out of scope**; event exposes `RequiresReindex: bool` hint for future consumers
- **D-13** Response: 200 + extended `UserKbDocDto` (adds `Title`, `Tags`, `UpdatedBy`)

## Schema change (additive)

- New columns on `pdf_documents`:
  - `title varchar(200) NULL`
  - `tags text[] NOT NULL DEFAULT '{}'`
  - `updated_at timestamp NULL`
  - `updated_by uuid NULL`
- New index: `IX_pdf_documents_tags_gin` (GIN) — forward-compat with #1686 facets
- Migration: `AddPdfDocumentMetadataEditableFields` (additive only, no DROP/RENAME — passes Migration Safety Gate by construction)

## Scope of this PR — 10/10 tasks complete

| Task | Commit | Scope |
|---|---|---|
| 1 | `1d512f87f` | EF migration: 4 columns + GIN index |
| 2 | `aac8a4754` | `PdfDocument` aggregate gains editable metadata mutators |
| 3 | `7338a74b4` | `PdfMetadataChangedEvent` + `MetadataChange` records |
| 4 | `f09407a68` | Register `PdfMetadataChangedEvent` in `EventTypeRegistry` |
| 5 | `def3d04ce` | `UpdateKbDocMetadataCommand` + FluentValidator |
| 6 | `e58abbb05` | `UpdateKbDocMetadataCommandHandler` (CQRS) |
| 7+10 | `100d9a1b6` | PATCH endpoint + request DTO + `UserKbDocDto` extension |
| 8 | `30c8819f9` | `PdfMetadataChangedCacheInvalidationHandler` |
| 9 | `26459c91d` | HTTP integration tests for PATCH endpoint |

## Test coverage

- **61 BE tests pass** (unit + integration, 6m 5s incl. Testcontainers Postgres)
- Unit: aggregate mutators, event mapper convention, validator partial-update semantics, cache-invalidation handler, EventTypeRegistry alias
- Integration: HTTP-level 8 G/W/T scenarios (RBAC × validation × concurrency × audit × cache-tag invalidation)

## Acceptance criteria — all met

- ✅ Endpoint `PATCH /api/v1/kb-docs/{id}` with body `{ title?, documentType?, language?, tags? }`
- ✅ RBAC: owner + Admin/SuperAdmin → 200 with updated `UserKbDocDto`; others → 404 (anti-info-leak)
- ✅ FluentValidation partial-update via `.When()`
- ✅ 422 on validation failure (via `ApiExceptionHandlerMiddleware`), 404 on not-accessible
- ✅ Concurrency LWW + audit columns
- ✅ `PdfMetadataChangedEvent` emitted; durable + cache invalidation handler
- ✅ OpenAPI/Scalar documents 200/401/404/422

## Follow-up issues (not in this PR)

To open post-merge:
- **`feat(kb-docs)`** — Optimistic concurrency via `RowVersion` (D-3 deferred to v2 when first user-conflict observed)
- **`feat(kb-docs)`** — Re-indexing trigger on language/documentType change (D-12, consume `RequiresReindex` hint)
- **`feat(kb-docs)`** — Expose `FAQ` / `Guide` in `DocumentCategory` (D-6 — currently only 7 canonical values)

## Refs

- Issue: #1687
- Epic: #1475 User-facing UI completion (Phase B sub-issue unblocker for #1482 Phase 2 `KbEditorDesktop`)
- Decisions doc: `claudedocs/spec-panel-1687-decisions.md`
- Plan: `docs/superpowers/plans/2026-05-31-kb-docs-patch-metadata-be.md`
- Companion PR: #1730 (#1686 facets, parallel BE work for same Phase 0.5 contract)