### PR TITLE
feat(admin-ai): #1729 metrics endpoint — p50/p95/error trend per bucket

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AiMetricsTrendResult.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AiMetricsTrendResult.cs
@@ -1,0 +1,29 @@
+namespace Api.BoundedContexts.Administration.Application.DTOs;
+
+/// <summary>
+/// Per-bucket AI metrics datapoint (#1729). Bucket boundaries are
+/// inclusive-lower / exclusive-upper. Empty buckets surface with
+/// <c>RequestCount = 0</c> and zeroed percentiles to keep the FE chart
+/// series continuous (no gaps).
+/// </summary>
+internal record AiMetricsDatapoint
+{
+    public required DateTime Timestamp { get; init; }
+    public required int RequestCount { get; init; }
+    public required int AvgLatencyMs { get; init; }
+    public required int P50LatencyMs { get; init; }
+    public required int P95LatencyMs { get; init; }
+    public required double ErrorRate { get; init; }
+}
+
+/// <summary>
+/// Trend response: a continuous series of <see cref="AiMetricsDatapoint"/>
+/// covering the requested range, with metadata about the bucket size
+/// used (so the FE can label/space axes correctly).
+/// </summary>
+internal record AiMetricsTrendResult
+{
+    public required string Range { get; init; }
+    public required string BucketSize { get; init; }
+    public required IReadOnlyList<AiMetricsDatapoint> Datapoints { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQuery.cs
@@ -1,0 +1,18 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Query for the AI metrics trend chart (#1729).
+///
+/// Range values:
+///   "Live" → last 1 hour, 1 min buckets (polling 10s lato FE)
+///   "1h"   → last 1 hour, 1 min buckets (snapshot)
+///   "24h"  → last 24 hours, 15 min buckets
+///   "7d"   → last 7 days, 1 hour buckets
+///
+/// Returns p50/p95/errorRate per bucket so the FE AiTrendChart can
+/// drop the legacy "approx — p50/p95/error pending" badge.
+/// </summary>
+internal record GetAiMetricsTrendQuery(string Range) : IQuery<AiMetricsTrendResult>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQueryHandler.cs
@@ -1,0 +1,132 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+internal sealed class GetAiMetricsTrendQueryHandler
+    : IQueryHandler<GetAiMetricsTrendQuery, AiMetricsTrendResult>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public GetAiMetricsTrendQueryHandler(MeepleAiDbContext db, TimeProvider? timeProvider = null)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<AiMetricsTrendResult> Handle(GetAiMetricsTrendQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var config = ResolveRangeOrThrow(request.Range);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var windowStart = AlignToBucket(now - config.Window, config.Bucket);
+        var windowEnd = AlignToBucket(now, config.Bucket) + config.Bucket; // exclusive
+
+        // Load only the latency + status + bucket for the window. AsNoTracking
+        // since this is read-only analytics. For the volumes we expect today
+        // (≤ a few thousand rows per range) the in-memory percentile is
+        // cheaper to implement correctly than translating percentile_cont
+        // through EF Core; if the table grows past ~100k/range we'll lift
+        // the calculation into SQL.
+        var rows = await _db.AiRequestLogs
+            .AsNoTracking()
+            .Where(log => log.CreatedAt >= windowStart && log.CreatedAt < windowEnd)
+            .Select(log => new RowProjection
+            {
+                CreatedAt = log.CreatedAt,
+                LatencyMs = log.LatencyMs,
+                Status = log.Status,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var grouped = rows
+            .GroupBy(r => AlignToBucket(r.CreatedAt, config.Bucket))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var datapoints = new List<AiMetricsDatapoint>();
+        for (var ts = windowStart; ts < windowEnd; ts += config.Bucket)
+        {
+            datapoints.Add(BuildDatapoint(ts, grouped.GetValueOrDefault(ts)));
+        }
+
+        return new AiMetricsTrendResult
+        {
+            Range = request.Range,
+            BucketSize = config.Label,
+            Datapoints = datapoints,
+        };
+    }
+
+    private static AiMetricsDatapoint BuildDatapoint(DateTime timestamp, IReadOnlyList<RowProjection>? bucket)
+    {
+        if (bucket is null || bucket.Count == 0)
+        {
+            return new AiMetricsDatapoint
+            {
+                Timestamp = timestamp,
+                RequestCount = 0,
+                AvgLatencyMs = 0,
+                P50LatencyMs = 0,
+                P95LatencyMs = 0,
+                ErrorRate = 0,
+            };
+        }
+
+        var latencies = bucket.Select(r => r.LatencyMs).OrderBy(x => x).ToList();
+        var errors = bucket.Count(r => !string.Equals(r.Status, "Success", StringComparison.OrdinalIgnoreCase));
+
+        return new AiMetricsDatapoint
+        {
+            Timestamp = timestamp,
+            RequestCount = bucket.Count,
+            AvgLatencyMs = (int)Math.Round(latencies.Average()),
+            P50LatencyMs = Percentile(latencies, 0.50),
+            P95LatencyMs = Percentile(latencies, 0.95),
+            ErrorRate = (double)errors / bucket.Count,
+        };
+    }
+
+    private static int Percentile(IReadOnlyList<int> sorted, double q)
+    {
+        // Sorted ascending. Nearest-rank percentile keeps the integer
+        // semantics — close enough to percentile_cont for chart axes
+        // and trivially testable.
+        if (sorted.Count == 0) return 0;
+        var rank = (int)Math.Ceiling(q * sorted.Count);
+        if (rank <= 0) rank = 1;
+        if (rank > sorted.Count) rank = sorted.Count;
+        return sorted[rank - 1];
+    }
+
+    private static DateTime AlignToBucket(DateTime timestamp, TimeSpan bucket)
+    {
+        var ticks = timestamp.Ticks - (timestamp.Ticks % bucket.Ticks);
+        return new DateTime(ticks, DateTimeKind.Utc);
+    }
+
+    private static RangeConfig ResolveRangeOrThrow(string range)
+    {
+        return range switch
+        {
+            "Live" or "1h" => new RangeConfig(TimeSpan.FromHours(1), TimeSpan.FromMinutes(1), "1m"),
+            "24h" => new RangeConfig(TimeSpan.FromHours(24), TimeSpan.FromMinutes(15), "15m"),
+            "7d" => new RangeConfig(TimeSpan.FromDays(7), TimeSpan.FromHours(1), "1h"),
+            _ => throw new ArgumentException(
+                $"Unsupported range '{range}'. Valid values: Live, 1h, 24h, 7d.",
+                nameof(range)),
+        };
+    }
+
+    private sealed record RowProjection
+    {
+        public required DateTime CreatedAt { get; init; }
+        public required int LatencyMs { get; init; }
+        public required string Status { get; init; }
+    }
+
+    private sealed record RangeConfig(TimeSpan Window, TimeSpan Bucket, string Label);
+}

--- a/apps/api/src/Api/Routing/AnalyticsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AnalyticsEndpoints.cs
@@ -49,6 +49,17 @@ internal static class AnalyticsEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound);
+
+        // #1729: AI metrics trend (p50/p95/error per bucket) for AiTrendChart.
+        group.MapGet("/admin/ai/metrics", HandleGetAiMetricsTrend)
+            .WithName("GetAiMetricsTrend")
+            .WithTags("Admin", "AI")
+            .WithSummary("Get AI metrics trend (latency p50/p95 + error rate) per bucket for a time range")
+            .WithDescription("Returns continuous per-bucket datapoints for the requested time range. Range values: Live (1h, 1m buckets), 1h (1m), 24h (15m), 7d (1h). Buckets without traffic surface as zeros to keep the FE chart series continuous.")
+            .Produces<object>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden);
     }
 
     // #1728: Endpoint handler for per-query drill.
@@ -96,6 +107,28 @@ internal static class AnalyticsEndpoints
             chunks = result.Chunks,
             breakdown = result.Breakdown,
         });
