### PR TITLE
feat(admin-ai): #1728 drill endpoint — chunks + per-stage breakdown

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/LogAiRequestCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/LogAiRequestCommand.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.Models;
 using Api.SharedKernel.Application.Interfaces;
 
@@ -25,5 +26,10 @@ internal record LogAiRequestCommand(
     string? Model = null,
     string? FinishReason = null,
     string? ApiKeyId = null,
-    QualityScores? QualityScores = null
+    QualityScores? QualityScores = null,
+    // #1728: Drill payload (jsonb). Both nullable; pipelines that did not
+    // record chunks/breakdown leave them null and the QueryDrillPanel
+    // surfaces "limited drill" / "breakdown unavailable" fallbacks.
+    IReadOnlyList<RetrievedChunkDto>? Chunks = null,
+    LatencyBreakdownDto? Breakdown = null
 ) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/LogAiRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/LogAiRequestCommandHandler.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using Api.BoundedContexts.Administration.Application.Commands;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -7,6 +9,8 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 
 internal class LogAiRequestCommandHandler : ICommandHandler<LogAiRequestCommand>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly MeepleAiDbContext _db;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<LogAiRequestCommandHandler> _logger;
@@ -51,7 +55,16 @@ internal class LogAiRequestCommandHandler : ICommandHandler<LogAiRequestCommand>
                 LlmConfidence = command.QualityScores?.LlmConfidence,
                 CitationQuality = command.QualityScores?.CitationQuality,
                 OverallConfidence = command.QualityScores?.OverallConfidence,
-                IsLowQuality = command.QualityScores?.IsLowQuality ?? false
+                IsLowQuality = command.QualityScores?.IsLowQuality ?? false,
+                // #1728: Serialize drill payload into jsonb columns. Null when
+                // the caller did not pass chunks/breakdown — surfaces as
+                // "limited drill" / "breakdown unavailable" on the FE.
+                ChunksJson = command.Chunks is { Count: > 0 }
+                    ? JsonSerializer.Serialize(command.Chunks, JsonOptions)
+                    : null,
+                BreakdownJson = command.Breakdown is not null
+                    ? JsonSerializer.Serialize(command.Breakdown, JsonOptions)
+                    : null,
             };
 
             _db.AiRequestLogs.Add(log);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AiQueryDrillResult.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AiQueryDrillResult.cs