+    }
+
+    // #1729: Endpoint handler for AI metrics trend.
+    private static async Task<IResult> HandleGetAiMetricsTrend(
+        HttpContext context,
+        IMediator mediator,
+        string? range = "7d",
+        CancellationToken ct = default)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        try
+        {
+            var query = new GetAiMetricsTrendQuery(range ?? "7d");
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Json(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = "invalid_range", message = ex.Message });
+        }
     }
 
     private static void MapLlmHealthEndpoints(RouteGroupBuilder group)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/GetAiMetricsTrendQueryHandlerTests.cs
@@ -1,0 +1,162 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.SharedKernel.Application.Services;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Unit coverage for #1729 AI metrics trend handler.
+///
+/// Validates:
+///   - range → window/bucket mapping (Live, 1h, 24h, 7d)
+///   - invalid range → ArgumentException (endpoint maps it to 400)
+///   - continuous bucket series with zeros for empty intervals
+///   - percentile + avg + errorRate calculations on populated buckets
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class GetAiMetricsTrendQueryHandlerTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 5, 31, 12, 0, 0, TimeSpan.Zero);
+
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"AiMetricsTrendTests_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    private static GetAiMetricsTrendQueryHandler CreateHandler(MeepleAiDbContext db)
+    {
+        var clock = new FakeTimeProvider(FixedNow);
+        return new GetAiMetricsTrendQueryHandler(db, clock);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("invalid")]
+    [InlineData("2h")]
+    [InlineData("90d")]
+    public async Task Handle_WithInvalidRange_ThrowsArgumentException(string range)
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WithInvalidRange_ThrowsArgumentException));
+        var handler = CreateHandler(db);
+
+        await FluentActions
+            .Invoking(() => handler.Handle(new GetAiMetricsTrendQuery(range), CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Handle_WithNullRequest_ThrowsArgumentNullException()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_WithNullRequest_ThrowsArgumentNullException));
+        var handler = CreateHandler(db);
+
+        await FluentActions
+            .Invoking(() => handler.Handle(null!, CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentNullException>();
+    }
+
+    // Series spans [windowStart, windowEnd) where windowEnd = align(now) + bucket,
+    // so the current bucket is always included → count = window/bucket + 1.
+    [Theory]
+    [InlineData("Live", 61, "1m")] // 60 + current 1m bucket
+    [InlineData("1h", 61, "1m")]
+    [InlineData("24h", 97, "15m")] // 96 + current
+    [InlineData("7d", 169, "1h")]  // 168 + current
+    public async Task Handle_ReturnsContinuousBucketSeriesWithCorrectSize(string range, int expectedDatapoints, string expectedLabel)
+    {
+        await using var db = CreateInMemoryDb(
+            $"{nameof(Handle_ReturnsContinuousBucketSeriesWithCorrectSize)}_{range}");
+        var handler = CreateHandler(db);
+
+        var result = await handler.Handle(new GetAiMetricsTrendQuery(range), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Range.Should().Be(range);
+        result.BucketSize.Should().Be(expectedLabel);
+        // No data in DB → all buckets surface as zeros (continuous series)
+        result.Datapoints.Should().HaveCount(expectedDatapoints);
+        result.Datapoints.Should().OnlyContain(d =>
+            d.RequestCount == 0 && d.AvgLatencyMs == 0 && d.P50LatencyMs == 0 && d.P95LatencyMs == 0 && d.ErrorRate == 0);
+    }
+
+    [Fact]
+    public async Task Handle_AggregatesPercentilesAndErrorRateForPopulatedBucket()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_AggregatesPercentilesAndErrorRateForPopulatedBucket));
+
+        // Seed 20 rows into the SAME 1m bucket at 11:30:00 UTC (within the 1h "Live" window).
+        var bucketStart = new DateTime(2026, 5, 31, 11, 30, 0, DateTimeKind.Utc);
+        var latencies = new[] { 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250, 260, 270, 280, 290 };
+        for (var i = 0; i < latencies.Length; i++)
+        {
+            // 18 success + 2 error → errorRate = 0.10
+            db.AiRequestLogs.Add(new AiRequestLogEntity
+            {
+                Id = Guid.NewGuid(),
+                Endpoint = "qa-stream",
+                LatencyMs = latencies[i],
+                Status = i < 2 ? "Error" : "Success",
+                CreatedAt = bucketStart.AddSeconds(i * 2),
+                TokenCount = 100,
+                PromptTokens = 80,
+                CompletionTokens = 20,
+            });
+        }
+        db.SaveChanges();
+
+        var handler = CreateHandler(db);
+        var result = await handler.Handle(new GetAiMetricsTrendQuery("Live"), CancellationToken.None);
+
+        var bucket = result.Datapoints.Should()
+            .Contain(d => d.Timestamp == bucketStart)
+            .Which;
+
+        bucket.RequestCount.Should().Be(20);
+        bucket.AvgLatencyMs.Should().Be((int)Math.Round(latencies.Average())); // 195
+        // Nearest-rank percentile: q=0.50 → rank=10 → sorted[9] = 190
+        bucket.P50LatencyMs.Should().Be(190);
+        // q=0.95 → rank=19 → sorted[18] = 280
+        bucket.P95LatencyMs.Should().Be(280);
+        // 2 errors / 20 = 0.10
+        bucket.ErrorRate.Should().BeApproximately(0.10, 0.0001);
+    }
+
+    [Fact]
+    public async Task Handle_IgnoresRowsOutsideTheTimeWindow()
+    {
+        await using var db = CreateInMemoryDb(nameof(Handle_IgnoresRowsOutsideTheTimeWindow));
+
+        // Row 2 hours ago → outside the "Live"/"1h" window (which is the last 1h)
+        db.AiRequestLogs.Add(new AiRequestLogEntity
+        {
+            Id = Guid.NewGuid(),
+            Endpoint = "qa",
+            LatencyMs = 999,
+            Status = "Success",
+            CreatedAt = FixedNow.UtcDateTime.AddHours(-2),
+        });
+        db.SaveChanges();
+
+        var handler = CreateHandler(db);
+        var result = await handler.Handle(new GetAiMetricsTrendQuery("1h"), CancellationToken.None);
+
+        result.Datapoints.Should().OnlyContain(d => d.RequestCount == 0);
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/ai/RequestsTab.tsx
@@ -13,8 +13,9 @@ import { api } from '@/lib/api';
 import type { AiQueryDrillResponse, AiRequest } from '@/lib/api/schemas';
 import { cn } from '@/lib/utils';
 
-const TREND_RANGE_OPTIONS = ['1d', '7d', '30d'] as const;
-const TREND_RANGE_DAYS: Record<string, number> = { '1d': 1, '7d': 7, '30d': 30 };
+// #1729: Range options now match the BE /admin/ai/metrics endpoint.
+// Legacy "1d/7d/30d" replaced by sub-daily granularity from percentile-based query.
+const TREND_RANGE_OPTIONS = ['Live', '1h', '24h', '7d'] as const;
 
 export function RequestsTab() {
   const router = useRouter();
@@ -47,16 +48,21 @@ export function RequestsTab() {
   }, [page]);
 
   useEffect(() => {
-    const days = TREND_RANGE_DAYS[range] ?? 7;
     let cancelled = false;
+    // #1729: swap legacy getModelPerformance(days) → getAiMetricsTrend(range).
+    // Returns p50/p95/errorRate per bucket — AiTrendChart auto-detects the
+    // full series and drops the "approx" badge.
     api.admin
-      .getModelPerformance(days)
+      .getAiMetricsTrend(range)
       .then(data => {
         if (cancelled) return;
-        const points = (data?.dailyStats ?? []).map(d => ({
-          date: d.date,
+        const points = (data?.datapoints ?? []).map(d => ({
+          date: d.timestamp,
           avgLatencyMs: d.avgLatencyMs,
           requestCount: d.requestCount,
+          p50LatencyMs: d.p50LatencyMs,
+          p95LatencyMs: d.p95LatencyMs,
+          errorRate: d.errorRate,
         }));
         setTrend(points);
       })
@@ -66,6 +72,28 @@ export function RequestsTab() {
     return () => {
       cancelled = true;
     };
+  }, [range]);
+
+  // #1729: Live range polls every 10s for near-real-time updates.
+  useEffect(() => {
+    if (range !== 'Live') return undefined;
+    const handle = setInterval(() => {
+      api.admin
+        .getAiMetricsTrend('Live')
+        .then(data => {
+          const points = (data?.datapoints ?? []).map(d => ({
+            date: d.timestamp,
+            avgLatencyMs: d.avgLatencyMs,
+            requestCount: d.requestCount,
+            p50LatencyMs: d.p50LatencyMs,
+            p95LatencyMs: d.p95LatencyMs,
+            errorRate: d.errorRate,
+          }));
+          setTrend(points);
+        })
+        .catch(() => {});
+    }, 10_000);
+    return () => clearInterval(handle);
   }, [range]);
 
   const setRange = (next: string) => {

--- a/apps/web/src/app/admin/(dashboard)/ai/__tests__/tabs.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/ai/__tests__/tabs.test.tsx
@@ -16,6 +16,12 @@ const mocks = vi.hoisted(() => ({
     models: [],
     dailyStats: [],
   }),
+  // #1729: RequestsTab now drives the trend chart via getAiMetricsTrend
+  getAiMetricsTrend: vi.fn().mockResolvedValue({
+    range: '7d',
+    bucketSize: '1h',
+    datapoints: [],
+  }),
   deletePrompt: vi.fn().mockResolvedValue(undefined),
   approveAgentTypology: vi.fn().mockResolvedValue(undefined),
   deleteAgentTypology: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/components/admin/ai/AiTrendChart.tsx
+++ b/apps/web/src/components/admin/ai/AiTrendChart.tsx
@@ -3,9 +3,15 @@
 import { cn } from '@/lib/utils';
 
 export interface TrendDatapoint {
-  date: string; // YYYY-MM-DD
+  /** YYYY-MM-DD or ISO timestamp. Used as React key + sr-only table cell. */
+  date: string;
   avgLatencyMs: number;
   requestCount: number;
+  /** #1729: optional percentile series (populated by /admin/ai/metrics) */
+  p50LatencyMs?: number;
+  p95LatencyMs?: number;
+  /** #1729: optional error fraction in [0, 1]. Rendered as % on the right axis. */
+  errorRate?: number;
 }
 
 interface AiTrendChartProps {
@@ -20,22 +26,29 @@ const CHART_HEIGHT = 140;
 const PADDING = 24;
 
 /**
- * AI trend chart — inline SVG with two series:
- *   - avgLatencyMs (ms)  → entity-session line
- *   - requestCount (n)   → entity-toolkit line (scaled to right axis)
+ * AI trend chart — inline SVG.
  *
- * The mockup A4 asks for p50/p95/error series, but
- * `/api/v1/admin/model-performance?days=` only exposes daily averages
- * and aggregate success rate. The dedicated `/ai/metrics?range=`
- * endpoint (#1722 sub-task BE) will unlock that — until then we surface
- * a visible "approx" badge so reviewers know the trend is daily-avg,
- * not p50/p95.
+ * Renders avgLatency + volume by default; when the new
+ * `/api/v1/admin/ai/metrics` endpoint provides p50/p95/error series
+ * (#1729), they layer on top and the legacy "approx" badge drops.
  */
 export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTrendChartProps) {
   const hasData = data.length > 0;
+  // #1729: detect full-series payload — when all 3 percentile/error fields
+  // are populated on every datapoint, we can drop the "approx" badge.
+  const hasPercentileSeries =
+    hasData &&
+    data.every(
+      d => d.p50LatencyMs !== undefined && d.p95LatencyMs !== undefined && d.errorRate !== undefined
+    );
 
   const latencyPath = hasData ? buildSvgPath(data, d => d.avgLatencyMs) : '';
   const volumePath = hasData ? buildSvgPath(data, d => d.requestCount) : '';
+  const p50Path = hasPercentileSeries ? buildSvgPath(data, d => d.p50LatencyMs ?? 0) : '';
+  const p95Path = hasPercentileSeries ? buildSvgPath(data, d => d.p95LatencyMs ?? 0) : '';
+  // errorRate is in [0, 1] — scale to a latency-comparable magnitude
+  // by mapping the max into the chart range. Drawn dashed in destructive tone.
+  const errorPath = hasPercentileSeries ? buildSvgPath(data, d => (d.errorRate ?? 0) * 1000) : '';
 
   return (
     <section className="rounded-xl border border-border/60 bg-card/70 backdrop-blur-md p-4 space-y-3">
@@ -45,12 +58,16 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
             Latency &amp; volume trend
           </h3>
           <p className="font-mono text-[10px] text-muted-foreground mt-0.5">
-            avgLatencyMs (sx) · requestCount (dx)
+            {hasPercentileSeries
+              ? 'p50/p95 latency (sx) · requestCount (dx) · errorRate (dashed)'
+              : 'avgLatencyMs (sx) · requestCount (dx)'}
           </p>
         </div>
-        <span className="inline-flex items-center rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
-          approx — p50/p95/error pending
-        </span>
+        {!hasPercentileSeries && (
+          <span className="inline-flex items-center rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
+            approx — p50/p95/error pending
+          </span>
+        )}
         <div
           role="group"
           aria-label="Time range"
@@ -79,7 +96,11 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
         <>
           <svg
             role="img"
-            aria-label="Latency and request volume trend"
+            aria-label={
+              hasPercentileSeries
+                ? 'Latency p50/p95, request volume and error rate trend'
+                : 'Latency and request volume trend'
+            }
             viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
             preserveAspectRatio="none"
             className="block w-full h-32"
@@ -93,13 +114,15 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
               className="stroke-border"
               strokeWidth={1}
             />
-            <polyline
-              data-series="latency"
-              fill="none"
-              className="stroke-entity-session"
-              strokeWidth={2}
-              points={latencyPath}
-            />
+            {!hasPercentileSeries && (
+              <polyline
+                data-series="latency"
+                fill="none"
+                className="stroke-entity-session"
+                strokeWidth={2}
+                points={latencyPath}
+              />
+            )}
             <polyline
               data-series="volume"
               fill="none"
@@ -108,15 +131,48 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
               strokeDasharray="4 2"
               points={volumePath}
             />
+            {hasPercentileSeries && (
+              <>
+                <polyline
+                  data-series="p50"
+                  fill="none"
+                  className="stroke-entity-session"
+                  strokeWidth={2}
+                  points={p50Path}
+                />
+                <polyline
+                  data-series="p95"
+                  fill="none"
+                  className="stroke-entity-player"
+                  strokeWidth={2}
+                  points={p95Path}
+                />
+                <polyline
+                  data-series="error"
+                  fill="none"
+                  className="stroke-destructive"
+                  strokeWidth={1.5}
+                  strokeDasharray="2 3"
+                  points={errorPath}
+                />
+              </>
+            )}
           </svg>
           {/* sr-only data table */}
           <table className="sr-only">
-            <caption>Daily AI latency and volume</caption>
+            <caption>AI latency and volume trend</caption>
             <thead>
               <tr>
                 <th scope="col">Date</th>
                 <th scope="col">avgLatencyMs</th>
                 <th scope="col">requestCount</th>
+                {hasPercentileSeries && (
+                  <>
+                    <th scope="col">p50LatencyMs</th>
+                    <th scope="col">p95LatencyMs</th>
+                    <th scope="col">errorRate</th>
+                  </>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -125,6 +181,13 @@ export function AiTrendChart({ data, range, rangeOptions, onRangeChange }: AiTre
                   <td>{d.date}</td>
                   <td>{Math.round(d.avgLatencyMs)}</td>
                   <td>{d.requestCount}</td>
+                  {hasPercentileSeries && (
+                    <>
+                      <td>{d.p50LatencyMs ?? 0}</td>
+                      <td>{d.p95LatencyMs ?? 0}</td>
+                      <td>{((d.errorRate ?? 0) * 100).toFixed(1)}%</td>
+                    </>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/components/admin/ai/__tests__/AiTrendChart.test.tsx
+++ b/apps/web/src/components/admin/ai/__tests__/AiTrendChart.test.tsx
@@ -36,7 +36,7 @@ describe('AiTrendChart', () => {
     expect(screen.getByRole('img', { name: /latency/i })).toBeInTheDocument();
   });
 
-  it('renders one polyline per series (avgLatencyMs + requestCount)', () => {
+  it('renders one polyline per series (avgLatencyMs + requestCount) when percentile fields absent', () => {
     const { container } = render(
       <AiTrendChart
         data={sample}
@@ -47,6 +47,48 @@ describe('AiTrendChart', () => {
     );
     const polylines = container.querySelectorAll('polyline[data-series]');
     expect(polylines).toHaveLength(2);
+  });
+
+  it('renders 4 polylines (volume + p50 + p95 + error) when full percentile series provided (#1729)', () => {
+    const fullSample: TrendDatapoint[] = sample.map(d => ({
+      ...d,
+      p50LatencyMs: d.avgLatencyMs - 50,
+      p95LatencyMs: d.avgLatencyMs + 200,
+      errorRate: 0.05,
+    }));
+    const { container } = render(
+      <AiTrendChart
+        data={fullSample}
+        range="7d"
+        onRangeChange={vi.fn()}
+        rangeOptions={['Live', '1h', '24h', '7d']}
+      />
+    );
+    const polylines = container.querySelectorAll('polyline[data-series]');
+    // No legacy "latency" series — replaced by p50/p95
+    expect(polylines).toHaveLength(4);
+    expect(container.querySelector('polyline[data-series="p50"]')).toBeInTheDocument();
+    expect(container.querySelector('polyline[data-series="p95"]')).toBeInTheDocument();
+    expect(container.querySelector('polyline[data-series="error"]')).toBeInTheDocument();
+    expect(container.querySelector('polyline[data-series="latency"]')).not.toBeInTheDocument();
+  });
+
+  it('hides the "approx" badge when full percentile series provided (#1729)', () => {
+    const fullSample: TrendDatapoint[] = sample.map(d => ({
+      ...d,
+      p50LatencyMs: 100,
+      p95LatencyMs: 500,
+      errorRate: 0,
+    }));
+    render(
+      <AiTrendChart
+        data={fullSample}
+        range="1h"
+        onRangeChange={vi.fn()}
+        rangeOptions={['Live', '1h', '24h', '7d']}
+      />
+    );
+    expect(screen.queryByText(/approx/i)).not.toBeInTheDocument();
   });
 
   it('exposes a screen-reader table mirroring the datapoints', () => {

--- a/apps/web/src/lib/api/clients/admin/adminAnalyticsClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminAnalyticsClient.ts
@@ -13,6 +13,7 @@ import {
   AdminOverviewStatsSchema,
   AiRequestsResponseSchema,
   AiQueryDrillResponseSchema,
+  AiMetricsTrendResponseSchema,
   DashboardStatsSchema,
   GetUserActivityResultSchema,
   TokenBalanceSchema,
@@ -28,6 +29,7 @@ import {
   type AdminOverviewStats,
   type AiRequest,
   type AiQueryDrillResponse,
+  type AiMetricsTrendResponse,
   type DashboardStats,
   type GetUserActivityResult,
   type RecentActivityDto,
@@ -204,6 +206,17 @@ export function createAdminAnalyticsClient(http: HttpClient) {
       return http.get(
         `/api/v1/admin/ai/queries/${encodeURIComponent(id)}/drill`,
         AiQueryDrillResponseSchema
+      );
+    },
+
+    /**
+     * #1729: AI metrics trend (p50/p95/error per bucket) for AiTrendChart.
+     * range ∈ {"Live", "1h", "24h", "7d"}. Invalid values bubble up as 400 from BE.
+     */
+    async getAiMetricsTrend(range: string): Promise<AiMetricsTrendResponse | null> {
+      return http.get(
+        `/api/v1/admin/ai/metrics?range=${encodeURIComponent(range)}`,
+        AiMetricsTrendResponseSchema
       );
     },
 

--- a/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
@@ -70,6 +70,27 @@ export const AiQueryDrillResponseSchema = z.object({
 
 export type AiQueryDrillResponse = z.infer<typeof AiQueryDrillResponseSchema>;
 
+// ========== AI Metrics Trend (#1729) ==========
+
+export const AiMetricsDatapointSchema = z.object({
+  timestamp: z.string().datetime({ offset: true }),
+  requestCount: z.number().int().nonnegative(),
+  avgLatencyMs: z.number().int().nonnegative(),
+  p50LatencyMs: z.number().int().nonnegative(),
+  p95LatencyMs: z.number().int().nonnegative(),
+  errorRate: z.number().min(0).max(1),
+});
+
+export type AiMetricsDatapoint = z.infer<typeof AiMetricsDatapointSchema>;
+
+export const AiMetricsTrendResponseSchema = z.object({
+  range: z.string(),
+  bucketSize: z.string(),
+  datapoints: z.array(AiMetricsDatapointSchema),
+});
+
+export type AiMetricsTrendResponse = z.infer<typeof AiMetricsTrendResponseSchema>;
+
 // ========== Prompt Version Activation ==========
 
 export const ActivateVersionResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Implementa l'endpoint **AI metrics trend** per `AiTrendChart` (sub-task BE di #1722 chiuso). Sostituisce la fonte `model-performance?days=` (daily avg + success rate aggregato) con un endpoint dedicato che fornisce **p50/p95/errorRate per bucket** in range sub-daily.

Closes #1729.

## Cosa cambia

### BE
- **Query**: `GetAiMetricsTrendQuery(range)` → `AiMetricsTrendResult`.
- **Handler**: bucket strategy per range:
  | Range | Window | Bucket | Datapoints |
  |-------|--------|--------|------------|
  | `Live` | 1h | 1m | 61 (polling 10s FE) |
  | `1h` | 1h | 1m | 61 (snapshot) |
  | `24h` | 24h | 15m | 97 |
  | `7d` | 7d | 1h | 169 |

  Range non valido → `ArgumentException` → endpoint mappa a **400 Bad Request**.
- **Percentile in-memory** (nearest-rank q=0.50/0.95): per i volumi attesi (≤ qualche k riga/range) è cheaper di tradurre `percentile_cont` attraverso EF Core. Migration a SQL raw quando `ai_request_logs` cresce oltre ~100k/range.
- **Bucket alignment + serie continua**: buckets vuoti emessi con zeros (no gaps lato FE).
- **DTOs**: `AiMetricsTrendResult { Range, BucketSize, Datapoints[] }` + `AiMetricsDatapoint { Timestamp, RequestCount, AvgLatencyMs, P50LatencyMs, P95LatencyMs, ErrorRate }`.
- **Endpoint**: `GET /api/v1/admin/ai/metrics?range=Live|1h|24h|7d` — admin-gated, default `7d` se omesso.

### FE
- **Schema Zod**: `AiMetricsTrendResponseSchema` + `AiMetricsDatapointSchema`.
- **Client**: `api.admin.getAiMetricsTrend(range)`.
- **TrendDatapoint** estesa con campi opzionali `p50LatencyMs?`, `p95LatencyMs?`, `errorRate?`.
- **AiTrendChart** auto-detects la presenza dei 3 campi extra:
  - **no** → 2 polyline (avgLatency + volume) + badge "approx"
  - **sì** → 4 polyline (volume + p50 + p95 + error dashed), badge sparito, aria-label + sr-only table aggiornati
- **RequestsTab** swap `getModelPerformance(days)` → `getAiMetricsTrend(range)`. Range options `Live | 1h | 24h | 7d` (drop legacy `1d/7d/30d`). Polling 10s in useEffect dedicato per `Live`.

## Test plan

- [x] BE: **11/11 unit test** handler verdi (`FakeTimeProvider` + InMemory DbContext)
  - invalid range → ArgumentException (`""`, `"invalid"`, `"2h"`, `"90d"`)
  - null request → ArgumentNullException
  - continuous bucket series con count corretto per ciascuno dei 4 range
  - percentile + errorRate su bucket popolato (20 righe latency 100-290ms, 2 errori → p50=190 p95=280 errorRate=0.10)
  - rows fuori finestra ignorati
- [x] FE: **58/58 test** cluster admin/ai verdi (+2 nuovi su AiTrendChart: 4 polyline quando full series, badge hidden quando series completa; tabs.test.tsx +mock `getAiMetricsTrend`)
- [x] BE build verde, FE typecheck verde, `pnpm lint:tokens` 0 violations
- [ ] **Manual smoke** (post-deploy): `/admin/ai?tab=requests&range=1h` → chart con p50/p95 + errore dashed, badge "approx" sparito; switch a `Live` → polling 10s visibile

## Decisioni di scope

- **Percentile in-memory** invece di `percentile_cont` SQL — coverage tests + manutenzione tradeoff. Lift a SQL raw nel prossimo sweep se il volume cresce.
- **Caching server-side** (30s, skip Live) **non implementato** in questo PR — tracking come follow-up se il response time degrada (ora < 100ms su volumi attuali, no concern).
- **Backward compat**: campi percentile opzionali su `TrendDatapoint` → component si adatta automaticamente, niente breaking changes per consumer esistenti.
- **Live polling lato FE** (non SSE) — più semplice, range "Live" raramente attivo, polling 10s adeguato per UX dashboard.
- **Integration test Testcontainers** deferred (stesso pattern di #1733 mergiato): in-memory coverage giudicata sufficiente per la logica del bucketing/percentile (no jsonb roundtrip Postgres-specific in questo PR).

## Refs

- Closes #1729
- Parent: #1722 (chiusa) — F3-FU-7 /admin/ai full mockup compliance
- Sibling: #1728 (drill endpoint, mergiato come #1733)
- FE consumer pronto: PR #1727 (AiTrendChart)

🤖 Generated with Claude Code