@@ -1,0 +1,54 @@
+using Api.Infrastructure.Entities;
+
+namespace Api.BoundedContexts.Administration.Application.DTOs;
+
+/// <summary>
+/// Result for the per-query drill endpoint (#1728).
+/// Contains the AI request log entity plus optional chunks list and
+/// per-stage latency breakdown.
+/// </summary>
+internal record AiQueryDrillResult
+{
+    /// <summary>The AI request log entity (canonical row).</summary>
+    public required AiRequestLogEntity Request { get; init; }
+
+    /// <summary>
+    /// Retrieved chunks for this query. Empty array when the pipeline
+    /// did not record chunks (legacy rows, error paths, or endpoints
+    /// without RAG retrieval).
+    /// </summary>
+    public required IReadOnlyList<RetrievedChunkDto> Chunks { get; init; }
+
+    /// <summary>
+    /// Per-stage latency breakdown. Null when not instrumented yet.
+    /// FE renders "breakdown unavailable" fallback in that case.
+    /// </summary>
+    public LatencyBreakdownDto? Breakdown { get; init; }
+}
+
+/// <summary>
+/// A single retrieved chunk surfaced by the drill endpoint.
+/// Shape mirrors `apps/web/.../sandbox/types.ts` <c>RetrievedChunk</c>.
+/// </summary>
+internal record RetrievedChunkDto
+{
+    public required string Id { get; init; }
+    public required double Score { get; init; }
+    public required string Text { get; init; }
+    public required int Page { get; init; }
+    public required int ChunkIndex { get; init; }
+    public required string PdfName { get; init; }
+    public required bool Used { get; init; }
+}
+
+/// <summary>
+/// Per-stage latency split for a single AI query.
+/// Must surface ALL four fields together (no partial breakdown).
+/// </summary>
+internal record LatencyBreakdownDto
+{
+    public required int RetrievalMs { get; init; }
+    public required int RerankMs { get; init; }
+    public required int LlmMs { get; init; }
+    public required int PostMs { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Query to fetch a single AI request log with drill payload (#1728):
+/// retrieved chunks + per-stage latency breakdown.
+/// Returns null when the id does not exist.
+/// </summary>
+internal record GetAiQueryDrillQuery(Guid Id) : IQuery<AiQueryDrillResult?>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQueryHandler.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+internal class GetAiQueryDrillQueryHandler : IQueryHandler<GetAiQueryDrillQuery, AiQueryDrillResult?>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<GetAiQueryDrillQueryHandler> _logger;
+
+    public GetAiQueryDrillQueryHandler(MeepleAiDbContext db, ILogger<GetAiQueryDrillQueryHandler> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AiQueryDrillResult?> Handle(GetAiQueryDrillQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.Id == Guid.Empty)
+        {
+            return null;
+        }
+
+        var entity = await _db.AiRequestLogs
+            .AsNoTracking()
+            .FirstOrDefaultAsync(log => log.Id == request.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        var chunks = DeserializeOrEmpty<List<RetrievedChunkDto>>(entity.ChunksJson, request.Id, nameof(entity.ChunksJson))
+                     ?? new List<RetrievedChunkDto>();
+
+        var breakdown = DeserializeOrEmpty<LatencyBreakdownDto>(entity.BreakdownJson, request.Id, nameof(entity.BreakdownJson));
+
+        return new AiQueryDrillResult
+        {
+            Request = entity,
+            Chunks = chunks,
+            Breakdown = breakdown,
+        };
+    }
+
+    private T? DeserializeOrEmpty<T>(string? json, Guid requestId, string columnName) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, JsonOptions);
+        }
+#pragma warning disable CA1031 // Drill is read-only telemetry — corrupted JSON must degrade to fallback, not fail the endpoint.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to deserialize {Column} for AiRequestLog {Id}; surfacing as null.",
+                columnName,
+                requestId);
+            return null;
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/AiRequestLogEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/AiRequestLogEntity.cs
@@ -32,4 +32,12 @@ public class AiRequestLogEntity
     public double? CitationQuality { get; set; }
     public double? OverallConfidence { get; set; }
     public bool IsLowQuality { get; set; }
+
+    // #1728: Drill payload (jsonb). Both nullable — legacy rows + pipelines
+    // without instrumentation surface as "limited drill" / "breakdown
+    // unavailable" on the FE QueryDrillPanel (degrade graceful).
+    // ChunksJson: serialized JSON array of {id, score, text, page, chunkIndex, pdfName, used}
+    // BreakdownJson: serialized JSON object {retrievalMs, rerankMs, llmMs, postMs}
+    public string? ChunksJson { get; set; }
+    public string? BreakdownJson { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/AiRequestLogEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/AiRequestLogEntityConfiguration.cs
@@ -28,6 +28,11 @@ internal class AiRequestLogEntityConfiguration : IEntityTypeConfiguration<AiRequ
         builder.Property(e => e.Model).HasMaxLength(128);
         builder.Property(e => e.FinishReason).HasMaxLength(64);
         builder.Property(e => e.CreatedAt).IsRequired();
+
+        // #1728: Drill payload columns (Postgres jsonb).
+        builder.Property(e => e.ChunksJson).HasColumnType("jsonb");
+        builder.Property(e => e.BreakdownJson).HasColumnType("jsonb");
+
         builder.HasIndex(e => e.CreatedAt);
         builder.HasIndex(e => e.Endpoint);
         builder.HasIndex(e => e.UserId);

--- a/apps/api/src/Api/Infrastructure/Migrations/20260531074336_AddDrillPayloadToAiRequestLogs.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260531074336_AddDrillPayloadToAiRequestLogs.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531074336_AddDrillPayloadToAiRequestLogs")]
+    partial class AddDrillPayloadToAiRequestLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260531074336_AddDrillPayloadToAiRequestLogs.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260531074336_AddDrillPayloadToAiRequestLogs.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDrillPayloadToAiRequestLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BreakdownJson",
+                table: "ai_request_logs",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ChunksJson",
+                table: "ai_request_logs",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BreakdownJson",
+                table: "ai_request_logs");
+
+            migrationBuilder.DropColumn(
+                name: "ChunksJson",
+                table: "ai_request_logs");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
@@ -26,6 +27,32 @@ namespace Api.Routing;
 internal static class AiEndpoints
 {
     private static readonly string[] ParagraphSeparators = { "\n\n", "\n" };
+
+    // #1728: Map RAG pipeline snippets to the drill payload chunks shape so
+    // QueryDrillPanel can render the retrieved-chunks list. Snippets without
+    // a `chunkId` (per-game endpoints) fall back to a composite "source#page.line"
+    // identifier — the FE only needs uniqueness within the panel.
+    private static IReadOnlyList<RetrievedChunkDto>? MapSnippetsToChunks(IReadOnlyList<Snippet>? snippets)
+    {
+        if (snippets is null || snippets.Count == 0) return null;
+        var chunks = new List<RetrievedChunkDto>(snippets.Count);
+        foreach (var s in snippets)
+        {
+            chunks.Add(new RetrievedChunkDto
+            {
+                Id = !string.IsNullOrWhiteSpace(s.chunkId)
+                    ? s.chunkId!
+                    : $"{s.source}#{s.page}.{s.line}",
+                Score = s.score,
+                Text = s.text,
+                Page = s.page,
+                ChunkIndex = s.chunkPosition ?? s.line,
+                PdfName = s.source,
+                Used = true,
+            });
+        }
+        return chunks;
+    }
 
     /// <summary>
     /// SSE events must use camelCase to match frontend qaStream parser expectations.
@@ -318,7 +345,10 @@ internal static class AiEndpoints
             ErrorMessage: streamContext.StreamErrorMessage,
             IpAddress: context.Connection.RemoteIpAddress?.ToString(),
             UserAgent: context.Request.Headers.UserAgent.ToString(),
-            CompletionTokens: streamContext.TotalTokens
+            CompletionTokens: streamContext.TotalTokens,
+            // #1728: drill payload (chunks from retrieved snippets; breakdown
+            // pending pipeline instrumentation)
+            Chunks: MapSnippetsToChunks(streamContext.Snippets)
         );
         await mediator.Send(logCommand, CancellationToken.None).ConfigureAwait(false);
     }
@@ -499,7 +529,9 @@ internal static class AiEndpoints
             PromptTokens: resp.promptTokens,
             CompletionTokens: resp.completionTokens,
             Model: null,
-            FinishReason: null
+            FinishReason: null,
+            // #1728: drill payload (citations as chunks)
+            Chunks: MapSnippetsToChunks(snippets)
         );
         await mediator.Send(logCommand, ct).ConfigureAwait(false);
 
@@ -874,7 +906,9 @@ internal static class AiEndpoints
             CompletionTokens: resp.completionTokens,
             Model: model,
             FinishReason: finishReason,
-            QualityScores: qualityScores
+            QualityScores: qualityScores,
+            // #1728: drill payload (snippets as chunks)
+            Chunks: MapSnippetsToChunks(resp.snippets)
         );
         await mediator.Send(logCommand, ct).ConfigureAwait(false);
     }

--- a/apps/api/src/Api/Routing/AnalyticsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AnalyticsEndpoints.cs
@@ -38,6 +38,64 @@ internal static class AnalyticsEndpoints
         group.MapGet("/admin/requests", HandleGetRequests);
 
         group.MapGet("/admin/stats", HandleGetStats);
+
+        // #1728: per-query drill (chunks + per-stage breakdown) for QueryDrillPanel
+        group.MapGet("/admin/ai/queries/{id:guid}/drill", HandleGetAiQueryDrill)
+            .WithName("GetAiQueryDrill")
+            .WithTags("Admin", "AI")
+            .WithSummary("Get retrieved chunks + per-stage latency breakdown for a single AI request")
+            .WithDescription("Returns the AI request log together with retrieved chunks (when the pipeline recorded them) and per-stage latency breakdown (retrieval/rerank/llm/post). Empty arrays / null breakdown surface as 'limited drill' on the FE.")
+            .Produces<object>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    // #1728: Endpoint handler for per-query drill.
+    private static async Task<IResult> HandleGetAiQueryDrill(
+        HttpContext context,
+        IMediator mediator,
+        Guid id,
+        CancellationToken ct = default)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var query = new GetAiQueryDrillQuery(id);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+
+        if (result is null)
+        {
+            return Results.NotFound(new { error = "not_found" });
+        }
+
+        var r = result.Request;
+        return Results.Json(new
+        {
+            request = new
+            {
+                id = r.Id,
+                userId = r.UserId,
+                gameId = r.GameId,
+                endpoint = r.Endpoint,
+                query = r.Query,
+                responseSnippet = r.ResponseSnippet,
+                latencyMs = r.LatencyMs,
+                tokenCount = r.TokenCount,
+                promptTokens = r.PromptTokens,
+                completionTokens = r.CompletionTokens,
+                confidence = r.Confidence,
+                status = r.Status,
+                errorMessage = r.ErrorMessage,
+                ipAddress = r.IpAddress,
+                userAgent = r.UserAgent,
+                createdAt = r.CreatedAt,
+                model = r.Model,
+                finishReason = r.FinishReason,
+            },
+            chunks = result.Chunks,
+            breakdown = result.Breakdown,
+        });
     }
 
     private static void MapLlmHealthEndpoints(RouteGroupBuilder group)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/GetAiQueryDrillQueryHandlerTests.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Unit coverage for #1728 drill query handler.
+///
+/// The handler reads a single <see cref="AiRequestLogEntity"/> by id and
+/// deserializes the optional jsonb columns (<c>ChunksJson</c> +
+/// <c>BreakdownJson</c>) into the FE-facing DTOs. Corrupted JSON must
+/// degrade gracefully (warn + null) — never throw — because the drill
+/// endpoint is read-only telemetry.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class GetAiQueryDrillQueryHandlerTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"GetAiQueryDrillTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    private static GetAiQueryDrillQueryHandler CreateHandler(MeepleAiDbContext db)
+    {
+        return new GetAiQueryDrillQueryHandler(db, Mock.Of<ILogger<GetAiQueryDrillQueryHandler>>());
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyGuid_ReturnsNullWithoutHittingTheDatabase()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WithEmptyGuid_ReturnsNullWithoutHittingTheDatabase));
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(Guid.Empty), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenIdNotFound_ReturnsNull()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenIdNotFound_ReturnsNull));
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WithNullRequest_ThrowsArgumentNullException()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WithNullRequest_ThrowsArgumentNullException));
+        var handler = CreateHandler(db);
+
+        await FluentActions
+            .Invoking(() => handler.Handle(null!, CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenEntityHasNoDrillPayload_ReturnsEmptyChunksAndNullBreakdown()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenEntityHasNoDrillPayload_ReturnsEmptyChunksAndNullBreakdown));
+        var entity = SeedLog(db, ChunksJson: null, BreakdownJson: null);
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(entity.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Request.Id.Should().Be(entity.Id);
+        result.Chunks.Should().BeEmpty();
+        result.Breakdown.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenEntityHasChunksJson_DeserializesChunks()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenEntityHasChunksJson_DeserializesChunks));
+        var chunks = new[]
+        {
+            new RetrievedChunkDto
+            {
+                Id = "chunk-1",
+                Score = 0.91,
+                Text = "Players draw cards at end of turn.",
+                Page = 12,
+                ChunkIndex = 4,
+                PdfName = "rulebook.pdf",
+                Used = true,
+            },
+            new RetrievedChunkDto
+            {
+                Id = "chunk-2",
+                Score = 0.74,
+                Text = "Hand limit is 7.",
+                Page = 14,
+                ChunkIndex = 7,
+                PdfName = "rulebook.pdf",
+                Used = false,
+            },
+        };
+        var entity = SeedLog(db, ChunksJson: JsonSerializer.Serialize(chunks, JsonOptions), BreakdownJson: null);
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(entity.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Chunks.Should().HaveCount(2);
+        result.Chunks[0].Id.Should().Be("chunk-1");
+        result.Chunks[0].Score.Should().Be(0.91);
+        result.Chunks[1].Used.Should().BeFalse();
+        result.Breakdown.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenEntityHasBreakdownJson_DeserializesBreakdown()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenEntityHasBreakdownJson_DeserializesBreakdown));
+        var breakdown = new LatencyBreakdownDto
+        {
+            RetrievalMs = 100,
+            RerankMs = 50,
+            LlmMs = 600,
+            PostMs = 92,
+        };
+        var entity = SeedLog(db, ChunksJson: null, BreakdownJson: JsonSerializer.Serialize(breakdown, JsonOptions));
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(entity.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Breakdown.Should().NotBeNull();
+        result.Breakdown!.RetrievalMs.Should().Be(100);
+        result.Breakdown.LlmMs.Should().Be(600);
+        result.Chunks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenChunksJsonIsCorrupted_ReturnsEmptyChunksWithoutThrowing()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenChunksJsonIsCorrupted_ReturnsEmptyChunksWithoutThrowing));
+        var entity = SeedLog(db, ChunksJson: "{ this is not valid json", BreakdownJson: null);
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(entity.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Chunks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WhenBreakdownJsonIsCorrupted_ReturnsNullBreakdownWithoutThrowing()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WhenBreakdownJsonIsCorrupted_ReturnsNullBreakdownWithoutThrowing));
+        var entity = SeedLog(db, ChunksJson: null, BreakdownJson: "{\"retrievalMs\": \"oops-not-a-number\"");
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiQueryDrillQuery(entity.Id), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Breakdown.Should().BeNull();
+    }
+
+    private static AiRequestLogEntity SeedLog(MeepleAiDbContext db, string? ChunksJson, string? BreakdownJson)
+    {
+        var entity = new AiRequestLogEntity
+        {
+            Id = Guid.NewGuid(),
+            Endpoint = "qa-stream",
+            Query = "test query",
+            ResponseSnippet = "test response",
+            LatencyMs = 842,
+            TokenCount = 1240,
+            PromptTokens = 980,
+            CompletionTokens = 260,
+            Status = "Success",
+            CreatedAt = DateTime.UtcNow,
+            ChunksJson = ChunksJson,
+            BreakdownJson = BreakdownJson,
+        };
+        db.AiRequestLogs.Add(entity);
+        db.SaveChanges();
+        return entity;
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
@@ -10,7 +10,7 @@ import { QueryDrillPanel } from '@/components/admin/ai/QueryDrillPanel';
 import { AdminHubEmptyState } from '@/components/admin/layout/AdminHubEmptyState';
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
-import type { AiRequest } from '@/lib/api/schemas';
+import type { AiQueryDrillResponse, AiRequest } from '@/lib/api/schemas';
 import { cn } from '@/lib/utils';
 
 const TREND_RANGE_OPTIONS = ['1d', '7d', '30d'] as const;
@@ -26,6 +26,10 @@ export function RequestsTab() {
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
   const [trend, setTrend] = useState<TrendDatapoint[]>([]);
+  // #1728: drill payload fetched from /api/v1/admin/ai/queries/{id}/drill
+  // when a row is selected. Null = not requested yet / clearing; undefined
+  // = endpoint resolved with 404 (rare).
+  const [drill, setDrill] = useState<AiQueryDrillResponse | null>(null);
 
   const fetchRequests = (pageNum: number) => {
     setLoading(true);
@@ -70,6 +74,27 @@ export function RequestsTab() {
     if (!params.get('tab')) params.set('tab', 'requests');
     router.replace(`?${params.toString()}`, { scroll: false });
   };
+
+  // #1728: fetch drill payload (chunks + breakdown) when a row is selected.
+  // Keeps the panel "limited drill" badge visible until the BE responds.
+  useEffect(() => {
+    if (!selectedId) {
+      setDrill(null);
+      return;
+    }
+    let cancelled = false;
+    api.admin
+      .getAiQueryDrill(selectedId)
+      .then(data => {
+        if (!cancelled) setDrill(data);
+      })
+      .catch(() => {
+        if (!cancelled) setDrill(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
 
   const selectedQuery = useMemo<AiRequest | null>(() => {
     if (!selectedId) return null;
@@ -254,7 +279,13 @@ export function RequestsTab() {
 
         {hasDrill && (
           <div className="hidden lg:block">
-            <QueryDrillPanel query={selectedQuery} onClose={closeDrill} />
+            <QueryDrillPanel
+              query={selectedQuery}
+              onClose={closeDrill}
+              breakdown={drill?.breakdown ?? null}
+              chunks={drill?.chunks ?? null}
+              drillReady={drill !== null}
+            />
           </div>
         )}
       </div>

--- a/apps/web/src/components/admin/ai/QueryDrillPanel.tsx
+++ b/apps/web/src/components/admin/ai/QueryDrillPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { X } from 'lucide-react';
+import { X, FileText } from 'lucide-react';
 
-import type { AiRequest } from '@/lib/api/schemas';
+import type { AiRequest, RetrievedChunkDto } from '@/lib/api/schemas';
 
 import { LatencyBreakdownBar, type LatencyBreakdown } from './LatencyBreakdownBar';
 
@@ -10,24 +10,44 @@ interface QueryDrillPanelProps {
   query: AiRequest | null;
   onClose: () => void;
   /**
-   * Per-stage latency split. Today the `/api/v1/admin/requests`
-   * payload doesn't include it — pass `null` to render the fallback
-   * caption. PR-wired prop ready for #1722 sub-task BE drill endpoint.
+   * Per-stage latency split. Populated by #1728 drill endpoint when
+   * the pipeline has been instrumented; null otherwise (FE renders
+   * "breakdown unavailable" fallback).
    */
   breakdown?: LatencyBreakdown | null;
+  /**
+   * Retrieved chunks for this query. Populated by #1728 drill
+   * endpoint when the pipeline captured them. Empty array surfaces
+   * the "no chunks recorded" empty state without the "limited drill"
+   * badge.
+   */
+  chunks?: readonly RetrievedChunkDto[] | null;
+  /**
+   * True when the drill endpoint has resolved successfully (even if
+   * chunks is empty). Controls the "limited drill" badge — hides it
+   * when the BE has spoken, surfaces it when we only have the base
+   * `/admin/requests` payload.
+   */
+  drillReady?: boolean;
 }
 
 /**
  * Right-side drill-down panel for a single AI request.
  *
- * Shows the prompt, response snippet, and metadata grid. Chunks +
- * latency breakdown require the dedicated drill endpoint (#1722
- * sub-task BE — `GET /api/v1/admin/ai/queries/{id}/drill`); until
- * then we render a "limited drill" badge and surface only what the
- * `/api/v1/admin/requests` payload already exposes.
+ * When the dedicated drill endpoint (`GET /api/v1/admin/ai/queries/{id}/drill`)
+ * has resolved (`drillReady=true`), surfaces chunks + breakdown. Falls
+ * back to a "limited drill" badge for legacy callers that only have
+ * the `/admin/requests` payload.
  */
-export function QueryDrillPanel({ query, onClose, breakdown = null }: QueryDrillPanelProps) {
+export function QueryDrillPanel({
+  query,
+  onClose,
+  breakdown = null,
+  chunks = null,
+  drillReady = false,
+}: QueryDrillPanelProps) {
   if (!query) return null;
+  const showLimitedBadge = !drillReady;
 
   return (
     <aside
@@ -42,9 +62,11 @@ export function QueryDrillPanel({ query, onClose, breakdown = null }: QueryDrill
               {query.endpoint}
             </span>
             <StatusPill status={query.status} />
-            <span className="ml-auto inline-flex items-center rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
-              limited drill
-            </span>
+            {showLimitedBadge && (
+              <span className="ml-auto inline-flex items-center rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
+                limited drill
+              </span>
+            )}
           </div>
           <div className="mt-1 flex items-center gap-3 text-[11px] text-muted-foreground tabular-nums">
             <span>{query.model ?? '—'}</span>
@@ -75,6 +97,36 @@ export function QueryDrillPanel({ query, onClose, breakdown = null }: QueryDrill
       </Section>
 
       <LatencyBreakdownBar breakdown={breakdown} totalMs={query.latencyMs} />
+
+      {drillReady && (
+        <Section label={`Retrieved chunks (${chunks?.length ?? 0})`}>
+          {chunks && chunks.length > 0 ? (
+            <ul className="space-y-2">
+              {chunks.map(c => (
+                <li
+                  key={c.id}
+                  className="rounded-md border border-border/60 bg-background p-2 space-y-1"
+                >
+                  <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                    <FileText className="h-3 w-3" />
+                    <span className="font-mono truncate">{c.pdfName}</span>
+                    <span className="ml-auto font-mono tabular-nums">p.{c.page}</span>
+                    <span className="font-mono tabular-nums">#{c.chunkIndex}</span>
+                    <span className="font-mono tabular-nums">{c.score.toFixed(2)}</span>
+                  </div>
+                  <p className="text-[12px] text-foreground/85 line-clamp-3 break-words">
+                    {c.text}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="rounded-md border border-dashed border-border/60 bg-muted/30 px-2 py-1.5 text-[11px] text-muted-foreground">
+              no chunks recorded for this query
+            </p>
+          )}
+        </Section>
+      )}
 
       <Section label="Metadata">
         <dl className="grid grid-cols-2 gap-2 text-[11px]">

--- a/apps/web/src/components/admin/ai/__tests__/QueryDrillPanel.test.tsx
+++ b/apps/web/src/components/admin/ai/__tests__/QueryDrillPanel.test.tsx
@@ -59,9 +59,53 @@ describe('QueryDrillPanel', () => {
     expect(screen.getAllByText(/842\s*ms/).length).toBeGreaterThan(0);
   });
 
-  it('surfaces a "limited drill" badge when chunks are unavailable', () => {
+  it('surfaces a "limited drill" badge when the drill endpoint has not resolved', () => {
     render(<QueryDrillPanel query={sampleRequest} onClose={vi.fn()} />);
     expect(screen.getByText(/limited drill/i)).toBeInTheDocument();
+  });
+
+  it('hides the "limited drill" badge once drillReady is true', () => {
+    render(<QueryDrillPanel query={sampleRequest} onClose={vi.fn()} drillReady chunks={[]} />);
+    expect(screen.queryByText(/limited drill/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the chunks section with the empty state when drillReady + chunks=[]', () => {
+    render(<QueryDrillPanel query={sampleRequest} onClose={vi.fn()} drillReady chunks={[]} />);
+    expect(screen.getByText(/Retrieved chunks \(0\)/)).toBeInTheDocument();
+    expect(screen.getByText(/no chunks recorded/i)).toBeInTheDocument();
+  });
+
+  it('renders one item per chunk when chunks are provided', () => {
+    render(
+      <QueryDrillPanel
+        query={sampleRequest}
+        onClose={vi.fn()}
+        drillReady
+        chunks={[
+          {
+            id: 'chunk-1',
+            score: 0.91,
+            text: 'A player draws cards at the end of each turn.',
+            page: 12,
+            chunkIndex: 4,
+            pdfName: 'rulebook.pdf',
+            used: true,
+          },
+          {
+            id: 'chunk-2',
+            score: 0.74,
+            text: 'Discard down to the hand limit.',
+            page: 14,
+            chunkIndex: 7,
+            pdfName: 'rulebook.pdf',
+            used: true,
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText(/Retrieved chunks \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText(/A player draws cards/)).toBeInTheDocument();
+    expect(screen.getByText(/Discard down to/)).toBeInTheDocument();
   });
 
   it('renders the panel with the region role and a descriptive label', () => {

--- a/apps/web/src/lib/api/clients/admin/adminAnalyticsClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminAnalyticsClient.ts
@@ -12,6 +12,7 @@ import {
   AdminStatsSchema,
   AdminOverviewStatsSchema,
   AiRequestsResponseSchema,
+  AiQueryDrillResponseSchema,
   DashboardStatsSchema,
   GetUserActivityResultSchema,
   TokenBalanceSchema,
@@ -26,6 +27,7 @@ import {
   type AdminStats,
   type AdminOverviewStats,
   type AiRequest,
+  type AiQueryDrillResponse,
   type DashboardStats,
   type GetUserActivityResult,
   type RecentActivityDto,
@@ -192,6 +194,17 @@ export function createAdminAnalyticsClient(http: HttpClient) {
         AiRequestsResponseSchema
       );
       return result ?? { requests: [], totalCount: 0 };
+    },
+
+    /**
+     * #1728: Per-query drill (chunks + per-stage breakdown) for QueryDrillPanel.
+     * Returns null when the id does not exist (BE responds 404 → http.get → null).
+     */
+    async getAiQueryDrill(id: string): Promise<AiQueryDrillResponse | null> {
+      return http.get(
+        `/api/v1/admin/ai/queries/${encodeURIComponent(id)}/drill`,
+        AiQueryDrillResponseSchema
+      );
     },
 
     async getChatAnalytics(days: number = 30): Promise<ChatAnalyticsDto | null> {

--- a/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
@@ -39,6 +39,37 @@ export const AiRequestsResponseSchema = z.object({
 
 export type AiRequestsResponse = z.infer<typeof AiRequestsResponseSchema>;
 
+// ========== AI Query Drill (#1728) ==========
+
+export const RetrievedChunkDtoSchema = z.object({
+  id: z.string(),
+  score: z.number(),
+  text: z.string(),
+  page: z.number(),
+  chunkIndex: z.number(),
+  pdfName: z.string(),
+  used: z.boolean(),
+});
+
+export type RetrievedChunkDto = z.infer<typeof RetrievedChunkDtoSchema>;
+
+export const LatencyBreakdownDtoSchema = z.object({
+  retrievalMs: z.number(),
+  rerankMs: z.number(),
+  llmMs: z.number(),
+  postMs: z.number(),
+});
+
+export type LatencyBreakdownDto = z.infer<typeof LatencyBreakdownDtoSchema>;
+
+export const AiQueryDrillResponseSchema = z.object({
+  request: AiRequestSchema,
+  chunks: z.array(RetrievedChunkDtoSchema),
+  breakdown: LatencyBreakdownDtoSchema.nullable(),
+});
+
+export type AiQueryDrillResponse = z.infer<typeof AiQueryDrillResponseSchema>;
+
 // ========== Prompt Version Activation ==========
 
 export const ActivateVersionResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Implementa l'endpoint **drill** per `QueryDrillPanel` (sub-task BE di #1722 chiuso). Sblocca il pannello dal fallback "limited drill" mostrando chunks reali della pipeline RAG + (predisposizione) breakdown per-stage.

Closes #1728.

## Cosa cambia

### BE
- **Entity**: `AiRequestLogEntity` + 2 colonne `jsonb` (`ChunksJson`, `BreakdownJson`). Migration reversible.
- **Query/Handler**: `GetAiQueryDrillQuery` + handler con deserializzazione JSON fail-safe (corrupt JSON → warn + null, mai throw).
- **DTOs**: `AiQueryDrillResult`, `RetrievedChunkDto`, `LatencyBreakdownDto`.
- **Endpoint**: `GET /api/v1/admin/ai/queries/{id:guid}/drill` — admin-gated, 404 se id non trovato.
- **Write-path**: `LogAiRequestCommand` esteso con `Chunks?` + `Breakdown?` opzionali. Popolati da `qa-stream` / `qa` / `explain` (i 3 caller con accesso a `Snippets`). `setup-stream` no chunks (no retrieval). Helper `MapSnippetsToChunks` per mapping `Snippet → RetrievedChunkDto`.

### FE
- **Schema Zod**: `AiQueryDrillResponseSchema` + sub-schemas.
- **Client**: `api.admin.getAiQueryDrill(id)`.
- **QueryDrillPanel**: nuove props `chunks` + `drillReady`. Sezione "Retrieved chunks (N)" con lista chunks + empty state. Badge "limited drill" condizionale (visibile solo finché `drillReady=false`).
- **RequestsTab**: `useEffect` fetcha il drill quando cambia `selectedId`, passa `breakdown`+`chunks`+`drillReady` al panel.

## Test plan

- [x] BE: **8/8 unit test** handler verdi (in-memory DbContext + xUnit + FluentAssertions)
  - empty Guid, id not found, no payload, chunks deserializzati, breakdown deserializzato, json corrotto chunks/breakdown, null request → ArgumentNullException
- [x] FE: **59/59 test** cluster admin/ai verdi (+4 nuovi su QueryDrillPanel: limited badge hidden when drillReady, chunks empty state, chunks list rendering, badge logic)
- [x] BE build verde, FE typecheck verde
- [ ] **Manual smoke** (post-deploy): `/admin/ai?tab=requests&queryId=<real-id>` → panel apre, badge "limited drill" sparito, lista chunks renderizzata
- [ ] **Integration test Testcontainers Postgres** — NOT incluso in questo PR (in-memory coverage giudicata sufficiente, Docker fixture pesante non giustificata). Tracking: pickup nel prossimo sweep BE integration.

## Decisioni di scope

- **Schema option A scelta** (jsonb su tabella esistente, single PK lookup) — pattern già usato altrove nel codebase per audit/outbox payloads. Niente nuova tabella `AiRequestTraces`.
- **Breakdown non ancora popolato dai callers**: nessun pipeline path ha tracking timings per-stage. La colonna è pronta e l'endpoint la deserializza; quando l'instrumentation arriverà (issue follow-up), basterà passare il `Breakdown` al `LogAiRequestCommand`. FE già rende fallback "breakdown unavailable" in attesa.
- **Backfill non richiesto**: log esistenti pre-migration → `chunks: []` + `breakdown: null` (FE degrade graceful).
- **Telemetry fail-safe**: JSON corrotto nei jsonb logga warning + restituisce null/empty, mai throw (mantiene contratto "telemetry deve degradare, mai propagare errori").

## Refs

- Closes #1728
- Parent: #1722 (chiusa) — F3-FU-7 /admin/ai full mockup compliance
- Sibling sub-task: #1729 (metrics endpoint, prossima PR)
- Spec FE consumer pronto: PR #1727 (QueryDrillPanel + LatencyBreakdownBar)

🤖 Generated with Claude Code